### PR TITLE
fix(installer): SDDM login theme silently fails to install in the default TUI

### DIFF
--- a/sdata/subcmd-install/5.sddm-theme.sh
+++ b/sdata/subcmd-install/5.sddm-theme.sh
@@ -48,6 +48,23 @@ if ! curl -fsSL "$SETUP_URL" -o "$TMP_SETUP"; then
 fi
 
 echo "[ImI] SDDM theme: handing off to the upstream installer (interactive)..."
+# The upstream installer is purely interactive: its very first action is a
+# `read -p "Continue? [y/n]"`, and it has no non-interactive/env-driven mode.
+# If our stdin is not a terminal, that `read` gets EOF, falls to its default
+# case, and the installer exits 0 — silently installing nothing. This bites the
+# quiet install path, which runs the whole pipeline with stdin on /dev/null.
+# So: if stdin isn't a TTY, reconnect the installer to the controlling terminal
+# (/dev/tty) so its prompts still reach the user; if there is no controlling
+# terminal at all (truly headless/CI), skip loudly rather than silently abort.
 # Optional extra — never let a decline/failure abort the whole install.
-bash "$TMP_SETUP" || echo "[ImI] SDDM theme: upstream installer exited non-zero (declined or error)."
+if [[ -t 0 ]]; then
+  bash "$TMP_SETUP" || echo "[ImI] SDDM theme: upstream installer exited non-zero (declined or error)."
+elif { : >/dev/tty; } 2>/dev/null; then
+  echo "[ImI] SDDM theme: stdin is not a terminal; reconnecting the installer to /dev/tty for its prompts."
+  bash "$TMP_SETUP" </dev/tty || echo "[ImI] SDDM theme: upstream installer exited non-zero (declined or error)."
+else
+  echo "[ImI] SDDM theme: the upstream installer is interactive but no terminal is available (stdin isn't a TTY and there is no controlling terminal); skipping." >&2
+  echo "[ImI] SDDM theme: to install it, run 'INSTALL_SDDM=1 sdata/subcmd-install/5.sddm-theme.sh' from a terminal." >&2
+  exit 0
+fi
 echo "[ImI] SDDM theme: done."

--- a/sdata/subcmd-install/tui.sh
+++ b/sdata/subcmd-install/tui.sh
@@ -215,7 +215,12 @@ VERBOSE_ON="${STATE[VERBOSE]}"
 # --- 4. Map choices to the existing flags/env --------------------------------
 INSTALL_FLAGS=()
 [[ "$WE_ON"   == on ]] && export INSTALL_WE=1
-[[ "$SDDM_ON" == on ]] && export INSTALL_SDDM=1
+# NOTE: INSTALL_SDDM is deliberately NOT exported into the install pipeline.
+# ii-sddm-theme's upstream installer is interactive (it prompts for the install
+# mode and several confirmations via `read`), and the default quiet install runs
+# the whole pipeline with stdin on /dev/null — the installer would EOF on its
+# first prompt and silently abort, installing nothing. So SDDM is handled as a
+# post-install step below (mirroring the fcitx5 extra), on the clean terminal.
 [[ "$DEPS_ON" == on ]] || INSTALL_FLAGS+=(--skip-alldeps)
 [[ "$FONTSET_CHOICE" != "none" ]] && INSTALL_FLAGS+=(--fontset "$FONTSET_CHOICE")
 
@@ -420,6 +425,18 @@ if [[ $INSTALL_RET -eq 0 && "$FCITX5_ON" == on ]]; then
   XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
   mkdir -p "${XDG_CONFIG_HOME}/fcitx5/conf"
   cp -f "${REPO_ROOT}/dots-extra/fcitx5/conf/classicui.conf" "${XDG_CONFIG_HOME}/fcitx5/conf/classicui.conf"
+fi
+
+# The SDDM login theme's upstream installer is interactive and CANNOT run inside
+# the quiet pipeline (stdin is /dev/null there — it would EOF on its first prompt
+# and silently abort). So run it here, after the install, on the clean terminal:
+# the progress bar is done, stdin is the real TTY, and its prompts reach the user.
+# 5.sddm-theme.sh is the same no-op-unless-INSTALL_SDDM=1 wrapper `setup install`
+# would have called; we just invoke it interactively instead of inside --force.
+if [[ $INSTALL_RET -eq 0 && "$SDDM_ON" == on ]]; then
+  echo "[tui] Installing the SDDM login theme (ii-sddm-theme) — interactive."
+  INSTALL_SDDM=1 bash "${REPO_ROOT}/sdata/subcmd-install/5.sddm-theme.sh" \
+    || echo "[tui] SDDM login theme: installer exited non-zero (declined or error)."
 fi
 
 exit $INSTALL_RET


### PR DESCRIPTION
## Problem

Selecting **SDDM login theme** in the installer silently installed nothing.

`ii-sddm-theme`'s upstream `setup.sh` is purely interactive — its first action is a
`read "Continue? [y/n]"`, and it has no non-interactive / env-driven mode. The default
fzf TUI's **quiet mode** runs the whole pipeline as `setup install --force </dev/null`,
so `5.sddm-theme.sh` handed off to the upstream installer with stdin on `/dev/null`. That
first `read` hit EOF, fell through to its default case, and the installer `exit 0`'d —
installing nothing, with no error.

Wallpaper Engine and Plymouth survive `</dev/null` because they never prompt; SDDM was the
only interactive step. The whiptail fallback and the fzf *verbose* path were unaffected
(real terminal), which is why the failure looked inconsistent.

## Fix

**`tui.sh`** — stop exporting `INSTALL_SDDM` into the quiet pipeline; run `5.sddm-theme.sh`
as a post-install step on the clean terminal after the progress bar finishes, mirroring how
the existing fcitx5 extra is already handled.

**`5.sddm-theme.sh`** — defense-in-depth: when stdin isn't a TTY, reconnect the upstream
installer to `/dev/tty` so its prompts still reach the user; if there's no controlling
terminal at all (headless/CI), skip loudly with guidance instead of aborting silently. This
hardens every other caller of the wrapper too.

## Testing

- `bash -n` clean on both scripts.
- Verified the three-way stdin guard selects the correct branch (interactive → run directly;
  non-TTY stdin with a controlling terminal → reconnect to `/dev/tty`; no terminal at all →
  skip loudly with `exit 0`, no silent abort).