### PR TITLE
fix(settings): import PluginState so presets can be saved

### DIFF
--- a/dots/.config/quickshell/ii/services/Presets.qml
+++ b/dots/.config/quickshell/ii/services/Presets.qml
@@ -9,6 +9,7 @@ import qs
 import qs.services
 import qs.modules.common
 import qs.modules.common.functions
+import qs.modules.common.plugins
 
 Singleton {
     id: root


### PR DESCRIPTION
`Presets.save()` calls `PluginState.snapshot()` to capture the authoritative in-memory plugin state, but `Presets.qml` never imported the module `PluginState` lives in (`qs.modules.common.plugins`). At runtime the reference threw `ReferenceError: PluginState is not defined` (visible in the shell log at `services/Presets.qml[61]`) **before** the save `Process` was ever started — so saving a preset silently did nothing and the presets directory stayed empty.

Adds the missing import. Every other consumer of `PluginState` already imports `qs.modules.common.plugins` the same way. Verified against the live shell: the ReferenceError is gone and presets now save.