### PR TITLE
NixOS flake: root flake, home-manager module, and a VM-tested three-tier split

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ __pycache__/
 /os-release
 # Emacs auto backup file
 *~
+# nix build leaves a result symlink at the root
+/result

--- a/README.md
+++ b/README.md
@@ -16,6 +16,26 @@ The installer is idempotent - re-running it updates an existing install
 components: Wallpaper Engine integration, the imi-sddm-theme login theme,
 and a Plymouth boot splash.
 
+### NixOS (experimental)
+
+The repository root is a Nix flake. Instead of the installer, a
+home-manager user adds:
+
+```nix
+inputs.immaterial-impulse.url = "github:XephyLon/immaterial-impulse";
+```
+
+and imports `inputs.immaterial-impulse.homeManagerModules.default` with
+`programs.immaterial-impulse.enable = true`. The module symlinks the
+shell tree and the matugen config from the store, seeds
+`~/.config/immaterial-impulse` once, and refuses to manage matugen's
+generated outputs (it warns if your home-manager config does).
+
+What does not work yet: wallpaper-driven colour generation (the scripts
+need a Python venv the module does not provide) and the Wallpaper Engine
+integration. Design, validation status, and open questions are in
+[docs/proposals/nixos-flake.md](docs/proposals/nixos-flake.md).
+
 ## Compositor support
 
 **Hyprland only.** There are no plans to support Niri or any other

--- a/docs/proposals/nixos-flake.md
+++ b/docs/proposals/nixos-flake.md
@@ -1,6 +1,11 @@
 # Proposal: NixOS flake
 
-> Draft / tracking proposal. Not scheduled.
+> In progress. The first pass is implemented on `feat/nixos-flake`: a root
+> `flake.nix` with `packages.<system>.immaterial-impulse`,
+> `homeManagerModules.default` and `devShells.default`, the three-tier
+> declarative/mutable split as designed below, and the nested
+> `sdata/dist-nix` flake marked superseded. See "Sketch" for the per-item
+> status and "Open questions" for what the implementation resolved.
 
 ## Goal
 
@@ -71,27 +76,46 @@ side of it rather than being an alternative to it.
 
 ## Sketch
 
-Rough shape, not a design:
+Status per item, now that the first pass exists:
 
-1. **Root `flake.nix`** with, at minimum:
-   - `packages.<system>.immaterial-impulse` — the shell tree as a derivation
-     (the `dots/.config/quickshell/imi` contents plus scripts), so it can be
-     referenced by store path rather than copied.
-   - `homeManagerModules.default` — options for enabling the shell, choosing a
-     panel family, and seeding `~/.config/immaterial-impulse/config.json`.
-   - `nixosModules.default` — the system-level pieces the installer currently does
-     in `install-setups`: services, polkit rules, greeter/SDDM theme, plymouth.
-   - `devShells.default` — quickshell + Qt + the Python test deps, so
-     `tests/run_tests.sh` runs under `nix develop`.
-2. **What is declarative vs mutable — settled, see the section below.** The
+1. **Root `flake.nix`** — done, with one deliberate omission:
+   - `packages.<system>.immaterial-impulse` — **done** (`nix/package.nix`):
+     the `dots/.config/quickshell/imi` tree, whole, as a store path.
+     `packages.<system>.quickshell-wrapped` sits beside it, importing the
+     nested flake's `quickshell.nix` (Qt bundling reused, not rewritten).
+   - `homeManagerModules.default` — **done** (`nix/hm-module.nix`): enable
+     option, package overrides, and the three-tier split below implemented
+     exactly — tier 1 symlinked from the store, tier 2 seeded by an
+     activation script only when absent (`seedConfig` gates the
+     `config.json` half), tier 3 refused, with warnings when the
+     surrounding home-manager configuration manages a matugen output.
+     No panel-family option: the shell has exactly one family today.
+   - `nixosModules.default` — **omitted, deliberately**, rather than
+     stubbed. The home-manager module covers the shell itself; the
+     system-level pieces (SDDM theme, plymouth, polkit rules, services)
+     have no flake story yet and stay under "Open questions".
+   - `devShells.default` — **done** (`nix/dev-shell.nix`): qmltestrunner
+     via `qt6.qtdeclarative`, python3 with PIL/numpy, weston, dbus and the
+     wrapped quickshell, so `tests/run_tests.sh` can run under
+     `nix develop`. Unvalidated so far — written on a machine with no
+     `nix` binary (see TODO below).
+2. **What is declarative vs mutable — settled and implemented.** The
    split is three-way, not two-way, and the third tier is the one that decides
    whether a `home-manager switch` quietly destroys the user's colours.
-3. **Reconcile with the existing `sdata/dist-nix` tree** — either promote it to
-   the root and delete the nested flake, or keep `--via-nix` as a legacy path and
-   mark it superseded. Do not ship two flakes.
-4. **Unpin quickshell** from the hardcoded commit, or at least move the pin
-   somewhere it is obviously a pin.
-5. **CI**: `nix flake check` on push is the only thing that keeps a flake honest.
+3. **Reconcile with the existing `sdata/dist-nix` tree** — done, by marking
+   `--via-nix` superseded (`sdata/dist-nix/README.md`) rather than deleting
+   the nested flake: that flake plus `install-deps.sh` is the whole working
+   path for non-NixOS distros via standalone home-manager, and nothing in
+   the root flake replaces it yet. The one file they would duplicate,
+   `quickshell.nix`, is shared — the root flake imports it in place.
+4. **Unpin quickshell** — done: the root flake's input has no commit in
+   its URL; the pin belongs to `flake.lock`. **TODO: no `flake.lock` is
+   committed yet** — the implementing machine had no `nix` binary, and an
+   invented lock is worse than an absent one. Generating and committing it
+   (and running `nix flake check` / `nix build .#immaterial-impulse` for
+   the first time) is the first task for a machine with nix.
+5. **CI**: `nix flake check` on push is the only thing that keeps a flake
+   honest. **TODO — not in this pass**; it needs the lock file first.
 
 ## Declarative vs mutable — settled
 
