### PR TITLE
Make the WE prebuilt installer tests actually run, and fix the dead skip path they were written to catch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,17 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y qt6-declarative-dev qml6-module-qttest qml6-module-qtquick qml6-module-qtqml qml6-module-qtquick-controls qml6-module-qtquick-layouts qml6-module-qtqml-workerscript qml6-module-qtquick-window
-      
+
+      # zstd builds the fixture release tarballs in
+      # test_wallpaperengine_prebuilt.py and extracts them in the installer under
+      # test. It is preinstalled on ubuntu-latest, so this is belt-and-braces -
+      # but that file spent its whole life reporting success without running
+      # anything, and it now refuses to pass when the tool is absent rather than
+      # quietly covering nothing. Naming the dependency keeps a future runner
+      # image change from turning that refusal into a mystery red build.
+      - name: Install release-fixture tooling
+        run: sudo apt-get install -y zstd
+
       - name: Run Tests
         env:
           QT_QPA_PLATFORM: offscreen

--- a/dots/.config/quickshell/imi/tests/test_wallpaperengine_prebuilt.py
+++ b/dots/.config/quickshell/imi/tests/test_wallpaperengine_prebuilt.py
@@ -207,6 +207,27 @@ class WallpaperEnginePrebuiltTest(unittest.TestCase):
         self.assertTrue(pathlib.Path(lib).is_dir(),
                         f"stamp field 3 is not a directory on its own: {lib!r}")
 
+    def test_a_stamp_naming_a_missing_binary_does_not_skip(self):
+        # up_to_date tests `-x` on the recorded binary because a matching ref
+        # does not prove the build output survived: a cleared cache dir, a
+        # pruned tmpfs or a manual rm all leave a current-looking stamp pointing
+        # at nothing. Skip on that and the wrapper is rewritten to exec a file
+        # that is not there, so the install reports success and the breakage
+        # surfaces later, at shell start. Deleting the `-x` line passed every
+        # other case in this file.
+        make_release(self.rel)
+        self.assertEqual(self.run_installer().returncode, 0)
+        binary = pathlib.Path(self.stamp.read_text().split()[1])
+        self.assertTrue(binary.exists(), "nothing recorded to delete")
+        binary.unlink()
+        # The fixture stays put, unlike the skip tests above: this run is
+        # *supposed* to reinstall, so it needs something to reinstall from.
+        r = self.run_installer()
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertNotIn("skipping", self.out(r),
+                         "stamp ref matched but its binary was gone, and the install skipped anyway")
+        self.assertTrue(binary.exists(), "the missing binary was not reinstalled")
+
     def test_skip_path_still_refreshes_the_wrapper(self):
         # The skip guards the expensive fetch/build, NOT the wrapper. A
         # wrapper-only fix has to reach an existing install, and once did not:

--- a/dots/.config/quickshell/imi/tests/test_wallpaperengine_prebuilt.py
+++ b/dots/.config/quickshell/imi/tests/test_wallpaperengine_prebuilt.py
@@ -107,6 +107,18 @@ class WallpaperEnginePrebuiltTest(unittest.TestCase):
         return subprocess.run(["bash", str(SH)], env=self.env(**extra),
                               capture_output=True, text=True, timeout=300)
 
+    def fake_pacman(self, qt_version):
+        # The host-Qt gate reads `pacman -Q qt6-base`. Off Arch there is no
+        # pacman, host_qt comes back empty and the whole comparison
+        # short-circuits - so without this stub that gate is unreachable and any
+        # test claiming to cover it would be passing vacuously.
+        bindir = self.tmp / "fakebin"
+        bindir.mkdir(exist_ok=True)
+        p = bindir / "pacman"
+        p.write_text(f'#!/bin/sh\n[ "$1" = "-Q" ] && echo "qt6-base {qt_version}"\n')
+        p.chmod(0o755)
+        return str(bindir) + os.pathsep + os.environ.get("PATH", "")
+
     @staticmethod
     def out(r):
         return (r.stdout + r.stderr).lower()
