### PR TITLE
Fix Hyprsunset cold-start temperature race

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -191,6 +191,18 @@ this query against a hardcoded `6500` to infer active state (also just factually
 restart. Don't rely on querying `hyprsunset`'s live state at all; track on/off intent yourself
 (see how `Hyprsunset.qml` now persists it via `Persistent.qml` instead).
 
+**That same bare `--temperature 6000` default also bit the daemon's cold start, not just state
+queries.** `Hyprsunset.qml` used to spawn `hyprsunset` with no flags (`pidof hyprsunset ||
+hyprsunset`) and immediately fire a separate, fire-and-forget `hyprctl hyprsunset identity`/
+`temperature` correction right after via `execDetached`. On a warm system that correction reaches
+the already-running daemon fine, but on a cold start (nothing running yet) it races the daemon's
+IPC socket coming up and can silently fail, leaving `hyprsunset` stuck at its own 6000K default
+indefinitely - toggling night light off after a restart looked like it did nothing, and toggling it
+on read as the tint "intensifying" (6000K → the configured, warmer temperature) rather than turning
+on from neutral. Fixed by launching `hyprsunset` with the target state already as CLI flags
+(`--temperature N` / `--identity`) instead of spawning bare and correcting after the fact - a
+freshly-spawned daemon now starts in the right state with no window where it's wrong.
+
 ## Layer-shell (wlr-layer-shell) gotchas
 
 Widgets that are `PanelWindow`s pick a `WlrLayershell.layer` (`Background < Bottom < Top < Overlay`).

--- a/services/Hyprsunset.qml
+++ b/services/Hyprsunset.qml
@@ -82,24 +82,32 @@ Singleton {
         }
     }
 
-    function startHyprsunset() {
-        Quickshell.execDetached(["bash", "-c", `pidof hyprsunset || hyprsunset`]);
+    function startHyprsunset(initialArgs = []) {
+        // hyprsunset defaults to `--temperature 6000` (a warm tint, not identity) when
+        // launched bare. If it isn't running yet, pass the target state as launch flags
+        // instead of spawning bare and correcting via a separate hyprctl call right
+        // after - that correction is fire-and-forget (execDetached) and races the
+        // daemon's socket coming up, so on a cold start it can silently fail and leave
+        // hyprsunset sitting at its own 6000K default indefinitely.
+        const initialCmd = initialArgs.length > 0 ? initialArgs.join(" ") : "";
+        Quickshell.execDetached(["bash", "-c", `pidof hyprsunset || hyprsunset ${initialCmd}`]);
     }
 
     function load() {
-        root.startHyprsunset();
         if (root.automatic) {
-            root.ensureState();
-        } else {
+            // Recompute shouldBeOn against the actual current time before deciding -
+            // its declared default (false) would otherwise stand until the next
+            // onClockMinuteChanged tick, up to a minute away.
+            root.firstEvaluation = true;
+            root.reEvaluate();
+        } else if (Persistent.states.night.temperatureActive) {
             // Not in automatic mode: there's no reliable way to query hyprsunset's actual
             // on/off state back (hyprctl hyprsunset temperature always reports the last
             // explicitly-set numeric value, identity mode never resets it), so restore
             // whatever we last explicitly set instead of guessing from that query.
-            if (Persistent.states.night.temperatureActive) {
-                root.enableTemperature();
-            } else {
-                root.disableTemperature();
-            }
+            root.enableTemperature();
+        } else {
+            root.disableTemperature();
         }
     }
 
@@ -118,7 +126,7 @@ Singleton {
         Persistent.states.night.temperatureActive = true;
 
         // console.log("[Hyprsunset] Enabling");
-        root.startHyprsunset();
+        root.startHyprsunset(["--temperature", String(root.colorTemperature)]);
         Quickshell.execDetached(["bash", "-c", `hyprctl hyprsunset temperature ${root.colorTemperature}`]);
     }
 
@@ -126,6 +134,7 @@ Singleton {
         root.temperatureActive = false;
         Persistent.states.night.temperatureActive = false;
         // console.log("[Hyprsunset] Disabling");
+        root.startHyprsunset(["--identity"]);
         Quickshell.execDetached(["hyprctl", "hyprsunset", "identity"]);
     }
 
@@ -134,7 +143,7 @@ Singleton {
 
         root.gammaChangeAttempt();
 
-        root.startHyprsunset();
+        root.startHyprsunset(root.temperatureActive ? ["--temperature", String(root.colorTemperature)] : ["--identity"]);
         Quickshell.execDetached(["bash", "-c", `hyprctl hyprsunset gamma ${root.gamma}`]);
     }
 


### PR DESCRIPTION
## Summary

Fixes night light remaining visibly warm after a cold shell start even though the UI reports it as off.

Hyprsunset defaults to a warm 6000K temperature when launched without flags. The previous startup path launched it bare and immediately issued a separate asynchronous hyprctl correction, which could run before the daemon socket was ready. The daemon is now launched with the intended initial state using either --temperature or --identity, avoiding that race.

Automatic mode also recalculates the desired state from the current time during load rather than waiting for the next minute tick.

## Changes

- Start a new Hyprsunset process with the intended temperature or identity state.
- Re-evaluate automatic mode immediately during service load.
- Document the cold-start behavior and rationale in AGENT.md.

## Test plan

- Start the shell while Hyprsunset is not already running and night light is disabled; verify the display remains neutral.
- Start during an active automatic schedule; verify the configured temperature is applied immediately.
- Toggle night light on and off after startup and verify both transitions work.
- Adjust gamma with night light enabled and disabled and verify the current temperature state is preserved.