### PR TITLE
Guard against Appearance.* usage missing its qs.modules.common import

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -352,6 +352,16 @@ design tokens - color roles (`Appearance.colors.col*`, `Appearance.m3colors.m3*`
 (`Appearance.animation.*`). New UI should pull from these rather than hardcoding colors/sizes/
 durations, both for dark/light theme correctness and for consistency with the rest of the shell.
 
+**Any `.qml` that references `Appearance` (or any other `qs.modules.common` singleton) as a bareword
+must `import qs.modules.common`.** That import is *not* transitive - a file that only has
+`import qs.modules.common.widgets` does not get `Appearance` in scope, and the reference silently
+throws `ReferenceError: Appearance is not defined` on every binding evaluation. This is not just a
+cosmetic error: when the missing token feeds a positioner's `spacing`/`margin`, the binding yields
+`undefined` -> NaN geometry, and QtQuick relayout never converges - it pegs a core at 100% CPU and
+freezes the shell (this is exactly what a bulk token migration did to `ConfigRow.qml`,
+`NotificationListView.qml`, `PluginOptions.qml`, and `StyledPopupMenu.qml`). `tests/lint_qml_imports.sh`
+(run by `tests/run_tests.sh` and CI) guards against reintroducing it.
+
 **Strict UI Guidelines:** See [`docs/M3_GUIDELINES.md`](docs/M3_GUIDELINES.md) for the definitive rules on tokens, rounding, layering, and expressive motion that all new components must follow.
 
 Shared building blocks to reach for before writing something from scratch: `StyledText`,

--- a/modules/common/widgets/shapes/example-squircle.qml
+++ b/modules/common/widgets/shapes/example-squircle.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import QtQuick.Layouts
 import QtQuick.Window
+import qs.modules.common
 import "material-shapes.js" as MaterialShapes
 import "shapes/corner-rounding.js" as CornerRounding
 import "geometry/offset.js" as Offset

--- a/tests/README.md
+++ b/tests/README.md
@@ -61,3 +61,9 @@ The initial phase covers components that represent pure logic and do not require
 * **Audio Device Name Priority (`tst_audio.qml`)**: Validates the priority selection of friendly audio device names (`description` > `nickname` > `"Unknown"`) and application display names.
 * **System Stats Parser (`tst_resource_usage.qml`)**: Tests parsing functions for `/proc/meminfo` contents, `df -k` disk usage output, and `nvidia-smi` GPU/VRAM statistics.
 * **Live Desktop Entry Resolution (`tst_live_desktop_entry.qml`)**: Tests `LiveDesktopEntry.qml` against a mock `DesktopEntries` (`tests/mocks/Quickshell/DesktopEntries.qml`) that can simulate `applications` populating after the resolver already exists, guarding against the dock's pinned-launcher regression where a `heuristicLookup()`-based binding never refreshed once the desktop entry database finished loading.
+
+## Static Lints
+
+In addition to the QML unit tests, `run_tests.sh` runs static lint checks first:
+
+* **QML import lint (`lint_qml_imports.sh`)**: Fails if any `.qml` under `modules/` references the `Appearance` singleton as a bareword without `import qs.modules.common`. That import is not transitive through `qs.modules.common.widgets`; omitting it throws `ReferenceError: Appearance is not defined` per binding evaluation, and when the missing token feeds a positioner's `spacing`/`margin` the resulting NaN geometry pegs the shell at 100% CPU. A bulk token migration introduced exactly this, so the lint prevents recurrence.

--- a/tests/lint_qml_imports.sh
+++ b/tests/lint_qml_imports.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# Regression guard: a .qml that uses the `Appearance` singleton as a bareword
+# (Appearance.colors, Appearance.spacing, ...) MUST import qs.modules.common,
+# where the singleton is declared. The import is NOT transitive through
+# qs.modules.common.widgets. Omitting it throws "ReferenceError: Appearance is
+# not defined" on every binding evaluation; when the missing token feeds a
+# positioner's spacing/margin, the resulting undefined -> NaN geometry thrashes
+# relayout and pegs a core at 100% CPU (see AGENT.md). The appearance-token
+# migration introduced exactly this in several files, so this check keeps it
+# from coming back.
+#
+# Exits non-zero and lists offenders if any file references bareword
+# `Appearance.` without an (unaliased) `import qs.modules.common`.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+violations=0
+
+while IFS= read -r -d '' f; do
+    # Bareword `Appearance.` = not preceded by a word char or dot (so an aliased
+    # `C.Appearance.` member access does not count).
+    if ! grep -qP '(?<![\w.])Appearance\.' "$f"; then
+        continue
+    fi
+    # Needs an unaliased `import qs.modules.common` (trailing comment allowed,
+    # but not `import qs.modules.common as X`).
+    if grep -qP '^import qs\.modules\.common(\s*//.*)?\s*$' "$f"; then
+        continue
+    fi
+    echo "  MISSING 'import qs.modules.common': ${f#$PROJECT_ROOT/}"
+    violations=$((violations + 1))
+done < <(find "$PROJECT_ROOT/modules" -name '*.qml' -print0)
+
+if [ "$violations" -gt 0 ]; then
+    echo "QML import lint FAILED: $violations file(s) use Appearance.* without importing qs.modules.common" >&2
+    exit 1
+fi
+
+echo "QML import lint passed: all Appearance.* users import qs.modules.common"
+exit 0

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -33,6 +33,14 @@ fi
 echo "Using test runner: $QMLTESTRUNNER"
 echo "Running QML unit test suite..."
 
+# Static lint: catch Appearance.* usage missing its qs.modules.common import
+# before running the QML tests (this class of bug pegs the shell at 100% CPU).
+echo "Running QML import lint..."
+if ! "$SCRIPT_DIR/lint_qml_imports.sh"; then
+    echo "Import lint failed."
+    exit 1
+fi
+
 # Run the test runner
 "$QMLTESTRUNNER" \
     -import "$PROJECT_ROOT/tests/mocks" \


### PR DESCRIPTION
## What

Adds a static lint (`tests/lint_qml_imports.sh`, wired into `run_tests.sh` + CI) that fails if any `.qml` under `modules/` references the `Appearance` singleton as a bareword without `import qs.modules.common`.

## Why

The appearance-token migration added `Appearance.*` refs to files that only imported `qs.modules.common.widgets` (not `qs.modules.common`, where the singleton is declared). The import isn't transitive, so each reference threw `ReferenceError: Appearance is not defined` per binding evaluation. Where the missing token fed a positioner's `spacing`/`margin`, the `undefined` → NaN geometry made QtQuick relayout never converge — pegging a core at 100% CPU and freezing the shell (`ConfigRow.qml`, `NotificationListView.qml`, `PluginOptions.qml`, `StyledPopupMenu.qml`).

The offending files were already fixed on `main`; this guards against reintroduction.

## Changes

- `tests/lint_qml_imports.sh` — bareword-`Appearance.`-without-import scan (excludes aliased `C.Appearance` via boundary matching).
- `tests/run_tests.sh` — runs the lint before the QML tests.
- `modules/common/widgets/shapes/example-squircle.qml` — added the missing import (last stray offender, a standalone demo).
- `AGENT.md` + `tests/README.md` — document the gotcha and the lint.

## Verification

Lint passes clean on the tree; confirmed it fails on a deliberately-broken file. `run_tests.sh`: lint + 52/52 QML tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)