@@ -142,6 +154,26 @@ class WallpaperEnginePrebuiltTest(unittest.TestCase):
         self.assertNotEqual(r.returncode, 0)
         self.assertIn("smoke", self.out(r))
         self.assertFalse((self.prefix / "bin" / "quickshell").exists())
+
+    def test_host_qt_older_than_build_qt_falls_back(self):
+        # A prebuilt linked against a newer Qt than the host has will not load,
+        # so the manifest's qt_min has to decline the binary before the smoke
+        # test does. WE_SKIP_OPT_CHECK is left on so the only thing that can
+        # reject this release is the version comparison.
+        make_release(self.rel, qt_min="6.9.0-1")
+        r = self.run_installer(PATH=self.fake_pacman("6.0.0-1"))
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn("qt", self.out(r))
+        self.assertFalse((self.prefix / "bin" / "quickshell").exists())
+
+    def test_host_qt_new_enough_installs(self):
+        # The other side of the same gate: an equal-or-newer host Qt must NOT be
+        # rejected. Without this, a version check that refused everything would
+        # still satisfy the test above.
+        make_release(self.rel, qt_min="6.0.0-1")
+        r = self.run_installer(PATH=self.fake_pacman("6.9.0-1"))
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertTrue((self.prefix / "bin" / "quickshell").exists())
 
     def test_second_run_skips_when_up_to_date(self):
         make_release(self.rel)

--- a/dots/.config/quickshell/imi/tests/test_wallpaperengine_prebuilt.py
+++ b/dots/.config/quickshell/imi/tests/test_wallpaperengine_prebuilt.py
@@ -1,12 +1,29 @@
+#!/usr/bin/env python3
 # test_wallpaperengine_prebuilt.py — drives 4.wallpaperengine.sh's try_prebuilt
-# in isolation against a local fixture "release" dir (WE_PREBUILT_DIR), with a
-# fake quickshell binary so the smoke test can pass without real Qt.
-import os, subprocess, tempfile, hashlib, json, shutil, pathlib
+# and its stamp/skip logic in isolation against a local fixture "release" dir
+# (WE_PREBUILT_DIR), with a fake quickshell binary so the smoke test can pass
+# without real Qt.
+#
+# unittest rather than pytest, and NOT bare `def test_*` functions: run_tests.sh
+# invokes every Python check as `python3 <file>`, so a module of module-level
+# test functions defines them, runs nothing and exits 0. This file shipped in
+# that shape and was a silent no-op for its whole life (#91) - it never once
+# executed, which is how a dead `up_to_date` skip path reached users.
+import hashlib
+import json
+import os
+import pathlib
+import shutil
+import subprocess
+import tempfile
+import unittest
+
 # 4.wallpaperengine.sh lives at <repo>/sdata/subcmd-install/4.wallpaperengine.sh
 ROOT = pathlib.Path(__file__).resolve()
 while not (ROOT / "sdata").exists():
     ROOT = ROOT.parent
 SH = ROOT / "sdata" / "subcmd-install" / "4.wallpaperengine.sh"
+
 
 def make_release(dirpath, tag="v0.0-test", qt_min="6.0.0-1", manifest_arch="x86_64",
                  tamper=False, fake_exits=0):
