### PR TITLE
feat(bar): adjustable bar background opacity (#83)

### DIFF
--- a/dots/.config/quickshell/imi/modules/common/Appearance.qml
+++ b/dots/.config/quickshell/imi/modules/common/Appearance.qml
@@ -126,6 +126,12 @@ Singleton {
         property color colLayer0Hover: ColorUtils.transparentize(ColorUtils.mix(colLayer0, colOnLayer0, 0.9, root.contentTransparency))
         property color colLayer0Active: ColorUtils.transparentize(ColorUtils.mix(colLayer0, colOnLayer0, 0.8, root.contentTransparency))
         property color colLayer0Border: ColorUtils.mix(root.m3colors.m3outlineVariant, colLayer0, 0.4)
+        // The bar's own background chrome (bar/pill fills, hug corners) thins
+        // colLayer0 by the user's bar opacity (Config.options.bar.backgroundOpacity,
+        // 1 = fully opaque = unchanged). Kept separate from colLayer0 so only the
+        // bar goes translucent, composing with — not overriding — the global
+        // transparency setting colLayer0 already carries.
+        property color colBarBackground: ColorUtils.transparentize(colLayer0, 1 - (Config?.options.bar.backgroundOpacity ?? 1))
         // Layer 1
         property color colLayer1Base: m3colors.m3surfaceContainerLow
         property color colLayer1: ColorUtils.solveOverlayColor(colLayer0Base, colLayer1Base, 1 - root.contentTransparency);

--- a/dots/.config/quickshell/imi/modules/common/Config.qml
+++ b/dots/.config/quickshell/imi/modules/common/Config.qml
@@ -878,6 +878,12 @@ Singleton {
                 property string borderless: "pills"
                 property string topLeftIcon: "spark" // Options: "distro" or any icon name in ~/.config/quickshell/imi/assets/icons
                 property bool showBackground: true
+                // Opacity of the bar's background chrome (bar/pill fills, hug
+                // corners), 0-1. 1 = fully opaque (unchanged). Multiplies the
+                // global appearance.transparency alpha rather than replacing it,
+                // so the two compose. Below the compositor's per-namespace
+                // ignore_alpha blur threshold it reads as plain transparency.
+                property real backgroundOpacity: 1.0
                 property bool verbose: true
                 property bool vertical: false
                 property JsonObject resources: JsonObject {

--- a/dots/.config/quickshell/imi/modules/imi/bar/Bar.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/Bar.qml
@@ -169,7 +169,7 @@ Scope {
                         visible: barContent.centerOnly && showBarBackground && Config.options.bar.cornerStyle === 0
                         x: barContent.centerPillX - implicitSize
                         implicitSize: Appearance.rounding.screenRounding
-                        color: Appearance.colors.colLayer0
+                        color: Appearance.colors.colBarBackground
                         corner: RoundCorner.CornerEnum.TopRight
 
                         states: State {
@@ -237,7 +237,7 @@ Scope {
                         visible: barContent.centerOnly && showBarBackground && Config.options.bar.cornerStyle === 0
                         x: barContent.centerPillX + barContent.centerPillWidth
                         implicitSize: Appearance.rounding.screenRounding
-                        color: Appearance.colors.colLayer0
+                        color: Appearance.colors.colBarBackground
                         corner: RoundCorner.CornerEnum.TopLeft
 
                         states: State {
@@ -297,7 +297,7 @@ Scope {
                                 }
 
                                 implicitSize: Appearance.rounding.screenRounding
-                                color: showBarBackground ? Appearance.colors.colLayer0 : "transparent"
+                                color: showBarBackground ? Appearance.colors.colBarBackground : "transparent"
 
                                 corner: RoundCorner.CornerEnum.TopLeft
                                 states: State {
@@ -316,7 +316,7 @@ Scope {
                                     bottom: Config.options.bar.bottom ? parent.bottom : undefined
                                 }
                                 implicitSize: Appearance.rounding.screenRounding
-                                color: showBarBackground ? Appearance.colors.colLayer0 : "transparent"
+                                color: showBarBackground ? Appearance.colors.colBarBackground : "transparent"
 
                                 corner: RoundCorner.CornerEnum.TopRight
                                 states: State {

--- a/dots/.config/quickshell/imi/modules/imi/bar/BarContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/BarContent.qml
@@ -103,7 +103,7 @@ Item {
         anchors.fill: parent
         anchors.margins: Config.options.bar.cornerStyle === 1 ? Appearance.sizes.hyprlandGapsOut : 0
         color: (!centerOnly && Config.options.bar.showBackground && Config.options.bar.cornerStyle !== 2 && !root.isMaterial) 
-            ? Appearance.colors.colLayer0 : "transparent"
+            ? Appearance.colors.colBarBackground : "transparent"
         radius: Config.options.bar.cornerStyle === 1 ? Appearance.rounding.windowRounding : 0
         border.width: (!centerOnly && Config.options.bar.cornerStyle === 1) ? 1 : 0
         border.color: Appearance.colors.colLayer0Border
@@ -130,7 +130,7 @@ Item {
         anchors.horizontalCenter: parent.horizontalCenter
         width: middleRow.implicitWidth + 10
         height: parent.height - (Config.options.bar.cornerStyle === 1 ? Appearance.sizes.hyprlandGapsOut * 2 : 0)
-        color: Appearance.colors.colLayer0
+        color: Appearance.colors.colBarBackground
         radius: Config.options.bar.cornerStyle === 1 ? Appearance.rounding.windowRounding : 0
         border.width: Config.options.bar.cornerStyle === 1 ? 1 : 0
         border.color: Appearance.colors.colLayer0Border
@@ -162,7 +162,7 @@ Item {
                 implicitWidth: leftMaterialRow.implicitWidth + 10
                 implicitHeight: leftMaterialRow.implicitHeight
                 radius: Appearance.rounding.full
-                color: Appearance.colors.colLayer0
+                color: Appearance.colors.colBarBackground
 
                 RowLayout {
                     id: leftMaterialRow
@@ -258,7 +258,7 @@ Item {
                 implicitWidth: centerMaterialRow.implicitWidth + 10
                 implicitHeight: centerMaterialRow.implicitHeight 
                 radius: Appearance.rounding.full
-                color: Appearance.colors.colLayer0
+                color: Appearance.colors.colBarBackground
 
                 RowLayout {
                     id: centerMaterialRow
@@ -354,7 +354,7 @@ Item {
                 implicitWidth: rightMaterialRow.implicitWidth + 10
                 implicitHeight: rightMaterialRow.implicitHeight 
                 radius: Appearance.rounding.full
-                color: Appearance.colors.colLayer0
+                color: Appearance.colors.colBarBackground
 
                 RowLayout {
                     id: rightMaterialRow

--- a/dots/.config/quickshell/imi/modules/imi/settings/pages/BarConfig.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/pages/BarConfig.qml
@@ -289,6 +289,18 @@ ContentPage {
                     checked: Config.options.bar.shadow
                     onCheckedChanged: { Config.options.bar.shadow = checked; }
                 }
+                ConfigSlider {
+                    text: Translation.tr("Background opacity")
+                    buttonIcon: "opacity"
+                    enabled: Config.options.bar.showBackground
+                    value: Config.options.bar.backgroundOpacity
+                    from: 0
+                    to: 1
+                    stopIndicatorValues: [1]
+                    onValueModified: {
+                        Config.options.bar.backgroundOpacity = newValue;
+                    }
+                }
                 ConfigSwitch {
                     buttonIcon: "cancel_presentation"
                     text: Translation.tr("Auto-dismiss popups on hide")

--- a/dots/.config/quickshell/imi/modules/imi/verticalBar/VerticalBar.qml
+++ b/dots/.config/quickshell/imi/modules/imi/verticalBar/VerticalBar.qml
@@ -90,7 +90,7 @@ Scope {
                         visible: barContent.centerOnly && showBarBackground && Config.options.bar.cornerStyle === 0
                         y: barContent.centerPillY - implicitSize
                         implicitSize: Appearance.rounding.screenRounding
-                        color: Appearance.colors.colLayer0
+                        color: Appearance.colors.colBarBackground
                         corner: RoundCorner.CornerEnum.BottomLeft
 
                         states: State {
@@ -118,7 +118,7 @@ Scope {
                         visible: barContent.centerOnly && showBarBackground && Config.options.bar.cornerStyle === 0
                         y: barContent.centerPillY + barContent.centerPillHeight
                         implicitSize: Appearance.rounding.screenRounding
-                        color: Appearance.colors.colLayer0
+                        color: Appearance.colors.colBarBackground
                         corner: RoundCorner.CornerEnum.TopLeft
 
                         states: State {
@@ -213,7 +213,7 @@ Scope {
                                 id: topCorner
                                 anchors { left: parent.left; right: parent.right; top: parent.top }
                                 implicitSize: Appearance.rounding.screenRounding
-                                color: showBarBackground ? Appearance.colors.colLayer0 : "transparent"
+                                color: showBarBackground ? Appearance.colors.colBarBackground : "transparent"
                                 corner: RoundCorner.CornerEnum.TopLeft
                                 states: State {
                                     name: "bottom"
@@ -229,7 +229,7 @@ Scope {
                                     right: Config.options.bar.bottom ? parent.right : undefined
                                 }
                                 implicitSize: Appearance.rounding.screenRounding
-                                color: showBarBackground ? Appearance.colors.colLayer0 : "transparent"
+                                color: showBarBackground ? Appearance.colors.colBarBackground : "transparent"
                                 corner: RoundCorner.CornerEnum.BottomLeft
                                 states: State {
                                     name: "bottom"

--- a/dots/.config/quickshell/imi/modules/imi/verticalBar/VerticalBarContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/verticalBar/VerticalBarContent.qml
@@ -90,7 +90,7 @@ Item {
             margins: Config.options.bar.cornerStyle === 1 ? Appearance.sizes.hyprlandGapsOut : 0
         }
         color: (Config.options.bar.showBackground && Config.options.bar.cornerStyle !== 2 && !root.isMaterial && !root.centerOnly)
-            ? Appearance.colors.colLayer0 : "transparent"
+            ? Appearance.colors.colBarBackground : "transparent"
         radius: Config.options.bar.cornerStyle === 1 ? Appearance.rounding.windowRounding : 0
         border.width: (!root.centerOnly && Config.options.bar.cornerStyle === 1) ? 1 : 0
         border.color: Appearance.colors.colLayer0Border
@@ -113,7 +113,7 @@ Item {
         anchors.verticalCenter: parent.verticalCenter
         height: middleCol.implicitHeight + 7
         width: parent.width - (Config.options.bar.cornerStyle === 1 ? Appearance.sizes.hyprlandGapsOut * 2 : 0)
-        color: Appearance.colors.colLayer0
+        color: Appearance.colors.colBarBackground
         radius: Config.options.bar.cornerStyle === 1 ? Appearance.rounding.windowRounding : 0
         border.width: Config.options.bar.cornerStyle === 1 ? 1 : 0
         border.color: Appearance.colors.colLayer0Border
@@ -144,7 +144,7 @@ Item {
                 implicitWidth: topMaterialCol.implicitWidth
                 implicitHeight: topMaterialCol.implicitHeight + 10
                 radius: Appearance.rounding.full
-                color: Appearance.colors.colLayer0
+                color: Appearance.colors.colBarBackground
 
                 ColumnLayout {
                     id: topMaterialCol
@@ -220,7 +220,7 @@ Item {
                 implicitWidth: centerMaterialCol.implicitWidth 
                 implicitHeight: centerMaterialCol.implicitHeight + 10
                 radius: Appearance.rounding.full
-                color: Appearance.colors.colLayer0
+                color: Appearance.colors.colBarBackground
 
                 ColumnLayout {
                     id: centerMaterialCol
@@ -297,7 +297,7 @@ Item {
                 implicitWidth: bottomMaterialCol.implicitWidth
                 implicitHeight: bottomMaterialCol.implicitHeight + 10 
                 radius: Appearance.rounding.full
-                color: Appearance.colors.colLayer0
+                color: Appearance.colors.colBarBackground
 
                 ColumnLayout {
                     id: bottomMaterialCol

--- a/dots/.config/quickshell/imi/tests/tst_config.qml
+++ b/dots/.config/quickshell/imi/tests/tst_config.qml
@@ -38,6 +38,11 @@ TestCase {
         compare(config.options.bar.divider.style, "rect")
         compare(config.options.bar.divider.spacing, 20)
 
+        // Bar background opacity must default to fully opaque so the out-of-box
+        // look is unchanged; Appearance.colBarBackground multiplies colLayer0 by
+        // this, and any value < 1 silently thins the whole bar chrome.
+        compare(config.options.bar.backgroundOpacity, 1.0)
+
         // Test other options
         compare(config.options.dock.enable, false)
         compare(config.options.osd.timeout, 1000)


### PR DESCRIPTION
Closes #83.

## What
Adds a first-class **`bar.backgroundOpacity`** setting (real, 0–1, default **1.0 = fully opaque**, so the out-of-box look is unchanged) with a Settings slider, for transparent/blurred setups.

## How
- `Config.qml` — `property real backgroundOpacity: 1.0` under `bar` (missing key falls back to the default; no migration needed).
- `Appearance.qml` — a derived `colBarBackground = transparentize(colLayer0, 1 - backgroundOpacity)`. At `1.0` it equals `colLayer0`. It *multiplies* `colLayer0` (which already carries the global `appearance.transparency` alpha) rather than setting an absolute alpha, so the two compose instead of fighting.
- `Bar.qml` / `BarContent.qml` / `VerticalBar.qml` / `VerticalBarContent.qml` — 18 bar-background / pill / hug-corner fills swapped `colLayer0 → colBarBackground` (horizontal + vertical bars, all four corner styles). `colLayer0Border` deliberately untouched.
- `settings/pages/BarConfig.qml` — a `ConfigSlider` (0–1) after "Bar shadow", gated `enabled: bar.showBackground`.
- `tests/tst_config.qml` — asserts the default stays `1.0`, so an accidental non-opaque default (which would silently thin the whole bar) fails the suite.

## Design decisions
- **Own `bar.` setting, not under `appearance.transparency`** — the global block thins *every* surface; the reporter wants the bar specifically. Matches sibling precedent (`dropShelf.backgroundOpacity`, `terminal.background.opacity`).
- **Independent of `transparency.enable`** but composes with it.
- **Scope = the bar's own background chrome only** (bar fill, center/material pills, hug corners). Widget pill fills stay on `colLayer1` so contents stay readable; a fully see-through bar is already available via Group style → none.
- **Blur:** at default `1.0` nothing changes. ~~At low opacity the surface falls below the bar namespace's compositor `ignore_alpha` blur threshold and reads as plain (unblurred) transparency.~~ **Updated:** with #85 merged (body-scoped blur regions), a lowered-opacity bar body gets a proper **frosted-glass** backdrop blur — verified live on the merged tree. Without #85, the pre-existing whole-surface blur behavior applies. Either way this PR is safe to merge in any order relative to #85 (auto-merge verified clean both ways).

## Testing
- `dots/.config/quickshell/imi/tests/run_tests.sh`: 200 passed (import lint, spacing lint, shared-widget contracts, new config-default assertion).
- **Verified live**: slider works across corner styles; bar/pills go translucent while icons/text stay crisp.

_CHANGELOG/VERSION intentionally omitted — release notes land in the catch-all release PR._