### PR TITLE
Proposal: drag-select multiple widgets to move together

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -687,6 +687,17 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   `FadeLoader`, rather than repeating only the enabled ids. Removing a model delegate destroys it
   immediately and makes an M3 exit transition impossible; keep disabled loaders dormant until their
   fade-and-scale exit reaches zero opacity.
+- **`MouseArea.drag` cannot accurately drag a target the MouseArea itself follows.** QQuickDrag
+  rebases its press origin when the grab is established, silently swallowing the arming move's
+  delta — a few threshold pixels under a real pointer, invisible behind the widget lattice's 12px
+  snap, but measured as half the gesture under a sparse synthetic drag — and a live binding on the
+  drag target (the old `Item { x: root.x }` drag proxy) re-yanks the target after every internal
+  write, measured as +168 applied for a +96 eight-step gesture. Where a drag must be pixel-exact
+  (the desktop widgets' group drag preserves follower offsets), compute it by hand instead: map the
+  press point and each move through the (moving) item into its static parent frame — the current
+  transform, press scale included, cancels out — and set the target to pressStart + delta, as
+  `widgetCanvas/AbstractWidget.qml` now does. d2ebb5aeb ("fix(widgetCanvas): compute the drag by
+  hand - MouseArea.drag cannot track it").
 - **A `Process`'s `onExited` handler that ignores its `exitCode` argument will happily act on stale
   data.** `TempScreenshotProcess` writes to a deterministic path (`image-${screen.name}`), so a failed
   `grim` run used to leave the *previous* successful capture sitting there untouched - the region

--- a/docs/proposals/multi-widget-selection.md
+++ b/docs/proposals/multi-widget-selection.md
@@ -2,6 +2,52 @@
 
 > Draft / tracking proposal. Not scheduled.
 
+## Outcome (implemented on this branch)
+
+The feature exists, built on the widget-canvas model that arrived after this
+proposal was written (`modules/common/widgets/widgetCanvas/`). What the
+implementation decided, including answers to the open questions below:
+
+- **Selection is canvas state and session state.** `WidgetCanvas` holds
+  `selectedWidgets`; widgets carry a `selected` flag the canvas writes and a
+  halo gated on it. Nothing is persisted — a reload deselects, and presets
+  cannot carry a selection.
+- **The marquee is opt-in per canvas** (`selectionEnabled`, default off). Only
+  the desktop background enables it; the overlay's canvas keeps its
+  dismiss-on-click behaviour.
+- **`draggable` is the entire selection filter.** It already folds in the
+  per-widget lock, click-through, the global lock and non-free placement — so
+  the full-bleed visualizer (which ships click-through) is never selected by a
+  marquee crossing it, answering that open question.
+- **Group drag is leader/follower.** The pressed widget's drag Binding keeps
+  moving it (snap first, then a group clamp the canvas computes at press);
+  followers are repositioned by the canvas with their position Behaviors gated
+  off, and are committed through the same `commitPosition()` a real release
+  runs — the two release paths were unified into that one function precisely
+  so a follower cannot end a gesture with a dead x/y binding.
+- **The group stops when its first member hits an edge** — the clamp lives in
+  the leader's drag Binding as leader-position bounds derived from every
+  member's extents.
+- **Multi-monitor:** a selection belongs to one canvas, and each monitor's
+  background owns its own canvas, so a selection cannot cross monitors.
+- **No `PluginState` batch write was needed:** each member commits via
+  `setPosition`, and the store's debounced write timer already coalesces the
+  burst into one file write.
+- **Deselection:** Escape (the canvas takes the layer surface's on-demand
+  keyboard focus while a selection exists), clicking empty desktop, grabbing
+  an unselected widget, or locking the desktop. Keyboard modifiers
+  (shift-add/ctrl-toggle) were not implemented; a marquee replaces the
+  selection.
+- A byproduct: driving the gesture with real events exposed `MouseArea.drag`
+  as inexact for a self-moving widget (its origin rebases at grab, and the old
+  drag-proxy binding fought its writes). The widget drag is now computed by
+  hand in the parent frame — see AGENT.md's gotcha entry.
+
+Pinned by `tests/test_widget_group_selection.py` (source contract) and
+`WidgetGroupDragRuntimeTest.qml` + `tests/test_widget_group_drag_runtime.py`
+(real events under headless weston). The sections below are the original
+proposal, kept for the reasoning.
+
 ## Goal
 
 Draw a marquee on the desktop to select several widgets at once, then drag the

--- a/docs/proposals/multi-widget-selection.md
+++ b/docs/proposals/multi-widget-selection.md
@@ -1,0 +1,104 @@
+# Proposal: drag-select multiple widgets to move together
+
+> Draft / tracking proposal. Not scheduled.
+
+## Goal
+
+Draw a marquee on the desktop to select several widgets at once, then drag the
+selection as a unit — every selected widget keeps its relative offset and they
+all persist their new positions on release.
+
+## Current state
+
+Desktop widgets move one at a time, and the machinery is deliberately
+single-widget all the way down.
+
+`modules/imi/background/widgets/AbstractBackgroundWidget.qml` is the host every
+desktop widget sits inside. It owns the drag:
+
+```qml
+draggable: placementStrategy === "free" && !Config.options.background.widgetsLocked
+scale: (draggable && containsPress) ? 1.05 : 1
+```
+
+and on release it writes its own position and nothing else's. There are two
+release paths, because there are two persistence backends:
+
+- Built-ins wrote through `configEntry` (`background.widgets.<key>.x/y`). As of
+  the widgets-as-plugins work there are **no built-ins left** — this path is
+  vestigial.
+- Plugins write through `PluginState.setPosition(manifest.id, screenName, …)`
+  in `modules/common/plugins/PluginWidget.qml`, keyed per plugin *and per
+  monitor*, because plugin ids and monitor names are dynamic and cannot live in
+  `Config`'s fixed `JsonAdapter` schema.
+
+Position is a plain `targetX`/`targetY` pair clamped into the screen:
+
+```qml
+function clampX(v) { return Math.max(0, Math.min(v, scaledScreenWidth - width)); }
+```
+
+Dragging assigns `x`/`y` directly and so **intentionally breaks their
+bindings**; `restoreXYBinding()` puts them back on release. The clock overrides
+that function because its `forceCenter` needs a different expression. Any
+group-move has to respect this — a naive "set x on each selected widget" would
+leave several widgets with dead bindings and no way back.
+
+There is a global `background.widgetsLocked` toggle (the last surviving row in
+`modules/common/widgets/WidgetsSubmenu.qml`), but it is all-or-nothing: there is
+no per-widget lock, and no concept of a widget being *selected* at all.
+
+The desktop itself — `modules/imi/background/Background.qml` — has no
+press/drag handler of its own. Its only child is now the plugin `Repeater`. So
+the marquee has somewhere to live, but nothing to build on.
+
+## Why
+
+- Arranging a dozen widgets one at a time is the actual cost of the plugin
+  system's flexibility. Nudging a column of four to make room means four drags
+  and four chances to break the alignment you had.
+- The grid work (`docs/widget-grid.md`) made widgets *tile* — 132x108 cell, 12px
+  gap — which makes clusters visually meaningful. A cluster you cannot move as a
+  cluster is a half-finished idea.
+- It is the natural home for other multi-select operations later: align, distribute,
+  lock together, enable/disable as a set.
+
+## Sketch
+
+Rough shape, not a design:
+
+1. **Selection state** — a set of plugin ids (or id+screen pairs) held on the
+   background, not on the widgets. Widgets read "am I selected" from it.
+2. **Marquee** — a `DragHandler` on `Background.qml` that draws a rubber-band
+   rectangle and hit-tests widget bounds on release. Must not fight the widgets'
+   own drag handlers; a press that starts *on* a widget is a widget drag, a press
+   that starts on empty wallpaper is a marquee.
+3. **Group drag** — dragging any selected widget moves all of them by the same
+   delta. Clamping becomes a group operation: the group stops when the *first*
+   member hits an edge, otherwise the cluster deforms.
+4. **Persist** — one `PluginState.setPosition` per member on release. Worth
+   checking whether `PluginState` should grow a batch write; today each call
+   rewrites the state file.
+5. **Selection affordance** — the existing `scale: 1.05` on press is the only
+   current feedback. Selected-but-not-dragging needs something distinct.
+
+## Open questions
+
+- Does selection survive a reload, or is it session state? (Session, probably —
+  but presets complicate it.)
+- Do full-bleed widgets participate? The visualizer spans the whole monitor, so
+  any marquee that touches it selects it. Possibly they should be unselectable,
+  which overlaps with the per-widget lock idea (see the "independently lockable
+  and click-through" work).
+- Multi-monitor: `PluginState` keys position per screen. A marquee cannot cross
+  monitors, so a selection is implicitly single-screen — worth asserting rather
+  than discovering.
+- Keyboard modifiers: shift-to-add, ctrl-to-toggle? The desktop has no key focus
+  today.
+
+## Prior art in-tree
+
+`modules/imi/regionSelector/` already draws a drag rectangle over the screen for
+screenshots, including `TargetRegion.qml`. Different lifecycle (it is a modal
+overlay, not an in-place interaction) but the geometry and the visual treatment
+are worth reading before inventing a second rubber-band.

--- a/dots/.config/quickshell/imi/WidgetGroupDragRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/WidgetGroupDragRuntimeTest.qml
@@ -1,0 +1,422 @@
+import QtQuick
+import QtTest
+import Quickshell
+import qs
+import qs.modules.common
+import qs.modules.common.plugins
+import qs.modules.common.widgets.widgetCanvas
+
+/**
+ * Drives marquee multi-select and group drag with real mouse events.
+ *
+ * `tests/test_widget_group_selection.py` can only grep the bindings, and the
+ * qmltestrunner suite cannot instantiate the host at all. Neither answers the
+ * questions that matter: does a marquee actually pick the widgets under it and
+ * only those, does dragging one selected widget move the others by the same
+ * delta without deforming the cluster at a screen edge, and does every member
+ * end the gesture with a live x/y binding and a persisted position.
+ *
+ * Five widgets cover the selection filter's whole truth table: two plain ones
+ * (the group), a click-through one and a per-widget-locked one inside the
+ * marquee (both must be passed over), and a plain one outside it. Every
+ * position in this file is a multiple of 12 so the leader's lattice snap never
+ * introduces an off-by-a-cell into an offset assertion.
+ *
+ * Run it against a throwaway config:
+ *   XDG_CONFIG_HOME=$(mktemp -d) XDG_STATE_HOME=$(mktemp -d) qs -p WidgetGroupDragRuntimeTest.qml
+ */
+ShellRoot {
+    id: harness
+
+    property int failures: 0
+    readonly property string testScreen: "GROUP-TEST"
+
+    function check(label, ok) {
+        console.log(`[WidgetGroupDrag] ${label}: ${ok ? "ok" : "FAIL"}`);
+        if (!ok)
+            harness.failures++;
+    }
+
+    function finish() {
+        console.log(`[WidgetGroupDrag] failures: ${harness.failures}`);
+        Qt.exit(harness.failures === 0 ? 0 : 1);
+    }
+
+    function manifestFor(id, extra) {
+        return {
+            id: id,
+            name: id,
+            defaultWidth: 160,
+            defaultHeight: 100,
+            desktopWidget: Object.assign({ type: "Item" }, extra || {})
+        };
+    }
+
+    readonly property var alphaManifest: harness.manifestFor("runtime_group_alpha")
+    readonly property var betaManifest: harness.manifestFor("runtime_group_beta")
+    // Ships click-through, like the bundled visualizer: inside every marquee,
+    // selectable by none of them.
+    readonly property var ghostManifest: harness.manifestFor("runtime_group_ghost", { clickThrough: true })
+    // Pinned per-widget: the other unselectable, for the other reason.
+    readonly property var pinnedManifest: harness.manifestFor("runtime_group_pinned", { locked: true })
+    readonly property var distantManifest: harness.manifestFor("runtime_group_distant")
+
+    function isSelected(widget) {
+        return canvas.selectedWidgets.indexOf(widget) !== -1;
+    }
+
+    function at(widget, x, y) {
+        return Math.round(widget.x) === x && Math.round(widget.y) === y;
+    }
+
+    // A drag with a midpoint, so the move crosses the drag threshold before it
+    // lands - same shape as WidgetGripLockRuntimeTest's dragPending.
+    function dragOnCanvas(x1, y1, x2, y2) {
+        driver.mousePress(canvas, x1, y1, Qt.LeftButton);
+        driver.mouseMove(canvas, (x1 + x2) / 2, (y1 + y2) / 2, 20, Qt.LeftButton);
+        driver.mouseMove(canvas, x2, y2, 20, Qt.LeftButton);
+        driver.mouseRelease(canvas, x2, y2, Qt.LeftButton);
+    }
+
+    function dragWidgetBy(widget, dx, dy) {
+        const cx = widget.x + widget.width / 2;
+        const cy = widget.y + widget.height / 2;
+        harness.dragOnCanvas(cx, cy, cx + dx, cy + dy);
+    }
+
+    // The whole cluster: alpha, beta, ghost and pinned - and not distant.
+    function marqueeCluster() {
+        harness.dragOnCanvas(12, 12, 432, 396);
+    }
+
+    TestCase {
+        id: driver
+        when: false
+        name: "WidgetGroupDragDriver"
+    }
+
+    FloatingWindow {
+        visible: true
+        implicitWidth: 1000
+        implicitHeight: 560
+        color: "black"
+
+        WidgetCanvas {
+            id: canvas
+            anchors.fill: parent
+            selectionEnabled: true
+
+            PluginWidget {
+                id: alphaWidget
+                manifest: harness.alphaManifest
+                screenName: harness.testScreen
+                screenWidth: 1000
+                screenHeight: 560
+                scaledScreenWidth: 1000
+                scaledScreenHeight: 560
+                wallpaperScale: 1
+            }
+
+            PluginWidget {
+                id: betaWidget
+                manifest: harness.betaManifest
+                screenName: harness.testScreen
+                screenWidth: 1000
+                screenHeight: 560
+                scaledScreenWidth: 1000
+                scaledScreenHeight: 560
+                wallpaperScale: 1
+            }
+
+            PluginWidget {
+                id: ghostWidget
+                manifest: harness.ghostManifest
+                screenName: harness.testScreen
+                screenWidth: 1000
+                screenHeight: 560
+                scaledScreenWidth: 1000
+                scaledScreenHeight: 560
+                wallpaperScale: 1
+            }
+
+            PluginWidget {
+                id: pinnedWidget
+                manifest: harness.pinnedManifest
+                screenName: harness.testScreen
+                screenWidth: 1000
+                screenHeight: 560
+                scaledScreenWidth: 1000
+                scaledScreenHeight: 560
+                wallpaperScale: 1
+            }
+
+            PluginWidget {
+                id: distantWidget
+                manifest: harness.distantManifest
+                screenName: harness.testScreen
+                screenWidth: 1000
+                screenHeight: 560
+                scaledScreenWidth: 1000
+                scaledScreenHeight: 560
+                wallpaperScale: 1
+            }
+        }
+    }
+
+    // All five default to the host's generic 100,100, which would stack them
+    // and make every gesture ambiguous.
+    function placeWidgets() {
+        PluginState.setPosition("runtime_group_alpha", harness.testScreen,
+                                { x: 48, y: 48, placementStrategy: "free" });
+        PluginState.setPosition("runtime_group_beta", harness.testScreen,
+                                { x: 240, y: 48, placementStrategy: "free" });
+        PluginState.setPosition("runtime_group_ghost", harness.testScreen,
+                                { x: 48, y: 240, placementStrategy: "free" });
+        PluginState.setPosition("runtime_group_pinned", harness.testScreen,
+                                { x: 240, y: 240, placementStrategy: "free" });
+        PluginState.setPosition("runtime_group_distant", harness.testScreen,
+                                { x: 600, y: 300, placementStrategy: "free" });
+    }
+
+    // PluginState's FileView load lands asynchronously and replaces the whole
+    // in-memory state, so anything written before it arrives is discarded -
+    // and on a config directory with no state file yet, the empty file it
+    // writes is then watched back in over whatever was set meanwhile. Keep
+    // asking until the positions stick and the position Behavior has finished
+    // animating to them.
+    Timer {
+        id: setup
+        interval: 250
+        repeat: true
+        running: true
+        onTriggered: {
+            if (!PluginState.ready || !Config.ready)
+                return;
+            Config.options.background.widgetsLocked = false;
+            if (harness.at(alphaWidget, 48, 48)
+                    && harness.at(betaWidget, 240, 48)
+                    && harness.at(ghostWidget, 48, 240)
+                    && harness.at(pinnedWidget, 240, 240)
+                    && harness.at(distantWidget, 600, 300)) {
+                setup.running = false;
+                step1.running = true;
+                return;
+            }
+            harness.placeWidgets();
+        }
+    }
+
+    // ---- marquee selection ----------------------------------------------
+
+    Timer {
+        id: step1
+        interval: 300
+        onTriggered: {
+            harness.marqueeCluster();
+            step2.running = true;
+        }
+    }
+
+    Timer {
+        id: step2
+        interval: 400
+        onTriggered: {
+            harness.check("the marquee picks both plain widgets",
+                          harness.isSelected(alphaWidget)
+                              && harness.isSelected(betaWidget));
+            harness.check("a click-through widget under the marquee is passed over",
+                          !harness.isSelected(ghostWidget));
+            harness.check("a per-widget-locked widget under it is passed over too",
+                          !harness.isSelected(pinnedWidget));
+            harness.check("a widget outside the marquee is not selected",
+                          !harness.isSelected(distantWidget));
+            harness.check("the selection is exactly the two",
+                          canvas.selectedWidgets.length === 2);
+            harness.check("a selected widget knows it",
+                          alphaWidget.selected === true
+                              && ghostWidget.selected === false);
+
+            // Group drag: +96,+48 keeps the leader on the lattice, so the
+            // offset assertions below cannot be muddied by the snap.
+            harness.dragWidgetBy(alphaWidget, 96, 48);
+            step3.running = true;
+        }
+    }
+
+    // ---- group drag ------------------------------------------------------
+
+    Timer {
+        id: step3
+        interval: 400
+        onTriggered: {
+            harness.check("the dragged widget lands where it was taken",
+                          harness.at(alphaWidget, 144, 96));
+            harness.check("the other selected widget moves by the same delta",
+                          harness.at(betaWidget, 336, 96));
+            harness.check("unselected widgets do not move",
+                          harness.at(ghostWidget, 48, 240)
+                              && harness.at(pinnedWidget, 240, 240)
+                              && harness.at(distantWidget, 600, 300));
+            harness.check("the selection survives the drag",
+                          canvas.selectedWidgets.length === 2);
+
+            const alphaSaved = PluginState.position("runtime_group_alpha", harness.testScreen);
+            const betaSaved = PluginState.position("runtime_group_beta", harness.testScreen);
+            harness.check("the leader's new position is persisted",
+                          alphaSaved.x === 144 && alphaSaved.y === 96);
+            harness.check("the follower's new position is persisted too",
+                          betaSaved.x === 336 && betaSaved.y === 96);
+
+            // Clamp: alpha is the leftmost member at x 144, so a hard-left
+            // drag must stop the whole group after exactly -144.
+            harness.dragWidgetBy(alphaWidget, -200, 0);
+            step4.running = true;
+        }
+    }
+
+    Timer {
+        id: step4
+        interval: 400
+        onTriggered: {
+            harness.check("the group stops when its first member hits the edge",
+                          harness.at(alphaWidget, 0, 96));
+            harness.check("the cluster does not deform at the edge",
+                          harness.at(betaWidget, 192, 96));
+
+            const betaSaved = PluginState.position("runtime_group_beta", harness.testScreen);
+            harness.check("the clamped positions are persisted",
+                          betaSaved.x === 192 && betaSaved.y === 96);
+
+            driver.keyClick(Qt.Key_Escape);
+            step5.running = true;
+        }
+    }
+
+    // ---- deselection -----------------------------------------------------
+
+    Timer {
+        id: step5
+        interval: 400
+        onTriggered: {
+            harness.check("escape clears the selection",
+                          canvas.selectedWidgets.length === 0
+                              && alphaWidget.selected === false);
+
+            // With the group disarmed, the same gesture moves one widget.
+            harness.dragWidgetBy(alphaWidget, 48, 48);
+            step6.running = true;
+        }
+    }
+
+    Timer {
+        id: step6
+        interval: 400
+        onTriggered: {
+            harness.check("after deselect a drag moves the dragged widget alone",
+                          harness.at(alphaWidget, 48, 144)
+                              && harness.at(betaWidget, 192, 96));
+
+            harness.marqueeCluster();
+            step7.running = true;
+        }
+    }
+
+    Timer {
+        id: step7
+        interval: 400
+        onTriggered: {
+            harness.check("a second marquee selects the pair again",
+                          canvas.selectedWidgets.length === 2);
+
+            // A plain click on empty desktop is the other way out.
+            driver.mouseClick(canvas, 900, 500, Qt.LeftButton);
+            step8.running = true;
+        }
+    }
+
+    Timer {
+        id: step8
+        interval: 400
+        onTriggered: {
+            harness.check("clicking empty desktop clears the selection",
+                          canvas.selectedWidgets.length === 0);
+
+            harness.marqueeCluster();
+            step9.running = true;
+        }
+    }
+
+    Timer {
+        id: step9
+        interval: 400
+        onTriggered: {
+            harness.check("the pair is selected once more",
+                          canvas.selectedWidgets.length === 2);
+
+            // Grabbing a widget outside the selection is also a click-away:
+            // it deselects, and only the grabbed widget moves.
+            harness.dragWidgetBy(distantWidget, 24, 0);
+            step10.running = true;
+        }
+    }
+
+    Timer {
+        id: step10
+        interval: 400
+        onTriggered: {
+            harness.check("dragging an unselected widget clears the selection",
+                          canvas.selectedWidgets.length === 0);
+            harness.check("and moves that widget alone",
+                          harness.at(distantWidget, 624, 300)
+                              && harness.at(alphaWidget, 48, 144)
+                              && harness.at(betaWidget, 192, 96));
+
+            harness.marqueeCluster();
+            step11.running = true;
+        }
+    }
+
+    // ---- the global lock -------------------------------------------------
+
+    Timer {
+        id: step11
+        interval: 400
+        onTriggered: {
+            harness.check("selected again before locking",
+                          canvas.selectedWidgets.length === 2);
+            Config.options.background.widgetsLocked = true;
+            harness.check("locking the desktop clears the selection",
+                          canvas.selectedWidgets.length === 0);
+
+            harness.marqueeCluster();
+            step12.running = true;
+        }
+    }
+
+    Timer {
+        id: step12
+        interval: 400
+        onTriggered: {
+            harness.check("a marquee on a locked desktop selects nothing",
+                          canvas.selectedWidgets.length === 0);
+            Config.options.background.widgetsLocked = false;
+
+            // The PR's dead-binding trap, on a real follower: after a group
+            // move, an external position change (a preset apply) must still
+            // reach the widget - a broken binding leaves it frozen instead.
+            PluginState.setPosition("runtime_group_beta", harness.testScreen,
+                                    { x: 480, y: 300, placementStrategy: "free" });
+            step13.running = true;
+        }
+    }
+
+    Timer {
+        id: step13
+        interval: 400
+        onTriggered: {
+            harness.check("a follower still follows external position changes",
+                          harness.at(betaWidget, 480, 300));
+            harness.finish();
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/WidgetGroupDragRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/WidgetGroupDragRuntimeTest.qml
@@ -89,17 +89,21 @@ ShellRoot {
         harness.dragOnCanvas(12, 12, 432, 396);
     }
 
-    TestCase {
-        id: driver
-        when: false
-        name: "WidgetGroupDragDriver"
-    }
-
     FloatingWindow {
         visible: true
         implicitWidth: 1000
         implicitHeight: 560
         color: "black"
+
+        // Inside the window, unlike the sibling harnesses: keyClick has no
+        // item argument to resolve a window from, so a TestCase parked on the
+        // ShellRoot fails it with "window not shown". The mouse functions
+        // resolve their window from the item and work from either place.
+        TestCase {
+            id: driver
+            when: false
+            name: "WidgetGroupDragDriver"
+        }
 
         WidgetCanvas {
             id: canvas
@@ -410,9 +414,12 @@ ShellRoot {
         }
     }
 
+    // 900, not 400: unlike a drag step this move rides the position Behavior
+    // (elementMove, 500ms) - checking at 400ms reads the animation midpoint
+    // and fails a binding that is perfectly alive.
     Timer {
         id: step13
-        interval: 400
+        interval: 900
         onTriggered: {
             harness.check("a follower still follows external position changes",
                           harness.at(betaWidget, 480, 300));

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
@@ -152,9 +152,16 @@ AbstractBackgroundWidget {
             : rootWidget.targetY);
     }
 
-    onReleased: {
+    // Overrides AbstractBackgroundWidget's release path, which calls this on a
+    // real release - and which WidgetCanvas calls on every group-drag follower,
+    // since a follower never gets a release event. One function on purpose:
+    // restoreXYBinding() keeps forceCenter and external position changes alive
+    // after the drag broke the x/y bindings, and setPosition is what makes the
+    // move survive a restart.
+    function commitPosition() {
         rootWidget.targetX = rootWidget.x;
         rootWidget.targetY = rootWidget.y;
+        rootWidget.restoreXYBinding();
         if (!manifest) return;
         PluginState.setPosition(manifest.id, screenName, {
             x: rootWidget.targetX,

--- a/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/AbstractWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/AbstractWidget.qml
@@ -12,7 +12,19 @@ MouseArea {
     property bool draggable: true
     property int gridSize: 12
     property bool snapEnabled: true
-    readonly property bool dragging: drag.active
+    // The drag is computed by hand from parent-frame pointer positions instead
+    // of MouseArea.drag. QQuickDrag rebases its press origin when the grab is
+    // established, silently swallowing the arming move's delta - invisible
+    // under a real pointer (a few px, absorbed by the lattice snap) but wrong,
+    // and it compounds with the old `dragProxy { x: root.x }` binding fighting
+    // QQuickDrag's writes into overshoot. Mapping the pointer through this
+    // (moving) item into the static parent frame is exact on every event.
+    readonly property bool dragging: dragActive
+    property bool dragActive: false
+    property real dragPressParentX: 0
+    property real dragPressParentY: 0
+    property real dragStartX: 0
+    property real dragStartY: 0
     // Lets the canvas find widgets in its subtree without walking into them.
     readonly property bool isCanvasWidget: true
 
@@ -58,7 +70,6 @@ MouseArea {
     }
 
     acceptedButtons: Qt.LeftButton | Qt.RightButton
-    drag.target: draggable ? dragProxy : undefined
     cursorShape: (draggable && containsPress) ? Qt.ClosedHandCursor : draggable ? Qt.OpenHandCursor : Qt.ArrowCursor
 
     onClicked: (mouse) => {
@@ -68,20 +79,47 @@ MouseArea {
     }
 
     // The canvas cannot see this widget's press/drag on its own, so report it.
-    // Reported from the press, not from `dragging`: drag.active only flips
-    // once the threshold is crossed, by which point the drag Binding has
-    // already snapped this widget a step - offsets captured then would bake
-    // that jump into every follower. At press nothing has moved yet.
+    // Reported from the press, not from the threshold crossing: at press
+    // nothing has moved yet, so the follower offsets and clamp bounds the
+    // canvas captures cannot bake a first-step jump into the cluster.
     onPressed: (mouse) => {
         if (mouse.button !== Qt.LeftButton || !root.draggable) return
+        const p = root.mapToItem(root.parent, mouse.x, mouse.y)
+        root.dragPressParentX = p.x
+        root.dragPressParentY = p.y
+        root.dragStartX = root.x
+        root.dragStartY = root.y
+        dragProxy.x = root.x
+        dragProxy.y = root.y
         const canvas = findCanvas(root.parent)
         if (canvas && canvas.widgetDragStarted) canvas.widgetDragStarted(root)
     }
+    onPositionChanged: (mouse) => {
+        if (!root.draggable || !(root.pressedButtons & Qt.LeftButton)) return
+        // mouse.x/y are local to this moving item; mapping through it into the
+        // parent recovers the pointer's absolute parent-frame position (the
+        // current transform, press scale included, cancels itself out).
+        const p = root.mapToItem(root.parent, mouse.x, mouse.y)
+        const deltaX = p.x - root.dragPressParentX
+        const deltaY = p.y - root.dragPressParentY
+        if (!root.dragActive
+                && Math.abs(deltaX) < drag.threshold && Math.abs(deltaY) < drag.threshold)
+            return
+        root.dragActive = true
+        dragProxy.x = root.dragStartX + deltaX
+        dragProxy.y = root.dragStartY + deltaY
+    }
+    // dragActive drops BEFORE the canvas is told: widgetDragEnded resets the
+    // group clamp bounds, and doing that under a still-active drag Binding
+    // re-evaluates it without the clamp - the leader jumps past the edge for
+    // one frame and the followers commit the deformed cluster.
     onReleased: {
+        root.dragActive = false
         const canvas = findCanvas(root.parent)
         if (canvas && canvas.widgetDragEnded) canvas.widgetDragEnded(root)
     }
     onCanceled: {
+        root.dragActive = false
         const canvas = findCanvas(root.parent)
         if (canvas && canvas.widgetDragEnded) canvas.widgetDragEnded(root)
     }
@@ -115,16 +153,15 @@ MouseArea {
         canvas.setCenterActive(nearX, nearY)
     }
 
-
+    // Carries the unsnapped drag position, in the parent's frame. Deliberately
+    // no `x: root.x` binding: a live binding here re-yanks the proxy to the
+    // snapped widget position after every drag step; it is synced imperatively
+    // at press and at each drag end instead.
     Item {
         id: dragProxy
         parent: root.parent
-        x: root.x
-        y: root.y
 
-        onXChanged: {
-            if (root.dragging) root.updateCenterHighlight()
-        }
+        onXChanged: if (root.dragging) root.updateCenterHighlight()
         onYChanged: if (root.dragging) root.updateCenterHighlight()
     }
 

--- a/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/AbstractWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/AbstractWidget.qml
@@ -13,6 +13,30 @@ MouseArea {
     property int gridSize: 12
     property bool snapEnabled: true
     readonly property bool dragging: drag.active
+    // Lets the canvas find widgets in its subtree without walking into them.
+    readonly property bool isCanvasWidget: true
+
+    // Marquee selection (WidgetCanvas). The canvas owns the selection set and
+    // writes this flag; the widget only renders it (the halo below) and offers
+    // itself for hit-testing. Session state - it does not survive a reload.
+    property bool selected: false
+
+    // True on every non-leader member while a group drag is in flight. A
+    // follower is not `dragging`, so without this second gate its position
+    // Behaviors would animate every incremental group step and the cluster
+    // would swim behind the pointer.
+    property bool groupDragging: false
+
+    // Group-drag clamp bounds, set by the canvas for the drag's leader so the
+    // whole selection stops when its first member hits an edge. They reach
+    // into the drag Binding below because that Binding is what moves the
+    // leader - clamping anywhere else lets the leader walk on while the
+    // followers stop, deforming the cluster. Defaults keep a single-widget
+    // drag exactly what it was before group drag existed.
+    property real groupDragMinX: -Infinity
+    property real groupDragMaxX: Infinity
+    property real groupDragMinY: -Infinity
+    property real groupDragMaxY: Infinity
 
     // Background desktop widgets can request keyboard focus for their layer
     // surface. The request is registered with the enclosing WidgetCanvas, which
@@ -29,6 +53,8 @@ MouseArea {
         const canvas = findCanvas(root.parent)
         if (canvas && canvas.setKeyboardFocusRequest)
             canvas.setKeyboardFocusRequest(root, false)
+        if (canvas && canvas.widgetRemoved)
+            canvas.widgetRemoved(root)
     }
 
     acceptedButtons: Qt.LeftButton | Qt.RightButton
@@ -39,6 +65,25 @@ MouseArea {
         if (mouse.button === Qt.RightButton) {
             Config.options.background.widgetsLocked = !Config.options.background.widgetsLocked
         }
+    }
+
+    // The canvas cannot see this widget's press/drag on its own, so report it.
+    // Reported from the press, not from `dragging`: drag.active only flips
+    // once the threshold is crossed, by which point the drag Binding has
+    // already snapped this widget a step - offsets captured then would bake
+    // that jump into every follower. At press nothing has moved yet.
+    onPressed: (mouse) => {
+        if (mouse.button !== Qt.LeftButton || !root.draggable) return
+        const canvas = findCanvas(root.parent)
+        if (canvas && canvas.widgetDragStarted) canvas.widgetDragStarted(root)
+    }
+    onReleased: {
+        const canvas = findCanvas(root.parent)
+        if (canvas && canvas.widgetDragEnded) canvas.widgetDragEnded(root)
+    }
+    onCanceled: {
+        const canvas = findCanvas(root.parent)
+        if (canvas && canvas.widgetDragEnded) canvas.widgetDragEnded(root)
     }
 
     function center() {
@@ -70,27 +115,35 @@ MouseArea {
         canvas.setCenterActive(nearX, nearY)
     }
 
+
     Item {
         id: dragProxy
         parent: root.parent
         x: root.x
         y: root.y
 
-        onXChanged: if (root.dragging) root.updateCenterHighlight()
+        onXChanged: {
+            if (root.dragging) root.updateCenterHighlight()
+        }
         onYChanged: if (root.dragging) root.updateCenterHighlight()
     }
 
+    // Snap first, clamp second: clamp-then-snap could round the leader back
+    // off the group bound by up to half a grid cell, deforming the cluster at
+    // the screen edge by exactly the amount the lattice is meant to guarantee.
     Binding {
         target: root
         property: "x"
-        value: root.snapEnabled ? root.snap(dragProxy.x) : dragProxy.x
+        value: Math.max(root.groupDragMinX, Math.min(root.groupDragMaxX,
+            root.snapEnabled ? root.snap(dragProxy.x) : dragProxy.x))
         when: root.dragging
         restoreMode: Binding.RestoreNone
     }
     Binding {
         target: root
         property: "y"
-        value: root.snapEnabled ? root.snap(dragProxy.y) : dragProxy.y
+        value: Math.max(root.groupDragMinY, Math.min(root.groupDragMaxY,
+            root.snapEnabled ? root.snap(dragProxy.y) : dragProxy.y))
         when: root.dragging
         restoreMode: Binding.RestoreNone
     }
@@ -124,12 +177,26 @@ MouseArea {
 
     Behavior on x {
         id: xBehavior
-        enabled: !root.dragging
+        enabled: !root.dragging && !root.groupDragging
         animation: Appearance.animation.elementMove.numberAnimation.createObject(this)
     }
     Behavior on y {
         id: yBehavior
-        enabled: !root.dragging
+        enabled: !root.dragging && !root.groupDragging
         animation: Appearance.animation.elementMove.numberAnimation.createObject(this)
+    }
+
+    // Selected-but-not-dragging feedback, distinct from the press scale. Lives
+    // on the widget so it tracks a group move with no coordinate mapping.
+    Rectangle {
+        id: selectionHalo
+        visible: root.selected
+        anchors.fill: parent
+        anchors.margins: -Appearance.spacing.space50
+        z: 2
+        radius: Appearance.rounding.large
+        color: Qt.alpha(Appearance.colors.colPrimary, 0.08)
+        border.color: Appearance.colors.colPrimary
+        border.width: Appearance.borderWidth.emphasis
     }
 }

--- a/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/WidgetCanvas.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/WidgetCanvas.qml
@@ -180,13 +180,16 @@ MouseArea {
     }
 
     function widgetDragEnded(widget) {
+        // Detach the group before resetting the clamp bounds: the bounds feed
+        // the leader's drag Binding, and a re-evaluation mid-teardown must not
+        // reach the followers as one more (unclamped) sync.
+        const group = root.groupDrag
+        if (group && group.leader === widget) root.groupDrag = null
         widget.groupDragMinX = -Infinity
         widget.groupDragMaxX = Infinity
         widget.groupDragMinY = -Infinity
         widget.groupDragMaxY = Infinity
-        const group = root.groupDrag
         if (!group || group.leader !== widget) return
-        root.groupDrag = null
         for (const entry of group.followers) {
             entry.widget.groupDragging = false
             if (entry.widget.commitPosition) entry.widget.commitPosition()

--- a/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/WidgetCanvas.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/WidgetCanvas.qml
@@ -42,7 +42,10 @@ MouseArea {
     // registers as a keyboard-focus requester alongside the widgets above.
     focus: root.selectionEnabled
     Keys.onEscapePressed: root.clearSelection()
-    onSelectedWidgetsChanged: root.setKeyboardFocusRequest(root, root.selectedWidgets.length > 0)
+    onSelectedWidgetsChanged: {
+        root.setKeyboardFocusRequest(root, root.selectedWidgets.length > 0)
+        if (root.selectedWidgets.length > 0) root.forceActiveFocus()
+    }
 
     // A press that starts ON a widget is that widget's drag - it never reaches
     // this handler. A press on empty canvas (or over a click-through widget,

--- a/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/WidgetCanvas.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/WidgetCanvas.qml
@@ -22,6 +22,183 @@ MouseArea {
         GlobalStates.desktopWidgetKeyboardFocus = root.keyboardFocusRequesters.length > 0
     }
 
+    // Marquee multi-select. Opt-in per canvas: the overlay reuses WidgetCanvas
+    // and closes itself on a plain click, so a marquee defaulting on would turn
+    // every overlay dismiss-click into a selection gesture. The desktop
+    // (Background.qml) is the one canvas that opts in.
+    //
+    // The selection is session state on this canvas - it does not survive a
+    // reload, cannot leak across monitors (each background owns its canvas),
+    // and is never persisted anywhere.
+    property bool selectionEnabled: false
+    property var selectedWidgets: []
+
+    property bool marqueeActive: false
+    property real marqueeAnchorX: 0
+    property real marqueeAnchorY: 0
+
+    // Escape is the keyboard way out of a selection. The desktop's layer
+    // surface only takes keys while it is OnDemand, so a live selection also
+    // registers as a keyboard-focus requester alongside the widgets above.
+    focus: root.selectionEnabled
+    Keys.onEscapePressed: root.clearSelection()
+    onSelectedWidgetsChanged: root.setKeyboardFocusRequest(root, root.selectedWidgets.length > 0)
+
+    // A press that starts ON a widget is that widget's drag - it never reaches
+    // this handler. A press on empty canvas (or over a click-through widget,
+    // which has left pointer routing) anchors the marquee; releasing it
+    // replaces the selection with whatever the band covered, so a plain click
+    // - a zero-size band over nothing draggable - is the click-away deselect.
+    onPressed: (mouse) => {
+        if (!root.selectionEnabled || mouse.button !== Qt.LeftButton) return
+        if (Config.options.background.widgetsLocked) return
+        root.marqueeAnchorX = mouse.x
+        root.marqueeAnchorY = mouse.y
+        root.marqueeActive = true
+    }
+    onReleased: {
+        if (!root.marqueeActive) return
+        root.marqueeActive = false
+        root.selectWidgetsInRect(Qt.rect(marqueeRect.x, marqueeRect.y,
+            marqueeRect.width, marqueeRect.height))
+    }
+
+    // Widgets are found by walking the subtree rather than kept in a registry:
+    // on the real background each PluginWidget sits inside its own FadeLoader,
+    // and a registry filled from Component.onCompleted would depend on the
+    // loader having parented the widget under the canvas by then.
+    function widgetsUnder(item, found) {
+        for (let i = 0; i < item.children.length; i++) {
+            const child = item.children[i]
+            if (child.isCanvasWidget === true) found.push(child)
+            else root.widgetsUnder(child, found)
+        }
+        return found
+    }
+
+    // `draggable` is the selection filter on purpose: it already folds in
+    // everything that must exclude a widget from a group move - the per-widget
+    // lock, click-through (the full-bleed visualizer ships it, so it does not
+    // select itself on every marquee), the global lock, and a non-free
+    // placement strategy. Filtering on anything narrower re-opens one of those.
+    function selectWidgetsInRect(rect) {
+        const picked = []
+        for (const widget of root.widgetsUnder(root, [])) {
+            if (!widget.draggable) continue
+            const pos = widget.parent.mapToItem(root, widget.x, widget.y)
+            if (pos.x < rect.x + rect.width && pos.x + widget.width > rect.x
+                    && pos.y < rect.y + rect.height && pos.y + widget.height > rect.y)
+                picked.push(widget)
+        }
+        root.applySelection(picked)
+    }
+
+    function applySelection(widgets) {
+        for (const widget of root.selectedWidgets) {
+            if (widgets.indexOf(widget) === -1) widget.selected = false
+        }
+        for (const widget of widgets) {
+            widget.selected = true
+        }
+        root.selectedWidgets = widgets
+    }
+
+    function clearSelection() {
+        root.applySelection([])
+    }
+
+    function widgetRemoved(widget) {
+        const idx = root.selectedWidgets.indexOf(widget)
+        if (idx !== -1) {
+            const next = root.selectedWidgets.slice()
+            next.splice(idx, 1)
+            root.selectedWidgets = next
+        }
+        if (root.groupDrag && (root.groupDrag.leader === widget
+                || root.groupDrag.followers.some(entry => entry.widget === widget)))
+            root.groupDrag = null
+    }
+
+    // Locking the desktop clears the selection: two widgets still haloed under
+    // a lock would look live while doing nothing, then spring back to life the
+    // moment the lock lifts.
+    Connections {
+        target: Config.options.background
+        function onWidgetsLockedChanged() {
+            if (Config.options.background.widgetsLocked) root.clearSelection()
+        }
+    }
+
+    // ---- group drag -------------------------------------------------------
+    // Dragging any selected widget (the leader) moves the whole selection by
+    // one delta. The leader reports its press and release; followers are moved
+    // here and committed here, through the same commitPosition path a real
+    // release runs - a follower never gets a release event, and a naive
+    // "set x" with no commit would leave it with a dead x/y binding.
+    property var groupDrag: null
+
+    function widgetDragStarted(widget) {
+        if (root.selectedWidgets.indexOf(widget) === -1) {
+            // Grabbing a widget outside the selection is a click-away.
+            root.clearSelection()
+            return
+        }
+        let deltaMinX = -Infinity
+        let deltaMaxX = Infinity
+        let deltaMinY = -Infinity
+        let deltaMaxY = Infinity
+        const followers = []
+        for (const member of root.selectedWidgets) {
+            // Map through the parent: mapping the widget itself would fold its
+            // press-scale transform into the bounds.
+            const pos = member.parent.mapToItem(root, member.x, member.y)
+            deltaMinX = Math.max(deltaMinX, -pos.x)
+            deltaMaxX = Math.min(deltaMaxX, root.width - member.width - pos.x)
+            deltaMinY = Math.max(deltaMinY, -pos.y)
+            deltaMaxY = Math.min(deltaMaxY, root.height - member.height - pos.y)
+            if (member !== widget) {
+                member.groupDragging = true
+                followers.push({ widget: member, startX: member.x, startY: member.y })
+            }
+        }
+        widget.groupDragMinX = widget.x + deltaMinX
+        widget.groupDragMaxX = widget.x + deltaMaxX
+        widget.groupDragMinY = widget.y + deltaMinY
+        widget.groupDragMaxY = widget.y + deltaMaxY
+        root.groupDrag = { leader: widget, startX: widget.x, startY: widget.y, followers: followers }
+    }
+
+    function syncGroupFollowers() {
+        const group = root.groupDrag
+        if (!group) return
+        const deltaX = group.leader.x - group.startX
+        const deltaY = group.leader.y - group.startY
+        for (const entry of group.followers) {
+            entry.widget.x = entry.startX + deltaX
+            entry.widget.y = entry.startY + deltaY
+        }
+    }
+
+    function widgetDragEnded(widget) {
+        widget.groupDragMinX = -Infinity
+        widget.groupDragMaxX = Infinity
+        widget.groupDragMinY = -Infinity
+        widget.groupDragMaxY = Infinity
+        const group = root.groupDrag
+        if (!group || group.leader !== widget) return
+        root.groupDrag = null
+        for (const entry of group.followers) {
+            entry.widget.groupDragging = false
+            if (entry.widget.commitPosition) entry.widget.commitPosition()
+        }
+    }
+
+    Connections {
+        target: root.groupDrag ? root.groupDrag.leader : null
+        function onXChanged() { root.syncGroupFollowers() }
+        function onYChanged() { root.syncGroupFollowers() }
+    }
+
     property bool centerXActive: false
     property bool centerYActive: false
 
@@ -98,6 +275,23 @@ MouseArea {
         Behavior on opacity {
             animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
         }
+    }
+
+    // The rubber band. Same visual family as the region selector's
+    // TargetRegion, but this one is an in-place interaction on the canvas, not
+    // a modal overlay. mouseX/mouseY track the pointer for the whole press.
+    Rectangle {
+        id: marqueeRect
+        visible: root.marqueeActive
+        z: 10
+        x: Math.min(root.marqueeAnchorX, root.mouseX)
+        y: Math.min(root.marqueeAnchorY, root.mouseY)
+        width: Math.abs(root.mouseX - root.marqueeAnchorX)
+        height: Math.abs(root.mouseY - root.marqueeAnchorY)
+        color: Qt.alpha(Appearance.colors.colPrimary, 0.08)
+        border.color: Appearance.colors.colPrimary
+        border.width: Appearance.borderWidth.standard
+        radius: Appearance.rounding.unsharpenslight
     }
 
     Component {

--- a/dots/.config/quickshell/imi/modules/imi/background/Background.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/Background.qml
@@ -1014,6 +1014,9 @@ Variants {
                 // Above the WE wallpaper-switch transition (weTransition, z 1) so the
                 // desktop widgets/plugins stay visible while wallpapers cross-fade.
                 z: 2
+                // The desktop is the canvas the marquee exists for: rubber-band
+                // several widgets, then drag any of them to move the cluster.
+                selectionEnabled: true
 
                 transitions: Transition {
                     PropertyAnimation {

--- a/dots/.config/quickshell/imi/modules/imi/background/widgets/AbstractBackgroundWidget.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/widgets/AbstractBackgroundWidget.qml
@@ -98,7 +98,16 @@ AbstractWidget {
     function clampX(v) { return Math.max(0, Math.min(v, scaledScreenWidth - width)); }
     function clampY(v) { return Math.max(0, Math.min(v, scaledScreenHeight - height)); }
 
-    onReleased: {
+    onReleased: root.commitPosition()
+
+    // The one write-back path for a finished move. A real release runs it via
+    // the handler above; a group drag runs it on every follower through
+    // WidgetCanvas.widgetDragEnded, because a follower never gets a release
+    // event of its own. Keeping both routes on one function is what stops the
+    // released-drag path and the group path drifting apart (a clamp added to
+    // one but not the other); PluginWidget overrides this same function for
+    // its PluginState persistence.
+    function commitPosition() {
         // Write configEntry FIRST, then rebind targetX/targetY THROUGH it (the
         // binding reads the fresh value, so the widget doesn't snap back to the
         // pre-drag position). Binding through configEntry means an external

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -157,6 +157,19 @@ if ! python3 "$SCRIPT_DIR/test_widget_grip_lock.py"; then
     exit 1
 fi
 
+echo "Running widget group selection tests..."
+if ! python3 "$SCRIPT_DIR/test_widget_group_selection.py"; then
+    echo "Widget group selection tests failed."
+    exit 1
+fi
+
+# Brings its own headless weston, like the interaction runtime tests above.
+echo "Running widget group drag runtime tests..."
+if ! python3 "$SCRIPT_DIR/test_widget_group_drag_runtime.py"; then
+    echo "Widget group drag runtime tests failed."
+    exit 1
+fi
+
 echo "Running widget plugin migration tests..."
 if ! python3 "$SCRIPT_DIR/test_widget_plugin_migration.py"; then
     echo "Widget plugin migration tests failed."

--- a/dots/.config/quickshell/imi/tests/test_widget_group_drag_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_widget_group_drag_runtime.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Drives marquee multi-select and group drag with real mouse events.
+
+`WidgetGroupDragRuntimeTest.qml` builds five real `PluginWidget`s on a real
+`WidgetCanvas` and rubber-bands, group-drags, clamps and deselects them through
+QtTest, which works inside `qs -p`. This module is the driver: it stands up a
+headless weston, points throwaway XDG dirs at it, and fails the suite on any
+check the harness reports.
+
+The source contract in `test_widget_group_selection.py` can only grep the
+bindings. It cannot answer the questions that matter - whether the marquee
+picks exactly the widgets under it, whether a group drag preserves the
+cluster's offsets at a screen edge, and whether every member ends the gesture
+with a live binding and a persisted position. Only real events can.
+
+Headless weston rather than the caller's session because the harness opens a
+window. It implements no wlr-layer-shell, so this proves nothing about the
+`PanelWindow` the real `Background.qml` puts the canvas on - the widget tree,
+the canvas and the marquee are ordinary Items and are what this exercises.
+
+Skips when weston or qs is missing, as in CI.
+"""
+
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HARNESS = ROOT / "WidgetGroupDragRuntimeTest.qml"
+SOCKET = "wayland-imi-widget-group-drag"
+
+
+def _stop(proc):
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+
+
+def _runtime_available():
+    return shutil.which("qs") is not None and shutil.which("weston") is not None
+
+
+@unittest.skipUnless(_runtime_available(), "needs qs and weston on PATH")
+class WidgetGroupDragRuntimeTest(unittest.TestCase):
+    def setUp(self):
+        self.home = Path(tempfile.mkdtemp(prefix="imi-widget-group-drag-"))
+        self.addCleanup(shutil.rmtree, self.home, ignore_errors=True)
+
+    def test_marquee_selection_and_group_drag(self):
+        env = dict(os.environ)
+        env.setdefault("XDG_RUNTIME_DIR", f"/run/user/{os.getuid()}")
+        env["WAYLAND_DISPLAY"] = SOCKET
+        env.pop("DISPLAY", None)
+
+        weston = subprocess.Popen(
+            ["weston", "--backend=headless", "--renderer=pixman",
+             f"--socket={SOCKET}", "--width=1200", "--height=800"],
+            env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        self.addCleanup(_stop, weston)
+
+        socket_path = Path(env["XDG_RUNTIME_DIR"]) / SOCKET
+        deadline = time.monotonic() + 15
+        while not socket_path.exists() and time.monotonic() < deadline:
+            time.sleep(0.2)
+        self.assertTrue(socket_path.exists(), "headless weston never came up")
+
+        # This box's headless EGL has no driver, so force software rendering.
+        env["LIBGL_ALWAYS_SOFTWARE"] = "1"
+        env["QT_QUICK_BACKEND"] = "software"
+        env["XDG_CONFIG_HOME"] = str(self.home / "config")
+        env["XDG_STATE_HOME"] = str(self.home / "state")
+
+        proc = subprocess.run(["qs", "-p", str(HARNESS)], cwd=str(ROOT), env=env,
+                              capture_output=True, text=True, timeout=180)
+        output = proc.stdout + proc.stderr
+        failed = [line for line in output.splitlines() if "FAIL" in line]
+        self.assertEqual(failed, [], f"harness reported failures:\n{output}")
+        self.assertIn("[WidgetGroupDrag] failures: 0", output,
+                      f"harness did not finish cleanly:\n{output}")
+
+        # A follower whose x binding died mid-group-drag, or a halo that got
+        # anchored into a cycle, shows up here rather than as a failed check.
+        self.assertNotIn("Binding loop", output,
+                         f"the host tree grew a binding loop:\n{output}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dots/.config/quickshell/imi/tests/test_widget_group_selection.py
+++ b/dots/.config/quickshell/imi/tests/test_widget_group_selection.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Source contract for marquee multi-select and group drag on the widget canvas.
+
+The composition this pins lives in QML property bindings across `WidgetCanvas`,
+`AbstractWidget`, `AbstractBackgroundWidget` and `PluginWidget` - none of it
+instantiable by the qmltestrunner suite, because the host needs Quickshell's
+types and a real canvas parent. `WidgetGroupDragRuntimeTest.qml` builds the
+real thing under `qs -p` and is the behavioural half; these are the greppable
+pins that run in CI.
+
+Each assertion below is mutation-checked: the comment on it names the specific
+edit it exists to redden.
+"""
+from pathlib import Path
+import re
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+CANVAS = ROOT / "modules/common/widgets/widgetCanvas/WidgetCanvas.qml"
+WIDGET = ROOT / "modules/common/widgets/widgetCanvas/AbstractWidget.qml"
+BASE = ROOT / "modules/imi/background/widgets/AbstractBackgroundWidget.qml"
+HOST = ROOT / "modules/common/plugins/PluginWidget.qml"
+BACKGROUND = ROOT / "modules/imi/background/Background.qml"
+OVERLAY = ROOT / "modules/imi/overlay/OverlayContent.qml"
+
+
+def source(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def uncommented(path: Path) -> str:
+    """Source with `//` comments stripped, so an assertion about what the code
+    does cannot be satisfied by the prose explaining what it used to do."""
+    return re.sub(r"//[^\n]*", "", source(path))
+
+
+def squashed(path: Path) -> str:
+    return re.sub(r"\s+", " ", uncommented(path))
+
+
+class TheCanvasOwnsSelection(unittest.TestCase):
+    """Selection is canvas state, not widget state (the proposal's first
+    decision): widgets read "am I selected" from the canvas, so a selection
+    cannot outlive the canvas or leak across monitors."""
+
+    def test_the_marquee_is_opt_in_and_defaults_off(self):
+        """The overlay reuses WidgetCanvas (`OverlayContent.qml`) and closes
+        itself on a plain click. A marquee defaulting on would turn every
+        overlay dismiss-click into a selection gesture instead.
+        """
+        self.assertIn("property bool selectionEnabled: false",
+                      uncommented(CANVAS))
+
+    def test_the_background_opts_its_canvas_in(self):
+        """Without this the whole feature is dead code: the desktop is the one
+        canvas the marquee was built for.
+        """
+        self.assertIn("selectionEnabled: true", uncommented(BACKGROUND))
+
+    def test_the_overlay_does_not(self):
+        self.assertNotIn("selectionEnabled", uncommented(OVERLAY))
+
+    def test_selection_is_session_state(self):
+        """The proposal's open question, answered: selection does not survive
+        a reload. The canvas therefore has no business importing either
+        persistence backend - a `PluginState` or `Persistent` reference
+        appearing here means someone started persisting it.
+        """
+        text = uncommented(CANVAS)
+        self.assertNotIn("PluginState", text)
+        self.assertNotIn("Persistent.", text)
+
+    def test_only_draggable_widgets_are_selectable(self):
+        """`draggable` already folds in everything that must exclude a widget
+        from a group move: the per-widget lock, click-through (the full-bleed
+        visualizer ships it, which answers the proposal's "does the visualizer
+        select itself on every marquee" question), the global lock, and a
+        non-free placement strategy. Filtering on anything narrower re-opens
+        one of those holes.
+        """
+        match = re.search(r"function selectWidgetsInRect[^{]*\{(.*?)\n    \}",
+                          uncommented(CANVAS), re.S)
+        self.assertIsNotNone(match, "WidgetCanvas has no selectWidgetsInRect")
+        self.assertIn(".draggable", match.group(1))
+
+    def test_the_global_lock_clears_the_selection(self):
+        """Locking the desktop with two widgets still haloed would leave a
+        selection that looks live and does nothing - and would spring back to
+        life the moment the lock lifts, moving widgets the user thought were
+        long deselected.
+        """
+        text = squashed(CANVAS)
+        self.assertIn("Config.options.background.widgetsLocked", text)
+        self.assertIn("clearSelection()", text)
+
+
+class GroupDragIsRigid(unittest.TestCase):
+    """Dragging any selected widget moves the whole selection by one delta.
+    The cluster must never deform: the group stops when the first member hits
+    an edge."""
+
+    def test_the_clamp_bounds_live_on_the_widget_and_default_open(self):
+        """The leader's drag Binding is what moves it, so the group clamp has
+        to reach into that Binding - a clamp applied anywhere else lets the
+        leader walk on while the followers stop, which is exactly the
+        deformation this exists to prevent. Defaulting to +/-Infinity keeps a
+        single-widget drag byte-for-byte what it was before this feature.
+        """
+        text = uncommented(WIDGET)
+        for name, value in (("groupDragMinX", "-Infinity"),
+                            ("groupDragMaxX", "Infinity"),
+                            ("groupDragMinY", "-Infinity"),
+                            ("groupDragMaxY", "Infinity")):
+            self.assertIn(f"property real {name}: {value}", text)
+
+    def test_the_drag_binding_snaps_first_and_clamps_second(self):
+        """Clamp-then-snap can round the leader back off the group bound by up
+        to half a grid cell, deforming the cluster at the edge by exactly the
+        amount the lattice was supposed to guarantee.
+        """
+        text = squashed(WIDGET)
+        for axis in ("X", "Y"):
+            proxy = f"dragProxy.{axis.lower()}"
+            self.assertRegex(
+                text,
+                rf"Math\.max\(root\.groupDragMin{axis}, Math\.min\("
+                rf"root\.groupDragMax{axis}, root\.snapEnabled \? "
+                rf"root\.snap\({re.escape(proxy)}\) : {re.escape(proxy)}\)\)",
+                f"the {axis} drag binding must clamp the snapped value")
+
+    def test_the_widget_reports_its_drag_to_the_canvas(self):
+        """The canvas cannot see `drag.active` on its own. Without both calls
+        the group never starts (or never commits) and every widget quietly
+        goes back to moving alone - all the single-drag tests still green.
+        """
+        text = uncommented(WIDGET)
+        self.assertIn("canvas.widgetDragStarted(root)", text)
+        self.assertIn("canvas.widgetDragEnded(root)", text)
+
+    def test_followers_move_with_animation_off(self):
+        """A follower is not `dragging`, so its position Behavior is live and
+        every incremental group step animates - the cluster swims behind the
+        pointer. `groupDragging` is the second gate on the same Behaviors.
+        """
+        text = squashed(WIDGET)
+        self.assertIn("property bool groupDragging: false", text)
+        self.assertEqual(
+            text.count("enabled: !root.dragging && !root.groupDragging"), 2,
+            "both position Behaviors must gate on groupDragging too")
+
+    def test_followers_commit_like_a_released_drag(self):
+        """A follower never gets a release event, so the canvas must call the
+        same commit path a real release runs - otherwise the follower is left
+        with a dead x/y binding (the PR's "naive set-x" trap) and its new
+        position evaporates on the next state reload.
+        """
+        self.assertIn("commitPosition()", uncommented(CANVAS))
+
+    def test_the_release_path_and_the_commit_path_are_one_function(self):
+        """Two copies of the write-back is how they drift: a fix to the
+        released-drag path (say, a new clamp) that never reaches the group
+        path, or the reverse. The base class releases through commitPosition
+        and PluginWidget overrides that one function.
+        """
+        self.assertIn("onReleased: root.commitPosition()", uncommented(BASE))
+        self.assertIn("function commitPosition()", uncommented(BASE))
+        host = uncommented(HOST)
+        self.assertIn("function commitPosition()", host)
+        self.assertNotIn("onReleased:", host,
+                         "PluginWidget must not keep a second release path")
+
+    def test_the_plugin_commit_still_restores_the_binding_and_persists(self):
+        """Dropping `restoreXYBinding()` leaves every group member frozen at
+        its last dragged position for the session (forceCenter dies with it);
+        dropping `setPosition` makes a group move revert on restart. Both
+        halves read fine on their own.
+        """
+        match = re.search(r"function commitPosition\(\)\s*\{(.*?)\n    \}",
+                          uncommented(HOST), re.S)
+        self.assertIsNotNone(match)
+        body = match.group(1)
+        self.assertIn("restoreXYBinding()", body)
+        self.assertIn("PluginState.setPosition", body)
+
+
+class TheSelectionIsVisible(unittest.TestCase):
+    def test_widgets_carry_a_selected_flag_and_a_halo_gated_on_it(self):
+        """Selected-but-not-dragging needs feedback distinct from the press
+        scale (the proposal's fifth point). The halo lives on the widget so it
+        tracks a group move with no coordinate mapping; gating it on anything
+        but `selected` (say `dragging`) makes selection invisible exactly when
+        the user is deciding what to drag.
+        """
+        text = uncommented(WIDGET)
+        self.assertIn("property bool selected:", text)
+        self.assertIn("visible: root.selected", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Draft / tracking proposal. Not scheduled.

Draw a marquee on the desktop to select several widgets at once, then drag the selection as a unit — every selected widget keeps its relative offset and they all persist their new positions on release.

Full write-up in [`docs/proposals/multi-widget-selection.md`](https://github.com/XephyLon/immaterial-impulse/blob/proposal/multi-widget-selection/docs/proposals/multi-widget-selection.md).

**Why now:** the widgets-as-plugins work (#11) put every desktop widget on one code path and on a shared 132x108 grid, which makes clusters visually meaningful. A cluster you cannot move as a cluster is a half-finished idea.

**What stands in the way:**

- Dragging is single-widget all the way down. `AbstractBackgroundWidget` owns the drag and writes only its own position on release.
- Dragging assigns `x`/`y` directly and **intentionally breaks their bindings**; `restoreXYBinding()` puts them back. The clock overrides that function for `forceCenter`. A naive "set x on each selected widget" leaves several widgets with dead bindings.
- Clamping becomes a group operation — the group has to stop when the *first* member hits an edge, or the cluster deforms.
- `PluginState.setPosition` is keyed per plugin **and per monitor**, and rewrites the state file per call. A batch write may be wanted.

**Open questions** in the doc: whether selection survives a reload, whether full-bleed widgets (the visualizer spans the whole monitor) are selectable at all, and how this interacts with a per-widget lock.

`modules/imi/regionSelector/` already draws a rubber band for screenshots and is worth reading before inventing a second one.

---

**Status: implemented on this branch.** Tests-first pins landed in 11081fd6e ("test(widgets): pin marquee multi-select and group drag before building it"); the implementation follows as eight granular commits — the commitPosition unification, the feature, then the three fixes real-event testing forced (a hand-computed drag replacing `MouseArea.drag`, whose grab-time origin rebase and drag-proxy binding fight made it inexact; group teardown ordering; selection focus for Escape) and two repairs to the harness's own defects. Full suite green including the headless-weston runtime harness (27/27 checks).

Docs: updated docs/proposals/multi-widget-selection.md §Outcome and AGENT.md §Dynamic/data-driven QML gotchas (the MouseArea.drag rebase entry)