@@ -157,6 +181,14 @@ Arch container. A Nix user gets the shell with static wallpapers, and
 `wallpaperSelector.wallpaperEngine` stays inert. Packaging that dependency tree
 is its own proposal.
 
+Also out of the first pass, still TODO here:
+
+- a replacement for Settings → Update Dots (`exp-update`) under a flake —
+  see "Open questions";
+- the CI `nix flake check` workflow (Sketch item 5);
+- `flake.lock` generation and the first real `nix flake check` /
+  `nix build .#immaterial-impulse` run (Sketch item 4).
+
 ## Open questions
 
 - Does the plugin system work under Nix? Partly answered: **bundled** plugins are
@@ -173,8 +205,12 @@ is its own proposal.
   `hyprctl`, `ffmpeg`, ImageMagick, `cava`, `ydotool`…). Each is a `makeWrapper`
   `PATH` entry that has to be enumerated — the per-distro dep lists are the
   starting point, but they are package names, not binary names.
-- Single-user vs system-wide, and whether the NixOS module is genuinely needed
-  or whether home-manager alone covers it.
+- Single-user vs system-wide — **resolved for the first pass**: home-manager
+  alone covers the shell, so the flake ships `homeManagerModules.default` and
+  no `nixosModules.default` at all (omitted, not stubbed). What stays open is
+  the system half the installer does today — SDDM theme, plymouth, polkit
+  rules, services — which is where a NixOS module would earn its existence
+  if it ever does.
 
 ## Prior art
 

--- a/docs/proposals/nixos-flake.md
+++ b/docs/proposals/nixos-flake.md
@@ -83,12 +83,9 @@ Rough shape, not a design:
      in `install-setups`: services, polkit rules, greeter/SDDM theme, plymouth.
    - `devShells.default` — quickshell + Qt + the Python test deps, so
      `tests/run_tests.sh` runs under `nix develop`.
-2. **Decide what config is declarative vs mutable.** The shell writes to
-   `~/.config/immaterial-impulse/config.json` and `plugin-state.json` **at
-   runtime** — widget positions, plugin options, enabled plugins. Those cannot
-   be read-only store paths. The likely split: the QML tree is declarative and
-   immutable; the user state directory is seeded once and then mutable. This is
-   the central design question and should be settled before any code.
+2. **What is declarative vs mutable — settled, see the section below.** The
+   split is three-way, not two-way, and the third tier is the one that decides
+   whether a `home-manager switch` quietly destroys the user's colours.
 3. **Reconcile with the existing `sdata/dist-nix` tree** — either promote it to
    the root and delete the nested flake, or keep `--via-nix` as a legacy path and
    mark it superseded. Do not ship two flakes.
@@ -96,13 +93,79 @@ Rough shape, not a design:
    somewhere it is obviously a pin.
 5. **CI**: `nix flake check` on push is the only thing that keeps a flake honest.
 
+## Declarative vs mutable — settled
+
+Checked against the tree at `4b43790`, not assumed.
+
+### The QML tree can be a read-only store path
+
+Nothing writes into it. Every consumer of `writeAdapter` / `setText`
+(`modules/common/Config.qml`, `Persistent.qml`, `plugins/PluginState.qml`,
+`services/{Notifications,Cliphist,Todo,FirstRunExperience}.qml`) targets the
+config or state directory. The only `path: Quickshell.shellPath(...)` bindings
+in the tree are **reads** — the two bundled plugin `manifest.json` files, and
+`VERSION` from the About page and the plugin store.
+
+So `dots/.config/quickshell/imi` can be a store path, which is the whole premise
+of the flake, and no part of the shell has to be relaxed to allow it.
+
+### Three tiers, not two
+
+| tier | what | where it lives |
+|---|---|---|
+| immutable | the QML tree, `scripts/`, matugen **templates** | store path, symlinked |
+| seeded once | `config.json`, `plugin-state.json`, `plugins/<id>/` | real files under `~/.config/immaterial-impulse`, written by an activation script only when absent |
+| **never managed** | every matugen **output** | plain files, owned by the running shell |
+
+That third tier is the trap. `dots/.config/matugen/config.toml` declares 11
+output paths that matugen **rewrites on every wallpaper change**, and six of them
+are ordinary dotfiles a home-manager user would reasonably expect to be
+declarative:
+
+```
+~/.config/hypr/hyprland/colors.lua      ~/.config/gtk-3.0/gtk.css
+~/.config/hypr/hyprlock/colors.conf     ~/.config/gtk-4.0/gtk.css
+~/.config/kitty/colors-matugen.conf     ~/.config/fuzzel/fuzzel_theme.ini
+```
+
+plus five under `~/.local/state/quickshell/user/generated/` (`colors.json`,
+`color.txt`, `apps/cava.ini`, `apps/tmux.conf`, `wallpaper/path.txt`).
+
+If the module writes any of those with `home.file`, home-manager makes them
+symlinks into the store. Matugen then either fails against a read-only target or
+replaces the symlink with a regular file — and the next `home-manager switch`
+reverts the user's generated colours with no error. Both outcomes are silent.
+
+**Rule: manage the templates, never the outputs.** A user who wants their
+Hyprland colours declarative wants a different feature (a static palette with
+matugen off), not this one, and the module should make that an explicit option
+rather than an accident of which files it happened to link.
+
+### Consequence for the module
+
+`homeManagerModules.default` therefore owns the immutable tier outright, seeds
+the second tier idempotently, and must *refuse* to touch the third. Options that
+seed `config.json` need `lib.mkDefault` semantics — the file is the user's after
+first write, and a switch must not stamp on it.
+
+## Out of scope for the first flake
+
+The embedded Wallpaper Engine renderer. `qs-wallpaperengine` builds a patched
+Quickshell against `linux-wallpaperengine`, which is not in nixpkgs and pulls
+CEF, mpv and SDL; the installer's fast path is a prebuilt tarball made in an
+Arch container. A Nix user gets the shell with static wallpapers, and
+`wallpaperSelector.wallpaperEngine` stays inert. Packaging that dependency tree
+is its own proposal.
+
 ## Open questions
 
