### PR TITLE
fix(dist-arch): let microtex supersede illogical-impulse-microtex-git

### DIFF
--- a/sdata/dist-arch/immaterial-impulse-microtex-git/PKGBUILD
+++ b/sdata/dist-arch/immaterial-impulse-microtex-git/PKGBUILD
@@ -2,13 +2,23 @@ groups=(immaterial-impulse)
 pkgname=immaterial-impulse-microtex-git
 _pkgname=MicroTeX
 pkgver=r494.0e3707f
-pkgrel=4
+pkgrel=5
 pkgdesc='MicroTeX for Immaterial Impulse dotfiles.'
 #pkgdesc="A dynamic, cross-platform, and embeddable LaTeX rendering library"
 arch=("x86_64")
 #url="https://github.com/NanoMichael/${_pkgname}"
 url="https://github.com/end-4/${_pkgname}"
 license=('MIT')
+# Supersede the upstream illogical-impulse packages. This builds the same
+# /opt/MicroTeX tree — and, via makepkg's split debug package, the same
+# /usr/lib/debug/opt/MicroTeX files — as illogical-impulse-microtex-git and
+# illogical-impulse-microtex-git-debug. Without conflict metadata pacman aborts
+# with "exists in filesystem (owned by illogical-impulse-microtex-git)". List
+# BOTH packages (the auto-generated -debug split does not inherit the main
+# package's conflicts) so pacman removes them in the same transaction before
+# extracting ours. Mirrors immaterial-impulse-bibata-* (a -bin, hence no -debug).
+conflicts=("illogical-impulse-microtex-git" "illogical-impulse-microtex-git-debug")
+replaces=("illogical-impulse-microtex-git" "illogical-impulse-microtex-git-debug")
 depends=(
   tinyxml2
   gtkmm3


### PR DESCRIPTION
## Problem

On a machine migrating from **illogical-impulse**, the install aborts while building `immaterial-impulse-microtex-git`:

```
immaterial-impulse-microtex-git: /opt/MicroTeX/res/greek/fcmrpg.ttf exists in filesystem
    (owned by illogical-impulse-microtex-git)
... (every /opt/MicroTeX file) ...
Errors occurred, no packages were upgraded.
==> WARNING: Failed to install built package(s).
Command "makepkg -Afsi --noconfirm" has failed.
```

Both packages install the same `/opt/MicroTeX` tree, but `immaterial-impulse-microtex-git` declared **no** conflict metadata, so pacman treats it as a raw file-ownership collision and fails the whole run. Most other renamed packages install to non-overlapping paths and coexist fine; microtex (`/opt`) is the exception, alongside quickshell-git (already handled via its `provides/conflicts`).

## Fix

Add `conflicts`/`replaces` for `illogical-impulse-microtex-git`, mirroring `immaterial-impulse-bibata-modern-classic-bin`, so pacman swaps the package cleanly on upgrade. The upstream package is `Required By: none`, so removal is safe. `pkgrel` bumped 4 → 5.

## Notes

- `immaterial-impulse-quickshell-git` already handles its illogical counterpart: it `provides`/`conflicts` `quickshell` + `quickshell-git`, which `illogical-impulse-quickshell-git` provides, and the only dependent (`illogical-updots`) requires the virtual `quickshell` — so it swaps automatically.
- Verified on an Arch machine with the full `illogical-impulse-*` set installed.
