### PR TITLE
fix(hypr): default terminal to kitty and fix the SUPER+I Settings keybind

### DIFF
--- a/dots/.config/hypr/hyprland/variables.lua
+++ b/dots/.config/hypr/hyprland/variables.lua
@@ -6,7 +6,7 @@ hl.env("qsConfig", "ii")
 
 -- Apps
 -- PULL REQUESTS ADDING MORE WILL NOT BE ACCEPTED, CONFIG FOR YOURSELF
-terminal = "~/.config/hypr/hyprland/scripts/launch_first_available.sh 'foot' 'kitty -1' 'alacritty' 'wezterm' 'konsole' 'kgx' 'uxterm' 'xterm'"
+terminal = "~/.config/hypr/hyprland/scripts/launch_first_available.sh 'kitty -1' 'foot' 'alacritty' 'wezterm' 'konsole' 'kgx' 'uxterm' 'xterm'"
 fileManager = "~/.config/hypr/hyprland/scripts/launch_first_available.sh 'dolphin' 'nautilus' 'nemo' 'thunar' 'kitty -1 fish -c yazi'"
 browser = "~/.config/hypr/hyprland/scripts/launch_first_available.sh 'google-chrome-stable' 'zen-browser' 'firefox' 'brave' 'chromium' 'microsoft-edge-stable' 'opera' 'librewolf'"
 codeEditor = "~/.config/hypr/hyprland/scripts/launch_first_available.sh 'windsurf' 'antigravity' 'code' 'codium' 'cursor' 'zed' 'zedit' 'zeditor' 'kate' 'gnome-text-editor' 'emacs' 'command -v nvim && kitty -1 nvim' 'command -v micro && kitty -1 micro'"

--- a/dots/.config/hypr/hyprland/variables.lua
+++ b/dots/.config/hypr/hyprland/variables.lua
@@ -13,7 +13,7 @@ codeEditor = "~/.config/hypr/hyprland/scripts/launch_first_available.sh 'windsur
 officeSoftware = "~/.config/hypr/hyprland/scripts/launch_first_available.sh 'wps' 'onlyoffice-desktopeditors' 'libreoffice'"
 textEditor = "~/.config/hypr/hyprland/scripts/launch_first_available.sh 'kate' 'gnome-text-editor' 'emacs'"
 volumeMixer = "~/.config/hypr/hyprland/scripts/launch_first_available.sh 'pavucontrol-qt' 'pavucontrol'"
-settingsApp = "XDG_CURRENT_DESKTOP=gnome ~/.config/hypr/hyprland/scripts/launch_first_available.sh 'qs -p ~/.config/quickshell/$qsConfig/settings.qml' 'systemsettings' 'gnome-control-center' 'better-control'"
+settingsApp = "XDG_CURRENT_DESKTOP=gnome ~/.config/hypr/hyprland/scripts/launch_first_available.sh 'qs -c $qsConfig ipc call settings toggle' 'systemsettings' 'gnome-control-center' 'better-control'"
 taskManager = "~/.config/hypr/hyprland/scripts/launch_first_available.sh 'gnome-system-monitor' 'plasma-systemmonitor --page-name Processes' 'command -v btop && kitty -1 fish -c btop'"
 
 workspaceGroupSize = 10


### PR DESCRIPTION
Two `variables.lua` default-config fixes:

- **Terminal** — the terminal launcher listed `foot` first, so foot won the `launch_first_available` chain wherever it's installed, even though the rest of the config (`Config.qml`, `defaults/config.json`, `fileManager`/`codeEditor`/`taskManager`) standardises on `kitty -1`. Put `kitty -1` first; foot stays as the next fallback.
- **SUPER+I** — `settingsApp` pointed at `qs -p ~/.config/quickshell/$qsConfig/settings.qml`, an entry point that no longer exists (Settings is now opened over IPC against the running shell). `launch_first_available` runs the first candidate whose binary resolves and then exits, so `qs` always resolved and it launched the broken `qs -p ...` — never falling through — and SUPER+I opened nothing. Repointed to `qs -c $qsConfig ipc call settings toggle`.