### PR TITLE
fix(bar): closing hover popup no longer paints over its neighbour (#71)

### DIFF
--- a/dots/.config/quickshell/imi/GlobalStates.qml
+++ b/dots/.config/quickshell/imi/GlobalStates.qml
@@ -46,6 +46,11 @@ Singleton {
     property real desktopMenuX: 0
     property real desktopMenuY: 0
     property string wallpaperSelectorTarget: "wallpaper"
+    // The bar hover popup (StyledPopup) whose target widget is currently
+    // hovered. Adjacent bar popups are separate layer-shell surfaces, so a
+    // lingering one can paint over a newly opened neighbour; each popup watches
+    // this so the previous one closes at once instead of overlapping the new one.
+    property var activeBarPopup: null
     property bool dropShelfOpen: false
     property real dropShelfX: 0
     property real dropShelfY: 0

--- a/dots/.config/quickshell/imi/modules/common/widgets/StyledPopup.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/StyledPopup.qml
@@ -1,3 +1,4 @@
+import qs
 import qs.modules.common
 import qs.modules.common.widgets
 import qs.modules.common.functions
@@ -42,8 +43,27 @@ LazyLoader {
         onTriggered: root.hoverHeld = false
     }
 
-    onTargetHoveredChanged: updateHoverHold()
+    onTargetHoveredChanged: {
+        // Claim the shared slot the moment this popup's widget is hovered, so any
+        // neighbour that was still open collapses before it can paint over us.
+        if (targetHovered) GlobalStates.activeBarPopup = root;
+        updateHoverHold();
+    }
     onPopupHoveredChanged: updateHoverHold()
+
+    // A different bar popup just took over. If we're only lingering on the
+    // hover-hold grace period (pointer no longer on our widget or our surface),
+    // close now rather than overlapping the incoming popup during that window.
+    Connections {
+        target: GlobalStates
+        function onActiveBarPopupChanged() {
+            if (GlobalStates.activeBarPopup !== root && root.hoverHeld
+                    && !root.targetHovered && !root.popupHovered) {
+                root.hoverCloseTimer.stop();
+                root.hoverHeld = false;
+            }
+        }
+    }
 
     readonly property bool barVertical: Config.options.bar.vertical
     readonly property string barEdge: {


### PR DESCRIPTION
Fixes #71.

## Problem
With two adjacent bar widgets (e.g. clock + weather), hovering the first then sweeping to the second made the **old tooltip's exit** render on top of the **new tooltip's entry** for the duration of the close animation.

## Root cause
The bar hover popups are each their own **layer-shell surface** (`StyledPopup.qml` → `PanelWindow`, `WlrLayer.Overlay`), not sibling `Item`s. Each has a 180 ms hover-hold grace period so you can move onto a popup without it vanishing. Moving clock→weather opens the new popup immediately while the old one lingers for up to 180 ms; both are ~340 px wide and centred under adjacent widgets, so they overlap — and same-layer wlr surfaces resolve overlap by **stacking order, not activeness**, so the lingering one can cover the new one. A `z` fix doesn't apply (independent Wayland surfaces).

## Fix
Temporal, not stacking. New shared slot `GlobalStates.activeBarPopup`:
- When a popup's target widget is hovered, it claims the slot.
- A `Connections` on the slot makes any *other* popup that is only lingering (`hoverHeld && !targetHovered && !popupHovered`, and not pinned) stop its timer and close immediately — in the same event-loop turn, before the next frame — so the two are never mapped simultaneously.

Lives in the one shared `StyledPopup`, so every bar hover popup benefits. Intra-popup travel (widget → its own popup) and pinned/interactive popups are unaffected.

## Testing
- Repo suite `dots/.config/quickshell/imi/tests/run_tests.sh`: **200 passed, 0 failed** (includes the QML import linter + shared-widget contract tests).
- Traced both repro chains (ClockWidget/WeatherBar → …Popup → StyledPopup) to confirm they share the widget.

## Note for review
Couldn't hot-reload the live shell from the worktree — please do one live confirmation: hover clock, sweep to weather and back (old popup no longer flashes on top), and confirm a pinned popup still stays open when a neighbour is hovered.