### PR TITLE
Restrict the spacing scale to multiples of four

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -376,10 +376,12 @@ design tokens - color roles (`Appearance.colors.col*`, `Appearance.m3colors.m3*`
 (`Appearance.spacing.*`), border widths (`Appearance.borderWidth.*`), animation curves/durations
 (`Appearance.animation.*`). New UI should pull from these rather than hardcoding colors/sizes/
 durations, both for dark/light theme correctness and for consistency with the rest of the shell.
-`Appearance.spacing.*` follows Material 3's system scale (`0, 2, 4, 6, 8, 10, 12, 14, 16, 20, 24,
-32, 36, 40, 48, 56, 64, 72`), named `space0` through `space900`; `space100` (8px) is the base unit.
-Prefer multiples of 8 for the main rhythm and the recommended intermediate tokens for nested
-spacing. Use canonical `spaceNNN` names directly; semantic aliases are not supported.
+`Appearance.spacing.*` follows Material 3's system scale restricted to this fork's rule - the two
+fine values, then multiples of 4 (`0, 2, 4, 8, 12, 16, 20, 24, 32, 36, 40, 48, 56, 64, 72`), named
+`space0` through `space900`; `space100` (8px) is the base unit. M3's `space75` (6), `space125` (10),
+and `space175` (14) are intentionally absent - round up to the next token. Prefer multiples of 8 for
+the main rhythm and the multiples of 4 between them for nested spacing. Use canonical `spaceNNN`
+names directly; semantic aliases are not supported.
 `Appearance.borderWidth.*` is `1/2/4`. Snap raw spacing/padding/margin to the nearest spacing token -
 `tests/lint_spacing.py` (run by `tests/run_tests.sh`) enforces declarations and assignments.
 

--- a/docs/M3_GUIDELINES.md
+++ b/docs/M3_GUIDELINES.md
@@ -62,11 +62,15 @@ a violation of this rule - keep the computed expression rather than snapping it 
 
 Always use predefined values from `Appearance.spacing` for `spacing`, `padding`, and margin
 properties. Never hardcode pixel gaps (e.g., `spacing: 12`). The canonical Material 3 system scale
-is `0, 2, 4, 6, 8, 10, 12, 14, 16, 20, 24, 32, 36, 40, 48, 56, 64, 72`, exposed as `space0`,
-`space25`, `space50`, `space75`, `space100`, `space125`, `space150`, `space175`, `space200`,
-`space250`, `space300`, `space400`, `space450`, `space500`, `space600`, `space700`, `space800`, and
-`space900`. `space100` (8px) is the base unit. Prefer multiples of 8 for the main layout rhythm and
-the intervening tokens for nested spacing. Snap raw spacing/padding/margin values to this scale.
+is `0, 2, 4, 8, 12, 16, 20, 24, 32, 36, 40, 48, 56, 64, 72`, exposed as `space0`, `space25`,
+`space50`, `space100`, `space150`, `space200`, `space250`, `space300`, `space400`, `space450`,
+`space500`, `space600`, `space700`, `space800`, and `space900`. `space100` (8px) is the base unit.
+
+Every step above the two fine values (2 and 4) is a multiple of 4, matching `borderWidth`'s
+`1/2/4`. M3's nested `space75` (6), `space125` (10), and `space175` (14) are deliberately **not**
+offered: a value that wants one of them rounds up to `space100`, `space150`, or `space200`. Prefer
+multiples of 8 for the main layout rhythm and the multiples of 4 between them for nested spacing.
+Snap raw spacing/padding/margin values to this scale.
 
 Use the canonical `spaceNNN` names directly; semantic aliases are intentionally not provided because
 they hide the actual spatial relationship. Only genuine large one-off *dimensions* outside the

--- a/modules/common/Appearance.qml
+++ b/modules/common/Appearance.qml
@@ -222,17 +222,15 @@ Singleton {
     }
 
     spacing: QtObject {
-        // Material 3 system spacing tokens. space100 (8dp) is the base unit;
-        // the primary rhythm uses multiples of 8dp, with recommended nested
-        // values between them. Keep the numbered names aligned with M3.
+        // Material 3 system spacing tokens, restricted to this fork's scale
+        // rule: the two fine values 2 and 4, then multiples of 4 only. The M3
+        // nested values 6, 10 and 14 are deliberately absent - anything that
+        // wants them rounds up to the next token.
         property int space0: 0
         property int space25: 2
         property int space50: 4
-        property int space75: 6
         property int space100: 8
-        property int space125: 10
         property int space150: 12
-        property int space175: 14
         property int space200: 16
         property int space250: 20
         property int space300: 24
@@ -457,7 +455,7 @@ Singleton {
         property real barCenterSideModuleWidthHellaShortened: 190
         property real barShortenScreenWidthThreshold: 1200 // Shorten if screen width is at most this value
         property real barHellaShortenScreenWidthThreshold: 1000 // Shorten even more...
-        property real elevationMargin: root.spacing.space125
+        property real elevationMargin: root.spacing.space150
         property real fabShadowRadius: 5
         property real fabHoveredShadowRadius: 7
         property real hyprlandGapsOut: 5
@@ -475,7 +473,7 @@ Singleton {
         property real wallpaperSelectorWidth: 1200
         property real wallpaperSelectorHeight: 690
         property real wallpaperSelectorItemMargins: root.spacing.space100
-        property real wallpaperSelectorItemPadding: root.spacing.space75
+        property real wallpaperSelectorItemPadding: root.spacing.space100
     }
 
     syntaxHighlightingTheme: root.m3colors.darkmode ? "Monokai" : "ayu Light"

--- a/modules/common/widgets/AttachedFileIndicator.qml
+++ b/modules/common/widgets/AttachedFileIndicator.qml
@@ -56,8 +56,8 @@ Rectangle {
     }
 
     // Styles/widgets
-    property real horizontalPadding: Appearance.spacing.space125
-    property real verticalPadding: Appearance.spacing.space125
+    property real horizontalPadding: Appearance.spacing.space150
+    property real verticalPadding: Appearance.spacing.space150
     radius: Appearance.rounding.small - anchors.margins
     color: highlight ? Appearance.colors.colPrimary : Appearance.colors.colLayer2
     implicitHeight: visible ? (contentItem.implicitHeight + verticalPadding * 2) : 0

--- a/modules/common/widgets/Carousel.qml
+++ b/modules/common/widgets/Carousel.qml
@@ -14,7 +14,7 @@ Item {
     property real largeItemWidthRatio: 0.52
     property real mediumItemWidthRatio: 0.32
     property real smallItemWidthRatio: 0.12
-    property real itemSpacing: Appearance.spacing.space75
+    property real itemSpacing: Appearance.spacing.space100
     property alias currentIndex: listView.currentIndex
 
     property bool wheelEnabled: true

--- a/modules/common/widgets/ColorSelectionArray.qml
+++ b/modules/common/widgets/ColorSelectionArray.qml
@@ -15,7 +15,7 @@ RowLayout {
     property string currentValue: ""
     property var options: ["primary", "secondary", "tertiary", "primaryContainer", "secondaryContainer", "tertiaryContainer", "layer1", "layer0"]
     property bool showLabel: true
-    property real itemSpacing: Appearance.spacing.space125
+    property real itemSpacing: Appearance.spacing.space150
     signal selected(string newValue)
 
     MaterialSymbol {

--- a/modules/common/widgets/KeyboardKey.qml
+++ b/modules/common/widgets/KeyboardKey.qml
@@ -5,7 +5,7 @@ Rectangle {
     id: root
     property string key
 
-    property real horizontalPadding: Appearance.spacing.space75
+    property real horizontalPadding: Appearance.spacing.space100
     property real verticalPadding: Appearance.spacing.space25
     property real borderWidth: 1
     property real extraBottomBorderWidth: 2

--- a/modules/common/widgets/MaterialPill.qml
+++ b/modules/common/widgets/MaterialPill.qml
@@ -6,7 +6,7 @@ Rectangle {
     id: root
     property bool vertical: false
     property real crossAxisSize: 32
-    property real mainAxisPadding: Appearance.spacing.space125
+    property real mainAxisPadding: Appearance.spacing.space150
     property real contentSpacing: Appearance.spacing.space50
     property real contentTopMargin: Appearance.spacing.space50
     property color bgColor: Appearance.colors.colPrimaryContainer

--- a/modules/common/widgets/PopupToolTip.qml
+++ b/modules/common/widgets/PopupToolTip.qml
@@ -11,7 +11,7 @@ Item {
     property string text: ""
     property bool extraVisibleCondition: true
     property bool alternativeVisibleCondition: false
-    property real horizontalPadding: Appearance.spacing.space125
+    property real horizontalPadding: Appearance.spacing.space150
     property real verticalPadding: Appearance.spacing.space50
     property real horizontalMargin: horizontalPadding
     property real verticalMargin: verticalPadding

--- a/modules/common/widgets/StyledToolTipContent.qml
+++ b/modules/common/widgets/StyledToolTipContent.qml
@@ -8,7 +8,7 @@ Item {
     id: root
     required property string text
     property bool shown: false
-    property real horizontalPadding: Appearance.spacing.space125
+    property real horizontalPadding: Appearance.spacing.space150
     property real verticalPadding: Appearance.spacing.space50
     property alias font: tooltipTextObject.font
     implicitWidth: tooltipTextObject.implicitWidth + 2 * root.horizontalPadding

--- a/modules/ii/bar/BarContent.qml
+++ b/modules/ii/bar/BarContent.qml
@@ -123,7 +123,7 @@ Item {
         // Left
         Item {
             anchors.left: parent.left
-            anchors.leftMargin: root.isMaterial ? (Config.options.hyprland.general.gapsOut || 5) : (Config.options.bar.cornerStyle === 1 ? Appearance.spacing.space50 : Appearance.spacing.space125)
+            anchors.leftMargin: root.isMaterial ? (Config.options.hyprland.general.gapsOut || 5) : (Config.options.bar.cornerStyle === 1 ? Appearance.spacing.space50 : Appearance.spacing.space150)
             anchors.top: parent.top
             anchors.bottom: parent.bottom
             width: root.isMaterial ? leftMaterialPill.implicitWidth : leftRow.implicitWidth
@@ -315,7 +315,7 @@ Item {
         // Right
         Item {
             anchors.right: parent.right
-            anchors.rightMargin: root.isMaterial ? (Config.options.hyprland.general.gapsOut || 5) : (Config.options.bar.cornerStyle === 1 ? Appearance.spacing.space50 : Appearance.spacing.space125)
+            anchors.rightMargin: root.isMaterial ? (Config.options.hyprland.general.gapsOut || 5) : (Config.options.bar.cornerStyle === 1 ? Appearance.spacing.space50 : Appearance.spacing.space150)
             anchors.top: parent.top
             anchors.bottom: parent.bottom
             width: root.isMaterial ? rightMaterialPill.implicitWidth : rightRow.implicitWidth

--- a/modules/ii/bar/ClockWidgetPopup.qml
+++ b/modules/ii/bar/ClockWidgetPopup.qml
@@ -73,7 +73,7 @@ StyledPopup {
                         anchors {
                             horizontalCenter: parent.horizontalCenter
                             top: parent.top
-                            topMargin: Appearance.spacing.space75
+                            topMargin: Appearance.spacing.space100
                         }
                         text: Qt.locale().toString(parent.date, "ddd").slice(0, 2)
                         font.pixelSize: Appearance.font.pixelSize.smaller
@@ -87,7 +87,7 @@ StyledPopup {
                         anchors {
                             horizontalCenter: parent.horizontalCenter
                             bottom: parent.bottom
-                            bottomMargin: Appearance.spacing.space75
+                            bottomMargin: Appearance.spacing.space100
                         }
                         text: parent.date.getDate()
                         font.pixelSize: parent.isToday

--- a/modules/ii/bar/Media.qml
+++ b/modules/ii/bar/Media.qml
@@ -349,7 +349,7 @@ Item {
                         }
                         StyledText {
                             id: titleText
-                            Layout.topMargin: (!root.activePlayer || root.trackArtist.length === 0) ? -Appearance.spacing.space175 : 0
+                            Layout.topMargin: (!root.activePlayer || root.trackArtist.length === 0) ? -Appearance.spacing.space200 : 0
                             text: StringUtils.cleanMusicTitle(root.trackTitle) || Translation.tr("No media")
                             font.pixelSize: Appearance.font.pixelSize.smallie
                             color: Appearance.colors.colOnSecondaryContainer

--- a/modules/ii/bar/Resources.qml
+++ b/modules/ii/bar/Resources.qml
@@ -24,46 +24,46 @@ BarWidgetSwitcherArea {
                 iconName: "planner_review"
                 shown: Config.options.bar.resources.alwaysShowCpu
                 percentage: ResourceUsage.cpuUsage
-                Layout.leftMargin: shown ? Appearance.spacing.space75 : 0
+                Layout.leftMargin: shown ? Appearance.spacing.space100 : 0
                 warningThreshold: Config.options.bar.resources.cpuWarningThreshold
             }
             Resource {
                 iconName: "thermostat"
                 shown: Config.options.bar.resources.alwaysShowCpuTemp
                 percentage: ResourceUsage.cpuTemp / 100
-                Layout.leftMargin: shown ? Appearance.spacing.space75 : 0
+                Layout.leftMargin: shown ? Appearance.spacing.space100 : 0
             }
             Resource {
                 iconName: "hard_drive"
                 shown: Config.options.bar.resources.alwaysShowDisk
                 percentage: ResourceUsage.diskUsedPercentage
-                Layout.leftMargin: shown ? Appearance.spacing.space75 : 0
+                Layout.leftMargin: shown ? Appearance.spacing.space100 : 0
             }
             Resource {
                 iconName: "swap_horiz"
                 shown: Config.options.bar.resources.alwaysShowSwap
                 percentage: ResourceUsage.swapUsedPercentage
-                Layout.leftMargin: shown ? Appearance.spacing.space75 : 0
+                Layout.leftMargin: shown ? Appearance.spacing.space100 : 0
                 warningThreshold: Config.options.bar.resources.swapWarningThreshold
             }
             Resource {
                 iconName: "monitor"
                 shown: Config.options.bar.resources.alwaysShowGpu
                 percentage: ResourceUsage.gpuUsage
-                Layout.leftMargin: shown ? Appearance.spacing.space75 : 0
+                Layout.leftMargin: shown ? Appearance.spacing.space100 : 0
                 warningThreshold: Config.options.bar.resources.gpuWarningThreshold
             }
             Resource {
                 iconName: "thermostat"
                 shown: Config.options.bar.resources.alwaysShowGpuTemp
                 percentage: ResourceUsage.gpuTemp / 100
-                Layout.leftMargin: shown ? Appearance.spacing.space75 : 0
+                Layout.leftMargin: shown ? Appearance.spacing.space100 : 0
             }
             Resource {
                 iconName: "memory"
                 shown: Config.options.bar.resources.alwaysShowVram
                 percentage: ResourceUsage.vramUsedPercentage
-                Layout.leftMargin: shown ? Appearance.spacing.space75 : 0
+                Layout.leftMargin: shown ? Appearance.spacing.space100 : 0
                 warningThreshold: Config.options.bar.resources.vramWarningThreshold
             }
         }
@@ -82,46 +82,46 @@ BarWidgetSwitcherArea {
                 iconName: "planner_review"
                 shown: Config.options.bar.resources.alwaysShowCpu
                 percentage: ResourceUsage.cpuUsage
-                Layout.leftMargin: shown ? Appearance.spacing.space75 : 0
+                Layout.leftMargin: shown ? Appearance.spacing.space100 : 0
                 warningThreshold: Config.options.bar.resources.cpuWarningThreshold
             }
             Resource {
                 iconName: "thermostat"
                 shown: Config.options.bar.resources.alwaysShowCpuTemp
                 percentage: ResourceUsage.cpuTemp / 100
-                Layout.leftMargin: shown ? Appearance.spacing.space75 : 0
+                Layout.leftMargin: shown ? Appearance.spacing.space100 : 0
             }
             Resource {
                 iconName: "hard_drive"
                 shown: Config.options.bar.resources.alwaysShowDisk
                 percentage: ResourceUsage.diskUsedPercentage
-                Layout.leftMargin: shown ? Appearance.spacing.space75 : 0
+                Layout.leftMargin: shown ? Appearance.spacing.space100 : 0
             }
             Resource {
                 iconName: "swap_horiz"
                 shown: Config.options.bar.resources.alwaysShowSwap
                 percentage: ResourceUsage.swapUsedPercentage
-                Layout.leftMargin: shown ? Appearance.spacing.space75 : 0
+                Layout.leftMargin: shown ? Appearance.spacing.space100 : 0
                 warningThreshold: Config.options.bar.resources.swapWarningThreshold
             }
             Resource {
                 iconName: "monitor"
                 shown: Config.options.bar.resources.alwaysShowGpu
                 percentage: ResourceUsage.gpuUsage
-                Layout.leftMargin: shown ? Appearance.spacing.space75 : 0
+                Layout.leftMargin: shown ? Appearance.spacing.space100 : 0
                 warningThreshold: Config.options.bar.resources.gpuWarningThreshold
             }
             Resource {
                 iconName: "thermostat"
                 shown: Config.options.bar.resources.alwaysShowGpuTemp
                 percentage: ResourceUsage.gpuTemp / 100
-                Layout.leftMargin: shown ? Appearance.spacing.space75 : 0
+                Layout.leftMargin: shown ? Appearance.spacing.space100 : 0
             }
             Resource {
                 iconName: "memory"
                 shown: Config.options.bar.resources.alwaysShowVram
                 percentage: ResourceUsage.vramUsedPercentage
-                Layout.leftMargin: shown ? Appearance.spacing.space75 : 0
+                Layout.leftMargin: shown ? Appearance.spacing.space100 : 0
                 warningThreshold: Config.options.bar.resources.vramWarningThreshold
             }
         }

--- a/modules/ii/bar/SystemIcons.qml
+++ b/modules/ii/bar/SystemIcons.qml
@@ -30,7 +30,7 @@ Item {
         anchors.centerIn: parent
         columns: root.vertical ? 1 : -1
         rows: root.vertical ? -1 : 1
-        columnSpacing: isMaterial ? Appearance.spacing.space25 : Appearance.spacing.space125
+        columnSpacing: isMaterial ? Appearance.spacing.space25 : Appearance.spacing.space150
         rowSpacing: columnSpacing
 
         Revealer {

--- a/modules/ii/onScreenDisplay/OsdValueIndicator.qml
+++ b/modules/ii/onScreenDisplay/OsdValueIndicator.qml
@@ -13,8 +13,8 @@ Item {
     property bool scaleIcon: false
     property alias from: valueProgressBar.from
     property alias to: valueProgressBar.to
-    property real valueIndicatorVerticalPadding: Appearance.spacing.space125
-    property real valueIndicatorLeftPadding: Appearance.spacing.space125
+    property real valueIndicatorVerticalPadding: Appearance.spacing.space150
+    property real valueIndicatorLeftPadding: Appearance.spacing.space150
     property real valueIndicatorRightPadding: Appearance.spacing.space250 // An icon is circle ish, a column isn't, hence the extra padding
 
     implicitWidth: Appearance.sizes.osdWidth + 4 * Appearance.sizes.elevationMargin

--- a/modules/ii/overlay/notes/NotesContent.qml
+++ b/modules/ii/overlay/notes/NotesContent.qml
@@ -194,7 +194,7 @@ OverlayBackground {
                         required property var modelData
                         readonly property real lineHeight: Math.min(Math.max(modelData.height, Appearance.font.pixelSize.normal + 6), root.maxCopyButtonSize)
                         readonly property real iconSizeLocal: Appearance.font.pixelSize.normal
-                        readonly property real hitPadding: Appearance.spacing.space75
+                        readonly property real hitPadding: Appearance.spacing.space100
                         property bool justCopied: false
 
                         implicitHeight: lineHeight

--- a/modules/ii/overview/NiriOverview.qml
+++ b/modules/ii/overview/NiriOverview.qml
@@ -26,7 +26,7 @@ Item {
 
     readonly property int maxWorkspaces: Config.options.bar.workspaces.shown ?? 10
     readonly property real wsHeight: (screen?.height ?? 1080) * 0.18
-    readonly property real wsPadding: Appearance.spacing.space125
+    readonly property real wsPadding: Appearance.spacing.space150
     readonly property real scale: Config.options.overview.scale
 
     readonly property real monitorW: screen?.width ?? 1920

--- a/modules/ii/overview/SearchItem.qml
+++ b/modules/ii/overview/SearchItem.qml
@@ -37,9 +37,9 @@ RippleButton {
     property bool blurImage: entry?.blurImage ?? false
     
     visible: root.entryShown
-    property int horizontalMargin: Appearance.spacing.space125
-    property int buttonHorizontalPadding: Appearance.spacing.space125
-    property int buttonVerticalPadding: Appearance.spacing.space75
+    property int horizontalMargin: Appearance.spacing.space150
+    property int buttonHorizontalPadding: Appearance.spacing.space150
+    property int buttonVerticalPadding: Appearance.spacing.space100
     property bool keyboardDown: false
     readonly property bool selected: (root.hovered || root.focus)
 
@@ -130,7 +130,7 @@ RippleButton {
 
     RowLayout {
         id: rowLayout
-        spacing: iconLoader.sourceComponent === null ? 0 : Appearance.spacing.space125
+        spacing: iconLoader.sourceComponent === null ? 0 : Appearance.spacing.space150
         anchors.fill: parent
         anchors.leftMargin: root.horizontalMargin + root.buttonHorizontalPadding
         anchors.rightMargin: root.horizontalMargin + root.buttonHorizontalPadding

--- a/modules/ii/regionSelector/TargetRegion.qml
+++ b/modules/ii/regionSelector/TargetRegion.qml
@@ -18,7 +18,7 @@ Rectangle {
     property color borderColor
     property color fillColor: "transparent"
     property string text: ""
-    property real textPadding: Appearance.spacing.space125
+    property real textPadding: Appearance.spacing.space150
     z: 2
     color: fillColor
     border.color: borderColor
@@ -49,7 +49,7 @@ Rectangle {
         active: root.showLabel
         sourceComponent: Rectangle {
             property real verticalPadding: Appearance.spacing.space50
-            property real horizontalPadding: Appearance.spacing.space125
+            property real horizontalPadding: Appearance.spacing.space150
             radius: 10
             color: root.colBackground
             border.width: Appearance.borderWidth.standard

--- a/modules/ii/sidebarLeft/SidebarLeftContent.qml
+++ b/modules/ii/sidebarLeft/SidebarLeftContent.qml
@@ -10,7 +10,7 @@ import Qt.labs.synchronizer
 Item {
     id: root
     required property var scopeRoot
-    property int sidebarPadding: Appearance.spacing.space125
+    property int sidebarPadding: Appearance.spacing.space150
     anchors.fill: parent
     property bool aiChatEnabled: Config.options.policies.ai !== 0
     property bool translatorEnabled: Config.options.sidebar.translator.enable

--- a/modules/ii/sidebarLeft/aiChat/AttachedFileIndicator.qml
+++ b/modules/ii/sidebarLeft/aiChat/AttachedFileIndicator.qml
@@ -54,8 +54,8 @@ Rectangle {
     }
 
     // Styles/widgets
-    property real horizontalPadding: Appearance.spacing.space125
-    property real verticalPadding: Appearance.spacing.space125
+    property real horizontalPadding: Appearance.spacing.space150
+    property real verticalPadding: Appearance.spacing.space150
     radius: Appearance.rounding.small - anchors.margins
     color: Appearance.colors.colLayer2
     implicitHeight: visible ? (contentItem.implicitHeight + verticalPadding * 2) : 0

--- a/modules/ii/sidebarLeft/aiChat/MessageThinkBlock.qml
+++ b/modules/ii/sidebarLeft/aiChat/MessageThinkBlock.qml
@@ -21,7 +21,7 @@ Item {
 
     property real thinkBlockBackgroundRounding: Appearance.rounding.small
     property real thinkBlockHeaderPaddingVertical: Appearance.spacing.space50
-    property real thinkBlockHeaderPaddingHorizontal: Appearance.spacing.space125
+    property real thinkBlockHeaderPaddingHorizontal: Appearance.spacing.space150
     property real thinkBlockComponentSpacing: Appearance.spacing.space25
 
     property var collapseAnimation: messageTextBlock.implicitHeight > 40 ? Appearance.animation.elementMoveEnter : Appearance.animation.elementMoveFast

--- a/modules/ii/sidebarRight/BottomWidgetGroup.qml
+++ b/modules/ii/sidebarRight/BottomWidgetGroup.qml
@@ -13,7 +13,12 @@ Rectangle {
     radius: Appearance.rounding.normal
     color: Appearance.colors.colLayer1
     clip: true
-    implicitHeight: collapsed ? collapsedBottomWidgetGroupRow.implicitHeight : 350
+    // 350 is the floor for the tabs that fill their parent (To Do, Timer). The
+    // calendar is content-sized and taller than that, so it was being clipped
+    // by the group's rounded surface - grow to whatever the loaded tab needs.
+    readonly property int expandedHeight: Math.max(350,
+        tabStack.implicitHeight + Appearance.spacing.space150 * 2)
+    implicitHeight: collapsed ? collapsedBottomWidgetGroupRow.implicitHeight : expandedHeight
     property int selectedTab: Persistent.states.sidebar.bottomGroup.tab
     property int previousIndex: -1
     property bool collapsed: Persistent.states.sidebar.bottomGroup.collapsed

--- a/modules/ii/sidebarRight/SidebarRightContent.qml
+++ b/modules/ii/sidebarRight/SidebarRightContent.qml
@@ -24,7 +24,7 @@ import qs.modules.ii.sidebarRight.iconPicker
 Item {
     id: root
     property int sidebarWidth: Appearance.sizes.sidebarWidth
-    property int sidebarPadding: Appearance.spacing.space125
+    property int sidebarPadding: Appearance.spacing.space150
     property string settingsQmlPath: Quickshell.shellPath("settings.qml")
     property bool showAudioOutputDialog: false
     property bool showAudioInputDialog: false

--- a/modules/ii/sidebarRight/calendar/CalendarHeaderButton.qml
+++ b/modules/ii/sidebarRight/calendar/CalendarHeaderButton.qml
@@ -8,8 +8,12 @@ RippleButton {
     property string tooltipText: ""
     property bool forceCircle: false
 
+    // Callers align this button against the day grid, so the inset the label
+    // sits behind has to be readable from outside.
+    property int horizontalPadding: Appearance.spacing.space150
+
     implicitHeight: 30
-    implicitWidth: forceCircle ? implicitHeight : (contentItem.implicitWidth + 10 * 2)
+    implicitWidth: forceCircle ? implicitHeight : (contentItem.implicitWidth + horizontalPadding * 2)
     Behavior on implicitWidth {
         SmoothedAnimation {
             velocity: Appearance.animation.elementMove.velocity

--- a/modules/ii/sidebarRight/calendar/CalendarWidget.qml
+++ b/modules/ii/sidebarRight/calendar/CalendarWidget.qml
@@ -6,13 +6,11 @@ import QtQuick
 import QtQuick.Layouts
 
 Item {
-    // Layout.topMargin: 10
-    anchors.topMargin: Appearance.spacing.space150
     property int monthShift: 0
     property var viewingDate: CalendarLayout.getDateInXMonthsTime(monthShift)
     property var calendarLayout: CalendarLayout.getCalendarLayout(viewingDate, monthShift === 0)
     width: calendarColumn.width
-    implicitHeight: calendarColumn.height + 10 * 2
+    implicitHeight: calendarColumn.height + Appearance.spacing.space150 * 2
 
     Keys.onPressed: (event) => {
         if ((event.key === Qt.Key_PageDown || event.key === Qt.Key_PageUp)

--- a/modules/ii/sidebarRight/calendar/CalendarWidget.qml
+++ b/modules/ii/sidebarRight/calendar/CalendarWidget.qml
@@ -6,7 +6,11 @@ import QtQuick
 import QtQuick.Layouts
 
 Item {
+    id: root
     property int monthShift: 0
+    // One grid column. The header's circular buttons match it so they sit
+    // centred over the last two day columns instead of a few pixels off.
+    readonly property int dayCellSize: 38
     property var viewingDate: CalendarLayout.getDateInXMonthsTime(monthShift)
     property var calendarLayout: CalendarLayout.getCalendarLayout(viewingDate, monthShift === 0)
     width: calendarColumn.width
@@ -44,7 +48,11 @@ Item {
             Layout.fillWidth: true
             spacing: Appearance.spacing.space100
             CalendarHeaderButton {
+                id: monthButton
                 clip: true
+                // Pull the button out by its own inset so the month label starts
+                // on the first day column's left edge instead of 12px right of it.
+                Layout.leftMargin: -horizontalPadding
                 buttonText: `${monthShift != 0 ? "• " : ""}${viewingDate.toLocaleDateString(Qt.locale(), "MMMM yyyy")}`
                 tooltipText: (monthShift === 0) ? "" : Translation.tr("Jump to current month")
                 downAction: () => {
@@ -57,6 +65,7 @@ Item {
             }
             CalendarHeaderButton {
                 forceCircle: true
+                implicitHeight: root.dayCellSize
                 downAction: () => {
                     monthShift--;
                 }
@@ -69,6 +78,7 @@ Item {
             }
             CalendarHeaderButton {
                 forceCircle: true
+                implicitHeight: root.dayCellSize
                 downAction: () => {
                     monthShift++;
                 }
@@ -90,6 +100,8 @@ Item {
             Repeater {
                 model: CalendarLayout.weekDays
                 delegate: CalendarDayButton {
+                    implicitWidth: root.dayCellSize
+                    implicitHeight: root.dayCellSize
                     day: Translation.tr(modelData.day)
                     isToday: modelData.today
                     bold: true
@@ -110,6 +122,8 @@ Item {
                 Repeater {
                     model: Array(7).fill(modelData)
                     delegate: CalendarDayButton {
+                        implicitWidth: root.dayCellSize
+                        implicitHeight: root.dayCellSize
                         day: calendarLayout[modelData][index].day
                         isToday: calendarLayout[modelData][index].today
                     }

--- a/modules/ii/sidebarRight/todo/TodoWidget.qml
+++ b/modules/ii/sidebarRight/todo/TodoWidget.qml
@@ -11,7 +11,7 @@ Item {
     property bool showAddDialog: false
     property int dialogMargins: Appearance.spacing.space250
     property int fabSize: 48
-    property int fabMargins: Appearance.spacing.space175
+    property int fabMargins: Appearance.spacing.space200
 
     Keys.onPressed: (event) => {
         if ((event.key === Qt.Key_PageDown || event.key === Qt.Key_PageUp) && event.modifiers === Qt.NoModifier) {

--- a/modules/ii/verticalBar/VerticalBarContent.qml
+++ b/modules/ii/verticalBar/VerticalBarContent.qml
@@ -112,7 +112,7 @@ Item {
         // Top
         Item {
             anchors.top: parent.top
-            anchors.topMargin: root.isMaterial ? (Config.options.hyprland.general.gapsOut || 5) : (Config.options.bar.cornerStyle === 1 ? Appearance.spacing.space50 : Appearance.spacing.space125)
+            anchors.topMargin: root.isMaterial ? (Config.options.hyprland.general.gapsOut || 5) : (Config.options.bar.cornerStyle === 1 ? Appearance.spacing.space50 : Appearance.spacing.space150)
             anchors.left: parent.left
             anchors.right: parent.right
             height: root.isMaterial ? topMaterialPill.implicitHeight : topCol.implicitHeight
@@ -265,7 +265,7 @@ Item {
         // Bottom
         Item {
             anchors.bottom: parent.bottom
-            anchors.bottomMargin: root.isMaterial ? (Config.options.hyprland.general.gapsOut || 5) : (Config.options.bar.cornerStyle === 1 ? Appearance.spacing.space50 : Appearance.spacing.space125)
+            anchors.bottomMargin: root.isMaterial ? (Config.options.hyprland.general.gapsOut || 5) : (Config.options.bar.cornerStyle === 1 ? Appearance.spacing.space50 : Appearance.spacing.space150)
             anchors.left: parent.left
             anchors.right: parent.right
             height: root.isMaterial ? bottomMaterialPill.implicitHeight : bottomCol.implicitHeight

--- a/tests/lint_spacing.py
+++ b/tests/lint_spacing.py
@@ -2,7 +2,8 @@
 #
 # Regression guard: spacing/padding/margin properties must use Appearance.spacing
 # tokens, not raw pixel literals. The Material 3 system scale is
-# 0,2,4,6,8,10,12,14,16,20,24,32,36,40,48,56,64,72. Any raw spacing value in
+# 0,2,4,8,12,16,20,24,32,36,40,48,56,64,72 - the two fine values, then
+# multiples of 4. Any raw spacing value in
 # that range should be snapped to the nearest token.
 #
 # It flags property assignments and spacing-like local property declarations
@@ -35,7 +36,12 @@ BARE_LITERAL = re.compile(r'^\s*(-?\d+)\s*$')
 BRANCH_LITERAL = re.compile(r'(?:\?|:)\s*(-?\d+)(?=\s*(?:[:,)]|$))')
 
 LEGACY_ALIAS = re.compile(
-    r'Appearance\.spacing\.(hairline|unsharpen|verysmall|small|normal|large|verylarge|huge)\b'
+    r'Appearance\.spacing\.('
+    r'hairline|unsharpen|verysmall|small|normal|large|verylarge|huge'
+    # Retired: the scale keeps 2 and 4, then multiples of 4 only. 6, 10 and 14
+    # round up to space100, space150 and space200.
+    r'|space75|space125|space175'
+    r')\b'
 )
 
 violations = []
@@ -64,7 +70,7 @@ for f in glob.glob(ROOT + "/**/*.qml", recursive=True):
 
 if violations:
     print("Spacing lint FAILED: raw pixel values must use Appearance.spacing tokens "
-          "(M3 scale 0,2,4,6,8,10,12,14,16,20,24,32,36,40,48,56,64,72 - snap to nearest):", file=sys.stderr)
+          "(scale 0,2,4,8,12,16,20,24,32,36,40,48,56,64,72 - snap to nearest):", file=sys.stderr)
     for rel, ln, prop, n in violations:
         print(f"  modules/{rel}:{ln}  {prop}: {n}", file=sys.stderr)
     sys.exit(1)

--- a/tests/tst_spacing_scale.qml
+++ b/tests/tst_spacing_scale.qml
@@ -5,22 +5,25 @@ import qs.modules.common
 TestCase {
     name: "SpacingScaleTest"
 
-    // Guards Material 3's system spacing scale. space100 (8dp) is the base
-    // unit; the other names are percentages of that base.
+    // Guards the spacing scale: the two fine values 2 and 4, then multiples
+    // of 4 only. M3's nested 6/10/14 steps are deliberately not offered.
     function test_scaleValues() {
         const actual = [Appearance.spacing.space0, Appearance.spacing.space25,
-                        Appearance.spacing.space50, Appearance.spacing.space75,
-                        Appearance.spacing.space100, Appearance.spacing.space125,
-                        Appearance.spacing.space150, Appearance.spacing.space175,
-                        Appearance.spacing.space200, Appearance.spacing.space250,
+                        Appearance.spacing.space50, Appearance.spacing.space100,
+                        Appearance.spacing.space150, Appearance.spacing.space200,
+                        Appearance.spacing.space250,
                         Appearance.spacing.space300, Appearance.spacing.space400,
                         Appearance.spacing.space450, Appearance.spacing.space500,
                         Appearance.spacing.space600, Appearance.spacing.space700,
                         Appearance.spacing.space800, Appearance.spacing.space900];
-        const expected = [0, 2, 4, 6, 8, 10, 12, 14, 16, 20, 24, 32, 36, 40, 48, 56, 64, 72];
+        const expected = [0, 2, 4, 8, 12, 16, 20, 24, 32, 36, 40, 48, 56, 64, 72];
         compare(actual.length, expected.length);
         for (let i = 0; i < expected.length; ++i)
             compare(actual[i], expected[i], "space token at index " + i);
+
+        // Every step above the two fine values must be a multiple of 4.
+        for (const value of expected.slice(2))
+            compare(value % 4, 0, "step " + value + " is not a multiple of 4");
     }
 
     function test_borderWidthTokens() {


### PR DESCRIPTION
## Summary

Brings `Appearance.spacing` in line with this fork's rule that measurements start at 1, 2, 4 and then follow a multiple-of-four rhythm — the rule `borderWidth`'s `1/2/4` already follows. Adds two calendar fixes found while testing the result.

## The scale

`space75` (6), `space125` (10) and `space175` (14) are retired. Their **48 call sites** round **up** — 6→8, 10→12, 14→16 — so nothing gets tighter than it was, only slightly airier.

Resulting scale: `0, 2, 4, 8, 12, 16, 20, 24, 32, 36, 40, 48, 56, 64, 72`.

## Guards

- `tests/lint_spacing.py` reports the retired names as legacy aliases. Verified it actually fails by reintroducing one.
- `tst_spacing_scale.qml` now asserts the multiple-of-four rule directly rather than only pinning the expected list, so adding a future 6 or 10 fails on principle.
- `AGENT.md` and `docs/M3_GUIDELINES.md` document the round-up rule.

## Calendar fixes (independent of the scale)

- **`BottomWidgetGroup`** had a fixed `implicitHeight: 350` with `clip: true`, so the calendar's last week row was sliced off by the rounded surface. 350 is now a floor for the tabs that fill their parent; the group otherwise grows to the loaded tab's implicit height.
- **Calendar header alignment**: the month label sat inside its button's inset, a dozen pixels right of the first day column, and the month arrows were sized independently of the grid. The header button's inset is now readable from outside, the month button is pulled out by it, and the arrows are one grid column wide so they centre over Sa and Su. The column size has a single owner instead of a `38` repeated per delegate.

## Testing

`./tests/run_tests.sh` green (69 QML tests plus the Python checks). Live shell reloaded with no QML warnings. Visually verified: calendar renders fully, header aligns to the grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)