### PR TITLE
fix(osd,overview): body-scoped blur for the last unported panels

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -419,6 +419,20 @@ Two non-obvious behaviors have bitten this codebase before and are worth knowing
   *not* blurred, they just show plain unblurred transparency. This is why picking the right
   `Appearance.colors.colLayer*` token matters for a floating popup, not just picking "a" transparent
   one - see the Design language section below.
+- **Blur is scoped per-panel now, and scoping it takes an edit in two different files.** The panels
+  ported so far - bar, vertical bar, dock, both sidebars, the OSDs and the overview - each turn the
+  catch-all whole-surface `blur` *off* for their namespace in
+  `~/.config/hypr/hyprland/rules.lua` and publish a `WindowBlurRegion`
+  (`modules/common/widgets/WindowBlurRegion.qml`) over just its painted body instead, so the
+  compositor never blurs the shadow (#82, #89). A blur region is a plain rounded rect and knows
+  nothing about `visible`, `opacity`, or a parent's `clip`, so each sub-region has to be gated on
+  exactly the condition that *paints* its shape - covering an unpainted one frosts bare wallpaper -
+  and `Appearance.rounding.full` (9999) is a "round me completely" sentinel that must be resolved to
+  `Math.round(item.height / 2)` before it goes into a region. A body reached through a `Loader` is
+  exposed to the window as a `backgroundItem`/`backgroundPainted` pair on the content component
+  rather than reached into. Both halves are silent when only one lands: a region without the layer
+  rule changes nothing at all, and the layer rule without a region leaves that panel with no blur
+  whatsoever. `tests/lint_blur_region_pairing.py` pins the two together.
 - **The region selector intentionally takes exclusive focus.** Dismissable panels normally close
   when `GlobalFocusGrab` is cleared, but the selector first sets
   `GlobalStates.settingsHeldForRegionSelector` so Settings can remain visible in screenshots without

--- a/dots/.config/hypr/hyprland/rules.lua
+++ b/dots/.config/hypr/hyprland/rules.lua
@@ -179,6 +179,12 @@ hl.layer_rule({ match = { namespace = "quickshell:sidebarLeft" }, blur = false})
 hl.layer_rule({ match = { namespace = "quickshell:bar" }, blur = false})
 hl.layer_rule({ match = { namespace = "quickshell:verticalBar" }, blur = false})
 hl.layer_rule({ match = { namespace = "quickshell:dock" }, blur = false})
+-- And the transient surfaces, which were the last panels still frosting their
+-- own shadow (#89): every OSD indicator sits in an elevation margin, and the
+-- overview surface carries two shadowed cards (the search widget and the
+-- overview itself). See WindowBlurRegion in OnScreenDisplay.qml / Overview.qml.
+hl.layer_rule({ match = { namespace = "quickshell:onScreenDisplay" }, blur = false})
+hl.layer_rule({ match = { namespace = "quickshell:overview" }, blur = false})
 hl.layer_rule({ match = { namespace = "quickshell:verticalBar" }, animation = "slide"})
 hl.layer_rule({ match = { namespace = "quickshell:osk" }, order = -1})
 -- Quickshell: waffles

--- a/dots/.config/quickshell/imi/modules/imi/onScreenDisplay/OnScreenDisplay.qml
+++ b/dots/.config/quickshell/imi/modules/imi/onScreenDisplay/OnScreenDisplay.qml
@@ -178,6 +178,23 @@ Scope {
                 item: osdValuesWrapper
             }
 
+            // Blur only the painted indicator body. Every indicator reserves an
+            // elevation margin inside this surface and the text ones draw their
+            // drop shadow into it, which the catch-all whole-surface blur frosted
+            // into a muddy fringe (#89, the deferred half of #82; the caps lock
+            // OSD is the one apollo79 reported). Same treatment as the
+            // bar/sidebars/dock; pairs with rules.lua turning the layerrule
+            // blur off for this namespace. The protection message is left out:
+            // its m3error fill is a flat opaque hex, so a backdrop blur behind
+            // it can never show, and it keeps its row in the column even while
+            // hidden by opacity alone - covering it would be a no-op that only
+            // risks frosting bare wallpaper if that gate were ever wrong.
+            WindowBlurRegion {
+                targetWindow: osdRoot
+                regionItem: osdIndicatorLoader.item?.backgroundItem ?? null
+                regionRadius: osdIndicatorLoader.item?.backgroundRadius ?? 0
+            }
+
             exclusionMode: ExclusionMode.Ignore
             exclusiveZone: 0
             margins {

--- a/dots/.config/quickshell/imi/modules/imi/onScreenDisplay/OsdTextIndicator.qml
+++ b/dots/.config/quickshell/imi/modules/imi/onScreenDisplay/OsdTextIndicator.qml
@@ -9,6 +9,14 @@ Item {
     required property string name
     required property string value
 
+    // The painted body, exposed so the OSD window can scope its compositor blur
+    // region to it (see WindowBlurRegion in OnScreenDisplay.qml). The radius is
+    // resolved here rather than at the call site because Appearance.rounding.full
+    // is the "round me completely" sentinel (9999) and not a length - a region is
+    // a plain rounded rect and would otherwise be squared off against the pill.
+    readonly property Item backgroundItem: indicator
+    readonly property real backgroundRadius: Math.round(indicator.height / 2)
+
     implicitWidth: Appearance.sizes.osdWidth + 4 * Appearance.sizes.elevationMargin
     implicitHeight: indicator.implicitHeight + 2 * Appearance.sizes.elevationMargin
 

--- a/dots/.config/quickshell/imi/modules/imi/onScreenDisplay/OsdValueIndicator.qml
+++ b/dots/.config/quickshell/imi/modules/imi/onScreenDisplay/OsdValueIndicator.qml
@@ -14,6 +14,12 @@ Item {
     property alias from: valueProgressBar.from
     property alias to: valueProgressBar.to
 
+    // Same contract as OsdTextIndicator: the painted body plus a radius with the
+    // Appearance.rounding.full sentinel already resolved, so OnScreenDisplay.qml
+    // can build one blur region without caring which indicator type is loaded.
+    readonly property Item backgroundItem: valueIndicator
+    readonly property real backgroundRadius: Math.round(valueIndicator.height / 2)
+
     implicitWidth: Appearance.sizes.osdWidth + 4 * Appearance.sizes.elevationMargin + 80
     implicitHeight: valueIndicator.implicitHeight + 2 * Appearance.sizes.elevationMargin
 

--- a/dots/.config/quickshell/imi/modules/imi/overview/NiriOverview.qml
+++ b/dots/.config/quickshell/imi/modules/imi/overview/NiriOverview.qml
@@ -46,6 +46,17 @@ Item {
     implicitWidth: monitorW
     implicitHeight: monitorH
 
+    // Counterpart to OverviewWidget's blur-region contract (see WindowBlurRegion
+    // in Overview.qml). This style paints no single body card - it fills the
+    // monitor with workspace rows inside a clipping Flickable, and a blur region
+    // is an unclipped plain rect, so there is nothing here the compositor can be
+    // pointed at without frosting the wallpaper in the gaps. Its rows keep their
+    // translucency, just unblurred, the same trade the bar's corner decorators
+    // and material pills already make.
+    readonly property Item backgroundItem: null
+    readonly property bool backgroundPainted: false
+    readonly property real backgroundRadius: 0
+
     onActiveWorkspaceIdChanged: scrollTimer.restart()
 
     Timer {

--- a/dots/.config/quickshell/imi/modules/imi/overview/Overview.qml
+++ b/dots/.config/quickshell/imi/modules/imi/overview/Overview.qml
@@ -31,6 +31,26 @@ Scope {
             item: GlobalStates.overviewOpen ? columnLayout : null
         }
 
+        // Blur only the painted body cards. This one surface carries two of
+        // them - the search widget and the overview below it - and both draw a
+        // drop shadow in the elevation margin around themselves, which the
+        // catch-all whole-surface blur frosted (#89, the deferred half of #82).
+        // Pairs with rules.lua turning the layerrule blur off for this
+        // namespace. The niri style contributes nothing (see NiriOverview.qml).
+        WindowBlurRegion {
+            targetWindow: panelWindow
+            region: Region {
+                Region {
+                    item: GlobalStates.overviewOpen ? searchWidget.backgroundItem : null
+                    radius: searchWidget.backgroundRadius
+                }
+                Region {
+                    item: (overviewLoader.item?.backgroundPainted ?? false) ? overviewLoader.item.backgroundItem : null
+                    radius: overviewLoader.item?.backgroundRadius ?? 0
+                }
+            }
+        }
+
         anchors {
             top: true
             bottom: true

--- a/dots/.config/quickshell/imi/modules/imi/overview/OverviewWidget.qml
+++ b/dots/.config/quickshell/imi/modules/imi/overview/OverviewWidget.qml
@@ -50,6 +50,14 @@ Item {
     implicitWidth: overviewBackground.implicitWidth + Appearance.sizes.elevationMargin * 2
     implicitHeight: overviewBackground.implicitHeight + Appearance.sizes.elevationMargin * 2
 
+    // The painted body, exposed so the overview window can scope its compositor
+    // blur region to it (see WindowBlurRegion in Overview.qml). The overview is
+    // hidden outright while a search is being typed, and a region over a hidden
+    // card would frost bare wallpaper - hence the "painted" flag.
+    readonly property Item backgroundItem: overviewBackground
+    readonly property bool backgroundPainted: root.visible
+    readonly property real backgroundRadius: overviewBackground.radius
+
     property Component windowComponent: OverviewWindow {}
     property list<OverviewWindow> windowWidgets: []
     

--- a/dots/.config/quickshell/imi/modules/imi/overview/SearchWidget.qml
+++ b/dots/.config/quickshell/imi/modules/imi/overview/SearchWidget.qml
@@ -25,6 +25,14 @@ Item { // Wrapper
     readonly property bool clipboardMode: root.searchingText.startsWith(Config.options.search.prefix.clipboard)
     readonly property bool clipboardSearching: root.clipboardMode && root.searchingText.length > Config.options.search.prefix.clipboard.length
     readonly property bool clearBtnHasFocus: clearResultsBtn.activeFocus || clearAllBtn.activeFocus
+
+    // The painted body, exposed so the overview window can scope its compositor
+    // blur region to it (see WindowBlurRegion in Overview.qml). Unconditionally
+    // painted, so there is no companion "painted" flag - only the window's own
+    // open state gates it.
+    readonly property Item backgroundItem: searchWidgetContent
+    readonly property real backgroundRadius: searchWidgetContent.radius
+
     implicitWidth: searchWidgetContent.implicitWidth + Appearance.sizes.elevationMargin * 2
     implicitHeight: searchWidgetContent.implicitHeight + searchBar.verticalPadding * 2 + Appearance.sizes.elevationMargin * 2
 

--- a/dots/.config/quickshell/imi/tests/lint_blur_region_pairing.py
+++ b/dots/.config/quickshell/imi/tests/lint_blur_region_pairing.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Fail if a panel's body-scoped blur and its Hyprland layer rule disagree.
+
+Scoping a panel's compositor blur to its painted body takes two edits in two
+different files, and either one alone is broken in its own way:
+
+  - `WindowBlurRegion` in the QML without `blur = false` in `rules.lua` leaves
+    the catch-all whole-surface blur running, so the drop shadow keeps getting
+    frosted (#82, #89) and the region changes nothing visible. The fix looks
+    applied and isn't.
+  - `blur = false` in `rules.lua` without a region in the QML is worse: the
+    panel loses blur entirely rather than gaining a crisp shadow, and nothing
+    errors - it just renders as flat unblurred transparency.
+
+Neither half announces itself at runtime, and the QML suite can't see either,
+so pin the pairing statically. This is the same two-sidedness as the
+Config-schema/settings-page and validator/renderer pairs in AGENT.md: a change
+to one side isn't done until the other side matches.
+"""
+import re
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+RULES = ROOT.parents[1] / "hypr/hyprland/rules.lua"
+MODULES = ROOT / "modules"
+
+# The widget's own definition, which names itself without instantiating one.
+WIDGET_DEFINITION = MODULES / "common/widgets/WindowBlurRegion.qml"
+
+BLUR_DISABLED = re.compile(
+    r'namespace\s*=\s*"([^"]+)"[^}]*}\s*,\s*blur\s*=\s*false')
+PUBLISHES_REGION = re.compile(r'\bWindowBlurRegion\s*\{')
+DECLARES_NAMESPACE = re.compile(r'WlrLayershell\.namespace:\s*"([^"]+)"')
+
+
+def namespaces_with_blur_disabled():
+    return {m.group(1) for m in BLUR_DISABLED.finditer(RULES.read_text())}
+
+
+def namespaces_publishing_a_region():
+    found = {}
+    for path in sorted(MODULES.rglob("*.qml")):
+        if path == WIDGET_DEFINITION:
+            continue
+        text = path.read_text(errors="ignore")
+        if not PUBLISHES_REGION.search(text):
+            continue
+        rel = str(path.relative_to(ROOT))
+        for match in DECLARES_NAMESPACE.finditer(text):
+            found.setdefault(match.group(1), rel)
+        if not DECLARES_NAMESPACE.search(text):
+            found.setdefault(f"<no namespace in {rel}>", rel)
+    return found
+
+
+class BlurRegionPairingLint(unittest.TestCase):
+    def setUp(self):
+        self.disabled = namespaces_with_blur_disabled()
+        self.publishers = namespaces_publishing_a_region()
+
+    def test_every_published_region_has_its_layerrule_blur_turned_off(self):
+        offenders = sorted(
+            f"{ns} ({self.publishers[ns]}) publishes a WindowBlurRegion, but "
+            f'rules.lua never sets blur = false for it'
+            for ns in self.publishers if ns not in self.disabled)
+        self.assertEqual(offenders, [], "\n".join(
+            ["the whole-surface blur is still on, so the region fixes nothing:"]
+            + offenders))
+
+    def test_every_disabled_namespace_publishes_a_region(self):
+        offenders = sorted(
+            f"{ns} has blur = false in rules.lua, but no QML under modules/ "
+            f"publishes a WindowBlurRegion for it"
+            for ns in self.disabled if ns not in self.publishers)
+        self.assertEqual(offenders, [], "\n".join(
+            ["these panels have no blur at all, not body-scoped blur:"]
+            + offenders))
+
+    def test_the_pairing_is_not_vacuous(self):
+        """Guards the lint itself: both regexes match real source today, so a
+        reformat that breaks either one fails here instead of passing silently
+        by finding nothing on both sides."""
+        self.assertTrue(RULES.is_file(), f"{RULES} is missing")
+        self.assertTrue(self.disabled,
+                        "no namespace in rules.lua matched the blur = false pattern")
+        self.assertTrue(self.publishers,
+                        "no QML under modules/ matched the WindowBlurRegion pattern")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -105,6 +105,14 @@ if ! python3 "$SCRIPT_DIR/lint_plugin_processes.py"; then
     exit 1
 fi
 
+# Static lint: a body-scoped blur region and its `blur = false` layer rule live
+# in two different files, and either half alone renders wrong without erroring.
+echo "Running blur region pairing lint..."
+if ! python3 "$SCRIPT_DIR/lint_blur_region_pairing.py"; then
+    echo "Blur region pairing lint failed."
+    exit 1
+fi
+
 echo "Running expandable panel contract tests..."
 if ! python3 "$SCRIPT_DIR/test_expandable_panel.py"; then
     echo "Expandable panel contract tests failed."


### PR DESCRIPTION
Closes #89.

## Describe your changes

The OSDs, the search bar and the overview menu were the only panels left frosting their own drop shadow. This ports them the same treatment as `7d93d0313` (sidebars), `d9a1afbfc` (bar) and `8fefa09e0` (verticalBar, dock): publish a `WindowBlurRegion` over just the painted body and turn the whole-surface layerrule blur off for the namespace, so the translucent shadow in the elevation margin sits outside the region and the compositor never blurs it.

**OSD.** The body arrives through a `Loader` that swaps between eight indicators across two base types, so `OsdTextIndicator` and `OsdValueIndicator` each expose the same `backgroundItem`/`backgroundRadius` pair and the window builds one region without caring which is loaded. The radius is resolved in the indicator rather than at the call site because both bodies use `Appearance.rounding.full` — the 9999 "round me completely" sentinel, not a length, which a region would otherwise square off against the painted pill.

**Overview.** One surface carrying two shadowed cards, so its region is the union of the search widget's background and the overview's. The overview half gates on `backgroundPainted` rather than on the loader having an item: while a search is being typed the loader stays active and only the card's `visible` goes false, and a region over the hidden card would frost bare wallpaper directly under the expanded results.

**Deliberately left out**, both because a blur region behind an opaque fill is invisible: the OSD's audio-protection message (a flat `m3error` hex) and, inside the overview, everything already contained by a regioned card.

The "Niri Like" overview style contributes nothing — it paints no body card, and its workspace rows live in a clipping `Flickable` while a region is an unclipped plain rect, so pointing the compositor at them would frost the wallpaper in the gaps. Under transparency mode those rows therefore lose the backdrop blur they have today. Layer rules are per-namespace and cannot be made style-conditional; this is the same trade `d9a1afbfc` already made for the bar's corner decorators and material pills.

**New lint.** The two halves of this fix live in different files and neither errors when it lands alone: a region without the layer rule changes nothing at all, and the layer rule without a region leaves that panel with no blur whatsoever. `tests/lint_blur_region_pairing.py` pins them together in both directions; it was checked against a deliberately broken half of each, and confirmed green again after. Wired into `run_tests.sh`, plus an `AGENT.md` gotcha entry.

## Is it ready? Questions/feedback needed?

Ready to review, but **not yet seen rendering** — this was developed in a container with no Hyprland session. All ten runnable lints are green (the QML suite needs `qmltestrunner`, which isn't available there), and the branch was verified to apply cleanly onto `72058b9c` with the suite still green. Per CONTRIBUTING's live-verification rule this still wants a real look before merge, particularly:

- the caps lock OSD, which is the surface apollo79 reported in #82;
- the overview and search bar under transparency mode;
- the "Niri Like" overview style, which is the one place this trades blur away.

Two things noticed while working that are **out of scope here** and probably want their own issues:

- `OsdValueIndicator` draws no `StyledRectangularShadow` at all, unlike `OsdTextIndicator` — so volume, brightness and gamma render without the drop shadow the text OSDs get. Looks like an oversight rather than intent, but adding one is a visual change beyond #89.
- Still unported for the same defect: `quickshell:cheatsheet`, `quickshell:osk` and `quickshell:wallpaperSelector`. (`mediaControls` has `ignore_alpha = 1` and `dropshelf`'s shadow target fills its whole surface, so neither has the problem.)