### PR TITLE
feat(ai): add custom OpenAI provider support

### DIFF
--- a/modules/common/Config.qml
+++ b/modules/common/Config.qml
@@ -88,6 +88,11 @@ Singleton {
             property JsonObject ai: JsonObject {
                 property string systemPrompt: "## Style\n- Use casual tone, don't be formal!\n- Always be brief and to the point, unless asked otherwise\n- Don't repeat the user's question\n- Be approachable: Avoid using overly complicated, domain-specific terms and provide analogies when asked to explain a concept\n\n## Context (ignore when irrelevant)\n- You are a helpful and inspiring sidebar assistant on a {DISTRO} Linux system\n- Desktop environment: {DE}\n- Current date & time: {DATETIME}\n- Focused app: {WINDOWCLASS}\n\n## Presentation\n- Use Markdown features in your response: \n  - **Bold** text to **highlight keywords** in your response\n  - **Split long information into small sections** with h2 headers and a relevant emoji at the start of it (for example `## 🐧 Linux`). Bullet points are preferred over long paragraphs, unless you're offering writing support or instructed otherwise by the user.\n- Asked to compare different options? You should firstly use a table to compare the main aspects, then elaborate or include relevant comments from online forums *after* the table. Make sure to provide a final recommendation for the user's use case!\n- Use LaTeX formatting for mathematical and scientific notations whenever appropriate. Enclose all LaTeX '$$' delimiters. NEVER generate LaTeX code in a latex block unless the user explicitly asks for it. DO NOT use LaTeX for regular documents (resumes, letters, essays, CVs, etc.).\n\nThanks!\n"
                 property string tool: "functions" // search, functions, or none
+                property JsonObject customProvider: JsonObject {
+                    property bool enabled: false
+                    property string name: "OpenRouter"
+                    property string baseUrl: "https://openrouter.ai/api/v1"
+                }
                 property list<var> extraModels: [
                     {
                         "api_format": "openai", // Most of the time you want "openai". Use "gemini" for Google's models

--- a/modules/ii/settings/pages/ServicesConfig.qml
+++ b/modules/ii/settings/pages/ServicesConfig.qml
@@ -56,6 +56,72 @@ ContentPage {
                     });
                 }
             }
+
+            ContentSubsection {
+                title: Translation.tr("Custom OpenAI-compatible Provider")
+                
+                GroupedList {
+                    ConfigSwitch {
+                        text: Translation.tr("Enable custom provider")
+                        checked: Config.options.ai.customProvider.enabled
+                        onCheckedChanged: {
+                            Config.options.ai.customProvider.enabled = checked;
+                        }
+                    }
+                }
+
+                MaterialTextArea {
+                    Layout.fillWidth: true
+                    placeholderText: Translation.tr("Provider Name (e.g. OpenRouter)")
+                    text: Config.options.ai.customProvider.name
+                    wrapMode: TextEdit.Wrap
+                    onTextChanged: {
+                        Config.options.ai.customProvider.name = text;
+                    }
+                }
+
+                MaterialTextArea {
+                    Layout.fillWidth: true
+                    placeholderText: Translation.tr("Base URL (e.g. https://openrouter.ai/api/v1)")
+                    text: Config.options.ai.customProvider.baseUrl
+                    wrapMode: TextEdit.Wrap
+                    onTextChanged: {
+                        Config.options.ai.customProvider.baseUrl = text;
+                    }
+                }
+
+                MaterialTextArea {
+                    Layout.fillWidth: true
+                    placeholderText: Translation.tr("API Key")
+                    text: KeyringStorage.loaded ? (KeyringStorage.keyringData.apiKeys?.custom_provider || "") : ""
+                    wrapMode: TextEdit.Wrap
+                    onTextChanged: {
+                        let currentText = text;
+                        Qt.callLater(() => {
+                            if (KeyringStorage.loaded) {
+                                KeyringStorage.setNestedField(["apiKeys", "custom_provider"], currentText);
+                            }
+                        });
+                    }
+                }
+
+                RippleButton {
+                    Layout.alignment: Qt.AlignRight
+                    Layout.topMargin: 10
+                    buttonText: Translation.tr("Fetch Models")
+                    onClicked: {
+                        Ai.fetchCustomModels();
+                    }
+                }
+
+                StyledText {
+                    Layout.fillWidth: true
+                    wrapMode: Text.WordWrap
+                    text: Ai.customProviderFeedbackText
+                    color: Appearance.colors.colSubtext
+                    visible: text.length > 0
+                }
+            }
         }
 
         ContentSection {

--- a/services/Ai.qml
+++ b/services/Ai.qml
@@ -8,6 +8,7 @@ import Quickshell.Io
 import Quickshell.Wayland
 import QtQuick
 import qs.services.ai
+import "AiModelsParser.js" as AiModelsParser
 
 /**
  * Basic service to handle LLM chats. Supports Google's and OpenAI's API formats.
@@ -349,6 +350,13 @@ Singleton {
         return result;
     }
 
+    property string customProviderFeedbackText: ""
+
+    function fetchCustomModels() {
+        customProviderFeedbackText = Translation.tr("Fetching models...");
+        getCustomModels.running = true;
+    }
+
     function addModel(modelName, data) {
         root.models = Object.assign({}, root.models, {
             [modelName]: aiModelComponent.createObject(this, data)
@@ -383,6 +391,34 @@ Singleton {
                 } catch (e) {
                     console.log("Could not fetch Ollama models:", e);
                 }
+            }
+        }
+    }
+
+    Process {
+        id: getCustomModels
+        running: false
+        property string baseUrl: Config.options.ai.customProvider?.baseUrl || ""
+        property string apiKey: KeyringStorage.loaded ? (KeyringStorage.keyringData.apiKeys?.custom_provider || "") : ""
+        command: ["bash", "-c", `curl -sL --max-time 10 -H "Authorization: Bearer ${apiKey}" "${baseUrl}/models" 2>/dev/null`]
+        stdout: StdioCollector {
+            onStreamFinished: {
+                if (text.length === 0) {
+                    root.customProviderFeedbackText = Translation.tr("Failed to fetch. Check base URL or network.");
+                    return;
+                }
+                const parsedModels = AiModelsParser.parseCustomProviderModels(text, getCustomModels.baseUrl, Config.options.ai.customProvider?.name || "Custom");
+                if (parsedModels.length === 0) {
+                    root.customProviderFeedbackText = Translation.tr("No models found or invalid response format.");
+                    return;
+                }
+                
+                parsedModels.forEach(model => {
+                    const safeModelName = root.safeModelName(model.model);
+                    root.addModel(safeModelName, model);
+                });
+                root.modelList = Object.keys(root.models);
+                root.customProviderFeedbackText = Translation.tr("Successfully fetched and added %1 models.").arg(parsedModels.length);
             }
         }
     }

--- a/services/AiModelsParser.js
+++ b/services/AiModelsParser.js
@@ -1,0 +1,42 @@
+.pragma library
+
+function guessModelName(model) {
+    const replaced = model.replace(/-/g, ' ').replace(/:/g, ' ');
+    let words = replaced.split(' ');
+    words[words.length - 1] = words[words.length - 1].replace(/(\d+)b$/, (_, num) => `${num}B`)
+    words = words.map((word) => {
+        return (word.charAt(0).toUpperCase() + word.slice(1))
+    });
+    if (words[words.length - 1] === "Latest") words.pop();
+    else words[words.length - 1] = `(${words[words.length - 1]})`;
+    const result = words.join(' ');
+    return result;
+}
+
+function parseCustomProviderModels(responseJsonString, baseUrl, providerName) {
+    try {
+        if (!responseJsonString || responseJsonString.trim() === "") return [];
+        const data = JSON.parse(responseJsonString);
+        if (!data || !Array.isArray(data.data)) return [];
+        let result = [];
+        let sanitizedBaseUrl = baseUrl;
+        if (sanitizedBaseUrl.endsWith("/")) {
+            sanitizedBaseUrl = sanitizedBaseUrl.slice(0, -1);
+        }
+        data.data.forEach(model => {
+            if (!model.id) return;
+            result.push({
+                name: guessModelName(model.id),
+                model: model.id,
+                description: `Online | Custom (${providerName}) | ${model.id}`,
+                endpoint: sanitizedBaseUrl + "/chat/completions",
+                requires_key: true,
+                key_id: "custom_provider",
+                api_format: "openai"
+            });
+        });
+        return result;
+    } catch (e) {
+        return [];
+    }
+}

--- a/tests/tst_ai_custom_models.qml
+++ b/tests/tst_ai_custom_models.qml
@@ -1,0 +1,46 @@
+import QtQuick
+import QtTest
+import "../services/AiModelsParser.js" as AiModelsParser
+
+TestCase {
+    name: "AiCustomModelsTest"
+
+    function test_parseCustomProviderModels() {
+        // Valid response
+        var validResponse = JSON.stringify({
+            data: [
+                { id: "model-1", name: "Model 1" },
+                { id: "model-2" }
+            ]
+        });
+
+        var parsed = AiModelsParser.parseCustomProviderModels(validResponse, "https://api.example.com/", "Example")
+        compare(parsed.length, 2)
+
+        compare(parsed[0].model, "model-1")
+        compare(parsed[0].endpoint, "https://api.example.com/chat/completions")
+        compare(parsed[0].requires_key, true)
+        compare(parsed[0].key_id, "custom_provider")
+        compare(parsed[0].api_format, "openai")
+        verify(parsed[0].description.indexOf("Example") !== -1)
+
+        compare(parsed[1].model, "model-2")
+        verify(parsed[1].name !== undefined)
+
+        // No trailing slash baseUrl
+        var parsedNoSlash = AiModelsParser.parseCustomProviderModels(validResponse, "https://api.example.com", "Example")
+        compare(parsedNoSlash[0].endpoint, "https://api.example.com/chat/completions")
+
+        // Invalid JSON
+        var parsedInvalid = AiModelsParser.parseCustomProviderModels("invalid json", "https://api.example.com", "Example")
+        compare(parsedInvalid.length, 0)
+
+        // Missing data array
+        var parsedMissingData = AiModelsParser.parseCustomProviderModels(JSON.stringify({ other: "data" }), "https://api.example.com", "Example")
+        compare(parsedMissingData.length, 0)
+
+        // Empty response
+        var parsedEmpty = AiModelsParser.parseCustomProviderModels("", "https://api.example.com", "Example")
+        compare(parsedEmpty.length, 0)
+    }
+}


### PR DESCRIPTION
Adds support for custom OpenAI-compatible AI providers (e.g. OpenRouter). Includes settings UI for Base URL and API key, storing the key securely in KeyringStorage.