-- Does the plugin system work under Nix? Bundled plugins load by absolute path
-  through Quickshell's `qs:` URL scheme, and **installed** plugins live in
-  `~/.config/immaterial-impulse/plugins/<id>/` — a mutable directory by design.
-  Third-party plugin install is inherently imperative; the flake has to leave
-  room for it.
+- Does the plugin system work under Nix? Partly answered: **bundled** plugins are
+  read through `Quickshell.shellPath()` and are fine in a store path, and
+  **installed** plugins live in `~/.config/immaterial-impulse/plugins/<id>/`,
+  which the table above puts in the seeded-once tier. What is still open is
+  whether a plugin installed at runtime can load from a mutable directory while
+  the rest of the tree is immutable, and what `PluginState.qml` does when its
+  state file names a plugin the current generation no longer ships.
 - The installer's update path (`exp-update`, `exp-merge`) uses `git rebase`
   against a checkout. That has no meaning under a flake. What replaces
   Settings → Update Dots for a Nix user?

--- a/docs/proposals/nixos-flake.md
+++ b/docs/proposals/nixos-flake.md
@@ -97,8 +97,8 @@ Status per item, now that the first pass exists:
    - `devShells.default` — **done** (`nix/dev-shell.nix`): qmltestrunner
      via `qt6.qtdeclarative`, python3 with PIL/numpy, weston, dbus and the
      wrapped quickshell, so `tests/run_tests.sh` can run under
-     `nix develop`. Unvalidated so far — written on a machine with no
-     `nix` binary (see TODO below).
+     `nix develop`. The dev shell itself evaluates (`nix flake check`
+     covers it); `run_tests.sh` under `nix develop` has not been run yet.
 2. **What is declarative vs mutable — settled and implemented.** The
    split is three-way, not two-way, and the third tier is the one that decides
    whether a `home-manager switch` quietly destroys the user's colours.
@@ -109,13 +109,33 @@ Status per item, now that the first pass exists:
    the root flake replaces it yet. The one file they would duplicate,
    `quickshell.nix`, is shared — the root flake imports it in place.
 4. **Unpin quickshell** — done: the root flake's input has no commit in
