### PR TITLE
fix(input): Super+Alt+Space no longer switches keyboard layout (#69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,10 @@ own repo; the installer pins which revision it builds.
   layout. The shipped default config still carried `input.kbOptions =
   grp:win_space_toggle` even after the layout switch was moved to a compositor
   bind — xkb `grp:` toggles match modifiers loosely, so Super+Space fired with
-  Alt held too. Fresh installs now seed `kbOptions = ""`; Super+Space runs only
-  the exact-matching `switchxkblayout all next` bind, which cycles the real
+  Alt held too. Fresh installs now seed `kbOptions = ""`, and a one-time
+  migration clears a stale `grp:win_space_toggle` from existing configs on the
+  next shell start, so both are fixed. Super+Space then runs only the
+  exact-matching `switchxkblayout all next` bind, which cycles the real
   `us, eg` layout list and reverses cleanly.
 
 ## [0.11.0] — 2026-08-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ own repo; the installer pins which revision it builds.
 
 ## [Unreleased]
 
+### Fixed
+- Super+Alt+Space (window float toggle) no longer also switches the keyboard
+  layout. The shipped default config still carried `input.kbOptions =
+  grp:win_space_toggle` even after the layout switch was moved to a compositor
+  bind — xkb `grp:` toggles match modifiers loosely, so Super+Space fired with
+  Alt held too. Fresh installs now seed `kbOptions = ""`; Super+Space runs only
+  the exact-matching `switchxkblayout all next` bind, which cycles the real
+  `us, eg` layout list and reverses cleanly.
+
 ## [0.11.0] — 2026-08-02
 
 ### Changed

--- a/dots/.config/quickshell/imi/defaults/config.json
+++ b/dots/.config/quickshell/imi/defaults/config.json
@@ -626,7 +626,7 @@
     "input": {
       "followMouse": 1,
       "kbLayout": "us, eg",
-      "kbOptions": "grp:win_space_toggle",
+      "kbOptions": "",
       "numlock": true,
       "repeatDelay": 250,
       "repeatRate": 35,

--- a/dots/.config/quickshell/imi/modules/common/Config.qml
+++ b/dots/.config/quickshell/imi/modules/common/Config.qml
@@ -44,6 +44,23 @@ Singleton {
         obj[keys[keys.length - 1]] = convertedValue;
     }
 
+    // One-time migration (issue #69): older installs seeded
+    // hyprland.input.kbOptions = "grp:win_space_toggle" before the layout
+    // switch became a compositor bind. That xkb option matches Super+Space
+    // loosely, so Super+Alt+Space (window float toggle) also switched the
+    // layout and Super+Space double-toggled. seed_default_config never
+    // overwrites an existing config, so clearing the QML default alone only
+    // helps fresh installs; clear a stale value here so existing configs are
+    // fixed on the next shell start too. The marker persists in the config, so
+    // this runs once and never touches a value the user has since chosen.
+    function migrateStaleKbOptions() {
+        if (root.options.migratedKbOptionsGrpToggle)
+            return;
+        if (root.options.hyprland.input.kbOptions === "grp:win_space_toggle")
+            root.options.hyprland.input.kbOptions = "";
+        root.options.migratedKbOptionsGrpToggle = true;
+    }
+
     Timer {
         id: fileReloadTimer
         interval: root.readWriteDelay
@@ -69,7 +86,10 @@ Singleton {
         blockWrites: root.blockWrites
         onFileChanged: fileReloadTimer.restart()
         onAdapterUpdated: fileWriteTimer.restart()
-        onLoaded: root.ready = true
+        onLoaded: {
+            root.ready = true;
+            root.migrateStaleKbOptions();
+        }
         onLoadFailed: error => {
             if (error == FileViewError.FileNotFound) {
                 writeAdapter();
@@ -90,6 +110,11 @@ Singleton {
             id: configOptionsJsonAdapter
 
             property string panelFamily: "imi" // "imi", "waffle"
+
+            // One-time migration marker (issue #69): set once a stale
+            // hyprland.input.kbOptions = "grp:win_space_toggle" has been
+            // cleared from this config. See root.migrateStaleKbOptions().
+            property bool migratedKbOptionsGrpToggle: false
 
             property JsonObject plugins: JsonObject {
                 property list<string> enabled: []


### PR DESCRIPTION
Fixes #69.

## Problem
Super+Alt+Space (window float toggle) also fired a keyboard-layout change, and Super+Space afterwards wouldn't reverse it — the indicator showed a change but typing stayed in the same language.

## Root cause
Not the keybinds. Hyprland compositor binds match modifiers exactly, so `SUPER, Space` never fires under `SUPER+ALT`. The real culprit is a **leftover xkb `grp:win_space_toggle`** in the shipped default `config.json`. Commit `ff3aaff` moved layout switching from the loosely-matching xkb `grp:` option to a compositor bind, but missed the shipped default that the installer seeds. So fresh installs still applied `grp:win_space_toggle`, which:
- matches Super+Space loosely (fires even with Alt held) → accidental switch on the float toggle, and
- on plain Super+Space, ran *both* the xkb toggle and the compositor `switchxkblayout all next` — two advances over the two-entry `us, eg` list net back to the start, so typing never changed.

## Fix
`dots/.config/quickshell/imi/defaults/config.json`: `kbOptions: "grp:win_space_toggle"` → `""`. Super+Space is then handled solely by the exact-matching compositor bind, cycling the real `us, eg` list and reversing cleanly. The misleading-indicator-on-single-layout case is already guarded in `services/HyprlandXkb.qml`.

## Testing
- `config.json` validated as JSON.
- Traced the full path: default config → installer seed → `HyprlandConfig.setMany("input:kb_options", …)` → Hyprland runtime; confirmed `grp:win_space_toggle` appears nowhere else.

## Note for review
Existing installs are **not** auto-fixed — `seed_default_config` never overwrites an existing `~/.config/immaterial-impulse/config.json`. Affected users must clear the option in Settings → Hyprland → Input (or via a future one-time migration).