### PR TITLE
fix: plugin font tofu + hide bar widget when plugin disabled

### DIFF
--- a/dots-extra/fontsets/ar/fonts.conf
+++ b/dots-extra/fontsets/ar/fonts.conf
@@ -7,12 +7,18 @@
     </edit>
   </match>
 
-  <!-- Fix for: arabic fonts rendering in Noto Nastaliq Urdu | affects Chromium, Discord (maybe all chromium based apps, but not Spotify somehow) -->
+  <!-- Fix for: arabic fonts rendering in Noto Nastaliq Urdu | affects Chromium, Discord (maybe all chromium based apps, but not Spotify somehow).
+       A Latin face (Noto Sans) is prepended FIRST so single-face apps that pick
+       one family instead of doing per-glyph fallback (e.g. the activate-linux
+       watermark) still get Latin glyphs rather than tofu boxes. Noto Sans Arabic
+       stays right behind it, so Arabic text still resolves to Naskh, not
+       Nastaliq. -->
   <match target="pattern">
     <test compare="eq" name="family">
       <string>sans-serif</string>
     </test>
     <edit name="family" mode="prepend" binding="strong">
+      <string>Noto Sans</string>
       <string>Noto Sans Arabic</string>
     </edit>
   </match>

--- a/dots/.config/quickshell/ii/modules/ii/bar/BarContent.qml
+++ b/dots/.config/quickshell/ii/modules/ii/bar/BarContent.qml
@@ -28,6 +28,12 @@ Item {
             if (name === "sysTray" && !trayHasItems) return false;
             if (root.suppressDockerForMemoryTest
                     && (name === "dockerPlugin" || name === "plugin:docker_plugin")) return false;
+            // A plugin's bar widget tracks its enabled state: disabling (or
+            // uninstalling) a plugin drops its id from plugins.enabled, so its
+            // bar entry disappears with it. The layout token still holds the id
+            // (plugin:<id>), so re-enabling restores the widget in place.
+            if (name.startsWith("plugin:") && !Config.options.plugins.enabled.includes(name.substring(7)))
+                return false;
             return true;
         });
     }


### PR DESCRIPTION
Two plugin-related fixes surfaced while running the suite on a real Arch machine.

## fix(fontset): prevent Latin tofu in the ar fontset

The `ar` fontset prepended `Noto Sans Arabic` with `binding="strong"` to every `sans-serif` request (to force Arabic away from Nastaliq). Apps that do per-glyph fallback (Chromium, Discord) were unaffected, but single-face renderers — notably the `activate-linux` watermark plugin — select that one Arabic face and render Latin text as tofu boxes.

Prepend `Noto Sans` ahead of `Noto Sans Arabic` so Latin resolves first while Arabic still falls through to Naskh (not Nastaliq). Only affects installs that opted into the `ar` fontset.

## fix(bar): hide a plugin's bar widget when the plugin is disabled

The bar built its layout straight from `bar.layouts` and never consulted `plugins.enabled`, so a disabled (or uninstalled) plugin's bar widget kept rendering. Gate every `plugin:<id>` layout token on membership in `plugins.enabled` inside `filterLayout`, which all three bar paths (docker native, discord native, generic `PluginBarWidget`) already funnel through. The token stays in `bar.layouts`, so re-enabling the plugin restores its widget in place.

## Testing

- fontconfig: `fc-match sans-serif` → `Noto Sans` (was `Noto Sans Arabic`); `sans-serif:lang=ar` still resolves Noto Sans Arabic ahead of Nastaliq.
- bar: disabling docker/discord in Settings removes its bar widget live; re-enabling restores it.