-   its URL; the pin belongs to `flake.lock`. **TODO: no `flake.lock` is
-   committed yet** — the implementing machine had no `nix` binary, and an
-   invented lock is worse than an absent one. Generating and committing it
-   (and running `nix flake check` / `nix build .#immaterial-impulse` for
-   the first time) is the first task for a machine with nix.
+   its URL; the pin lives in the committed `flake.lock` (nixpkgs at
+   nixos-25.11, quickshell following the mirror's default branch).
 5. **CI**: `nix flake check` on push is the only thing that keeps a flake
-   honest. **TODO — not in this pass**; it needs the lock file first.
+   honest. **TODO — not in this pass.** It has been run by hand, and
+   passes; see "Validated so far" below.
+
+## Validated so far
+
+Run via rootless `nix-portable` (nix 2.20.6) on the authoring machine,
+which has no system nix:
+
+- `nix flake check` — green. First run caught a real bug: fixupPhase's
+  shebang patcher aborts on `generate_colors_material.py`'s `env -S`
+  venv-activating interpreter directive; the package now sets
+  `dontPatchShebangs` and ships the tree byte-identical.
+- `nix build .#immaterial-impulse` — green; output tree verified verbatim
+  (VERSION, exotic shebang intact, `defaults/config.json` and bundled
+  plugins present).
+- A consumer-side home-manager eval (home-manager `release-25.11`):
+  `homeManagerConfiguration` with the module enabled **builds a full
+  generation**, its activation script contains the seed-once logic, and a
+  probe config that manages `xdg.configFile."gtk-3.0/gtk.css"` — a matugen
+  output — makes the module emit exactly the tier-3 warning.
+
+Not yet validated: actually *running* the shell from the store path
+(needs a NixOS machine or VM with a Wayland session), and
+`tests/run_tests.sh` under `nix develop`.
 
 ## Declarative vs mutable — settled
 

--- a/docs/proposals/nixos-flake.md
+++ b/docs/proposals/nixos-flake.md
@@ -1,6 +1,6 @@
 # Proposal: NixOS flake
 
-> In progress. The first pass is implemented on `feat/nixos-flake`: a root
+> In progress. The first pass is implemented on `proposal/nixos-flake`: a root
 > `flake.nix` with `packages.<system>.immaterial-impulse`,
 > `homeManagerModules.default` and `devShells.default`, the three-tier
 > declarative/mutable split as designed below, and the nested
@@ -148,9 +148,29 @@ Not yet validated: running the shell's Wayland session from the store
 path (needs a compositor in the guest), and `tests/run_tests.sh` under
 `nix develop`.
 
+**Known blocker, named rather than fixed in this pass: the shell the
+module installs cannot generate colours.** Eight scripts under
+`scripts/` — `colors/generate_colors_material.py` (the whole wallpaper →
+palette path), `colors/switchwall.sh`, `colors/scheme_preview.py`,
+`background/subject_mask.py`, `hyprland/hyprconfigurator.py` and the
+three `*-venv.sh` wrappers — run inside the venv
+`sdata/lib/package-installers.sh` creates (`uv venv … -p 3.12` from
+`sdata/uv/requirements.txt`) and find it through
+`IMMATERIAL_IMPULSE_VIRTUAL_ENV`. The module ships the tree verbatim
+(`dontPatchShebangs` keeps the `env -S … source $VENV` shebang intact)
+and provides neither the venv nor the variable, so the first wallpaper
+change fails. This is the first thing a NixOS user hits, and it is
+separate from the PATH-enumeration open question below. A
+`python312.withPackages` closure is not a small addition:
+`requirements.txt` pins `materialyoucolor`, `material-color-utilities`
+and `kde-material-you-colors`, which nixpkgs' python package set does
+not carry, so closing this means packaging those or providing the venv
+another way — its own follow-up.
+
 ## Declarative vs mutable — settled
 
-Checked against the tree at `4b43790`, not assumed.
+Checked against the tree at 4b437909 ("feat(background): tell the renderer
+when its output is covered"), not assumed.
 
 ### The QML tree can be a read-only store path
 
@@ -235,7 +255,9 @@ Also out of the first pass, still TODO here:
 - `scripts/` shells out to a lot of binaries (`matugen`, `grim`, `slurp`,
   `hyprctl`, `ffmpeg`, ImageMagick, `cava`, `ydotool`…). Each is a `makeWrapper`
   `PATH` entry that has to be enumerated — the per-distro dep lists are the
-  starting point, but they are package names, not binary names.
+  starting point, but they are package names, not binary names. Separate from
+  and larger than this: the uv venv the colour scripts run inside (see the
+  known blocker under "Validated so far") — that one is not a PATH entry.
 - Single-user vs system-wide — **resolved for the first pass**: home-manager
   alone covers the shell, so the flake ships `homeManagerModules.default` and
   no `nixosModules.default` at all (omitted, not stubbed). What stays open is

--- a/docs/proposals/nixos-flake.md
+++ b/docs/proposals/nixos-flake.md
@@ -1,0 +1,121 @@
+# Proposal: NixOS flake
+
+> Draft / tracking proposal. Not scheduled.
+
+## Goal
+
+Expose Immaterial Impulse as a first-class Nix flake at the repository root — a
+`nixosModule`, a `homeManagerModule`, and a buildable package — so a NixOS user
+adds the shell declaratively instead of running an imperative installer that
+copies files into `~/.config`.
+
+## Current state
+
+There is already Nix support, but it is upstream-inherited, marked WIP, and is
+not what a NixOS user would expect.
+
+`sdata/dist-nix/README.md` says it in one line:
+
+```
+# Install scripts using Nix to achieve cross-distros
+- This directory is currently WIP.
+```
+
+What exists:
+
+- `sdata/dist-nix/home-manager/flake.nix` — a flake **nested inside the repo's
+  data directory**, not at the root. It pins `nixpkgs/nixos-25.11`,
+  home-manager `release-25.11`, and quickshell at a **hardcoded commit**
+  (`7511545e…`).
+- `sdata/dist-nix/home-manager/quickshell.nix` — a `stdenv.mkDerivation` wrapper
+  that bundles Qt deps around the upstream quickshell package. Carries commented-out
+  `nixGL` plumbing.
+- `sdata/dist-nix/home-manager/home.nix`, plus a `flake.lock`.
+- `sdata/dist-nix/install-deps.sh` — sourced by the installer's `--via-nix`
+  path. It **installs Nix itself** (via the experimental installer), installs
+  home-manager via `nix-channel`, then runs
+  `home-manager switch --flake .#immaterial_impulse`.
+- `sdata/dist-nix/outdate-detect-mode` contains the single word `WIP`.
+
+The flake reads `./username.nix` — a file that is not in the tree — so the
+existing configuration is not usable as-is without generating that first. And
+`install-deps.sh` warns the user directly:
+
+```
+If you are already using home-manager,
+it may override your current config,
+```
+
+Meanwhile the actual install path is `get.sh` → `setup` → whiptail TUI →
+`sdata/subcmd-install`, which copies `dots/` into `~/.config` and runs
+permission/service setup. That is the supported path on Arch, Fedora and Gentoo
+(`sdata/dist-arch`, `dist-fedora`, `dist-gentoo`), and Nix is bolted onto the
+side of it rather than being an alternative to it.
+
+## Why
+
+- **The imperative installer and Nix are opposed.** `setup install-files` copies
+  a tree into `~/.config/quickshell/imi` and `~/.config/immaterial-impulse`. On
+  NixOS that is the wrong shape: those paths want to be managed by
+  home-manager, and anything the installer writes is invisible to the system
+  configuration and lost on rollback.
+- **The current flake is not addressable.** A flake at `sdata/dist-nix/home-manager/`
+  cannot be consumed as `inputs.immaterial-impulse.url = "github:XephyLon/immaterial-impulse"`.
+  A root flake can.
+- **The dependency list already exists in a machine-readable form** —
+  `sdata/deps-info.md` plus the per-distro `dist-*` directories. Deriving a Nix
+  package's `buildInputs` from the same source keeps them from drifting.
+- **A known hazard this would fix**: the dots-hyprland-style update flow *deletes*
+  `~/.config/quickshell` before reinstalling. Declarative management removes that
+  class of accident entirely.
+
+## Sketch
+
+Rough shape, not a design:
+
+1. **Root `flake.nix`** with, at minimum:
+   - `packages.<system>.immaterial-impulse` — the shell tree as a derivation
+     (the `dots/.config/quickshell/imi` contents plus scripts), so it can be
+     referenced by store path rather than copied.
+   - `homeManagerModules.default` — options for enabling the shell, choosing a
+     panel family, and seeding `~/.config/immaterial-impulse/config.json`.
+   - `nixosModules.default` — the system-level pieces the installer currently does
+     in `install-setups`: services, polkit rules, greeter/SDDM theme, plymouth.
+   - `devShells.default` — quickshell + Qt + the Python test deps, so
+     `tests/run_tests.sh` runs under `nix develop`.
+2. **Decide what config is declarative vs mutable.** The shell writes to
+   `~/.config/immaterial-impulse/config.json` and `plugin-state.json` **at
+   runtime** — widget positions, plugin options, enabled plugins. Those cannot
+   be read-only store paths. The likely split: the QML tree is declarative and
+   immutable; the user state directory is seeded once and then mutable. This is
+   the central design question and should be settled before any code.
+3. **Reconcile with the existing `sdata/dist-nix` tree** — either promote it to
+   the root and delete the nested flake, or keep `--via-nix` as a legacy path and
+   mark it superseded. Do not ship two flakes.
+4. **Unpin quickshell** from the hardcoded commit, or at least move the pin
+   somewhere it is obviously a pin.
+5. **CI**: `nix flake check` on push is the only thing that keeps a flake honest.
+
+## Open questions
+
+- Does the plugin system work under Nix? Bundled plugins load by absolute path
+  through Quickshell's `qs:` URL scheme, and **installed** plugins live in
+  `~/.config/immaterial-impulse/plugins/<id>/` — a mutable directory by design.
+  Third-party plugin install is inherently imperative; the flake has to leave
+  room for it.
+- The installer's update path (`exp-update`, `exp-merge`) uses `git rebase`
+  against a checkout. That has no meaning under a flake. What replaces
+  Settings → Update Dots for a Nix user?
+- `scripts/` shells out to a lot of binaries (`matugen`, `grim`, `slurp`,
+  `hyprctl`, `ffmpeg`, ImageMagick, `cava`, `ydotool`…). Each is a `makeWrapper`
+  `PATH` entry that has to be enumerated — the per-distro dep lists are the
+  starting point, but they are package names, not binary names.
+- Single-user vs system-wide, and whether the NixOS module is genuinely needed
+  or whether home-manager alone covers it.
+
+## Prior art
+
+`sdata/dist-nix/home-manager/quickshell.nix` already solved the Qt-wrapping
+problem for quickshell itself and should be reused rather than rewritten. The
+upstream dots-hyprland project's Nix community packaging is the other obvious
+reference.

--- a/docs/proposals/nixos-flake.md
+++ b/docs/proposals/nixos-flake.md
@@ -133,9 +133,20 @@ which has no system nix:
   probe config that manages `xdg.configFile."gtk-3.0/gtk.css"` — a matugen
   output — makes the module emit exactly the tier-3 warning.
 
-Not yet validated: actually *running* the shell from the store path
-(needs a NixOS machine or VM with a Wayland session), and
-`tests/run_tests.sh` under `nix develop`.
+- A NixOS VM test (`testers.runNixOSTest`, qemu/KVM): a full NixOS guest
+  with the module enabled boots, activation succeeds, and in-guest
+  assertions hold — both tier-1 symlinks resolve into a read-only store,
+  `config.json` seeds byte-equal to the package's defaults as a real
+  file, a user overwrite of it **survives a service restart** (seed-once
+  proven live, not just read from the script), no matugen output is
+  store-managed, and `qs --version` runs from the user profile. The test
+  flake needs a home-manager input the root flake deliberately lacks, so
+  it lives outside the tree for now; folding it into CI is part of the
+  CI TODO above.
+
+Not yet validated: running the shell's Wayland session from the store
+path (needs a compositor in the guest), and `tests/run_tests.sh` under
+`nix develop`.
 
 ## Declarative vs mutable — settled
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,47 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1782847189,
+        "narHash": "sha256-twXPFqFsrrY5r28Zh7Homgcp2gUMBgQ6WDS98Q/3xFI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b6018f87da91d19d0ab4cf979885689b469cdd41",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-25.11",
+        "type": "indirect"
+      }
+    },
+    "quickshell": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787703747,
+        "narHash": "sha256-mSKjFcYgjfiXXzMYKIFec1t8Cl+bGOgAjobLNz7FHns=",
+        "owner": "quickshell-mirror",
+        "repo": "quickshell",
+        "rev": "9f59d0a05dff3865cf5bdff19309627214e18363",
+        "type": "github"
+      },
+      "original": {
+        "owner": "quickshell-mirror",
+        "repo": "quickshell",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "quickshell": "quickshell"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -22,11 +22,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787703747,
-        "narHash": "sha256-mSKjFcYgjfiXXzMYKIFec1t8Cl+bGOgAjobLNz7FHns=",
+        "lastModified": 1784600537,
+        "narHash": "sha256-4i2GzlclQ+SEYlcEZs0kFNI8iBk+sbQlVUtMiiogvck=",
         "owner": "quickshell-mirror",
         "repo": "quickshell",
-        "rev": "9f59d0a05dff3865cf5bdff19309627214e18363",
+        "rev": "e649d247498512464457aefcd05b73038c4e65a1",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -10,6 +10,12 @@
     # `nix flake update quickshell` can move it and the diff shows what moved.
     # The nested sdata/dist-nix flake used to hardcode a commit here, which is
     # a pin nothing updates and nothing explains.
+    #
+    # The lock's pin follows _commit in
+    # sdata/dist-arch/immaterial-impulse-quickshell-git/PKGBUILD - the commit
+    # the shell is built and tested against everywhere else. When that moves,
+    # `nix flake update quickshell` alone lands on the mirror's master, not on
+    # the PKGBUILD's commit; re-pin the lock to the same _commit instead.
     quickshell = {
       url = "github:quickshell-mirror/quickshell";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/flake.nix
+++ b/flake.nix
@@ -44,6 +44,16 @@
           default = immaterial-impulse;
         });
 
