### PR TITLE
fix(dist-arch): remove superseded illogical-impulse packages before install

### DIFF
--- a/sdata/dist-arch/immaterial-impulse-quickshell-git/PKGBUILD
+++ b/sdata/dist-arch/immaterial-impulse-quickshell-git/PKGBUILD
@@ -8,7 +8,7 @@ _prefix='immaterial-impulse'
 _pkgname=quickshell
 pkgname="$_prefix-$_pkgname-git"
 pkgver=0.1.0.r1
-pkgrel=9
+pkgrel=10
 pkgdesc="$_pkgname-git pinned commit and extra deps for $_prefix"
 arch=(x86_64 aarch64)
 url='https://git.outfoxxed.me/quickshell/quickshell'
@@ -55,6 +55,10 @@ makedepends=(
 )
 provides=("$_pkgname" "$_pkgname-git")
 conflicts=("$_pkgname" "$_pkgname-git")
+# Supersede the upstream illogical-impulse build. It provides the same virtual
+# `quickshell`/`quickshell-git`, so on a migration pacman -U would abort on the
+# conflict; install-deps.sh reads this `replaces` and removes it first.
+replaces=("illogical-impulse-quickshell-git")
 
 _pkgsrc="$_pkgname"
 source=("$_pkgsrc::git+$url.git#commit=$_commit"

--- a/sdata/dist-arch/install-deps.sh
+++ b/sdata/dist-arch/install-deps.sh
@@ -82,6 +82,11 @@ install-local-pkgbuild() {
 
   x pushd $location
 
+  # Fresh per-package metadata: `source` does not clear arrays a previous
+  # PKGBUILD set, so a package that omits `replaces` would inherit the last
+  # one's. Unset it first so the supersede loop below only ever sees the current
+  # package's own value.
+  unset replaces
   source ./PKGBUILD
 
   # Idempotent local install: if this exact version is already installed and we
@@ -100,6 +105,26 @@ install-local-pkgbuild() {
   fi
 
   x yay -S --sudoloop $installflags --asdeps "${depends[@]}"
+
+  # Honour `replaces` ourselves. makepkg -i runs `pacman -U --noconfirm`, which
+  # does NOT act on replaces/conflicts non-interactively: pacman's "Remove the
+  # conflicting X? [y/N]" prompt defaults to No, so an installed predecessor
+  # (the illogical-impulse-* packages this suite supersedes, which share e.g.
+  # /opt/MicroTeX or the `quickshell` provides) makes the install step abort with
+  # "unresolvable package conflicts". Remove any still-installed predecessor
+  # first so the build's install step is a clean upgrade. -Rdd skips dependency
+  # checks: the new package re-provides whatever the old one did, so a transient
+  # reverse-dep (e.g. illogical-updots -> quickshell) is satisfied again the
+  # moment the new package installs.
+  local _old
+  for _old in "${replaces[@]:-}"; do
+    [[ -n "$_old" ]] || continue
+    if pacman -Qq "$_old" >/dev/null 2>&1; then
+      printf "${STY_CYAN}[$0]: %s supersedes installed %s; removing it first.${STY_RST}\n" "$pkgname" "$_old"
+      x sudo pacman -Rdd --noconfirm "$_old"
+    fi
+  done
+
   # man makepkg:
   # -A, --ignorearch: Ignore a missing or incomplete arch field in the build script.
   # -s, --syncdeps: Install missing dependencies using pacman. When build-time or run-time dependencies are not found, pacman will try to resolve them.


### PR DESCRIPTION
## Problem

The suite's local packages install via `makepkg -Afsi --noconfirm` → `pacman -U --noconfirm`, which **does not act on `replaces`/`conflicts` non-interactively**. pacman's conflict prompt defaults to **No**, so on a machine migrating from `illogical-impulse` the install aborts:

```
:: immaterial-impulse-microtex-git and illogical-impulse-microtex-git are in conflict.
   Remove illogical-impulse-microtex-git? [y/N]  error: unresolvable package conflicts
==> WARNING: Failed to install built package(s).
```

`replaces` only auto-applies during `-Sy`/`-Su` sync transactions, never `-U`. So the `conflicts`/`replaces` metadata added for microtex (#16) and bibata is correct but inert here — a fresh migration still required manual `pacman -Rdd` of microtex, quickshell, and bibata.

## Fix

Honour `replaces` in `install-local-pkgbuild()`: after sourcing each PKGBUILD, remove any package it lists in `replaces` that is still installed, **before** building — so the install step is a clean upgrade.

- `unset replaces` before each `source` so a package that omits `replaces` can't inherit the previous one's array.
- Guarded by `pacman -Qq` (only remove if installed) → idempotent; a second run is a no-op.
- `-Rdd` skips dep checks because the replacement re-provides whatever the old package did; the only transient reverse-dep (`illogical-updots` → virtual `quickshell`) is satisfied again the moment `immaterial-impulse-quickshell-git` installs.

Also add `replaces=("illogical-impulse-quickshell-git")` to the quickshell PKGBUILD (it declared `provides`/`conflicts` for the virtual `quickshell` but no `replaces` for the illogical package) and bump `pkgrel` 9 → 10. microtex and bibata already declare their `replaces`, so all three now supersede automatically.

## Testing

- `bash -n` clean on both files.
- Logic-tested the loop: 0 iterations when `replaces` is unset, N when set, and **no leak** to a subsequent package that omits it.
- End-to-end: reproduced the original `unresolvable package conflicts` abort; with the manual `pacman -Rdd` (what this automates) the full install then completed. This change performs that removal automatically.
