### PR TITLE
fix(hypr): make Quickshell blur work on the default config

### DIFF
--- a/dots/.config/hypr/hyprland/general.lua
+++ b/dots/.config/hypr/hyprland/general.lua
@@ -76,7 +76,7 @@ hl.config({
 
         blur = {
             enabled = true,
-            xray = true,
+            xray = false,
             special = false,
             new_optimizations = true,
             size = 10,

--- a/dots/.config/hypr/hyprland/rules.lua
+++ b/dots/.config/hypr/hyprland/rules.lua
@@ -6,6 +6,11 @@ hl.window_rule({match = {class = "^()$", title = "^()$" },                   no_
 -- Disable blur for every window
 hl.window_rule({match = {class = ".*" }, no_blur = true })
 
+-- ...except the shell's own translucent toplevels (e.g. the Settings window,
+-- class org.quickshell). The catch-all above would otherwise leave sharp
+-- wallpaper showing through them instead of the frosted look the panels have.
+hl.window_rule({match = {class = "^(org.quickshell)$" },                     no_blur = false })
+
 -- Floating
 hl.window_rule({match = {title = "^(Open File)(.*)$" },                      center = true})
 hl.window_rule({match = {title = "^(Open File)(.*)$" },                      float = true})

--- a/dots/.config/hypr/hyprland/rules.lua
+++ b/dots/.config/hypr/hyprland/rules.lua
@@ -131,7 +131,11 @@ hl.layer_rule({ match = { namespace = "osk[0-9]*" }, ignore_alpha = 0.6})
 -- Quickshell: immaterial-impulse
 hl.layer_rule({ match = { namespace = "quickshell:.*" }, blur_popups = true})
 hl.layer_rule({ match = { namespace = "quickshell:.*" }, blur = true})
-hl.layer_rule({ match = { namespace = "quickshell:.*" }, ignore_alpha = 0.79})
+-- Low threshold: pixels below it are left unblurred, so a high value skipped
+-- blur on the shell's own translucent panel backgrounds and let the sharp
+-- wallpaper show straight through the bar/dock/sidebars. Namespace-specific
+-- overrides below (popup/mediaControls/session/...) still set their own.
+hl.layer_rule({ match = { namespace = "quickshell:.*" }, ignore_alpha = 0.05})
 hl.layer_rule({ match = { namespace = "quickshell:bar" }, animation = "slide"})
 hl.layer_rule({ match = { namespace = "quickshell:actionCenter" }, no_anim = true})
 hl.layer_rule({ match = { namespace = "quickshell:cheatsheet" }, animation = "slide bottom"})

--- a/dots/.config/hypr/hyprland/rules.lua
+++ b/dots/.config/hypr/hyprland/rules.lua
@@ -89,7 +89,7 @@ hl.window_rule({match = {float = 0 }, no_shadow = true})
 hl.workspace_rule({ workspace = "special:special", gaps_out = 30 })
 
 -- ######## Layer rules ########
-hl.layer_rule({ match = { namespace = ".*" }, xray = true})
+hl.layer_rule({ match = { namespace = ".*" }, xray = false})
 hl.layer_rule({ match = { namespace = "walker" }, no_anim = true})
 hl.layer_rule({ match = { namespace = "selection" }, no_anim = true})
 hl.layer_rule({ match = { namespace = "overview" }, no_anim = true})


### PR DESCRIPTION
Three fixes so the shell's own surfaces actually blur on a fresh install:

- **Panels blur** — the `quickshell:.*` layer rule set `ignore_alpha = 0.79`, which tells Hyprland to skip blur on any pixel below that alpha. The shell's translucent panel backgrounds (bar, dock, sidebars) sit below it, so blur was skipped and the sharp wallpaper showed through. Lowered to `0.05`. The per-namespace `ignore_alpha` overrides further down (popup/mediaControls/session/overlay) are unaffected.
- **Shell windows blur** — the "no_blur for every window" catch-all also matched the shell's own translucent toplevels (Settings, class `org.quickshell`), leaving sharp wallpaper showing through them. Added a `no_blur = false` exception after the catch-all.
- **xray off** — disabled `blur:xray` globally and the all-layers xray rule. The shell renders its own wallpaper/panels as layer surfaces, so blur should sample the live content behind a surface, not the optimized wallpaper framebuffer.

`session_lock_xray` is intentionally left as-is (lock-screen privacy).