### PR TITLE
fix(install): pin WE_REF to a commit that has scripts/build-we.sh

### DIFF
--- a/sdata/subcmd-install/4.wallpaperengine.sh
+++ b/sdata/subcmd-install/4.wallpaperengine.sh
@@ -39,9 +39,12 @@ set -euo pipefail
 [[ "${INSTALL_WE:-0}" == "1" ]] || { echo "[ImI] Wallpaper Engine: skipped."; exit 0; }
 
 WE_REPO="${WE_REPO:-https://github.com/XephyLon/qs-wallpaperengine}"
-WE_REF="${WE_REF:-a721ef1}"                      # working commit pin; NO prebuilt release exists for it, so installs
-                                                 # fall back to a source build (git checkout a721ef1 succeeds). Bump this
-                                                 # to a release tag (vX.Y.Z) once one is cut to activate the prebuilt
+WE_REF="${WE_REF:-6e17750}"                      # working commit pin; NO prebuilt release exists for it, so installs
+                                                 # fall back to a source build. MUST be >= 40427cf, the commit that added
+                                                 # scripts/build-we.sh (source_build() runs it, and eval's its stdout —
+                                                 # 71dea54 made that eval-safe); the previous a721ef1 pin predated the
+                                                 # script and failed with "scripts/build-we.sh: No such file or directory".
+                                                 # Bump to a release tag (vX.Y.Z) once one is cut to activate the prebuilt
                                                  # fast-path — see qs-wallpaperengine/docs/cutting-a-release.md.
 BUILD_DIR="${BUILD_DIR:-$HOME/.cache/immaterial-impulse/qs-wallpaperengine-build}"
 PREBUILT_ROOT="${PREBUILT_ROOT:-$HOME/.cache/immaterial-impulse/prebuilt}"


### PR DESCRIPTION
## Problem

With `INSTALL_WE=1`, the install runs to completion (theme fully installed, "Finished" printed) and then **exits 127** at the very last step, the Wallpaper Engine source build:

```
[ImI] Wallpaper Engine: building qs-wallpaperengine from source...
HEAD is now at a721ef1 fix(bootstrap): robust WallpaperApplication getFirst* patch + force checkout
bash: .../qs-wallpaperengine-build/scripts/build-we.sh: No such file or directory
```

`source_build()` in `sdata/subcmd-install/4.wallpaperengine.sh` does:

```sh
paths="$(REPO_ROOT="$BUILD_DIR" bash "$BUILD_DIR/scripts/build-we.sh")"
eval "$paths"
```

but `WE_REF` was pinned to `a721ef1`, a commit that **predates `scripts/build-we.sh`** entirely (that commit has no `scripts/` dir).

## Fix

`scripts/build-we.sh` was added in `40427cf` and made eval-safe (stdout kept clean, compile output routed to stderr — required for the `eval` above) in `71dea54`. Bump the pin to **`6e17750`**, the current `qs-wallpaperengine` `main` HEAD, which:

- is a **descendant of `a721ef1`**, so it retains the bootstrap `getFirst*` fix that pin was chosen for;
- contains `scripts/build-we.sh` (the eval-safe version);
- still has **no prebuilt release**, so the source-build path is exercised exactly as intended (`try_prebuilt` fails → `source_build`).

Verified against the actual checkout: `git ls-tree -r 6e17750` contains both `bootstrap.sh` and `scripts/build-we.sh`, and `a721ef1..6e17750` is linear.
