### PR TITLE
feat(ai): support multiple custom providers and update UI

### DIFF
--- a/modules/common/Config.qml
+++ b/modules/common/Config.qml
@@ -88,11 +88,13 @@ Singleton {
             property JsonObject ai: JsonObject {
                 property string systemPrompt: "## Style\n- Use casual tone, don't be formal!\n- Always be brief and to the point, unless asked otherwise\n- Don't repeat the user's question\n- Be approachable: Avoid using overly complicated, domain-specific terms and provide analogies when asked to explain a concept\n\n## Context (ignore when irrelevant)\n- You are a helpful and inspiring sidebar assistant on a {DISTRO} Linux system\n- Desktop environment: {DE}\n- Current date & time: {DATETIME}\n- Focused app: {WINDOWCLASS}\n\n## Presentation\n- Use Markdown features in your response: \n  - **Bold** text to **highlight keywords** in your response\n  - **Split long information into small sections** with h2 headers and a relevant emoji at the start of it (for example `## 🐧 Linux`). Bullet points are preferred over long paragraphs, unless you're offering writing support or instructed otherwise by the user.\n- Asked to compare different options? You should firstly use a table to compare the main aspects, then elaborate or include relevant comments from online forums *after* the table. Make sure to provide a final recommendation for the user's use case!\n- Use LaTeX formatting for mathematical and scientific notations whenever appropriate. Enclose all LaTeX '$$' delimiters. NEVER generate LaTeX code in a latex block unless the user explicitly asks for it. DO NOT use LaTeX for regular documents (resumes, letters, essays, CVs, etc.).\n\nThanks!\n"
                 property string tool: "functions" // search, functions, or none
-                property JsonObject customProvider: JsonObject {
-                    property bool enabled: false
-                    property string name: "OpenRouter"
-                    property string baseUrl: "https://openrouter.ai/api/v1"
-                }
+                property list<var> customProviders: [
+                    {
+                        "enabled": false,
+                        "name": "OpenRouter",
+                        "baseUrl": "https://openrouter.ai/api/v1"
+                    }
+                ]
                 property list<var> extraModels: [
                     {
                         "api_format": "openai", // Most of the time you want "openai". Use "gemini" for Google's models

--- a/modules/ii/settings/pages/ServicesConfig.qml
+++ b/modules/ii/settings/pages/ServicesConfig.qml
@@ -126,7 +126,7 @@ ContentPage {
                                 }
                             }
 
-                            RippleButton {
+                            DialogButton {
                                 Layout.alignment: Qt.AlignRight
                                 buttonText: Translation.tr("Remove Provider")
                                 onClicked: {
@@ -142,7 +142,7 @@ ContentPage {
                         }
                     }
 
-                    RippleButton {
+                    DialogButton {
                         Layout.alignment: Qt.AlignCenter
                         Layout.topMargin: 10
                         buttonText: Translation.tr("Add Provider")
@@ -154,7 +154,7 @@ ContentPage {
                     }
                 }
 
-                RippleButton {
+                DialogButton {
                     Layout.alignment: Qt.AlignRight
                     Layout.topMargin: 10
                     buttonText: Translation.tr("Fetch Models")

--- a/modules/ii/settings/pages/ServicesConfig.qml
+++ b/modules/ii/settings/pages/ServicesConfig.qml
@@ -58,50 +58,99 @@ ContentPage {
             }
 
             ContentSubsection {
-                title: Translation.tr("Custom OpenAI-compatible Provider")
-                
-                GroupedList {
-                    ConfigSwitch {
-                        text: Translation.tr("Enable custom provider")
-                        checked: Config.options.ai.customProvider.enabled
-                        onCheckedChanged: {
-                            Config.options.ai.customProvider.enabled = checked;
+                title: Translation.tr("Custom OpenAI-compatible Providers")
+
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    spacing: 15
+
+                    Repeater {
+                        model: Config.options.ai.customProviders ? Config.options.ai.customProviders.length : 0
+
+                        delegate: ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: Appearance.rounding.small
+
+                            GroupedList {
+                                ConfigSwitch {
+                                    text: Translation.tr("Enable provider %1").arg(index + 1)
+                                    checked: Config.options.ai.customProviders[index].enabled
+                                    onCheckedChanged: {
+                                        let providers = [...Config.options.ai.customProviders];
+                                        providers[index].enabled = checked;
+                                        Config.options.ai.customProviders = providers;
+                                    }
+                                }
+                            }
+
+                            MaterialTextArea {
+                                Layout.fillWidth: true
+                                placeholderText: Translation.tr("Provider Name (e.g. OpenRouter)")
+                                text: Config.options.ai.customProviders[index].name
+                                wrapMode: TextEdit.Wrap
+                                onTextChanged: {
+                                    let providers = [...Config.options.ai.customProviders];
+                                    if (providers[index].name !== text) {
+                                        providers[index].name = text;
+                                        Config.options.ai.customProviders = providers;
+                                    }
+                                }
+                            }
+
+                            MaterialTextArea {
+                                Layout.fillWidth: true
+                                placeholderText: Translation.tr("Base URL (e.g. https://openrouter.ai/api/v1)")
+                                text: Config.options.ai.customProviders[index].baseUrl
+                                wrapMode: TextEdit.Wrap
+                                onTextChanged: {
+                                    let providers = [...Config.options.ai.customProviders];
+                                    if (providers[index].baseUrl !== text) {
+                                        providers[index].baseUrl = text;
+                                        Config.options.ai.customProviders = providers;
+                                    }
+                                }
+                            }
+
+                            MaterialTextArea {
+                                Layout.fillWidth: true
+                                placeholderText: Translation.tr("API Key")
+                                text: KeyringStorage.loaded ? (KeyringStorage.keyringData.apiKeys?.[`custom_provider_${index}`] || "") : ""
+                                wrapMode: TextEdit.Wrap
+                                onTextChanged: {
+                                    let currentText = text;
+                                    Qt.callLater(() => {
+                                        if (KeyringStorage.loaded) {
+                                            KeyringStorage.setNestedField(["apiKeys", `custom_provider_${index}`], currentText);
+                                        }
+                                    });
+                                }
+                            }
+
+                            RippleButton {
+                                Layout.alignment: Qt.AlignRight
+                                buttonText: Translation.tr("Remove Provider")
+                                onClicked: {
+                                    let providers = [...Config.options.ai.customProviders];
+                                    providers.splice(index, 1);
+                                    Config.options.ai.customProviders = providers;
+                                    
+                                    if (KeyringStorage.loaded) {
+                                        KeyringStorage.setNestedField(["apiKeys", `custom_provider_${index}`], "");
+                                    }
+                                }
+                            }
                         }
                     }
-                }
 
-                MaterialTextArea {
-                    Layout.fillWidth: true
-                    placeholderText: Translation.tr("Provider Name (e.g. OpenRouter)")
-                    text: Config.options.ai.customProvider.name
-                    wrapMode: TextEdit.Wrap
-                    onTextChanged: {
-                        Config.options.ai.customProvider.name = text;
-                    }
-                }
-
-                MaterialTextArea {
-                    Layout.fillWidth: true
-                    placeholderText: Translation.tr("Base URL (e.g. https://openrouter.ai/api/v1)")
-                    text: Config.options.ai.customProvider.baseUrl
-                    wrapMode: TextEdit.Wrap
-                    onTextChanged: {
-                        Config.options.ai.customProvider.baseUrl = text;
-                    }
-                }
-
-                MaterialTextArea {
-                    Layout.fillWidth: true
-                    placeholderText: Translation.tr("API Key")
-                    text: KeyringStorage.loaded ? (KeyringStorage.keyringData.apiKeys?.custom_provider || "") : ""
-                    wrapMode: TextEdit.Wrap
-                    onTextChanged: {
-                        let currentText = text;
-                        Qt.callLater(() => {
-                            if (KeyringStorage.loaded) {
-                                KeyringStorage.setNestedField(["apiKeys", "custom_provider"], currentText);
-                            }
-                        });
+                    RippleButton {
+                        Layout.alignment: Qt.AlignCenter
+                        Layout.topMargin: 10
+                        buttonText: Translation.tr("Add Provider")
+                        onClicked: {
+                            let providers = [...(Config.options.ai.customProviders || [])];
+                            providers.push({ enabled: false, name: "New Provider", baseUrl: "" });
+                            Config.options.ai.customProviders = providers;
+                        }
                     }
                 }
 

--- a/services/Ai.qml
+++ b/services/Ai.qml
@@ -352,9 +352,62 @@ Singleton {
 
     property string customProviderFeedbackText: ""
 
+    Component {
+        id: customModelFetcherComponent
+        Process {
+            id: fetcherProcess
+            property string baseUrl
+            property string apiKey
+            property string providerName
+            property int providerIndex
+            
+            command: ["bash", "-c", `curl -sL --max-time 10 -H "Authorization: Bearer ${apiKey}" "${baseUrl}/models" 2>/dev/null`]
+            stdout: StdioCollector {
+                onStreamFinished: {
+                    if (text.length === 0) {
+                        root.customProviderFeedbackText = Translation.tr("Failed to fetch from %1.").arg(fetcherProcess.providerName);
+                        return;
+                    }
+                    const parsedModels = AiModelsParser.parseCustomProviderModels(text, fetcherProcess.baseUrl, fetcherProcess.providerName, `custom_provider_${fetcherProcess.providerIndex}`);
+                    if (parsedModels.length > 0) {
+                        parsedModels.forEach(model => {
+                            const safeModelName = root.safeModelName(model.model);
+                            root.addModel(safeModelName, model);
+                        });
+                        root.modelList = Object.keys(root.models);
+                        root.customProviderFeedbackText = Translation.tr("Successfully fetched from %1.").arg(fetcherProcess.providerName);
+                    } else {
+                        root.customProviderFeedbackText = Translation.tr("No models found from %1.").arg(fetcherProcess.providerName);
+                    }
+                }
+            }
+            onExited: {
+                Qt.callLater(() => fetcherProcess.destroy());
+            }
+        }
+    }
+
     function fetchCustomModels() {
         customProviderFeedbackText = Translation.tr("Fetching models...");
-        getCustomModels.running = true;
+        let providers = Config.options.ai.customProviders || [];
+        let anyEnabled = false;
+        
+        for (let i = 0; i < providers.length; i++) {
+            let provider = providers[i];
+            if (!provider.enabled) continue;
+            anyEnabled = true;
+            let fetcher = customModelFetcherComponent.createObject(root, {
+                baseUrl: provider.baseUrl || "",
+                apiKey: KeyringStorage.loaded ? (KeyringStorage.keyringData.apiKeys?.[`custom_provider_${i}`] || "") : "",
+                providerName: provider.name || "Custom",
+                providerIndex: i
+            });
+            fetcher.running = true;
+        }
+        
+        if (!anyEnabled) {
+            customProviderFeedbackText = Translation.tr("No custom providers enabled.");
+        }
     }
 
     function addModel(modelName, data) {
@@ -391,34 +444,6 @@ Singleton {
                 } catch (e) {
                     console.log("Could not fetch Ollama models:", e);
                 }
-            }
-        }
-    }
-
-    Process {
-        id: getCustomModels
-        running: false
-        property string baseUrl: Config.options.ai.customProvider?.baseUrl || ""
-        property string apiKey: KeyringStorage.loaded ? (KeyringStorage.keyringData.apiKeys?.custom_provider || "") : ""
-        command: ["bash", "-c", `curl -sL --max-time 10 -H "Authorization: Bearer ${apiKey}" "${baseUrl}/models" 2>/dev/null`]
-        stdout: StdioCollector {
-            onStreamFinished: {
-                if (text.length === 0) {
-                    root.customProviderFeedbackText = Translation.tr("Failed to fetch. Check base URL or network.");
-                    return;
-                }
-                const parsedModels = AiModelsParser.parseCustomProviderModels(text, getCustomModels.baseUrl, Config.options.ai.customProvider?.name || "Custom");
-                if (parsedModels.length === 0) {
-                    root.customProviderFeedbackText = Translation.tr("No models found or invalid response format.");
-                    return;
-                }
-                
-                parsedModels.forEach(model => {
-                    const safeModelName = root.safeModelName(model.model);
-                    root.addModel(safeModelName, model);
-                });
-                root.modelList = Object.keys(root.models);
-                root.customProviderFeedbackText = Translation.tr("Successfully fetched and added %1 models.").arg(parsedModels.length);
             }
         }
     }

--- a/services/AiModelsParser.js
+++ b/services/AiModelsParser.js
@@ -13,7 +13,7 @@ function guessModelName(model) {
     return result;
 }
 
-function parseCustomProviderModels(responseJsonString, baseUrl, providerName) {
+function parseCustomProviderModels(responseJsonString, baseUrl, providerName, keyId) {
     try {
         if (!responseJsonString || responseJsonString.trim() === "") return [];
         const data = JSON.parse(responseJsonString);
@@ -31,7 +31,7 @@ function parseCustomProviderModels(responseJsonString, baseUrl, providerName) {
                 description: `Online | Custom (${providerName}) | ${model.id}`,
                 endpoint: sanitizedBaseUrl + "/chat/completions",
                 requires_key: true,
-                key_id: "custom_provider",
+                key_id: keyId,
                 api_format: "openai"
             });
         });

--- a/tests/tst_ai_custom_models.qml
+++ b/tests/tst_ai_custom_models.qml
@@ -14,7 +14,7 @@ TestCase {
             ]
         });
 
-        var parsed = AiModelsParser.parseCustomProviderModels(validResponse, "https://api.example.com/", "Example")
+        var parsed = AiModelsParser.parseCustomProviderModels(validResponse, "https://api.example.com/", "Example", "custom_provider")
         compare(parsed.length, 2)
 
         compare(parsed[0].model, "model-1")
@@ -28,19 +28,19 @@ TestCase {
         verify(parsed[1].name !== undefined)
 
         // No trailing slash baseUrl
-        var parsedNoSlash = AiModelsParser.parseCustomProviderModels(validResponse, "https://api.example.com", "Example")
+        var parsedNoSlash = AiModelsParser.parseCustomProviderModels(validResponse, "https://api.example.com", "Example", "custom_provider")
         compare(parsedNoSlash[0].endpoint, "https://api.example.com/chat/completions")
 
         // Invalid JSON
-        var parsedInvalid = AiModelsParser.parseCustomProviderModels("invalid json", "https://api.example.com", "Example")
+        var parsedInvalid = AiModelsParser.parseCustomProviderModels("invalid json", "https://api.example.com", "Example", "custom_provider")
         compare(parsedInvalid.length, 0)
 
         // Missing data array
-        var parsedMissingData = AiModelsParser.parseCustomProviderModels(JSON.stringify({ other: "data" }), "https://api.example.com", "Example")
+        var parsedMissingData = AiModelsParser.parseCustomProviderModels(JSON.stringify({ other: "data" }), "https://api.example.com", "Example", "custom_provider")
         compare(parsedMissingData.length, 0)
 
         // Empty response
-        var parsedEmpty = AiModelsParser.parseCustomProviderModels("", "https://api.example.com", "Example")
+        var parsedEmpty = AiModelsParser.parseCustomProviderModels("", "https://api.example.com", "Example", "custom_provider")
         compare(parsedEmpty.length, 0)
     }
 }


### PR DESCRIPTION
Follow-up to PR #2. This adds support for configuring an arbitrary number of custom AI providers (e.g. OpenRouter) instead of just one. Rebuilds the custom provider UI using a Repeater, and updates the action buttons to use the proper DialogButton component with M3 pill styling.