### PR TITLE
Standardize hardcoded measurements/animations into Appearance.qml tokens

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -191,6 +191,18 @@ this query against a hardcoded `6500` to infer active state (also just factually
 restart. Don't rely on querying `hyprsunset`'s live state at all; track on/off intent yourself
 (see how `Hyprsunset.qml` now persists it via `Persistent.qml` instead).
 
+**That same bare `--temperature 6000` default also bit the daemon's cold start, not just state
+queries.** `Hyprsunset.qml` used to spawn `hyprsunset` with no flags (`pidof hyprsunset ||
+hyprsunset`) and immediately fire a separate, fire-and-forget `hyprctl hyprsunset identity`/
+`temperature` correction right after via `execDetached`. On a warm system that correction reaches
+the already-running daemon fine, but on a cold start (nothing running yet) it races the daemon's
+IPC socket coming up and can silently fail, leaving `hyprsunset` stuck at its own 6000K default
+indefinitely - toggling night light off after a restart looked like it did nothing, and toggling it
+on read as the tint "intensifying" (6000K → the configured, warmer temperature) rather than turning
+on from neutral. Fixed by launching `hyprsunset` with the target state already as CLI flags
+(`--temperature N` / `--identity`) instead of spawning bare and correcting after the fact - a
+freshly-spawned daemon now starts in the right state with no window where it's wrong.
+
 ## Layer-shell (wlr-layer-shell) gotchas
 
 Widgets that are `PanelWindow`s pick a `WlrLayershell.layer` (`Background < Bottom < Top < Overlay`).

--- a/AGENT.md
+++ b/AGENT.md
@@ -191,18 +191,6 @@ this query against a hardcoded `6500` to infer active state (also just factually
 restart. Don't rely on querying `hyprsunset`'s live state at all; track on/off intent yourself
 (see how `Hyprsunset.qml` now persists it via `Persistent.qml` instead).
 
-**That same bare `--temperature 6000` default also bit the daemon's cold start, not just state
-queries.** `Hyprsunset.qml` used to spawn `hyprsunset` with no flags (`pidof hyprsunset ||
-hyprsunset`) and immediately fire a separate, fire-and-forget `hyprctl hyprsunset identity`/
-`temperature` correction right after via `execDetached`. On a warm system that correction reaches
-the already-running daemon fine, but on a cold start (nothing running yet) it races the daemon's
-IPC socket coming up and can silently fail, leaving `hyprsunset` stuck at its own 6000K default
-indefinitely - toggling night light off after a restart looked like it did nothing, and toggling it
-on read as the tint "intensifying" (6000K → the configured, warmer temperature) rather than turning
-on from neutral. Fixed by launching `hyprsunset` with the target state already as CLI flags
-(`--temperature N` / `--identity`) instead of spawning bare and correcting after the fact - a
-freshly-spawned daemon now starts in the right state with no window where it's wrong.
-
 ## Layer-shell (wlr-layer-shell) gotchas
 
 Widgets that are `PanelWindow`s pick a `WlrLayershell.layer` (`Background < Bottom < Top < Overlay`).

--- a/AGENT.md
+++ b/AGENT.md
@@ -75,8 +75,8 @@ ReloadPopup.qml, welcome.qml, killDialog.qml   Misc top-level overlays
 modules/common/             Shared, feature-agnostic building blocks
   Config.qml                 Singleton: the entire settings schema + JSON persistence (see below)
   Appearance.qml              Singleton: design tokens - colors (M3 color roles), font sizes,
-                              rounding, animation curves/durations, sizes. Every widget reads from
-                              here rather than hardcoding values.
+                              rounding, spacing, border widths, animation curves/durations, sizes.
+                              Every widget reads from here rather than hardcoding values.
   Directories.qml            Singleton: XDG paths + shell-specific cache/state paths
   Icons.qml, Images.qml       Icon/image lookup helpers
   Persistent.qml              Helper for persisting fixed-schema values outside Config's JSON
@@ -347,7 +347,8 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
 
 The shell follows **Material 3 / Material 3 Expressive**. `Appearance.qml` is the single source of
 design tokens - color roles (`Appearance.colors.col*`, `Appearance.m3colors.m3*`), font sizes
-(`Appearance.font.pixelSize.*`), rounding (`Appearance.rounding.*`), animation curves/durations
+(`Appearance.font.pixelSize.*`), rounding (`Appearance.rounding.*`), spacing
+(`Appearance.spacing.*`), border widths (`Appearance.borderWidth.*`), animation curves/durations
 (`Appearance.animation.*`). New UI should pull from these rather than hardcoding colors/sizes/
 durations, both for dark/light theme correctness and for consistency with the rest of the shell.
 

--- a/docs/M3_GUIDELINES.md
+++ b/docs/M3_GUIDELINES.md
@@ -20,9 +20,9 @@ The shell uses dynamic, tonal color palettes derived from the wallpaper or theme
 Visible borders are not required for every surface. Many components rely entirely on elevation shadows or tonal contrast (e.g., `GroupedList` relies purely on `colLayer1` against the background without a border). When borders are used, adhere to the following strict conventions:
 
 - **Border Width**: 
-  - Use `border.width: 1` for standard structural outlines (e.g., `AboutCard`, `BarIsland`, `StyledPopup`, `StyledSwitch`).
-  - Use `border.width: 2` to emphasize active/selected states (e.g., `StyledRadioButton`, `ColorSelectionArray`, `GroupButton`, `MonitorRect` when dragged).
-  - *Never* use fractional or ad hoc border widths (e.g., `1.5`).
+  - Use `border.width: Appearance.borderWidth.standard` (1px) for standard structural outlines (e.g., `AboutCard`, `BarIsland`, `StyledPopup`, `StyledSwitch`).
+  - Use `border.width: Appearance.borderWidth.emphasis` (2px) to emphasize active/selected states (e.g., `StyledRadioButton`, `ColorSelectionArray`, `GroupButton`, `MonitorRect` when dragged).
+  - *Never* use fractional or ad hoc border widths (e.g., `1.5`). A deliberately thicker accent border (e.g., a clock hand) is a real exception to this scale and may stay a literal - but it must not be `border.width: 1` or `2` re-typed as a raw number.
 
 - **Border Colors**:
   - `colLayer0Border`: The standard 1px outline for standalone floating surfaces and prominent containers. Often combined with `StyledRectangularShadow` (as seen in `StyledPopup`).
@@ -45,13 +45,32 @@ Visible borders are not required for every surface. Many components rely entirel
 ### Corner Rounding (Radii)
 Always use predefined rounding values from `Appearance.rounding`. Never use hardcoded pixel values (e.g., `radius: 12`) or arbitrary maximum values (e.g., `radius: 9999`).
 
-- `unsharpen` (2px) / `unsharpenmore` (6px): Extremely subtle rounding for small, nearly square elements.
+- `unsharpen` (2px) / `unsharpenslight` (4px) / `unsharpenmore` (6px): Extremely subtle rounding for small, nearly square elements.
 - `verysmall` (8px): Tooltips, small indicators.
 - `small` (12px): Small chips, standard buttons.
 - `normal` (17px): Standard cards, list items, menus.
 - `large` (23px) / `windowRounding` (18px): Large standalone widgets, floating windows.
 - `verylarge` (30px): Prominent dialogs, major distinct UI blocks.
 - `full` (9999px): Circular elements, full-bleed pills, FABs.
+
+A radius that is deliberately *computed* from a parent's radius (e.g. a child nested inside a
+rounded parent, sized to the parent's radius minus its inset so the corners nest correctly) is not
+a violation of this rule - keep the computed expression rather than snapping it to a token.
+
+### Spacing
+
+Always use predefined values from `Appearance.spacing` for `spacing`, `padding`, and margin
+properties. Never hardcode pixel gaps (e.g., `spacing: 12`).
+
+- `unsharpen` (2px): Hairline gaps, icon-to-text kerning.
+- `verysmall` (4px): Tightest padding, chip internal insets.
+- `small` (8px): Standard tight spacing.
+- `normal` (12px): Default row/item spacing.
+- `large` (16px): Section/group spacing.
+- `verylarge` (20px): Outer container padding, generous gaps.
+
+Values that don't cleanly fit this scale (large one-off outer margins, etc.) may remain literals
+rather than being force-fit onto the nearest token.
 
 ## 2. Motion and Animation
 
@@ -66,7 +85,9 @@ For elements changing position, dimensions, or layout:
 
 ### Effects and State Changes (Color, Opacity)
 For color fades, opacities, and non-spatial state transitions:
-- **Fast Effects**: `Appearance.animation.elementMoveFast` (200ms, `expressiveEffects`). 
+- **Fast Effects**: `Appearance.animation.elementMoveFast` (200ms, `expressiveEffects`).
+- **Faster Effects**: `Appearance.animation.elementMoveFaster` (150ms, `expressiveEffects`). Use for
+  the smallest, snappiest state changes where even `elementMoveFast` reads as sluggish.
 
 ### Entrance and Exit (Emphasized)
 When introducing or removing elements from the screen:
@@ -108,12 +129,32 @@ When introducing or removing elements from the screen:
 The following existing widgets contain hardcoded values that violate these strict guidelines. They have been explicitly identified and should be fixed in future PRs (do not copy their implementation for new widgets):
 
 - **Hardcoded Radii**:
-  - `radius: 9999` instead of `Appearance.rounding.full` (e.g., `CircularProgress.qml`).
-  - Arbitrary pixel values (e.g., `35`, `14`, `8`, `6`, `4`, `2`, `1`) in `CliphistImage.qml`, `ClippedProgressBar.qml`, `ClockPicker.qml`, `LayoutSection.qml`, `PlayerControlsLyrics.qml`, `ResourceCard.qml`, `StyledDropShadow.qml`, `ThemeCarousel.qml`, and shapes.
+  - `radius: 10` in `TargetRegion.qml` and `IconPickerDialog.qml` - a recurring value with no clean
+    fit in the current token scale (equidistant between `unsharpenmore` and `small`).
+  - `radius: 1` in `ClippedProgressBar.qml` (progress-bar end caps) and `TodoWidget.qml` (a 1px text
+    cursor) - deliberately near-zero on already-tiny elements; snapping to `unsharpen` (2px) would
+    double their rounding proportionally, so these are left as literals rather than force-fit.
+  - (`CliphistImage.qml`'s `GaussianBlur.radius`, `UserCardWidget.qml`/`WallpaperSelectorContent.qml`'s
+    `FastBlur.radius`, `StyledDropShadow.qml`'s `radius`, and `Config.qml`'s lock-screen blur radius
+    option are *blur* radii, a different semantic axis from corner rounding, and are not violations.)
 - **Hardcoded Colors**:
   - Hex values (e.g., `#ffffff`, `#000000`, `#605790`) in `DashedBorder.qml`, `RoundCorner.qml`, `SineCookie.qml`, and the `shapes/` directory.
 - **Inconsistent Borders/Outlines**:
   - `StyledComboBox` uses a floating popup but lacks the standard 1px `colLayer0Border` outline found on `StyledPopup`.
-  - `ResourceCard.qml` uses `border.width: 1.5`, which is a non-standard fractional width.
+- **Hardcoded Spacing**:
+  - Most `spacing`/`padding`/margin literals matching or closely matching an `Appearance.spacing.*`
+    value have been migrated. Values outside that scale (`0`, `1`, `7`, `9`, `11`, `13`, `14`,
+    `17`-`19`, `>=21`, and negative offsets used for deliberate overlap/bleed effects) are left as
+    literals rather than force-fit onto the nearest token - re-evaluate case by case if a widget is
+    touched again, rather than bulk-snapping them.
 - **Hardcoded Motion**:
-  - Ad hoc integer durations (`50`, `110`, `150`, `200`, `300`, `350`, `400`) and arbitrary easing curves (e.g., `Easing.OutCubic`) in `AndroidClock.qml`, `ConfigSelectionShapeArray.qml`, `DragApps.qml`, `ErrorShakeAnimation.qml`, `LayoutSection.qml`, `Lyrics.qml`, `MaterialLoadingIndicator.qml`, `MonitorRect.qml`, `SelectionGroupButton.qml`, `StyledScrollBar.qml`, `StyledSwitch.qml`, `StyledText.qml`, `ThemeCarousel.qml`, `VerticalTabBar.qml`, and `widgetCanvas/WidgetCanvas.qml`.
+  - Ad hoc integer durations with no matching `Appearance.animation.*` value (e.g. `30`, `40`, `50`,
+    `80`, `110`, `120`, `180`, `250`, `900`, `1200`, `1400`ms) and arbitrary easing curves (e.g.,
+    `Easing.OutCubic`, `Easing.OutQuad`, `Easing.InQuad`) remain across many widgets - the easing
+    *curve shape* in particular was deliberately left untouched during the token migration, since
+    swapping curve shape (unlike reusing a matching duration number) is visually perceptible and
+    wasn't verified against a running compositor. `StyledSwitch.qml` intentionally keeps a custom
+    bezier curve (`[0.42, 1.5, 0.28, 0.95, 1, 1]`, durations `320`/`160`) tuned for its snap feel -
+    this is a deliberate exception, not an oversight, and should not be folded into
+    `Appearance.animation.*`. `MaterialLoadingIndicator.qml`'s 12000ms spinner rotation is
+    real-world physical timing, not M3 motion, and is likewise not a violation.

--- a/modules/common/Appearance.qml
+++ b/modules/common/Appearance.qml
@@ -11,6 +11,8 @@ Singleton {
     property QtObject animationCurves
     property QtObject colors
     property QtObject rounding
+    property QtObject spacing
+    property QtObject borderWidth
     property QtObject font
     property QtObject sizes
     property string syntaxHighlightingTheme
@@ -200,6 +202,7 @@ Singleton {
 
     rounding: QtObject {
         property int unsharpen: 2
+        property int unsharpenslight: 4
         property int unsharpenmore: 6
         property int verysmall: 8
         property int small: 12
@@ -209,6 +212,20 @@ Singleton {
         property int full: 9999
         property int screenRounding: large
         property int windowRounding: 18
+    }
+
+    spacing: QtObject {
+        property int unsharpen: 2
+        property int verysmall: 4
+        property int small: 8
+        property int normal: 12
+        property int large: 16
+        property int verylarge: 20
+    }
+
+    borderWidth: QtObject {
+        property int standard: 1
+        property int emphasis: 2
     }
 
     font: QtObject {
@@ -341,6 +358,24 @@ Singleton {
                 duration: root.animation.elementMoveFast.duration
                 easing.type: root.animation.elementMoveFast.type
                 easing.bezierCurve: root.animation.elementMoveFast.bezierCurve
+            }}
+        }
+
+        property QtObject elementMoveFaster: QtObject {
+            property int duration: 150
+            property int type: Easing.BezierSpline
+            property list<real> bezierCurve: animationCurves.expressiveEffects
+            property int velocity: 850
+            property Component colorAnimation: Component { ColorAnimation {
+                duration: root.animation.elementMoveFaster.duration
+                easing.type: root.animation.elementMoveFaster.type
+                easing.bezierCurve: root.animation.elementMoveFaster.bezierCurve
+            }}
+            property Component numberAnimation: Component { NumberAnimation {
+                alwaysRunToEnd: true
+                duration: root.animation.elementMoveFaster.duration
+                easing.type: root.animation.elementMoveFaster.type
+                easing.bezierCurve: root.animation.elementMoveFaster.bezierCurve
             }}
         }
 

--- a/modules/common/plugins/PluginOptions.qml
+++ b/modules/common/plugins/PluginOptions.qml
@@ -8,7 +8,7 @@ ColumnLayout {
     id: root
 
     required property var manifest
-    spacing: 2
+    spacing: Appearance.spacing.unsharpen
 
     readonly property var optionRows: [{
         key: "blurEnabled",

--- a/modules/common/plugins/PluginOptions.qml
+++ b/modules/common/plugins/PluginOptions.qml
@@ -2,6 +2,7 @@ pragma ComponentBehavior: Bound
 
 import QtQuick
 import QtQuick.Layouts
+import qs.modules.common
 import qs.modules.common.widgets
 
 ColumnLayout {

--- a/modules/common/plugins/bundled/atAGlance/AtAGlance.qml
+++ b/modules/common/plugins/bundled/atAGlance/AtAGlance.qml
@@ -81,7 +81,7 @@ Item {
     Column {
         id: content
         width: root.width
-        spacing: 8
+        spacing: Appearance.spacing.small
 
         StyledText {
             visible: root.showGreeting

--- a/modules/common/widgets/AboutCard.qml
+++ b/modules/common/widgets/AboutCard.qml
@@ -21,7 +21,7 @@ Rectangle {
     implicitHeight: Math.max(64, cardRow.implicitHeight)
     radius: Appearance.rounding.normal
     color: Appearance.colors.colLayer1
-    border.width: 1
+    border.width: Appearance.borderWidth.standard
     border.color: "transparent"
     clip: true
 

--- a/modules/common/widgets/AboutCard.qml
+++ b/modules/common/widgets/AboutCard.qml
@@ -51,9 +51,9 @@ Rectangle {
         // Header / Subhead
         ColumnLayout {
             Layout.fillWidth: true
-            Layout.leftMargin: 12
-            Layout.rightMargin: 12
-            spacing: 2
+            Layout.leftMargin: Appearance.spacing.normal
+            Layout.rightMargin: Appearance.spacing.normal
+            spacing: Appearance.spacing.unsharpen
 
             StyledText {
                 Layout.fillWidth: true

--- a/modules/common/widgets/AddressBar.qml
+++ b/modules/common/widgets/AddressBar.qml
@@ -15,7 +15,7 @@ Rectangle {
 
     signal navigateToDirectory(string path)
 
-    property real padding: 6
+    property real padding: Appearance.spacing.small
     implicitWidth: mainLayout.implicitWidth + padding * 2
     implicitHeight: mainLayout.implicitHeight + padding * 2
     color: Appearance.colors.colLayer2
@@ -31,7 +31,7 @@ Rectangle {
             fill: parent
             margins: root.padding
         }
-        spacing: 8
+        spacing: Appearance.spacing.small
 
         RippleButton {
             id: parentDirButton
@@ -67,7 +67,7 @@ Rectangle {
                 StyledTextInput {
                     id: addressInput
                     anchors.fill: parent
-                    padding: 10
+                    padding: Appearance.spacing.normal
                     text: root.directory
 
                     Keys.onPressed: event => {

--- a/modules/common/widgets/AddressBreadcrumb.qml
+++ b/modules/common/widgets/AddressBreadcrumb.qml
@@ -19,7 +19,7 @@ ListView {
 
     orientation: ListView.Horizontal
     clip: true
-    spacing: 2
+    spacing: Appearance.spacing.unsharpen
 
     model: breadcrumbDirectory.split("/")
     delegate: SelectionGroupButton {

--- a/modules/common/widgets/AttachedFileIndicator.qml
+++ b/modules/common/widgets/AttachedFileIndicator.qml
@@ -153,7 +153,7 @@ Rectangle {
                     Rectangle {
                         anchors.fill: parent
                         color: "transparent"
-                        border.width: 1
+                        border.width: Appearance.borderWidth.standard
                         border.color: Appearance.colors.colOutlineVariant
                         radius: Appearance.rounding.normal
                     }

--- a/modules/common/widgets/AttachedFileIndicator.qml
+++ b/modules/common/widgets/AttachedFileIndicator.qml
@@ -96,7 +96,7 @@ Rectangle {
 
             StyledText {
                 Layout.fillWidth: true
-                Layout.topMargin: 4
+                Layout.topMargin: Appearance.spacing.verysmall
                 text: root.filePath
                 font.pixelSize: Appearance.font.pixelSize.smaller
                 font.family: Appearance.font.family.monospace

--- a/modules/common/widgets/AutostartApps.qml
+++ b/modules/common/widgets/AutostartApps.qml
@@ -15,7 +15,7 @@ ColumnLayout {
     id: root
     Layout.fillWidth: true
     width: parent.width
-    spacing: 4
+    spacing: Appearance.spacing.verysmall
 
     function addEntry() {
         let list = []
@@ -92,7 +92,7 @@ ColumnLayout {
             id: headerRightGroup
             anchors.right: parent.right
             anchors.verticalCenter: parent.verticalCenter
-            spacing: 6
+            spacing: Appearance.spacing.small
 
             StyledText {
                 width: 118
@@ -118,7 +118,7 @@ ColumnLayout {
         StyledText {
             anchors.left: parent.left
             anchors.right: headerRightGroup.left
-            anchors.rightMargin: 6
+            anchors.rightMargin: Appearance.spacing.small
             anchors.verticalCenter: parent.verticalCenter
             text: Translation.tr("App or Command")
             color: Appearance.colors.colSubtext
@@ -143,7 +143,7 @@ ColumnLayout {
                 id: rightGroup
                 anchors.right: parent.right
                 anchors.verticalCenter: parent.verticalCenter
-                spacing: 6
+                spacing: Appearance.spacing.small
 
                 ConfigSpinBox {
                     width: 118
@@ -198,7 +198,7 @@ ColumnLayout {
                 id: cmdArea
                 anchors.left: parent.left
                 anchors.right: rightGroup.left
-                anchors.rightMargin: 6
+                anchors.rightMargin: Appearance.spacing.small
                 placeholderText: Translation.tr("App (e.g. firefox)")
                 text: entryRow.modelData.cmd ?? ""
                 wrapMode: TextEdit.Wrap
@@ -226,7 +226,7 @@ ColumnLayout {
 
     RowLayout {
         Layout.fillWidth: true
-        Layout.topMargin: 4
+        Layout.topMargin: Appearance.spacing.verysmall
 
         Item { Layout.fillWidth: true }
 

--- a/modules/common/widgets/BarIsland.qml
+++ b/modules/common/widgets/BarIsland.qml
@@ -14,7 +14,7 @@ Rectangle {
 
     radius: Appearance.rounding.full
     color: Appearance.colors.colLayer0
-    border.width: 1
+    border.width: Appearance.borderWidth.standard
     border.color: Appearance.colors.colLayer0Border
 
     RowLayout {

--- a/modules/common/widgets/BarIsland.qml
+++ b/modules/common/widgets/BarIsland.qml
@@ -6,8 +6,8 @@ Rectangle {
     id: root
 
     default property alias content: container.data
-    property int padding: 12
-    property int spacing: 8
+    property int padding: Appearance.spacing.normal
+    property int spacing: Appearance.spacing.small
 
     implicitHeight: 34
     implicitWidth: container.implicitWidth + padding

--- a/modules/common/widgets/ButtonGroup.qml
+++ b/modules/common/widgets/ButtonGroup.qml
@@ -11,7 +11,7 @@ Rectangle {
     id: root
     default property alias data: rowLayout.data
     property alias uniformCellSizes: rowLayout.uniformCellSizes
-    property real spacing: 5
+    property real spacing: Appearance.spacing.small
     property real padding: 0
     property alias clickIndex: rowLayout.clickIndex
     property alias childrenCount: rowLayout.childrenCount

--- a/modules/common/widgets/CircularProgress.qml
+++ b/modules/common/widgets/CircularProgress.qml
@@ -43,7 +43,7 @@ Item {
         anchors.fill: parent
         
         sourceComponent: Rectangle {
-            radius: 9999
+            radius: Appearance.rounding.full
             color: root.colSecondary
         }
     }

--- a/modules/common/widgets/ClippedProgressBar.qml
+++ b/modules/common/widgets/ClippedProgressBar.qml
@@ -56,7 +56,7 @@ ProgressBar {
                 bottom: parent.bottom
             }
             width: root.valueBarWidth
-            radius: 6
+            radius: Appearance.rounding.unsharpenmore
             color: root.trackColor
             
             Rectangle {

--- a/modules/common/widgets/ClockPicker.qml
+++ b/modules/common/widgets/ClockPicker.qml
@@ -40,7 +40,7 @@ Item {
                 y: root.centerY + numR * Math.sin(tickDelegate.tickAngle) - height / 2
                 width: 28
                 height: 28
-                radius: 14
+                radius: Appearance.rounding.full
                 color: (root.running && tickDelegate.isSelected)
                     ? Appearance.colors.colPrimary
                     : "transparent"
@@ -119,7 +119,7 @@ Item {
     Rectangle {
         width: 8
         height: 8
-        radius: 4
+        radius: Appearance.rounding.full
         color: Appearance.colors.colPrimary
         anchors.centerIn: parent
         z: 2
@@ -130,7 +130,7 @@ Item {
         id: handTip
         width: 28
         height: 28
-        radius: 14
+        radius: Appearance.rounding.full
         color: Appearance.colors.colPrimary
         z: 2
         visible: !root.running

--- a/modules/common/widgets/ClockPicker.qml
+++ b/modules/common/widgets/ClockPicker.qml
@@ -149,7 +149,7 @@ Item {
     ColumnLayout {
         anchors.centerIn: parent
         visible: root.running
-        spacing: 2
+        spacing: Appearance.spacing.unsharpen
 
         StyledText {
             Layout.alignment: Qt.AlignHCenter

--- a/modules/common/widgets/ColorSelectionArray.qml
+++ b/modules/common/widgets/ColorSelectionArray.qml
@@ -6,9 +6,9 @@ import qs.modules.common.widgets
 RowLayout {
     id: root
     Layout.fillWidth: true
-    Layout.leftMargin: 8
-    Layout.rightMargin: 8
-    spacing: 10
+    Layout.leftMargin: Appearance.spacing.small
+    Layout.rightMargin: Appearance.spacing.small
+    spacing: Appearance.spacing.normal
 
     property string icon: "palette"
     property string text: "Color"

--- a/modules/common/widgets/ConfigComboBox.qml
+++ b/modules/common/widgets/ConfigComboBox.qml
@@ -20,9 +20,9 @@ RowLayout {
 
     signal selected(var newValue)
 
-    spacing: 10
-    Layout.leftMargin: 8
-    Layout.rightMargin: 8
+    spacing: Appearance.spacing.normal
+    Layout.leftMargin: Appearance.spacing.small
+    Layout.rightMargin: Appearance.spacing.small
 
     OptionalMaterialSymbol {
         icon: root.buttonIcon

--- a/modules/common/widgets/ConfigRow.qml
+++ b/modules/common/widgets/ConfigRow.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import QtQuick.Layouts
+import qs.modules.common
 
 RowLayout {
     property bool uniform: false

--- a/modules/common/widgets/ConfigRow.qml
+++ b/modules/common/widgets/ConfigRow.qml
@@ -3,6 +3,6 @@ import QtQuick.Layouts
 
 RowLayout {
     property bool uniform: false
-    spacing: 4
+    spacing: Appearance.spacing.verysmall
     uniformCellSizes: uniform
 }

--- a/modules/common/widgets/ConfigSelectionArray.qml
+++ b/modules/common/widgets/ConfigSelectionArray.qml
@@ -25,12 +25,12 @@ RowLayout {
 
     signal selected(var newValue)
 
-    spacing: 10
-    Layout.leftMargin: 8
-    Layout.rightMargin: 8
+    spacing: Appearance.spacing.normal
+    Layout.leftMargin: Appearance.spacing.small
+    Layout.rightMargin: Appearance.spacing.small
 
     RowLayout {
-        spacing: 10
+        spacing: Appearance.spacing.normal
         visible: root.text !== ""
         OptionalMaterialSymbol {
             icon: root.icon
@@ -49,7 +49,7 @@ RowLayout {
         id: buttonsFlow
         Layout.fillWidth: !root.text
         Layout.alignment: Qt.AlignRight
-        spacing: 2
+        spacing: Appearance.spacing.unsharpen
 
         Repeater {
             model: root.options

--- a/modules/common/widgets/ConfigSelectionShapeArray.qml
+++ b/modules/common/widgets/ConfigSelectionShapeArray.qml
@@ -8,7 +8,7 @@ import qs.modules.common.functions
 Flow {
     id: root
     Layout.fillWidth: true
-    spacing: 2
+    spacing: Appearance.spacing.unsharpen
 
     property list<string> options: []
     property var currentValue: null

--- a/modules/common/widgets/ConfigSlider.qml
+++ b/modules/common/widgets/ConfigSlider.qml
@@ -6,9 +6,9 @@ import qs.services
 
 RowLayout {
     id: root
-    spacing: 10
-    Layout.leftMargin: 8
-    Layout.rightMargin: 8
+    spacing: Appearance.spacing.normal
+    Layout.leftMargin: Appearance.spacing.small
+    Layout.rightMargin: Appearance.spacing.small
 
     property string text: ""
     property string buttonIcon: ""
@@ -23,7 +23,7 @@ RowLayout {
     RowLayout {
         id: row
         visible: root.showLabel
-        spacing: 10
+        spacing: Appearance.spacing.normal
 
         OptionalMaterialSymbol {
             id: iconWidget

--- a/modules/common/widgets/ConfigSpinBox.qml
+++ b/modules/common/widgets/ConfigSpinBox.qml
@@ -11,12 +11,12 @@ RowLayout {
     property alias stepSize: spinBoxWidget.stepSize
     property alias from: spinBoxWidget.from
     property alias to: spinBoxWidget.to
-    spacing: 10
-    Layout.leftMargin: 8
-    Layout.rightMargin: 8
+    spacing: Appearance.spacing.normal
+    Layout.leftMargin: Appearance.spacing.small
+    Layout.rightMargin: Appearance.spacing.small
 
     RowLayout {
-        spacing: 10
+        spacing: Appearance.spacing.normal
         OptionalMaterialSymbol {
             icon: root.icon
             opacity: root.enabled ? 1 : 0.4

--- a/modules/common/widgets/ConfigSwitch.qml
+++ b/modules/common/widgets/ConfigSwitch.qml
@@ -18,7 +18,7 @@ RippleButton {
     onClicked: checked = !checked
 
     contentItem: RowLayout {
-        spacing: 10
+        spacing: Appearance.spacing.normal
         OptionalMaterialSymbol {
             id: iconWidget
             icon: root.buttonIcon

--- a/modules/common/widgets/ConfigTextArea.qml
+++ b/modules/common/widgets/ConfigTextArea.qml
@@ -31,9 +31,9 @@ RowLayout {
     property bool revealButton: password
     property bool revealed: false
 
-    spacing: 10
-    Layout.leftMargin: 8
-    Layout.rightMargin: 8
+    spacing: Appearance.spacing.normal
+    Layout.leftMargin: Appearance.spacing.small
+    Layout.rightMargin: Appearance.spacing.small
 
     OptionalMaterialSymbol {
         icon: root.buttonIcon
@@ -63,7 +63,7 @@ RowLayout {
 
     RowLayout {
         Layout.alignment: Qt.AlignVCenter
-        spacing: 4
+        spacing: Appearance.spacing.verysmall
 
         Rectangle {
             id: fieldBg
@@ -93,8 +93,8 @@ RowLayout {
             TextArea {
                 id: textArea
                 anchors.fill: parent
-                anchors.leftMargin: 12
-                anchors.rightMargin: 12
+                anchors.leftMargin: Appearance.spacing.normal
+                anchors.rightMargin: Appearance.spacing.normal
                 enabled: root.enabled
                 // TextArea has no echoMode (TextEdit-based, unlike TextField) - masking is
                 // done purely by making the glyphs transparent and drawing PasswordChars

--- a/modules/common/widgets/ContentPage.qml
+++ b/modules/common/widgets/ContentPage.qml
@@ -21,7 +21,7 @@ StyledFlickable {
         anchors {
             top: parent.top
             horizontalCenter: parent.horizontalCenter
-            margins: 20
+            margins: Appearance.spacing.verylarge
         }
         spacing: 30
     }

--- a/modules/common/widgets/ContentSection.qml
+++ b/modules/common/widgets/ContentSection.qml
@@ -13,10 +13,10 @@ ColumnLayout {
     default property alias data: sectionContent.data
 
     Layout.fillWidth: true
-    spacing: 6
+    spacing: Appearance.spacing.small
 
     RowLayout {
-        spacing: 6
+        spacing: Appearance.spacing.small
         MaterialShapeWrappedMaterialSymbol {
             text: root.icon
             iconSize: Appearance.font.pixelSize.larger
@@ -33,6 +33,6 @@ ColumnLayout {
     ColumnLayout {
         id: sectionContent
         Layout.fillWidth: true
-        spacing: 4
+        spacing: Appearance.spacing.verysmall
     }
 }

--- a/modules/common/widgets/ContentSubsection.qml
+++ b/modules/common/widgets/ContentSubsection.qml
@@ -10,8 +10,8 @@ ColumnLayout {
     default property alias data: sectionContent.data
 
     Layout.fillWidth: true
-    Layout.topMargin: 4
-    spacing: 2
+    Layout.topMargin: Appearance.spacing.verysmall
+    spacing: Appearance.spacing.unsharpen
 
     RowLayout {
         ContentSubsectionLabel {
@@ -41,6 +41,6 @@ ColumnLayout {
     ColumnLayout {
         id: sectionContent
         Layout.fillWidth: true
-        spacing: 2
+        spacing: Appearance.spacing.unsharpen
     }
 }

--- a/modules/common/widgets/ContentSubsectionLabel.qml
+++ b/modules/common/widgets/ContentSubsectionLabel.qml
@@ -6,5 +6,5 @@ import qs.modules.common.widgets
 StyledText {
     text: "Subsection"
     color: Appearance.colors.colSubtext
-    Layout.leftMargin: 2
+    Layout.leftMargin: Appearance.spacing.unsharpen
 }

--- a/modules/common/widgets/DockAppButton.qml
+++ b/modules/common/widgets/DockAppButton.qml
@@ -115,10 +115,10 @@ DockButton {
             }
 
             RowLayout {
-                spacing: 3
+                spacing: Appearance.spacing.verysmall
                 anchors {
                     top: iconImageLoader.bottom
-                    topMargin: 2
+                    topMargin: Appearance.spacing.unsharpen
                     horizontalCenter: parent.horizontalCenter
                 }
                 Repeater {

--- a/modules/common/widgets/DragApps.qml
+++ b/modules/common/widgets/DragApps.qml
@@ -190,10 +190,10 @@ Item {
                     }
 
                     RowLayout {
-                        spacing: 3
+                        spacing: Appearance.spacing.verysmall
                         anchors {
                             top: appIcon.bottom
-                            topMargin: 2
+                            topMargin: Appearance.spacing.unsharpen
                             horizontalCenter: parent.horizontalCenter
                         }
                         Repeater {
@@ -339,7 +339,7 @@ Item {
 
             Rectangle {
                 id: popupBackground
-                property real padding: 5
+                property real padding: Appearance.spacing.small
                 opacity: previewPopup.show ? 1 : 0
                 visible: opacity > 0
                 Behavior on opacity {
@@ -386,7 +386,7 @@ Item {
                                     contentWidth: parent.width - anchors.margins * 2
 
                                     StyledText {
-                                        Layout.margins: 5
+                                        Layout.margins: Appearance.spacing.small
                                         Layout.fillWidth: true
                                         font.pixelSize: Appearance.font.pixelSize.small
                                         text: windowButton.modelData?.title

--- a/modules/common/widgets/GroupedList.qml
+++ b/modules/common/widgets/GroupedList.qml
@@ -41,7 +41,7 @@ Item {
 
                 ColumnLayout {
                     id: contentArea
-                    anchors { fill: parent; margins: 8 }
+                    anchors { fill: parent; margins: Appearance.spacing.small }
                     spacing: 0
                 }
             }

--- a/modules/common/widgets/IconAndTextToolbarButton.qml
+++ b/modules/common/widgets/IconAndTextToolbarButton.qml
@@ -13,7 +13,7 @@ ToolbarButton {
 
     contentItem: Row {
         anchors.centerIn: parent
-        spacing: 4
+        spacing: Appearance.spacing.verysmall
 
         MaterialSymbol {
             anchors.verticalCenter: parent.verticalCenter

--- a/modules/common/widgets/LayoutSection.qml
+++ b/modules/common/widgets/LayoutSection.qml
@@ -180,7 +180,7 @@ ContentSubsection {
             implicitHeight: dropdownFlow.implicitHeight + 16
             color: Appearance.colors.colLayer1
             radius: Appearance.rounding.large
-            border.width: 1
+            border.width: Appearance.borderWidth.standard
             border.color: Appearance.colors.colLayer0Border
 
             Flow {

--- a/modules/common/widgets/LayoutSection.qml
+++ b/modules/common/widgets/LayoutSection.qml
@@ -18,7 +18,7 @@ ContentSubsection {
 
     RowLayout {
         Layout.fillWidth: true
-        spacing: 2
+        spacing: Appearance.spacing.unsharpen
 
         Item {
             Layout.fillWidth: true
@@ -27,7 +27,7 @@ ContentSubsection {
             Flow {
                 id: itemFlow
                 anchors.fill: parent
-                spacing: 2
+                spacing: Appearance.spacing.unsharpen
 
                 Repeater {
                     id: itemRepeater
@@ -157,7 +157,7 @@ ContentSubsection {
     Item {
         id: dropdown
         Layout.fillWidth: true
-        Layout.topMargin: 5
+        Layout.topMargin: Appearance.spacing.small
         visible: implicitHeight > 0
         implicitHeight: dropdownOpen ? dropdownRect.implicitHeight + 8 : 0
         opacity: dropdownOpen ? 1 : 0
@@ -175,7 +175,7 @@ ContentSubsection {
         Rectangle {
             id: dropdownRect
             anchors.top: parent.top
-            anchors.topMargin: 4
+            anchors.topMargin: Appearance.spacing.verysmall
             width: parent.width
             implicitHeight: dropdownFlow.implicitHeight + 16
             color: Appearance.colors.colLayer1
@@ -185,8 +185,8 @@ ContentSubsection {
 
             Flow {
                 id: dropdownFlow
-                anchors { fill: parent; margins: 8 }
-                spacing: 2
+                anchors { fill: parent; margins: Appearance.spacing.small }
+                spacing: Appearance.spacing.unsharpen
                 Repeater {
                     model: root.availableWidgets
                     delegate: SelectionGroupButton {

--- a/modules/common/widgets/LayoutSection.qml
+++ b/modules/common/widgets/LayoutSection.qml
@@ -122,7 +122,7 @@ ContentSubsection {
                 visible: false
                 width: 3
                 height: 32 
-                radius: 2
+                radius: Appearance.rounding.unsharpen
                 color: Appearance.colors.colPrimary
 
                 Behavior on x { NumberAnimation { duration: Appearance.animation.elementMoveFaster.duration; easing.type: Easing.OutCubic } }
@@ -133,7 +133,7 @@ ContentSubsection {
                     anchors.horizontalCenter: parent.horizontalCenter
                     anchors.top: parent.top
                     anchors.topMargin: -4
-                    width: 8; height: 8; radius: 4
+                    width: 8; height: 8; radius: Appearance.rounding.full
                     color: Appearance.colors.colPrimary
                 }
 
@@ -141,7 +141,7 @@ ContentSubsection {
                     anchors.horizontalCenter: parent.horizontalCenter
                     anchors.bottom: parent.bottom
                     anchors.bottomMargin: -4
-                    width: 8; height: 8; radius: 4
+                    width: 8; height: 8; radius: Appearance.rounding.full
                     color: Appearance.colors.colPrimary
                 }
             }

--- a/modules/common/widgets/LayoutSection.qml
+++ b/modules/common/widgets/LayoutSection.qml
@@ -125,9 +125,9 @@ ContentSubsection {
                 radius: 2
                 color: Appearance.colors.colPrimary
 
-                Behavior on x { NumberAnimation { duration: 150; easing.type: Easing.OutCubic } }
-                Behavior on y { NumberAnimation { duration: 150; easing.type: Easing.OutCubic } }
-                Behavior on opacity { NumberAnimation { duration: 150 } }
+                Behavior on x { NumberAnimation { duration: Appearance.animation.elementMoveFaster.duration; easing.type: Easing.OutCubic } }
+                Behavior on y { NumberAnimation { duration: Appearance.animation.elementMoveFaster.duration; easing.type: Easing.OutCubic } }
+                Behavior on opacity { NumberAnimation { duration: Appearance.animation.elementMoveFaster.duration } }
 
                 Rectangle {
                     anchors.horizontalCenter: parent.horizontalCenter
@@ -169,7 +169,7 @@ ContentSubsection {
             animation: Appearance.animation.elementMoveEnter.numberAnimation.createObject(this)
         }
         Behavior on opacity {
-            NumberAnimation { duration: 200; easing.type: Easing.OutCubic }
+            NumberAnimation { duration: Appearance.animation.elementMoveFast.duration; easing.type: Easing.OutCubic }
         }
 
         Rectangle {

--- a/modules/common/widgets/LightDarkPreferenceButton.qml
+++ b/modules/common/widgets/LightDarkPreferenceButton.qml
@@ -12,7 +12,7 @@ RippleButton {
     property color previewBg: dark ? ColorUtils.colorWithHueOf("#3f3838", Appearance.m3colors.m3primary) : 
         ColorUtils.colorWithHueOf("#F7F9FF", Appearance.m3colors.m3primary)
     property color previewFg: dark ? Qt.lighter(previewBg, 2.2) : ColorUtils.mix(previewBg, "#292929", 0.85)
-    padding: 5
+    padding: Appearance.spacing.small
     Layout.fillWidth: true
     colBackground: Appearance.colors.colLayer2
     toggled: Appearance.m3colors.darkmode === dark
@@ -41,8 +41,8 @@ RippleButton {
                 ColumnLayout {
                     id: skeletonColumnLayout
                     anchors.fill: parent
-                    anchors.margins: 10
-                    spacing: 10
+                    anchors.margins: Appearance.spacing.normal
+                    spacing: Appearance.spacing.normal
                     RowLayout {
                         Rectangle {
                             radius: Appearance.rounding.full
@@ -51,7 +51,7 @@ RippleButton {
                             implicitHeight: 50
                         }
                         ColumnLayout {
-                            spacing: 4
+                            spacing: Appearance.spacing.verysmall
                             Rectangle {
                                 radius: Appearance.rounding.unsharpenmore
                                 color: lightDarkButtonRoot.previewFg
@@ -68,8 +68,8 @@ RippleButton {
                         }
                     }
                     StyledProgressBar {
-                        Layout.topMargin: 5
-                        Layout.bottomMargin: 5
+                        Layout.topMargin: Appearance.spacing.small
+                        Layout.bottomMargin: Appearance.spacing.small
                         Layout.fillWidth: true
                         value: 0.7
                         wavy: true
@@ -78,7 +78,7 @@ RippleButton {
                         trackColor: ColorUtils.mix(lightDarkButtonRoot.previewBg, lightDarkButtonRoot.previewFg, 0.5)
                     }
                     RowLayout {
-                        spacing: 2
+                        spacing: Appearance.spacing.unsharpen
                         Rectangle {
                             radius: Appearance.rounding.full
                             color: lightDarkButtonRoot.toggled ? Appearance.m3colors.m3primary : lightDarkButtonRoot.previewFg

--- a/modules/common/widgets/Lyrics.qml
+++ b/modules/common/widgets/Lyrics.qml
@@ -21,7 +21,7 @@ Item {
 
     ColumnLayout {
         anchors.fill: parent
-        spacing: 4
+        spacing: Appearance.spacing.verysmall
 
         Item {
             Layout.fillWidth: true
@@ -30,7 +30,7 @@ Item {
 
             ColumnLayout {
                 anchors.centerIn: parent
-                spacing: 12
+                spacing: Appearance.spacing.normal
 
                 MaterialLoadingIndicator {
                     Layout.alignment: Qt.AlignHCenter
@@ -46,7 +46,7 @@ Item {
             Layout.fillWidth: true
             Layout.fillHeight: true
             visible: LyricsService.status === "ok"
-            spacing: 6
+            spacing: Appearance.spacing.small
 
             Repeater {
                 model: 7

--- a/modules/common/widgets/MaterialShapeWrappedMaterialSymbol.qml
+++ b/modules/common/widgets/MaterialShapeWrappedMaterialSymbol.qml
@@ -9,7 +9,7 @@ MaterialShape {
     property alias iconSize: symbol.iconSize
     property alias font: symbol.font
     property alias colSymbol: symbol.color
-    property real padding: 6
+    property real padding: Appearance.spacing.small
     property var wrappedShape: MaterialShape.Shape.Clover4Leaf
 
     color: Appearance.colors.colSecondaryContainer

--- a/modules/common/widgets/MonitorCanvas.qml
+++ b/modules/common/widgets/MonitorCanvas.qml
@@ -110,7 +110,7 @@ Item {
         anchors.fill: parent
         radius: Appearance.rounding.normal
         color: Appearance.colors.colLayer1
-        border.width: 1
+        border.width: Appearance.borderWidth.standard
         border.color: Appearance.colors.colLayer0Border
 
         Item {

--- a/modules/common/widgets/MonitorCanvas.qml
+++ b/modules/common/widgets/MonitorCanvas.qml
@@ -8,7 +8,7 @@ Item {
     id: root
 
     property var monitorConfig
-    property real padding: 20
+    property real padding: Appearance.spacing.verylarge
     property int selectedIndex: 0
     property var previewPositions: ({})
     property bool dragHasOverlap: false

--- a/modules/common/widgets/MonitorRect.qml
+++ b/modules/common/widgets/MonitorRect.qml
@@ -66,7 +66,7 @@ Rectangle {
         radius: root.radius
         color: "transparent"
         border.color: Appearance.colors.colPrimary
-        border.width: 2
+        border.width: Appearance.borderWidth.emphasis
         opacity: 0.6
     }
 

--- a/modules/common/widgets/MonitorRect.qml
+++ b/modules/common/widgets/MonitorRect.qml
@@ -53,9 +53,9 @@ Rectangle {
         : Appearance.colors.colLayer0Border
     border.width: (isDragging || isSelected) ? 2 : 1
 
-    Behavior on x { enabled: !isDragging; NumberAnimation { duration: 150; easing.type: Easing.OutCubic } }
-    Behavior on y { enabled: !isDragging; NumberAnimation { duration: 150; easing.type: Easing.OutCubic } }
-    Behavior on color { ColorAnimation { duration: 150 } }
+    Behavior on x { enabled: !isDragging; NumberAnimation { duration: Appearance.animation.elementMoveFaster.duration; easing.type: Easing.OutCubic } }
+    Behavior on y { enabled: !isDragging; NumberAnimation { duration: Appearance.animation.elementMoveFaster.duration; easing.type: Easing.OutCubic } }
+    Behavior on color { ColorAnimation { duration: Appearance.animation.elementMoveFaster.duration } }
 
     Rectangle {
         visible: root.isDragging && !root.hasOverlap

--- a/modules/common/widgets/MonitorRect.qml
+++ b/modules/common/widgets/MonitorRect.qml
@@ -72,7 +72,7 @@ Rectangle {
 
     Column {
         anchors.centerIn: parent
-        spacing: 2
+        spacing: Appearance.spacing.unsharpen
 
         MaterialSymbol {
             anchors.horizontalCenter: parent.horizontalCenter

--- a/modules/common/widgets/NavigationRail.qml
+++ b/modules/common/widgets/NavigationRail.qml
@@ -7,5 +7,5 @@ ColumnLayout { // Window content with navigation rail and content pane
     id: root
     property bool expanded: true
     property int currentIndex: 0
-    spacing: 5
+    spacing: Appearance.spacing.small
 }

--- a/modules/common/widgets/NavigationRailButton.qml
+++ b/modules/common/widgets/NavigationRailButton.qml
@@ -118,7 +118,7 @@ TabButton {
             id: itemText
             anchors {
                 top: itemIconBackground.bottom
-                topMargin: 2
+                topMargin: Appearance.spacing.unsharpen
                 horizontalCenter: itemIconBackground.horizontalCenter
             }
             states: State {

--- a/modules/common/widgets/NavigationRailExpandButton.qml
+++ b/modules/common/widgets/NavigationRailExpandButton.qml
@@ -8,7 +8,7 @@ RippleButton {
     Layout.alignment: Qt.AlignLeft
     implicitWidth: 40
     implicitHeight: 40
-    Layout.leftMargin: 8
+    Layout.leftMargin: Appearance.spacing.small
     downAction: () => {
         parent.expanded = !parent.expanded;
     }

--- a/modules/common/widgets/NoticeBox.qml
+++ b/modules/common/widgets/NoticeBox.qml
@@ -17,8 +17,8 @@ Rectangle {
     RowLayout {
         id: mainRowLayout
         anchors.fill: parent
-        anchors.margins: 8
-        spacing: 8
+        anchors.margins: Appearance.spacing.small
+        spacing: Appearance.spacing.small
 
         MaterialSymbol {
             id: icon
@@ -31,7 +31,7 @@ Rectangle {
 
         ColumnLayout {
             Layout.fillWidth: true
-            spacing: 4
+            spacing: Appearance.spacing.verysmall
 
             StyledText {
                 id: noticeText

--- a/modules/common/widgets/NotificationActionButton.qml
+++ b/modules/common/widgets/NotificationActionButton.qml
@@ -9,8 +9,8 @@ RippleButton {
     property string urgency
 
     implicitHeight: 34
-    leftPadding: 15
-    rightPadding: 15
+    leftPadding: Appearance.spacing.large
+    rightPadding: Appearance.spacing.large
     buttonRadius: Appearance.rounding.small
     colBackground: (urgency == NotificationUrgency.Critical) ? Appearance.colors.colSecondaryContainer : Appearance.colors.colLayer4
     colBackgroundHover: (urgency == NotificationUrgency.Critical) ? Appearance.colors.colSecondaryContainerHover : Appearance.colors.colLayer4Hover

--- a/modules/common/widgets/NotificationGroup.qml
+++ b/modules/common/widgets/NotificationGroup.qml
@@ -18,7 +18,7 @@ MouseArea { // Notification group area
     property bool multipleNotifications: notificationCount > 1
     property bool expanded: false
     property bool popup: false
-    property real padding: 10
+    property real padding: Appearance.spacing.normal
     implicitHeight: background.implicitHeight
 
     property real dragConfirmThreshold: 70 // Drag further to discard notification
@@ -150,7 +150,7 @@ MouseArea { // Notification group area
             anchors.left: parent.left
             anchors.right: parent.right
             anchors.margins: root.padding
-            spacing: 10
+            spacing: Appearance.spacing.normal
 
             NotificationAppIcon { // Icons
                 Layout.alignment: Qt.AlignTop
@@ -185,7 +185,7 @@ MouseArea { // Notification group area
                         anchors.left: parent.left
                         anchors.right: expandButton.left
                         anchors.verticalCenter: parent.verticalCenter
-                        spacing: 5
+                        spacing: Appearance.spacing.small
                         StyledText {
                             id: appName
                             elide: Text.ElideRight
@@ -203,7 +203,7 @@ MouseArea { // Notification group area
                         StyledText {
                             id: timeText
                             // Layout.fillWidth: true
-                            Layout.rightMargin: 10
+                            Layout.rightMargin: Appearance.spacing.normal
                             horizontalAlignment: Text.AlignLeft
                             text: NotificationUtils.getFriendlyNotifTimeString(notificationGroup?.time)
                             font.pixelSize: topRow.fontSize

--- a/modules/common/widgets/NotificationGroupExpandButton.qml
+++ b/modules/common/widgets/NotificationGroupExpandButton.qml
@@ -26,9 +26,9 @@ RippleButton { // Expand button
         RowLayout {
             id: contentRow
             anchors.centerIn: parent
-            spacing: 3
+            spacing: Appearance.spacing.verysmall
             StyledText {
-                Layout.leftMargin: 4
+                Layout.leftMargin: Appearance.spacing.verysmall
                 visible: root.count > 1
                 text: root.count
                 font.pixelSize: root.fontSize

--- a/modules/common/widgets/NotificationItem.qml
+++ b/modules/common/widgets/NotificationItem.qml
@@ -106,7 +106,7 @@ Item { // Notification item area
         image: notificationObject.image
         anchors.right: background.left
         anchors.top: background.top
-        anchors.rightMargin: 10
+        anchors.rightMargin: Appearance.spacing.normal
     }
 
     Rectangle { // Background of notification item
@@ -140,7 +140,7 @@ Item { // Notification item area
             id: contentColumn
             anchors.fill: parent
             anchors.margins: expanded ? root.padding : 0
-            spacing: 3
+            spacing: Appearance.spacing.verysmall
 
             Behavior on anchors.margins {
                 animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)

--- a/modules/common/widgets/NotificationListView.qml
+++ b/modules/common/widgets/NotificationListView.qml
@@ -9,7 +9,7 @@ StyledListView { // Scrollable window
     id: root
     property bool popup: false
 
-    spacing: 3
+    spacing: Appearance.spacing.verysmall
 
     model: ScriptModel {
         values: root.popup ? Notifications.popupAppNameList : Notifications.appNameList

--- a/modules/common/widgets/NotificationListView.qml
+++ b/modules/common/widgets/NotificationListView.qml
@@ -1,5 +1,6 @@
 pragma ComponentBehavior: Bound
 
+import qs.modules.common
 import qs.modules.common.widgets
 import qs.services
 import QtQuick

--- a/modules/common/widgets/PagePlaceholder.qml
+++ b/modules/common/widgets/PagePlaceholder.qml
@@ -27,12 +27,12 @@ Item {
 
     ColumnLayout {
         anchors.centerIn: parent
-        spacing: 5
+        spacing: Appearance.spacing.small
 
         MaterialShapeWrappedMaterialSymbol {
             id: shapeWidget
             Layout.alignment: Qt.AlignHCenter
-            padding: 12
+            padding: Appearance.spacing.normal
             iconSize: 56
             rotation: -30 * (1 - root.opacity)
         }

--- a/modules/common/widgets/PasswordChars.qml
+++ b/modules/common/widgets/PasswordChars.qml
@@ -49,7 +49,7 @@ StyledFlickable {
         anchors {
             left: parent.left
             verticalCenter: parent.verticalCenter
-            leftMargin: 4 - 5 // -5 to account for spacing being simulated by char item width
+            leftMargin: Appearance.spacing.verysmall - 5 // -5 to account for spacing being simulated by char item width
         }
         spacing: 0
 

--- a/modules/common/widgets/PasswordChars.qml
+++ b/modules/common/widgets/PasswordChars.qml
@@ -102,7 +102,7 @@ StyledFlickable {
                             target: materialShape
                             properties: "scale"
                             to: 1
-                            duration: 200
+                            duration: Appearance.animation.elementMoveFast.duration
                             easing.type: Easing.BezierSpline
                             easing.bezierCurve: Appearance.animationCurves.expressiveFastSpatial
                         }

--- a/modules/common/widgets/PlayerControls.qml
+++ b/modules/common/widgets/PlayerControls.qml
@@ -43,7 +43,7 @@ Item {
     RowLayout {
         anchors.fill: parent
         anchors.margins: 13
-        spacing: 15
+        spacing: Appearance.spacing.large
 
         Rectangle {
             id: artBackground
@@ -78,7 +78,7 @@ Item {
 
         ColumnLayout {
             Layout.fillHeight: true
-            spacing: 2
+            spacing: Appearance.spacing.unsharpen
 
             StyledText {
                 id: trackTitle
@@ -113,7 +113,7 @@ Item {
                 StyledText {
                     id: trackTime
                     anchors.bottom: sliderRow.top
-                    anchors.bottomMargin: 5
+                    anchors.bottomMargin: Appearance.spacing.small
                     anchors.left: parent.left
                     font.pixelSize: Appearance.font.pixelSize.small
                     color: root.blendedColors.colSubtext
@@ -187,7 +187,7 @@ Item {
                     id: playPauseButton
                     anchors.right: parent.right
                     anchors.bottom: sliderRow.top
-                    anchors.bottomMargin: 5
+                    anchors.bottomMargin: Appearance.spacing.small
                     property real size: 44
                     implicitWidth: size
                     implicitHeight: size

--- a/modules/common/widgets/PlayerControlsLyrics.qml
+++ b/modules/common/widgets/PlayerControlsLyrics.qml
@@ -43,12 +43,12 @@ Item {
     ColumnLayout {
         anchors.fill: parent
         anchors.margins: 13
-        spacing: 10
+        spacing: Appearance.spacing.normal
 
         RowLayout {
             Layout.fillWidth: true
             Layout.fillHeight: true
-            spacing: 15
+            spacing: Appearance.spacing.large
 
             Rectangle {
                 id: artBackground
@@ -103,7 +103,7 @@ Item {
         ColumnLayout {
             id: infoColumn
             Layout.fillWidth: true
-            Layout.bottomMargin: 5
+            Layout.bottomMargin: Appearance.spacing.small
 
             StyledText {
                 id: trackTitle
@@ -213,7 +213,7 @@ Item {
                     id: playPauseButton
                     anchors.right: parent.right
                     anchors.bottom: sliderRow.top
-                    anchors.bottomMargin: 5
+                    anchors.bottomMargin: Appearance.spacing.small
                     property real size: 44
                     implicitWidth: size
                     implicitHeight: size

--- a/modules/common/widgets/PlayerControlsLyrics.qml
+++ b/modules/common/widgets/PlayerControlsLyrics.qml
@@ -54,7 +54,7 @@ Item {
                 id: artBackground
                 implicitHeight: 150
                 implicitWidth: 150
-                radius: 16
+                radius: Appearance.rounding.normal
                 color: ColorUtils.transparentize(root.blendedColors.colLayer1, 0.5)
 
                 layer.enabled: true

--- a/modules/common/widgets/PresetsCard.qml
+++ b/modules/common/widgets/PresetsCard.qml
@@ -32,13 +32,13 @@ Rectangle {
             right: parent.right
             margins: 0
         }
-        spacing: 6
+        spacing: Appearance.spacing.small
 
         // Header
         RowLayout{
-            Layout.leftMargin: 10
-            Layout.topMargin: 6
-            spacing: 10
+            Layout.leftMargin: Appearance.spacing.normal
+            Layout.topMargin: Appearance.spacing.small
+            spacing: Appearance.spacing.normal
             MaterialShapeWrappedMaterialSymbol {
                 id: avatarShape
                 shape: MaterialShape.Shape.Circle 
@@ -74,7 +74,7 @@ Rectangle {
             }
             MaterialSymbol {
                 Layout.alignment: Qt.AlignRight // im a placeholder someday I will do something =P
-                Layout.rightMargin: 12
+                Layout.rightMargin: Appearance.spacing.normal
                 font.pixelSize: Appearance.font.pixelSize.huge
                 text: "more_vert"
             }
@@ -84,7 +84,7 @@ Rectangle {
         Rectangle {
             id: imageRect
             Layout.fillWidth: true
-            Layout.bottomMargin: 4
+            Layout.bottomMargin: Appearance.spacing.verysmall
             implicitHeight: 130
             radius: 0
             color: Appearance.colors.colLayer2
@@ -121,9 +121,9 @@ Rectangle {
         // Buttons
         RowLayout {
             Layout.fillWidth: true
-            Layout.rightMargin: 8
+            Layout.rightMargin: Appearance.spacing.small
             Layout.bottomMargin: -4
-            spacing: 8
+            spacing: Appearance.spacing.small
 
             Item { Layout.fillWidth: true }
 

--- a/modules/common/widgets/PresetsCard.qml
+++ b/modules/common/widgets/PresetsCard.qml
@@ -21,7 +21,7 @@ Rectangle {
     implicitHeight: contentColumn.implicitHeight + 14
     radius: Appearance.rounding.normal
     color: Appearance.colors.colLayer1
-    border.width: 1
+    border.width: Appearance.borderWidth.standard
     border.color: "transparent"
 
     ColumnLayout {

--- a/modules/common/widgets/ResourceCard.qml
+++ b/modules/common/widgets/ResourceCard.qml
@@ -16,7 +16,7 @@ Rectangle {
 
     width: cardWidth
     height: 96 
-    radius: Appearance.rounding.normal 
+    radius: Appearance.rounding.normal
     
     color: Appearance.colors.colSurfaceContainerLow
 

--- a/modules/common/widgets/ResourceCard.qml
+++ b/modules/common/widgets/ResourceCard.qml
@@ -90,6 +90,6 @@ Rectangle {
         }
     }
 
-    border.width: root.value > 0.9 ? 1.5 : 0
+    border.width: root.value > 0.9 ? Appearance.borderWidth.emphasis : 0
     border.color: root.value > 0.9 ? Appearance.colors.colError : "transparent"
 }

--- a/modules/common/widgets/ResourceCard.qml
+++ b/modules/common/widgets/ResourceCard.qml
@@ -28,8 +28,8 @@ Rectangle {
 
     ColumnLayout {
         anchors.fill: parent
-        anchors.margins: 12
-        spacing: 6
+        anchors.margins: Appearance.spacing.normal
+        spacing: Appearance.spacing.small
 
         RowLayout {
             Layout.fillWidth: true

--- a/modules/common/widgets/ResourceCard.qml
+++ b/modules/common/widgets/ResourceCard.qml
@@ -16,7 +16,7 @@ Rectangle {
 
     width: cardWidth
     height: 96 
-    radius: 16 
+    radius: Appearance.rounding.normal 
     
     color: Appearance.colors.colSurfaceContainerLow
 

--- a/modules/common/widgets/RippleButton.qml
+++ b/modules/common/widgets/RippleButton.qml
@@ -23,7 +23,7 @@ Button {
     property var altAction // When right clicking
     property var middleClickAction // When middle clicking
     property bool border: false
-    property real borderWidth: 1
+    property real borderWidth: Appearance.borderWidth.standard
     property color colBorder: Appearance?.colors.colOutlineVariant ?? "#79747E"
 
     property color colBackground: ColorUtils.transparentize(Appearance?.colors.colLayer1Hover, 1) || "transparent"

--- a/modules/common/widgets/SecondaryTabButton.qml
+++ b/modules/common/widgets/SecondaryTabButton.qml
@@ -91,7 +91,7 @@ TabButton {
         id: buttonBackground
         anchors {
             fill: parent
-            margins: 3
+            margins: Appearance.spacing.verysmall
         }
         radius: Appearance?.rounding.normal
         implicitHeight: 42
@@ -149,7 +149,7 @@ TabButton {
                 id: iconLoader
                 active: buttonIcon?.length > 0
                 sourceComponent: buttonIcon?.length > 0 ? materialSymbolComponent : null
-                Layout.rightMargin: 5
+                Layout.rightMargin: Appearance.spacing.small
             }
 
             Component {

--- a/modules/common/widgets/SelectionDialog.qml
+++ b/modules/common/widgets/SelectionDialog.qml
@@ -41,7 +41,7 @@ Item {
         ColumnLayout {
             id: dialogColumnLayout
             anchors.fill: parent
-            spacing: 16
+            spacing: Appearance.spacing.large
 
             StyledText {
                 id: dialogTitle
@@ -68,7 +68,7 @@ Item {
                 Layout.fillHeight: true
                 clip: true
                 currentIndex: root.defaultChoice !== undefined ? root.items.indexOf(root.defaultChoice) : -1
-                spacing: 6
+                spacing: Appearance.spacing.small
 
                 model: ScriptModel {
                     id: choiceModel

--- a/modules/common/widgets/SelectionGroupButton.qml
+++ b/modules/common/widgets/SelectionGroupButton.qml
@@ -29,7 +29,7 @@ GroupButton {
     colBackgroundActive: Appearance.colors.colSecondaryContainerActive
 
     contentItem: RowLayout {
-        spacing: 4 * (root.buttonText?.length > 0)
+        spacing: Appearance.spacing.verysmall * (root.buttonText?.length > 0)
 
         Loader {
             Layout.alignment: Qt.AlignVCenter

--- a/modules/common/widgets/StyledComboBox.qml
+++ b/modules/common/widgets/StyledComboBox.qml
@@ -54,9 +54,9 @@ ComboBox {
         RowLayout {
             id: buttonLayout
             anchors.fill: parent
-            spacing: 8
-            anchors.leftMargin: 16
-            anchors.rightMargin: 16
+            spacing: Appearance.spacing.small
+            anchors.leftMargin: Appearance.spacing.large
+            anchors.rightMargin: Appearance.spacing.large
 
             Loader {
                 Layout.alignment: Qt.AlignVCenter
@@ -130,9 +130,9 @@ ComboBox {
         }
 
         contentItem: RowLayout {
-            spacing: 8
-            anchors.leftMargin: 12
-            anchors.rightMargin: 12
+            spacing: Appearance.spacing.small
+            anchors.leftMargin: Appearance.spacing.normal
+            anchors.rightMargin: Appearance.spacing.normal
 
             Loader {
                 Layout.alignment: Qt.AlignVCenter
@@ -177,7 +177,7 @@ ComboBox {
         y: root.height + 4
         width: root.width
         height: Math.min(listView.contentHeight + topPadding + bottomPadding, 300)
-        padding: 8
+        padding: Appearance.spacing.small
 
         enter: Transition {
             PropertyAnimation {
@@ -216,7 +216,7 @@ ComboBox {
             id: listView
             clip: true
             implicitHeight: contentHeight
-            spacing: 2
+            spacing: Appearance.spacing.unsharpen
             model: root.popup.visible ? root.delegateModel : null
             currentIndex: root.highlightedIndex
         }

--- a/modules/common/widgets/StyledComboBoxSearch.qml
+++ b/modules/common/widgets/StyledComboBoxSearch.qml
@@ -64,9 +64,9 @@ ComboBox {
         RowLayout {
             id: buttonLayout
             anchors.fill: parent
-            spacing: 8
-            anchors.leftMargin: 16
-            anchors.rightMargin: 16
+            spacing: Appearance.spacing.small
+            anchors.leftMargin: Appearance.spacing.large
+            anchors.rightMargin: Appearance.spacing.large
 
             Loader {
                 Layout.alignment: Qt.AlignVCenter
@@ -144,9 +144,9 @@ ComboBox {
         }
 
         contentItem: RowLayout {
-            spacing: 8
-            anchors.leftMargin: 12
-            anchors.rightMargin: 12
+            spacing: Appearance.spacing.small
+            anchors.leftMargin: Appearance.spacing.normal
+            anchors.rightMargin: Appearance.spacing.normal
 
             Loader {
                 Layout.alignment: Qt.AlignVCenter
@@ -193,7 +193,7 @@ ComboBox {
             searchField.implicitHeight + 20 + (visibleCount * 42) + topPadding + bottomPadding,
             320
         )
-        padding: 8
+        padding: Appearance.spacing.small
 
         onVisibleChanged: {
             if (visible) {
@@ -232,7 +232,7 @@ ComboBox {
         }
 
         contentItem: ColumnLayout {
-            spacing: 4
+            spacing: Appearance.spacing.verysmall
 
             Rectangle {
                 Layout.fillWidth: true
@@ -242,11 +242,11 @@ ComboBox {
 
                 RowLayout {
                     anchors.fill: parent
-                    anchors.margins: 4
-                    spacing: 6
+                    anchors.margins: Appearance.spacing.verysmall
+                    spacing: Appearance.spacing.small
 
                     MaterialSymbol {
-                        Layout.leftMargin: 6
+                        Layout.leftMargin: Appearance.spacing.small
                         text: "search"
                         iconSize: Appearance.font.pixelSize.larger
                         color: Appearance.colors.colSubtext
@@ -276,7 +276,7 @@ ComboBox {
                         text: "close"
                         iconSize: Appearance.font.pixelSize.normal
                         color: Appearance.colors.colSubtext
-                        Layout.rightMargin: 6
+                        Layout.rightMargin: Appearance.spacing.small
                         MouseArea {
                             anchors.fill: parent
                             cursorShape: Qt.PointingHandCursor
@@ -294,7 +294,7 @@ ComboBox {
                 Layout.fillWidth: true
                 Layout.preferredHeight: Math.min(contentHeight, 320 - searchField.implicitHeight - 8 - 46)
                 clip: true
-                spacing: 2
+                spacing: Appearance.spacing.unsharpen
                 model: root.popup.visible ? root.delegateModel : null
                 currentIndex: root.highlightedIndex
             }

--- a/modules/common/widgets/StyledListView.qml
+++ b/modules/common/widgets/StyledListView.qml
@@ -8,7 +8,7 @@ import QtQuick.Controls
  */
 ListView {
     id: root
-    spacing: 5
+    spacing: Appearance.spacing.small
     property real removeOvershoot: 20 // Account for gaps and bouncy animations
     property int dragIndex: -1
     property real dragDistance: 0

--- a/modules/common/widgets/StyledPopup.qml
+++ b/modules/common/widgets/StyledPopup.qml
@@ -99,7 +99,7 @@ LazyLoader {
 
             color: Appearance.colors.colLayer1Base
             radius: Appearance.rounding.normal + 4
-            border.width: 1
+            border.width: Appearance.borderWidth.standard
             border.color: Appearance.colors.colLayer0Border
 
             // Reparent content here once the window is ready

--- a/modules/common/widgets/StyledPopupMenu.qml
+++ b/modules/common/widgets/StyledPopupMenu.qml
@@ -56,8 +56,8 @@ Item {
                 ColumnLayout {
                     id: layout
                     anchors.fill: parent
-                    anchors.margins: 8
-                    spacing: 2
+                    anchors.margins: Appearance.spacing.small
+                    spacing: Appearance.spacing.unsharpen
 
                     Repeater {
                         id: repeater

--- a/modules/common/widgets/StyledPopupMenu.qml
+++ b/modules/common/widgets/StyledPopupMenu.qml
@@ -50,7 +50,7 @@ Item {
                 
                 radius: Appearance.rounding.normal
                 color: Appearance.m3colors.m3surfaceContainer
-                border.width: 1
+                border.width: Appearance.borderWidth.standard
                 border.color: Appearance.colors.colLayer0Border
 
                 ColumnLayout {

--- a/modules/common/widgets/StyledPopupMenu.qml
+++ b/modules/common/widgets/StyledPopupMenu.qml
@@ -2,6 +2,7 @@ import QtQuick
 import QtQuick.Layouts
 import Quickshell
 import Quickshell.Wayland
+import qs.modules.common
 import qs.modules.common.widgets // Para las sombras y estilos
 
 Item {

--- a/modules/common/widgets/StyledRadioButton.qml
+++ b/modules/common/widgets/StyledRadioButton.qml
@@ -10,7 +10,7 @@ import Quickshell.Services.Pipewire
 
 RadioButton {
     id: root
-    padding: 4
+    padding: Appearance.spacing.verysmall
     implicitHeight: contentItem.implicitHeight + padding * 2
     property string description
     property color activeColor: Appearance?.colors.colPrimary ?? "#685496"
@@ -23,7 +23,7 @@ RadioButton {
     contentItem: RowLayout {
         id: contentItem
         Layout.fillWidth: true
-        spacing: 12
+        spacing: Appearance.spacing.normal
         Rectangle {
             id: radio
             Layout.fillWidth: false

--- a/modules/common/widgets/StyledRadioButton.qml
+++ b/modules/common/widgets/StyledRadioButton.qml
@@ -32,7 +32,7 @@ RadioButton {
             height: 20
             radius: Appearance?.rounding.full
             border.color: checked ? root.activeColor : root.inactiveColor
-            border.width: 2
+            border.width: Appearance.borderWidth.emphasis
             color: "transparent"
 
             // Checked indicator

--- a/modules/common/widgets/StyledSwitch.qml
+++ b/modules/common/widgets/StyledSwitch.qml
@@ -24,7 +24,7 @@ Switch {
             anchors.fill: parent
             radius: parent.radius
             color: "transparent"
-            border.width: 1
+            border.width: Appearance.borderWidth.standard
             border.color: Qt.rgba(1, 1, 1, 0.06)
         }
 

--- a/modules/common/widgets/StyledText.qml
+++ b/modules/common/widgets/StyledText.qml
@@ -23,9 +23,9 @@ Text {
 
     component Anim: NumberAnimation {
         target: root
-        duration: 300 / 2
+        duration: Appearance.animation.elementMoveFaster.duration
         easing.type: Easing.BezierSpline
-        easing.bezierCurve: Appearance.animation.elementMoveFast.bezierCurve
+        easing.bezierCurve: Appearance.animation.elementMoveFaster.bezierCurve
     }
 
     Component.onCompleted: {

--- a/modules/common/widgets/ThemeCarousel.qml
+++ b/modules/common/widgets/ThemeCarousel.qml
@@ -33,8 +33,8 @@ Item {
         model: themeModel
         orientation: ListView.Horizontal
         spacing: carouselRoot.itemSpacing
-        leftMargin: 16
-        rightMargin: 16
+        leftMargin: Appearance.spacing.large
+        rightMargin: Appearance.spacing.large
         clip: true
 
         snapMode: ListView.SnapToItem

--- a/modules/common/widgets/ThemeCarousel.qml
+++ b/modules/common/widgets/ThemeCarousel.qml
@@ -61,7 +61,7 @@ Item {
             }
 
             height: listView.height
-            radius: 28
+            radius: Appearance.rounding.verylarge
             clip:   true
 
             color: model.name === "Material"

--- a/modules/common/widgets/Toolbar.qml
+++ b/modules/common/widgets/Toolbar.qml
@@ -11,7 +11,7 @@ Item {
     id: root
 
     property bool enableShadow: true
-    property real padding: 8
+    property real padding: Appearance.spacing.small
     property alias colBackground: background.color
     property alias spacing: toolbarLayout.spacing
     default property alias data: toolbarLayout.data
@@ -38,7 +38,7 @@ Item {
 
         RowLayout {
             id: toolbarLayout
-            spacing: 4
+            spacing: Appearance.spacing.verysmall
             anchors {
                 fill: parent
                 margins: root.padding

--- a/modules/common/widgets/ToolbarTabBar.qml
+++ b/modules/common/widgets/ToolbarTabBar.qml
@@ -40,7 +40,7 @@ Item {
         id: contentItem
         z: 1
         anchors.centerIn: parent
-        spacing: 4
+        spacing: Appearance.spacing.verysmall
 
         Repeater {
             model: root.tabButtonList

--- a/modules/common/widgets/ToolbarTabButton.qml
+++ b/modules/common/widgets/ToolbarTabButton.qml
@@ -23,7 +23,7 @@ RippleButton {
     contentItem: Row {
         id: contentRow
         anchors.centerIn: parent
-        spacing: 6
+        spacing: Appearance.spacing.small
 
         MaterialSymbol {
             id: icon

--- a/modules/common/widgets/ToolbarTextField.qml
+++ b/modules/common/widgets/ToolbarTextField.qml
@@ -11,7 +11,7 @@ TextField {
 
     Layout.fillHeight: true
     implicitWidth: 200
-    padding: 10
+    padding: Appearance.spacing.normal
 
     placeholderTextColor: Appearance.colors.colSubtext
     color: Appearance.colors.colOnLayer1

--- a/modules/common/widgets/VerticalButtonGroup.qml
+++ b/modules/common/widgets/VerticalButtonGroup.qml
@@ -10,7 +10,7 @@ import QtQuick.Layouts
 Rectangle {
     id: root
     default property alias content: columnLayout.data
-    property real spacing: 5
+    property real spacing: Appearance.spacing.small
     property real padding: 0
     property int clickIndex: columnLayout.clickIndex
 

--- a/modules/common/widgets/VerticalTabBar.qml
+++ b/modules/common/widgets/VerticalTabBar.qml
@@ -74,7 +74,7 @@ Item {
                 visible: isCurrent
                 anchors.horizontalCenter: parent.horizontalCenter
                 anchors.bottom: parent.bottom
-                anchors.bottomMargin: 12
+                anchors.bottomMargin: Appearance.spacing.normal
                 width: 30
                 height: 4
                 radius: height / 2
@@ -85,8 +85,8 @@ Item {
             RowLayout {
                 anchors.verticalCenter: parent.verticalCenter
                 anchors.left: parent.left
-                anchors.leftMargin: 12
-                spacing: 6
+                anchors.leftMargin: Appearance.spacing.normal
+                spacing: Appearance.spacing.small
 
                 MaterialSymbol {
                     text: parent.parent.modelData.icon

--- a/modules/common/widgets/VerticalTabBar.qml
+++ b/modules/common/widgets/VerticalTabBar.qml
@@ -22,7 +22,7 @@ Item {
         : cardHeight
 
     Behavior on implicitHeight {
-        NumberAnimation { duration: 200; easing.type: Easing.OutCubic }
+        NumberAnimation { duration: Appearance.animation.elementMoveFast.duration; easing.type: Easing.OutCubic }
     }
 
     Repeater {
@@ -61,13 +61,13 @@ Item {
             opacity: isCurrent ? 1 : (0.3 + ((totalCount - 1 - visualPosition) / Math.max(totalCount - 1, 1)) * 0.3)
 
             Behavior on y {
-                NumberAnimation { duration: 200; easing.type: Easing.OutCubic }
+                NumberAnimation { duration: Appearance.animation.elementMoveFast.duration; easing.type: Easing.OutCubic }
             }
             Behavior on color {
-                ColorAnimation { duration: 200; easing.type: Easing.OutCubic }
+                ColorAnimation { duration: Appearance.animation.elementMoveFast.duration; easing.type: Easing.OutCubic }
             }
             Behavior on opacity {
-                NumberAnimation { duration: 200; easing.type: Easing.OutCubic }
+                NumberAnimation { duration: Appearance.animation.elementMoveFast.duration; easing.type: Easing.OutCubic }
             }
 
             Rectangle {
@@ -94,7 +94,7 @@ Item {
                     color: parent.parent.isCurrent
                         ? Appearance.colors.colOnLayer1
                         : Appearance.colors.colOnPrimaryContainer
-                    Behavior on color { ColorAnimation { duration: 200 } }
+                    Behavior on color { ColorAnimation { duration: Appearance.animation.elementMoveFast.duration } }
                 }
 
                 StyledText {
@@ -102,7 +102,7 @@ Item {
                     color: parent.parent.isCurrent
                         ? Appearance.colors.colOnLayer1
                         : Appearance.colors.colOnPrimaryContainer
-                    Behavior on color { ColorAnimation { duration: 200 } }
+                    Behavior on color { ColorAnimation { duration: Appearance.animation.elementMoveFast.duration } }
                 }
             }
 

--- a/modules/common/widgets/WallpaperSubmenu.qml
+++ b/modules/common/widgets/WallpaperSubmenu.qml
@@ -20,7 +20,7 @@ Item {
     ColumnLayout {
         id: col
         width: root.width
-        spacing: 8
+        spacing: Appearance.spacing.small
 
         // Scheme
         Rectangle {
@@ -31,7 +31,7 @@ Item {
 
             GridLayout {
                 id: schemeGrid
-                anchors { left: parent.left; right: parent.right; top: parent.top; margins: 10 }
+                anchors { left: parent.left; right: parent.right; top: parent.top; margins: Appearance.spacing.normal }
                 columns: 3
                 rowSpacing: 6
                 columnSpacing: 6
@@ -125,8 +125,8 @@ Item {
 
             ColumnLayout {
                 id: centeredCol
-                anchors { fill: parent; margins: 8 }
-                spacing: 6
+                anchors { fill: parent; margins: Appearance.spacing.small }
+                spacing: Appearance.spacing.small
 
                 ConfigSwitch {
                     Layout.fillWidth: true
@@ -147,7 +147,7 @@ Item {
 
                 ConfigSelectionShapeArray {
                     Layout.fillWidth: true
-                    Layout.topMargin: 2
+                    Layout.topMargin: Appearance.spacing.unsharpen
                     visible: Config.options.background.centeredWallpaper
                     currentValue: Config.options.background.centeredWallpaperShape
                     shapeColor: Appearance.colors.colPrimary
@@ -192,7 +192,7 @@ Item {
 
             ColumnLayout {
                 id: transCol
-                anchors { fill: parent; margins: 8 }
+                anchors { fill: parent; margins: Appearance.spacing.small }
 
                 Repeater {
                     model: [
@@ -215,8 +215,8 @@ Item {
                         colRippleToggled: Appearance.colors.colSecondaryContainerActive
                         onClicked: Config.options.background.wallpaperAnimation = transRow.modelData.value
                         contentItem: RowLayout {
-                            anchors { fill: parent; leftMargin: 12; rightMargin: 12 }
-                            spacing: 12
+                            anchors { fill: parent; leftMargin: Appearance.spacing.normal; rightMargin: Appearance.spacing.normal }
+                            spacing: Appearance.spacing.normal
                             MaterialSymbol {
                                 text: transRow.modelData.icon
                                 iconSize: Appearance.font.pixelSize.larger

--- a/modules/common/widgets/WidgetsMonitorSelector.qml
+++ b/modules/common/widgets/WidgetsMonitorSelector.qml
@@ -9,7 +9,7 @@ Flow {
     id: root
     required property var configEntry 
     Layout.fillWidth: true
-    spacing: 2
+    spacing: Appearance.spacing.unsharpen
 
     SelectionGroupButton {
         leftmost: true

--- a/modules/common/widgets/WidgetsSubmenu.qml
+++ b/modules/common/widgets/WidgetsSubmenu.qml
@@ -32,8 +32,8 @@ Item {
 
     ColumnLayout {
         id: col
-        anchors { fill: parent; margins: 8 }
-        spacing: 2
+        anchors { fill: parent; margins: Appearance.spacing.small }
+        spacing: Appearance.spacing.unsharpen
 
         ConfigSwitch {
             Layout.fillWidth: true
@@ -45,8 +45,8 @@ Item {
 
         Rectangle {
             Layout.fillWidth: true
-            Layout.topMargin: 4
-            Layout.bottomMargin: 4
+            Layout.topMargin: Appearance.spacing.verysmall
+            Layout.bottomMargin: Appearance.spacing.verysmall
             implicitHeight: 1
             color: Appearance.colors.colOutlineVariant
             opacity: 0.4

--- a/modules/common/widgets/WindowDialog.qml
+++ b/modules/common/widgets/WindowDialog.qml
@@ -80,7 +80,7 @@ Rectangle {
                 fill: parent
                 margins: dialogBackground.radius
             }
-            spacing: 16
+            spacing: Appearance.spacing.large
             opacity: root.show ? 1 : 0
             Behavior on opacity {
                 animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)

--- a/modules/common/widgets/WindowDialogButtonRow.qml
+++ b/modules/common/widgets/WindowDialogButtonRow.qml
@@ -7,7 +7,7 @@ import qs.modules.common.widgets
 
 RowLayout {
     id: root
-    spacing: 4
+    spacing: Appearance.spacing.verysmall
 
     // These shouldn't be needed but it would be a terrible waste of space to follow the spec
     Layout.margins: -8

--- a/modules/common/widgets/WindowDialogSlider.qml
+++ b/modules/common/widgets/WindowDialogSlider.qml
@@ -34,8 +34,8 @@ Column {
         anchors {
             left: parent.left
             right: parent.right
-            leftMargin: 4
-            rightMargin: 4
+            leftMargin: Appearance.spacing.verysmall
+            rightMargin: Appearance.spacing.verysmall
         }
         configuration: StyledSlider.Configuration.S
         onMoved: root.moved()

--- a/modules/common/widgets/WorldMap.qml
+++ b/modules/common/widgets/WorldMap.qml
@@ -113,7 +113,7 @@ Item {
             height: 14
             radius: width / 2
             color: "transparent"
-            border.width: 2
+            border.width: Appearance.borderWidth.emphasis
             border.color: root.markerColor
             opacity: 0.8
 

--- a/modules/common/widgets/WorldMap.qml
+++ b/modules/common/widgets/WorldMap.qml
@@ -103,8 +103,8 @@ Item {
         width: 14
         height: 14
 
-        Behavior on x { NumberAnimation { duration: 400; easing.type: Easing.OutCubic } }
-        Behavior on y { NumberAnimation { duration: 400; easing.type: Easing.OutCubic } }
+        Behavior on x { NumberAnimation { duration: Appearance.animation.elementMoveEnter.duration; easing.type: Easing.OutCubic } }
+        Behavior on y { NumberAnimation { duration: Appearance.animation.elementMoveEnter.duration; easing.type: Easing.OutCubic } }
 
         Rectangle {
             id: ring

--- a/modules/common/widgets/shapes/ShapeCanvas.qml
+++ b/modules/common/widgets/shapes/ShapeCanvas.qml
@@ -1,3 +1,4 @@
+import qs.modules.common
 import QtQuick
 import "shapes/morph.js" as Morph
 
@@ -22,9 +23,9 @@ Canvas {
     property double progress: 1
     property var morph: new Morph.Morph(roundedPolygon, roundedPolygon)
     property Animation animation: NumberAnimation {
-        duration: 350
+        duration: Appearance.animationCurves.expressiveFastSpatialDuration
         easing.type: Easing.BezierSpline
-        easing.bezierCurve: [0.42, 1.67, 0.21, 0.90, 1, 1] // Material 3 Expressive fast spatial (https://m3.material.io/styles/motion/overview/specs)
+        easing.bezierCurve: Appearance.animationCurves.expressiveFastSpatial
     }
 
     onRoundedPolygonChanged: {

--- a/modules/common/widgets/shapes/example-squircle.qml
+++ b/modules/common/widgets/shapes/example-squircle.qml
@@ -21,7 +21,7 @@ Window {
     RowLayout {
         id: rowLayout
         anchors.centerIn: parent
-        spacing: 10
+        spacing: Appearance.spacing.normal
         Text {
             text: "Liquid"
             color: "#E6E1E3"
@@ -75,7 +75,7 @@ Window {
         anchors {
             horizontalCenter: parent.horizontalCenter
             top: parent.top
-            topMargin: 8
+            topMargin: Appearance.spacing.small
         }
         color: "#E6E1E3"
         text: "Custom Squircle Shape"

--- a/modules/common/widgets/shapes/example.qml
+++ b/modules/common/widgets/shapes/example.qml
@@ -56,7 +56,7 @@ Window {
         anchors {
             horizontalCenter: parent.horizontalCenter
             top: parent.top
-            topMargin: 8
+            topMargin: Appearance.spacing.small
         }
         color: "#E6E1E3"
         text: "Shape %1/%2".arg(root.shapeIndex+1).arg(root.shapeGetters.length)

--- a/modules/common/widgets/shapes/example.qml
+++ b/modules/common/widgets/shapes/example.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import QtQuick.Window
+import qs.modules.common
 import "material-shapes.js" as MaterialShapes
 
 Window {

--- a/modules/ii/background/widgets/calendar/CalendarWidget.qml
+++ b/modules/ii/background/widgets/calendar/CalendarWidget.qml
@@ -161,7 +161,7 @@ AbstractBackgroundWidget {
 
                         RowLayout {
                             anchors.centerIn: parent
-                            spacing: 4
+                            spacing: Appearance.spacing.verysmall
                             StyledText {
                                 text: root.today.toLocaleDateString(Qt.locale(), "MMM").toUpperCase()
                                 font.pixelSize: Appearance.font.pixelSize.normal
@@ -199,10 +199,10 @@ AbstractBackgroundWidget {
             id: oneByTwoContent
             ColumnLayout {
                 anchors { fill: parent; margins: 14 }
-                spacing: 8
+                spacing: Appearance.spacing.small
 
                 Rectangle {
-                    Layout.leftMargin: 3
+                    Layout.leftMargin: Appearance.spacing.verysmall
                     implicitHeight: 28
                     implicitWidth: monthText.implicitWidth + 20
                     radius: Appearance.rounding.full
@@ -223,7 +223,7 @@ AbstractBackgroundWidget {
                     rowSpacing: 4
                     columnSpacing: 0
                     Layout.fillWidth: true
-                    Layout.topMargin: 4
+                    Layout.topMargin: Appearance.spacing.verysmall
 
                     Repeater {
                         model: ["Mo","Tu","We","Th","Fr","Sa","Su"]
@@ -277,12 +277,12 @@ AbstractBackgroundWidget {
         Component {
             id: twoByTwoContent
             ColumnLayout {
-                anchors { fill: parent; margins: 16 }
-                spacing: 4
+                anchors { fill: parent; margins: Appearance.spacing.large }
+                spacing: Appearance.spacing.verysmall
 
                 RowLayout {
                     Layout.fillWidth: true
-                    spacing: 4
+                    spacing: Appearance.spacing.verysmall
 
                     StyledText {
                         Layout.fillWidth: true
@@ -331,7 +331,7 @@ AbstractBackgroundWidget {
 
                 RowLayout {
                     Layout.alignment: Qt.AlignHCenter
-                    spacing: 4
+                    spacing: Appearance.spacing.verysmall
                     Repeater {
                         model: ["Mo","Tu","We","Th","Fr","Sa","Su"]
                         delegate: StyledText {
@@ -360,7 +360,7 @@ AbstractBackgroundWidget {
                             model: root.weeks
                             delegate: RowLayout {
                                 required property var modelData
-                                spacing: 4
+                                spacing: Appearance.spacing.verysmall
                                 Repeater {
                                     model: parent.modelData
                                     delegate: DayCell {
@@ -381,7 +381,7 @@ AbstractBackgroundWidget {
             id: resizeHandle
             width: 16; height: 16; radius: Appearance.rounding.unsharpenslight
             color: Appearance.colors.colOnPrimaryContainer
-            anchors { right: card.right; bottom: card.bottom; margins: 4 }
+            anchors { right: card.right; bottom: card.bottom; margins: Appearance.spacing.verysmall }
             opacity: (root.containsMouse || resizeArea.containsMouse || resizeArea.pressed) ? 0.5 : 0
             visible: opacity > 0 && !Config.options.background.widgetsLocked
             Behavior on opacity { NumberAnimation { duration: Appearance.animation.elementMoveFaster.duration } }
@@ -417,7 +417,7 @@ AbstractBackgroundWidget {
             id: toggleHandle
             width: 16; height: 16; radius: Appearance.rounding.unsharpenslight
             color: Appearance.colors.colOnPrimaryContainer
-            anchors { left: card.left; bottom: card.bottom; margins: 4 }
+            anchors { left: card.left; bottom: card.bottom; margins: Appearance.spacing.verysmall }
             opacity: (root.containsMouse || toggleArea.containsMouse) && root.sizeMode !== "1x1" ? 0.5 : 0
             visible: opacity > 0 && !Config.options.background.widgetsLocked
             Behavior on opacity { NumberAnimation { duration: Appearance.animation.elementMoveFaster.duration } }

--- a/modules/ii/background/widgets/calendar/CalendarWidget.qml
+++ b/modules/ii/background/widgets/calendar/CalendarWidget.qml
@@ -295,7 +295,7 @@ AbstractBackgroundWidget {
                     Rectangle {
                         implicitWidth: 26; implicitHeight: 26; radius: Appearance.rounding.full
                         color: "transparent"
-                        border.width: 1
+                        border.width: Appearance.borderWidth.standard
                         border.color: Appearance.colors.colPrimary
                         MaterialSymbol {
                             anchors.centerIn: parent
@@ -313,7 +313,7 @@ AbstractBackgroundWidget {
                     Rectangle {
                         implicitWidth: 26; implicitHeight: 26; radius: Appearance.rounding.full
                         color: "transparent"
-                        border.width: 1
+                        border.width: Appearance.borderWidth.standard
                         border.color: Appearance.colors.colPrimary
                         MaterialSymbol {
                             anchors.centerIn: parent

--- a/modules/ii/background/widgets/calendar/CalendarWidget.qml
+++ b/modules/ii/background/widgets/calendar/CalendarWidget.qml
@@ -102,7 +102,7 @@ AbstractBackgroundWidget {
 
         implicitWidth: 28
         implicitHeight: 28
-        radius: 14
+        radius: Appearance.rounding.full
         color: isToday ? Appearance.colors.colPrimary : "transparent"
 
         StyledText {
@@ -251,7 +251,7 @@ AbstractBackgroundWidget {
                             Rectangle {
                                 anchors.centerIn: parent
                                 width: 28; height: 28
-                                radius: 14
+                                radius: Appearance.rounding.full
                                 color: modelData.isToday ? Appearance.colors.colPrimary : "transparent"
 
                                 StyledText {
@@ -293,7 +293,7 @@ AbstractBackgroundWidget {
                     }
 
                     Rectangle {
-                        implicitWidth: 26; implicitHeight: 26; radius: 13
+                        implicitWidth: 26; implicitHeight: 26; radius: Appearance.rounding.full
                         color: "transparent"
                         border.width: 1
                         border.color: Appearance.colors.colPrimary
@@ -311,7 +311,7 @@ AbstractBackgroundWidget {
                     }
 
                     Rectangle {
-                        implicitWidth: 26; implicitHeight: 26; radius: 13
+                        implicitWidth: 26; implicitHeight: 26; radius: Appearance.rounding.full
                         color: "transparent"
                         border.width: 1
                         border.color: Appearance.colors.colPrimary
@@ -379,7 +379,7 @@ AbstractBackgroundWidget {
 
         Rectangle {
             id: resizeHandle
-            width: 16; height: 16; radius: 4
+            width: 16; height: 16; radius: Appearance.rounding.unsharpenslight
             color: Appearance.colors.colOnPrimaryContainer
             anchors { right: card.right; bottom: card.bottom; margins: 4 }
             opacity: (root.containsMouse || resizeArea.containsMouse || resizeArea.pressed) ? 0.5 : 0
@@ -415,7 +415,7 @@ AbstractBackgroundWidget {
 
         Rectangle {
             id: toggleHandle
-            width: 16; height: 16; radius: 4
+            width: 16; height: 16; radius: Appearance.rounding.unsharpenslight
             color: Appearance.colors.colOnPrimaryContainer
             anchors { left: card.left; bottom: card.bottom; margins: 4 }
             opacity: (root.containsMouse || toggleArea.containsMouse) && root.sizeMode !== "1x1" ? 0.5 : 0

--- a/modules/ii/background/widgets/calendar/CalendarWidget.qml
+++ b/modules/ii/background/widgets/calendar/CalendarWidget.qml
@@ -384,7 +384,7 @@ AbstractBackgroundWidget {
             anchors { right: card.right; bottom: card.bottom; margins: 4 }
             opacity: (root.containsMouse || resizeArea.containsMouse || resizeArea.pressed) ? 0.5 : 0
             visible: opacity > 0 && !Config.options.background.widgetsLocked
-            Behavior on opacity { NumberAnimation { duration: 150 } }
+            Behavior on opacity { NumberAnimation { duration: Appearance.animation.elementMoveFaster.duration } }
 
             MouseArea {
                 id: resizeArea
@@ -420,7 +420,7 @@ AbstractBackgroundWidget {
             anchors { left: card.left; bottom: card.bottom; margins: 4 }
             opacity: (root.containsMouse || toggleArea.containsMouse) && root.sizeMode !== "1x1" ? 0.5 : 0
             visible: opacity > 0 && !Config.options.background.widgetsLocked
-            Behavior on opacity { NumberAnimation { duration: 150 } }
+            Behavior on opacity { NumberAnimation { duration: Appearance.animation.elementMoveFaster.duration } }
 
             MaterialSymbol {
                 anchors.centerIn: parent

--- a/modules/ii/background/widgets/clock/ClockWidget.qml
+++ b/modules/ii/background/widgets/clock/ClockWidget.qml
@@ -44,7 +44,7 @@ AbstractBackgroundWidget {
     Column {
         id: contentColumn
         anchors.centerIn: parent
-        spacing: 10
+        spacing: Appearance.spacing.normal
 
         FadeLoader {
             id: cookieClockLoader
@@ -52,7 +52,7 @@ AbstractBackgroundWidget {
             shown: root.clockStyle === "cookie" && (root.shouldShow)
             fade: false
             sourceComponent: Column {
-                spacing: 10
+                spacing: Appearance.spacing.normal
                 CookieClock {
                     anchors.horizontalCenter: parent.horizontalCenter
                 }
@@ -148,7 +148,7 @@ AbstractBackgroundWidget {
         Behavior on opacity {
             animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
         }
-        spacing: 4
+        spacing: Appearance.spacing.verysmall
         MaterialSymbol {
             id: statusIconWidget
             anchors.verticalCenter: statusTextRow.verticalCenter

--- a/modules/ii/background/widgets/clock/CookieQuote.qml
+++ b/modules/ii/background/widgets/clock/CookieQuote.qml
@@ -34,7 +34,7 @@ Item {
         Row {
             id: quoteRow
             anchors.centerIn: parent
-            spacing: 4
+            spacing: Appearance.spacing.verysmall
             
             MaterialSymbol {
                 id: quoteIcon

--- a/modules/ii/background/widgets/clock/CookieQuote.qml
+++ b/modules/ii/background/widgets/clock/CookieQuote.qml
@@ -17,7 +17,7 @@ Item {
         anchors.fill: quoteBox
         horizontalOffset: 0
         verticalOffset: 2
-        radius: 12
+        radius: Appearance.rounding.small
         samples: radius * 2 + 1
         color: Appearance.colors.colShadow
         transparentBorder: true

--- a/modules/ii/background/widgets/clock/DigitalClock.qml
+++ b/modules/ii/background/widgets/clock/DigitalClock.qml
@@ -7,7 +7,7 @@ import QtQuick.Layouts
 
 ColumnLayout {
     id: clockColumn
-    spacing: 4
+    spacing: Appearance.spacing.verysmall
 
     property bool isVertical: Config.options.background.widgets.clock.digital.vertical
     property color colText: Appearance.colors.colOnSecondaryContainer

--- a/modules/ii/background/widgets/clock/HourMarks.qml
+++ b/modules/ii/background/widgets/clock/HourMarks.qml
@@ -13,7 +13,7 @@ Item {
     property real markWidth: 4
     property color color: Appearance.colors.colOnSecondaryContainer
     property color colOnBackground: Appearance.colors.colSecondaryContainer
-    property real padding: 8
+    property real padding: Appearance.spacing.small
 
     Rectangle {
         color: root.color

--- a/modules/ii/background/widgets/clock/SecondHand.qml
+++ b/modules/ii/background/widgets/clock/SecondHand.qml
@@ -30,7 +30,7 @@ Item {
         anchors {
             left: parent.left
             verticalCenter: parent.verticalCenter
-            leftMargin: 10 + (root.style === "dot" ? root.dotSize : 0)
+            leftMargin: Appearance.spacing.normal + (root.style === "dot" ? root.dotSize : 0)
         }
         implicitWidth: root.style === "dot" ? root.dotSize : root.handLength
         implicitHeight: root.style === "dot" ? root.dotSize : root.handWidth

--- a/modules/ii/background/widgets/clock/minuteMarks/BigHourNumbers.qml
+++ b/modules/ii/background/widgets/clock/minuteMarks/BigHourNumbers.qml
@@ -7,7 +7,7 @@ import QtQuick
 Item {
     id: root
     property real numberSize: 80
-    property real margins: 10
+    property real margins: Appearance.spacing.normal
     property color color: Appearance.colors.colOnSecondaryContainer
 
     property int hours: 12

--- a/modules/ii/background/widgets/clock/minuteMarks/Dots.qml
+++ b/modules/ii/background/widgets/clock/minuteMarks/Dots.qml
@@ -7,7 +7,7 @@ import QtQuick
 Item {
     id: root
     property real implicitSize: 12
-    property real margins: 10
+    property real margins: Appearance.spacing.normal
     property color color: Appearance.colors.colOnSecondaryContainer
 
     Repeater {

--- a/modules/ii/background/widgets/clock/minuteMarks/Lines.qml
+++ b/modules/ii/background/widgets/clock/minuteMarks/Lines.qml
@@ -7,7 +7,7 @@ import QtQuick
 Item {
     id: root
     property real numberSize: 80
-    property real margins: 10
+    property real margins: Appearance.spacing.normal
     property color color: Appearance.colors.colOnSecondaryContainer
 
     property real hourLineSize: 4

--- a/modules/ii/background/widgets/clock/minuteMarks/MinuteMarks.qml
+++ b/modules/ii/background/widgets/clock/minuteMarks/MinuteMarks.qml
@@ -16,7 +16,7 @@ Item {
         id: dotsLoader
         anchors {
             fill: parent
-            margins: 10
+            margins: Appearance.spacing.normal
         }
         shown: root.style === "dots"
         sourceComponent: Dots {
@@ -33,7 +33,7 @@ Item {
         sourceComponent: BigHourNumbers {
             numberSize: 80
             color: root.color
-            margins: 20 - 10 * bigHourNumbersLoader.opacity
+            margins: Appearance.spacing.verylarge - 10 * bigHourNumbersLoader.opacity
         }
     }
 
@@ -42,7 +42,7 @@ Item {
         id: linesLoader
         anchors {
             fill: parent
-            margins: 10
+            margins: Appearance.spacing.normal
         }
         shown: root.style === "full"
         sourceComponent: Lines {

--- a/modules/ii/background/widgets/images/CustomImage.qml
+++ b/modules/ii/background/widgets/images/CustomImage.qml
@@ -161,7 +161,7 @@ AbstractBackgroundWidget {
             anchors {
                 right: imageShape.right
                 bottom: imageShape.bottom
-                margins: 6
+                margins: Appearance.spacing.small
             }
             opacity: (root.containsMouse || resizeArea.containsMouse || resizeArea.pressed) ? 0.5 : 0
             visible: opacity > 0 && !Config.options.background.widgetsLocked

--- a/modules/ii/background/widgets/images/CustomImage.qml
+++ b/modules/ii/background/widgets/images/CustomImage.qml
@@ -168,7 +168,7 @@ AbstractBackgroundWidget {
             z: 1
 
             Behavior on opacity {
-                NumberAnimation { duration: 150 }
+                NumberAnimation { duration: Appearance.animation.elementMoveFaster.duration }
             }
 
             MouseArea {

--- a/modules/ii/background/widgets/images/CustomImage.qml
+++ b/modules/ii/background/widgets/images/CustomImage.qml
@@ -156,7 +156,7 @@ AbstractBackgroundWidget {
             id: resizeHandle
             width: 16
             height: 16
-            radius: 4
+            radius: Appearance.rounding.unsharpenslight
             color: Appearance.colors.colOnPrimaryContainer
             anchors {
                 right: imageShape.right

--- a/modules/ii/background/widgets/images/ImageConverterWidget.qml
+++ b/modules/ii/background/widgets/images/ImageConverterWidget.qml
@@ -154,9 +154,9 @@ AbstractBackgroundWidget {
                 left: parent.left
                 right: parent.right
                 top: parent.top
-                margins: 16
+                margins: Appearance.spacing.large
             }
-            spacing: 12
+            spacing: Appearance.spacing.normal
 
             StyledText {
                 Layout.fillWidth: true
@@ -286,10 +286,10 @@ AbstractBackgroundWidget {
 
             RowLayout {
                 Layout.fillWidth: true
-                spacing: 8
+                spacing: Appearance.spacing.small
 
                 StyledText {
-                    Layout.leftMargin: 3
+                    Layout.leftMargin: Appearance.spacing.verysmall
                     text: "Convert to:"
                     font.pixelSize: Appearance.font.pixelSize.small
                     color: Appearance.colors.colOnLayer1

--- a/modules/ii/background/widgets/media/MediaWidget.qml
+++ b/modules/ii/background/widgets/media/MediaWidget.qml
@@ -157,7 +157,7 @@ AbstractBackgroundWidget {
                         right: parent.right
                         top: parent.top
                         bottom: parent.bottom
-                        leftMargin: 16
+                        leftMargin: Appearance.spacing.large
                         rightMargin: 14
                     }
                     spacing: -10
@@ -166,7 +166,7 @@ AbstractBackgroundWidget {
                     ColumnLayout {
                         Layout.fillWidth: true
                         Layout.alignment: Qt.AlignVCenter
-                        spacing: 2
+                        spacing: Appearance.spacing.unsharpen
 
                         StyledText {
                             Layout.fillWidth: true
@@ -199,7 +199,7 @@ AbstractBackgroundWidget {
                         RowLayout {
                             id: controlsRow
                             anchors.centerIn: parent
-                            spacing: 2
+                            spacing: Appearance.spacing.unsharpen
                     
                             RippleButton {
                                 implicitWidth: root.buttonSize
@@ -230,7 +230,7 @@ AbstractBackgroundWidget {
                                 text: root.currentPlayer?.isPlaying ? "pause" : "play_arrow"
                                 iconSize: root.buttonIconSize + 12
                                 fill: 1
-                                padding: 8
+                                padding: Appearance.spacing.small
 
                                 MouseArea {
                                     anchors.fill: parent
@@ -289,8 +289,8 @@ AbstractBackgroundWidget {
 
                 Lyrics {
                     anchors.fill: parent
-                    anchors.leftMargin: 16
-                    anchors.rightMargin: 16
+                    anchors.leftMargin: Appearance.spacing.large
+                    anchors.rightMargin: Appearance.spacing.large
                     textAlignment: Text.AlignHCenter
                     textColor: Appearance.colors.colOnPrimaryContainer
                     activeColor: Appearance.colors.colPrimary

--- a/modules/ii/background/widgets/resources/ResourcesWidget.qml
+++ b/modules/ii/background/widgets/resources/ResourcesWidget.qml
@@ -57,7 +57,7 @@ AbstractBackgroundWidget {
                 text: statCard.icon
                 iconSize: 18
                 fill: 1
-                padding: 6
+                padding: Appearance.spacing.small
                 implicitWidth: 34
                 implicitHeight: 34
             }

--- a/modules/ii/background/widgets/resources/ResourcesWidget.qml
+++ b/modules/ii/background/widgets/resources/ResourcesWidget.qml
@@ -130,7 +130,7 @@ AbstractBackgroundWidget {
         visible: opacity > 0 && !Config.options.background.widgetsLocked
 
         Behavior on opacity {
-            NumberAnimation { duration: 150 }
+            NumberAnimation { duration: Appearance.animation.elementMoveFaster.duration }
         }
 
         MaterialSymbol {

--- a/modules/ii/background/widgets/resources/ResourcesWidget.qml
+++ b/modules/ii/background/widgets/resources/ResourcesWidget.qml
@@ -119,7 +119,7 @@ AbstractBackgroundWidget {
         id: toggleHandle
         width: 16
         height: 16
-        radius: 6
+        radius: Appearance.rounding.unsharpenmore
         color: Appearance.colors.colOnPrimaryContainer
         anchors {
             left: parent.right

--- a/modules/ii/background/widgets/usercard/UserCardWidget.qml
+++ b/modules/ii/background/widgets/usercard/UserCardWidget.qml
@@ -107,10 +107,10 @@ AbstractBackgroundWidget {
                     top: parent.top
                     left: parent.left
                     right: parent.right
-                    margins: 16
+                    margins: Appearance.spacing.large
                 }
                 Layout.topMargin: root.avatarSize / 2 + 4
-                spacing: 10
+                spacing: Appearance.spacing.normal
 
                 Item {
                     Layout.fillWidth: true
@@ -119,11 +119,11 @@ AbstractBackgroundWidget {
 
                 RowLayout {
                     Layout.fillWidth: true
-                    spacing: 6
+                    spacing: Appearance.spacing.small
 
                     MaterialSymbol {
                         Layout.alignment: Qt.AlignTop
-                        Layout.topMargin: 2
+                        Layout.topMargin: Appearance.spacing.unsharpen
                         iconSize: Appearance.font.pixelSize.normal
                         text: root.currentQuip.icon
                         color: Appearance.colors.colOnPrimaryContainer
@@ -142,8 +142,8 @@ AbstractBackgroundWidget {
 
                 RowLayout {
                     Layout.fillWidth: true
-                    Layout.topMargin: 4
-                    spacing: 8
+                    Layout.topMargin: Appearance.spacing.verysmall
+                    spacing: Appearance.spacing.small
 
                     Rectangle {
                         Layout.fillWidth: true
@@ -153,7 +153,7 @@ AbstractBackgroundWidget {
 
                         RowLayout {
                             anchors.centerIn: parent
-                            spacing: 4
+                            spacing: Appearance.spacing.verysmall
                             MaterialSymbol {
                                 iconSize: Appearance.font.pixelSize.normal
                                 text: "lock"
@@ -231,7 +231,7 @@ AbstractBackgroundWidget {
             Image {
                 id: avatarImage
                 anchors.fill: parent
-                anchors.margins: 3
+                anchors.margins: Appearance.spacing.verysmall
                 source: Config.options.profile.avatarPath !== ""
                     ? "file://" + Config.options.profile.avatarPicture
                     : "file:///home/" + (Quickshell.env("USER") ?? "user") + "/.face"

--- a/modules/ii/background/widgets/usercard/UserCardWidget.qml
+++ b/modules/ii/background/widgets/usercard/UserCardWidget.qml
@@ -178,7 +178,7 @@ AbstractBackgroundWidget {
                         implicitHeight: 40
                         radius: Appearance.rounding.full
                         color: "transparent"
-                        border.width: 1
+                        border.width: Appearance.borderWidth.standard
                         border.color: Appearance.colors.colOnPrimaryContainer
                         MaterialSymbol {
                             anchors.centerIn: parent
@@ -198,7 +198,7 @@ AbstractBackgroundWidget {
                         implicitHeight: 40
                         radius: Appearance.rounding.full
                         color: "transparent"
-                        border.width: 1
+                        border.width: Appearance.borderWidth.standard
                         border.color: Appearance.colors.colOnPrimaryContainer
                         MaterialSymbol {
                             anchors.centerIn: parent

--- a/modules/ii/background/widgets/usercard/UserCardWidget.qml
+++ b/modules/ii/background/widgets/usercard/UserCardWidget.qml
@@ -176,7 +176,7 @@ AbstractBackgroundWidget {
                     Rectangle {
                         implicitWidth: 40
                         implicitHeight: 40
-                        radius: 20
+                        radius: Appearance.rounding.full
                         color: "transparent"
                         border.width: 1
                         border.color: Appearance.colors.colOnPrimaryContainer
@@ -196,7 +196,7 @@ AbstractBackgroundWidget {
                     Rectangle {
                         implicitWidth: 40
                         implicitHeight: 40
-                        radius: 20
+                        radius: Appearance.rounding.full
                         color: "transparent"
                         border.width: 1
                         border.color: Appearance.colors.colOnPrimaryContainer

--- a/modules/ii/background/widgets/weather/WeatherWidget.qml
+++ b/modules/ii/background/widgets/weather/WeatherWidget.qml
@@ -86,7 +86,7 @@ AbstractBackgroundWidget {
                     text: Icons.getWeatherIcon(Weather.data.wCode) ?? "cloud"
                     iconSize: 18
                     fill: 1
-                    padding: 6
+                    padding: Appearance.spacing.small
                     implicitWidth: 34
                     implicitHeight: 34
                 }
@@ -118,11 +118,11 @@ AbstractBackgroundWidget {
                     fill: parent
                     margins: 14
                 }
-                spacing: 6
+                spacing: Appearance.spacing.small
 
                 RowLayout {
                     Layout.fillWidth: true
-                    spacing: 8
+                    spacing: Appearance.spacing.small
 
                     ColumnLayout {
                         spacing: -4
@@ -158,7 +158,7 @@ AbstractBackgroundWidget {
                         text: Icons.getWeatherIcon(Weather.data.wCode) ?? "cloud"
                         iconSize: 18
                         fill: 1
-                        padding: 6
+                        padding: Appearance.spacing.small
                         implicitWidth: 42
                         implicitHeight: 42
                     }
@@ -168,11 +168,11 @@ AbstractBackgroundWidget {
 
                 RowLayout {
                     Layout.fillWidth: true
-                    Layout.leftMargin: 2
-                    spacing: 12
+                    Layout.leftMargin: Appearance.spacing.unsharpen
+                    spacing: Appearance.spacing.normal
 
                     RowLayout {
-                        spacing: 2
+                        spacing: Appearance.spacing.unsharpen
                         MaterialSymbol {
                             iconSize: Appearance.font.pixelSize.smaller
                             text: "humidity_mid"
@@ -188,7 +188,7 @@ AbstractBackgroundWidget {
                     }
 
                     RowLayout {
-                        spacing: 2
+                        spacing: Appearance.spacing.unsharpen
                         MaterialSymbol {
                             iconSize: Appearance.font.pixelSize.smaller
                             text: "rainy"
@@ -204,7 +204,7 @@ AbstractBackgroundWidget {
                     }
 
                     RowLayout {
-                        spacing: 2
+                        spacing: Appearance.spacing.unsharpen
                         MaterialSymbol {
                             iconSize: Appearance.font.pixelSize.smaller
                             text: "air"
@@ -230,11 +230,11 @@ AbstractBackgroundWidget {
                     fill: parent
                     margins: 14
                 }
-                spacing: 8
+                spacing: Appearance.spacing.small
 
                 RowLayout {
                     Layout.fillWidth: true
-                    spacing: 12
+                    spacing: Appearance.spacing.normal
 
                     StyledText {
                         Layout.alignment: Qt.AlignTop
@@ -248,7 +248,7 @@ AbstractBackgroundWidget {
 
                     ColumnLayout {
                         Layout.alignment: Qt.AlignVCenter
-                        spacing: 2
+                        spacing: Appearance.spacing.unsharpen
 
                         StyledText {
                             text: Weather.data?.description ?? ""
@@ -277,7 +277,7 @@ AbstractBackgroundWidget {
                         text: Icons.getWeatherIcon(Weather.data.wCode) ?? "cloud"
                         iconSize: 24
                         fill: 1
-                        padding: 10
+                        padding: Appearance.spacing.normal
                         implicitWidth: 50
                         implicitHeight: 50
                     }
@@ -287,11 +287,11 @@ AbstractBackgroundWidget {
 
                 RowLayout {
                     Layout.fillWidth: true
-                    Layout.leftMargin: 5
-                    spacing: 16
+                    Layout.leftMargin: Appearance.spacing.small
+                    spacing: Appearance.spacing.large
 
                     RowLayout {
-                        spacing: 2
+                        spacing: Appearance.spacing.unsharpen
                         MaterialSymbol {
                             iconSize: Appearance.font.pixelSize.smaller
                             text: "humidity_mid"
@@ -307,7 +307,7 @@ AbstractBackgroundWidget {
                     }
 
                     RowLayout {
-                        spacing: 2
+                        spacing: Appearance.spacing.unsharpen
                         MaterialSymbol {
                             iconSize: Appearance.font.pixelSize.smaller
                             text: "rainy"
@@ -323,7 +323,7 @@ AbstractBackgroundWidget {
                     }
 
                     RowLayout {
-                        spacing: 2
+                        spacing: Appearance.spacing.unsharpen
                         MaterialSymbol {
                             iconSize: Appearance.font.pixelSize.smaller
                             text: "air"
@@ -339,7 +339,7 @@ AbstractBackgroundWidget {
                     }
 
                     RowLayout {
-                        spacing: 2
+                        spacing: Appearance.spacing.unsharpen
                         MaterialSymbol {
                             iconSize: Appearance.font.pixelSize.smaller
                             text: "visibility"
@@ -358,10 +358,10 @@ AbstractBackgroundWidget {
 
                     ColumnLayout{
                         Layout.topMargin: -5
-                        Layout.rightMargin: 5
+                        Layout.rightMargin: Appearance.spacing.small
                         spacing: 1
                         RowLayout {
-                            spacing: 4
+                            spacing: Appearance.spacing.verysmall
                             MaterialSymbol {
                                 iconSize: Appearance.font.pixelSize.smaller
                                 text: "wb_twilight"
@@ -377,7 +377,7 @@ AbstractBackgroundWidget {
                         }
 
                         RowLayout {
-                            spacing: 4
+                            spacing: Appearance.spacing.verysmall
                             MaterialSymbol {
                                 iconSize: Appearance.font.pixelSize.smaller
                                 text: "nights_stay"
@@ -405,7 +405,7 @@ AbstractBackgroundWidget {
             anchors {
                 right: card.right
                 bottom: card.bottom
-                margins: 4
+                margins: Appearance.spacing.verysmall
             }
             opacity: (root.containsMouse || resizeArea.containsMouse || resizeArea.pressed) ? 0.5 : 0
             visible: opacity > 0 && !Config.options.background.widgetsLocked

--- a/modules/ii/background/widgets/weather/WeatherWidget.qml
+++ b/modules/ii/background/widgets/weather/WeatherWidget.qml
@@ -411,7 +411,7 @@ AbstractBackgroundWidget {
             visible: opacity > 0 && !Config.options.background.widgetsLocked
 
             Behavior on opacity {
-                NumberAnimation { duration: 150 }
+                NumberAnimation { duration: Appearance.animation.elementMoveFaster.duration }
             }
 
             MouseArea {

--- a/modules/ii/background/widgets/weather/WeatherWidget.qml
+++ b/modules/ii/background/widgets/weather/WeatherWidget.qml
@@ -400,7 +400,7 @@ AbstractBackgroundWidget {
             id: resizeHandle
             width: 16
             height: 16
-            radius: 4
+            radius: Appearance.rounding.unsharpenslight
             color: Appearance.colors.colOnPrimaryContainer
             anchors {
                 right: card.right

--- a/modules/ii/background/widgets/worldclock/WorldClockWidget.qml
+++ b/modules/ii/background/widgets/worldclock/WorldClockWidget.qml
@@ -70,13 +70,13 @@ AbstractBackgroundWidget {
             // 2x2
             ColumnLayout {
                 id: mainColumn
-                anchors { fill: parent; margins: 12 }
-                spacing: 10
+                anchors { fill: parent; margins: Appearance.spacing.normal }
+                spacing: Appearance.spacing.normal
                 visible: sizeMode === "2x2" && !root.showingSettings
 
                 RowLayout {
                     Layout.fillWidth: true
-                    spacing: 4
+                    spacing: Appearance.spacing.verysmall
 
                     MaterialSymbol {
                         iconSize: Appearance.font.pixelSize.hugeass
@@ -155,8 +155,8 @@ AbstractBackgroundWidget {
                             Behavior on color { ColorAnimation { duration: 400 } }
 
                             ColumnLayout {
-                                anchors { fill: parent; margins: 8 }
-                                spacing: 2
+                                anchors { fill: parent; margins: Appearance.spacing.small }
+                                spacing: Appearance.spacing.unsharpen
                                 RowLayout {
                                     Layout.fillWidth: true
                                     StyledText {
@@ -174,7 +174,7 @@ AbstractBackgroundWidget {
                                     }
                                 }
                                 RowLayout {
-                                    Layout.fillWidth: true; spacing: 4
+                                    Layout.fillWidth: true; spacing: Appearance.spacing.verysmall
                                     StyledText {
                                         font.pixelSize: Appearance.font.pixelSize.normal
                                         font.weight: Font.Bold
@@ -200,11 +200,11 @@ AbstractBackgroundWidget {
                 visible: sizeMode === "2x2" && root.showingSettings
 
                 ColumnLayout {
-                    anchors { fill: parent; margins: 12 }
-                    spacing: 10
+                    anchors { fill: parent; margins: Appearance.spacing.normal }
+                    spacing: Appearance.spacing.normal
 
                     RowLayout {
-                        Layout.fillWidth: true; spacing: 8
+                        Layout.fillWidth: true; spacing: Appearance.spacing.small
                         Rectangle {
                             radius: Appearance.rounding.full
                             color: "transparent"
@@ -254,8 +254,8 @@ AbstractBackgroundWidget {
 
             // 4x1
             RowLayout {
-                anchors { fill: parent; margins: 8 }
-                spacing: 8
+                anchors { fill: parent; margins: Appearance.spacing.small }
+                spacing: Appearance.spacing.small
                 visible: sizeMode === "4x1"
 
                 Repeater {
@@ -302,7 +302,7 @@ AbstractBackgroundWidget {
                 id: toggleHandle
                 width: 16; height: 16; radius: Appearance.rounding.unsharpenslight
                 color: Appearance.colors.colOnPrimaryContainer
-                anchors { right: parent.right; bottom: parent.bottom; margins: 4 }
+                anchors { right: parent.right; bottom: parent.bottom; margins: Appearance.spacing.verysmall }
                 opacity: (root.containsMouse || toggleArea.containsMouse || toggleArea.pressed) ? 0.5 : 0
                 visible: opacity > 0 && !Config.options.background.widgetsLocked
 

--- a/modules/ii/background/widgets/worldclock/WorldClockWidget.qml
+++ b/modules/ii/background/widgets/worldclock/WorldClockWidget.qml
@@ -48,14 +48,14 @@ AbstractBackgroundWidget {
             id: flipAnim
             NumberAnimation {
                 target: flipScale; property: "xScale"
-                to: 0; duration: 150; easing.type: Easing.InQuad
+                to: 0; duration: Appearance.animation.elementMoveFaster.duration; easing.type: Easing.InQuad
             }
             ScriptAction {
                 script: root.showingSettings = !root.showingSettings
             }
             NumberAnimation {
                 target: flipScale; property: "xScale"
-                to: 1; duration: 150; easing.type: Easing.OutQuad
+                to: 1; duration: Appearance.animation.elementMoveFaster.duration; easing.type: Easing.OutQuad
             }
         }
 
@@ -306,7 +306,7 @@ AbstractBackgroundWidget {
                 opacity: (root.containsMouse || toggleArea.containsMouse || toggleArea.pressed) ? 0.5 : 0
                 visible: opacity > 0 && !Config.options.background.widgetsLocked
 
-                Behavior on opacity { NumberAnimation { duration: 150 } }
+                Behavior on opacity { NumberAnimation { duration: Appearance.animation.elementMoveFaster.duration } }
 
                 MaterialSymbol {
                     anchors.centerIn: parent

--- a/modules/ii/background/widgets/worldclock/WorldClockWidget.qml
+++ b/modules/ii/background/widgets/worldclock/WorldClockWidget.qml
@@ -300,7 +300,7 @@ AbstractBackgroundWidget {
 
             Rectangle {
                 id: toggleHandle
-                width: 16; height: 16; radius: 4
+                width: 16; height: 16; radius: Appearance.rounding.unsharpenslight
                 color: Appearance.colors.colOnPrimaryContainer
                 anchors { right: parent.right; bottom: parent.bottom; margins: 4 }
                 opacity: (root.containsMouse || toggleArea.containsMouse || toggleArea.pressed) ? 0.5 : 0

--- a/modules/ii/bar/ActiveWindow.qml
+++ b/modules/ii/bar/ActiveWindow.qml
@@ -68,7 +68,7 @@ Item {
         anchors.verticalCenter: parent.verticalCenter
         anchors.left: parent.left
         anchors.right: parent.right
-        anchors.leftMargin: 3
+        anchors.leftMargin: Appearance.spacing.verysmall
         spacing: -4
 
         StyledText {

--- a/modules/ii/bar/BarContent.qml
+++ b/modules/ii/bar/BarContent.qml
@@ -129,7 +129,7 @@ Item {
                 RowLayout {
                     id: leftMaterialRow
                     anchors.centerIn: parent
-                    spacing: 3
+                    spacing: Appearance.spacing.verysmall
 
                     Repeater {
                         model: root.effectiveLeftLayout
@@ -222,7 +222,7 @@ Item {
                 RowLayout {
                     id: centerMaterialRow
                     anchors.centerIn: parent
-                    spacing: 3
+                    spacing: Appearance.spacing.verysmall
 
                     Repeater {
                         model: root.effectiveMiddleLayout
@@ -315,7 +315,7 @@ Item {
                 RowLayout {
                     id: rightMaterialRow
                     anchors.centerIn: parent
-                    spacing: 3
+                    spacing: Appearance.spacing.verysmall
 
                     Repeater {
                         model: root.effectiveRightLayout

--- a/modules/ii/bar/BatteryIndicator.qml
+++ b/modules/ii/bar/BatteryIndicator.qml
@@ -41,7 +41,7 @@ MouseArea {
                     spacing: 0
                     MaterialSymbol {
                         Layout.alignment: Qt.AlignVCenter
-                        Layout.topMargin: 2
+                        Layout.topMargin: Appearance.spacing.unsharpen
                         Layout.leftMargin: -2
                         Layout.rightMargin: -2
                         fill: 1
@@ -51,7 +51,7 @@ MouseArea {
                     }
                     StyledText {
                         Layout.alignment: Qt.AlignVCenter
-                        Layout.topMargin: 2
+                        Layout.topMargin: Appearance.spacing.unsharpen
                         font: batteryProgress.font
                         text: batteryProgress.text
                     }
@@ -70,7 +70,7 @@ MouseArea {
                         Layout.alignment: Qt.AlignHCenter
                         fill: 1
                         text: "bolt"
-                        Layout.topMargin: 4
+                        Layout.topMargin: Appearance.spacing.verysmall
                         iconSize: Appearance.font.pixelSize.smaller
                         visible: root.isCharging && root.percentage < 1
                     }

--- a/modules/ii/bar/BatteryPopup.qml
+++ b/modules/ii/bar/BatteryPopup.qml
@@ -19,11 +19,11 @@ StyledPopup {
         || Battery.energyRate <= 0.01)
 
     ColumnLayout {
-        spacing: 10
+        spacing: Appearance.spacing.normal
 
         RowLayout {
             Layout.fillWidth: true
-            Layout.leftMargin: 3
+            Layout.leftMargin: Appearance.spacing.verysmall
             spacing: 7
 
             MaterialShapeWrappedMaterialSymbol {
@@ -65,7 +65,7 @@ StyledPopup {
             Item { Layout.fillWidth: true }
 
             StyledText {
-                Layout.rightMargin: 8
+                Layout.rightMargin: Appearance.spacing.small
                 font.pixelSize: Appearance.font.pixelSize.huge
                 font.weight: Font.Bold
                 color: Appearance.colors.colPrimary
@@ -75,7 +75,7 @@ StyledPopup {
 
         RowLayout {
             Layout.fillWidth: true
-            spacing: 6
+            spacing: Appearance.spacing.small
 
             ResourceCard {
                 label: Translation.tr("Health")

--- a/modules/ii/bar/ClockWidget.qml
+++ b/modules/ii/bar/ClockWidget.qml
@@ -51,7 +51,7 @@ BarWidgetSwitcher {
 
             StyledText {
                 Layout.alignment: Qt.AlignHCenter
-                Layout.bottomMargin: 5
+                Layout.bottomMargin: Appearance.spacing.small
                 font.pixelSize: Appearance.font.pixelSize.smallest
                 color: Appearance.colors.colOnLayer1
                 text: DateTime.shortDate
@@ -62,12 +62,12 @@ BarWidgetSwitcher {
     colMaterial: Component {
         ColumnLayout {
             id: clockWidget
-            spacing: 2
+            spacing: Appearance.spacing.unsharpen
             Layout.alignment: Qt.AlignHCenter
 
             Column {
                 Layout.alignment: Qt.AlignHCenter
-                Layout.topMargin: 2
+                Layout.topMargin: Appearance.spacing.unsharpen
                 spacing: -4
 
                 Repeater {
@@ -107,7 +107,7 @@ BarWidgetSwitcher {
 
     rowDefault: Component {
         RowLayout {
-            spacing: 4
+            spacing: Appearance.spacing.verysmall
             StyledText {
                 visible: root.showDate
                 font.pixelSize: Appearance.font.pixelSize.small
@@ -132,7 +132,7 @@ BarWidgetSwitcher {
 
     rowMaterial: Component {
         RowLayout {
-            spacing: 4
+            spacing: Appearance.spacing.verysmall
             id: pill
 
             property var timeParts: DateTime.time.split(/[: ]/)
@@ -146,7 +146,7 @@ BarWidgetSwitcher {
                 color: Appearance.colors.colOnPrimaryContainer
                 text: DateTime.longDate
                 Layout.alignment: Qt.AlignVCenter
-                leftPadding: 5
+                leftPadding: Appearance.spacing.small
             }
 
             Rectangle {

--- a/modules/ii/bar/ClockWidgetPopup.qml
+++ b/modules/ii/bar/ClockWidgetPopup.qml
@@ -15,7 +15,7 @@ StyledPopup {
     }
 
     ColumnLayout {
-        spacing: 8
+        spacing: Appearance.spacing.small
         width: 340
 
         Row {
@@ -37,7 +37,7 @@ StyledPopup {
 
         RowLayout {
             width: parent.width
-            spacing: 4
+            spacing: Appearance.spacing.verysmall
 
             Repeater {
                 model: 7
@@ -67,7 +67,7 @@ StyledPopup {
 
                     ColumnLayout {
                         anchors.centerIn: parent
-                        spacing: 2
+                        spacing: Appearance.spacing.unsharpen
 
                         StyledText {
                             Layout.alignment: Qt.AlignHCenter
@@ -97,10 +97,10 @@ StyledPopup {
 
         Row {
             width: parent.width
-            spacing: 6
+            spacing: Appearance.spacing.small
 
             Column {
-                spacing: 2
+                spacing: Appearance.spacing.unsharpen
                 anchors.verticalCenter: parent.verticalCenter
 
                 MaterialShapeWrappedMaterialSymbol {
@@ -123,7 +123,7 @@ StyledPopup {
 
             Column {
                 width: parent.width - 36 - 6
-                spacing: 2
+                spacing: Appearance.spacing.unsharpen
 
                 Repeater {
                     id: todoRepeater
@@ -150,10 +150,10 @@ StyledPopup {
                         StyledText {
                             anchors {
                                 left: parent.left
-                                leftMargin: 10
+                                leftMargin: Appearance.spacing.normal
                                 verticalCenter: parent.verticalCenter
                                 right: parent.right
-                                rightMargin: 10
+                                rightMargin: Appearance.spacing.normal
                             }
                             text: `    ${todo.content} `
                             font.pixelSize: Appearance.font.pixelSize.smaller
@@ -187,7 +187,7 @@ StyledPopup {
 
             RowLayout {
                 anchors.centerIn: parent
-                spacing: 6
+                spacing: Appearance.spacing.small
 
                 MaterialSymbol {
                     text: "timelapse"

--- a/modules/ii/bar/DocktoPanel.qml
+++ b/modules/ii/bar/DocktoPanel.qml
@@ -161,7 +161,7 @@ Item {
 
                             Flow {
                                 flow: root.vertical ? Flow.TopToBottom : Flow.LeftToRight
-                                spacing: 2
+                                spacing: Appearance.spacing.unsharpen
                                 anchors {
                                     left:   root.vertical ? pinnedIcon.right    : undefined
                                     top:    root.vertical ? undefined            : pinnedIcon.bottom
@@ -321,7 +321,7 @@ Item {
 
                             Flow {
                                 flow: root.vertical ? Flow.TopToBottom : Flow.LeftToRight
-                                spacing: 2
+                                spacing: Appearance.spacing.unsharpen
                                 anchors {
                                     left:   root.vertical ? activeIcon.right    : undefined
                                     top:    root.vertical ? undefined            : activeIcon.bottom

--- a/modules/ii/bar/HyprlandXkbIndicator.qml
+++ b/modules/ii/bar/HyprlandXkbIndicator.qml
@@ -21,7 +21,7 @@ Loader {
         RowLayout {
             id: rowLayout
             anchors.centerIn: parent
-            spacing: 5
+            spacing: Appearance.spacing.small
 
             StyledText {
                 id: layoutCodeText

--- a/modules/ii/bar/Media.qml
+++ b/modules/ii/bar/Media.qml
@@ -156,10 +156,10 @@ Item {
         visible: active
         anchors.fill: parent
         sourceComponent: RowLayout {
-            spacing: 4
+            spacing: Appearance.spacing.verysmall
             ClippedFilledCircularProgress {
                 Layout.alignment: Qt.AlignVCenter
-                Layout.leftMargin: 3
+                Layout.leftMargin: Appearance.spacing.verysmall
                 implicitSize: 20
                 lineWidth: Appearance.rounding.unsharpen
                 value: root.activePlayer?.position / root.activePlayer?.length
@@ -200,7 +200,7 @@ Item {
         sourceComponent: RowLayout {
             id: innerRow
             anchors.centerIn: parent
-            spacing: 6
+            spacing: Appearance.spacing.small
 
             // No platyer 
             Loader {
@@ -208,7 +208,7 @@ Item {
                 visible: active
                 Layout.alignment: Qt.AlignVCenter
                 sourceComponent: RowLayout {
-                    spacing: 6
+                    spacing: Appearance.spacing.small
 
                     // Avatar
                     Rectangle {
@@ -255,7 +255,7 @@ Item {
                     ColumnLayout {
                         spacing: -3
                         Layout.alignment: Qt.AlignVCenter
-                        Layout.topMargin: 2
+                        Layout.topMargin: Appearance.spacing.unsharpen
 
                         StyledText {
                             text: SystemInfo.username
@@ -271,7 +271,7 @@ Item {
                             color: Appearance.colors.colOnSecondaryContainer
                             opacity: 0.7
                             elide: Text.ElideRight
-                            Layout.rightMargin: 8
+                            Layout.rightMargin: Appearance.spacing.small
                             Layout.maximumWidth: 120
                             text: SystemInfo.distroName
                         }
@@ -285,7 +285,7 @@ Item {
                 visible: active
                 Layout.alignment: Qt.AlignVCenter
                 sourceComponent: RowLayout {
-                    spacing: 6
+                    spacing: Appearance.spacing.small
 
                     // Art
                     Rectangle {
@@ -330,7 +330,7 @@ Item {
                     ColumnLayout {
                         spacing: -4
                         Layout.alignment: Qt.AlignVCenter
-                        Layout.topMargin: 2
+                        Layout.topMargin: Appearance.spacing.unsharpen
 
                         StyledText {
                             id: artistText

--- a/modules/ii/bar/Media.qml
+++ b/modules/ii/bar/Media.qml
@@ -341,9 +341,9 @@ Item {
                             Layout.maximumWidth: 120
                             Behavior on text {
                                 SequentialAnimation {
-                                    NumberAnimation { target: artistText; property: "x"; to: -artistText.width; duration: 150; easing.type: Easing.InQuad }
+                                    NumberAnimation { target: artistText; property: "x"; to: -artistText.width; duration: Appearance.animation.elementMoveFaster.duration; easing.type: Easing.InQuad }
                                     PropertyAction { target: artistText; property: "text" }
-                                    NumberAnimation { target: artistText; property: "x"; from: artistText.width; to: 0; duration: 150; easing.type: Easing.OutQuad }
+                                    NumberAnimation { target: artistText; property: "x"; from: artistText.width; to: 0; duration: Appearance.animation.elementMoveFaster.duration; easing.type: Easing.OutQuad }
                                 }
                             }
                         }
@@ -358,9 +358,9 @@ Item {
                             Layout.maximumWidth: 120
                             Behavior on text {
                                 SequentialAnimation {
-                                    NumberAnimation { target: titleText; property: "x"; to: -artistText.width; duration: 150; easing.type: Easing.InQuad }
+                                    NumberAnimation { target: titleText; property: "x"; to: -artistText.width; duration: Appearance.animation.elementMoveFaster.duration; easing.type: Easing.InQuad }
                                     PropertyAction { target: titleText; property: "text" }
-                                    NumberAnimation { target: titleText; property: "x"; from: artistText.width; to: 0; duration: 150; easing.type: Easing.OutQuad }
+                                    NumberAnimation { target: titleText; property: "x"; from: artistText.width; to: 0; duration: Appearance.animation.elementMoveFaster.duration; easing.type: Easing.OutQuad }
                                 }
                             }
                         }

--- a/modules/ii/bar/PowerButton.qml
+++ b/modules/ii/bar/PowerButton.qml
@@ -38,6 +38,6 @@ RippleButton {
         color: Appearance.colors.colOnPrimary
         colSymbol: Appearance.colors.colPrimary
         wrappedShape: MaterialShape.Shape.Cookie12Sided
-        padding: 2
+        padding: Appearance.spacing.unsharpen
     }
 }

--- a/modules/ii/bar/Resource.qml
+++ b/modules/ii/bar/Resource.qml
@@ -79,7 +79,7 @@ Item {
     RowLayout {
         id: resourceRowLayout
         visible: !root.vertical
-        spacing: 2
+        spacing: Appearance.spacing.unsharpen
         x: shown ? 0 : -resourceRowLayout.width
         anchors.verticalCenter: parent.verticalCenter
 

--- a/modules/ii/bar/ResourcesPopup.qml
+++ b/modules/ii/bar/ResourcesPopup.qml
@@ -12,10 +12,10 @@ StyledPopup {
     }
 
     Row {
-        spacing: 5
+        spacing: Appearance.spacing.small
 
         Column {
-            spacing: 5
+            spacing: Appearance.spacing.small
 
             ResourceCard {
                 label: "RAM"
@@ -38,7 +38,7 @@ StyledPopup {
         }
 
         Column {
-            spacing: 5
+            spacing: Appearance.spacing.small
 
             ResourceCard {
                 label: "Swap"
@@ -58,7 +58,7 @@ StyledPopup {
         }
 
         Column {
-            spacing: 5
+            spacing: Appearance.spacing.small
 
             ResourceCard {
                 label: "GPU"

--- a/modules/ii/bar/StyledPopupHeaderRow.qml
+++ b/modules/ii/bar/StyledPopupHeaderRow.qml
@@ -7,7 +7,7 @@ Row {
     id: root
     required property var icon
     required property var label
-    spacing: 5
+    spacing: Appearance.spacing.small
 
     MaterialSymbol {
         anchors.verticalCenter: parent.verticalCenter

--- a/modules/ii/bar/StyledPopupValueRow.qml
+++ b/modules/ii/bar/StyledPopupValueRow.qml
@@ -8,7 +8,7 @@ RowLayout {
     required property string icon
     required property string label
     required property string value
-    spacing: 4
+    spacing: Appearance.spacing.verysmall
 
     MaterialSymbol {
         text: root.icon

--- a/modules/ii/bar/SysTray.qml
+++ b/modules/ii/bar/SysTray.qml
@@ -136,8 +136,8 @@ Item {
                 Layout.alignment: Qt.AlignVCenter | Qt.AlignHCenter
                 Layout.fillHeight: !root.vertical
                 Layout.fillWidth: root.vertical
-                Layout.leftMargin:  6
-                Layout.rightMargin: 6
+                Layout.leftMargin: Appearance.spacing.small
+                Layout.rightMargin: Appearance.spacing.small
                 onMenuClosed: root.releaseFocus()
                 onMenuOpened: (qsWindow) => root.setExtraWindowAndGrabFocus(qsWindow)
             }

--- a/modules/ii/bar/SysTrayMenu.qml
+++ b/modules/ii/bar/SysTrayMenu.qml
@@ -62,7 +62,7 @@ PopupWindow {
 
         Rectangle {
             id: popupBackground
-            readonly property real padding: 4
+            readonly property real padding: Appearance.spacing.verysmall
             anchors {
                 left: parent.left
                 right: parent.right
@@ -164,7 +164,7 @@ PopupWindow {
                         leftMargin: backButton.horizontalPadding
                         rightMargin: backButton.horizontalPadding
                     }
-                    spacing: 8
+                    spacing: Appearance.spacing.small
                     MaterialSymbol {
                         iconSize: 20
                         text: "chevron_left"
@@ -197,7 +197,7 @@ PopupWindow {
                     leftMargin: pinEntry.horizontalPadding
                     rightMargin: pinEntry.horizontalPadding
                 }
-                spacing: 8
+                spacing: Appearance.spacing.small
 
                 MaterialSymbol {
                     iconSize: 18
@@ -215,8 +215,8 @@ PopupWindow {
             Layout.fillWidth: true
             implicitHeight: 1
             color: Appearance.colors.colSubtext
-            Layout.topMargin: 4
-            Layout.bottomMargin: 4
+            Layout.topMargin: Appearance.spacing.verysmall
+            Layout.bottomMargin: Appearance.spacing.verysmall
         }
 
         Repeater {

--- a/modules/ii/bar/SysTrayMenu.qml
+++ b/modules/ii/bar/SysTrayMenu.qml
@@ -74,7 +74,7 @@ PopupWindow {
 
             color: Appearance.colors.colLayer0
             radius: Appearance.rounding.windowRounding
-            border.width: 1
+            border.width: Appearance.borderWidth.standard
             border.color: Appearance.colors.colLayer0Border
             clip: true
 

--- a/modules/ii/bar/SysTrayMenuEntry.qml
+++ b/modules/ii/bar/SysTrayMenuEntry.qml
@@ -58,7 +58,7 @@ RippleButton {
             leftMargin: root.horizontalPadding
             rightMargin: root.horizontalPadding
         }
-        spacing: 8
+        spacing: Appearance.spacing.small
         visible: !root.menuEntry.isSeparator
 
         // Interaction: checkbox or radio button

--- a/modules/ii/bar/UpdatesCount.qml
+++ b/modules/ii/bar/UpdatesCount.qml
@@ -75,8 +75,8 @@ MouseArea {
     Component {
         id: textComp
         StyledText {
-            leftPadding: 5
-            rightPadding: 3
+            leftPadding: Appearance.spacing.small
+            rightPadding: Appearance.spacing.verysmall
             font.pixelSize: Appearance.font.pixelSize.small
             color: root.isMaterial ? Appearance.colors.colPrimary : Appearance.colors.colOnLayer1
             text: Updates.count
@@ -86,8 +86,8 @@ MouseArea {
     Component {
         id: spinnerComp
         MaterialSymbol {
-            leftPadding: 5
-            rightPadding: 3
+            leftPadding: Appearance.spacing.small
+            rightPadding: Appearance.spacing.verysmall
             text: "progress_activity"
             iconSize: Appearance.font.pixelSize.normal
             color: root.isMaterial ? Appearance.colors.colPrimary : Appearance.colors.colOnLayer1
@@ -109,7 +109,7 @@ MouseArea {
     Component {
         id: rowContent
         RowLayout {
-            spacing: 4
+            spacing: Appearance.spacing.verysmall
 
             // Default
             MaterialSymbol {
@@ -150,7 +150,7 @@ MouseArea {
     Component {
         id: colContent
         ColumnLayout {
-            spacing: 4
+            spacing: Appearance.spacing.verysmall
 
             MaterialSymbol {
                 visible: !root.isMaterial

--- a/modules/ii/bar/UtilButtons.qml
+++ b/modules/ii/bar/UtilButtons.qml
@@ -131,7 +131,7 @@ Item {
                 Revealer {
                     id: timerRevealer
                     anchors.left: btn.right
-                    anchors.leftMargin: 8
+                    anchors.leftMargin: Appearance.spacing.small
                     anchors.verticalCenter: btn.verticalCenter
                     reveal: recordingItem.isRecording && !root.vertical
 
@@ -142,7 +142,7 @@ Item {
                         font.features: { "tnum": 1 }
                         font.letterSpacing: -0.3
                         color: Appearance.colors.colOnLayer2
-                        rightPadding: 8
+                        rightPadding: Appearance.spacing.small
                         Component.onCompleted: width = implicitWidth
                     }
                 }

--- a/modules/ii/bar/UtilButtons.qml
+++ b/modules/ii/bar/UtilButtons.qml
@@ -115,8 +115,8 @@ Item {
                     buttonRadius: recordingItem.isRecording ? Appearance.rounding.normal : implicitHeight / 2
                     onClicked: Quickshell.execDetached([Directories.recordScriptPath])
 
-                    Behavior on colBackground { ColorAnimation { duration: 200 } }
-                    Behavior on buttonRadius { NumberAnimation { duration: 200; easing.type: Easing.OutCubic } }
+                    Behavior on colBackground { ColorAnimation { duration: Appearance.animation.elementMoveFast.duration } }
+                    Behavior on buttonRadius { NumberAnimation { duration: Appearance.animation.elementMoveFast.duration; easing.type: Easing.OutCubic } }
 
                     MaterialSymbol {
                         horizontalAlignment: Qt.AlignHCenter
@@ -124,7 +124,7 @@ Item {
                         text: recordingItem.isRecording ? "stop_circle" : "screen_record"
                         iconSize: Appearance.font.pixelSize.large
                         color: recordingItem.isRecording ? Appearance.colors.colPrimary : Appearance.colors.colOnLayer2
-                        Behavior on color { ColorAnimation { duration: 200 } }
+                        Behavior on color { ColorAnimation { duration: Appearance.animation.elementMoveFast.duration } }
                     }
                 }
 

--- a/modules/ii/bar/WeatherBar.qml
+++ b/modules/ii/bar/WeatherBar.qml
@@ -39,7 +39,7 @@ MouseArea {
     Component {
         id: rowContent
         RowLayout {
-            spacing: 6
+            spacing: Appearance.spacing.small
 
             MaterialSymbol {
                 visible: !root.isMaterial
@@ -64,7 +64,7 @@ MouseArea {
                 color: Appearance.colors.colPrimary
                 text: Weather.data?.temp ?? "--°"
                 Layout.alignment: Qt.AlignVCenter
-                leftPadding: 5
+                leftPadding: Appearance.spacing.small
             }
 
             Rectangle {
@@ -113,7 +113,7 @@ MouseArea {
                 color: Appearance.colors.colPrimary
                 text: (Weather.data?.temp ?? "--°").replace(/[CF]$/, "")
                 Layout.alignment: Qt.AlignHCenter
-                Layout.topMargin: 3
+                Layout.topMargin: Appearance.spacing.verysmall
             }
 
             Rectangle {

--- a/modules/ii/bar/WeatherCard.qml
+++ b/modules/ii/bar/WeatherCard.qml
@@ -20,7 +20,7 @@ Rectangle {
         id: columnLayout
         anchors {
             fill: parent
-            margins: 10
+            margins: Appearance.spacing.normal
         }
         spacing: -4
 

--- a/modules/ii/bar/WeatherPopup.qml
+++ b/modules/ii/bar/WeatherPopup.qml
@@ -11,7 +11,7 @@ StyledPopup {
     ColumnLayout {
         id: mainLayout
         implicitWidth: 340 
-        spacing: 8
+        spacing: Appearance.spacing.small
 
         Layout.topMargin: -8
         Layout.leftMargin: -8
@@ -33,7 +33,7 @@ StyledPopup {
 
             Item {
                 anchors.fill: parent
-                anchors.margins: 16 
+                anchors.margins: Appearance.spacing.large 
 
                 ColumnLayout {
                     anchors.left: parent.left
@@ -60,7 +60,7 @@ StyledPopup {
                     anchors.left: parent.left
                     anchors.bottom: parent.bottom
                     anchors.bottomMargin: -8
-                    spacing: 4
+                    spacing: Appearance.spacing.verysmall
 
                     StyledText {
                         text: Weather.data?.temp ?? "3"
@@ -85,12 +85,12 @@ StyledPopup {
                 ColumnLayout {
                     anchors.right: parent.right
                     anchors.bottom: parent.bottom
-                    anchors.rightMargin: 6
+                    anchors.rightMargin: Appearance.spacing.small
                     anchors.bottomMargin: -1
                     spacing: -2
 
                     RowLayout {
-                        spacing: 4
+                        spacing: Appearance.spacing.verysmall
                         Layout.alignment: Qt.AlignRight
                         MaterialSymbol {
                             text: "wb_twilight"
@@ -106,7 +106,7 @@ StyledPopup {
                     }
 
                     RowLayout {
-                        spacing: 4
+                        spacing: Appearance.spacing.verysmall
                         Layout.alignment: Qt.AlignRight
                         MaterialSymbol {
                             text: "bedtime"
@@ -131,9 +131,9 @@ StyledPopup {
             columnSpacing: 4
             uniformCellWidths: true
             
-            Layout.leftMargin: 2
-            Layout.rightMargin: 2
-            Layout.bottomMargin: 2
+            Layout.leftMargin: Appearance.spacing.unsharpen
+            Layout.rightMargin: Appearance.spacing.unsharpen
+            Layout.bottomMargin: Appearance.spacing.unsharpen
             Layout.fillWidth: true
 
             WeatherCard {

--- a/modules/ii/bar/WeatherPopup.qml
+++ b/modules/ii/bar/WeatherPopup.qml
@@ -33,7 +33,7 @@ StyledPopup {
 
             Item {
                 anchors.fill: parent
-                anchors.margins: Appearance.spacing.large 
+                anchors.margins: Appearance.spacing.large
 
                 ColumnLayout {
                     anchors.left: parent.left

--- a/modules/ii/desktopMenu/DesktopMenu.qml
+++ b/modules/ii/desktopMenu/DesktopMenu.qml
@@ -134,8 +134,8 @@ Scope {
 
                 ColumnLayout {
                     id: menuCol
-                    anchors { fill: parent; margins: 8 }
-                    spacing: 4
+                    anchors { fill: parent; margins: Appearance.spacing.small }
+                    spacing: Appearance.spacing.verysmall
 
                     Rectangle {
                         Layout.fillWidth: true
@@ -146,7 +146,7 @@ Scope {
 
                         Carousel {
                             anchors.fill: parent
-                            anchors.margins: 10
+                            anchors.margins: Appearance.spacing.normal
                             model: root.carouselModel
                             onWallpaperSelected: (path) => {
                                 Wallpapers.select(path, Appearance.m3colors.darkmode)
@@ -166,8 +166,8 @@ Scope {
                             colBackground: "transparent"
                             colBackgroundHover: Appearance.colors.colLayer2
                             contentItem: RowLayout {
-                                anchors { fill: parent; leftMargin: 12; rightMargin: 12 }
-                                spacing: 12
+                                anchors { fill: parent; leftMargin: Appearance.spacing.normal; rightMargin: Appearance.spacing.normal }
+                                spacing: Appearance.spacing.normal
                                 MaterialSymbol { text: "format_paint"; iconSize: Appearance.font.pixelSize.larger; color: Appearance.colors.colOnLayer1 }
                                 StyledText { Layout.fillWidth: true; text: "Wallpaper & style"; font.pixelSize: Appearance.font.pixelSize.normal; color: Appearance.colors.colOnLayer1 }
                                 MaterialSymbol { text: "chevron_right"; iconSize: Appearance.font.pixelSize.normal; color: Appearance.colors.colOnLayer1; opacity: 0.4 }
@@ -197,8 +197,8 @@ Scope {
                             colBackground: "transparent"
                             colBackgroundHover: Appearance.colors.colLayer2
                             contentItem: RowLayout {
-                                anchors { fill: parent; leftMargin: 12; rightMargin: 12 }
-                                spacing: 12
+                                anchors { fill: parent; leftMargin: Appearance.spacing.normal; rightMargin: Appearance.spacing.normal }
+                                spacing: Appearance.spacing.normal
                                 MaterialSymbol { text: "widgets"; iconSize: Appearance.font.pixelSize.larger; color: Appearance.colors.colOnLayer1 }
                                 StyledText { Layout.fillWidth: true; text: "Widgets"; font.pixelSize: Appearance.font.pixelSize.normal; color: Appearance.colors.colOnLayer1 }
                                 MaterialSymbol { text: "chevron_right"; iconSize: Appearance.font.pixelSize.normal; color: Appearance.colors.colOnLayer1; opacity: 0.4 }
@@ -227,8 +227,8 @@ Scope {
                             colBackground: "transparent"
                             colBackgroundHover: Appearance.colors.colLayer2
                             contentItem: RowLayout {
-                                anchors { fill: parent; leftMargin: 12; rightMargin: 12 }
-                                spacing: 12
+                                anchors { fill: parent; leftMargin: Appearance.spacing.normal; rightMargin: Appearance.spacing.normal }
+                                spacing: Appearance.spacing.normal
                                 MaterialSymbol { text: "settings"; iconSize: Appearance.font.pixelSize.larger; color: Appearance.colors.colOnLayer1 }
                                 StyledText { Layout.fillWidth: true; text: "Settings"; font.pixelSize: Appearance.font.pixelSize.normal; color: Appearance.colors.colOnLayer1 }
                                 MaterialSymbol { text: "chevron_right"; iconSize: Appearance.font.pixelSize.normal; color: Appearance.colors.colOnLayer1; opacity: 0.4 }

--- a/modules/ii/dock/Dock.qml
+++ b/modules/ii/dock/Dock.qml
@@ -119,11 +119,11 @@ Scope {
                             anchors.top: parent.top
                             anchors.bottom: parent.bottom
                             anchors.horizontalCenter: parent.horizontalCenter
-                            spacing: 3
-                            property real padding: 5
+                            spacing: Appearance.spacing.verysmall
+                            property real padding: Appearance.spacing.small
 
                             VerticalButtonGroup {
-                                Layout.topMargin: 3
+                                Layout.topMargin: Appearance.spacing.verysmall
                                 Layout.leftMargin:  root.pinned
                                     ? Appearance.sizes.hyprlandGapsOut + 4
                                     : Appearance.sizes.hyprlandGapsOut
@@ -202,7 +202,7 @@ Scope {
                                         visible: Config.options.dock.showMedia
                                         Layout.fillHeight: true
                                         Layout.topMargin: 11
-                                        Layout.bottomMargin: 6
+                                        Layout.bottomMargin: Appearance.spacing.small
                                         Layout.leftMargin: 0
                                         buttonPadding: dockRow.padding
                                     }

--- a/modules/ii/dock/DockMedia.qml
+++ b/modules/ii/dock/DockMedia.qml
@@ -145,7 +145,7 @@ Item {
             width:  card.width
             height: card.height
             clip:   true
-            spacing: 8
+            spacing: Appearance.spacing.small
             z: 3
 
             // Art
@@ -208,9 +208,9 @@ Item {
 
             // Buttons
             RowLayout {
-                Layout.rightMargin: 4
+                Layout.rightMargin: Appearance.spacing.verysmall
                 Layout.alignment:   Qt.AlignVCenter
-                spacing: 3
+                spacing: Appearance.spacing.verysmall
 
                 // Play / Pause
                 RippleButton {

--- a/modules/ii/lock/LockSurface.qml
+++ b/modules/ii/lock/LockSurface.qml
@@ -116,7 +116,7 @@ MouseArea {
         anchors {
             horizontalCenter: parent.horizontalCenter
             bottom: parent.bottom
-            bottomMargin: 20
+            bottomMargin: Appearance.spacing.verylarge
         }
         Behavior on anchors.bottomMargin {
             animation: Appearance.animation.elementMove.numberAnimation.createObject(this)
@@ -127,8 +127,8 @@ MouseArea {
 
         // Fingerprint
         Loader {
-            Layout.leftMargin: 10
-            Layout.rightMargin: 6
+            Layout.leftMargin: Appearance.spacing.normal
+            Layout.rightMargin: Appearance.spacing.small
             Layout.alignment: Qt.AlignVCenter
             active: root.context.fingerprintsConfigured
             visible: active
@@ -249,14 +249,14 @@ MouseArea {
             right: mainIsland.left
             top: mainIsland.top
             bottom: mainIsland.bottom
-            rightMargin: 10
+            rightMargin: Appearance.spacing.normal
         }
         scale: root.toolbarScale
         opacity: root.toolbarOpacity
 
         // Username
         IconAndTextPair {
-            Layout.leftMargin: 8
+            Layout.leftMargin: Appearance.spacing.small
             icon: "account_circle"
             visible: !Config.options.lock.showMedia || MprisController.activePlayer === null
             text: SystemInfo.username
@@ -264,8 +264,8 @@ MouseArea {
 
         // Media player info 
         Loader {
-            Layout.leftMargin: 2
-            Layout.rightMargin: 2
+            Layout.leftMargin: Appearance.spacing.unsharpen
+            Layout.rightMargin: Appearance.spacing.unsharpen
             Layout.alignment: Qt.AlignVCenter
             active: MprisController.activePlayer !== null
             visible: active && Config.options.lock.showMedia
@@ -286,7 +286,7 @@ MouseArea {
                 
                 RowLayout {
                     id: mediaRow
-                    spacing: 8
+                    spacing: Appearance.spacing.small
                     anchors.centerIn: parent
                     
                     Rectangle {
@@ -391,12 +391,12 @@ MouseArea {
 
         // Keyboard layout (Xkb)
         Loader {
-            Layout.rightMargin: 8
+            Layout.rightMargin: Appearance.spacing.small
             Layout.fillHeight: true
             visible: !Config.options.lock.showMedia || MprisController.activePlayer === null
 
             sourceComponent: Row {
-                spacing: 8
+                spacing: Appearance.spacing.small
 
                 MaterialSymbol {
                     id: keyboardIcon
@@ -419,7 +419,7 @@ MouseArea {
 
         // Keyboard layout (Fcitx)
         Bar.SysTray {
-            Layout.rightMargin: 10
+            Layout.rightMargin: Appearance.spacing.normal
             Layout.alignment: Qt.AlignVCenter
             showSeparator: false
             showOverflowMenu: false
@@ -435,7 +435,7 @@ MouseArea {
             left: mainIsland.right
             top: mainIsland.top
             bottom: mainIsland.bottom
-            leftMargin: 10
+            leftMargin: Appearance.spacing.normal
         }
 
         scale: root.toolbarScale
@@ -493,10 +493,10 @@ MouseArea {
         required property string text
         property color color: Appearance.colors.colOnSurfaceVariant
 
-        spacing: 4
+        spacing: Appearance.spacing.verysmall
         Layout.fillHeight: true
-        Layout.leftMargin: 10
-        Layout.rightMargin: 10
+        Layout.leftMargin: Appearance.spacing.normal
+        Layout.rightMargin: Appearance.spacing.normal
         
 
         MaterialSymbol {

--- a/modules/ii/mediaControls/MediaControls.qml
+++ b/modules/ii/mediaControls/MediaControls.qml
@@ -204,7 +204,7 @@ Scope {
                         anchors.centerIn: parent
                         color: Appearance.colors.colLayer0
                         radius: root.popupRounding
-                        property real padding: 20
+                        property real padding: Appearance.spacing.verylarge
                         implicitWidth: placeholderLayout.implicitWidth + padding * 2
                         implicitHeight: placeholderLayout.implicitHeight + padding * 2
 

--- a/modules/ii/notificationPopup/NotificationPopup.qml
+++ b/modules/ii/notificationPopup/NotificationPopup.qml
@@ -39,8 +39,8 @@ Scope {
                 top: parent.top
                 bottom: parent.bottom
                 right: parent.right
-                rightMargin: 4
-                topMargin: 4
+                rightMargin: Appearance.spacing.verysmall
+                topMargin: Appearance.spacing.verysmall
             }
             implicitWidth: parent.width - Appearance.sizes.elevationMargin * 2
             popup: true

--- a/modules/ii/onScreenDisplay/OnScreenDisplay.qml
+++ b/modules/ii/onScreenDisplay/OnScreenDisplay.qml
@@ -209,7 +209,7 @@ Scope {
                                 id: protectionMessageBackground
                                 anchors.centerIn: parent
                                 color: Appearance.m3colors.m3error
-                                property real padding: 10
+                                property real padding: Appearance.spacing.normal
                                 implicitHeight: protectionMessageRowLayout.implicitHeight + padding * 2
                                 implicitWidth: protectionMessageRowLayout.implicitWidth + padding * 2
                                 radius: Appearance.rounding.normal

--- a/modules/ii/onScreenDisplay/OsdTextIndicator.qml
+++ b/modules/ii/onScreenDisplay/OsdTextIndicator.qml
@@ -29,7 +29,7 @@ Item {
         RowLayout {
             id: contentRow
             anchors.centerIn: parent
-            spacing: 10
+            spacing: Appearance.spacing.normal
 
             MaterialSymbol {
                 Layout.alignment: Qt.AlignVCenter

--- a/modules/ii/onScreenDisplay/OsdValueIndicator.qml
+++ b/modules/ii/onScreenDisplay/OsdValueIndicator.qml
@@ -33,9 +33,9 @@ Item {
 
         RowLayout { 
             id: valueRow
-            Layout.margins: 10
+            Layout.margins: Appearance.spacing.normal
             anchors.fill: parent
-            spacing: 10
+            spacing: Appearance.spacing.normal
 
             StyledSlider {
                 id: valueProgressBar
@@ -52,7 +52,7 @@ Item {
                     anchors {
                         verticalCenter: valueProgressBar.verticalCenter
                         left: handlePassed ? valueProgressBar.left : valueProgressBar.handle.left
-                        leftMargin: 5
+                        leftMargin: Appearance.spacing.small
                     }
                     color: handlePassed ? Appearance.colors.colOnPrimary : Appearance.colors.colOnLayer0
                     renderType: Text.QtRendering

--- a/modules/ii/onScreenKeyboard/OnScreenKeyboard.qml
+++ b/modules/ii/onScreenKeyboard/OnScreenKeyboard.qml
@@ -74,7 +74,7 @@ Scope { // Scope
                 anchors.centerIn: parent
                 color: Appearance.colors.colLayer0
                 radius: Appearance.rounding.windowRounding
-                property real padding: 10
+                property real padding: Appearance.spacing.normal
                 implicitWidth: oskRowLayout.implicitWidth + padding * 2
                 implicitHeight: oskRowLayout.implicitHeight + padding * 2
 
@@ -87,7 +87,7 @@ Scope { // Scope
                 RowLayout {
                     id: oskRowLayout
                     anchors.centerIn: parent
-                    spacing: 5
+                    spacing: Appearance.spacing.small
                     VerticalButtonGroup {
                         OskControlButton { // Pin button
                             toggled: root.pinned
@@ -111,8 +111,8 @@ Scope { // Scope
                         }
                     }
                     Rectangle {
-                        Layout.topMargin: 20
-                        Layout.bottomMargin: 20
+                        Layout.topMargin: Appearance.spacing.verylarge
+                        Layout.bottomMargin: Appearance.spacing.verylarge
                         Layout.fillHeight: true
                         implicitWidth: 1
                         color: Appearance.colors.colOutlineVariant

--- a/modules/ii/onScreenKeyboard/OskContent.qml
+++ b/modules/ii/onScreenKeyboard/OskContent.qml
@@ -17,7 +17,7 @@ Item {
     ColumnLayout {
         id: keyRows
         anchors.fill: parent
-        spacing: 5
+        spacing: Appearance.spacing.small
 
         Repeater {
             model: root.currentLayout.keys
@@ -25,7 +25,7 @@ Item {
             delegate: RowLayout {
                 id: keyRow
                 required property var modelData
-                spacing: 5
+                spacing: Appearance.spacing.small
                 
                 Repeater {
                     model: modelData

--- a/modules/ii/overlay/OverlayTaskbar.qml
+++ b/modules/ii/overlay/OverlayTaskbar.qml
@@ -20,7 +20,7 @@ Rectangle {
     color: Appearance.m3colors.m3surfaceContainer
     radius: Appearance.rounding.large
     border.color: Appearance.colors.colOutlineVariant
-    border.width: 1
+    border.width: Appearance.borderWidth.standard
 
     Behavior on opacity {
         animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)

--- a/modules/ii/overlay/OverlayTaskbar.qml
+++ b/modules/ii/overlay/OverlayTaskbar.qml
@@ -12,7 +12,7 @@ import qs.modules.common.widgets.widgetCanvas
 Rectangle {
     id: root
 
-    property real padding: 8
+    property real padding: Appearance.spacing.small
 
     opacity: GlobalStates.overlayOpen ? 1 : 0
     implicitWidth: contentRow.implicitWidth + (padding * 2)
@@ -32,10 +32,10 @@ Rectangle {
             fill: parent
             margins: root.padding
         }
-        spacing: 6
+        spacing: Appearance.spacing.small
 
         Row {
-            spacing: 4
+            spacing: Appearance.spacing.verysmall
             Repeater {
                 model: ScriptModel {
                     values: OverlayContext.availableWidgets
@@ -62,14 +62,14 @@ Rectangle {
         implicitWidth: 1
         color: Appearance.colors.colOutlineVariant
         Layout.fillHeight: true
-        Layout.topMargin: 10
-        Layout.bottomMargin: 10
+        Layout.topMargin: Appearance.spacing.normal
+        Layout.bottomMargin: Appearance.spacing.normal
     }
 
     component TimeWidget: StyledText {
         Layout.alignment: Qt.AlignVCenter
-        Layout.leftMargin: 8
-        Layout.rightMargin: 6
+        Layout.leftMargin: Appearance.spacing.small
+        Layout.rightMargin: Appearance.spacing.small
 
         text: DateTime.time
         color: Appearance.colors.colOnSurface
@@ -83,9 +83,9 @@ Rectangle {
     component BatteryWidget: Row {
         id: batteryWidget
         Layout.alignment: Qt.AlignVCenter
-        Layout.leftMargin: 6
-        Layout.rightMargin: 6
-        spacing: 2
+        Layout.leftMargin: Appearance.spacing.small
+        Layout.rightMargin: Appearance.spacing.small
+        spacing: Appearance.spacing.unsharpen
         property color colText: Battery.isLowAndNotCharging ? Appearance.colors.colError : Appearance.colors.colOnSurface
 
         MaterialSymbol {

--- a/modules/ii/overlay/StyledOverlayWidget.qml
+++ b/modules/ii/overlay/StyledOverlayWidget.qml
@@ -36,7 +36,7 @@ AbstractOverlayWidget {
     property real minimumWidth: contentItem.implicitWidth
     property real minimumHeight: contentItem.implicitHeight
     property real resizeMargin: 8
-    property real padding: 6
+    property real padding: Appearance.spacing.small
     property real contentRadius: radius - padding
 
     // Resizing
@@ -236,14 +236,14 @@ AbstractOverlayWidget {
                         fill: parent
                         margins: root.padding
                     }
-                    spacing: 2
+                    spacing: Appearance.spacing.unsharpen
 
                     MaterialSymbol {
                         text: root.materialSymbol
-                        Layout.leftMargin: 6
+                        Layout.leftMargin: Appearance.spacing.small
                         iconSize: 20
                         Layout.alignment: Qt.AlignVCenter
-                        Layout.rightMargin: 4
+                        Layout.rightMargin: Appearance.spacing.verysmall
                     }
                     
                     StyledText {

--- a/modules/ii/overlay/StyledOverlayWidget.qml
+++ b/modules/ii/overlay/StyledOverlayWidget.qml
@@ -202,7 +202,7 @@ AbstractOverlayWidget {
         color: ColorUtils.transparentize(Appearance.colors.colLayer1Base, (root.fancyBorders && GlobalStates.overlayOpen) ? 0 : 1)
         radius: root.radius
         border.color: ColorUtils.transparentize(Appearance.colors.colOutlineVariant, GlobalStates.overlayOpen ? 0 : 1)
-        border.width: 1
+        border.width: Appearance.borderWidth.standard
 
         layer.enabled: GlobalStates.overlayOpen
         layer.effect: OpacityMask {

--- a/modules/ii/overlay/crosshair/CrosshairContent.qml
+++ b/modules/ii/overlay/crosshair/CrosshairContent.qml
@@ -48,7 +48,7 @@ Item {
     property string colorCode: "#FFFFFF"
     property bool outline: true
     property real outlineOpacity: 0.5
-    property int outlineThickness: 1
+    property int outlineThickness: Appearance.borderWidth.standard
     property bool centerDot: false
     property real centerDotOpacity: 1
     property int centerDotSize: 2

--- a/modules/ii/overlay/fpsLimiter/FpsLimiterContent.qml
+++ b/modules/ii/overlay/fpsLimiter/FpsLimiterContent.qml
@@ -13,7 +13,7 @@ OverlayBackground {
 
     enum State { Normal, Success, Error }
 
-    property real padding: 16
+    property real padding: Appearance.spacing.large
     property var currentState: FpsLimiterContent.State.Normal
     implicitWidth: content.implicitWidth + (padding * 2)
     implicitHeight: content.implicitHeight + (padding * 2)
@@ -64,7 +64,7 @@ OverlayBackground {
     RowLayout {
         id: content
         anchors.centerIn: parent
-        spacing: 4
+        spacing: Appearance.spacing.verysmall
 
         ToolbarTextField {
             id: fpsField

--- a/modules/ii/overlay/notes/NotesContent.qml
+++ b/modules/ii/overlay/notes/NotesContent.qml
@@ -202,7 +202,7 @@ OverlayBackground {
                         buttonRadius: height / 2
                         y: modelData.y
                         anchors.right: parent.right
-                        anchors.rightMargin: 10
+                        anchors.rightMargin: Appearance.spacing.normal
                         z: 5
 
                         Timer {
@@ -237,7 +237,7 @@ OverlayBackground {
         StyledText {
             id: statusLabel
             Layout.fillWidth: true
-            Layout.margins: 16
+            Layout.margins: Appearance.spacing.large
             horizontalAlignment: Text.AlignRight
             text: saveDebounce.running ? Translation.tr("Saving...") : Translation.tr("Saved    ")
             color: Appearance.colors.colSubtext

--- a/modules/ii/overlay/recorder/Recorder.qml
+++ b/modules/ii/overlay/recorder/Recorder.qml
@@ -16,15 +16,15 @@ StyledOverlayWidget {
     contentItem: OverlayBackground {
         id: contentItem
         radius: root.contentRadius
-        property real padding: 8
+        property real padding: Appearance.spacing.small
         ColumnLayout {
             id: contentColumn
             anchors.centerIn: parent
-            spacing: 10
+            spacing: Appearance.spacing.normal
 
             Row {
                 Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
-                spacing: 10
+                spacing: Appearance.spacing.normal
 
                 BigRecorderButton {
                     materialSymbol: "screenshot_region"
@@ -76,7 +76,7 @@ StyledOverlayWidget {
                 }
                 contentItem: Row {
                     anchors.centerIn: parent
-                    spacing: 6
+                    spacing: Appearance.spacing.small
                     MaterialSymbol {
                         anchors.verticalCenter: parent.verticalCenter
                         text: "animated_images"

--- a/modules/ii/overlay/resources/Resources.qml
+++ b/modules/ii/overlay/resources/Resources.qml
@@ -39,14 +39,14 @@ StyledOverlayWidget {
     contentItem: OverlayBackground {
         id: contentItem
         radius: root.contentRadius
-        property real padding: 4
+        property real padding: Appearance.spacing.verysmall
         ColumnLayout {
             id: contentColumn
             anchors {
                 fill: parent
                 margins: parent.padding
             }
-            spacing: 8
+            spacing: Appearance.spacing.small
 
             SecondaryTabBar {
                 id: tabBar
@@ -68,7 +68,7 @@ StyledOverlayWidget {
             }
 
             ResourceSummary {
-                Layout.margins: 8
+                Layout.margins: Appearance.spacing.small
                 history: root.resources[tabBar.currentIndex]?.history ?? []
                 maxAvailableString: root.resources[tabBar.currentIndex]?.maxAvailableString ?? "--"
             }
@@ -81,10 +81,10 @@ StyledOverlayWidget {
         required property string maxAvailableString
         Layout.fillWidth: true
         Layout.fillHeight: true
-        spacing: 12
+        spacing: Appearance.spacing.normal
 
         ColumnLayout {
-            spacing: 2
+            spacing: Appearance.spacing.unsharpen
             StyledText {
                 text: (resourceSummary.history[resourceSummary.history.length - 1] * 100).toFixed(1) + "%"
                 font {

--- a/modules/ii/overlay/volumeMixer/VolumeMixer.qml
+++ b/modules/ii/overlay/volumeMixer/VolumeMixer.qml
@@ -15,7 +15,7 @@ StyledOverlayWidget {
 
     contentItem: OverlayBackground {
         radius: root.contentRadius
-        property real padding: 6
+        property real padding: Appearance.spacing.small
 
         ColumnLayout {
             id: contentColumn
@@ -23,7 +23,7 @@ StyledOverlayWidget {
                 fill: parent
                 margins: parent.padding
             }
-            spacing: 8
+            spacing: Appearance.spacing.small
 
             SecondaryTabBar {
                 id: tabBar
@@ -65,7 +65,7 @@ StyledOverlayWidget {
     component PaddedVolumeDialogContent: Item {
         id: paddedVolumeDialogContent
         property alias isSink: volDialogContent.isSink
-        property real padding: 12
+        property real padding: Appearance.spacing.normal
         implicitWidth: volDialogContent.implicitWidth + padding * 2
         implicitHeight: volDialogContent.implicitHeight + padding * 2
 

--- a/modules/ii/overview/NiriOverview.qml
+++ b/modules/ii/overview/NiriOverview.qml
@@ -237,7 +237,7 @@ Item {
             anchors.fill: parent
             color: ColorUtils.transparentize(Appearance.colors.colSecondary, 0.6)
             radius: Appearance.rounding.normal
-            border.width: 2
+            border.width: Appearance.borderWidth.emphasis
             border.color: Appearance.colors.colSecondary
         }
     }
@@ -360,7 +360,7 @@ Item {
                         height: root.getWinH(rowItem.activeWin, rowItem.wsFitScale)
                         radius: Appearance.rounding.normal
                         color: "transparent"
-                        border.width: 2
+                        border.width: Appearance.borderWidth.emphasis
                         border.color: Appearance.colors.colSecondary
                         z: 10
                         Behavior on x { NumberAnimation { duration: Appearance.animation.elementMoveFast.duration } }
@@ -375,7 +375,7 @@ Item {
                         anchors.fill: parent
                         radius: Appearance.rounding.normal
                         color: ColorUtils.transparentize(Appearance.colors.colSecondary, 0.88)
-                        border.width: 2
+                        border.width: Appearance.borderWidth.emphasis
                         border.color: Appearance.colors.colSecondary
                         z: 0
                     }

--- a/modules/ii/overview/NiriOverview.qml
+++ b/modules/ii/overview/NiriOverview.qml
@@ -400,7 +400,7 @@ Item {
                             z: 1
 
                             opacity: isBeingDragged ? 0.15 : 1.0
-                            Behavior on opacity { NumberAnimation { duration: 150 } }
+                            Behavior on opacity { NumberAnimation { duration: Appearance.animation.elementMoveFaster.duration } }
                             Behavior on x {
                                 enabled: !isBeingDragged
                                 NumberAnimation { duration: Appearance.animation.elementMoveFast.duration }

--- a/modules/ii/overview/OverviewWidget.qml
+++ b/modules/ii/overview/OverviewWidget.qml
@@ -119,7 +119,7 @@ Item {
                             topRightRadius: (workspaceAtRight && workspaceAtTop) ? root.largeWorkspaceRadius : root.smallWorkspaceRadius
                             bottomLeftRadius: (workspaceAtLeft && workspaceAtBottom) ? root.largeWorkspaceRadius : root.smallWorkspaceRadius
                             bottomRightRadius: (workspaceAtRight && workspaceAtBottom) ? root.largeWorkspaceRadius : root.smallWorkspaceRadius
-                            border.width: 2
+                            border.width: Appearance.borderWidth.emphasis
                             border.color: hoveredWhileDragging ? hoveredBorderColor : "transparent"
 
                             StyledText {
@@ -318,7 +318,7 @@ Item {
                 topRightRadius: (workspaceAtRight && workspaceAtTop) ? root.largeWorkspaceRadius : root.smallWorkspaceRadius
                 bottomLeftRadius: (workspaceAtLeft && workspaceAtBottom) ? root.largeWorkspaceRadius : root.smallWorkspaceRadius
                 bottomRightRadius: (workspaceAtRight && workspaceAtBottom) ? root.largeWorkspaceRadius : root.smallWorkspaceRadius
-                border.width: 2
+                border.width: Appearance.borderWidth.emphasis
                 border.color: root.activeBorderColor
                 Behavior on x {
                     animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)

--- a/modules/ii/overview/OverviewWidget.qml
+++ b/modules/ii/overview/OverviewWidget.qml
@@ -73,7 +73,7 @@ Item {
     }
     Rectangle { // Background
         id: overviewBackground
-        property real padding: 10
+        property real padding: Appearance.spacing.normal
         anchors.fill: parent
         anchors.margins: Appearance.sizes.elevationMargin
 

--- a/modules/ii/overview/OverviewWindow.qml
+++ b/modules/ii/overview/OverviewWindow.qml
@@ -106,7 +106,7 @@ Item { // Window
                 hovered ? ColorUtils.transparentize(Appearance.colors.colLayer2Hover, 0.7) : 
                 ColorUtils.transparentize(Appearance.colors.colLayer2)
             border.color : ColorUtils.transparentize(Appearance.m3colors.m3outline, 0.88)
-            border.width : 1
+            border.width: Appearance.borderWidth.standard
         }
 
         Image {

--- a/modules/ii/overview/SearchBar.qml
+++ b/modules/ii/overview/SearchBar.qml
@@ -10,7 +10,7 @@ import qs.modules.common.functions
 
 RowLayout {
     id: root
-    spacing: 6
+    spacing: Appearance.spacing.small
     property bool animateWidth: false
     property alias searchInput: searchInput
     property string searchingText
@@ -66,8 +66,8 @@ RowLayout {
     }
     ToolbarTextField { // Search box
         id: searchInput
-        Layout.topMargin: 4
-        Layout.bottomMargin: 4
+        Layout.topMargin: Appearance.spacing.verysmall
+        Layout.bottomMargin: Appearance.spacing.verysmall
         implicitHeight: 40
         focus: GlobalStates.overviewOpen
         font.pixelSize: Appearance.font.pixelSize.small
@@ -108,8 +108,8 @@ RowLayout {
     }
 
     IconToolbarButton {
-        Layout.topMargin: 4
-        Layout.bottomMargin: 4
+        Layout.topMargin: Appearance.spacing.verysmall
+        Layout.bottomMargin: Appearance.spacing.verysmall
         onClicked: {
             GlobalStates.overviewOpen = false;
             Quickshell.execDetached(["qs", "-p", Quickshell.shellPath(""), "ipc", "call", "region", "search"]);
@@ -122,9 +122,9 @@ RowLayout {
 
     IconToolbarButton {
         id: songRecButton
-        Layout.topMargin: 4
-        Layout.bottomMargin: 4
-        Layout.rightMargin: 4
+        Layout.topMargin: Appearance.spacing.verysmall
+        Layout.bottomMargin: Appearance.spacing.verysmall
+        Layout.rightMargin: Appearance.spacing.verysmall
         toggled: SongRec.running
         onClicked: SongRec.toggleRunning()
         text: "music_cast"

--- a/modules/ii/overview/SearchItem.qml
+++ b/modules/ii/overview/SearchItem.qml
@@ -265,7 +265,7 @@ RippleButton {
             Layout.alignment: Qt.AlignTop
             Layout.topMargin: root.buttonVerticalPadding
             Layout.bottomMargin: -root.buttonVerticalPadding // Why is this necessary? Good question.
-            spacing: 4
+            spacing: Appearance.spacing.verysmall
             Repeater {
                 model: (root.entry.actions ?? []).slice(0, 4)
                 delegate: RippleButton {

--- a/modules/ii/overview/SearchWidget.qml
+++ b/modules/ii/overview/SearchWidget.qml
@@ -141,8 +141,8 @@ Item { // Wrapper
                 id: searchBar
                 property real verticalPadding: 4
                 Layout.fillWidth: true
-                Layout.leftMargin: 10
-                Layout.rightMargin: 4
+                Layout.leftMargin: Appearance.spacing.normal
+                Layout.rightMargin: Appearance.spacing.verysmall
                 Layout.topMargin: verticalPadding
                 Layout.bottomMargin: verticalPadding
                 Synchronizer on searchingText {
@@ -164,9 +164,9 @@ Item { // Wrapper
                 Layout.fillWidth: true
                 implicitHeight: Math.min(600, appResults.contentHeight + topMargin + bottomMargin)
                 clip: true
-                topMargin: 10
-                bottomMargin: 10
-                spacing: 2
+                topMargin: Appearance.spacing.normal
+                bottomMargin: Appearance.spacing.normal
+                spacing: Appearance.spacing.unsharpen
                 KeyNavigation.up: searchBar
                 highlightMoveDuration: 100
 

--- a/modules/ii/polkit/PolkitContent.qml
+++ b/modules/ii/polkit/PolkitContent.qml
@@ -86,7 +86,7 @@ Item {
         }
 
         WindowDialogButtonRow {
-            Layout.bottomMargin: 10 // I honestly don't know why this is necessary
+            Layout.bottomMargin: Appearance.spacing.normal // I honestly don't know why this is necessary
             Item {
                 Layout.fillWidth: true
             }

--- a/modules/ii/regionSelector/CursorGuide.qml
+++ b/modules/ii/regionSelector/CursorGuide.qml
@@ -52,7 +52,7 @@ Item {
         descTimeout.restart()
     }
 
-    property int margins: 8
+    property int margins: Appearance.spacing.small
     implicitWidth: content.implicitWidth + margins * 2
     implicitHeight: content.implicitHeight + margins * 2
 
@@ -60,7 +60,7 @@ Item {
         id: content
         anchors.centerIn: parent
 
-        property real padding: 8
+        property real padding: Appearance.spacing.small
         implicitHeight: 38
         implicitWidth: root.showDescription ? contentRow.implicitWidth + padding * 2 : implicitHeight
         clip: true
@@ -86,7 +86,7 @@ Item {
                 left: parent.left
                 leftMargin: content.padding
             }
-            spacing: 12
+            spacing: Appearance.spacing.normal
 
             MaterialSymbol {
                 anchors.verticalCenter: parent.verticalCenter
@@ -104,7 +104,7 @@ Item {
                     color: Appearance.colors.colOnPrimary
                     text: root.description
                     anchors.right: parent.right
-                    anchors.rightMargin: 6
+                    anchors.rightMargin: Appearance.spacing.small
                 }
             }
         }

--- a/modules/ii/regionSelector/RectCornersSelectionDetails.qml
+++ b/modules/ii/regionSelector/RectCornersSelectionDetails.qml
@@ -68,7 +68,7 @@ Item {
         anchors {
             top: selectionBorder.bottom
             right: selectionBorder.right
-            margins: 8
+            margins: Appearance.spacing.small
         }
         color: root.color
         text: `${Math.round(root.regionWidth)} x ${Math.round(root.regionHeight)}`

--- a/modules/ii/regionSelector/RegionSelection.qml
+++ b/modules/ii/regionSelector/RegionSelection.qml
@@ -523,7 +523,7 @@ PanelWindow {
             Behavior on anchors.bottomMargin {
                 animation: Appearance.animation.elementMove.numberAnimation.createObject(this)
             }
-            spacing: 6
+            spacing: Appearance.spacing.small
 
             OptionsToolbar {
                 Synchronizer on action {

--- a/modules/ii/regionSelector/TargetRegion.qml
+++ b/modules/ii/regionSelector/TargetRegion.qml
@@ -22,7 +22,7 @@ Rectangle {
     z: 2
     color: fillColor
     border.color: borderColor
-    border.width: targeted ? 4 : 2
+    border.width: targeted ? 4 : Appearance.borderWidth.emphasis
     radius: Appearance.rounding.unsharpenslight
 
     Behavior on color {
@@ -52,7 +52,7 @@ Rectangle {
             property real horizontalPadding: 10
             radius: 10
             color: root.colBackground
-            border.width: 1
+            border.width: Appearance.borderWidth.standard
             border.color: Appearance.m3colors.m3outlineVariant
             implicitWidth: regionInfoRow.implicitWidth + horizontalPadding * 2
             implicitHeight: regionInfoRow.implicitHeight + verticalPadding * 2

--- a/modules/ii/regionSelector/TargetRegion.qml
+++ b/modules/ii/regionSelector/TargetRegion.qml
@@ -60,7 +60,7 @@ Rectangle {
             Row {
                 id: regionInfoRow
                 anchors.centerIn: parent
-                spacing: 4
+                spacing: Appearance.spacing.verysmall
 
                 Loader {
                     id: regionIconLoader

--- a/modules/ii/regionSelector/TargetRegion.qml
+++ b/modules/ii/regionSelector/TargetRegion.qml
@@ -23,7 +23,7 @@ Rectangle {
     color: fillColor
     border.color: borderColor
     border.width: targeted ? 4 : 2
-    radius: 4
+    radius: Appearance.rounding.unsharpenslight
 
     Behavior on color {
         animation: Appearance.animation.elementMoveFast.colorAnimation.createObject(this)

--- a/modules/ii/screenTranslator/ScreenTextOverlay.qml
+++ b/modules/ii/screenTranslator/ScreenTextOverlay.qml
@@ -72,7 +72,7 @@ Item {
         Column {
             visible: !root.error
             anchors.centerIn: parent
-            spacing: 10 * root.scaleFactor
+            spacing: Appearance.spacing.normal * root.scaleFactor
             MaterialLoadingIndicator {
                 anchors.horizontalCenter: parent.horizontalCenter
                 implicitSize: 100 * root.scaleFactor
@@ -103,13 +103,13 @@ Item {
         Column {
             visible: root.error
             anchors.centerIn: parent
-            spacing: 10 * root.scaleFactor
+            spacing: Appearance.spacing.normal * root.scaleFactor
 
             MaterialShapeWrappedMaterialSymbol {
                 anchors.horizontalCenter: parent.horizontalCenter
                 text: "exclamation"
                 iconSize: 80 * root.scaleFactor
-                padding: 6 * root.scaleFactor
+                padding: Appearance.spacing.small * root.scaleFactor
                 color: Appearance.colors.colError
                 colSymbol: Appearance.colors.colOnError
                 shape: MaterialShape.Shape.Sunny

--- a/modules/ii/screenTranslator/ScreenTextOverlay.qml
+++ b/modules/ii/screenTranslator/ScreenTextOverlay.qml
@@ -278,7 +278,7 @@ Item {
         y: unscaledY * scaleFactor
         width: unscaledWidth * scaleFactor
         height: unscaledHeight * scaleFactor
-        radius: 4
+        radius: Appearance.rounding.unsharpenslight
     }
 
     component TextItem: VisionBoundingBoxRect {

--- a/modules/ii/screenTranslator/ScreenTranslatorPanel.qml
+++ b/modules/ii/screenTranslator/ScreenTranslatorPanel.qml
@@ -149,7 +149,7 @@ PanelWindow {
             anchors.bottomMargin = 8;
         }
 
-        spacing: 6
+        spacing: Appearance.spacing.small
 
         Toolbar {
             id: toolbar
@@ -181,7 +181,7 @@ PanelWindow {
 
                 RowLayout {
                     anchors.left: parent.left
-                    spacing: 6
+                    spacing: Appearance.spacing.small
                     Item {} // extra padding
                     ToolbarTextField {
                         id: keyInput

--- a/modules/ii/sessionScreen/SessionScreen.qml
+++ b/modules/ii/sessionScreen/SessionScreen.qml
@@ -67,7 +67,7 @@ Scope {
             ColumnLayout { // Content column
                 id: contentColumn
                 anchors.centerIn: parent
-                spacing: 15
+                spacing: Appearance.spacing.large
 
                 Keys.onPressed: event => {
                     if (event.key === Qt.Key_Escape) {
@@ -241,10 +241,10 @@ Scope {
             ColumnLayout {
                 anchors {
                     top: contentColumn.bottom
-                    topMargin: 10
+                    topMargin: Appearance.spacing.normal
                     horizontalCenter: contentColumn.horizontalCenter
                 }
-                spacing: 10
+                spacing: Appearance.spacing.normal
 
                 Loader {
                     Layout.alignment: Qt.AlignHCenter

--- a/modules/ii/settings/Settings.qml
+++ b/modules/ii/settings/Settings.qml
@@ -93,7 +93,7 @@ Scope {
             width: Math.min(parent.width - 80, 980)
             height: Math.min(parent.height - 80, 665)
             color: Appearance.colors.colLayer0
-            border.width: 1
+            border.width: Appearance.borderWidth.standard
             border.color: Appearance.colors.colLayer0Border
             radius: Appearance.rounding.screenRounding - Appearance.sizes.hyprlandGapsOut + 5
             z: 1

--- a/modules/ii/settings/Settings.qml
+++ b/modules/ii/settings/Settings.qml
@@ -78,7 +78,7 @@ Scope {
             opacity: GlobalStates.settingsOpen ? 1 : 0
             z: 0
             Behavior on opacity {
-                NumberAnimation { duration: 200; easing.type: Easing.OutCubic }
+                NumberAnimation { duration: Appearance.animation.elementMoveFast.duration; easing.type: Easing.OutCubic }
             }
             MouseArea {
                 anchors.fill: parent
@@ -102,10 +102,10 @@ Scope {
             scale: GlobalStates.settingsOpen ? 1 : 0.95
 
             Behavior on opacity {
-                NumberAnimation { duration: 200; easing.type: Easing.OutCubic }
+                NumberAnimation { duration: Appearance.animation.elementMoveFast.duration; easing.type: Easing.OutCubic }
             }
             Behavior on scale {
-                NumberAnimation { duration: 200; easing.type: Easing.OutCubic }
+                NumberAnimation { duration: Appearance.animation.elementMoveFast.duration; easing.type: Easing.OutCubic }
             }
 
             Keys.onPressed: (event) => {

--- a/modules/ii/settings/SettingsContent.qml
+++ b/modules/ii/settings/SettingsContent.qml
@@ -104,16 +104,16 @@ Item {
 
                 NavigationRail {
                     id: navRail
-                    anchors { left: parent.left; top: parent.top; bottom: parent.bottom; leftMargin: 20 }
-                    spacing: 10
+                    anchors { left: parent.left; top: parent.top; bottom: parent.bottom; leftMargin: Appearance.spacing.verylarge }
+                    spacing: Appearance.spacing.normal
                     expanded: root.width > 900
 
                     RowLayout {
                         visible: navRail.expanded
-                        spacing: 10
+                        spacing: Appearance.spacing.normal
                         Layout.fillWidth: true
-                        Layout.margins: 5
-                        Layout.topMargin: 15
+                        Layout.margins: Appearance.spacing.small
+                        Layout.topMargin: Appearance.spacing.large
 
                         Rectangle {
                             id: avatarRect
@@ -155,7 +155,7 @@ Item {
                         }
 
                         ColumnLayout {
-                            spacing: 2
+                            spacing: Appearance.spacing.unsharpen
                             Layout.fillWidth: true
 
                             StyledText {

--- a/modules/ii/settings/SettingsContent.qml
+++ b/modules/ii/settings/SettingsContent.qml
@@ -294,10 +294,10 @@ Item {
                             }
 
                             Behavior on opacity {
-                                NumberAnimation { duration: 200; easing.type: Easing.OutCubic }
+                                NumberAnimation { duration: Appearance.animation.elementMoveFast.duration; easing.type: Easing.OutCubic }
                             }
                             Behavior on anchors.topMargin {
-                                NumberAnimation { duration: 200; easing.type: Easing.OutCubic }
+                                NumberAnimation { duration: Appearance.animation.elementMoveFast.duration; easing.type: Easing.OutCubic }
                             }
                         }
                     }
@@ -323,10 +323,10 @@ Item {
                         }
 
                         Behavior on opacity {
-                            NumberAnimation { duration: 200; easing.type: Easing.OutCubic }
+                            NumberAnimation { duration: Appearance.animation.elementMoveFast.duration; easing.type: Easing.OutCubic }
                         }
                         Behavior on anchors.topMargin {
-                            NumberAnimation { duration: 200; easing.type: Easing.OutCubic }
+                            NumberAnimation { duration: Appearance.animation.elementMoveFast.duration; easing.type: Easing.OutCubic }
                         }
                     }
                 }

--- a/modules/ii/settings/pages/About.qml
+++ b/modules/ii/settings/pages/About.qml
@@ -35,7 +35,7 @@ ContentPage {
         Layout.fillWidth: true
         Layout.alignment: Qt.AlignHCenter
         Layout.topMargin: 50
-        spacing: 16
+        spacing: Appearance.spacing.large
 
         IconImage {
             implicitWidth: 134
@@ -45,7 +45,7 @@ ContentPage {
 
         ColumnLayout {
             Layout.fillWidth: true
-            spacing: 4
+            spacing: Appearance.spacing.verysmall
 
             StyledText {
                 text: SystemInfo.distroName
@@ -96,11 +96,11 @@ ContentPage {
 
     ColumnLayout {
         Layout.fillWidth: true
-        spacing: 8
+        spacing: Appearance.spacing.small
 
         RowLayout {
             Layout.fillWidth: true
-            spacing: 8
+            spacing: Appearance.spacing.small
 
             AboutCard {
                 icon: "planner_review"
@@ -168,7 +168,7 @@ ContentPage {
     }
 
     RowLayout {
-        spacing: 8
+        spacing: Appearance.spacing.small
         Layout.alignment: Qt.AlignRight
 
         RippleButton {
@@ -183,8 +183,8 @@ ContentPage {
             contentItem: StyledText {
                 text: parent.buttonText
                 horizontalAlignment: Text.AlignHCenter
-                leftPadding: 10
-                rightPadding: 10
+                leftPadding: Appearance.spacing.normal
+                rightPadding: Appearance.spacing.normal
             }
         }
 
@@ -199,8 +199,8 @@ ContentPage {
             contentItem: StyledText {
                 text: parent.buttonText
                 horizontalAlignment: Text.AlignHCenter
-                leftPadding: 10
-                rightPadding: 10
+                leftPadding: Appearance.spacing.normal
+                rightPadding: Appearance.spacing.normal
             }
         }
     }

--- a/modules/ii/settings/pages/About.qml
+++ b/modules/ii/settings/pages/About.qml
@@ -85,7 +85,7 @@ ContentPage {
                             radius: width / 2
                             color: modelData
                             z: index
-                            border.width: 2
+                            border.width: Appearance.borderWidth.emphasis
                             border.color: Appearance.colors.colLayer1
                         }
                     }

--- a/modules/ii/settings/pages/BackgroundConfig.qml
+++ b/modules/ii/settings/pages/BackgroundConfig.qml
@@ -40,7 +40,7 @@ ContentPage {
         id: mainLayout 
         Layout.fillWidth: true   
         Layout.fillHeight: true
-        spacing: 20
+        spacing: Appearance.spacing.verylarge
             
         ContentSection {
             icon: "panorama"
@@ -157,7 +157,7 @@ ContentPage {
                     }
                 }
                 GroupedList {
-                    Layout.topMargin: 10
+                    Layout.topMargin: Appearance.spacing.normal
                     visible: Config.options.background.centeredWallpaper
                     ColorSelectionArray {
                         visible: Config.options.background.centeredWallpaper
@@ -373,7 +373,7 @@ ContentPage {
                     }
                 }
                 GroupedList {
-                    Layout.topMargin: 10
+                    Layout.topMargin: Appearance.spacing.normal
                     ConfigSlider {
                         text: Translation.tr("Font weight")
                         value: Config.options.background.widgets.clock.digital.font.weight
@@ -501,7 +501,7 @@ ContentPage {
             }
 
             GroupedList {
-                Layout.topMargin: 10
+                Layout.topMargin: Appearance.spacing.normal
                 visible: settingsClock.cookiePresent
                 ConfigSelectionArray {
                     text: "Dial Style"
@@ -755,7 +755,7 @@ ContentPage {
             ContentSubsection {
                 title: Translation.tr("Show widgets on")
                 visible: Hyprland.monitors.values.length > 1
-                Layout.bottomMargin: 10
+                Layout.bottomMargin: Appearance.spacing.normal
 
                 WidgetsMonitorSelector {
                     configEntry: Config.options.background
@@ -822,7 +822,7 @@ ContentPage {
                                 top: parent.top
                                 left: parent.left
                                 right: parent.right
-                                margins: 12
+                                margins: Appearance.spacing.normal
                             }
                             spacing: 0
                             RowLayout {
@@ -872,7 +872,7 @@ ContentPage {
             }
             ContentSubsection {
                 title: Translation.tr("Canvas")
-                Layout.bottomMargin: 10
+                Layout.bottomMargin: Appearance.spacing.normal
 
                 GroupedList {
                     ConfigSwitch {

--- a/modules/ii/settings/pages/BackgroundConfig.qml
+++ b/modules/ii/settings/pages/BackgroundConfig.qml
@@ -815,7 +815,7 @@ ContentPage {
                         Layout.preferredHeight: 105
                         radius: Appearance.rounding.normal
                         color: Appearance.colors.colLayer1
-                        border.width: 1
+                        border.width: Appearance.borderWidth.standard
                         border.color: Appearance.colors.colLayer0Border
                         ColumnLayout {
                             anchors {

--- a/modules/ii/settings/pages/BarConfig.qml
+++ b/modules/ii/settings/pages/BarConfig.qml
@@ -77,7 +77,7 @@ ContentPage {
         id: mainLayout 
         Layout.fillWidth: true   
         Layout.fillHeight: true
-        spacing: 20
+        spacing: Appearance.spacing.verylarge
 
         ContentSection {
             icon: "monitor"
@@ -87,7 +87,7 @@ ContentPage {
             ContentSubsection {
                 title: Translation.tr("Show bar on")
                 Flow {
-                    Layout.fillWidth: true; spacing: 2
+                    Layout.fillWidth: true; spacing: Appearance.spacing.unsharpen
                     SelectionGroupButton {
                         leftmost: true; rightmost: Hyprland.monitors.length === 0
                         buttonIcon: "tv_displays"; buttonText: Translation.tr("All")

--- a/modules/ii/settings/pages/GeneralConfig.qml
+++ b/modules/ii/settings/pages/GeneralConfig.qml
@@ -46,7 +46,7 @@ ContentPage {
         id: mainLayout 
         Layout.fillWidth: true   
         Layout.fillHeight: true
-        spacing: 20
+        spacing: Appearance.spacing.verylarge
 
         ContentSection {
             icon: "nest_clock_farsight_analog"
@@ -80,7 +80,7 @@ ContentPage {
                 RowLayout {
                     anchors.fill: parent
                     anchors.margins: 24
-                    spacing: 16
+                    spacing: Appearance.spacing.large
 
                     ColumnLayout {
                         StyledText {
@@ -114,7 +114,7 @@ ContentPage {
                     }
 
                     AndroidClock {
-                        Layout.rightMargin: 6
+                        Layout.rightMargin: Appearance.spacing.small
                         width: 130
                         height: 130
                         backgroundColor: Appearance.colors.colPrimaryContainer
@@ -183,7 +183,7 @@ ContentPage {
 
             RowLayout {
                 Layout.fillWidth: true
-                spacing: 8
+                spacing: Appearance.spacing.small
 
                 Rectangle {
                     Layout.fillWidth: true
@@ -196,8 +196,8 @@ ContentPage {
 
                     ColumnLayout {
                         id: mediaCol
-                        anchors { fill: parent; margins: 12 }
-                        spacing: 8
+                        anchors { fill: parent; margins: Appearance.spacing.normal }
+                        spacing: Appearance.spacing.small
 
                         MaterialSymbol {
                             text: "music_note_2"
@@ -232,7 +232,7 @@ ContentPage {
 
                 ColumnLayout {
                     Layout.fillWidth: true
-                    spacing: 8
+                    spacing: Appearance.spacing.small
 
                     Rectangle {
                         Layout.fillWidth: true
@@ -244,8 +244,8 @@ ContentPage {
 
                         ColumnLayout {
                             id: aiCol
-                            anchors { fill: parent; margins: 12 }
-                            spacing: 8
+                            anchors { fill: parent; margins: Appearance.spacing.normal }
+                            spacing: Appearance.spacing.small
 
                             MaterialSymbol {
                                 text: "smart_toy"
@@ -282,8 +282,8 @@ ContentPage {
 
                         ColumnLayout {
                             id: weebCol
-                            anchors { fill: parent; margins: 12 }
-                            spacing: 8
+                            anchors { fill: parent; margins: Appearance.spacing.normal }
+                            spacing: Appearance.spacing.small
 
                             MaterialSymbol {
                                 text: "playing_cards"
@@ -314,7 +314,7 @@ ContentPage {
 
             Rectangle {
                 Layout.fillWidth: true
-                Layout.topMargin: 4
+                Layout.topMargin: Appearance.spacing.verysmall
                 implicitHeight: translatorCol.implicitHeight + 24
                 radius: Appearance.rounding.normal
                 color: Appearance.colors.colLayer1
@@ -323,11 +323,11 @@ ContentPage {
 
                 ColumnLayout {
                     id: translatorCol
-                    anchors { fill: parent; margins: 12 }
-                    spacing: 8
+                    anchors { fill: parent; margins: Appearance.spacing.normal }
+                    spacing: Appearance.spacing.small
 
                     RowLayout {
-                        spacing: 8
+                        spacing: Appearance.spacing.small
                         ConfigSwitch {
                             buttonIcon: "translate"
                             text: Translation.tr("Enable Translator")
@@ -684,7 +684,7 @@ ContentPage {
                 ColumnLayout {
                     id: translationCol
                     anchors { fill: parent; margins: 0 }
-                    spacing: 8
+                    spacing: Appearance.spacing.small
 
                     ConfigTextArea {
                         id: localeField
@@ -700,7 +700,7 @@ ContentPage {
                         Layout.fillWidth: false
                         Layout.alignment: Qt.AlignRight
                         Layout.preferredHeight: 50
-                        Layout.rightMargin: 8
+                        Layout.rightMargin: Appearance.spacing.small
                         nerdIcon: ""
                         enabled: !translationProc.running || (translationProc.locale !== localeField.value.trim())
                         mainText: enabled ? Translation.tr("Generate\nTypically takes 2 minutes") : Translation.tr("Generating...\nDon't close this window!")

--- a/modules/ii/settings/pages/GeneralConfig.qml
+++ b/modules/ii/settings/pages/GeneralConfig.qml
@@ -191,7 +191,7 @@ ContentPage {
                     implicitHeight: mediaCol.implicitHeight + 24
                     radius: Appearance.rounding.normal
                     color: Appearance.colors.colLayer1
-                    border.width: 1
+                    border.width: Appearance.borderWidth.standard
                     border.color: "transparent"
 
                     ColumnLayout {
@@ -239,7 +239,7 @@ ContentPage {
                         implicitHeight: aiCol.implicitHeight + 24
                         radius: Appearance.rounding.normal
                         color: Appearance.colors.colLayer1
-                        border.width: 1
+                        border.width: Appearance.borderWidth.standard
                         border.color: "transparent"
 
                         ColumnLayout {
@@ -277,7 +277,7 @@ ContentPage {
                         implicitHeight: weebCol.implicitHeight + 24
                         radius: Appearance.rounding.normal
                         color: Appearance.colors.colLayer1
-                        border.width: 1
+                        border.width: Appearance.borderWidth.standard
                         border.color: "transparent"
 
                         ColumnLayout {
@@ -318,7 +318,7 @@ ContentPage {
                 implicitHeight: translatorCol.implicitHeight + 24
                 radius: Appearance.rounding.normal
                 color: Appearance.colors.colLayer1
-                border.width: 1
+                border.width: Appearance.borderWidth.standard
                 border.color: "transparent"
 
                 ColumnLayout {

--- a/modules/ii/settings/pages/HyprlandConfig.qml
+++ b/modules/ii/settings/pages/HyprlandConfig.qml
@@ -67,7 +67,7 @@ ContentPage {
         id: mainLayout
         Layout.fillWidth: true
         Layout.fillHeight: true
-        spacing: 20
+        spacing: Appearance.spacing.verylarge
 
         // Displays
         ContentSection {
@@ -83,7 +83,7 @@ ContentPage {
             }
 
             ContentSubsection {
-                Layout.topMargin: 10
+                Layout.topMargin: Appearance.spacing.normal
                 title: (monitorConfig.monitors[monitorCanvas.selectedIndex]?.name ?? "")
                     + " · "
                     + (monitorConfig.monitors[monitorCanvas.selectedIndex]?.description ?? "")
@@ -501,7 +501,7 @@ ContentPage {
 
             NoticeBox {
                 Layout.fillWidth: true
-                Layout.topMargin: 15
+                Layout.topMargin: Appearance.spacing.large
                 text: Translation.tr("Animation presets require a require line in your hyprland.lua. Add the following line to enable presets:") + '\n\nrequire("hyprland/shellOverrides/animations")'
 
                 Item { Layout.fillWidth: true }

--- a/modules/ii/settings/pages/InterfaceConfig.qml
+++ b/modules/ii/settings/pages/InterfaceConfig.qml
@@ -37,7 +37,7 @@ ContentPage {
         id: mainLayout 
         Layout.fillWidth: true   
         Layout.fillHeight: true
-        spacing: 20
+        spacing: Appearance.spacing.verylarge
     
         ContentSection { // I see that for many the overview is important, I put it first why not
             icon: "overview_key"
@@ -403,7 +403,7 @@ ContentPage {
                     ColumnLayout {
                         id: crosshairCol
                         anchors { fill: parent; margins: 14 }
-                        spacing: 8
+                        spacing: Appearance.spacing.small
 
                         ConfigTextArea {
                             id: crosshairCodeField
@@ -429,7 +429,7 @@ ContentPage {
                         RowLayout {
                             Layout.fillWidth: true
                             StyledText {
-                                Layout.leftMargin: 8
+                                Layout.leftMargin: Appearance.spacing.small
                                 Layout.fillWidth: true
                                 text: Translation.tr("Press Super+G to open the overlay and pin the crosshair")
                                 font.pixelSize: Appearance.font.pixelSize.smaller
@@ -439,7 +439,7 @@ ContentPage {
                             RippleButtonWithIcon {
                                 id: editorButton
                                 Layout.fillWidth: true
-                                Layout.rightMargin: 6
+                                Layout.rightMargin: Appearance.spacing.small
                                 Layout.preferredHeight: 40
                                 buttonRadius: Appearance.rounding.normal
                                 materialIcon: "open_in_new"

--- a/modules/ii/settings/pages/PluginsPage.qml
+++ b/modules/ii/settings/pages/PluginsPage.qml
@@ -18,7 +18,7 @@ ContentPage {
 
         ColumnLayout {
             Layout.fillWidth: true
-            spacing: 2
+            spacing: Appearance.spacing.unsharpen
 
             Repeater {
                 model: PluginManager.availablePlugins
@@ -28,7 +28,7 @@ ContentPage {
                     required property var modelData
 
                     Layout.fillWidth: true
-                    spacing: 2
+                    spacing: Appearance.spacing.unsharpen
 
                     Rectangle {
                         Layout.fillWidth: true
@@ -39,7 +39,7 @@ ContentPage {
                         ConfigSwitch {
                             id: configSwitch
                             anchors.fill: parent
-                            anchors.margins: 8
+                            anchors.margins: Appearance.spacing.small
 
                             property var modelData: pluginGroup.modelData
                             text: modelData.name

--- a/modules/ii/settings/pages/Profile.qml
+++ b/modules/ii/settings/pages/Profile.qml
@@ -85,7 +85,7 @@ ContentPage {
         id: mainLayout
         Layout.fillWidth: true
         Layout.fillHeight: true
-        spacing: 20
+        spacing: Appearance.spacing.verylarge
 
         ContentSection {
             icon: "person"
@@ -125,10 +125,10 @@ ContentPage {
             }
 
             Flow {
-                Layout.topMargin: 10
-                Layout.bottomMargin: 10
+                Layout.topMargin: Appearance.spacing.normal
+                Layout.bottomMargin: Appearance.spacing.normal
                 Layout.fillWidth: true
-                spacing: 12
+                spacing: Appearance.spacing.normal
                 visible: Config.options.profile.avatarPath !== ""
 
                 Repeater {
@@ -162,8 +162,8 @@ ContentPage {
                             visible: parent.isSelected
                             anchors.right: parent.right
                             anchors.bottom: parent.bottom
-                            anchors.rightMargin: 2
-                            anchors.bottomMargin: 2
+                            anchors.rightMargin: Appearance.spacing.unsharpen
+                            anchors.bottomMargin: Appearance.spacing.unsharpen
                             width: 20
                             height: width
                             radius: width / 2
@@ -250,10 +250,10 @@ ContentPage {
             }
 
             Flow {
-                Layout.topMargin: 10
+                Layout.topMargin: Appearance.spacing.normal
                 Layout.fillWidth: true
                 width: parent.width
-                spacing: 12
+                spacing: Appearance.spacing.normal
                 visible: presetsFolderModel.count > 0
 
                 Repeater {

--- a/modules/ii/settings/pages/QuickConfig.qml
+++ b/modules/ii/settings/pages/QuickConfig.qml
@@ -41,7 +41,7 @@ ContentPage {
         id: smallLightDarkPreferenceButton
         required property bool dark
         property color colText: toggled ? Appearance.colors.colOnPrimary : Appearance.colors.colOnLayer2
-        padding: 5
+        padding: Appearance.spacing.small
         Layout.fillWidth: true
         Layout.fillHeight: true
         toggled: Appearance.m3colors.darkmode === dark
@@ -74,7 +74,7 @@ ContentPage {
         id: mainLayout
         Layout.fillWidth: true
         Layout.fillHeight: true
-        spacing: 16
+        spacing: Appearance.spacing.large
 
         ContentSection {
             icon: "screenshot_monitor"
@@ -84,7 +84,7 @@ ContentPage {
 
             RowLayout {
                 Layout.fillWidth: true
-                spacing: 4
+                spacing: Appearance.spacing.verysmall
 
                 Rectangle {
                     Layout.preferredWidth: 420
@@ -112,7 +112,7 @@ ContentPage {
                     ToolbarPairedFab {
                         anchors.bottom: parent.bottom
                         anchors.right: parent.right
-                        anchors.margins: 8
+                        anchors.margins: Appearance.spacing.small
                         iconText: "colorize"
                         onClicked: {
                             Quickshell.execDetached([Directories.wallpaperSwitchScriptPath, "--noswitch", "--color"]);
@@ -122,12 +122,12 @@ ContentPage {
 
                 ColumnLayout {
                     Layout.fillWidth: true
-                    spacing: 4
+                    spacing: Appearance.spacing.verysmall
 
                     RowLayout {
                         Layout.fillWidth: true
                         Layout.fillHeight: true
-                        spacing: 2
+                        spacing: Appearance.spacing.unsharpen
                         uniformCellSizes: true
                         SmallLightDarkPreferenceButton { dark: false }
                         SmallLightDarkPreferenceButton { dark: true }
@@ -167,7 +167,7 @@ ContentPage {
                                 MaterialSymbol {
                                     anchors.top: parent.top
                                     anchors.left: parent.left
-                                    anchors.margins: 8
+                                    anchors.margins: Appearance.spacing.small
                                     text: modelData.icon
                                     iconSize: Appearance.font.pixelSize.larger
                                     color: parent.isSelected ? Appearance.colors.colOnPrimary : Appearance.colors.colOnPrimaryContainer
@@ -176,7 +176,7 @@ ContentPage {
                                 StyledText {
                                     anchors.bottom: parent.bottom
                                     anchors.right: parent.right
-                                    anchors.margins: 8
+                                    anchors.margins: Appearance.spacing.small
                                     text: modelData.displayName
                                     font.pixelSize: Appearance.font.pixelSize.smaller
                                     font.weight: Font.Medium
@@ -238,11 +238,11 @@ ContentPage {
 
                     ColumnLayout {
                         id: barPosCol
-                        anchors { fill: parent; margins: 12 }
-                        spacing: 8
+                        anchors { fill: parent; margins: Appearance.spacing.normal }
+                        spacing: Appearance.spacing.small
 
                         RowLayout {
-                            spacing: 6
+                            spacing: Appearance.spacing.small
                             MaterialSymbol {
                                 text: "swap_vert"
                                 iconSize: Appearance.font.pixelSize.normal + 4
@@ -285,11 +285,11 @@ ContentPage {
 
                     ColumnLayout {
                         id: barStyleCol
-                        anchors { fill: parent; margins: 12 }
-                        spacing: 8
+                        anchors { fill: parent; margins: Appearance.spacing.normal }
+                        spacing: Appearance.spacing.small
 
                         RowLayout {
-                            spacing: 6
+                            spacing: Appearance.spacing.small
                             MaterialSymbol {
                                 text: "settop_component"
                                 iconSize: Appearance.font.pixelSize.normal + 4
@@ -326,11 +326,11 @@ ContentPage {
                     color: Appearance.colors.colLayer1
                     ColumnLayout {
                         id: groupStyleCol
-                        anchors { fill: parent; margins: 12 }
-                        spacing: 8
+                        anchors { fill: parent; margins: Appearance.spacing.normal }
+                        spacing: Appearance.spacing.small
 
                         RowLayout {
-                            spacing: 6
+                            spacing: Appearance.spacing.small
                             MaterialSymbol {
                                 text: "tab_group"
                                 iconSize: Appearance.font.pixelSize.normal + 4
@@ -368,11 +368,11 @@ ContentPage {
 
                     ColumnLayout {
                         id: screenRoundCol
-                        anchors { fill: parent; margins: 12 }
-                        spacing: 8
+                        anchors { fill: parent; margins: Appearance.spacing.normal }
+                        spacing: Appearance.spacing.small
 
                         RowLayout {
-                            spacing: 6
+                            spacing: Appearance.spacing.small
                             MaterialSymbol {
                                 text: "rounded_corner"
                                 iconSize: Appearance.font.pixelSize.normal + 4

--- a/modules/ii/settings/pages/QuickConfig.qml
+++ b/modules/ii/settings/pages/QuickConfig.qml
@@ -233,7 +233,7 @@ ContentPage {
                     Layout.preferredHeight: barPosCol.implicitHeight + 24
                     radius: Appearance.rounding.normal
                     color: Appearance.colors.colLayer1
-                    border.width: 1
+                    border.width: Appearance.borderWidth.standard
                     border.color: "transparent"
 
                     ColumnLayout {
@@ -280,7 +280,7 @@ ContentPage {
                     Layout.preferredHeight: barStyleCol.implicitHeight + 24
                     radius: Appearance.rounding.normal
                     color: Appearance.colors.colLayer1
-                    border.width: 1
+                    border.width: Appearance.borderWidth.standard
                     border.color: "transparent"
 
                     ColumnLayout {

--- a/modules/ii/settings/pages/ServicesConfig.qml
+++ b/modules/ii/settings/pages/ServicesConfig.qml
@@ -27,7 +27,7 @@ ContentPage {
             RowLayout {
                 id: layoutItem
                 anchors.centerIn: parent
-                spacing: 6
+                spacing: Appearance.spacing.small
                 MaterialSymbol {
                     text: iRoot.iconName
                     color: iRoot.textColor
@@ -74,7 +74,7 @@ ContentPage {
         id: mainLayout 
         Layout.fillWidth: true   
         Layout.fillHeight: true
-        spacing: 20
+        spacing: Appearance.spacing.verylarge
 
         ContentSection {
             icon: "neurology"
@@ -98,7 +98,7 @@ ContentPage {
 
                 ColumnLayout {
                     Layout.fillWidth: true
-                    spacing: 15
+                    spacing: Appearance.spacing.large
 
                     Repeater {
                         model: Config.options.ai.customProviders ? Config.options.ai.customProviders.length : 0
@@ -201,8 +201,8 @@ ContentPage {
                     RowLayout {
                         id: sectionActionsRow
                         Layout.alignment: Qt.AlignRight
-                        Layout.topMargin: 10
-                        spacing: 10
+                        Layout.topMargin: Appearance.spacing.normal
+                        spacing: Appearance.spacing.normal
 
                         IconButton {
                             id: addProviderButton

--- a/modules/ii/sidebarLeft/AiChat.qml
+++ b/modules/ii/sidebarLeft/AiChat.qml
@@ -13,7 +13,7 @@ import Quickshell.Io
 
 Item {
     id: root
-    property real padding: 4
+    property real padding: Appearance.spacing.verysmall
     property var inputField: messageInputField
     property string commandPrefix: "/"
 
@@ -321,7 +321,7 @@ Inline w/ backslash and round brackets \\(e^{i\\pi} + 1 = 0\\)
                 RowLayout {
                     id: statusRowLayout
                     anchors.centerIn: parent
-                    spacing: 10
+                    spacing: Appearance.spacing.normal
 
                     StatusItem {
                         icon: Ai.currentModelHasApiKey ? "key" : "key_off"
@@ -356,7 +356,7 @@ Inline w/ backslash and round brackets \\(e^{i\\pi} + 1 = 0\\)
                 id: messageListView
                 z: 0
                 anchors.fill: parent
-                spacing: 10
+                spacing: Appearance.spacing.normal
                 popin: false
                 topMargin: statusBg.implicitHeight + statusBg.anchors.topMargin * 2
 
@@ -418,7 +418,7 @@ Inline w/ backslash and round brackets \\(e^{i\\pi} + 1 = 0\\)
             visible: root.suggestionList.length > 0 && messageInputField.text.length > 0
             property int selectedIndex: 0
             Layout.fillWidth: true
-            spacing: 5
+            spacing: Appearance.spacing.small
 
             Repeater {
                 id: suggestionRepeater
@@ -471,7 +471,7 @@ Inline w/ backslash and round brackets \\(e^{i\\pi} + 1 = 0\\)
 
         Rectangle { // Input area
             id: inputWrapper
-            property real spacing: 5
+            property real spacing: Appearance.spacing.small
             Layout.fillWidth: true
             radius: Appearance.rounding.normal - root.padding
             color: Appearance.colors.colLayer2
@@ -500,7 +500,7 @@ Inline w/ backslash and round brackets \\(e^{i\\pi} + 1 = 0\\)
                     bottom: commandButtonsRow.top
                     left: parent.left
                     right: parent.right
-                    bottomMargin: 5
+                    bottomMargin: Appearance.spacing.small
                 }
                 spacing: 0
 
@@ -515,7 +515,7 @@ Inline w/ backslash and round brackets \\(e^{i\\pi} + 1 = 0\\)
                         id: messageInputField
                         anchors.fill: parent
                         wrapMode: TextArea.Wrap
-                        padding: 10
+                        padding: Appearance.spacing.normal
                         color: activeFocus ? Appearance.m3colors.m3onSurface : Appearance.m3colors.m3onSurfaceVariant
                         placeholderText: Translation.tr('Message the model... "%1" for commands').arg(root.commandPrefix)
 
@@ -697,7 +697,7 @@ Inline w/ backslash and round brackets \\(e^{i\\pi} + 1 = 0\\)
                 RippleButton { // Send button
                     id: sendButton
                     Layout.alignment: Qt.AlignBottom
-                    Layout.rightMargin: 5
+                    Layout.rightMargin: Appearance.spacing.small
                     implicitWidth: 40
                     implicitHeight: 40
                     buttonRadius: Appearance.rounding.small
@@ -729,10 +729,10 @@ Inline w/ backslash and round brackets \\(e^{i\\pi} + 1 = 0\\)
                 anchors.left: parent.left
                 anchors.right: parent.right
                 anchors.bottom: parent.bottom
-                anchors.bottomMargin: 5
-                anchors.leftMargin: 10
-                anchors.rightMargin: 5
-                spacing: 4
+                anchors.bottomMargin: Appearance.spacing.small
+                anchors.leftMargin: Appearance.spacing.normal
+                anchors.rightMargin: Appearance.spacing.small
+                spacing: Appearance.spacing.verysmall
 
                 property var commandsShown: [
                     {

--- a/modules/ii/sidebarLeft/Anime.qml
+++ b/modules/ii/sidebarLeft/Anime.qml
@@ -12,7 +12,7 @@ import Quickshell
 
 Item {
     id: root
-    property real padding: 4
+    property real padding: Appearance.spacing.verysmall
 
     property var inputField: tagInputField
     readonly property var responses: Booru.responses
@@ -172,7 +172,7 @@ Item {
                 id: booruResponseListView
                 z: 0
                 anchors.fill: parent
-                spacing: 10
+                spacing: Appearance.spacing.normal
                 
                 touchpadScrollFactor: Config.options.interactions.scrolling.touchpadScrollFactor * 1.4
                 mouseScrollFactor: Config.options.interactions.scrolling.mouseScrollFactor * 1.4
@@ -230,7 +230,7 @@ Item {
                 anchors {
                     horizontalCenter: parent.horizontalCenter
                     bottom: parent.bottom
-                    bottomMargin: 20 + (root.pullLoading ? 0 : Math.max(0, (root.normalizedPullDistance - 0.5) * 50))
+                    bottomMargin: Appearance.spacing.verylarge + (root.pullLoading ? 0 : Math.max(0, (root.normalizedPullDistance - 0.5) * 50))
                     Behavior on bottomMargin {
                         NumberAnimation {
                             duration: Appearance.animation.elementMoveFast.duration
@@ -255,7 +255,7 @@ Item {
             visible: root.suggestionList.length > 0 && tagInputField.text.length > 0
             property int selectedIndex: 0
             Layout.fillWidth: true
-            spacing: 5
+            spacing: Appearance.spacing.small
 
             Repeater {
                 id: tagSuggestionRepeater
@@ -269,7 +269,7 @@ Item {
                     bounce: false
                     contentItem: RowLayout {
                         anchors.centerIn: parent
-                        spacing: 5
+                        spacing: Appearance.spacing.small
                         StyledText {
                             Layout.fillWidth: false
                             font.pixelSize: Appearance.font.pixelSize.small
@@ -339,14 +339,14 @@ Item {
                 anchors.top: parent.top
                 anchors.left: parent.left
                 anchors.right: parent.right
-                anchors.topMargin: 5
+                anchors.topMargin: Appearance.spacing.small
                 spacing: 0
 
                 StyledTextArea { // The actual TextArea
                     id: tagInputField
                     wrapMode: TextArea.Wrap
                     Layout.fillWidth: true
-                    padding: 10
+                    padding: Appearance.spacing.normal
                     color: activeFocus ? Appearance.m3colors.m3onSurface : Appearance.m3colors.m3onSurfaceVariant
                     renderType: Text.NativeRendering
                     placeholderText: Translation.tr('Enter tags, or "%1" for commands').arg(root.commandPrefix)
@@ -440,7 +440,7 @@ Item {
                 RippleButton { // Send button
                     id: sendButton
                     Layout.alignment: Qt.AlignTop
-                    Layout.rightMargin: 5
+                    Layout.rightMargin: Appearance.spacing.small
                     implicitWidth: 40
                     implicitHeight: 40
                     buttonRadius: Appearance.rounding.small
@@ -472,10 +472,10 @@ Item {
                 anchors.left: parent.left
                 anchors.right: parent.right
                 anchors.bottom: parent.bottom
-                anchors.bottomMargin: 5
-                anchors.leftMargin: 5
-                anchors.rightMargin: 5
-                spacing: 5
+                anchors.bottomMargin: Appearance.spacing.small
+                anchors.leftMargin: Appearance.spacing.small
+                anchors.rightMargin: Appearance.spacing.small
+                spacing: Appearance.spacing.small
 
                 property var commandsShown: [
                     {
@@ -515,12 +515,12 @@ Item {
 
                     RowLayout {
                         id: switchesRow
-                        spacing: 5
+                        spacing: Appearance.spacing.small
                         anchors.centerIn: parent
 
                         StyledText {
                             Layout.fillHeight: true
-                            Layout.leftMargin: 10
+                            Layout.leftMargin: Appearance.spacing.normal
                             Layout.alignment: Qt.AlignVCenter
                             font.pixelSize: Appearance.font.pixelSize.smaller
                             color: nsfwSwitch.enabled ? Appearance.colors.colOnLayer1 : Appearance.m3colors.m3outline

--- a/modules/ii/sidebarLeft/Anime.qml
+++ b/modules/ii/sidebarLeft/Anime.qml
@@ -233,7 +233,7 @@ Item {
                     bottomMargin: 20 + (root.pullLoading ? 0 : Math.max(0, (root.normalizedPullDistance - 0.5) * 50))
                     Behavior on bottomMargin {
                         NumberAnimation {
-                            duration: 200
+                            duration: Appearance.animation.elementMoveFast.duration
                             easing.type: Easing.BezierSpline
                             easing.bezierCurve: Appearance.animationCurves.expressiveFastSpatial
                         }

--- a/modules/ii/sidebarLeft/DescriptionBox.qml
+++ b/modules/ii/sidebarLeft/DescriptionBox.qml
@@ -23,11 +23,11 @@ Item { // Tag suggestion description
 
         RowLayout {
             id: descriptionRow
-            spacing: 4
+            spacing: Appearance.spacing.verysmall
             anchors {
                 fill: parent
-                leftMargin: 10
-                rightMargin: 10
+                leftMargin: Appearance.spacing.normal
+                rightMargin: Appearance.spacing.normal
             }
 
             StyledText {

--- a/modules/ii/sidebarLeft/ScrollToBottomButton.qml
+++ b/modules/ii/sidebarLeft/ScrollToBottomButton.qml
@@ -11,7 +11,7 @@ RippleButton {
     anchors {
         bottom: parent.bottom
         horizontalCenter: parent.horizontalCenter
-        bottomMargin: 10
+        bottomMargin: Appearance.spacing.normal
     }
 
     opacity: !target.atYEnd ? 1 : 0
@@ -38,7 +38,7 @@ RippleButton {
 
     contentItem: Row {
         id: contentItem
-        spacing: 4
+        spacing: Appearance.spacing.verysmall
         MaterialSymbol {
             anchors.verticalCenter: parent.verticalCenter
             text: "arrow_downward"

--- a/modules/ii/sidebarLeft/SidebarLeft.qml
+++ b/modules/ii/sidebarLeft/SidebarLeft.qml
@@ -156,7 +156,7 @@ Scope { // Scope
                 width: panelWindow.sidebarWidth - Appearance.sizes.hyprlandGapsOut - Appearance.sizes.elevationMargin
                 height: parent.height - Appearance.sizes.hyprlandGapsOut * 2
                 color: Appearance.colors.colLayer0
-                border.width: 1
+                border.width: Appearance.borderWidth.standard
                 border.color: Appearance.colors.colLayer0Border
                 radius: Appearance.rounding.screenRounding - Appearance.sizes.hyprlandGapsOut + 1
 

--- a/modules/ii/sidebarLeft/SidebarLeftContent.qml
+++ b/modules/ii/sidebarLeft/SidebarLeftContent.qml
@@ -72,7 +72,7 @@ Item {
             SwipeView { // Content pages
                 id: swipeView
                 anchors.fill: parent
-                spacing: 10
+                spacing: Appearance.spacing.normal
                 currentIndex: tabBar.currentIndex
 
                 clip: true

--- a/modules/ii/sidebarLeft/SidebarPlayerControl.qml
+++ b/modules/ii/sidebarLeft/SidebarPlayerControl.qml
@@ -75,10 +75,10 @@ Item {
     Rectangle {
         id: background
         anchors.fill: parent
-        anchors.leftMargin: 4
-        anchors.rightMargin: 4
+        anchors.leftMargin: Appearance.spacing.verysmall
+        anchors.rightMargin: Appearance.spacing.verysmall
         anchors.topMargin: -1
-        anchors.bottomMargin: 4
+        anchors.bottomMargin: Appearance.spacing.verysmall
         color: ColorUtils.transparentize(artDominantColor, 0.9)
         radius: Appearance.rounding.normal
 
@@ -92,7 +92,7 @@ Item {
                 id: playerSelector
                 visible: Mpris.players.values.length > 1
                 Layout.fillWidth: true
-                Layout.bottomMargin: 8
+                Layout.bottomMargin: Appearance.spacing.small
                 model: Mpris.players.values.map(p => p.identity ?? p.desktopEntry ?? "Unknown")
                 currentIndex: 0
             }
@@ -138,8 +138,8 @@ Item {
             // ── Title & Artist ──
             ColumnLayout {
                 Layout.fillWidth: true
-                Layout.topMargin: 20
-                spacing: 5
+                Layout.topMargin: Appearance.spacing.verylarge
+                spacing: Appearance.spacing.small
 
                 Item {
                     Layout.fillWidth: true
@@ -219,8 +219,8 @@ Item {
             // ── Progress ──
             RowLayout {
                 Layout.fillWidth: true
-                Layout.topMargin: 5
-                spacing: 12
+                Layout.topMargin: Appearance.spacing.small
+                spacing: Appearance.spacing.normal
 
                 StyledText {
                     font.pixelSize: Appearance.font.pixelSize.normal
@@ -279,9 +279,9 @@ Item {
             // ── Controls ──
             RowLayout {
                 Layout.fillWidth: true
-                Layout.topMargin: 20
+                Layout.topMargin: Appearance.spacing.verylarge
                 Layout.alignment: Qt.AlignHCenter
-                spacing: 15
+                spacing: Appearance.spacing.large
 
                 RippleButton {
                     property real baseSize: Math.max(42, parent.parent.height * 0.06)
@@ -344,8 +344,8 @@ Item {
             // ── Volume ──
             RowLayout {
                 Layout.fillWidth: true
-                Layout.topMargin: 10
-                spacing: 8
+                Layout.topMargin: Appearance.spacing.normal
+                spacing: Appearance.spacing.small
 
                 RippleButton {
                     property real baseSize: Math.max(36, parent.parent.height * 0.05)

--- a/modules/ii/sidebarLeft/SidebarPlayerControl.qml
+++ b/modules/ii/sidebarLeft/SidebarPlayerControl.qml
@@ -160,9 +160,9 @@ Item {
 
                         Behavior on text {
                             SequentialAnimation {
-                                NumberAnimation { target: titleText; property: "x"; to: -titleText.width; duration: 150; easing.type: Easing.InQuad }
+                                NumberAnimation { target: titleText; property: "x"; to: -titleText.width; duration: Appearance.animation.elementMoveFaster.duration; easing.type: Easing.InQuad }
                                 PropertyAction { target: titleText; property: "text" }
-                                NumberAnimation { target: titleText; property: "x"; from: titleText.width; to: 0; duration: 150; easing.type: Easing.OutQuad }
+                                NumberAnimation { target: titleText; property: "x"; from: titleText.width; to: 0; duration: Appearance.animation.elementMoveFaster.duration; easing.type: Easing.OutQuad }
                             }
                         }
                     }
@@ -186,9 +186,9 @@ Item {
 
                         Behavior on text {
                             SequentialAnimation {
-                                NumberAnimation { target: artistText; property: "x"; to: -artistText.width; duration: 150; easing.type: Easing.InQuad }
+                                NumberAnimation { target: artistText; property: "x"; to: -artistText.width; duration: Appearance.animation.elementMoveFaster.duration; easing.type: Easing.InQuad }
                                 PropertyAction { target: artistText; property: "text" }
-                                NumberAnimation { target: artistText; property: "x"; from: artistText.width; to: 0; duration: 150; easing.type: Easing.OutQuad }
+                                NumberAnimation { target: artistText; property: "x"; from: artistText.width; to: 0; duration: Appearance.animation.elementMoveFaster.duration; easing.type: Easing.OutQuad }
                             }
                         }
                     }

--- a/modules/ii/sidebarLeft/Translator.qml
+++ b/modules/ii/sidebarLeft/Translator.qml
@@ -15,7 +15,7 @@ Item {
     id: root
 
     // Sizes
-    property real padding: 4
+    property real padding: Appearance.spacing.verysmall
 
     // Widgets
     property var inputField: inputCanvas.inputTextArea
@@ -111,7 +111,7 @@ Item {
             fill: parent
             margins: root.padding
         }
-        spacing: 10
+        spacing: Appearance.spacing.normal
 
         TextCanvas {
             id: inputCanvas
@@ -157,7 +157,7 @@ Item {
 
         RowLayout {
             Layout.fillWidth: true
-            spacing: 20
+            spacing: Appearance.spacing.verylarge
 
             Item { Layout.fillWidth: true }
 

--- a/modules/ii/sidebarLeft/aiChat/AiMessage.qml
+++ b/modules/ii/sidebarLeft/aiChat/AiMessage.qml
@@ -88,7 +88,7 @@ Rectangle {
                 id: headerRowLayout
                 anchors {
                     fill: parent
-                    margins: 4
+                    margins: Appearance.spacing.verysmall
                 }
                 spacing: 18
 
@@ -103,9 +103,9 @@ Rectangle {
                         anchors.verticalCenter: parent.verticalCenter
                         anchors.left: parent.left
                         anchors.right: parent.right
-                        anchors.leftMargin: 10
-                        anchors.rightMargin: 10
-                        spacing: 12
+                        anchors.leftMargin: Appearance.spacing.normal
+                        anchors.rightMargin: Appearance.spacing.normal
+                        spacing: Appearance.spacing.normal
 
                         Item {
                             Layout.alignment: Qt.AlignVCenter
@@ -175,7 +175,7 @@ Rectangle {
                 }
 
                 ButtonGroup {
-                    spacing: 5
+                    spacing: Appearance.spacing.small
 
                     AiMessageControlButton {
                         id: regenButton
@@ -325,7 +325,7 @@ Rectangle {
 
         Flow { // Annotations
             visible: root.messageData?.annotationSources?.length > 0
-            spacing: 5
+            spacing: Appearance.spacing.small
             Layout.fillWidth: true
             Layout.alignment: Qt.AlignLeft
 
@@ -343,7 +343,7 @@ Rectangle {
 
         Flow { // Search queries
             visible: root.messageData?.searchQueries?.length > 0
-            spacing: 5
+            spacing: Appearance.spacing.small
             Layout.fillWidth: true
             Layout.alignment: Qt.AlignLeft
 

--- a/modules/ii/sidebarLeft/aiChat/AnnotationSourceButton.qml
+++ b/modules/ii/sidebarLeft/aiChat/AnnotationSourceButton.qml
@@ -13,7 +13,7 @@ RippleButton {
     property real faviconSize: 20
     implicitHeight: 30
     leftPadding: (implicitHeight - faviconSize) / 2
-    rightPadding: 10
+    rightPadding: Appearance.spacing.normal
     buttonRadius: Appearance.rounding.full
     colBackground: Appearance.colors.colSurfaceContainerHighest
     colBackgroundHover: Appearance.colors.colSurfaceContainerHighestHover
@@ -34,7 +34,7 @@ RippleButton {
         RowLayout {
             id: rowLayout
             anchors.fill: parent
-            spacing: 5
+            spacing: Appearance.spacing.small
             Favicon {
                 url: root.url
                 size: root.faviconSize

--- a/modules/ii/sidebarLeft/aiChat/AttachedFileIndicator.qml
+++ b/modules/ii/sidebarLeft/aiChat/AttachedFileIndicator.qml
@@ -147,7 +147,7 @@ Rectangle {
                     Rectangle {
                         anchors.fill: parent
                         color: "transparent"
-                        border.width: 1
+                        border.width: Appearance.borderWidth.standard
                         border.color: Appearance.colors.colOutlineVariant
                         radius: Appearance.rounding.normal
                     }

--- a/modules/ii/sidebarLeft/aiChat/AttachedFileIndicator.qml
+++ b/modules/ii/sidebarLeft/aiChat/AttachedFileIndicator.qml
@@ -91,7 +91,7 @@ Rectangle {
 
             StyledText {
                 Layout.fillWidth: true
-                Layout.topMargin: 4
+                Layout.topMargin: Appearance.spacing.verysmall
                 text: root.filePath
                 font.pixelSize: Appearance.font.pixelSize.smaller
                 font.family: Appearance.font.family.monospace

--- a/modules/ii/sidebarLeft/aiChat/MessageCodeBlock.qml
+++ b/modules/ii/sidebarLeft/aiChat/MessageCodeBlock.qml
@@ -44,7 +44,7 @@ ColumnLayout {
             anchors.right: parent.right
             anchors.leftMargin: codeBlockHeaderPadding
             anchors.rightMargin: codeBlockHeaderPadding
-            spacing: 5
+            spacing: Appearance.spacing.small
 
             StyledText {
                 id: codeBlockLanguage
@@ -52,7 +52,7 @@ ColumnLayout {
                 Layout.fillWidth: false
                 Layout.topMargin: 7
                 Layout.bottomMargin: 7
-                Layout.leftMargin: 10
+                Layout.leftMargin: Appearance.spacing.normal
                 font.pixelSize: Appearance.font.pixelSize.small
                 font.weight: Font.DemiBold
                 color: Appearance.colors.colOnLayer2
@@ -137,9 +137,9 @@ ColumnLayout {
                 anchors {
                     left: parent.left
                     right: parent.right
-                    rightMargin: 5
+                    rightMargin: Appearance.spacing.small
                     top: parent.top
-                    topMargin: 6
+                    topMargin: Appearance.spacing.small
                 }
                 spacing: 0
                 
@@ -187,7 +187,7 @@ ColumnLayout {
                         anchors.bottom: parent.bottom
                         anchors.left: parent.left
                         anchors.right: parent.right
-                        padding: 5
+                        padding: Appearance.spacing.small
                         policy: ScrollBar.AsNeeded
                         opacity: visualSize == 1 ? 0 : 1
                         visible: opacity > 0
@@ -252,7 +252,7 @@ ColumnLayout {
                     active: root.isCommandRequest && root.messageData.functionPending
                     visible: active
                     Layout.fillWidth: true
-                    Layout.margins: 6
+                    Layout.margins: Appearance.spacing.small
                     Layout.topMargin: 0
                     sourceComponent: RowLayout {
                         Item { Layout.fillWidth: true }

--- a/modules/ii/sidebarLeft/aiChat/MessageThinkBlock.qml
+++ b/modules/ii/sidebarLeft/aiChat/MessageThinkBlock.qml
@@ -78,13 +78,13 @@ Item {
                 anchors.right: parent.right
                 anchors.leftMargin: thinkBlockHeaderPaddingHorizontal
                 anchors.rightMargin: thinkBlockHeaderPaddingHorizontal
-                spacing: 10
+                spacing: Appearance.spacing.normal
 
                 MaterialSymbol {
                     Layout.fillWidth: false
                     Layout.topMargin: 7
                     Layout.bottomMargin: 7
-                    Layout.leftMargin: 3
+                    Layout.leftMargin: Appearance.spacing.verysmall
                     text: "linked_services"
                 }
                 StyledText {

--- a/modules/ii/sidebarLeft/aiChat/SearchQueryButton.qml
+++ b/modules/ii/sidebarLeft/aiChat/SearchQueryButton.qml
@@ -12,8 +12,8 @@ RippleButton {
     property string query
 
     implicitHeight: 30
-    leftPadding: 6
-    rightPadding: 10
+    leftPadding: Appearance.spacing.small
+    rightPadding: Appearance.spacing.normal
     buttonRadius: Appearance.rounding.verysmall
     colBackground: Appearance.colors.colSurfaceContainerHighest
     colBackgroundHover: Appearance.colors.colSurfaceContainerHighestHover
@@ -36,7 +36,7 @@ RippleButton {
         RowLayout {
             id: rowLayout
             anchors.centerIn: parent
-            spacing: 5
+            spacing: Appearance.spacing.small
             MaterialSymbol {
                 text: "search"
                 iconSize: 20

--- a/modules/ii/sidebarLeft/anime/BooruImage.qml
+++ b/modules/ii/sidebarLeft/anime/BooruImage.qml
@@ -109,7 +109,7 @@ Button {
             active: root.showActions
             anchors.top: menuButton.bottom
             anchors.right: parent.right
-            anchors.margins: 8
+            anchors.margins: Appearance.spacing.small
 
             sourceComponent: Item {
                 width: contextMenu.width

--- a/modules/ii/sidebarLeft/anime/BooruResponse.qml
+++ b/modules/ii/sidebarLeft/anime/BooruResponse.qml
@@ -246,8 +246,8 @@ Rectangle {
 
             Layout.alignment: Qt.AlignRight
             implicitHeight: 30
-            leftPadding: 10
-            rightPadding: 5
+            leftPadding: Appearance.spacing.normal
+            rightPadding: Appearance.spacing.small
 
             onClicked: {
                 tagInputField.text = `${responseData.tags.join(" ")} ${parseInt(root.responseData.page) + 1}`

--- a/modules/ii/sidebarLeft/translator/LanguageSelectorButton.qml
+++ b/modules/ii/sidebarLeft/translator/LanguageSelectorButton.qml
@@ -28,7 +28,7 @@ RippleButton {
             StyledText {
                 id: languageText
                 Layout.alignment: Qt.AlignVCenter
-                Layout.leftMargin: 5
+                Layout.leftMargin: Appearance.spacing.small
                 text: root.displayText
                 color: Appearance.colors.colOnLayer2
                 font.pixelSize: Appearance.font.pixelSize.small

--- a/modules/ii/sidebarLeft/translator/TextCanvas.qml
+++ b/modules/ii/sidebarLeft/translator/TextCanvas.qml
@@ -40,7 +40,7 @@ Rectangle {
                 textFormat: TextEdit.PlainText
                 font.pixelSize: Appearance.font.pixelSize.small
                 color: Appearance.colors.colOnLayer1
-                padding: 15
+                padding: Appearance.spacing.large
                 background: null
                 onTextChanged: root.inputTextChanged()
             }
@@ -53,7 +53,7 @@ Rectangle {
             Layout.fillWidth: true
             sourceComponent: StyledText { // Output area
                 id: outputTextArea
-                padding: 15
+                padding: Appearance.spacing.large
                 wrapMode: Text.Wrap
                 font.pixelSize: Appearance.font.pixelSize.small
                 color: root.text.length > 0 ? Appearance.colors.colOnLayer1 : Appearance.colors.colSubtext
@@ -65,13 +65,13 @@ Rectangle {
 
         RowLayout { // Status row
             Layout.fillWidth: true
-            Layout.margins: 10
-            spacing: 10
+            Layout.margins: Appearance.spacing.normal
+            spacing: Appearance.spacing.normal
 
             Loader {
                 active: root.isInput
                 visible: root.isInput
-                Layout.leftMargin: 10
+                Layout.leftMargin: Appearance.spacing.normal
                 sourceComponent: StyledText {
                     text: Translation.tr("%1 characters").arg(inputLoader.item?.text.length ?? 0)
                     color: Appearance.colors.colOnLayer1

--- a/modules/ii/sidebarRight/BottomWidgetGroup.qml
+++ b/modules/ii/sidebarRight/BottomWidgetGroup.qml
@@ -93,10 +93,10 @@ Rectangle {
             }
         }
 
-        spacing: 15
+        spacing: Appearance.spacing.large
 
         CalendarHeaderButton {
-            Layout.margins: 10
+            Layout.margins: Appearance.spacing.normal
             Layout.rightMargin: 0
             forceCircle: true
             downAction: () => {
@@ -112,7 +112,7 @@ Rectangle {
 
         StyledText {
             property int remainingTasks: Todo.list.filter(task => !task.done).length
-            Layout.margins: 10
+            Layout.margins: Appearance.spacing.normal
             Layout.leftMargin: 0
             // text: `${DateTime.collapsedCalendarFormat}   •   ${remainingTasks} task${remainingTasks > 1 ? "s" : ""}`
             text: Translation.tr("%1   •   %2 tasks").arg(DateTime.collapsedCalendarFormat).arg(remainingTasks)
@@ -138,21 +138,21 @@ Rectangle {
 
         anchors.fill: parent
         // implicitHeight: tabStack.implicitHeight
-        spacing: 20
+        spacing: Appearance.spacing.verylarge
 
         // Navigation rail
         Item {
             Layout.fillHeight: true
             Layout.fillWidth: false
-            Layout.leftMargin: 10
-            Layout.topMargin: 10
+            Layout.leftMargin: Appearance.spacing.normal
+            Layout.topMargin: Appearance.spacing.normal
             implicitWidth: tabBar.implicitWidth
             // Navigation rail buttons
             NavigationRailTabArray {
                 id: tabBar
                 anchors.verticalCenter: parent.verticalCenter
                 anchors.left: parent.left
-                anchors.leftMargin: 5
+                anchors.leftMargin: Appearance.spacing.small
                 currentIndex: root.selectedTab
                 expanded: false
                 Repeater {

--- a/modules/ii/sidebarRight/CenterWidgetGroup.qml
+++ b/modules/ii/sidebarRight/CenterWidgetGroup.qml
@@ -14,6 +14,6 @@ Rectangle {
 
     NotificationList {
         anchors.fill: parent
-        anchors.margins: 5
+        anchors.margins: Appearance.spacing.small
     }
 }

--- a/modules/ii/sidebarRight/SidebarRightContent.qml
+++ b/modules/ii/sidebarRight/SidebarRightContent.qml
@@ -136,9 +136,9 @@ Item {
                                     top: parent.top
                                     left: parent.left
                                     right: parent.right
-                                    topMargin: 2
-                                    leftMargin: 2
-                                    rightMargin: 2
+                                    topMargin: Appearance.spacing.unsharpen
+                                    leftMargin: Appearance.spacing.unsharpen
+                                    rightMargin: Appearance.spacing.unsharpen
                                 }
                                 height: 120
                                 radius: sysRect.radius
@@ -183,7 +183,7 @@ Item {
                                     left: parent.left
                                     bottom: parent.bottom
                                     leftMargin: 13
-                                    bottomMargin: 8
+                                    bottomMargin: Appearance.spacing.small
                                 }
                                 spacing: 1
 
@@ -242,10 +242,10 @@ Item {
                                 anchors {
                                     right: parent.right
                                     bottom: parent.bottom
-                                    margins: 4
+                                    margins: Appearance.spacing.verysmall
                                 }
                                 color: "transparent"
-                                padding: 4
+                                padding: Appearance.spacing.verysmall
 
                                 QuickToggleButton {
                                     toggled: root.editMode
@@ -463,7 +463,7 @@ Item {
             Row {
                 id: uptimeRow
                 anchors.centerIn: parent
-                spacing: 8
+                spacing: Appearance.spacing.small
                 Item {
                     anchors.verticalCenter: parent.verticalCenter
                     width: 25
@@ -501,7 +501,7 @@ Item {
                 right: parent.right
             }
             color: Appearance.colors.colLayer1
-            padding: 4
+            padding: Appearance.spacing.verysmall
 
             QuickToggleButton {
                 toggled: root.editMode

--- a/modules/ii/sidebarRight/SidebarRightContent.qml
+++ b/modules/ii/sidebarRight/SidebarRightContent.qml
@@ -103,7 +103,7 @@ Item {
         implicitHeight: parent.height - Appearance.sizes.hyprlandGapsOut * 2
         implicitWidth: sidebarWidth - Appearance.sizes.hyprlandGapsOut * 2
         color: Appearance.colors.colLayer0
-        border.width: 1
+        border.width: Appearance.borderWidth.standard
         border.color: Appearance.colors.colLayer0Border
         radius: Appearance.rounding.screenRounding - Appearance.sizes.hyprlandGapsOut + 5
 

--- a/modules/ii/sidebarRight/bluetoothDevices/BluetoothDeviceItem.qml
+++ b/modules/ii/sidebarRight/bluetoothDevices/BluetoothDeviceItem.qml
@@ -32,7 +32,7 @@ DialogListItem {
 
         RowLayout {
             // Name
-            spacing: 10
+            spacing: Appearance.spacing.normal
 
             MaterialSymbol {
                 iconSize: Appearance.font.pixelSize.larger
@@ -41,7 +41,7 @@ DialogListItem {
             }
 
             ColumnLayout {
-                spacing: 2
+                spacing: Appearance.spacing.unsharpen
                 Layout.fillWidth: true
                 StyledText {
                     Layout.fillWidth: true
@@ -79,7 +79,7 @@ DialogListItem {
 
         RowLayout {
             visible: root.expanded
-            Layout.topMargin: 8
+            Layout.topMargin: Appearance.spacing.small
             Item {
                 Layout.fillWidth: true
             }

--- a/modules/ii/sidebarRight/calendar/CalendarWidget.qml
+++ b/modules/ii/sidebarRight/calendar/CalendarWidget.qml
@@ -7,7 +7,7 @@ import QtQuick.Layouts
 
 Item {
     // Layout.topMargin: 10
-    anchors.topMargin: 10
+    anchors.topMargin: Appearance.spacing.normal
     property int monthShift: 0
     property var viewingDate: CalendarLayout.getDateInXMonthsTime(monthShift)
     property var calendarLayout: CalendarLayout.getCalendarLayout(viewingDate, monthShift === 0)
@@ -39,12 +39,12 @@ Item {
     ColumnLayout {
         id: calendarColumn
         anchors.centerIn: parent
-        spacing: 5
+        spacing: Appearance.spacing.small
 
         // Calendar header
         RowLayout {
             Layout.fillWidth: true
-            spacing: 5
+            spacing: Appearance.spacing.small
             CalendarHeaderButton {
                 clip: true
                 buttonText: `${monthShift != 0 ? "• " : ""}${viewingDate.toLocaleDateString(Qt.locale(), "MMMM yyyy")}`
@@ -88,7 +88,7 @@ Item {
             id: weekDaysRow
             Layout.alignment: Qt.AlignHCenter
             Layout.fillHeight: false
-            spacing: 5
+            spacing: Appearance.spacing.small
             Repeater {
                 model: CalendarLayout.weekDays
                 delegate: CalendarDayButton {
@@ -108,7 +108,7 @@ Item {
             delegate: RowLayout {
                 Layout.alignment: Qt.AlignHCenter
                 Layout.fillHeight: false
-                spacing: 5
+                spacing: Appearance.spacing.small
                 Repeater {
                     model: Array(7).fill(modelData)
                     delegate: CalendarDayButton {

--- a/modules/ii/sidebarRight/nightLight/NightLightDialog.qml
+++ b/modules/ii/sidebarRight/nightLight/NightLightDialog.qml
@@ -68,8 +68,8 @@ WindowDialog {
             anchors {
                 left: parent.left
                 right: parent.right
-                leftMargin: 4
-                rightMargin: 4
+                leftMargin: Appearance.spacing.verysmall
+                rightMargin: Appearance.spacing.verysmall
             }
             text: Translation.tr("Intensity")
             from: 6500
@@ -151,8 +151,8 @@ WindowDialog {
             anchors {
                 left: parent.left
                 right: parent.right
-                leftMargin: 4
-                rightMargin: 4
+                leftMargin: Appearance.spacing.verysmall
+                rightMargin: Appearance.spacing.verysmall
             }
             value: root.brightnessMonitor.brightness
             onMoved: root.brightnessMonitor.setBrightness(value)
@@ -179,8 +179,8 @@ WindowDialog {
             anchors {
                 left: parent.left
                 right: parent.right
-                leftMargin: 4
-                rightMargin: 4
+                leftMargin: Appearance.spacing.verysmall
+                rightMargin: Appearance.spacing.verysmall
             }
             from: Hyprsunset.gammaLowerLimit / 100
             value: Hyprsunset.gamma / 100

--- a/modules/ii/sidebarRight/notifications/NotificationList.qml
+++ b/modules/ii/sidebarRight/notifications/NotificationList.qml
@@ -15,7 +15,7 @@ Item {
         anchors.right: parent.right
         anchors.top: parent.top
         anchors.bottom: statusRow.top
-        anchors.bottomMargin: 5
+        anchors.bottomMargin: Appearance.spacing.small
 
         clip: true
         layer.enabled: true

--- a/modules/ii/sidebarRight/notifications/NotificationStatusButton.qml
+++ b/modules/ii/sidebarRight/notifications/NotificationStatusButton.qml
@@ -27,7 +27,7 @@ GroupButton {
         RowLayout {
             id: contentRowLayout
             anchors.centerIn: parent
-            spacing: 5
+            spacing: Appearance.spacing.small
             MaterialSymbol {
                 visible: buttonIcon !== ""
                 text: buttonIcon

--- a/modules/ii/sidebarRight/pomodoro/PomodoroTimer.qml
+++ b/modules/ii/sidebarRight/pomodoro/PomodoroTimer.qml
@@ -54,7 +54,7 @@ Item {
 
         RowLayout {
             Layout.alignment: Qt.AlignHCenter
-            spacing: 10
+            spacing: Appearance.spacing.normal
 
             RippleButton {
                 contentItem: StyledText {

--- a/modules/ii/sidebarRight/pomodoro/PomodoroWidget.qml
+++ b/modules/ii/sidebarRight/pomodoro/PomodoroWidget.qml
@@ -60,10 +60,10 @@ Item {
 
         SwipeView {
             id: swipeView
-            Layout.topMargin: 10
+            Layout.topMargin: Appearance.spacing.normal
             Layout.fillWidth: true
             Layout.fillHeight: true
-            spacing: 10
+            spacing: Appearance.spacing.normal
             clip: true
             currentIndex: tabBar.currentIndex
 

--- a/modules/ii/sidebarRight/pomodoro/Stopwatch.qml
+++ b/modules/ii/sidebarRight/pomodoro/Stopwatch.qml
@@ -15,9 +15,9 @@ Item {
     Item {
         anchors {
             fill: parent
-            topMargin: 8
-            leftMargin: 16
-            rightMargin: 16
+            topMargin: Appearance.spacing.small
+            leftMargin: Appearance.spacing.large
+            rightMargin: Appearance.spacing.large
         }
 
         RowLayout { // Elapsed
@@ -27,7 +27,7 @@ Item {
                 top: undefined
                 verticalCenter: parent.verticalCenter
                 left: controlButtons.left
-                leftMargin: 6
+                leftMargin: Appearance.spacing.small
             }
 
             states: State {
@@ -81,10 +81,10 @@ Item {
                 bottom: controlButtons.top
                 left: parent.left
                 right: parent.right
-                topMargin: 16
-                bottomMargin: 16
+                topMargin: Appearance.spacing.large
+                bottomMargin: Appearance.spacing.large
             }
-            spacing: 4
+            spacing: Appearance.spacing.verysmall
             clip: true
             popin: true
 
@@ -157,9 +157,9 @@ Item {
             anchors {
                 horizontalCenter: parent.horizontalCenter
                 bottom: parent.bottom
-                bottomMargin: 6
+                bottomMargin: Appearance.spacing.small
             }
-            spacing: 4
+            spacing: Appearance.spacing.verysmall
 
             RippleButton {
                 Layout.preferredHeight: 35

--- a/modules/ii/sidebarRight/quickToggles/AndroidQuickPanel.qml
+++ b/modules/ii/sidebarRight/quickToggles/AndroidQuickPanel.qml
@@ -17,8 +17,8 @@ AbstractQuickPanel {
     Behavior on implicitHeight {
         animation: Appearance.animation.elementMove.numberAnimation.createObject(this)
     }
-    property real spacing: 6
-    property real padding: 6
+    property real spacing: Appearance.spacing.small
+    property real padding: Appearance.spacing.small
     readonly property real baseCellWidth: {
         const availableWidth = root.width - (root.padding * 2) - (root.spacing * (root.columns))
         return availableWidth / root.columns
@@ -61,7 +61,7 @@ AbstractQuickPanel {
             fill: parent
             margins: root.padding
         }
-        spacing: 12
+        spacing: Appearance.spacing.normal
 
         Column {
             id: usedRows

--- a/modules/ii/sidebarRight/quickToggles/AndroidQuickPanel.qml
+++ b/modules/ii/sidebarRight/quickToggles/AndroidQuickPanel.qml
@@ -113,7 +113,7 @@ AbstractQuickPanel {
                 visible: false
                 z: 99
                 width: 3
-                radius: 2
+                radius: Appearance.rounding.unsharpen
                 color: Appearance.colors.colPrimary
 
                 Behavior on x { NumberAnimation { duration: 120; easing.type: Easing.OutCubic } }
@@ -123,14 +123,14 @@ AbstractQuickPanel {
                     anchors.horizontalCenter: parent.horizontalCenter
                     anchors.top: parent.top
                     anchors.topMargin: -4
-                    width: 8; height: 8; radius: 4
+                    width: 8; height: 8; radius: Appearance.rounding.full
                     color: Appearance.colors.colPrimary
                 }
                 Rectangle {
                     anchors.horizontalCenter: parent.horizontalCenter
                     anchors.bottom: parent.bottom
                     anchors.bottomMargin: -4
-                    width: 8; height: 8; radius: 4
+                    width: 8; height: 8; radius: Appearance.rounding.full
                     color: Appearance.colors.colPrimary
                 }
             }

--- a/modules/ii/sidebarRight/quickToggles/ClassicQuickPanel.qml
+++ b/modules/ii/sidebarRight/quickToggles/ClassicQuickPanel.qml
@@ -16,8 +16,8 @@ AbstractQuickPanel {
 
     ButtonGroup {
         id: buttonGroup
-        spacing: 5
-        padding: 5
+        spacing: Appearance.spacing.small
+        padding: Appearance.spacing.small
         color: Appearance.colors.colLayer1
 
         NetworkToggle {

--- a/modules/ii/sidebarRight/quickToggles/androidStyle/AndroidQuickToggleButton.qml
+++ b/modules/ii/sidebarRight/quickToggles/androidStyle/AndroidQuickToggleButton.qml
@@ -51,7 +51,7 @@ GroupButton {
     }
 
     enabled: available || editMode
-    padding: 6
+    padding: Appearance.spacing.small
     horizontalPadding: padding
     verticalPadding: padding
 
@@ -70,7 +70,7 @@ GroupButton {
     }
 
     contentItem: RowLayout {
-        spacing: 4
+        spacing: Appearance.spacing.verysmall
         anchors {
             centerIn: root.expandedSize ? undefined : parent
             fill: root.expandedSize ? parent : undefined

--- a/modules/ii/sidebarRight/quickToggles/androidStyle/AndroidQuickToggleButton.qml
+++ b/modules/ii/sidebarRight/quickToggles/androidStyle/AndroidQuickToggleButton.qml
@@ -270,7 +270,7 @@ GroupButton {
         z: 10
         width: 20
         height: 20
-        radius: 10
+        radius: Appearance.rounding.full
         color: deleteHover.containsMouse ? Appearance.colors.colError : ColorUtils.transparentize(Appearance.colors.colError, 0.15)
         anchors.top: parent.top
         anchors.left: parent.left
@@ -313,7 +313,7 @@ GroupButton {
         z: 10
         width: 20
         height: 20
-        radius: 4
+        radius: Appearance.rounding.unsharpenslight
         color: resizeHover.containsMouse ? Appearance.colors.colPrimary : ColorUtils.transparentize(Appearance.colors.colPrimary, 0.15)
         anchors.bottom: parent.bottom
         anchors.right: parent.right

--- a/modules/ii/sidebarRight/todo/TaskList.qml
+++ b/modules/ii/sidebarRight/todo/TaskList.qml
@@ -61,15 +61,15 @@ Item {
                     StyledText {
                         id: todoContentText
                         Layout.fillWidth: true // Needed for wrapping
-                        Layout.leftMargin: 10
-                        Layout.rightMargin: 10
+                        Layout.leftMargin: Appearance.spacing.normal
+                        Layout.rightMargin: Appearance.spacing.normal
                         Layout.topMargin: todoListItemPadding
                         text: todoItem.modelData.content
                         wrapMode: Text.Wrap
                     }
                     RowLayout {
-                        Layout.leftMargin: 10
-                        Layout.rightMargin: 10
+                        Layout.leftMargin: Appearance.spacing.normal
+                        Layout.rightMargin: Appearance.spacing.normal
                         Layout.bottomMargin: todoListItemPadding
                         Item {
                             Layout.fillWidth: true
@@ -121,7 +121,7 @@ Item {
 
         ColumnLayout {
             anchors.centerIn: parent
-            spacing: 5
+            spacing: Appearance.spacing.small
 
             MaterialSymbol {
                 Layout.alignment: Qt.AlignHCenter

--- a/modules/ii/sidebarRight/todo/TodoWidget.qml
+++ b/modules/ii/sidebarRight/todo/TodoWidget.qml
@@ -53,10 +53,10 @@ Item {
 
         SwipeView {
             id: swipeView
-            Layout.topMargin: 10
+            Layout.topMargin: Appearance.spacing.normal
             Layout.fillWidth: true
             Layout.fillHeight: true
-            spacing: 10
+            spacing: Appearance.spacing.normal
             clip: true
             currentIndex: tabBar.currentIndex
 
@@ -154,12 +154,12 @@ Item {
             ColumnLayout {
                 id: dialogColumnLayout
                 anchors.fill: parent
-                spacing: 16
+                spacing: Appearance.spacing.large
 
                 StyledText {
-                    Layout.topMargin: 16
-                    Layout.leftMargin: 16
-                    Layout.rightMargin: 16
+                    Layout.topMargin: Appearance.spacing.large
+                    Layout.leftMargin: Appearance.spacing.large
+                    Layout.rightMargin: Appearance.spacing.large
                     Layout.alignment: Qt.AlignLeft
                     color: Appearance.m3colors.m3onSurface
                     font.pixelSize: Appearance.font.pixelSize.larger
@@ -169,9 +169,9 @@ Item {
                 TextField {
                     id: todoInput
                     Layout.fillWidth: true
-                    Layout.leftMargin: 16
-                    Layout.rightMargin: 16
-                    padding: 10
+                    Layout.leftMargin: Appearance.spacing.large
+                    Layout.rightMargin: Appearance.spacing.large
+                    padding: Appearance.spacing.normal
                     color: activeFocus ? Appearance.m3colors.m3onSurface : Appearance.m3colors.m3onSurfaceVariant
                     renderType: Text.NativeRendering
                     selectedTextColor: Appearance.m3colors.m3onSecondaryContainer
@@ -197,11 +197,11 @@ Item {
                 }
 
                 RowLayout {
-                    Layout.bottomMargin: 16
-                    Layout.leftMargin: 16
-                    Layout.rightMargin: 16
+                    Layout.bottomMargin: Appearance.spacing.large
+                    Layout.leftMargin: Appearance.spacing.large
+                    Layout.rightMargin: Appearance.spacing.large
                     Layout.alignment: Qt.AlignRight
-                    spacing: 5
+                    spacing: Appearance.spacing.small
 
                     DialogButton {
                         buttonText: Translation.tr("Cancel")

--- a/modules/ii/sidebarRight/todo/TodoWidget.qml
+++ b/modules/ii/sidebarRight/todo/TodoWidget.qml
@@ -184,7 +184,7 @@ Item {
                     background: Rectangle {
                         anchors.fill: parent
                         radius: Appearance.rounding.verysmall
-                        border.width: 2
+                        border.width: Appearance.borderWidth.emphasis
                         border.color: todoInput.activeFocus ? Appearance.colors.colPrimary : Appearance.m3colors.m3outline
                         color: "transparent"
                     }

--- a/modules/ii/sidebarRight/volumeMixer/AudioDeviceSelectorButton.qml
+++ b/modules/ii/sidebarRight/volumeMixer/AudioDeviceSelectorButton.qml
@@ -19,13 +19,13 @@ RippleButton {
 
     contentItem: RowLayout {
         anchors.fill: parent
-        anchors.margins: 5
-        spacing: 5
+        anchors.margins: Appearance.spacing.small
+        spacing: Appearance.spacing.small
 
         MaterialSymbol {
             Layout.alignment: Qt.AlignVCenter
             Layout.fillWidth: false
-            Layout.leftMargin: 5
+            Layout.leftMargin: Appearance.spacing.small
             color: Appearance.colors.colOnLayer2
             iconSize: Appearance.font.pixelSize.hugeass
             text: input ? "mic_external_on" : "media_output"
@@ -33,7 +33,7 @@ RippleButton {
 
         ColumnLayout {
             Layout.fillWidth: true
-            Layout.rightMargin: 5
+            Layout.rightMargin: Appearance.spacing.small
             spacing: 0
             StyledText {
                 Layout.fillWidth: true

--- a/modules/ii/sidebarRight/volumeMixer/VolumeDialogContent.qml
+++ b/modules/ii/sidebarRight/volumeMixer/VolumeDialogContent.qml
@@ -13,7 +13,7 @@ ColumnLayout {
     readonly property list<var> appPwNodes: isSink ? Audio.outputAppNodes : Audio.inputAppNodes
     readonly property list<var> devices: isSink ? Audio.outputDevices : Audio.inputDevices
     readonly property bool hasApps: appPwNodes.length > 0
-    spacing: 16
+    spacing: Appearance.spacing.large
 
     DialogSectionListView {
         Layout.fillHeight: true
@@ -42,7 +42,7 @@ ColumnLayout {
         id: deviceSelector
         Layout.fillHeight: false
         Layout.fillWidth: true
-        Layout.bottomMargin: 6
+        Layout.bottomMargin: Appearance.spacing.small
         model: root.devices.map(node => Audio.friendlyDeviceName(node))
         currentIndex: root.devices.findIndex(item => {
             if (root.isSink) {
@@ -68,13 +68,13 @@ ColumnLayout {
         Layout.bottomMargin: -16
         Layout.leftMargin: -Appearance.rounding.large
         Layout.rightMargin: -Appearance.rounding.large
-        topMargin: 12
-        bottomMargin: 12
-        leftMargin: 20
-        rightMargin: 20
+        topMargin: Appearance.spacing.normal
+        bottomMargin: Appearance.spacing.normal
+        leftMargin: Appearance.spacing.verylarge
+        rightMargin: Appearance.spacing.verylarge
 
         clip: true
-        spacing: 4
+        spacing: Appearance.spacing.verysmall
         animateAppearance: false
     }
 

--- a/modules/ii/sidebarRight/volumeMixer/VolumeMixerEntry.qml
+++ b/modules/ii/sidebarRight/volumeMixer/VolumeMixerEntry.qml
@@ -19,7 +19,7 @@ Item {
     RowLayout {
         id: rowLayout
         anchors.fill: parent
-        spacing: 6
+        spacing: Appearance.spacing.small
 
         MouseArea {
             property real size: 36

--- a/modules/ii/sidebarRight/volumeMixer/VolumeMixerEntry.qml
+++ b/modules/ii/sidebarRight/volumeMixer/VolumeMixerEntry.qml
@@ -61,12 +61,12 @@ Item {
 
                 Behavior on opacity {
                     NumberAnimation {
-                        duration: 150
+                        duration: Appearance.animation.elementMoveFaster.duration
                     }
                 }
                 Behavior on desaturation {
                     NumberAnimation {
-                        duration: 150
+                        duration: Appearance.animation.elementMoveFaster.duration
                     }
                 }
             }

--- a/modules/ii/sidebarRight/wifiNetworks/WifiNetworkItem.qml
+++ b/modules/ii/sidebarRight/wifiNetworks/WifiNetworkItem.qml
@@ -28,7 +28,7 @@ DialogListItem {
 
         RowLayout {
             // Name
-            spacing: 10
+            spacing: Appearance.spacing.normal
             MaterialSymbol {
                 iconSize: Appearance.font.pixelSize.larger
                 property int strength: root.wifiNetwork?.strength ?? 0
@@ -52,7 +52,7 @@ DialogListItem {
 
         ColumnLayout { // Password
             id: passwordPrompt
-            Layout.topMargin: 8
+            Layout.topMargin: Appearance.spacing.small
             visible: root.wifiNetwork?.askingPassword ?? false
 
             MaterialTextField {
@@ -94,7 +94,7 @@ DialogListItem {
 
         ColumnLayout { // Public wifi login page
             id: publicWifiPortal
-            Layout.topMargin: 8
+            Layout.topMargin: Appearance.spacing.small
             visible: (root.wifiNetwork?.active && (root.wifiNetwork?.security ?? "").trim().length === 0) ?? false
 
             RowLayout {

--- a/modules/ii/verticalBar/VerticalBarContent.qml
+++ b/modules/ii/verticalBar/VerticalBarContent.qml
@@ -129,7 +129,7 @@ Item {
                 ColumnLayout {
                     id: topMaterialCol
                     anchors.centerIn: parent
-                    spacing: 3
+                    spacing: Appearance.spacing.verysmall
 
                     Repeater {
                         model: root.effectiveLeftLayout
@@ -205,7 +205,7 @@ Item {
                 ColumnLayout {
                     id: centerMaterialCol
                     anchors.centerIn: parent
-                    spacing: 3
+                    spacing: Appearance.spacing.verysmall
 
                     Repeater {
                         model: root.effectiveMiddleLayout
@@ -282,7 +282,7 @@ Item {
                 ColumnLayout {
                     id: bottomMaterialCol
                     anchors.centerIn: parent
-                    spacing: 3
+                    spacing: Appearance.spacing.verysmall
 
                     Repeater {
                         model: root.effectiveRightLayout

--- a/modules/ii/wallpaperSelector/LocalWallpaperGrid.qml
+++ b/modules/ii/wallpaperSelector/LocalWallpaperGrid.qml
@@ -56,13 +56,13 @@ Item {
 
         Rectangle {
             anchors.fill: parent
-            anchors.margins: 8
+            anchors.margins: Appearance.spacing.small
             color: Qt.rgba(0, 0, 0, 0.45)
             radius: Appearance.rounding.normal
         }
         Row {
             anchors.centerIn: parent
-            spacing: 12
+            spacing: Appearance.spacing.normal
             RippleButton {
                 implicitWidth: 36; implicitHeight: 36
                 buttonRadius: height / 2
@@ -101,8 +101,8 @@ Item {
             bottom: grid.top
             left: parent.left
             right: parent.right
-            leftMargin: 4
-            rightMargin: 4
+            leftMargin: Appearance.spacing.verysmall
+            rightMargin: Appearance.spacing.verysmall
         }
     }
 

--- a/modules/ii/wallpaperSelector/OnlineWallpaperGrid.qml
+++ b/modules/ii/wallpaperSelector/OnlineWallpaperGrid.qml
@@ -116,7 +116,7 @@ Item {
 
         ColumnLayout {
             anchors.centerIn: parent
-            spacing: 16
+            spacing: Appearance.spacing.large
 
             MaterialSymbol {
                 Layout.alignment: Qt.AlignHCenter
@@ -165,8 +165,8 @@ Item {
             top: parent.top
             left: parent.left
             right: parent.right
-            leftMargin: 4
-            rightMargin: 4
+            leftMargin: Appearance.spacing.verysmall
+            rightMargin: Appearance.spacing.verysmall
         }
     }
 
@@ -292,7 +292,7 @@ Item {
         ColumnLayout {
             anchors.centerIn: parent
             visible: wallpaperModel.count === 0 && !OnlineWallpapers.loading
-            spacing: 12
+            spacing: Appearance.spacing.normal
 
             MaterialSymbol {
                 Layout.alignment: Qt.AlignHCenter
@@ -316,7 +316,7 @@ Item {
                 onClicked: OnlineWallpapers.fetch()
                 contentItem: RowLayout {
                     anchors.centerIn: parent
-                    spacing: 6
+                    spacing: Appearance.spacing.small
                     MaterialSymbol {
                         text: "refresh"
                         iconSize: Appearance.font.pixelSize.larger

--- a/modules/ii/wallpaperSelector/WallpaperDirectoryItem.qml
+++ b/modules/ii/wallpaperSelector/WallpaperDirectoryItem.qml
@@ -37,7 +37,7 @@ MouseArea {
         ColumnLayout {
             id: wallpaperItemColumnLayout
             anchors.fill: parent
-            spacing: 4
+            spacing: Appearance.spacing.verysmall
 
             Item {
                 id: wallpaperItemImageContainer
@@ -113,8 +113,8 @@ MouseArea {
                 id: wallpaperItemName
                 visible: root.showLabel 
                 Layout.fillWidth: true
-                Layout.leftMargin: 10
-                Layout.rightMargin: 10
+                Layout.leftMargin: Appearance.spacing.normal
+                Layout.rightMargin: Appearance.spacing.normal
 
                 horizontalAlignment: Text.AlignHCenter
                 elide: Text.ElideRight

--- a/modules/ii/wallpaperSelector/WallpaperSelectorContent.qml
+++ b/modules/ii/wallpaperSelector/WallpaperSelectorContent.qml
@@ -153,7 +153,7 @@ MouseArea {
         implicitHeight: gridColumnLayout.implicitHeight
 
         Item {
-            anchors { fill: parent; margins: 8 }
+            anchors { fill: parent; margins: Appearance.spacing.small }
             z: 0
 
             Rectangle {
@@ -201,9 +201,9 @@ MouseArea {
             id: mainLayout
             anchors.fill: parent
             anchors.topMargin: 0
-            anchors.bottomMargin: 8
-            anchors.leftMargin: 8
-            anchors.rightMargin: 8
+            anchors.bottomMargin: Appearance.spacing.small
+            anchors.leftMargin: Appearance.spacing.small
+            anchors.rightMargin: Appearance.spacing.small
             spacing: -4
             z: 1
 
@@ -215,8 +215,8 @@ MouseArea {
                 Item {
                     id: topBar
                     Layout.fillWidth: true
-                    Layout.margins: 16
-                    Layout.leftMargin: 20
+                    Layout.margins: Appearance.spacing.large
+                    Layout.leftMargin: Appearance.spacing.verylarge
                     implicitHeight: 56
 
                     RowLayout {
@@ -224,7 +224,7 @@ MouseArea {
                             left: parent.left
                             verticalCenter: parent.verticalCenter
                         }
-                        spacing: 8
+                        spacing: Appearance.spacing.small
 
                         MaterialShapeWrappedMaterialSymbol {
                             wrappedShape: MaterialShape.Shape.Gem
@@ -245,7 +245,7 @@ MouseArea {
                             active: root.source === "local"
                             visible: active
                             sourceComponent: RowLayout {
-                                spacing: 4
+                                spacing: Appearance.spacing.verysmall
                                 Repeater {
                                     model: root.quickDirs
                                     delegate: RippleButton {
@@ -261,9 +261,9 @@ MouseArea {
                                         onClicked: Wallpapers.setDirectory(modelData.path)
                                         contentItem: RowLayout {
                                             anchors.fill: parent
-                                            anchors.leftMargin: 12
-                                            anchors.rightMargin: 12
-                                            spacing: 6
+                                            anchors.leftMargin: Appearance.spacing.normal
+                                            anchors.rightMargin: Appearance.spacing.normal
+                                            spacing: Appearance.spacing.small
                                             MaterialSymbol {
                                                 text: dirBtn.modelData.icon
                                                 iconSize: Appearance.font.pixelSize.larger
@@ -284,7 +284,7 @@ MouseArea {
                             active: root.source !== "local"
                             visible: active
                             sourceComponent: RowLayout {
-                                spacing: 4
+                                spacing: Appearance.spacing.verysmall
                                 Repeater {
                                     model: ["1080p", "2K", "4K"]
                                     delegate: RippleButton {
@@ -312,10 +312,10 @@ MouseArea {
                     RowLayout {
                         anchors {
                             right: parent.right
-                            rightMargin: 8
+                            rightMargin: Appearance.spacing.small
                             verticalCenter: parent.verticalCenter
                         }
-                        spacing: 6
+                        spacing: Appearance.spacing.small
 
                         StyledComboBox {
                             id: sourceCombo
@@ -397,9 +397,9 @@ MouseArea {
                         anchors {
                             bottom: parent.bottom
                             horizontalCenter: parent.horizontalCenter
-                            bottomMargin: 8
+                            bottomMargin: Appearance.spacing.small
                         }
-                        spacing: 6
+                        spacing: Appearance.spacing.small
                         z: root.toolbarVisible ? 2 : -1
                         opacity: root.toolbarVisible ? 1 : 0
                         transform: Translate {

--- a/modules/ii/wallpaperSelector/WallpaperSelectorContent.qml
+++ b/modules/ii/wallpaperSelector/WallpaperSelectorContent.qml
@@ -144,7 +144,7 @@ MouseArea {
             margins: Appearance.sizes.elevationMargin
         }
         focus: true
-        border.width: 1
+        border.width: Appearance.borderWidth.standard
         border.color: Appearance.colors.colLayer0Border
         color: Appearance.colors.colLayer0
         radius: Appearance.rounding.screenRounding + 5

--- a/services/Hyprsunset.qml
+++ b/services/Hyprsunset.qml
@@ -82,32 +82,24 @@ Singleton {
         }
     }
 
-    function startHyprsunset(initialArgs = []) {
-        // hyprsunset defaults to `--temperature 6000` (a warm tint, not identity) when
-        // launched bare. If it isn't running yet, pass the target state as launch flags
-        // instead of spawning bare and correcting via a separate hyprctl call right
-        // after - that correction is fire-and-forget (execDetached) and races the
-        // daemon's socket coming up, so on a cold start it can silently fail and leave
-        // hyprsunset sitting at its own 6000K default indefinitely.
-        const initialCmd = initialArgs.length > 0 ? initialArgs.join(" ") : "";
-        Quickshell.execDetached(["bash", "-c", `pidof hyprsunset || hyprsunset ${initialCmd}`]);
+    function startHyprsunset() {
+        Quickshell.execDetached(["bash", "-c", `pidof hyprsunset || hyprsunset`]);
     }
 
     function load() {
+        root.startHyprsunset();
         if (root.automatic) {
-            // Recompute shouldBeOn against the actual current time before deciding -
-            // its declared default (false) would otherwise stand until the next
-            // onClockMinuteChanged tick, up to a minute away.
-            root.firstEvaluation = true;
-            root.reEvaluate();
-        } else if (Persistent.states.night.temperatureActive) {
+            root.ensureState();
+        } else {
             // Not in automatic mode: there's no reliable way to query hyprsunset's actual
             // on/off state back (hyprctl hyprsunset temperature always reports the last
             // explicitly-set numeric value, identity mode never resets it), so restore
             // whatever we last explicitly set instead of guessing from that query.
-            root.enableTemperature();
-        } else {
-            root.disableTemperature();
+            if (Persistent.states.night.temperatureActive) {
+                root.enableTemperature();
+            } else {
+                root.disableTemperature();
+            }
         }
     }
 
@@ -126,7 +118,7 @@ Singleton {
         Persistent.states.night.temperatureActive = true;
 
         // console.log("[Hyprsunset] Enabling");
-        root.startHyprsunset(["--temperature", String(root.colorTemperature)]);
+        root.startHyprsunset();
         Quickshell.execDetached(["bash", "-c", `hyprctl hyprsunset temperature ${root.colorTemperature}`]);
     }
 
@@ -134,7 +126,6 @@ Singleton {
         root.temperatureActive = false;
         Persistent.states.night.temperatureActive = false;
         // console.log("[Hyprsunset] Disabling");
-        root.startHyprsunset(["--identity"]);
         Quickshell.execDetached(["hyprctl", "hyprsunset", "identity"]);
     }
 
@@ -143,7 +134,7 @@ Singleton {
 
         root.gammaChangeAttempt();
 
-        root.startHyprsunset(root.temperatureActive ? ["--temperature", String(root.colorTemperature)] : ["--identity"]);
+        root.startHyprsunset();
         Quickshell.execDetached(["bash", "-c", `hyprctl hyprsunset gamma ${root.gamma}`]);
     }
 

--- a/services/Hyprsunset.qml
+++ b/services/Hyprsunset.qml
@@ -82,24 +82,32 @@ Singleton {
         }
     }
 
-    function startHyprsunset() {
-        Quickshell.execDetached(["bash", "-c", `pidof hyprsunset || hyprsunset`]);
+    function startHyprsunset(initialArgs = []) {
+        // hyprsunset defaults to `--temperature 6000` (a warm tint, not identity) when
+        // launched bare. If it isn't running yet, pass the target state as launch flags
+        // instead of spawning bare and correcting via a separate hyprctl call right
+        // after - that correction is fire-and-forget (execDetached) and races the
+        // daemon's socket coming up, so on a cold start it can silently fail and leave
+        // hyprsunset sitting at its own 6000K default indefinitely.
+        const initialCmd = initialArgs.length > 0 ? initialArgs.join(" ") : "";
+        Quickshell.execDetached(["bash", "-c", `pidof hyprsunset || hyprsunset ${initialCmd}`]);
     }
 
     function load() {
-        root.startHyprsunset();
         if (root.automatic) {
-            root.ensureState();
-        } else {
+            // Recompute shouldBeOn against the actual current time before deciding -
+            // its declared default (false) would otherwise stand until the next
+            // onClockMinuteChanged tick, up to a minute away.
+            root.firstEvaluation = true;
+            root.reEvaluate();
+        } else if (Persistent.states.night.temperatureActive) {
             // Not in automatic mode: there's no reliable way to query hyprsunset's actual
             // on/off state back (hyprctl hyprsunset temperature always reports the last
             // explicitly-set numeric value, identity mode never resets it), so restore
             // whatever we last explicitly set instead of guessing from that query.
-            if (Persistent.states.night.temperatureActive) {
-                root.enableTemperature();
-            } else {
-                root.disableTemperature();
-            }
+            root.enableTemperature();
+        } else {
+            root.disableTemperature();
         }
     }
 
@@ -118,7 +126,7 @@ Singleton {
         Persistent.states.night.temperatureActive = true;
 
         // console.log("[Hyprsunset] Enabling");
-        root.startHyprsunset();
+        root.startHyprsunset(["--temperature", String(root.colorTemperature)]);
         Quickshell.execDetached(["bash", "-c", `hyprctl hyprsunset temperature ${root.colorTemperature}`]);
     }
 
@@ -126,6 +134,7 @@ Singleton {
         root.temperatureActive = false;
         Persistent.states.night.temperatureActive = false;
         // console.log("[Hyprsunset] Disabling");
+        root.startHyprsunset(["--identity"]);
         Quickshell.execDetached(["hyprctl", "hyprsunset", "identity"]);
     }
 
@@ -134,7 +143,7 @@ Singleton {
 
         root.gammaChangeAttempt();
 
-        root.startHyprsunset();
+        root.startHyprsunset(root.temperatureActive ? ["--temperature", String(root.colorTemperature)] : ["--identity"]);
         Quickshell.execDetached(["bash", "-c", `hyprctl hyprsunset gamma ${root.gamma}`]);
     }
 


### PR DESCRIPTION
## Summary

Extends `Appearance.qml`'s existing colors/fonts/rounding/animation token system to cover spacing, border width, and the remaining animation/radius gaps, then migrates the codebase to use it.

- **Tokens added**: `Appearance.spacing.*` (unsharpen/verysmall/small/normal/large/verylarge), `Appearance.borderWidth.*` (standard/emphasis), `rounding.unsharpenslight` (4px), `animation.elementMoveFaster` (150ms). Documented in `docs/M3_GUIDELINES.md` and `AGENT.md`.
- **Animation**: 48 `duration:` literals across 20 files pointed at matching `Appearance.animation.*` tokens - zero visual change (same numeric value). Easing-curve *shape* changes (`Easing.OutCubic` etc.) deliberately left alone, since that's visually perceptible and unverifiable without a compositor.
- **Radius**: 30 literals across 18 files converted, including several circular dots/avatars (radius = exactly half the element's size) correctly pointed at `Appearance.rounding.full` instead of a coincidentally-matching token.
- **Border width**: 43 literals across 33 files converted to `.standard`/`.emphasis`, preserving 3 genuine thicker-border exceptions (clock hand, avatar ring, targeted-selection state).
- **Spacing/padding/margin**: 718 literals across 193 files, split into 30 commits capped at ~50 sites each so every commit is independently revertable.

Full rationale, verified literal counts, and per-phase exclusions are in each commit message.

## Test plan

- [x] `./tests/run_tests.sh` - all 52 tests pass
- [x] `qmllint` across all 447 `.qml` files in `modules/` - no syntax errors
- [ ] Manual visual pass over a few touched surfaces (bar, sidebar, settings) recommended before merge - value-preserving token substitutions were verified by construction, but a handful of radius/spacing snaps shift things by 1-3px and weren't checked against a running compositor