### PR TITLE
Proposal: Phone Connect (KDE Connect / Valent integration)

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -296,6 +296,13 @@ services/                  Singletons wrapping external state/processes - one pe
                               backlight write through it (IncBl/DecBl) so the daemon's next
                               recalculation does not revert the change; night-light ownership stays
                               with Hyprsunset.qml. See docs/proposals/clight-integration.md
+  PhoneConnect.qml             Paired-phone state from KDE Connect or Valent, driven over
+                              `busctl --json=short` Process calls (the shell has no D-Bus
+                              binding) - backend detection from the bus name list, one
+                              normalized device/battery model for both daemons, ring/ping/
+                              clipboard actions. Its parser logic is kept byte-for-byte in
+                              sync with a logic-only test double
+                              (tests/test_phone_connect_contract.py enforces it)
   Brightness.qml, Battery.qml, Hyprsunset.qml, Network.qml, BluetoothStatus.qml, TrayService.qml,
   MprisController.qml, Weather.qml, Docker.qml, ... (one per integration)
 

--- a/docs/proposals/phone-connect.md
+++ b/docs/proposals/phone-connect.md
@@ -1,6 +1,6 @@
 # Proposal: Phone Connect (KDE Connect / Valent integration)
 
-> Draft / tracking proposal. Not scheduled.
+> Draft / tracking proposal. First slice implemented on this branch.
 
 ## Goal
 
@@ -10,7 +10,27 @@ whichever the user has installed.
 
 ## Current state
 
-Nothing exists. No service, no widget, no quick toggle. This is greenfield.
+The first slice exists on this branch:
+
+- `services/PhoneConnect.qml` — `busctl --json=short` transport (the
+  recommendation below), backend detection from the bus name list, one
+  normalized device/battery model for both daemons, ring/ping/clipboard
+  actions, clean degraded state when neither daemon runs. Bounded polling for
+  now; `busctl monitor` streaming remains open (see below).
+- Sidebar surface: a quick toggle (classic + android styles) and a device
+  dialog, following the Tailscale surface pattern rather than a bundled
+  plugin — the toggle hides when no daemon runs (classic) or is opt-in
+  (android), so the "dead widget for phoneless users" concern is answered
+  without plugin packaging. A bundled *desktop-widget* plugin remains a
+  possible follow-up, not a replacement.
+- Config (`networking.phoneConnect`) + settings rows, and a contract test
+  keeping the service's parser logic byte-for-byte in sync with the QML
+  suite's logic-only double.
+
+Still open: notification mirroring, media, file send, clipboard *receive*,
+`busctl monitor` streaming, and Valent action coverage beyond
+`findmyphone.ring` (its other action names were not verifiable without a live
+Valent daemon — ping/clipboard are KDE Connect-only for now).
 
 ## Transport constraint (read this first)
 

--- a/docs/proposals/phone-connect.md
+++ b/docs/proposals/phone-connect.md
@@ -1,0 +1,74 @@
+# Proposal: Phone Connect (KDE Connect / Valent integration)
+
+> Draft / tracking proposal. Not scheduled.
+
+## Goal
+
+Surface a paired phone inside the shell — battery, notifications, media, file
+send, clipboard, find-my-phone — backed by either **KDE Connect** or **Valent**,
+whichever the user has installed.
+
+## Current state
+
+Nothing exists. No service, no widget, no quick toggle. This is greenfield.
+
+## Transport constraint (read this first)
+
+**The shell has no D-Bus binding today.** Every service integrates by shelling
+out through `Process` — see `services/Brightness.qml:71,90,134` for the pattern.
+Both KDE Connect and Valent are D-Bus daemons, so this proposal has to pick a
+transport rather than assume one:
+
+- **CLI wrapper** (`kdeconnect-cli`) — matches every existing service, no new
+  dependency, but polling-only and awkward for live notification streams.
+- **`busctl --json=short` via `Process`** — still shells out, so it fits the
+  established pattern, and `busctl monitor` can stream signals rather than
+  poll. Structured JSON output parses cleanly.
+- **A real D-Bus binding** — cleanest for a notification-mirroring feature, but
+  it is a new integration primitive for this codebase and should be justified
+  on its own rather than smuggled in with a feature.
+
+Recommendation: `busctl --json` via `Process`, because the interesting features
+(notification mirroring, battery updates) are event-driven, and polling them
+would be both laggy and wasteful.
+
+## Why
+
+- A phone panel is one of the most-requested desktop-shell features and one of
+  the few remaining reasons to keep a separate KDE Connect tray applet running
+  alongside the shell.
+- Both daemons expose the same conceptual objects (device, battery, notification,
+  share, clipboard), so a single abstraction can cover both rather than picking
+  a winner and alienating users of the other.
+- Valent is the actively maintained GNOME-side implementation; KDE Connect is
+  the incumbent. Supporting only one would be a coin flip.
+
+## Approach
+
+- New `services/PhoneConnect.qml`: detects which daemon is running, normalizes
+  both onto one device model (`id`, `name`, `type`, `reachable`, `paired`,
+  `battery`, `charging`), and exposes actions (`ping`, `ring`, `sendFile`,
+  `sendClipboard`).
+- Backend detection at startup, with the chosen backend exposed as a read-only
+  property so the UI can say which one is in use and degrade honestly when
+  neither is installed.
+- A right-sidebar surface for device state, plus a quick toggle following the
+  existing `modules/common/models/quickToggles/` pattern.
+- Notification mirroring routes through the shell's existing notification
+  system rather than introducing a parallel one.
+- Ship it as a **bundled plugin**, not a hardcoded surface, so users without a
+  phone are not carrying a dead widget. This also exercises the plugin API on a
+  non-trivial integration.
+
+## Open questions
+
+- Whether pairing should be driveable from the shell or deferred to the
+  daemon's own UI. Pairing involves a confirmation on both ends and is
+  security-relevant; wrapping it badly is worse than not wrapping it.
+- Whether file-send should accept drops onto the drop shelf
+  (`modules/imi/dropShelf/`), which already handles mid-drag interaction.
+
+## Out of scope
+
+- Implementing the KDE Connect protocol directly.
+- Any feature requiring a companion app change on the phone.

--- a/dots/.config/quickshell/imi/modules/common/Config.qml
+++ b/dots/.config/quickshell/imi/modules/common/Config.qml
@@ -1140,6 +1140,12 @@ Singleton {
                     property bool enable: true
                     property int pollInterval: 5000 // ms
                 }
+                property JsonObject phoneConnect: JsonObject {
+                    property bool enable: true
+                    // Battery/reachability drift slowly, and each sweep is a
+                    // chain of busctl processes - poll gentler than the others.
+                    property int pollInterval: 10000 // ms
+                }
             }
 
             // Keep-awake. autoOnExternalMonitor (ported from end-4/dots-hyprland

--- a/dots/.config/quickshell/imi/modules/common/models/quickToggles/PhoneConnectToggle.qml
+++ b/dots/.config/quickshell/imi/modules/common/models/quickToggles/PhoneConnectToggle.qml
@@ -1,0 +1,26 @@
+import QtQuick
+import qs.services
+import qs.modules.common
+import qs.modules.common.widgets
+
+QuickToggleModel {
+    id: root
+    name: Translation.tr("Phone")
+    icon: PhoneConnect.materialSymbol
+
+    available: PhoneConnect.available
+    toggled: PhoneConnect.activeDevice !== null
+    statusText: {
+        const device = PhoneConnect.activeDevice;
+        if (!device) return Translation.tr("Disconnected");
+        if (device.batteryAvailable) return `${device.name} • ${device.batteryCharge}%`;
+        return device.name;
+    }
+    tooltipText: Translation.tr("Phone Connect | Click for devices")
+
+    // A status tile, not an on/off switch - there is no daemon the shell
+    // should be starting or stopping here. Every click lands on the device
+    // dialog; the style buttons route their plain click there too.
+    mainAction: null
+    hasMenu: true
+}

--- a/dots/.config/quickshell/imi/modules/imi/settings/pages/ServicesConfig.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/pages/ServicesConfig.qml
@@ -254,6 +254,32 @@ ContentPage {
                     Config.options.networking.userAgent = text;
                 }
             }