+      homeManagerModules = rec {
+        immaterial-impulse = import ./nix/hm-module.nix { inherit self; };
+        default = immaterial-impulse;
+      };
+
+      # No nixosModules yet, deliberately: the home-manager module covers the
+      # shell itself, and the system-level pieces the installer does (SDDM
+      # theme, plymouth, polkit rules, services) are future work - see
+      # docs/proposals/nixos-flake.md, "Open questions".
+
       devShells = forAllSystems (system:
         let
           pkgs = import nixpkgs { inherit system; };

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,62 @@
+{
+  description = "Immaterial Impulse - a Quickshell shell configuration for Hyprland";
+
+  inputs = {
+    # Kept on the same channel the nested sdata/dist-nix flake pins, so the
+    # two resolve the same package set for as long as both exist.
+    nixpkgs.url = "nixpkgs/nixos-25.11";
+
+    # Deliberately no commit in this URL: the pin lives in flake.lock, where
+    # `nix flake update quickshell` can move it and the diff shows what moved.
+    # The nested sdata/dist-nix flake used to hardcode a commit here, which is
+    # a pin nothing updates and nothing explains.
+    quickshell = {
+      url = "github:quickshell-mirror/quickshell";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { self, nixpkgs, quickshell, ... }:
+    let
+      inherit (nixpkgs) lib;
+      systems = [ "x86_64-linux" "aarch64-linux" ];
+      forAllSystems = f: lib.genAttrs systems f;
+      version = lib.removeSuffix "\n" (builtins.readFile ./VERSION);
+    in
+    {
+      packages = forAllSystems (system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in
+        rec {
+          # The shell tree (dots/.config/quickshell/imi) as a store path.
+          immaterial-impulse = pkgs.callPackage ./nix/package.nix {
+            inherit version;
+          };
+
+          # The Qt-bundled quickshell wrapper the nested home-manager flake
+          # already carries - reused, not rewritten (see that file's header).
+          quickshell-wrapped = import ./sdata/dist-nix/home-manager/quickshell.nix {
+            inherit pkgs;
+            qsPackage = quickshell.packages.${system}.default;
+          };
+
+          default = immaterial-impulse;
+        });
+
+      devShells = forAllSystems (system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in
+        {
+          default = import ./nix/dev-shell.nix {
+            inherit pkgs;
+            quickshellWrapped = self.packages.${system}.quickshell-wrapped;
+          };
+        });
+
+      checks = forAllSystems (system: {
+        package = self.packages.${system}.immaterial-impulse;
+      });
+    };
+}

--- a/nix/dev-shell.nix
+++ b/nix/dev-shell.nix
@@ -1,0 +1,40 @@
+{ pkgs, quickshellWrapped }:
+
+# Everything dots/.config/quickshell/imi/tests/run_tests.sh reaches for:
+# qmltestrunner (shipped by qt6.qtdeclarative), python3 with the two
+# third-party modules the pixel-scoring tests import (PIL, numpy), weston
+# for the headless runtime harnesses, dbus-run-session for the harnesses
+# that lint_runtime_bus_isolation.py holds to their own bus, and the
+# wrapped quickshell for the qs -p probes. matugen is here because the
+# colour-generation tests drive it.
+let
+  inherit (pkgs) lib;
+  qtLibs = with pkgs.qt6; [
+    qtbase
+    qtdeclarative
+    qt5compat
+    qtsvg
+    qtimageformats
+    qtmultimedia
+    qtwayland
+  ];
+in
+pkgs.mkShell {
+  packages = qtLibs ++ [
+    quickshellWrapped
+    (pkgs.python3.withPackages (ps: with ps; [ pillow numpy ]))
+    pkgs.weston
+    pkgs.dbus
+    pkgs.matugen
+  ];
+
+  # An interactive mkShell does not wrap Qt tools, so qmltestrunner needs to
+  # be told where the platform plugins and QML modules are. run_tests.sh
+  # already defaults QT_QPA_PLATFORM=offscreen itself.
+  shellHook = ''
+    export QT_PLUGIN_PATH="${lib.makeSearchPath pkgs.qt6.qtbase.qtPluginPrefix qtLibs}''${QT_PLUGIN_PATH:+:$QT_PLUGIN_PATH}"
+    export QML2_IMPORT_PATH="${lib.makeSearchPath pkgs.qt6.qtbase.qtQmlPrefix qtLibs}''${QML2_IMPORT_PATH:+:$QML2_IMPORT_PATH}"
+    echo "Immaterial Impulse dev shell."
+    echo "Run the suite with: dots/.config/quickshell/imi/tests/run_tests.sh"
+  '';
+}

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -1,0 +1,132 @@
+{ self }:
+{ config, lib, pkgs, ... }:
+
+# The three-tier split this module implements is settled in
+# docs/proposals/nixos-flake.md ("Declarative vs mutable"):
+#
+#   immutable     the QML tree, scripts/, the matugen config + templates
+#                 -> symlinked from the store, owned by this module outright
+#   seeded once   ~/.config/immaterial-impulse/{config.json,
+#                 plugin-state.json, plugins/}
+#                 -> real files, written by the activation script ONLY when
+#                    absent; the user's from first write onward
+#   never managed every matugen OUTPUT
+#                 -> plain files the running shell rewrites on every
+#                    wallpaper change; this module must refuse to touch them
+#
+# The third tier is the trap: a matugen output managed with home.file/
+# xdg.configFile becomes a store symlink, matugen either fails against the
+# read-only target or replaces the symlink, and the next `home-manager
+# switch` silently reverts the user's generated colours. This module never
+# declares one, and warns when the surrounding home-manager configuration
+# does.
+let
+  cfg = config.programs.immaterial-impulse;
+
+  # dots/.config/matugen/config.toml's output_path list, as home-manager
+  # attribute names. Six under ~/.config (xdg.configFile), five under
+  # ~/.local/state (xdg.stateFile).
+  matugenConfigOutputs = [
+    "hypr/hyprland/colors.lua"
+    "hypr/hyprlock/colors.conf"
+    "fuzzel/fuzzel_theme.ini"
+    "kitty/colors-matugen.conf"
+    "gtk-3.0/gtk.css"
+    "gtk-4.0/gtk.css"
+  ];
+  matugenStateOutputs = [
+    "quickshell/user/generated/colors.json"
+    "quickshell/user/generated/color.txt"
+    "quickshell/user/generated/wallpaper/path.txt"
+    "quickshell/user/generated/apps/cava.ini"
+    "quickshell/user/generated/apps/tmux.conf"
+  ];
+
+  managedIn = fileset: paths:
+    builtins.filter (p: (fileset ? ${p}) && (fileset.${p}.enable or true)) paths;
+
+  emptyPluginState = pkgs.writeText "plugin-state.json" "{}\n";
+in
+{
+  options.programs.immaterial-impulse = {
+    enable = lib.mkEnableOption "Immaterial Impulse, a Quickshell shell for Hyprland";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = self.packages.${pkgs.stdenv.hostPlatform.system}.immaterial-impulse;
+      defaultText = lib.literalExpression
+        "immaterial-impulse.packages.\${system}.immaterial-impulse";
+      description = "The shell tree linked to ~/.config/quickshell/imi.";
+    };
+
+    quickshell.package = lib.mkOption {
+      type = lib.types.package;
+      default = self.packages.${pkgs.stdenv.hostPlatform.system}.quickshell-wrapped;
+      defaultText = lib.literalExpression
+        "immaterial-impulse.packages.\${system}.quickshell-wrapped";
+      description = "The quickshell build that runs the shell (`qs -c imi`).";
+    };
+
+    seedConfig = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Seed ~/.config/immaterial-impulse/config.json from the shell's
+        curated defaults on first activation. Never touches an existing
+        file - it is the user's live settings, which the shell itself
+        rewrites; managing it declaratively would fight the running shell
+        the same way managing a matugen output would.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ cfg.quickshell.package ];
+
+    # Tier 1: the immutable tree, straight from the store. The matugen
+    # directory is config + templates only - its outputs land elsewhere.
+    xdg.configFile."quickshell/imi".source = cfg.package;
+    xdg.configFile."matugen".source = "${self}/dots/.config/matugen";
+
+    # Tier 2: seeded once, only when absent, then never touched again.
+    # `run` keeps this honest under `home-manager switch --dry-run`.
+    home.activation.immaterialImpulseSeed =
+      lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        imiConfDir="''${XDG_CONFIG_HOME:-$HOME/.config}/immaterial-impulse"
+        run mkdir -p "$imiConfDir/plugins"
+        ${lib.optionalString cfg.seedConfig ''
+          if [ ! -e "$imiConfDir/config.json" ]; then
+            run install -m 0644 \
+              "${cfg.package}/defaults/config.json" \
+              "$imiConfDir/config.json"
+          fi
+        ''}
+        if [ ! -e "$imiConfDir/plugin-state.json" ]; then
+          run install -m 0644 \
+            "${emptyPluginState}" \
+            "$imiConfDir/plugin-state.json"
+        fi
+      '';
+
+    # Tier 3: refused. This module manages none of these, and a matugen
+    # output managed elsewhere in the configuration breaks silently - warn.
+    warnings =
+      map
+        (p: ''
+          programs.immaterial-impulse: xdg.configFile."${p}" is a matugen
+          OUTPUT (declared in the shell's matugen config.toml). The running
+          shell rewrites it on every wallpaper change; managing it makes it
+          a store symlink that matugen fails against or replaces, and the
+          next switch reverts the generated colours with no error. If you
+          want that file declarative, you want matugen off, not this.
+        '')
+        (managedIn config.xdg.configFile matugenConfigOutputs)
+      ++ map
+        (p: ''
+          programs.immaterial-impulse: xdg.stateFile."${p}" is a matugen
+          OUTPUT the running shell rewrites on every wallpaper change; do
+          not manage it declaratively.
+        '')
+        (managedIn config.xdg.stateFile matugenStateOutputs);
+  };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -17,6 +17,12 @@ stdenvNoCC.mkDerivation {
   dontConfigure = true;
   dontBuild = true;
 
+  # The tree ships verbatim. Scripts resolve interpreters through the user's
+  # environment at runtime like on every other distro, and the fixup patcher
+  # cannot parse generate_colors_material.py's `env -S ... source $VENV`
+  # shebang anyway - it aborts the build on it.
+  dontPatchShebangs = true;
+
   installPhase = ''
     runHook preInstall
     mkdir -p "$out"

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,33 @@
+{ lib, stdenvNoCC, version }:
+
+# The shell tree - the contents of dots/.config/quickshell/imi - as a store
+# path. This is the whole tree the installer would rsync to
+# ~/.config/quickshell/imi, tests and probes included, because the matugen
+# config and several services resolve scripts inside it by that layout.
+# Nothing in the shell writes into this directory (settled in
+# docs/proposals/nixos-flake.md, "Declarative vs mutable"): every
+# writeAdapter/setText consumer targets ~/.config/immaterial-impulse or
+# XDG state, so a read-only store path needs no part of the shell relaxed.
+stdenvNoCC.mkDerivation {
+  pname = "immaterial-impulse";
+  inherit version;
+
+  src = lib.cleanSource ../dots/.config/quickshell/imi;
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p "$out"
+    cp -R ./. "$out"/
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Immaterial Impulse - a Quickshell shell configuration for Hyprland";
+    homepage = "https://github.com/XephyLon/immaterial-impulse";
+    license = lib.licenses.gpl3Only;
+    platforms = lib.platforms.linux;
+  };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -12,7 +12,16 @@ stdenvNoCC.mkDerivation {
   pname = "immaterial-impulse";
   inherit version;
 
-  src = lib.cleanSource ../dots/.config/quickshell/imi;
+  # cleanSource drops VCS and editor litter but not Python's caches, and a
+  # local build after a test-suite run would ship __pycache__/.pytest_cache
+  # into the store otherwise.
+  src = lib.cleanSourceWith {
+    src = ../dots/.config/quickshell/imi;
+    filter = path: type:
+      lib.cleanSourceFilter path type
+      && !(type == "directory"
+        && lib.elem (baseNameOf path) [ "__pycache__" ".pytest_cache" ]);
+  };
 
   dontConfigure = true;
   dontBuild = true;

--- a/sdata/dist-nix/README.md
+++ b/sdata/dist-nix/README.md
@@ -1,4 +1,18 @@
 # Install scripts using Nix to achieve cross-distros
+
+> **Superseded.** The repository now carries a flake at its root
+> (`/flake.nix`) exposing `packages.<system>.immaterial-impulse`,
+> `homeManagerModules.default` and `devShells.default`, addressable as
+> `github:XephyLon/immaterial-impulse` — see
+> `docs/proposals/nixos-flake.md`. That is the supported Nix path. The
+> nested flake in `home-manager/` and the installer's `--via-nix` path
+> that drives it are kept working but superseded: `--via-nix` writes a
+> `username.nix`, installs Nix and home-manager imperatively, and switches
+> a whole home configuration, where the root flake's module composes into
+> a configuration the user already owns. `home-manager/quickshell.nix` is
+> the one file both flakes share — the root flake imports it rather than
+> carrying a copy, so changes to it serve both paths.
+
 - This directory is currently WIP.
 - See also [Install scripts | illogical-impulse](https://ii.clsty.link/en/dev/inst-script/)
 - See also [#1061](https://github.com/end-4/dots-hyprland/issues/1061)

--- a/sdata/dist-nix/home-manager/quickshell.nix
+++ b/sdata/dist-nix/home-manager/quickshell.nix
@@ -1,9 +1,14 @@
-{ pkgs, quickshell, 
+{ pkgs, quickshell ? null,
+# The root flake passes the already-resolved per-system quickshell package
+# here; the nested home-manager flake keeps passing the whole `quickshell`
+# flake input and the default below resolves it the way this file always
+# did. Both callers share this one wrapper - do not fork it.
+qsPackage ? quickshell.packages.x86_64-linux.default,
 #nixGLWrap,
 ... }:
 let
   #qs = nixGLWrap quickshell.packages.x86_64-linux.default;
-  qs = quickshell.packages.x86_64-linux.default;
+  qs = qsPackage;
 in pkgs.stdenv.mkDerivation {
   name = "immaterial-impulse-quickshell-wrapper";
   meta = with pkgs.lib; {


### PR DESCRIPTION
Implements the first pass of the NixOS flake proposal this PR has tracked since the draft. The proposal doc rides in the branch and now describes what exists rather than what might.

What's in:

- **Root `flake.nix`** — `packages.<system>.immaterial-impulse` (the shell tree, byte-verbatim, as a store path), `quickshell-wrapped` (shared with the nested dist-nix flake via a new `qsPackage` argument instead of being duplicated), and `devShells.default`.
- **`nix/hm-module.nix`** — the home-manager module implementing the settled three-tier split: the QML tree and matugen config + templates symlinked from the store; `config.json`, `plugin-state.json` and `plugins/` seeded by activation only when absent, the user's from first write onward; matugen **outputs** never managed, with a warning when the surrounding home-manager configuration manages one.
- **`sdata/dist-nix` reconciled** — `--via-nix` marked superseded in its README; the nested flake stays (it is the whole working non-NixOS standalone home-manager path), and `quickshell.nix` is imported by the root flake in place.
- **`flake.lock` committed** — nixpkgs at nixos-25.11; quickshell pinned in the lock to the PKGBUILD's `_commit` (e649d247, the commit the shell is built and tested against everywhere else), with `flake.nix` naming the PKGBUILD as the source of truth for re-pins. The hardcoded-commit pin is gone from the URL.
- `nixosModules.default` is **omitted, not stubbed** — home-manager alone covers the shell; the system half (SDDM, plymouth, polkit) stays under open questions.

Validated (details in the doc's "Validated so far"):

- `nix flake check` green. The first run caught a real bug — fixupPhase's shebang patcher aborts on `generate_colors_material.py`'s `env -S` venv shebang — fixed by shipping the tree verbatim (`dontPatchShebangs`).
- `nix build .#immaterial-impulse` green; output tree verified byte-identical.
- A consumer-side home-manager eval builds a full generation, and a probe config managing `gtk-3.0/gtk.css` makes the module emit exactly the tier-3 warning.
- A qemu/KVM NixOS VM test: a guest with the module enabled boots, both tier-1 symlinks resolve into a read-only store, `config.json` seeds byte-equal to the defaults, a user overwrite of it survives a home-manager service restart, no matugen output is store-managed, and `qs --version` runs from the user profile.

Review round (all three must-fix items addressed):

- quickshell re-pinned to the PKGBUILD's commit (above); `nix flake check` and `nix build` re-run green on the new lock.
- The venv hole is **named, not fixed**: the doc's "Validated so far" now states that the module ships a shell that cannot generate colours — eight scripts need the uv venv and `IMMATERIAL_IMPULSE_VIRTUAL_ENV`, and closing it is its own follow-up because `requirements.txt` pins three packages nixpkgs' python set does not carry.
- README gains a "NixOS (experimental)" install subsection naming the flake input, the module, and what does not work yet.
- Nits: branch name in the doc header corrected, the `4b43790` citation carries its subject, `.gitignore` ignores `result`, and the package filters `__pycache__`/`.pytest_cache` out of the source (proven against a real cache in the tree).

Still open, named in the doc: the venv for colour generation (first blocker of a usable shell), running the Wayland session from the store path, `run_tests.sh` under `nix develop`, runtime plugin install under an immutable tree, the `exp-update` replacement, the `scripts/` PATH enumeration, CI `nix flake check`, and the matugen-output-list drift guard.

Changelog: not user-visible — nothing under dots/ changes in this PR
Docs: updated docs/proposals/nixos-flake.md §"Sketch", §"Validated so far", §"Open questions"; README.md §"Install / update"

