### PR TITLE
Fall back to the static image when the WE renderer fails

### DIFF
--- a/dots/.config/quickshell/imi/modules/imi/background/Background.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/Background.qml
@@ -192,10 +192,20 @@ Variants {
         // wallpaper for them. Case-insensitive: the scanner emits "Web".
         property bool weActive: bgRoot.weProjectPath !== "" && !bgRoot.wallpaperSafetyTriggered
             && (Config.options.wallpaperSelector.wallpaperEngine.activeType ?? "").toLowerCase() !== "web"
+        // The renderer can also give up on a project it did load: it reports
+        // `failed` when the WE thread could not start, or when its render targets
+        // came back INCOMPLETE - a scene whose source texture plus per-element
+        // composite buffers do not fit in VRAM at screen size. Nothing is ever
+        // drawn into the surface in that state, so leaving it on screen is a
+        // black desktop; degrade to the static image exactly as `web` does above.
+        //
+        // Read defensively: `failed` only exists on newer qs-wallpaperengine
+        // builds, and on an older one the lookup is undefined, not an error.
+        property bool weFailed: (weLoader.item?.failed ?? false)
         // Only hide the static-image layers once the WE surface has actually
         // loaded. If the module is missing (stock binary) the Loader errors and
         // weShown stays false, so the static wallpaper still shows.
-        property bool weShown: weLoader.status === Loader.Ready
+        property bool weShown: weLoader.status === Loader.Ready && !bgRoot.weFailed
 
         // Lock wallpaper peel (WE desktop + a distinct lock image). Rendered here
         // on the background - below the desktop widgets, which must stay visible on


### PR DESCRIPTION
Shell side of XephyLon/qs-wallpaperengine#3. **Do not merge before that one lands and is built** — it reads a `failed` property that exists in no shipped binary yet.

## Why

The Wallpaper Engine renderer can give up on a project it did load: the WE thread failing to start, or its render targets coming back `INCOMPLETE` when a scene's textures plus per-element composite buffers do not fit in VRAM at screen size. Nothing is ever drawn into the surface in that state, so leaving it on screen is a black desktop with a clean log and `rendered == true`.

This degrades to the static image exactly as `web` wallpapers already do, reusing the existing `weShown` lever so the static layers take over unchanged:

```qml
+ property bool weFailed: (weLoader.item?.failed ?? false)
- property bool weShown: weLoader.status === Loader.Ready
+ property bool weShown: weLoader.status === Loader.Ready && !bgRoot.weFailed
```

## Safety

The lookup is optional-chained, so on any current build `failed` is `undefined`, `weFailed` is `false`, and behaviour is byte-for-byte what it is today. It is inert until the paired build lands — which is why it is a branch rather than main, not because it is risky to run.

Untested end to end: the C++ that sets `failed` is written but not compiled, so the propagation into QML has never been exercised.