### PR TITLE
style(settings): add custom IconButton with appropriate icons and colors to provider actions

### DIFF
--- a/modules/ii/settings/pages/ServicesConfig.qml
+++ b/modules/ii/settings/pages/ServicesConfig.qml
@@ -8,6 +8,41 @@ ContentPage {
     id: page
     forceWidth: true
 
+    component IconButton : RippleButton {
+        id: iRoot
+        property string iconName
+        property string textString
+        property color textColor: Appearance.colors.colOnPrimary
+
+        toggled: true
+        implicitHeight: 36
+        padding: 14
+        implicitWidth: layoutItem.implicitWidth + padding * 2
+        buttonRadius: Appearance.rounding.full
+
+        contentItem: Item {
+            implicitWidth: layoutItem.implicitWidth
+            implicitHeight: layoutItem.implicitHeight
+            RowLayout {
+                id: layoutItem
+                anchors.centerIn: parent
+                spacing: 6
+                MaterialSymbol {
+                    text: iRoot.iconName
+                    color: iRoot.textColor
+                    iconSize: Appearance.font.pixelSize.normal
+                    Layout.alignment: Qt.AlignVCenter
+                }
+                StyledText {
+                    text: iRoot.textString
+                    color: iRoot.textColor
+                    font.pixelSize: Appearance.font.pixelSize.small
+                    Layout.alignment: Qt.AlignVCenter
+                }
+            }
+        }
+    }
+
     //This was intended to go into the results more deeply but in the end I didn't like it but I left it just in case lol
     function goTo(term) {
         const t = term.toLowerCase().trim()
@@ -126,9 +161,14 @@ ContentPage {
                                 }
                             }
 
-                            DialogButton {
+                            IconButton {
                                 Layout.alignment: Qt.AlignRight
-                                buttonText: Translation.tr("Remove Provider")
+                                textString: Translation.tr("Remove Provider")
+                                iconName: "delete"
+                                colBackgroundToggled: Appearance.colors.colError
+                                colBackgroundToggledHover: Appearance.colors.colErrorHover
+                                colRippleToggled: Appearance.colors.colErrorActive
+                                textColor: Appearance.colors.colOnError
                                 onClicked: {
                                     let providers = [...Config.options.ai.customProviders];
                                     providers.splice(index, 1);
@@ -142,10 +182,11 @@ ContentPage {
                         }
                     }
 
-                    DialogButton {
+                    IconButton {
                         Layout.alignment: Qt.AlignCenter
                         Layout.topMargin: 10
-                        buttonText: Translation.tr("Add Provider")
+                        textString: Translation.tr("Add Provider")
+                        iconName: "add"
                         onClicked: {
                             let providers = [...(Config.options.ai.customProviders || [])];
                             providers.push({ enabled: false, name: "New Provider", baseUrl: "" });
@@ -154,10 +195,11 @@ ContentPage {
                     }
                 }
 
-                DialogButton {
+                IconButton {
                     Layout.alignment: Qt.AlignRight
                     Layout.topMargin: 10
-                    buttonText: Translation.tr("Fetch Models")
+                    textString: Translation.tr("Fetch Models")
+                    iconName: "sync"
                     onClicked: {
                         Ai.fetchCustomModels();
                     }


### PR DESCRIPTION
This PR fixes the AI provider action buttons to have properly sized and centered icons with accurate semantic colors for actions (e.g. error colors for removal).