@@ -16,119 +33,205 @@ def make_release(dirpath, tag="v0.0-test", qt_min="6.0.0-1", manifest_arch="x86_
     # independently of the filename.
     dirpath = pathlib.Path(dirpath)
     stage = pathlib.Path(tempfile.mkdtemp())
-    (stage/"bin").mkdir(); (stage/"lib").mkdir()
-    qs = stage/"bin"/"quickshell"
-    qs.write_text(f"#!/bin/sh\nexit {fake_exits}\n"); qs.chmod(0o755)
-    (stage/"lib"/"liblinux-wallpaperengine-lib.so").write_text("x")
-    tb = dirpath/f"qs-wallpaperengine-{tag}-x86_64.tar.zst"
-    # zstd via tar
-    subprocess.run(["tar","--use-compress-program=zstd","-C",str(stage),
-                    "-cf",str(tb),"bin","lib"], check=True)
+    (stage / "bin").mkdir()
+    (stage / "lib").mkdir()
+    qs = stage / "bin" / "quickshell"
+    qs.write_text(f"#!/bin/sh\nexit {fake_exits}\n")
+    qs.chmod(0o755)
+    (stage / "lib" / "liblinux-wallpaperengine-lib.so").write_text("x")
+    tb = dirpath / f"qs-wallpaperengine-{tag}-x86_64.tar.zst"
+    subprocess.run(["tar", "--use-compress-program=zstd", "-C", str(stage),
+                    "-cf", str(tb), "bin", "lib"], check=True)
     if tamper:
-        with open(tb,"ab") as f: f.write(b"junk")
-    (dirpath/"manifest.json").write_text(json.dumps(
-        {"schema":1,"version":tag,"commit":"x","qt_min":qt_min,"arch":manifest_arch,
-         "built_at":"t","files":["bin/quickshell","lib/liblinux-wallpaperengine-lib.so"]}))
-    # SHA256SUMS computed over the ORIGINAL (pre-tamper is wrong on purpose when tamper=True)
+        with open(tb, "ab") as f:
+            f.write(b"junk")
+    (dirpath / "manifest.json").write_text(json.dumps(
+        {"schema": 1, "version": tag, "commit": "x", "qt_min": qt_min, "arch": manifest_arch,
+         "built_at": "t", "files": ["bin/quickshell", "lib/liblinux-wallpaperengine-lib.so"]}))
+
     def sh(p):
         return hashlib.sha256(pathlib.Path(p).read_bytes()).hexdigest()
-    # deliberately hash the tarball as-it-should-be (re-pack clean copy for the sum)
-    clean = dirpath/"_clean.tar.zst"
-    subprocess.run(["tar","--use-compress-program=zstd","-C",str(stage),
-                    "-cf",str(clean),"bin","lib"], check=True)
-    sums = f"{sh(clean)}  {tb.name}\n{sh(dirpath/'manifest.json')}  manifest.json\n"
-    (dirpath/"SHA256SUMS").write_text(sums)
+
+    # SHA256SUMS is computed over a CLEAN re-pack, so a tampered tarball is
+    # exactly a checksum mismatch and nothing else.
+    clean = dirpath / "_clean.tar.zst"
+    subprocess.run(["tar", "--use-compress-program=zstd", "-C", str(stage),
+                    "-cf", str(clean), "bin", "lib"], check=True)
+    sums = f"{sh(clean)}  {tb.name}\n{sh(dirpath / 'manifest.json')}  manifest.json\n"
+    (dirpath / "SHA256SUMS").write_text(sums)
     clean.unlink()
     shutil.rmtree(stage)
 
-def run(env_extra):
-    env = dict(os.environ)
-    env.update({"INSTALL_WE":"1","WE_REF":"v0.0-test"})
-    env.setdefault("WE_STAMP_FILE", env_extra.get("WE_STAMP_FILE", "/dev/null"))
-    env.update(env_extra)
-    # WE_INSTALL_PREFIX redirects the wrapper install away from /usr/local/bin
-    return subprocess.run(["bash", str(SH)], env=env, capture_output=True, text=True)
 
-def test_prebuilt_happy_path(tmp_path):
-    rel = tmp_path/"rel"; rel.mkdir()
-    make_release(rel)
-    prefix = tmp_path/"prefix"; prefix.mkdir()
-    cache = tmp_path/"cache"
-    r = run({"WE_PREBUILT_DIR":str(rel), "WE_INSTALL_PREFIX":str(prefix),
-             "BUILD_DIR":str(cache/"build"), "WE_SKIP_OPT_CHECK":"1"})
-    assert r.returncode == 0, r.stderr
-    assert (prefix/"bin"/"quickshell").exists(), "wrapper not installed"
-    assert "prebuilt" in (r.stdout+r.stderr).lower()
+class WallpaperEnginePrebuiltTest(unittest.TestCase):
+    # Every WE_* the script reads is pinned per-test, so a developer who happens
+    # to have WE_FORCE_REBUILD or WE_STAMP_FILE exported cannot change what these
+    # assert. PREBUILT_ROOT in particular used to default to the real
+    # ~/.cache/immaterial-impulse, which meant running the suite wrote into the
+    # user's actual install cache and let one test's extracted tree satisfy the
+    # next test's -x check.
+    def setUp(self):
+        self.tmp = pathlib.Path(tempfile.mkdtemp())
+        self.rel = self.tmp / "rel"
+        self.rel.mkdir()
+        self.prefix = self.tmp / "prefix"
+        self.prefix.mkdir()
+        self.stamp = self.tmp / "stamp"
 
-def test_tamper_falls_back(tmp_path):
-    rel = tmp_path/"rel"; rel.mkdir()
-    make_release(rel, tamper=True)
-    r = run({"WE_PREBUILT_DIR":str(rel), "WE_INSTALL_PREFIX":str(tmp_path/"p"),
-             "BUILD_DIR":str(tmp_path/"b"), "WE_NO_SOURCE_FALLBACK":"1"})
-    # fallback disabled for the test => nonzero, and it must NOT have installed
-    assert r.returncode != 0
-    assert "checksum" in (r.stdout+r.stderr).lower()
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
 
-def test_arch_mismatch_falls_back(tmp_path):
-    rel = tmp_path/"rel"; rel.mkdir()
-    make_release(rel, manifest_arch="aarch64")   # x86_64-named tarball, aarch64 in manifest
-    r = run({"WE_PREBUILT_DIR":str(rel), "WE_INSTALL_PREFIX":str(tmp_path/"p"),
-             "BUILD_DIR":str(tmp_path/"b"), "WE_NO_SOURCE_FALLBACK":"1"})
-    assert r.returncode != 0
-    assert "arch" in (r.stdout+r.stderr).lower()
+    def env(self, **extra):
+        env = dict(os.environ)
+        for k in list(env):
+            if k.startswith("WE_") or k in ("BUILD_DIR", "PREBUILT_ROOT"):
+                del env[k]
+        env.update({
+            "INSTALL_WE": "1",
+            "WE_REF": "v0.0-test",
+            "WE_PREBUILT_DIR": str(self.rel),
+            "WE_INSTALL_PREFIX": str(self.prefix),
+            "BUILD_DIR": str(self.tmp / "b"),
+            "PREBUILT_ROOT": str(self.tmp / "pb"),
+            "WE_STAMP_FILE": str(self.stamp),
+            "WE_SKIP_OPT_CHECK": "1",
+            # No test may reach the real source build: it clones over the network
+            # and compiles for tens of minutes. Tests that assert a fallback
+            # keep this; the happy paths never get that far.
+            "WE_NO_SOURCE_FALLBACK": "1",
+        })
+        env.update({k: str(v) for k, v in extra.items()})
+        return env
 
-def test_smoke_failure_falls_back(tmp_path):
-    rel = tmp_path/"rel"; rel.mkdir()
-    make_release(rel, fake_exits=1)   # fake quickshell --version returns 1
-    r = run({"WE_PREBUILT_DIR":str(rel), "WE_INSTALL_PREFIX":str(tmp_path/"p"),
-             "BUILD_DIR":str(tmp_path/"b"), "WE_NO_SOURCE_FALLBACK":"1",
-             "WE_SKIP_OPT_CHECK":"1"})
-    assert r.returncode != 0
-    assert "smoke" in (r.stdout+r.stderr).lower()
+    def run_installer(self, **extra):
+        return subprocess.run(["bash", str(SH)], env=self.env(**extra),
+                              capture_output=True, text=True, timeout=300)
+
+    @staticmethod
+    def out(r):
+        return (r.stdout + r.stderr).lower()
+
+    def test_prebuilt_happy_path(self):
+        make_release(self.rel)
+        r = self.run_installer()
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertTrue((self.prefix / "bin" / "quickshell").exists(), "wrapper not installed")
+        self.assertIn("prebuilt", self.out(r))
+
+    def test_tamper_falls_back(self):
+        make_release(self.rel, tamper=True)
+        r = self.run_installer()
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn("checksum", self.out(r))
+        self.assertFalse((self.prefix / "bin" / "quickshell").exists(),
+                         "a tampered tarball must not install anything")
+
+    def test_arch_mismatch_falls_back(self):
+        # x86_64-named tarball, aarch64 in the manifest: the manifest gate has to
+        # catch it on its own, without help from the filename.
+        make_release(self.rel, manifest_arch="aarch64")
+        r = self.run_installer()
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn("arch", self.out(r))
+        self.assertFalse((self.prefix / "bin" / "quickshell").exists())
+
+    def test_smoke_failure_falls_back(self):
+        # fake quickshell --version returns 1
+        make_release(self.rel, fake_exits=1)
+        r = self.run_installer()
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn("smoke", self.out(r))
+        self.assertFalse((self.prefix / "bin" / "quickshell").exists())
+
+    def test_second_run_skips_when_up_to_date(self):
+        make_release(self.rel)
+        r1 = self.run_installer()
+        self.assertEqual(r1.returncode, 0, r1.stderr)
+        self.assertTrue(self.stamp.exists(), "stamp not written after install")
+        # Remove the release fixture entirely: the skip path must not need it,
+        # because nothing is downloaded or built when the stamp matches. If the
+        # skip does not fire, the run falls through to try_prebuilt (which now
+        # has no fixture) and then to the source build, which is a hard failure
+        # here rather than a silent slow path.
+        shutil.rmtree(self.rel)
+        r2 = self.run_installer()
+        self.assertEqual(r2.returncode, 0, r2.stderr)
+        self.assertIn("skipping", self.out(r2))
+
+    def test_stamp_fields_are_individually_recoverable(self):
+        # The regression this pins: write_stamp emits three fields and
+        # up_to_date read them into two names, so bash's `read` folded the lib
+        # dir into the binary path and `-x` could never pass. Asserting the file
+        # merely "has three fields" would not have caught it - what matters is
+        # that field 2 is a usable path on its own.
+        make_release(self.rel)
+        self.assertEqual(self.run_installer().returncode, 0)
+        fields = self.stamp.read_text().split()
+        self.assertEqual(len(fields), 3, f"expected 'ref bin lib', got {fields!r}")
+        ref, binary, lib = fields
+        self.assertEqual(ref, "v0.0-test")
+        self.assertTrue(os.access(binary, os.X_OK),
+                        f"stamp field 2 is not an executable on its own: {binary!r}")
+        self.assertTrue(pathlib.Path(lib).is_dir(),
+                        f"stamp field 3 is not a directory on its own: {lib!r}")
+
+    def test_skip_path_still_refreshes_the_wrapper(self):
+        # The skip guards the expensive fetch/build, NOT the wrapper. A
+        # wrapper-only fix has to reach an existing install, and once did not:
+        # the stamp matched, the script exited early, and the old wrapper stayed
+        # on disk, which is how an LD_LIBRARY_PATH leak survived an update and a
+        # restart. Corrupt the wrapper, take the skip, and require it back.
+        make_release(self.rel)
+        self.assertEqual(self.run_installer().returncode, 0)
+        wrapper = self.prefix / "bin" / "quickshell"
+        wrapper.write_text("#!/bin/sh\n# stale wrapper from an older install\n")
+        shutil.rmtree(self.rel)
+        r = self.run_installer()
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertIn("skipping", self.out(r))
+        body = wrapper.read_text()
+        self.assertNotIn("stale wrapper", body, "skip path left the old wrapper in place")
+        self.assertIn("QSG_RENDER_LOOP=threaded", body)
+
+    def test_force_rebuild_overrides_skip(self):
+        make_release(self.rel)
+        self.assertEqual(self.run_installer().returncode, 0)
+        r = self.run_installer(WE_FORCE_REBUILD="1")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertIn("prebuilt", self.out(r))
+        self.assertNotIn("skipping", self.out(r))
+
+    def test_stale_stamp_ref_does_not_skip(self):
+        # Install first, then rewrite ONLY the ref. Everything else up_to_date
+        # checks - the extracted binary, the installed wrapper - stays valid, so
+        # the ref comparison is the only gate left that can decline the skip.
+        #
+        # Writing a stale stamp into a fresh prefix instead (the obvious shape,
+        # and what this test used to do) proves nothing: with no wrapper
+        # installed yet, up_to_date bails on the -x $PREFIX/bin/quickshell check
+        # and never reaches the ref at all. That version passed with the ref
+        # comparison deleted from the script entirely.
+        make_release(self.rel)
+        self.assertEqual(self.run_installer().returncode, 0)
+        _ref, binary, lib = self.stamp.read_text().split()
+        self.assertTrue(os.access(binary, os.X_OK))
+        self.assertTrue((self.prefix / "bin" / "quickshell").exists())
+        self.stamp.write_text(f"someOldRef {binary} {lib}\n")
+        r = self.run_installer()
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertNotIn("skipping", self.out(r))
+        self.assertEqual(self.stamp.read_text().split()[0], "v0.0-test", "stamp not refreshed")
 
 
-def test_second_run_skips_when_up_to_date(tmp_path):
-    rel = tmp_path/"rel"; rel.mkdir()
-    make_release(rel)
-    prefix = tmp_path/"prefix"; prefix.mkdir()
-    stamp = tmp_path/"stamp"
-    env = {"WE_PREBUILT_DIR":str(rel), "WE_INSTALL_PREFIX":str(prefix),
-           "BUILD_DIR":str(tmp_path/"b"), "WE_SKIP_OPT_CHECK":"1",
-           "WE_STAMP_FILE":str(stamp)}
-    r1 = run(env)
-    assert r1.returncode == 0, r1.stderr
-    assert stamp.exists(), "stamp not written after install"
-    # Second run: remove the release fixture entirely - the skip path must not
-    # need it (nothing is downloaded or built when the stamp matches).
-    shutil.rmtree(rel)
-    r2 = run(env)
-    assert r2.returncode == 0, r2.stderr
-    assert "skipping" in (r2.stdout+r2.stderr).lower()
-
-def test_force_rebuild_overrides_skip(tmp_path):
-    rel = tmp_path/"rel"; rel.mkdir()
-    make_release(rel)
-    prefix = tmp_path/"prefix"; prefix.mkdir()
-    stamp = tmp_path/"stamp"
-    env = {"WE_PREBUILT_DIR":str(rel), "WE_INSTALL_PREFIX":str(prefix),
-           "BUILD_DIR":str(tmp_path/"b"), "WE_SKIP_OPT_CHECK":"1",
-           "WE_STAMP_FILE":str(stamp)}
-    assert run(env).returncode == 0
-    r = run({**env, "WE_FORCE_REBUILD":"1"})
-    assert r.returncode == 0, r.stderr
-    assert "prebuilt" in (r.stdout+r.stderr).lower()   # went through install again
-    assert "skipping" not in (r.stdout+r.stderr).lower()
-
-def test_stale_stamp_ref_does_not_skip(tmp_path):
-    rel = tmp_path/"rel"; rel.mkdir()
-    make_release(rel)
-    prefix = tmp_path/"prefix"; prefix.mkdir()
-    stamp = tmp_path/"stamp"
-    stamp.write_text("someOldRef /bin/true\n")   # ref mismatch => no skip
-    env = {"WE_PREBUILT_DIR":str(rel), "WE_INSTALL_PREFIX":str(prefix),
-           "BUILD_DIR":str(tmp_path/"b"), "WE_SKIP_OPT_CHECK":"1",
-           "WE_STAMP_FILE":str(stamp)}
-    r = run(env)
-    assert r.returncode == 0, r.stderr
-    assert "skipping" not in (r.stdout+r.stderr).lower()
-    assert stamp.read_text().split()[0] == "v0.0-test"  # stamp refreshed
+if __name__ == "__main__":
+    # A missing zstd is a hard failure, not a skip. These tests exist because
+    # this file spent its life reporting success without running; "quietly
+    # covered nothing" is the exact outcome being fixed, and a skip on a missing
+    # tool is the same outcome wearing a different hat.
+    if shutil.which("zstd") is None:
+        raise SystemExit(
+            "test_wallpaperengine_prebuilt.py: zstd not found, but the release "
+            "fixtures are zstd tarballs. Install zstd and re-run; this check "
+            "will not silently pass without exercising the installer."
+        )
+    unittest.main(verbosity=2)

--- a/sdata/subcmd-install/4.wallpaperengine.sh
+++ b/sdata/subcmd-install/4.wallpaperengine.sh
@@ -114,8 +114,15 @@ write_stamp(){ # $1 = installed ref, $2 = qs binary path, $3 = WE lib dir
 up_to_date(){
   [[ "${WE_FORCE_REBUILD:-0}" == "1" ]] && return 1
   [[ -f "$STAMP_FILE" ]] || return 1
-  local ref bin
-  read -r ref bin < "$STAMP_FILE" || return 1
+  # Three variables for a three-field stamp. `read` puts every remaining field
+  # into the LAST name, so `read -r ref bin` left bin holding "<binary> <libdir>"
+  # once write_stamp started recording the lib dir - a string that is never an
+  # executable, so the -x below could not pass and this function could not return
+  # 0. The skip was dead: every re-run paid the full fetch+build it exists to
+  # avoid. The main block below already reads three, which is why the bug hid -
+  # the code after the gate was correct, the gate just never opened.
+  local ref bin lib
+  read -r ref bin lib < "$STAMP_FILE" || return 1
   [[ "$ref" == "$WE_REF" ]] || return 1
   [[ -x "$bin" ]] || return 1                    # build output still on disk
   [[ -x "$PREFIX/bin/quickshell" ]] || return 1  # wrapper still installed


### PR DESCRIPTION
## Describe your changes

Closes #91.

`tests/test_wallpaperengine_prebuilt.py` was written for pytest — seven module-level `def test_*(tmp_path)` functions, no `__main__` block — but `run_tests.sh` invokes every Python check as `python3 <file>`. It defined its functions, called none of them, and exited 0. pytest is not installed in CI, so nothing anywhere has ever executed these assertions.

Making them run immediately surfaced a real bug, which is the second commit here.

**`up_to_date` could never return 0.** `write_stamp` records three fields (`ref`, binary, lib dir); `up_to_date` read them into two variables. bash's `read` assigns every remaining field to the last name, so `bin` held `"<binary> <libdir>"` as one string — never a path to an executable, so `[[ -x "$bin" ]]` could not pass. The skip was dead: **every re-run of the installer went through a full `try_prebuilt` or source build**, which for anyone without a prebuilt release is the 5–40 minute recompile the stamp exists to avoid, on every update, including ones that did not move `WE_REF`. It hid because the code on the far side of the gate is correct — the main block already reads three fields — so it never looked like a broken conditional, only like a slow installer.

Three commits, kept separate: the installer fix, the test conversion, and the CI dependency.

### What the tests now pin

Nine cases, up from seven. Two are new: that each stamp field is recoverable *on its own* (the property that actually broke — "the stamp has three fields" would not have caught it, since the writer was always correct), and that taking the skip still rewrites the wrapper (deliberate behaviour with its own regression history — a wrapper-only fix could not reach an existing install, which is how an `LD_LIBRARY_PATH` leak survived an update).

`test_stale_stamp_ref_does_not_skip` was rewritten because it did not test what it claimed — see the PR comment for how that was found.

### Verification

Every assertion was proven by mutation: nine separate breakages of `4.wallpaperengine.sh`, each confirmed to turn the file red, each reverted. Full suite green at **260 passed, 0 failed** before each commit. Details in the comment below.

## Is it ready? Questions/feedback needed?

Ready to review. Not merged, nothing tagged, no release cut, `WE_REF` and `SDDM_REF` untouched.

Two things worth a maintainer's eye, both called out in the comment: the installer fix is a behaviour change beyond the issue's stated scope (it was required to make the tests pass), and `CONTRIBUTING.md` points at a `tests/README.md` that does not exist in the repo.
