### PR TITLE
fix(panels): blur only the panel body, not the drop shadow (#82)

### DIFF
--- a/dots/.config/hypr/hyprland/rules.lua
+++ b/dots/.config/hypr/hyprland/rules.lua
@@ -172,10 +172,13 @@ hl.layer_rule({ match = { namespace = "quickshell:sidebarLeft" }, animation = "s
 -- translucent body still gets its backdrop blur while the shadow stays crisp.
 hl.layer_rule({ match = { namespace = "quickshell:sidebarRight" }, blur = false})
 hl.layer_rule({ match = { namespace = "quickshell:sidebarLeft" }, blur = false})
--- Same treatment for the bar: its drop shadow (bar.shadow) and screen-rounding
--- margin share the surface with the body, so the whole-surface blur frosted
--- them too. The shell scopes blur to the painted body rects (see Bar.qml).
+-- Same treatment for the bars and dock: their drop shadows and margin strips
+-- share the surface with the body, so the whole-surface blur frosted them
+-- too. The shell scopes blur to the painted body rects instead (see
+-- WindowBlurRegion in Bar.qml / VerticalBar.qml / Dock.qml).
 hl.layer_rule({ match = { namespace = "quickshell:bar" }, blur = false})
+hl.layer_rule({ match = { namespace = "quickshell:verticalBar" }, blur = false})
+hl.layer_rule({ match = { namespace = "quickshell:dock" }, blur = false})
 hl.layer_rule({ match = { namespace = "quickshell:verticalBar" }, animation = "slide"})
 hl.layer_rule({ match = { namespace = "quickshell:osk" }, order = -1})
 -- Quickshell: waffles

--- a/dots/.config/hypr/hyprland/rules.lua
+++ b/dots/.config/hypr/hyprland/rules.lua
@@ -172,6 +172,10 @@ hl.layer_rule({ match = { namespace = "quickshell:sidebarLeft" }, animation = "s
 -- translucent body still gets its backdrop blur while the shadow stays crisp.
 hl.layer_rule({ match = { namespace = "quickshell:sidebarRight" }, blur = false})
 hl.layer_rule({ match = { namespace = "quickshell:sidebarLeft" }, blur = false})
+-- Same treatment for the bar: its drop shadow (bar.shadow) and screen-rounding
+-- margin share the surface with the body, so the whole-surface blur frosted
+-- them too. The shell scopes blur to the painted body rects (see Bar.qml).
+hl.layer_rule({ match = { namespace = "quickshell:bar" }, blur = false})
 hl.layer_rule({ match = { namespace = "quickshell:verticalBar" }, animation = "slide"})
 hl.layer_rule({ match = { namespace = "quickshell:osk" }, order = -1})
 -- Quickshell: waffles

--- a/dots/.config/hypr/hyprland/rules.lua
+++ b/dots/.config/hypr/hyprland/rules.lua
@@ -164,6 +164,14 @@ hl.layer_rule({ match = { namespace = "quickshell:session" }, no_anim = true})
 hl.layer_rule({ match = { namespace = "quickshell:session" }, ignore_alpha = 0})
 hl.layer_rule({ match = { namespace = "quickshell:sidebarRight" }, animation = "slide right"})
 hl.layer_rule({ match = { namespace = "quickshell:sidebarLeft" }, animation = "slide left"})
+-- The sidebars draw a translucent drop shadow (StyledRectangularShadow) in
+-- their surface's elevation margin. The catch-all whole-surface blur above
+-- frosts that shadow into an ugly band along the panel's edge (#82). Turn the
+-- layerrule blur off for these namespaces; the shell scopes blur to just the
+-- panel body instead, via ext-background-effect (WindowBlurRegion.qml), so a
+-- translucent body still gets its backdrop blur while the shadow stays crisp.
+hl.layer_rule({ match = { namespace = "quickshell:sidebarRight" }, blur = false})
+hl.layer_rule({ match = { namespace = "quickshell:sidebarLeft" }, blur = false})
 hl.layer_rule({ match = { namespace = "quickshell:verticalBar" }, animation = "slide"})
 hl.layer_rule({ match = { namespace = "quickshell:osk" }, order = -1})
 -- Quickshell: waffles

--- a/dots/.config/quickshell/imi/modules/common/widgets/WindowBlurRegion.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/WindowBlurRegion.qml
@@ -25,8 +25,10 @@ Item {
     property Item regionItem
     property int regionRadius: 0
 
-    Region {
-        id: blurRegion
+    // The published region. Defaults to regionItem's rect; a caller whose body
+    // is not a single rect (the bar's background + center pill, say) can
+    // replace it with a composed Region whose children Combine into a union.
+    property Region region: Region {
         item: root.regionItem
         radius: root.regionRadius
     }
@@ -35,8 +37,10 @@ Item {
         if (!root.targetWindow)
             return;
         root.targetWindow.BackgroundEffect.blurRegion = null;
-        root.targetWindow.BackgroundEffect.blurRegion = blurRegion;
+        root.targetWindow.BackgroundEffect.blurRegion = root.region;
     }
+
+    onRegionChanged: settleTimer.restart()
 
     Timer {
         id: settleTimer
@@ -62,7 +66,7 @@ Item {
 
     Component.onCompleted: {
         if (targetWindow)
-            targetWindow.BackgroundEffect.blurRegion = blurRegion;
+            targetWindow.BackgroundEffect.blurRegion = region;
         settleTimer.restart();
     }
     Component.onDestruction: {

--- a/dots/.config/quickshell/imi/modules/common/widgets/WindowBlurRegion.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/WindowBlurRegion.qml
@@ -1,0 +1,72 @@
+import QtQuick
+import Quickshell
+import Quickshell.Wayland
+
+/**
+ * Publishes an ext-background-effect blur region for a panel window, so the
+ * compositor blurs only `regionItem`'s rect (the opaque panel body) instead of
+ * the whole layer surface. A panel that draws its drop shadow in the surface's
+ * margin can then keep that shadow crisp: it sits outside the region, so the
+ * compositor's blur never touches it (#82). Requires the compositor to
+ * implement ext_background_effect_manager_v1 (Hyprland ≥ 0.51); on others
+ * setting the region is a harmless no-op, matching the unblurred fallback.
+ *
+ * Quickshell's BackgroundEffect re-applies the region across surface
+ * creation/map internally, but a region committed while the surface is mid
+ * (re)configure can still be dropped compositor-side; the settle timer
+ * re-publishes shortly after map/resize to cover that race (the same
+ * "kick after geometry settles" DankMaterialShell's WindowBlur does).
+ */
+Item {
+    id: root
+    visible: false
+
+    required property var targetWindow
+    property Item regionItem
+    property int regionRadius: 0
+
+    Region {
+        id: blurRegion
+        item: root.regionItem
+        radius: root.regionRadius
+    }
+
+    function republish() {
+        if (!root.targetWindow)
+            return;
+        root.targetWindow.BackgroundEffect.blurRegion = null;
+        root.targetWindow.BackgroundEffect.blurRegion = blurRegion;
+    }
+
+    Timer {
+        id: settleTimer
+        interval: 96
+        repeat: false
+        onTriggered: root.republish()
+    }
+
+    Connections {
+        target: root.targetWindow ?? null
+        ignoreUnknownSignals: true
+        function onVisibleChanged() {
+            if (root.targetWindow.visible)
+                settleTimer.restart();
+        }
+        function onWidthChanged() {
+            settleTimer.restart();
+        }
+        function onHeightChanged() {
+            settleTimer.restart();
+        }
+    }
+
+    Component.onCompleted: {
+        if (targetWindow)
+            targetWindow.BackgroundEffect.blurRegion = blurRegion;
+        settleTimer.restart();
+    }
+    Component.onDestruction: {
+        if (targetWindow && targetWindow.BackgroundEffect)
+            targetWindow.BackgroundEffect.blurRegion = null;
+    }
+}

--- a/dots/.config/quickshell/imi/modules/imi/bar/Bar.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/Bar.qml
@@ -92,6 +92,32 @@ Scope {
                 }
                 color: "transparent"
 
+                // Blur only the painted body shapes. The bar's drop shadow and
+                // the screen-rounding margin live outside these rects, so the
+                // compositor's blur can't frost them (#82) — same treatment as
+                // the sidebars. Pairs with rules.lua turning the whole-surface
+                // layerrule blur off for this namespace. The RoundCorner
+                // decorators and the islands/material pills are left out: a
+                // region is a plain rect, so covering their transparent parts
+                // would frost bare wallpaper; they are opaque by default and
+                // merely read as unblurred translucency under transparency mode.
+                WindowBlurRegion {
+                    targetWindow: barRoot
+                    region: Region {
+                        Region {
+                            item: barContent.backgroundPainted ? barContent.backgroundItem : null
+                            radius: barContent.backgroundItem.radius
+                        }
+                        Region {
+                            item: barContent.centerPillPainted ? barContent.centerPillItem : null
+                            topLeftRadius: barContent.centerPillItem.topLeftRadius
+                            topRightRadius: barContent.centerPillItem.topRightRadius
+                            bottomLeftRadius: barContent.centerPillItem.bottomLeftRadius
+                            bottomRightRadius: barContent.centerPillItem.bottomRightRadius
+                        }
+                    }
+                }
+
                 // Positioning
                 anchors {
                     top: !Config.options.bar.bottom

--- a/dots/.config/quickshell/imi/modules/imi/bar/BarContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/BarContent.qml
@@ -22,6 +22,17 @@ Item {
 
     readonly property bool trayHasItems: SystemTray.items.values.length > 0
 
+    // The painted body shapes, exposed so the hosting window can scope its
+    // compositor blur region to them (see WindowBlurRegion in Bar.qml). The
+    // "painted" flags mirror each shape's own color/visible condition: a blur
+    // region is a plain rect, so covering an unpainted (transparent) shape
+    // would frost the bare wallpaper behind it.
+    readonly property Item backgroundItem: barBackground
+    readonly property bool backgroundPainted: !centerOnly && Config.options.bar.showBackground
+        && Config.options.bar.cornerStyle !== 2 && !root.isMaterial
+    readonly property Item centerPillItem: centerPill
+    readonly property bool centerPillPainted: centerPill.visible
+
     function filterLayout(layout) {
         return layout.filter(name => {
             if (name === "sysTray" && !trayHasItems) return false;

--- a/dots/.config/quickshell/imi/modules/imi/dock/Dock.qml
+++ b/dots/.config/quickshell/imi/modules/imi/dock/Dock.qml
@@ -56,6 +56,19 @@ Scope {
 
             mask: Region { item: dockMouseArea }
 
+            // Blur only the painted dock body — its surface carries an
+            // elevation margin for the drop shadow, and the whole-surface
+            // layerrule blur frosted that margin too (#82). Same treatment as
+            // the bar/sidebars; pairs with rules.lua turning the layerrule
+            // blur off for this namespace. No region when the background
+            // isn't painted: blurring a transparent rect frosts bare
+            // wallpaper.
+            WindowBlurRegion {
+                targetWindow: dockRoot
+                regionItem: Config.options.dock.showBackground ? dockVisualBackground : null
+                regionRadius: dockVisualBackground.radius
+            }
+
             DockContextMenu {
                 id: dockContextMenu
             }

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/SidebarLeft.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/SidebarLeft.qml
@@ -139,6 +139,16 @@ Scope { // Scope
                 item: sidebarLeftBackground
             }
 
+            // Blur only the panel body. The drop shadow is drawn in the
+            // surface's elevation margin, outside this region, so the
+            // compositor's blur can't frost it (#82). Pairs with rules.lua
+            // turning the whole-surface layerrule blur off for this namespace.
+            WindowBlurRegion {
+                targetWindow: panelWindow
+                regionItem: sidebarLeftBackground
+                regionRadius: sidebarLeftBackground.radius
+            }
+
             onVisibleChanged: {
                 if (visible) {
                     GlobalFocusGrab.addDismissable(panelWindow);

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/SidebarRight.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/SidebarRight.qml
@@ -1,6 +1,7 @@
 import qs
 import qs.services
 import qs.modules.common
+import qs.modules.common.widgets
 import QtQuick
 import Quickshell.Io
 import Quickshell
@@ -56,6 +57,16 @@ Scope {
             top: true
             right: true
             bottom: true
+        }
+
+        // Blur only the panel body (exposed by SidebarRightContent) — the drop
+        // shadow in the elevation margin stays outside the region, so the
+        // compositor's blur can't frost it (#82). Pairs with rules.lua turning
+        // the whole-surface layerrule blur off for this namespace.
+        WindowBlurRegion {
+            targetWindow: panelWindow
+            regionItem: sidebarContentLoader.item?.backgroundItem ?? null
+            regionRadius: sidebarContentLoader.item?.backgroundItem?.radius ?? 0
         }
 
         margins {

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/SidebarRightContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/SidebarRightContent.qml
@@ -38,6 +38,10 @@ Item {
 
     readonly property bool sidebarOpen: GlobalStates.sidebarRightOpen
 
+    // The opaque panel body, exposed so the hosting window can scope its
+    // compositor blur region to it (see WindowBlurRegion in SidebarRight.qml).
+    readonly property Item backgroundItem: sidebarRightBackground
+
     readonly property MprisPlayer activePlayer: MprisController.activePlayer
     readonly property var realPlayers: MprisController.players
     readonly property var meaningfulPlayers: {

--- a/dots/.config/quickshell/imi/modules/imi/verticalBar/VerticalBar.qml
+++ b/dots/.config/quickshell/imi/modules/imi/verticalBar/VerticalBar.qml
@@ -61,6 +61,27 @@ Scope {
                 mask: Region { item: hoverMaskRegion }
                 color: "transparent"
 
+                // Blur only the painted body shapes — same treatment as the
+                // horizontal bar (see Bar.qml for the full rationale). Pairs
+                // with rules.lua turning the whole-surface layerrule blur off
+                // for this namespace.
+                WindowBlurRegion {
+                    targetWindow: barRoot
+                    region: Region {
+                        Region {
+                            item: barContent.backgroundPainted ? barContent.backgroundItem : null
+                            radius: barContent.backgroundItem.radius
+                        }
+                        Region {
+                            item: barContent.centerPillPainted ? barContent.centerPillItem : null
+                            topLeftRadius: barContent.centerPillItem.topLeftRadius
+                            topRightRadius: barContent.centerPillItem.topRightRadius
+                            bottomLeftRadius: barContent.centerPillItem.bottomLeftRadius
+                            bottomRightRadius: barContent.centerPillItem.bottomRightRadius
+                        }
+                    }
+                }
+
                 anchors {
                     left: !Config.options.bar.bottom
                     right: Config.options.bar.bottom

--- a/dots/.config/quickshell/imi/modules/imi/verticalBar/VerticalBarContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/verticalBar/VerticalBarContent.qml
@@ -72,6 +72,17 @@ Item {
 
     property var screen: root.QsWindow.window?.screen
 
+    // The painted body shapes, exposed so the hosting window can scope its
+    // compositor blur region to them (see WindowBlurRegion in VerticalBar.qml).
+    // The "painted" flags mirror each shape's own color/visible condition: a
+    // blur region is a plain rect, so covering an unpainted (transparent)
+    // shape would frost the bare wallpaper behind it.
+    readonly property Item backgroundItem: barBackground
+    readonly property bool backgroundPainted: Config.options.bar.showBackground
+        && Config.options.bar.cornerStyle !== 2 && !root.isMaterial && !root.centerOnly
+    readonly property Item centerPillItem: centerPill
+    readonly property bool centerPillPainted: centerPill.visible
+
     // Optional soft drop shadow under the bar background (Config.options.bar.shadow).
     // Only rendered when the background itself is painted (mirrors barBackground's color condition).
     Loader {


### PR DESCRIPTION
Fixes #82.

> **Approach replaced** (branch force-pushed early on): the first version raised the sidebars' layerrule `ignore_alpha` to 0.6. Live testing showed the frost persisted on busy wallpapers; researching how DankMaterialShell renders crisp panel shadows led to a fundamentally better mechanism, which was then extended to every panel family at maintainer request.

## Problem
The sidebars — and equally the bar, vertical bar and dock — draw translucent drop shadows (`StyledRectangularShadow`) and rounding/elevation margins in the same layer surface as their body. Hyprland's catch-all `quickshell:.*` layerrule blurs the **whole surface**, shadow and margins included, leaving a frosted band along panel edges (obvious on busy wallpapers, subtle on dark ones).

## Fix (DMS-style blur region)
Scope the compositor blur to the painted body shapes only, via `ext_background_effect_manager_v1` (Hyprland ≥ 0.51; exposed by Quickshell as `BackgroundEffect.blurRegion`):

- **`modules/common/widgets/WindowBlurRegion.qml`** (new) — publishes a blur `Region` (item-tracked, radius-matched) on a panel window. Declarative binding plus a short settle-republish after map/resize, mirroring DankMaterialShell's `WindowBlur` "kick": a region committed mid-configure can be dropped compositor-side. Simple `regionItem` API for single-rect bodies; an overridable `region` property lets multi-rect bodies compose child `Region`s into a union.
- **Sidebars** (`ffdab66`) — region = the body rect each window's input `mask` already tracks (`SidebarRightContent` exposes its nested body via `backgroundItem`).
- **Bar** (`09043d8`) — composed region over the *painted* shapes: main background (Hug/Float styles) + center-only pill, each gated on the exact condition that paints it. A blur region is a plain rect, so unpainted/transparent shapes must stay out — covering them would frost bare wallpaper. `RoundCorner` decorators and islands/material pills are deliberately uncovered: opaque by default, they merely read as unblurred translucency under transparency mode.
- **Vertical bar + dock** (`d1e1dce`) — vertical bar mirrors the bar exactly (same exposed contract); the dock is a single rect gated on `dock.showBackground`.
- **`rules.lua`** — layerrule `blur = false` for all five namespaces (`sidebarLeft/Right`, `bar`, `verticalBar`, `dock`), so the region is the sole blur source.

Result: shadows and margins stay crisp on every wallpaper, while a translucent body (transparency mode, or #86's bar opacity) **keeps** its backdrop blur — no tradeoff. On compositors without the protocol the region is a harmless no-op and those panels are simply unblurred.

## Testing
- `luac -p` clean; `tests/run_tests.sh`: **200 passed, 0 failed**; qmllint: no errors on any touched file.
- **Verified live via screenshots on Hyprland 0.56**, per panel: sidebars (crisp shadow + frosted translucent body over terminal text), bar (before/after: frosted band under the Float-style bar gone), dock (wallpaper razor-sharp to the pill's rounded edge, no halo), vertical bar (terminal text crisp through the whole shadow strip).
- **Auto-merges cleanly with #86** (verified on the merged tree, re-checked after each commit); the combination gives a lowered-opacity bar a proper frosted-glass body instead of plain transparency.

_CHANGELOG/VERSION intentionally omitted — release notes land in the catch-all release PR._