### PR TITLE
feat: Add Docker status plugin

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -241,6 +241,24 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   or two inside the actual delegate root throws `Required property modelData was not initialized`
   for every instance. Put the `required property` on the outermost delegate item and forward it down
   as an ordinary (non-required) property if a nested child needs it.
+- **`qs` is not a usable JS object from inside a `Qt.binding(function() {...})` closure.** It's a
+  module-namespace prefix the QML engine resolves at compile time for declarative bindings, not a
+  runtime global - `qs.modules.common.Appearance.colors[colorName]` inside an imperative closure
+  throws `ReferenceError: qs is not defined`, silently leaving that binding's target property
+  undefined (no crash, so it's easy to miss unless you actually watch the log with a plugin
+  enabled). Import the singleton directly (`import qs.modules.common`) and reference it by its bare
+  name (`Appearance.colors[colorName]`) instead. This one went unnoticed through two prior plugin
+  merges (clock, battery) because `plugins.enabled` in the shared config was empty the whole time -
+  the manifests were validated and rendered structurally, but never with `Appearance.colors.*`/
+  `Appearance.rounding.*` bindings actually resolving against a real running instance.
+- **Never `anchors.fill: parent` a `Loader` whose *own* size is meant to be derived from the loaded
+  item's implicit size.** `Loader` forces the loaded item to match the Loader's size whenever the
+  Loader itself has an explicit size (anchors count as explicit sizing) - but if the wrapping
+  `Item`'s `implicitWidth`/`implicitHeight` are themselves bound to `loader.item.implicitWidth`,
+  that's a direct cycle (item forced to match wrapper, wrapper's size derived from item) and Qt logs
+  `Binding loop detected for property "implicitWidth"` and gives up re-evaluating it. Leave the
+  Loader unanchored so it mirrors the item's natural size instead; set explicit width/height via the
+  item's own properties (e.g. manifest `props`) when a fixed size is actually wanted.
 
 ## Design language
 

--- a/AGENT.md
+++ b/AGENT.md
@@ -111,7 +111,7 @@ services/                  Singletons wrapping external state/processes - one pe
   HyprlandXkb.qml              Tracks active keyboard layout via Hyprland's `activelayout` IPC event
   Notifications.qml            org.freedesktop.Notifications server + notification history
   Brightness.qml, Battery.qml, Hyprsunset.qml, Network.qml, BluetoothStatus.qml, TrayService.qml,
-  MprisController.qml, Weather.qml, ... (one per integration)
+  MprisController.qml, Weather.qml, Docker.qml, ... (one per integration)
 
 panelFamilies/              PanelLoader.qml (thin LazyLoader) + IllogicalImpulseFamily.qml (the
                             actual list of panels for the "ii" family)

