### PR TITLE
fix(installer): keep quiet-mode install in-session so sudo can authenticate

### DIFF
--- a/sdata/subcmd-install/tui.sh
+++ b/sdata/subcmd-install/tui.sh
@@ -289,7 +289,7 @@ progress_loop(){
 }
 
 # Cancel handler for quiet-mode: SIGINT/SIGTERM here means the user pressed
-# Ctrl-C while the (setsid'd) install group was building. TERM the whole group,
+# Ctrl-C while the (job-controlled) install group was building. TERM the whole group,
 # grace, then KILL. Also try the kills under `sudo -n` so root-owned children
 # (an in-flight pacman) go down too — the sudo timestamp is warm from the
 # keepalive. Compiler children (make/ninja/cc) run as the user during the long
@@ -328,14 +328,27 @@ run_quiet_install(){
   clear; banner; printf '\n'
   # --force -> ask=false (no pauses/confirms); </dev/null -> functions.sh x()
   # aborts on failure instead of prompting; all output goes to the log.
-  # setsid: run the install as its OWN process-group leader so a cancel can
-  # take down the whole build tree (make/ninja/cc) via `kill -- -PGID`, and so
-  # terminal Ctrl-C reaches only this script's on_cancel handler (which then
-  # forwards a clean TERM to the group) instead of half-killing the build.
+  #
+  # Run the install as its OWN process-group leader so a cancel can take down the
+  # whole build tree (make/ninja/cc) via `kill -- -PGID`, and so terminal Ctrl-C
+  # reaches only this script's on_cancel handler (which then forwards a clean
+  # TERM to the group) instead of half-killing the build.
+  #
+  # We isolate the group with job control (set -m), NOT setsid: the child must
+  # stay in THIS session so it keeps the controlling terminal. sudo's default
+  # timestamp_type is `tty`, which ties the credential we warmed above (sudo -v)
+  # to this terminal — a setsid-detached child gets a brand-new, tty-less session
+  # and cannot see that credential, so setup's own sudo keepalive aborts with
+  # "a terminal is required to read the password". Backgrounding under `set -m`
+  # still makes the child a process-group leader (PGID == PID) for the cancel
+  # path, while /dev/tty stays reachable so `sudo` re-authenticates silently.
   CANCELLED_INSTALL=0
-  setsid "$SETUP_BIN" install "${INSTALL_FLAGS[@]}" --force </dev/null >"$log" 2>&1 &
+  local had_monitor=1; case "$-" in *m*) : ;; *) had_monitor=0 ;; esac
+  set -m
+  "$SETUP_BIN" install "${INSTALL_FLAGS[@]}" --force </dev/null >"$log" 2>&1 &
   local pid=$!
-  INSTALL_PGID="$pid"                 # setsid makes the child its own group leader (PGID == PID)
+  (( had_monitor )) || set +m         # restore prior state; the child keeps its own group
+  INSTALL_PGID="$pid"                 # job-control backgrounding makes the child its own group leader (PGID == PID)
   trap on_cancel INT TERM
   progress_loop "$pid" "$log"
   wait "$pid"; INSTALL_RET=$?


### PR DESCRIPTION
## Problem

Every **quiet-mode** (default) install fails on a stock sudo config with:

```
[…/setup]: Requesting sudo privileges for installation...
sudo: a terminal is required to read the password; either use the -S option to read from standard input or configure an askpass helper
sudo: a password is required
[…/setup]: Failed to obtain sudo privileges. Aborting...
```

### Root cause

`run_quiet_install` (`sdata/subcmd-install/tui.sh`) warms the sudo timestamp in the parent (`sudo -v`) and then launches the real installer under **`setsid`**:

```sh
setsid "$SETUP_BIN" install "${INSTALL_FLAGS[@]}" --force </dev/null >"$log" 2>&1 &
```

`setsid` starts a **brand-new session with no controlling terminal**. sudo's default `timestamp_type` is `tty`, which binds the warmed credential to the parent's terminal. The detached, tty-less child cannot see that credential and cannot prompt either, so `setup`'s own sudo keepalive (`sudo true` in `sdata/lib/functions.sh`) aborts.

The **verbose** path was unaffected because it runs the installer attached to the terminal.

## Fix

Isolate the install's process group with **job control (`set -m`)** instead of `setsid`. The child still becomes its own process-group leader (`PGID == PID`), so the cancel path's `kill -- -PGID` is unchanged — but it stays in the current session, keeps `/dev/tty` reachable, and re-authenticates silently from the warmed timestamp. Brings quiet mode to parity with verbose.

Prior job-control state is saved/restored so the change is self-contained.

## Testing

Reproduced and verified the mechanism on Arch (default sudo, `timestamp_type=tty`):

- **`setsid` child** → `sudo -n true` **FAILS** (reproduces the bug).
- **`set -m` child** → `sudo -n true` **SUCCEEDS**, child is its own group leader (`PGID == PID`).
- **Cancel** → `kill -- -PGID` reaches and terminates the whole group.
- `bash -n` clean.