+
+            ContentSubsection {
+                title: Translation.tr("Phone Connect")
+
+                GroupedList {
+                    ConfigSwitch {
+                        buttonIcon: "mobile"
+                        text: Translation.tr("Show your phone (via KDE Connect or Valent)")
+                        checked: Config.options.networking.phoneConnect.enable
+                        onCheckedChanged: {
+                            Config.options.networking.phoneConnect.enable = checked;
+                        }
+                    }
+                    ConfigSpinBox {
+                        icon: "av_timer"
+                        text: Translation.tr("Polling interval (s)")
+                        value: Config.options.networking.phoneConnect.pollInterval / 1000
+                        from: 2
+                        to: 120
+                        stepSize: 1
+                        onValueModified: {
+                            Config.options.networking.phoneConnect.pollInterval = newValue * 1000;
+                        }
+                    }
+                }
+            }
         }
 
         ContentSection {

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/SidebarRightContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/SidebarRightContent.qml
@@ -20,6 +20,7 @@ import qs.modules.imi.sidebarRight.nightLight
 import qs.modules.imi.sidebarRight.volumeMixer
 import qs.modules.imi.sidebarRight.wifiNetworks
 import qs.modules.imi.sidebarRight.tailscale
+import qs.modules.imi.sidebarRight.phoneConnect
 import qs.modules.imi.sidebarRight.iconPicker
 
 Item {
@@ -33,6 +34,7 @@ Item {
     property bool showNightLightDialog: false
     property bool showWifiDialog: false
     property bool showTailscaleDialog: false
+    property bool showPhoneConnectDialog: false
     property bool editMode: false
     property bool showIconPickerDialog: false
 
@@ -94,6 +96,7 @@ Item {
             if (!GlobalStates.sidebarRightOpen) {
                 root.showWifiDialog = false;
                 root.showTailscaleDialog = false;
+                root.showPhoneConnectDialog = false;
                 root.showBluetoothDialog = false;
                 root.showAudioOutputDialog = false;
                 root.showAudioInputDialog = false;
@@ -435,6 +438,14 @@ Item {
     }
 
     ToggleDialog {
+        shownPropertyString: "showPhoneConnectDialog"
+        dialog: PhoneConnectDialog {}
+        onShownChanged: {
+            if (shown) PhoneConnect.refresh();
+        }
+    }
+
+    ToggleDialog {
         shownPropertyString: "showIconPickerDialog"
         dialog: IconPickerDialog {}
     }
@@ -482,6 +493,7 @@ Item {
             function onOpenNightLightDialog() { root.showNightLightDialog = true; }
             function onOpenWifiDialog() { root.showWifiDialog = true; }
             function onOpenTailscaleDialog() { root.showTailscaleDialog = true; }
+            function onOpenPhoneConnectDialog() { root.showPhoneConnectDialog = true; }
         }
     }
 

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/phoneConnect/PhoneConnectDeviceItem.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/phoneConnect/PhoneConnectDeviceItem.qml
@@ -1,0 +1,127 @@
+import qs.services
+import qs.modules.common
+import qs.modules.common.widgets
+import QtQuick
+import QtQuick.Layouts
+
+DialogListItem {
+    id: root
+    // Device entry from PhoneConnect.devices.
+    required property var device
+    readonly property bool online: root.device.paired && root.device.reachable
+
+    active: PhoneConnect.activeDevice !== null && PhoneConnect.activeDevice.id === root.device.id
+    pointingHandCursor: false
+
+    contentItem: RowLayout {
+        anchors {
+            fill: parent
+            topMargin: root.verticalPadding
+            bottomMargin: root.verticalPadding
+            leftMargin: root.horizontalPadding
+            rightMargin: root.horizontalPadding
+        }
+        spacing: Appearance.spacing.space150
+
+        MaterialSymbol {
+            iconSize: Appearance.font.pixelSize.larger
+            text: {
+                switch (root.device.type) {
+                case "phone": return "smartphone";
+                case "tablet": return "tablet";
+                case "laptop": return "laptop";
+                case "desktop": return "computer";
+                case "tv": return "tv";
+                default: return "devices";
+                }
+            }
+            color: root.online ? Appearance.colors.colPrimary : Appearance.colors.colOnSurfaceVariant
+        }
+
+        ColumnLayout {
+            Layout.fillWidth: true
+            spacing: 0
+
+            StyledText {
+                Layout.fillWidth: true
+                color: Appearance.colors.colOnSurfaceVariant
+                elide: Text.ElideRight
+                text: root.device.name || root.device.id
+                textFormat: Text.PlainText
+            }
+            StyledText {
+                Layout.fillWidth: true
+                color: Appearance.colors.colSubtext
+                font.pixelSize: Appearance.font.pixelSize.smaller
+                elide: Text.ElideRight
+                textFormat: Text.PlainText
+                text: {
+                    if (!root.device.paired) return Translation.tr("Not paired");
+                    if (!root.device.reachable) return Translation.tr("Paired • Offline");
+                    if (root.device.batteryAvailable)
+                        return root.device.batteryCharging
+                            ? Translation.tr("%1% • Charging").arg(root.device.batteryCharge)
+                            : Translation.tr("%1%").arg(root.device.batteryCharge);
+                    return Translation.tr("Connected");
+                }
+            }
+        }
+
+        DialogButton {
+            id: ringButton
+            visible: root.online
+            implicitWidth: implicitHeight
+
+            onClicked: PhoneConnect.ring(root.device)
+
+            contentItem: MaterialSymbol {
+                anchors.centerIn: parent
+                text: "ring_volume"
+                iconSize: Appearance.font.pixelSize.larger
+                color: ringButton.colEnabled
+            }
+
+            StyledToolTip {
+                text: Translation.tr("Ring")
+            }
+        }
+
+        DialogButton {
+            id: pingButton
+            visible: root.online && PhoneConnect.canPing
+            implicitWidth: implicitHeight
+
+            onClicked: PhoneConnect.ping(root.device)
+
+            contentItem: MaterialSymbol {
+                anchors.centerIn: parent
+                text: "send"
+                iconSize: Appearance.font.pixelSize.larger
+                color: pingButton.colEnabled
+            }
+
+            StyledToolTip {
+                text: Translation.tr("Ping")
+            }
+        }
+
+        DialogButton {
+            id: clipboardButton
+            visible: root.online && PhoneConnect.canSendClipboard
+            implicitWidth: implicitHeight
+
+            onClicked: PhoneConnect.sendClipboard(root.device)
+
+            contentItem: MaterialSymbol {
+                anchors.centerIn: parent
+                text: "content_paste"
+                iconSize: Appearance.font.pixelSize.larger
+                color: clipboardButton.colEnabled
+            }
+
+            StyledToolTip {
+                text: Translation.tr("Send clipboard")
+            }
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/phoneConnect/PhoneConnectDialog.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/phoneConnect/PhoneConnectDialog.qml
@@ -1,0 +1,94 @@
+import qs
+import qs.services
+import qs.modules.common
+import qs.modules.common.widgets
+import QtQuick
+import QtQuick.Layouts
+import Quickshell
+
+WindowDialog {
+    id: root
+    backgroundHeight: 480
+
+    RowLayout {
+        Layout.fillWidth: true
+        spacing: Appearance.spacing.space100
+
+        WindowDialogTitle {
+            Layout.fillWidth: true
+            text: Translation.tr("Phone Connect")
+        }
+
+        DialogButton {
+            id: refreshButton
+            Layout.alignment: Qt.AlignVCenter
+            implicitWidth: implicitHeight
+
+            onClicked: PhoneConnect.refresh()
+
+            contentItem: MaterialSymbol {
+                anchors.centerIn: parent
+                text: "refresh"
+                iconSize: Appearance.font.pixelSize.larger
+                color: refreshButton.colEnabled
+            }
+
+            StyledToolTip {
+                text: Translation.tr("Refresh")
+            }
+        }
+    }
+    WindowDialogSeparator {}
+    ListView {
+        Layout.fillHeight: true
+        Layout.fillWidth: true
+        Layout.topMargin: -Appearance.spacing.space200
+        Layout.bottomMargin: -Appearance.spacing.space200
+        Layout.leftMargin: -Appearance.rounding.large
+        Layout.rightMargin: -Appearance.rounding.large
+
+        clip: true
+        spacing: 0
+
+        model: ScriptModel {
+            values: PhoneConnect.devices
+        }
+        delegate: PhoneConnectDeviceItem {
+            required property var modelData
+            device: modelData
+            width: ListView.view.width
+        }
+    }
+    StyledText {
+        visible: PhoneConnect.devices.length === 0
+        Layout.fillWidth: true
+        wrapMode: Text.WordWrap
+        color: Appearance.colors.colSubtext
+        font.pixelSize: Appearance.font.pixelSize.small
+        text: !PhoneConnect.installed
+            ? Translation.tr("busctl was not found on PATH")
+            : !PhoneConnect.available
+                ? Translation.tr("Neither KDE Connect nor Valent is running")
+                : Translation.tr("No devices yet — pair your phone from KDE Connect or Valent")
+    }
+    WindowDialogSeparator {}
+    WindowDialogButtonRow {
+        StyledText {
+            visible: PhoneConnect.available
+            color: Appearance.colors.colSubtext
+            font.pixelSize: Appearance.font.pixelSize.small
+            text: PhoneConnect.backend === "kdeconnect"
+                ? Translation.tr("Backend: KDE Connect")
+                : Translation.tr("Backend: Valent")
+        }
+
+        Item {
+            Layout.fillWidth: true
+        }
+
+        DialogButton {
+            buttonText: Translation.tr("Done")
+            onClicked: root.dismiss()
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/quickToggles/AbstractQuickPanel.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/quickToggles/AbstractQuickPanel.qml
@@ -13,4 +13,5 @@ Rectangle {
     signal openNightLightDialog()
     signal openWifiDialog()
     signal openTailscaleDialog()
+    signal openPhoneConnectDialog()
 }

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/quickToggles/AndroidQuickPanel.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/quickToggles/AndroidQuickPanel.qml
@@ -25,7 +25,7 @@ AbstractQuickPanel {
     }
     readonly property real baseCellHeight: 56
 
-    readonly property list<string> availableToggleTypes: ["network", "bluetooth", "vpn", "tailscale", "idleInhibitor", "easyEffects", "nightLight", "darkMode", "cloudflareWarp", "gameMode", "screenSnip", "colorPicker", "onScreenKeyboard", "mic", "audio", "notifications", "powerProfile","musicRecognition", "antiFlashbang", "instantReplay"]
+    readonly property list<string> availableToggleTypes: ["network", "bluetooth", "vpn", "tailscale", "phoneConnect", "idleInhibitor", "easyEffects", "nightLight", "darkMode", "cloudflareWarp", "gameMode", "screenSnip", "colorPicker", "onScreenKeyboard", "mic", "audio", "notifications", "powerProfile","musicRecognition", "antiFlashbang", "instantReplay"]
     readonly property int columns: Config.options.sidebar.quickToggles.android.columns
     readonly property list<var> toggles: Config.ready ? Config.options.sidebar.quickToggles.android.toggles : []
     readonly property list<var> toggleRows: toggleRowsForList(toggles)
@@ -149,6 +149,7 @@ AbstractQuickPanel {
                             onOpenNightLightDialog: root.openNightLightDialog()
                             onOpenWifiDialog: root.openWifiDialog()
                             onOpenTailscaleDialog: root.openTailscaleDialog()
+                            onOpenPhoneConnectDialog: root.openPhoneConnectDialog()
                         }
                     }
                 }

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/quickToggles/ClassicQuickPanel.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/quickToggles/ClassicQuickPanel.qml
@@ -41,6 +41,11 @@ AbstractQuickPanel {
                 root.openTailscaleDialog();
             }
         }
+        PhoneConnectToggle {
+            altAction: () => {
+                root.openPhoneConnectDialog();
+            }
+        }
         Repeater {
             model: Vpn.connections
             delegate: VpnToggle {

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/quickToggles/androidStyle/AndroidPhoneConnectToggle.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/quickToggles/androidStyle/AndroidPhoneConnectToggle.qml
@@ -1,0 +1,13 @@
+import qs.modules.common.models.quickToggles
+import qs.modules.common.widgets
+import QtQuick
+
+AndroidQuickToggleButton {
+    id: root
+
+    toggleModel: PhoneConnectToggle {}
+    // The model has no primary action (nothing to toggle), so a plain click
+    // on the compact tile opens the device dialog like the expanded tile's
+    // menu click does.
+    mainAction: () => root.openMenu()
+}

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/quickToggles/androidStyle/AndroidToggleDelegateChooser.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/quickToggles/androidStyle/AndroidToggleDelegateChooser.qml
@@ -23,6 +23,7 @@ DelegateChooser {
     signal openNightLightDialog()
     signal openWifiDialog()
     signal openTailscaleDialog()
+    signal openPhoneConnectDialog()
 
     role: "type"
 
@@ -108,6 +109,23 @@ DelegateChooser {
         dropIndicatorRef: root.dropIndicatorRef
         isUnused: root.isUnused
         onOpenMenu: root.openTailscaleDialog()
+    } }
+
+    DelegateChoice { roleValue: "phoneConnect"; AndroidPhoneConnectToggle {
+        required property int index
+        required property var modelData
+        buttonIndex: root.startingIndex + index
+        buttonData: modelData
+        editMode: root.editMode
+        gridRef: root.gridRef
+        expandedSize: modelData.size > 1
+        baseCellWidth: root.baseCellWidth
+        baseCellHeight: root.baseCellHeight
+        cellSpacing: root.spacing
+        cellSize: modelData.size
+        dropIndicatorRef: root.dropIndicatorRef
+        isUnused: root.isUnused
+        onOpenMenu: root.openPhoneConnectDialog()
     } }
 
     DelegateChoice { roleValue: "vpn"; AndroidVpnToggle {

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/quickToggles/classicStyle/PhoneConnectToggle.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/quickToggles/classicStyle/PhoneConnectToggle.qml
@@ -1,0 +1,24 @@
+import qs.services
+import qs.modules.common
+import qs.modules.common.widgets
+import QtQuick
+
+QuickToggleButton {
+    id: root
+    visible: PhoneConnect.available
+    toggled: PhoneConnect.activeDevice !== null
+    buttonIcon: PhoneConnect.materialSymbol
+    // Nothing to toggle - a plain click opens the device dialog like the
+    // right click does.
+    onClicked: root.altAction?.()
+
+    StyledToolTip {
+        text: {
+            const device = PhoneConnect.activeDevice;
+            if (!device) return Translation.tr("Phone Connect | Click for devices");
+            if (device.batteryAvailable)
+                return Translation.tr("Phone Connect: %1 (%2%) | Click for devices").arg(device.name).arg(device.batteryCharge);
+            return Translation.tr("Phone Connect: %1 | Click for devices").arg(device.name);
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/services/PhoneConnect.qml
+++ b/dots/.config/quickshell/imi/services/PhoneConnect.qml
@@ -1,0 +1,354 @@
+pragma Singleton
+pragma ComponentBehavior: Bound
+
+import Quickshell
+import Quickshell.Io
+import QtQuick
+import qs.modules.common
+
+/**
+ * Paired-phone state via KDE Connect or Valent (docs/proposals/phone-connect.md).
+ *
+ * The shell has no D-Bus binding, so both daemons are driven through
+ * `busctl --json=short` Process calls - structured JSON replies, argv arrays,
+ * never shell strings. Backend detection reads the bus name list: whichever
+ * daemon owns its well-known name wins, KDE Connect first on a tie (running
+ * both daemons double-pairs phones anyway). No daemon at all is a clean
+ * degraded state: backend "none", no devices, UI hides.
+ *
+ * Updates are bounded polling like Tailscale.qml, not `busctl monitor`
+ * streaming - a persistent streaming Process needs backoff and a retry
+ * ceiling (see CONTRIBUTING.md) that this feature does not justify yet.
+ *
+ * Device ids and object paths get spliced into D-Bus object paths, so both
+ * are validated first (validDeviceId / validValentObjectPath); anything that
+ * fails the check is dropped rather than escaped.
+ *
+ * The parser/normalization functions between the sync markers are kept
+ * byte-for-byte in sync with the logic-only test double
+ * (tests/imports/testservices/PhoneConnect.qml);
+ * tests/test_phone_connect_contract.py enforces it.
+ */
+Singleton {
+    id: root
+
+    readonly property int pollInterval: Config.options.networking?.phoneConnect?.pollInterval ?? 10000
+    readonly property bool enableService: Config.options.networking?.phoneConnect?.enable ?? true
+
+    property bool installed: false // busctl found on PATH
+    property string backend: "none" // "kdeconnect" | "valent" | "none"
+    readonly property bool available: root.backend !== "none"
+    // [{ id, name, type, reachable, paired, batteryAvailable, batteryCharge, batteryCharging }]
+    property var devices: []
+
+    readonly property var activeDevice: root.devices.find(d => d.paired && d.reachable && d.type === "phone")
+        ?? root.devices.find(d => d.paired && d.reachable)
+        ?? null
+    readonly property string materialSymbol: (root.available && root.activeDevice) ? "mobile" : "mobile_off"
+
+    // Valent action names beyond findmyphone.ring were not verifiable against
+    // a live daemon, so only the verified surface is offered there.
+    readonly property bool canPing: root.backend === "kdeconnect"
+    readonly property bool canSendClipboard: root.backend === "kdeconnect"
+
+    // BEGIN phone-connect parser logic (synced with tests/imports/testservices/PhoneConnect.qml)
+    // Parses one `busctl --json=short` reply. Returns the payload ("data")
+    // array, or null when the text is not a busctl JSON document (empty
+    // output, "Call failed: ..." error text, malformed JSON).
+    function parseBusctlReply(text: string): var {
+        const trimmed = (text ?? "").trim();
+        if (trimmed.length === 0) return null;
+        let doc;
+        try {
+            doc = JSON.parse(trimmed);
+        } catch (e) {
+            return null;
+        }
+        if (!doc || typeof doc !== "object" || !Array.isArray(doc.data)) return null;
+        return doc.data;
+    }
+
+    // GetAll replies carry a{sv}: { key: { type, data } }. Flattens the
+    // variant cells to plain values.
+    function unwrapVariants(dict: var): var {
+        const out = {};
+        for (const key in (dict ?? {})) {
+            const cell = dict[key];
+            out[key] = (cell && typeof cell === "object" && "data" in cell) ? cell.data : cell;
+        }
+        return out;
+    }
+
+    // Maps a ListNames reply to the backend it implies. KDE Connect wins a
+    // tie: it is the incumbent, and running both daemons at once double-pairs
+    // phones anyway.
+    function backendFromNames(names: var): string {
+        const list = names ?? [];
+        if (list.includes("org.kde.kdeconnect.daemon")) return "kdeconnect";
+        if (list.includes("ca.andyholmes.Valent")) return "valent";
+        return "none";
+    }
+
+    // Normalizes one org.kde.kdeconnect.device GetAll reply (plus its
+    // battery GetAll, or null when the battery object does not exist - it is
+    // absent for unpaired devices) onto the shared device model.
+    function normalizeKdeconnectDevice(id: string, rawProps: var, rawBatteryProps: var): var {
+        const props = root.unwrapVariants(rawProps);
+        const battery = rawBatteryProps === null || rawBatteryProps === undefined
+            ? null : root.unwrapVariants(rawBatteryProps);
+        return {
+            id: id,
+            name: props.name ?? "",
+            type: props.type ?? "",
+            reachable: props.isReachable === true,
+            paired: props.isPaired === true,
+            batteryAvailable: battery !== null && typeof battery.charge === "number",
+            batteryCharge: (battery !== null && typeof battery.charge === "number") ? battery.charge : -1,
+            batteryCharging: battery !== null && battery.isCharging === true
+        };
+    }
+
+    // Valent device State flags (valent-device.h): 1 = connected, 2 = paired.
+    function normalizeValentObjects(managedObjects: var): var {
+        const objects = (managedObjects ?? [])[0] ?? {};
+        const devices = [];
+        for (const path in objects) {
+            const ifaces = objects[path];
+            const raw = ifaces?.["ca.andyholmes.Valent.Device"];
+            if (!raw) continue;
+            const props = root.unwrapVariants(raw);
+            const state = Number(props.State ?? 0);
+            devices.push({
+                id: props.Id ?? "",
+                name: props.Name ?? "",
+                type: props.Type ?? "",
+                reachable: (state & 1) !== 0,
+                paired: (state & 2) !== 0,
+                objectPath: path,
+                batteryAvailable: false,
+                batteryCharge: -1,
+                batteryCharging: false
+            });
+        }
+        return devices;
+    }
+
+    // Decodes an org.gtk.Actions DescribeAll reply (a{s(bgav)}) into battery
+    // state via the stateful `battery.state` action's vardict.
+    function decodeValentBattery(describeAllData: var): var {
+        const none = { available: false, charge: -1, charging: false };
+        const actions = (describeAllData ?? [])[0] ?? {};
+        const batteryAction = actions["battery.state"];
+        if (!Array.isArray(batteryAction) || batteryAction.length < 3) return none;
+        const stateCells = batteryAction[2];
+        if (!Array.isArray(stateCells) || stateCells.length === 0) return none;
+        const state = root.unwrapVariants(stateCells[0]?.data ?? null);
+        if (typeof state.percentage !== "number") return none;
+        return {
+            available: state["is-present"] !== false,
+            charge: Math.round(state.percentage),
+            charging: state.charging === true
+        };
+    }
+
+    // Reachable-and-paired devices first, then paired, then by name/id.
+    function sortDevices(list: var): var {
+        const rank = d => (d.paired && d.reachable) ? 0 : d.paired ? 1 : 2;
+        return [...(list ?? [])].sort((a, b) => rank(a) - rank(b)
+            || String(a.name || a.id).localeCompare(String(b.name || b.id)));
+    }
+
+    // Object paths and argv both splice the id in; keep it boring.
+    function validDeviceId(id: var): bool {
+        return typeof id === "string" && /^[A-Za-z0-9_-]+$/.test(id);
+    }
+    // END phone-connect parser logic
+
+    function applyBackend(newBackend: string): void {
+        root.backend = newBackend;
+        if (newBackend === "none") root.devices = [];
+    }
+
+    function applyDevices(list: var): void {
+        root.devices = root.sortDevices(list);
+    }
+
+    // Valent exports devices under /ca/andyholmes/Valent/Device/<n>; anything
+    // else coming back from ObjectManager is not a path worth calling into.
+    function validValentObjectPath(path: var): bool {
+        return typeof path === "string" && /^\/ca\/andyholmes\/Valent\/Device\/[A-Za-z0-9_]+$/.test(path);
+    }
+
+    function busctlCall(dest: string, path: string, iface: string, member: string, extra: var): var {
+        return ["busctl", "--user", "--json=short", "--timeout=5", "call", dest, path, iface, member, ...extra];
+    }
+
+    function refresh(): void {
+        if (!root.enableService || !root.installed) return;
+        if (busProc.running || root.callQueue.length > 0) return; // previous sweep still in flight
+        root.enqueue(root.busctlCall("org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus", "ListNames", []), text => {
+            const data = root.parseBusctlReply(text);
+            const newBackend = data === null ? "none" : root.backendFromNames(data[0] ?? []);
+            root.applyBackend(newBackend);
+            if (newBackend === "kdeconnect") root.refreshKdeconnect();
+            else if (newBackend === "valent") root.refreshValent();
+        });
+    }
+
+    function refreshKdeconnect(): void {
+        root.enqueue(root.busctlCall("org.kde.kdeconnect.daemon", "/modules/kdeconnect", "org.kde.kdeconnect.daemon", "devices", ["bb", "false", "false"]), text => {
+            const data = root.parseBusctlReply(text);
+            if (data === null) { root.applyDevices([]); return; }
+            const ids = (data[0] ?? []).filter(id => root.validDeviceId(id));
+            if (ids.length === 0) { root.applyDevices([]); return; }
+            const collected = [];
+            for (const id of ids) root.collectKdeconnectDevice(id, collected, ids.length);
+        });
+    }
+
+    function collectKdeconnectDevice(id: string, collected: var, total: int): void {
+        const devicePath = `/modules/kdeconnect/devices/${id}`;
+        root.enqueue(root.busctlCall("org.kde.kdeconnect.daemon", devicePath, "org.freedesktop.DBus.Properties", "GetAll", ["s", "org.kde.kdeconnect.device"]), propsText => {
+            const propsData = root.parseBusctlReply(propsText);
+            // The battery object does not exist for unpaired devices; the
+            // failed GetAll parses to null and normalization degrades cleanly.
+            root.enqueue(root.busctlCall("org.kde.kdeconnect.daemon", devicePath + "/battery", "org.freedesktop.DBus.Properties", "GetAll", ["s", "org.kde.kdeconnect.device.battery"]), batteryText => {
+                const batteryData = root.parseBusctlReply(batteryText);
+                collected.push(root.normalizeKdeconnectDevice(id, propsData?.[0] ?? {}, batteryData?.[0] ?? null));
+                if (collected.length === total) root.applyDevices(collected);
+            });
+        });
+    }
+
+    function refreshValent(): void {
+        root.enqueue(root.busctlCall("ca.andyholmes.Valent", "/ca/andyholmes/Valent", "org.freedesktop.DBus.ObjectManager", "GetManagedObjects", []), text => {
+            const data = root.parseBusctlReply(text);
+            if (data === null) { root.applyDevices([]); return; }
+            const found = root.normalizeValentObjects(data).filter(d => root.validValentObjectPath(d.objectPath));
+            if (found.length === 0) { root.applyDevices([]); return; }
+            let pending = found.length;
+            for (const device of found) {
+                root.enqueue(root.busctlCall("ca.andyholmes.Valent", device.objectPath, "org.gtk.Actions", "DescribeAll", []), describeText => {
+                    const battery = root.decodeValentBattery(root.parseBusctlReply(describeText));
+                    device.batteryAvailable = battery.available;
+                    device.batteryCharge = battery.charge;
+                    device.batteryCharging = battery.charging;
+                    if (--pending === 0) root.applyDevices(found);
+                });
+            }
+        });
+    }
+
+    // ---- actions ----
+
+    function ring(device: var): void {
+        const d = device ?? root.activeDevice;
+        if (!d) return;
+        if (root.backend === "kdeconnect" && root.validDeviceId(d.id))
+            root.runAction(root.busctlCall("org.kde.kdeconnect.daemon", `/modules/kdeconnect/devices/${d.id}/findmyphone`, "org.kde.kdeconnect.device.findmyphone", "ring", []));
+        else if (root.backend === "valent" && root.validValentObjectPath(d.objectPath))
+            root.runAction(root.busctlCall("ca.andyholmes.Valent", d.objectPath, "org.gtk.Actions", "Activate", ["sava{sv}", "findmyphone.ring", "0", "0"]));
+    }
+
+    function ping(device: var): void {
+        const d = device ?? root.activeDevice;
+        if (!d || root.backend !== "kdeconnect" || !root.validDeviceId(d.id)) return;
+        root.runAction(root.busctlCall("org.kde.kdeconnect.daemon", `/modules/kdeconnect/devices/${d.id}/ping`, "org.kde.kdeconnect.device.ping", "sendPing", []));
+    }
+
+    function sendClipboard(device: var): void {
+        const d = device ?? root.activeDevice;
+        if (!d || root.backend !== "kdeconnect" || !root.validDeviceId(d.id)) return;
+        root.runAction(root.busctlCall("org.kde.kdeconnect.daemon", `/modules/kdeconnect/devices/${d.id}/clipboard`, "org.kde.kdeconnect.device.clipboard", "sendClipboard", []));
+    }
+
+    function runAction(argv: var): void {
+        actionProc.exec(argv);
+    }
+
+    Process {
+        id: actionProc
+        environment: ({
+            LANG: "C",
+            LC_ALL: "C"
+        })
+        stderr: StdioCollector {
+            id: actionErr
+        }
+        onExited: (exitCode, exitStatus) => {
+            if (exitCode !== 0) {
+                Quickshell.execDetached(["notify-send",
+                    Translation.tr("Phone Connect"),
+                    actionErr.text.trim() || Translation.tr("Phone Connect command failed"),
+                    "-a", "Shell"
+                ]);
+            }
+        }
+    }
+
+    // ---- serialized busctl queue ----
+
+    property var callQueue: []
+    property var activeCallback: null
+
+    function enqueue(argv: var, callback: var): void {
+        root.callQueue.push({ argv: argv, callback: callback });
+        root.pump();
+    }
+
+    function pump(): void {
+        if (busProc.running || root.callQueue.length === 0) return;
+        const next = root.callQueue.shift();
+        root.activeCallback = next.callback;
+        busProc.exec(next.argv);
+    }
+
+    Process {
+        id: busProc
+        environment: ({
+            LANG: "C",
+            LC_ALL: "C"
+        })
+        stdout: StdioCollector {
+            id: busOut
+        }
+        // "Call failed: ..." on stderr is expected for absent objects (e.g.
+        // the battery of an unpaired device); the empty stdout parses to null.
+        stderr: StdioCollector {}
+        onExited: (exitCode, exitStatus) => {
+            const callback = root.activeCallback;
+            root.activeCallback = null;
+            callback?.(busOut.text);
+            root.pump();
+        }
+    }
+
+    onEnableServiceChanged: {
+        if (!root.enableService) {
+            root.callQueue = [];
+            root.activeCallback = null;
+            root.applyBackend("none");
+        } else if (root.installed) {
+            root.refresh();
+        }
+    }
+
+    // One-shot presence check; everything else is gated on it.
+    Process {
+        id: whichProc
+        running: root.enableService
+        command: ["sh", "-c", "command -v busctl"]
+        onExited: (exitCode, exitStatus) => {
+            root.installed = (exitCode === 0);
+            if (root.installed) root.refresh();
+        }
+    }
+
+    Timer {
+        interval: root.pollInterval
+        running: root.enableService && root.installed
+        repeat: true
+        triggeredOnStart: true
+        onTriggered: root.refresh()
+    }
+}

--- a/dots/.config/quickshell/imi/tests/imports/testservices/PhoneConnect.qml
+++ b/dots/.config/quickshell/imi/tests/imports/testservices/PhoneConnect.qml
@@ -1,0 +1,146 @@
+pragma Singleton
+pragma ComponentBehavior: Bound
+
+import Quickshell
+import QtQuick
+
+// Logic-only double of services/PhoneConnect.qml. The parser/normalization
+// functions between the sync markers are kept byte-for-byte in sync with the
+// real service (tests/test_phone_connect_contract.py enforces it); the busctl
+// Process/Timer I/O is omitted so tests stay deterministic and offline.
+Singleton {
+    id: root
+
+    property bool installed: false // busctl found on PATH
+    property string backend: "none" // "kdeconnect" | "valent" | "none"
+    readonly property bool available: root.backend !== "none"
+    // [{ id, name, type, reachable, paired, batteryAvailable, batteryCharge, batteryCharging }]
+    property var devices: []
+
+    readonly property var activeDevice: root.devices.find(d => d.paired && d.reachable && d.type === "phone")
+        ?? root.devices.find(d => d.paired && d.reachable)
+        ?? null
+    readonly property string materialSymbol: (root.available && root.activeDevice) ? "mobile" : "mobile_off"
+
+    // BEGIN phone-connect parser logic (synced with services/PhoneConnect.qml)
+    // Parses one `busctl --json=short` reply. Returns the payload ("data")
+    // array, or null when the text is not a busctl JSON document (empty
+    // output, "Call failed: ..." error text, malformed JSON).
+    function parseBusctlReply(text: string): var {
+        const trimmed = (text ?? "").trim();
+        if (trimmed.length === 0) return null;
+        let doc;
+        try {
+            doc = JSON.parse(trimmed);
+        } catch (e) {
+            return null;
+        }
+        if (!doc || typeof doc !== "object" || !Array.isArray(doc.data)) return null;
+        return doc.data;
+    }
+
+    // GetAll replies carry a{sv}: { key: { type, data } }. Flattens the
+    // variant cells to plain values.
+    function unwrapVariants(dict: var): var {
+        const out = {};
+        for (const key in (dict ?? {})) {
+            const cell = dict[key];
+            out[key] = (cell && typeof cell === "object" && "data" in cell) ? cell.data : cell;
+        }
+        return out;
+    }
+
+    // Maps a ListNames reply to the backend it implies. KDE Connect wins a
+    // tie: it is the incumbent, and running both daemons at once double-pairs
+    // phones anyway.
+    function backendFromNames(names: var): string {
+        const list = names ?? [];
+        if (list.includes("org.kde.kdeconnect.daemon")) return "kdeconnect";
+        if (list.includes("ca.andyholmes.Valent")) return "valent";
+        return "none";
+    }
+
+    // Normalizes one org.kde.kdeconnect.device GetAll reply (plus its
+    // battery GetAll, or null when the battery object does not exist - it is
+    // absent for unpaired devices) onto the shared device model.
+    function normalizeKdeconnectDevice(id: string, rawProps: var, rawBatteryProps: var): var {
+        const props = root.unwrapVariants(rawProps);
+        const battery = rawBatteryProps === null || rawBatteryProps === undefined
+            ? null : root.unwrapVariants(rawBatteryProps);
+        return {
+            id: id,
+            name: props.name ?? "",
+            type: props.type ?? "",
+            reachable: props.isReachable === true,
+            paired: props.isPaired === true,
+            batteryAvailable: battery !== null && typeof battery.charge === "number",
+            batteryCharge: (battery !== null && typeof battery.charge === "number") ? battery.charge : -1,
+            batteryCharging: battery !== null && battery.isCharging === true
+        };
+    }
+
+    // Valent device State flags (valent-device.h): 1 = connected, 2 = paired.
+    function normalizeValentObjects(managedObjects: var): var {
+        const objects = (managedObjects ?? [])[0] ?? {};
+        const devices = [];
+        for (const path in objects) {
+            const ifaces = objects[path];
+            const raw = ifaces?.["ca.andyholmes.Valent.Device"];
+            if (!raw) continue;
+            const props = root.unwrapVariants(raw);
+            const state = Number(props.State ?? 0);
+            devices.push({
+                id: props.Id ?? "",
+                name: props.Name ?? "",
+                type: props.Type ?? "",
+                reachable: (state & 1) !== 0,
+                paired: (state & 2) !== 0,
+                objectPath: path,
+                batteryAvailable: false,
+                batteryCharge: -1,
+                batteryCharging: false
+            });
+        }
+        return devices;
+    }
+
+    // Decodes an org.gtk.Actions DescribeAll reply (a{s(bgav)}) into battery
+    // state via the stateful `battery.state` action's vardict.
+    function decodeValentBattery(describeAllData: var): var {
+        const none = { available: false, charge: -1, charging: false };
+        const actions = (describeAllData ?? [])[0] ?? {};
+        const batteryAction = actions["battery.state"];
+        if (!Array.isArray(batteryAction) || batteryAction.length < 3) return none;
+        const stateCells = batteryAction[2];
+        if (!Array.isArray(stateCells) || stateCells.length === 0) return none;
+        const state = root.unwrapVariants(stateCells[0]?.data ?? null);
+        if (typeof state.percentage !== "number") return none;
+        return {
+            available: state["is-present"] !== false,
+            charge: Math.round(state.percentage),
+            charging: state.charging === true
+        };
+    }
+
+    // Reachable-and-paired devices first, then paired, then by name/id.
+    function sortDevices(list: var): var {
+        const rank = d => (d.paired && d.reachable) ? 0 : d.paired ? 1 : 2;
+        return [...(list ?? [])].sort((a, b) => rank(a) - rank(b)
+            || String(a.name || a.id).localeCompare(String(b.name || b.id)));
+    }
+
+    // Object paths and argv both splice the id in; keep it boring.
+    function validDeviceId(id: var): bool {
+        return typeof id === "string" && /^[A-Za-z0-9_-]+$/.test(id);
+    }
+    // END phone-connect parser logic
+
+    function applyBackend(newBackend: string): void {
+        root.backend = newBackend;
+        if (newBackend === "none") root.devices = [];
+    }
+
+    function applyDevices(list: var): void {
+        root.devices = root.sortDevices(list);
+    }
+}

--- a/dots/.config/quickshell/imi/tests/imports/testservices/qmldir
+++ b/dots/.config/quickshell/imi/tests/imports/testservices/qmldir
@@ -3,6 +3,7 @@ singleton Battery Battery.qml
 singleton BluetoothStatus BluetoothStatus.qml
 singleton MediaCapture MediaCapture.qml
 singleton OpenRgb OpenRgb.qml
+singleton PhoneConnect PhoneConnect.qml
 singleton PluginStore PluginStore.qml
 singleton Tailscale Tailscale.qml
 singleton Vpn Vpn.qml

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -611,6 +611,14 @@ if ! python3 "$SCRIPT_DIR/test_openrgb_detector_sync.py"; then
     exit 1
 fi
 
+# The QML suite drives a logic-only double; this is the sync check that makes
+# its green transfer to the real service, plus the busctl argv/id-guard pins.
+echo "Running Phone Connect contract tests..."
+if ! python3 "$SCRIPT_DIR/test_phone_connect_contract.py"; then
+    echo "Phone Connect contract tests failed."
+    exit 1
+fi
+
 echo "Running registry entry validator tests..."
 if ! python3 "$SCRIPT_DIR/test_registry_validate.py"; then
     echo "Registry entry validator tests failed."

--- a/dots/.config/quickshell/imi/tests/test_phone_connect_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_connect_contract.py
@@ -1,0 +1,126 @@
+"""Contract checks for services/PhoneConnect.qml.
+
+The QML suite (tst_phone_connect.qml) exercises the parser/normalization
+logic through a logic-only double, so the double proving something means
+nothing unless the real service carries the same logic. The sync check here
+is what makes the double's green transfer: the region between the
+`BEGIN/END phone-connect parser logic` markers must be byte-for-byte
+identical in both files (the BEGIN line itself may differ - each side points
+its "synced with" note at the other).
+
+The rest pins the busctl I/O the double deliberately omits:
+- every busctl invocation is an argv array; the only shell string is the
+  static `command -v busctl` presence probe, with nothing interpolated;
+- device ids are filtered through validDeviceId before they are spliced
+  into object paths, and Valent object paths pass validValentObjectPath
+  before they are called into;
+- no `busctl monitor`: updates are bounded polling (a persistent streaming
+  Process needs backoff and a retry ceiling per CONTRIBUTING.md), and the
+  poll timer is gated on enableService && installed.
+"""
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SERVICE = ROOT / "services" / "PhoneConnect.qml"
+DOUBLE = ROOT / "tests" / "imports" / "testservices" / "PhoneConnect.qml"
+
+BEGIN = "// BEGIN phone-connect parser logic"
+END = "    // END phone-connect parser logic"
+
+
+def _synced_region(path: Path) -> str:
+    text = path.read_text()
+    assert text.count(BEGIN) == 1, f"{path}: expected exactly one BEGIN marker"
+    assert text.count(END) == 1, f"{path}: expected exactly one END marker"
+    start = text.index("\n", text.index(BEGIN)) + 1
+    return text[start:text.index(END)]
+
+
+def test_parser_region_is_byte_identical_between_service_and_double():
+    service_region = _synced_region(SERVICE)
+    double_region = _synced_region(DOUBLE)
+    assert service_region, "synced region is empty"
+    assert service_region == double_region, (
+        "services/PhoneConnect.qml and tests/imports/testservices/PhoneConnect.qml "
+        "have drifted between the phone-connect parser logic markers; edit both "
+        "sides identically"
+    )
+
+
+def test_state_application_helpers_match_the_double():
+    # applyBackend/applyDevices sit outside the marked region (the double's
+    # versions are what the QML suite drives), but their semantics are part
+    # of the tested contract too - keep the bodies identical.
+    for name in ("applyBackend", "applyDevices"):
+        pattern = rf"    function {name}\(.*?\n    \}}\n"
+        service_fn = re.search(pattern, SERVICE.read_text(), re.S)
+        double_fn = re.search(pattern, DOUBLE.read_text(), re.S)
+        assert service_fn and double_fn, f"{name} missing on one side"
+        assert service_fn.group(0) == double_fn.group(0), f"{name} drifted"
+
+
+def test_only_shell_string_is_the_static_presence_probe():
+    source = SERVICE.read_text()
+    shell_commands = re.findall(r'\["sh",\s*"-c",\s*(.*?)\]', source)
+    assert shell_commands == ['"command -v busctl"'], (
+        f"unexpected shell strings in PhoneConnect.qml: {shell_commands}"
+    )
+    for line in source.splitlines():
+        if '"sh"' in line and "${" in line:
+            raise AssertionError(f"interpolation into a shell command: {line.strip()}")
+
+
+def test_busctl_calls_are_argv_arrays_via_busctl_call():
+    source = SERVICE.read_text()
+    builder = re.search(
+        r'function busctlCall\(.*?\{\n(.*?)\n    \}', source, re.S
+    )
+    assert builder, "busctlCall builder missing"
+    assert '["busctl", "--user", "--json=short"' in builder.group(1)
+    # Every exec goes through the queue or the action process, both fed by
+    # busctlCall argv arrays - no other busctl literal should exist.
+    busctl_literals = [
+        line.strip() for line in source.splitlines()
+        if '"busctl"' in line
+        and not line.strip().startswith('return ["busctl"')
+        and "command -v" not in line
+    ]
+    assert busctl_literals == [], f"busctl invoked outside busctlCall: {busctl_literals}"
+
+
+def test_device_ids_are_validated_before_path_splicing():
+    source = SERVICE.read_text()
+    assert ".filter(id => root.validDeviceId(id))" in source, (
+        "kdeconnect device ids must be filtered through validDeviceId before "
+        "being spliced into object paths"
+    )
+    assert ".filter(d => root.validValentObjectPath(d.objectPath))" in source, (
+        "valent object paths must be validated before DescribeAll is called on them"
+    )
+    # Actions build paths from ids/paths too - each must re-check.
+    for action in ("ring", "ping", "sendClipboard"):
+        body = re.search(rf"function {action}\(.*?\n    \}}\n", source, re.S)
+        assert body, f"{action}() missing"
+        assert "validDeviceId" in body.group(0) or "validValentObjectPath" in body.group(0), (
+            f"{action}() splices without validating"
+        )
+
+
+def test_no_streaming_monitor_and_poll_timer_is_gated():
+    source = SERVICE.read_text()
+    assert '"monitor"' not in source, (
+        "busctl monitor is a persistent streaming Process; bounded polling was "
+        "the reviewed decision (see the service header comment)"
+    )
+    timer = re.search(r"Timer \{(.*?)\n    \}", source, re.S)
+    assert timer, "poll Timer missing"
+    assert "running: root.enableService && root.installed" in timer.group(1)
+    assert "repeat: true" in timer.group(1)
+
+
+if __name__ == "__main__":
+    import sys
+    from contract_runner import run
+    sys.exit(run(globals()))

--- a/dots/.config/quickshell/imi/tests/tst_phone_connect.qml
+++ b/dots/.config/quickshell/imi/tests/tst_phone_connect.qml
@@ -1,0 +1,273 @@
+import QtQuick
+import QtTest
+import testservices
+
+// Behavioral tests for the parsing/normalization logic of
+// services/PhoneConnect.qml, exercised through the logic-only double in
+// tests/imports/testservices. Fixtures follow real `busctl --json=short`
+// replies captured from a live KDE Connect daemon (a paired, reachable phone
+// and an unpaired desktop); the Valent fixtures encode the documented
+// signatures (ObjectManager device export, org.gtk.Actions battery state)
+// since no live Valent daemon was available.
+TestCase {
+    name: "PhoneConnectTest"
+
+    function init() {
+        PhoneConnect.installed = false
+        PhoneConnect.backend = "none"
+        PhoneConnect.devices = []
+    }
+
+    // ---- parseBusctlReply ----
+
+    function test_parse_busctl_reply_unwraps_data() {
+        const data = PhoneConnect.parseBusctlReply('{"type":"as","data":[["a","b"]]}')
+        compare(data.length, 1)
+        compare(data[0][1], "b")
+    }
+
+    function test_parse_busctl_reply_rejects_non_reply_output() {
+        compare(PhoneConnect.parseBusctlReply(""), null)
+        compare(PhoneConnect.parseBusctlReply("   \n"), null)
+        compare(PhoneConnect.parseBusctlReply(null), null)
+        compare(PhoneConnect.parseBusctlReply("Call failed: No such object path"), null)
+        compare(PhoneConnect.parseBusctlReply('{"type":"as"}'), null)
+        compare(PhoneConnect.parseBusctlReply('"just a string"'), null)
+    }
+
+    // ---- unwrapVariants ----
+
+    function test_unwrap_variants_flattens_variant_cells() {
+        const flat = PhoneConnect.unwrapVariants({
+            "name": { "type": "s", "data": "Galaxy S23 Ultra" },
+            "isPaired": { "type": "b", "data": true },
+            "charge": { "type": "i", "data": 100 }
+        })
+        compare(flat.name, "Galaxy S23 Ultra")
+        compare(flat.isPaired, true)
+        compare(flat.charge, 100)
+    }
+
+    function test_unwrap_variants_tolerates_null_and_plain_values() {
+        compare(JSON.stringify(PhoneConnect.unwrapVariants(null)), "{}")
+        const flat = PhoneConnect.unwrapVariants({ "plain": 5 })
+        compare(flat.plain, 5)
+    }
+
+    // ---- backendFromNames ----
+
+    function test_backend_detection_kdeconnect() {
+        compare(PhoneConnect.backendFromNames([":1.5", "org.kde.kdeconnect.daemon", "org.freedesktop.DBus"]), "kdeconnect")
+    }
+
+    function test_backend_detection_valent() {
+        compare(PhoneConnect.backendFromNames(["ca.andyholmes.Valent", ":1.9"]), "valent")
+    }
+
+    function test_backend_detection_prefers_kdeconnect_when_both_own_names() {
+        compare(PhoneConnect.backendFromNames(["ca.andyholmes.Valent", "org.kde.kdeconnect.daemon"]), "kdeconnect")
+    }
+
+    function test_backend_detection_none() {
+        compare(PhoneConnect.backendFromNames([":1.5", "org.freedesktop.DBus"]), "none")
+        compare(PhoneConnect.backendFromNames([]), "none")
+        compare(PhoneConnect.backendFromNames(null), "none")
+    }
+
+    // ---- normalizeKdeconnectDevice ----
+
+    function pairedPhoneProps() {
+        // Captured shape: GetAll on org.kde.kdeconnect.device, variant cells intact.
+        return {
+            "name": { "type": "s", "data": "Galaxy S23 Ultra" },
+            "type": { "type": "s", "data": "phone" },
+            "isPaired": { "type": "b", "data": true },
+            "isReachable": { "type": "b", "data": true },
+            "isPairRequestedByPeer": { "type": "b", "data": false }
+        }
+    }
+
+    function test_normalize_kdeconnect_paired_phone_with_battery() {
+        const device = PhoneConnect.normalizeKdeconnectDevice("6131a746", pairedPhoneProps(), {
+            "charge": { "type": "i", "data": 100 },
+            "isCharging": { "type": "b", "data": true }
+        })
+        compare(device.id, "6131a746")
+        compare(device.name, "Galaxy S23 Ultra")
+        compare(device.type, "phone")
+        compare(device.paired, true)
+        compare(device.reachable, true)
+        compare(device.batteryAvailable, true)
+        compare(device.batteryCharge, 100)
+        compare(device.batteryCharging, true)
+    }
+
+    function test_normalize_kdeconnect_missing_battery_degrades_cleanly() {
+        // The battery object does not exist for unpaired devices - GetAll
+        // fails and the pipeline passes null through.
+        const device = PhoneConnect.normalizeKdeconnectDevice("3b767a24", {
+            "name": { "type": "s", "data": "rox-xbox-ally-x" },
+            "type": { "type": "s", "data": "desktop" },
+            "isPaired": { "type": "b", "data": false },
+            "isReachable": { "type": "b", "data": true }
+        }, null)
+        compare(device.paired, false)
+        compare(device.type, "desktop")
+        compare(device.batteryAvailable, false)
+        compare(device.batteryCharge, -1)
+        compare(device.batteryCharging, false)
+    }
+
+    function test_normalize_kdeconnect_missing_props_default_safe() {
+        const device = PhoneConnect.normalizeKdeconnectDevice("x", {}, null)
+        compare(device.name, "")
+        compare(device.type, "")
+        compare(device.paired, false)
+        compare(device.reachable, false)
+    }
+
+    // ---- Valent ----
+
+    function valentManagedObjects() {
+        return [{
+            "/ca/andyholmes/Valent/Device/0": {
+                "ca.andyholmes.Valent.Device": {
+                    "Id": { "type": "s", "data": "abc123" },
+                    "Name": { "type": "s", "data": "Pixel 9" },
+                    "Type": { "type": "s", "data": "phone" },
+                    "State": { "type": "u", "data": 3 }
+                },
+                "org.gtk.Actions": {}
+            },
+            "/ca/andyholmes/Valent/Device/1": {
+                "ca.andyholmes.Valent.Device": {
+                    "Id": { "type": "s", "data": "def456" },
+                    "Name": { "type": "s", "data": "Tablet" },
+                    "Type": { "type": "s", "data": "tablet" },
+                    "State": { "type": "u", "data": 2 }
+                }
+            },
+            "/ca/andyholmes/Valent": {
+                "org.freedesktop.DBus.ObjectManager": {}
+            }
+        }]
+    }
+
+    function test_normalize_valent_objects_decodes_state_flags() {
+        const devices = PhoneConnect.normalizeValentObjects(valentManagedObjects())
+        compare(devices.length, 2)
+        const phone = devices.find(d => d.id === "abc123")
+        compare(phone.name, "Pixel 9")
+        compare(phone.type, "phone")
+        compare(phone.reachable, true) // state bit 1 = connected
+        compare(phone.paired, true) // state bit 2 = paired
+        compare(phone.objectPath, "/ca/andyholmes/Valent/Device/0")
+        const tablet = devices.find(d => d.id === "def456")
+        compare(tablet.reachable, false)
+        compare(tablet.paired, true)
+    }
+
+    function test_normalize_valent_objects_ignores_non_device_paths() {
+        const devices = PhoneConnect.normalizeValentObjects([{
+            "/ca/andyholmes/Valent": { "org.freedesktop.DBus.ObjectManager": {} }
+        }])
+        compare(devices.length, 0)
+        compare(PhoneConnect.normalizeValentObjects(null).length, 0)
+    }
+
+    function test_decode_valent_battery_state() {
+        const battery = PhoneConnect.decodeValentBattery([{
+            "battery.state": [true, "", [{
+                "type": "a{sv}",
+                "data": {
+                    "charging": { "type": "b", "data": false },
+                    "percentage": { "type": "d", "data": 85.0 },
+                    "is-present": { "type": "b", "data": true }
+                }
+            }]],
+            "findmyphone.ring": [true, "", []]
+        }])
+        compare(battery.available, true)
+        compare(battery.charge, 85)
+        compare(battery.charging, false)
+    }
+
+    function test_decode_valent_battery_absent_action_degrades() {
+        const battery = PhoneConnect.decodeValentBattery([{ "findmyphone.ring": [true, "", []] }])
+        compare(battery.available, false)
+        compare(battery.charge, -1)
+        compare(PhoneConnect.decodeValentBattery(null).available, false)
+    }
+
+    // ---- sorting / active device / state application ----
+
+    function device(id, overrides) {
+        return Object.assign({
+            id: id, name: id, type: "phone", reachable: false, paired: false,
+            batteryAvailable: false, batteryCharge: -1, batteryCharging: false
+        }, overrides ?? {})
+    }
+
+    function test_sort_devices_reachable_paired_first_then_name() {
+        const sorted = PhoneConnect.sortDevices([
+            device("c", { paired: true, reachable: false }),
+            device("b", { paired: true, reachable: true }),
+            device("a", { paired: false, reachable: true }),
+            device("d", { paired: true, reachable: true })
+        ])
+        compare(sorted.map(d => d.id).join(","), "b,d,c,a")
+    }
+
+    function test_active_device_prefers_reachable_paired_phone() {
+        PhoneConnect.applyBackend("kdeconnect")
+        PhoneConnect.applyDevices([
+            device("laptop", { type: "laptop", paired: true, reachable: true, name: "aaa" }),
+            device("phone1", { type: "phone", paired: true, reachable: true, name: "zzz" })
+        ])
+        compare(PhoneConnect.activeDevice.id, "phone1")
+        compare(PhoneConnect.materialSymbol, "mobile")
+    }
+
+    function test_active_device_falls_back_to_any_reachable_paired() {
+        PhoneConnect.applyBackend("kdeconnect")
+        PhoneConnect.applyDevices([
+            device("laptop", { type: "laptop", paired: true, reachable: true }),
+            device("phone1", { type: "phone", paired: true, reachable: false })
+        ])
+        compare(PhoneConnect.activeDevice.id, "laptop")
+    }
+
+    function test_no_backend_resets_to_clean_degraded_state() {
+        PhoneConnect.applyBackend("kdeconnect")
+        PhoneConnect.applyDevices([device("phone1", { paired: true, reachable: true })])
+        compare(PhoneConnect.available, true)
+        PhoneConnect.applyBackend("none")
+        compare(PhoneConnect.available, false)
+        compare(PhoneConnect.devices.length, 0)
+        compare(PhoneConnect.activeDevice, null)
+        compare(PhoneConnect.materialSymbol, "mobile_off")
+    }
+
+    function test_unreachable_only_devices_yield_no_active_device() {
+        PhoneConnect.applyBackend("kdeconnect")
+        PhoneConnect.applyDevices([device("phone1", { paired: true, reachable: false })])
+        compare(PhoneConnect.activeDevice, null)
+        compare(PhoneConnect.materialSymbol, "mobile_off")
+    }
+
+    // ---- device id guard ----
+
+    function test_valid_device_id_accepts_kdeconnect_and_valent_ids() {
+        compare(PhoneConnect.validDeviceId("6131a746_571a_4176_a007_95625ff8e08e"), true)
+        compare(PhoneConnect.validDeviceId("3b767a2479954eceaf9f1e7fa212f48e"), true)
+        compare(PhoneConnect.validDeviceId("abc-123"), true)
+    }
+
+    function test_valid_device_id_rejects_path_and_shell_metacharacters() {
+        compare(PhoneConnect.validDeviceId("../../etc"), false)
+        compare(PhoneConnect.validDeviceId("a/b"), false)
+        compare(PhoneConnect.validDeviceId("a b"), false)
+        compare(PhoneConnect.validDeviceId(""), false)
+        compare(PhoneConnect.validDeviceId(null), false)
+    }
+}

--- a/dots/.config/quickshell/imi/translations/en_US.json
+++ b/dots/.config/quickshell/imi/translations/en_US.json
@@ -780,5 +780,8 @@
   "Off": "Off",
   "Tailscale daemon is not running": "Tailscale daemon is not running",
   "Tailscale is down": "Tailscale is down",
-  "No peer advertises itself as an exit node": "No peer advertises itself as an exit node"
+  "No peer advertises itself as an exit node": "No peer advertises itself as an exit node",
+  "Phone Connect": "Phone Connect",
+  "Phone Connect command failed": "Phone Connect command failed",
+  "Show your phone (via KDE Connect or Valent)": "Show your phone (via KDE Connect or Valent)"
 }

--- a/dots/.config/quickshell/imi/translations/en_US.json
+++ b/dots/.config/quickshell/imi/translations/en_US.json
@@ -783,5 +783,22 @@
   "No peer advertises itself as an exit node": "No peer advertises itself as an exit node",
   "Phone Connect": "Phone Connect",
   "Phone Connect command failed": "Phone Connect command failed",
-  "Show your phone (via KDE Connect or Valent)": "Show your phone (via KDE Connect or Valent)"
+  "Show your phone (via KDE Connect or Valent)": "Show your phone (via KDE Connect or Valent)",
+  "Phone": "Phone",
+  "Disconnected": "Disconnected",
+  "Phone Connect | Click for devices": "Phone Connect | Click for devices",
+  "Phone Connect: %1 (%2%) | Click for devices": "Phone Connect: %1 (%2%) | Click for devices",
+  "Phone Connect: %1 | Click for devices": "Phone Connect: %1 | Click for devices",
+  "busctl was not found on PATH": "busctl was not found on PATH",
+  "Neither KDE Connect nor Valent is running": "Neither KDE Connect nor Valent is running",
+  "No devices yet — pair your phone from KDE Connect or Valent": "No devices yet — pair your phone from KDE Connect or Valent",
+  "Backend: KDE Connect": "Backend: KDE Connect",
+  "Backend: Valent": "Backend: Valent",
+  "Not paired": "Not paired",
+  "Paired • Offline": "Paired • Offline",
+  "%1% • Charging": "%1% • Charging",
+  "%1%": "%1%",
+  "Ring": "Ring",
+  "Ping": "Ping",
+  "Send clipboard": "Send clipboard"
 }


### PR DESCRIPTION
Tracking proposal. Not scheduled.

Surfaces a paired phone in the shell — battery, notifications, media, file send, clipboard — backed by whichever of **KDE Connect** or **Valent** the user has installed. Greenfield; no service or widget exists today.

**Transport constraint:** the shell has no D-Bus binding anywhere. Every service shells out via `Process` (`services/Brightness.qml:71,90,134`). Both daemons are D-Bus, so the doc picks a transport rather than assuming one — recommending `busctl --json` via `Process`, since the interesting features (notification mirroring, battery) are event-driven and `busctl monitor` streams signals instead of polling.

Proposed as a **bundled plugin** rather than a hardcoded surface, so users without a phone aren't carrying a dead widget — and it exercises the plugin API on a non-trivial integration.

Open question in the doc: whether pairing should be driveable from the shell at all, given it's security-relevant and wrapping it badly is worse than not wrapping it.

See `docs/proposals/phone-connect.md`.

---

## Implementation status (first slice)

- **`services/PhoneConnect.qml`** — `busctl --json=short` transport as recommended above. Backend detection from `ListNames` (KDE Connect wins a tie — running both daemons double-pairs phones), one normalized device/battery model for both daemons, serialized busctl call queue, argv arrays only. No daemon = clean degraded state. Bounded polling (10s default) rather than `busctl monitor` streaming: a persistent streaming Process needs backoff/retry-ceiling machinery (CONTRIBUTING.md) this slice does not justify.
- **Sidebar surface** — quick toggle (classic + android styles) + device dialog on the Tailscale surface pattern. The tile is a status surface, not a switch: every click opens the device dialog. The dialog lists devices with pairing/reachability/battery and offers ring (both backends), ping and clipboard-send (KDE Connect only — Valent action names beyond `findmyphone.ring` were not verifiable without a live daemon). The classic toggle hides when no daemon runs and the android tile is opt-in, which answers the dead-widget concern the bundled-plugin idea was raised for; a bundled desktop-widget plugin stays a possible follow-up.
- **Config + settings** — `networking.phoneConnect { enable, pollInterval }` with matching rows in Services → Networking (spin box writes back from `onValueModified` only).
- **Tests** — the inherited parser/state suite (`tst_phone_connect.qml`, fixtures captured from a live KDE Connect daemon) now runs against logic the real service carries: `tests/test_phone_connect_contract.py` pins the marked parser region byte-for-byte between service and double, plus the busctl I/O rules (argv-only, id/path validation before splicing, no `monitor`, gated poll timer). Mutation-proven in a clean tree.
- **Pairing** stays in the daemons' own UIs — the open question above, resolved conservatively.

## Testing

- `tests/run_tests.sh` green: 299 QML tests (including the 24-case phone-connect suite) + all Python contract checks/lints, including the new phone-connect contract module wired into the runner.
- **Not yet live-verified**: `PhoneConnect.qml` is a new `pragma Singleton`, so it only registers on a full `qs` restart, not a hot reload (AGENT.md, Runtime model). The running shell was deliberately left untouched; the sidebar surface and a live daemon sweep need that restart before merge.
- Valent path is fixture-verified only (documented signatures); no live Valent daemon was available.

Docs: updated AGENT.md §Directory map (services — PhoneConnect.qml entry); docs/proposals/phone-connect.md §Current state