--- a/modules/common/plugins/PluginManager.qml
+++ b/modules/common/plugins/PluginManager.qml
@@ -12,7 +12,7 @@ Singleton {
     function rebuildFromLoadedFiles() {
         let loaded = [];
         let map = {};
-        [clockManifestFile, batteryManifestFile].forEach(fileView => {
+        [clockManifestFile, batteryManifestFile, dockerManifestFile].forEach(fileView => {
             if (!fileView.loaded) return;
             try {
                 const text = fileView.text();
@@ -36,6 +36,11 @@ Singleton {
     FileView {
         id: batteryManifestFile
         path: Quickshell.shellPath("modules/common/plugins/bundled/battery/manifest.json")
+        onLoaded: root.rebuildFromLoadedFiles()
+    }
+    FileView {
+        id: dockerManifestFile
+        path: Quickshell.shellPath("modules/common/plugins/bundled/docker/manifest.json")
         onLoaded: root.rebuildFromLoadedFiles()
     }
 }

--- a/modules/common/plugins/PluginNode.qml
+++ b/modules/common/plugins/PluginNode.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import Quickshell
+import qs.modules.common
 import qs.modules.common.widgets
 import qs.services
 
@@ -34,7 +35,13 @@ Item {
 
     Loader {
         id: componentLoader
-        anchors.fill: parent
+        // No anchors.fill here: rootNode's own size is *derived from* this
+        // loaded item's implicit size (see implicitWidth/implicitHeight above),
+        // so forcing the Loader to fill rootNode would force the item to match
+        // rootNode's size right back - a circular binding ("binding loop
+        // detected for property implicitWidth"). Let the Loader mirror the
+        // item's natural size instead; explicit width/height come from the
+        // manifest's own props (assigned directly onto the item in onLoaded).
         sourceComponent: {
             if (!manifestNode) return null;
             switch(manifestNode.type) {
@@ -66,10 +73,10 @@ Item {
                     
                     if (typeof val === "string" && val.startsWith("Appearance.colors.")) {
                         let colorName = val.substring(18);
-                        finalVal = Qt.binding(function() { return qs.modules.common.Appearance.colors[colorName]; });
+                        finalVal = Qt.binding(function() { return Appearance.colors[colorName]; });
                     } else if (typeof val === "string" && val.startsWith("Appearance.rounding.")) {
                         let rName = val.substring(20);
-                        finalVal = Qt.binding(function() { return qs.modules.common.Appearance.rounding[rName]; });
+                        finalVal = Qt.binding(function() { return Appearance.rounding[rName]; });
                     } else if (typeof val === "string" && val === "parent" && prop.startsWith("anchors")) {
                         finalVal = item.parent;
                     }

--- a/modules/common/plugins/PluginNode.qml
+++ b/modules/common/plugins/PluginNode.qml
@@ -26,6 +26,8 @@ Item {
             case "SystemInfo.ramUsage": return SystemInfo.ramUsage;
             case "Audio.volume": return Audio.volume;
             case "Audio.muted": return Audio.muted;
+            case "Docker.runningCount": return Docker.runningCount;
+            case "Docker.totalCount": return Docker.totalCount;
             default: return undefined;
         }
     }

--- a/modules/common/plugins/PluginValidator.js
+++ b/modules/common/plugins/PluginValidator.js
@@ -10,7 +10,8 @@ const bindingWhitelist = [
     "DateTime.time", "DateTime.date", "DateTime.shortDate",
     "Battery.percentage", "Battery.charging", "Battery.pluggedIn",
     "Network.networkName", "Network.primaryIp", "SystemInfo.cpuUsage",
-    "SystemInfo.ramUsage", "Audio.volume", "Audio.muted"
+    "SystemInfo.ramUsage", "Audio.volume", "Audio.muted",
+    "Docker.runningCount", "Docker.totalCount"
 ];
 
 function validateManifest(manifest) {

--- a/modules/common/plugins/bundled/docker/manifest.json
+++ b/modules/common/plugins/bundled/docker/manifest.json
@@ -1,0 +1,66 @@
+{
+    "id": "docker_plugin",
+    "name": "Docker Status Plugin",
+    "description": "A declarative docker status indicator",
+    "defaultWidth": 200,
+    "defaultHeight": 100,
+    "desktopWidget": {
+        "type": "Rectangle",
+        "props": {
+            "radius": "Appearance.rounding.large",
+            "color": "Appearance.colors.colLayer0",
+            "width": 200,
+            "height": 100
+        },
+        "children": [
+            {
+                "type": "Row",
+                "props": {
+                    "anchors.centerIn": "parent",
+                    "spacing": 8
+                },
+                "children": [
+                    {
+                        "type": "MaterialSymbol",
+                        "props": {
+                            "text": "deployed_code",
+                            "font.pixelSize": 36,
+                            "color": "Appearance.colors.colOnLayer0"
+                        }
+                    },
+                    {
+                        "type": "StyledText",
+                        "props": {
+                            "font.pixelSize": 24,
+                            "font.weight": 600,
+                            "color": "Appearance.colors.colOnLayer0"
+                        },
+                        "bindings": {
+                            "text": "Docker.runningCount"
+                        }
+                    },
+                    {
+                        "type": "StyledText",
+                        "props": {
+                            "text": "/",
+                            "font.pixelSize": 24,
+                            "font.weight": 400,
+                            "color": "Appearance.colors.colOnLayer0"
+                        }
+                    },
+                    {
+                        "type": "StyledText",
+                        "props": {
+                            "font.pixelSize": 24,
+                            "font.weight": 400,
+                            "color": "Appearance.colors.colOnLayer0"
+                        },
+                        "bindings": {
+                            "text": "Docker.totalCount"
+                        }
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/services/Docker.qml
+++ b/services/Docker.qml
@@ -1,0 +1,74 @@
+pragma Singleton
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import qs.modules.common
+
+Singleton {
+    id: root
+
+    property int totalCount: 0
+    property int runningCount: 0
+    property list<string> containerNames: []
+
+    function parseDockerPs(text) {
+        let lines = text.split('\n');
+        let total = 0;
+        let running = 0;
+        let names = [];
+        
+        for (let i = 0; i < lines.length; i++) {
+            let line = lines[i].trim();
+            if (line.length === 0) continue;
+            
+            try {
+                let obj = JSON.parse(line);
+                total++;
+                if (obj.State === "running" || obj.State === "Up") {
+                    running++;
+                } else if (obj.Status && obj.Status.startsWith("Up")) {
+                    // Sometimes docker outputs "Status": "Up 2 hours" instead of State in some versions/configurations, though format json usually has State
+                    running++;
+                }
+                if (obj.Names) {
+                    names.push(obj.Names);
+                }
+            } catch (e) {
+                // Ignore parse errors for individual lines
+            }
+        }
+        
+        return {
+            totalCount: total,
+            runningCount: running,
+            containerNames: names
+        };
+    }
+
+    Process {
+        id: dockerProc
+        command: ["bash", "-c", "docker ps -a --format '{{json .}}' 2>/dev/null || echo ''"]
+        stdout: StdioCollector {
+            onStreamFinished: {
+                let parsed = root.parseDockerPs(text);
+                if (parsed !== null) {
+                    root.totalCount = parsed.totalCount;
+                    root.runningCount = parsed.runningCount;
+                    root.containerNames = parsed.containerNames;
+                }
+            }
+        }
+    }
+
+    Timer {
+        interval: Config?.options?.resources?.updateInterval ?? 3000
+        running: true
+        repeat: true
+        onTriggered: {
+            dockerProc.running = false;
+            dockerProc.running = true;
+        }
+    }
+}

--- a/tests/imports/qs/services/Docker.qml
+++ b/tests/imports/qs/services/Docker.qml
@@ -1,0 +1,1 @@
+../../../../services/Docker.qml

--- a/tests/imports/qs/services/qmldir
+++ b/tests/imports/qs/services/qmldir
@@ -2,3 +2,4 @@ module qs.services
 singleton Audio Audio.qml
 singleton ResourceUsage ResourceUsage.qml
 singleton Translation Translation.qml
+singleton Docker Docker.qml

--- a/tests/tst_docker.qml
+++ b/tests/tst_docker.qml
@@ -1,0 +1,33 @@
+import QtQuick
+import QtTest
+import qs.services
+
+TestCase {
+    name: "DockerServiceTest"
+
+    function test_parseDockerPs() {
+        var docker = Docker;
+        verify(docker !== null);
+
+        // docker ps -a --format '{{json .}}' sample output
+        var dockerData = 
+            '{"ID":"5adc504ae4dd","Names":"odysseus-odysseus-1","State":"exited","Status":"Exited (0) 2 weeks ago"}\n' +
+            '{"ID":"ae5ebea00db2","Names":"odysseus-chromadb-1","State":"running","Status":"Up 3 weeks"}\n';
+
+        var parsed = docker.parseDockerPs(dockerData);
+        verify(parsed !== null);
+        compare(parsed.totalCount, 2);
+        compare(parsed.runningCount, 1);
+        compare(parsed.containerNames.length, 2);
+        compare(parsed.containerNames[0], "odysseus-odysseus-1");
+        compare(parsed.containerNames[1], "odysseus-chromadb-1");
+
+        // Test with empty/invalid data
+        var invalidData = "invalid data\n{}\n";
+        var parsedInvalid = docker.parseDockerPs(invalidData);
+        verify(parsedInvalid !== null);
+        compare(parsedInvalid.totalCount, 1);
+        compare(parsedInvalid.runningCount, 0);
+        compare(parsedInvalid.containerNames.length, 0);
+    }
+}

--- a/tests/tst_plugin_validator.qml
+++ b/tests/tst_plugin_validator.qml
@@ -25,6 +25,29 @@ TestCase {
         verify(result.valid, "Manifest should be valid: " + (result.error ? result.error : ""));
     }
 
+    function test_validDockerManifest() {
+        var manifest = {
+            "id": "my_docker",
+            "name": "My Docker",
+            "desktopWidget": {
+                "type": "Row",
+                "children": [
+                    {
+                        "type": "StyledText",
+                        "bindings": { "text": "Docker.runningCount" }
+                    },
+                    {
+                        "type": "StyledText",
+                        "bindings": { "text": "Docker.totalCount" }
+                    }
+                ]
+            }
+        };
+
+        var result = PluginValidator.validateManifest(manifest);
+        verify(result.valid, "Docker manifest should be valid: " + (result.error ? result.error : ""));
+    }
+
     function test_missingId() {
         var manifest = {
             "name": "My Clock",


### PR DESCRIPTION
This PR introduces a declarative Docker status indicator for the theme plugin system, complete with a polled Docker service, whitelisted bindings, unit tests, and live validation.