### PR TITLE
fix(bar): bar window margins and standalone badge centring (#98, #99)

### DIFF
--- a/dots/.config/quickshell/imi/modules/common/Appearance.qml
+++ b/dots/.config/quickshell/imi/modules/common/Appearance.qml
@@ -519,6 +519,36 @@ Singleton {
         // Standalone widget pills (Timer, Privacy) read as compact dynamic-island
         // badges: a touch shorter than the full group pill.
         property real barStandalonePillHeight: root.sizes.barPillHeight - root.sizes.barPillMargin
+        // The bar *surface's* own margins, as opposed to barMarginTop/Bottom
+        // above, which inset its body. Two terms, and they are alternatives
+        // rather than things to add up:
+        //
+        //   M3 (3) is the only style that detaches the whole surface from the
+        //   monitor edge, by the same gap Hyprland leaves around windows.
+        //
+        //   Hyprland leaves one untouchable pixel row on the right and bottom
+        //   screen edges. `interactions.deadPixelWorkaround` pulls the surface
+        //   1px *past* the edge so that row falls outside it - which replaces
+        //   the detach margin, since a surface already hanging over the edge
+        //   has no gap left to keep.
+        //
+        // Both used to be open-coded in Bar.qml as
+        //     (enable && anchors.bottom) * -1 || cornerStyle === 3 ? 5 : 0
+        // `||` binds tighter than `?:`, so the entire left-hand side was only
+        // the ternary's *condition*: with the workaround live that condition
+        // was truthy and the margin came out +5 for every style, pushing the
+        // bar away from the edge it was meant to overhang and making Hyprland
+        // reserve 5px more with it. They live here so the arithmetic is one
+        // expression a test can read rather than three inline ternaries.
+        property real barDetachMargin: Config?.options.bar.cornerStyle === 3
+            ? root.sizes.hyprlandGapsOut : 0
+        // One physical pixel, not a design token - it is the width of the row
+        // the compositor leaves out, so it does not scale with anything.
+        property real barDeadPixelOverhang: Config?.options.interactions.deadPixelWorkaround.enable
+            ? -1 : 0
+        property real barBottomMargin: (Config?.options.bar.bottom && root.sizes.barDeadPixelOverhang !== 0)
+            ? root.sizes.barDeadPixelOverhang
+            : root.sizes.barDetachMargin
         property real barCenterSideModuleWidth: Config.options?.bar.verbose ? 360 : 140
         property real barCenterSideModuleWidthShortened: 280
         property real barCenterSideModuleWidthHellaShortened: 190

--- a/dots/.config/quickshell/imi/modules/common/Appearance.qml
+++ b/dots/.config/quickshell/imi/modules/common/Appearance.qml
@@ -516,9 +516,23 @@ Singleton {
         // Follows from the two margins rather than assuming a symmetric inset,
         // so Hug's body reclaims the space its missing top margin frees.
         property real barPillHeight: baseBarHeight - root.sizes.barMarginTop - root.sizes.barMarginBottom
-        // Standalone widget pills (Timer, Privacy) read as compact dynamic-island
-        // badges: a touch shorter than the full group pill.
-        property real barStandalonePillHeight: root.sizes.barPillHeight - root.sizes.barPillMargin
+        // Standalone widget pills (Timer, Privacy, Submap) read as compact
+        // dynamic-island badges: a touch shorter than the group pill they sit
+        // inside, inset from it evenly on every side.
+        property real barStandalonePillMargin: root.spacing.space25
+        property real barStandalonePillHeight: root.sizes.barPillHeight
+            - root.sizes.barStandalonePillMargin * 2
+        // The badges centre themselves in the whole bar, but the group pill they
+        // sit inside is only centred there while its own two margins match -
+        // which stopped being true when Hug dropped its edge-side one, leaving
+        // the badge flush against the pill's window-side edge with all the slack
+        // on the other. This is the group pill's centre relative to the bar's,
+        // and it applies along whichever axis the bar's thickness runs:
+        // vertically for a horizontal bar, horizontally for a vertical one.
+        // `bar.bottom` puts the edge margin on the far side, so it mirrors.
+        property real barStandalonePillOffset: Config?.options.bar.bottom
+            ? (root.sizes.barMarginBottom - root.sizes.barMarginTop) / 2
+            : (root.sizes.barMarginTop - root.sizes.barMarginBottom) / 2
         // The bar *surface's* own margins, as opposed to barMarginTop/Bottom
         // above, which inset its body. Two terms, and they are alternatives
         // rather than things to add up:

--- a/dots/.config/quickshell/imi/modules/imi/bar/Bar.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/Bar.qml
@@ -146,10 +146,14 @@ Scope {
                     right: true
                 }
 
+                // The dead row is on the right and bottom screen edges only, so
+                // a top-anchored bar has nothing to overhang. See the tokens'
+                // own comment in Appearance for what these two terms are and
+                // why the bottom one used to come out +5 instead of -1.
                 margins {
-                    top: Config.options.bar.cornerStyle === 3 ? 5 : 0
-                    right: (Config.options.interactions.deadPixelWorkaround.enable && barRoot.anchors.right) * -1
-                    bottom: (Config.options.interactions.deadPixelWorkaround.enable && barRoot.anchors.bottom) * -1 || Config.options.bar.cornerStyle === 3 ? 5 : 0
+                    top: Appearance.sizes.barDetachMargin
+                    right: Appearance.sizes.barDeadPixelOverhang
+                    bottom: Appearance.sizes.barBottomMargin
                 }
 
                 // Include in focus grab

--- a/dots/.config/quickshell/imi/modules/imi/bar/PrivacyIndicator.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/PrivacyIndicator.qml
@@ -73,6 +73,11 @@ MouseArea {
     Rectangle {
         id: pill
         anchors.centerIn: parent
+        // The badge belongs to the group pill's footprint, not the bar's, and
+        // those two only share a centre while the group pill's insets match.
+        // Shift onto the group pill's centre along the bar's thickness.
+        anchors.verticalCenterOffset: root.vertical ? 0 : Appearance.sizes.barStandalonePillOffset
+        anchors.horizontalCenterOffset: root.vertical ? Appearance.sizes.barStandalonePillOffset : 0
         radius: Appearance.rounding.full
         color: root.pillColor
         // Fade + scale with the whole show/hide so it eases in and out.
@@ -86,7 +91,7 @@ MouseArea {
             animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
         }
         implicitWidth: (root.vertical ? iconColumn.implicitWidth : iconRow.implicitWidth) + Appearance.spacing.space100 * 2
-        // Match the M3 group pill height (bar height minus BarGroup's 4px insets).
+        // A badge inside the group pill, not a group pill of its own.
         implicitHeight: root.vertical
             ? iconColumn.implicitHeight + Appearance.spacing.space50 * 2
             : Appearance.sizes.barStandalonePillHeight

--- a/dots/.config/quickshell/imi/modules/imi/bar/SubmapIndicator.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/SubmapIndicator.qml
@@ -43,6 +43,11 @@ Item {
     Rectangle {
         id: pill
         anchors.centerIn: parent
+        // The badge belongs to the group pill's footprint, not the bar's, and
+        // those two only share a centre while the group pill's insets match.
+        // Shift onto the group pill's centre along the bar's thickness.
+        anchors.verticalCenterOffset: root.vertical ? 0 : Appearance.sizes.barStandalonePillOffset
+        anchors.horizontalCenterOffset: root.vertical ? Appearance.sizes.barStandalonePillOffset : 0
         radius: Appearance.rounding.full
         color: root.pillColor
         // Fade + scale with the show/hide so it eases in and out.
@@ -58,7 +63,7 @@ Item {
         implicitWidth: root.vertical
             ? verticalIcon.implicitWidth + Appearance.spacing.space50 * 2
             : pillRow.implicitWidth + Appearance.spacing.space150 * 2
-        // Match the M3 group pill height (bar height minus BarGroup's 4px insets).
+        // A badge inside the group pill, not a group pill of its own.
         implicitHeight: root.vertical
             ? verticalIcon.implicitHeight + Appearance.spacing.space50 * 2
             : Appearance.sizes.barStandalonePillHeight

--- a/dots/.config/quickshell/imi/modules/imi/bar/TimerPill.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/TimerPill.qml
@@ -57,6 +57,11 @@ MouseArea {
     Rectangle {
         id: pill
         anchors.centerIn: parent
+        // The badge belongs to the group pill's footprint, not the bar's, and
+        // those two only share a centre while the group pill's insets match.
+        // Shift onto the group pill's centre along the bar's thickness.
+        anchors.verticalCenterOffset: root.vertical ? 0 : Appearance.sizes.barStandalonePillOffset
+        anchors.horizontalCenterOffset: root.vertical ? Appearance.sizes.barStandalonePillOffset : 0
         radius: Appearance.rounding.full
         color: root.pillColor
         // Fade + scale with the show/hide so it eases in and out.
@@ -70,7 +75,7 @@ MouseArea {
             animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
         }
         implicitWidth: pillRow.implicitWidth + Appearance.spacing.space150 * 2
-        // Match the M3 group pill height (bar height minus BarGroup's 4px insets).
+        // A badge inside the group pill, not a group pill of its own.
         implicitHeight: root.vertical
             ? pillColumn.implicitHeight + Appearance.spacing.space50 * 2
             : Appearance.sizes.barStandalonePillHeight

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -257,6 +257,12 @@ if ! python3 "$SCRIPT_DIR/test_default_config.py"; then
     exit 1
 fi
 
+echo "Running bar geometry contract tests..."
+if ! python3 "$SCRIPT_DIR/test_bar_geometry_contract.py"; then
+    echo "Bar geometry contract tests failed."
+    exit 1
+fi
+
 echo "Running dock motion contract tests..."
 if ! python3 "$SCRIPT_DIR/test_dock_motion.py"; then
     echo "Dock motion contract tests failed."

--- a/dots/.config/quickshell/imi/tests/test_bar_geometry_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_bar_geometry_contract.py
@@ -2,17 +2,21 @@
 """Source pins holding bar geometry where a unit test can reach it.
 
 `tst_bar_geometry.qml` evaluates the real `Appearance.sizes.*` tokens and
-proves the arithmetic. That only guards anything for as long as the call site
-actually *reads* those tokens - an inline expression in Bar.qml is invisible to
-it, and inline is exactly where the bug lived:
+proves the arithmetic. That only guards anything for as long as the call sites
+actually *read* those tokens - an inline expression in Bar.qml or in one of the
+badges is invisible to it, and inline is exactly where both bugs lived:
 
   - #98: `margins.bottom` was
         (enable && anchors.bottom) * -1 || cornerStyle === 3 ? 5 : 0
     and `||` binds tighter than `?:`, so the whole left-hand side was only the
     ternary's condition. A live dead-pixel workaround yielded +5 instead of -1.
 
-This pin is about *where the arithmetic lives*, not about its result. It
-reuses the structural QML reader from the background suppression pins
+  - #99: the standalone badges centred themselves in the whole bar, which is
+    the group pill's centre only while the pill's two insets match. Hug's stop
+    matching, and the badge went flush against one edge of the pill.
+
+So these pins are about *where the arithmetic lives*, not about its result.
+They reuse the structural QML reader from the background suppression pins
 rather than grepping raw text, for the reason recorded there: a text pattern
 over QML decays into one that matches nothing after any reformat.
 """
@@ -24,6 +28,11 @@ from test_background_fullscreen_suppression import _qml_source
 
 ROOT = Path(__file__).resolve().parents[1]
 BAR = ROOT / "modules/imi/bar/Bar.qml"
+BADGES = (
+    ROOT / "modules/imi/bar/TimerPill.qml",
+    ROOT / "modules/imi/bar/PrivacyIndicator.qml",
+    ROOT / "modules/imi/bar/SubmapIndicator.qml",
+)
 
 # A margin that is nothing but one named token: `Appearance.sizes.barX`.
 _TOKEN_ONLY = re.compile(r"^Appearance\.sizes\.(\w+)$")
@@ -78,6 +87,56 @@ class BarWindowMarginTests(unittest.TestCase):
                           "bottom": "barBottomMargin"},
                          "tst_bar_geometry.qml evaluates these token names by "
                          "hand; renaming one here leaves it unevaluated.")
+
+
+class StandaloneBadgeOffsetTests(unittest.TestCase):
+    """Each badge has to be shifted onto its group pill's centre on both axes.
+
+    A horizontal bar insets the group pill along its height and a vertical one
+    along its width, so a badge that only corrects one axis is still off-centre
+    in the other orientation.
+    """
+
+    def _pill(self, path):
+        qml = _qml_source(path)
+        pills = [b for b in qml.elements("Rectangle") if qml.element_id(b) == "pill"]
+        self.assertEqual(len(pills), 1, f"expected one `pill` Rectangle in {path.name}")
+        self.assertEqual(qml.unclosed, 0, f"unbalanced braces in {path.name}")
+        return qml, dict(qml.members(pills[0]))
+
+    def test_each_badge_shifts_onto_its_group_pills_centre(self):
+        for path in BADGES:
+            with self.subTest(badge=path.name):
+                _, members = self._pill(path)
+                self.assertEqual(
+                    members.get("anchors.centerIn", "").strip(), "parent",
+                    f"{path.name}'s pill should still centre itself in the badge root")
+                for axis in ("anchors.verticalCenterOffset", "anchors.horizontalCenterOffset"):
+                    value = members.get(axis)
+                    self.assertIsNotNone(
+                        value,
+                        f"{path.name} never sets {axis}, so the badge stays centred "
+                        "in the whole bar rather than in the group pill it sits in.")
+                    self.assertIn(
+                        "barStandalonePillOffset", value,
+                        f"{path.name}'s {axis} does not read the shared offset "
+                        f"({value.strip()!r}); the four corner styles disagree about "
+                        "where the group pill's centre is.")
+
+    def test_each_badge_takes_its_height_from_the_shared_token(self):
+        """The badge's size and its position are one design decision.
+
+        Deriving the height locally is how the three drifted apart before, and
+        the concentricity the unit test proves only holds for the token pair.
+        """
+        for path in BADGES:
+            with self.subTest(badge=path.name):
+                _, members = self._pill(path)
+                self.assertIn(
+                    "barStandalonePillHeight", members.get("implicitHeight", ""),
+                    f"{path.name}'s pill no longer sizes itself from "
+                    "Appearance.sizes.barStandalonePillHeight.")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/dots/.config/quickshell/imi/tests/test_bar_geometry_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_bar_geometry_contract.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Source pins holding bar geometry where a unit test can reach it.
+
+`tst_bar_geometry.qml` evaluates the real `Appearance.sizes.*` tokens and
+proves the arithmetic. That only guards anything for as long as the call site
+actually *reads* those tokens - an inline expression in Bar.qml is invisible to
+it, and inline is exactly where the bug lived:
+
+  - #98: `margins.bottom` was
+        (enable && anchors.bottom) * -1 || cornerStyle === 3 ? 5 : 0
+    and `||` binds tighter than `?:`, so the whole left-hand side was only the
+    ternary's condition. A live dead-pixel workaround yielded +5 instead of -1.
+
+This pin is about *where the arithmetic lives*, not about its result. It
+reuses the structural QML reader from the background suppression pins
+rather than grepping raw text, for the reason recorded there: a text pattern
+over QML decays into one that matches nothing after any reformat.
+"""
+import re
+import unittest
+from pathlib import Path
+
+from test_background_fullscreen_suppression import _qml_source
+
+ROOT = Path(__file__).resolve().parents[1]
+BAR = ROOT / "modules/imi/bar/Bar.qml"
+
+# A margin that is nothing but one named token: `Appearance.sizes.barX`.
+_TOKEN_ONLY = re.compile(r"^Appearance\.sizes\.(\w+)$")
+
+
+class BarWindowMarginTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.qml = _qml_source(BAR)
+        windows = cls.qml.elements("PanelWindow")
+        assert len(windows) == 1, (
+            f"expected exactly one PanelWindow in {BAR}, found {len(windows)}")
+        cls.window = windows[0]
+        groups = [b for b in cls.window.children
+                  if b.kind == "group" and b.name == "margins"]
+        assert len(groups) == 1, (
+            f"expected exactly one `margins` group on the bar window, found {len(groups)}")
+        cls.margins = dict(cls.qml.members(groups[0]))
+
+    def test_the_file_parses(self):
+        self.assertEqual(self.qml.unclosed, 0,
+                         "unbalanced braces in Bar.qml - the pins below would "
+                         "silently stop covering anything.")
+        self.assertEqual(sorted(self.margins), ["bottom", "right", "top"],
+                         "the bar window's margins should still be exactly these three")
+
+    def test_every_margin_is_a_single_named_token(self):
+        """No arithmetic here at all, which is what makes the trap unreachable.
+
+        The precedence bug needed two things in one expression: a `?:` and a
+        `||`. Admitting only a bare token reference means neither can be
+        written in this position again, and it keeps the real expression in
+        Appearance.qml where `tst_bar_geometry.qml` evaluates it for real.
+        """
+        for side, value in sorted(self.margins.items()):
+            self.assertRegex(
+                value.strip(), _TOKEN_ONLY,
+                f"margins.{side} computes its own value ({value.strip()!r}). "
+                "Put the arithmetic in an Appearance.sizes token so the unit "
+                "test can evaluate it - inline is how `||` binding tighter "
+                "than `?:` turned the dead-pixel workaround's -1 into +5.")
+
+    def test_the_margins_are_the_tokens_the_unit_test_evaluates(self):
+        """A token that no test knows about is no better than an inline one."""
+        named = {}
+        for side, value in self.margins.items():
+            match = _TOKEN_ONLY.match(value.strip())
+            named[side] = match.group(1) if match else value.strip()
+        self.assertEqual(named,
+                         {"top": "barDetachMargin",
+                          "right": "barDeadPixelOverhang",
+                          "bottom": "barBottomMargin"},
+                         "tst_bar_geometry.qml evaluates these token names by "
+                         "hand; renaming one here leaves it unevaluated.")
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dots/.config/quickshell/imi/tests/tst_bar_geometry.qml
+++ b/dots/.config/quickshell/imi/tests/tst_bar_geometry.qml
@@ -3,7 +3,9 @@ import QtTest
 import qs.modules.common
 
 // Bar geometry that only exists as arithmetic between Appearance tokens, and
-// so is the one part of the bar a unit test can actually reach.
+// so is the one part of the bar a unit test can actually reach. Both bugs
+// pinned here were invisible in review because each individual token still
+// looked right on its own.
 TestCase {
     name: "BarGeometryTest"
 
@@ -24,6 +26,83 @@ TestCase {
         Config.options.bar.cornerStyle = savedCornerStyle;
         Config.options.bar.bottom = savedBottom;
         Config.options.interactions.deadPixelWorkaround.enable = savedDeadPixel;
+    }
+
+    // BarGroup.qml paints its background inset by the edge-side margin at the
+    // monitor edge and the window-side margin opposite it, inside a box that is
+    // always baseBarHeight along the bar's thickness. `bar.bottom` names the far
+    // edge for both orientations, so it swaps which margin lands where.
+    function groupPillSpan(barBottom) {
+        const nearInset = barBottom ? Appearance.sizes.barMarginBottom
+                                    : Appearance.sizes.barMarginTop;
+        const farInset = barBottom ? Appearance.sizes.barMarginTop
+                                   : Appearance.sizes.barMarginBottom;
+        return { start: nearInset, end: Appearance.sizes.baseBarHeight - farInset };
+    }
+
+    // TimerPill/PrivacyIndicator/SubmapIndicator each centre their pill in that
+    // same box, offset by barStandalonePillOffset, at barStandalonePillHeight.
+    function standaloneBadgeSpan() {
+        const centre = Appearance.sizes.baseBarHeight / 2
+            + Appearance.sizes.barStandalonePillOffset;
+        const half = Appearance.sizes.barStandalonePillHeight / 2;
+        return { start: centre - half, end: centre + half };
+    }
+
+    // A standalone badge reads as a compact dynamic-island pill sitting inside
+    // the group pill it belongs to, so it has to be inset from that pill by the
+    // same amount on both sides. Centring it in the whole bar produced that
+    // only while the group pill's own two margins matched; Hug dropped its
+    // edge-side margin (131ce1165) and the badge went flush against the pill's
+    // window-side edge with all 4px of slack on the other, which is exactly the
+    // configuration most users see - Hug is the default cornerStyle.
+    function test_standaloneBadgeIsConcentricInsideItsGroupPill() {
+        for (let b = 0; b < 2; ++b) {
+            const barBottom = b === 1;
+            Config.options.bar.bottom = barBottom;
+            for (const style of cornerStyles) {
+                Config.options.bar.cornerStyle = style;
+                const pill = groupPillSpan(barBottom);
+                const badge = standaloneBadgeSpan();
+                const where = "cornerStyle " + style + ", bottom " + barBottom;
+
+                const nearInset = badge.start - pill.start;
+                const farInset = pill.end - badge.end;
+                compare(nearInset, farInset,
+                        "badge is not concentric in its group pill (" + where + ")");
+                compare(nearInset, Appearance.sizes.barStandalonePillMargin,
+                        "badge inset is not barStandalonePillMargin (" + where + ")");
+                verify(badge.start >= pill.start && badge.end <= pill.end,
+                       "badge escapes its group pill (" + where + ")");
+            }
+        }
+    }
+
+    // The offset has to be a real shift, not a constant zero that happens to be
+    // right for three of the four styles.
+    function test_hugIsTheStyleThatNeedsTheOffset() {
+        Config.options.bar.bottom = false;
+        Config.options.bar.cornerStyle = 0;
+        compare(Appearance.sizes.barMarginTop, 0,
+                "Hug should still sit flush against the monitor edge");
+        verify(Appearance.sizes.barStandalonePillOffset !== 0,
+               "Hug's group pill is off-centre in the bar, so the badge must be "
+               + "shifted to match it");
+
+        Config.options.bar.cornerStyle = 1;
+        compare(Appearance.sizes.barStandalonePillOffset, 0,
+                "a symmetric group pill needs no shift");
+    }
+
+    // `bar.bottom` moves the edge-side margin to the other side, so the shift
+    // has to mirror with it rather than always pointing the same way.
+    function test_theOffsetMirrorsWithTheBarsEdge() {
+        Config.options.bar.cornerStyle = 0;
+        Config.options.bar.bottom = false;
+        const top = Appearance.sizes.barStandalonePillOffset;
+        Config.options.bar.bottom = true;
+        compare(Appearance.sizes.barStandalonePillOffset, -top,
+                "the shift must follow the bar to the other monitor edge");
     }
 
     // Bar.qml's `margins.bottom` used to read

--- a/dots/.config/quickshell/imi/tests/tst_bar_geometry.qml
+++ b/dots/.config/quickshell/imi/tests/tst_bar_geometry.qml
@@ -1,0 +1,82 @@
+import QtQuick
+import QtTest
+import qs.modules.common
+
+// Bar geometry that only exists as arithmetic between Appearance tokens, and
+// so is the one part of the bar a unit test can actually reach.
+TestCase {
+    name: "BarGeometryTest"
+
+    readonly property var cornerStyles: [0, 1, 2, 3]
+    readonly property int m3CornerStyle: 3
+
+    property int savedCornerStyle: 0
+    property bool savedBottom: false
+    property bool savedDeadPixel: false
+
+    function initTestCase() {
+        savedCornerStyle = Config.options.bar.cornerStyle;
+        savedBottom = Config.options.bar.bottom;
+        savedDeadPixel = Config.options.interactions.deadPixelWorkaround.enable;
+    }
+
+    function cleanupTestCase() {
+        Config.options.bar.cornerStyle = savedCornerStyle;
+        Config.options.bar.bottom = savedBottom;
+        Config.options.interactions.deadPixelWorkaround.enable = savedDeadPixel;
+    }
+
+    // Bar.qml's `margins.bottom` used to read
+    //     (enable && anchors.bottom) * -1 || cornerStyle === 3 ? 5 : 0
+    // where `||` binds tighter than `?:`, so the whole left-hand side was only
+    // the ternary's *condition*. A live workaround made that condition truthy
+    // and the margin came out +5 for every corner style - pushing the bar away
+    // from the very edge it was meant to overhang, and making Hyprland reserve
+    // 5px more with it (exclusive + margin).
+    function test_deadPixelOverhangBeatsTheM3DetachMargin() {
+        Config.options.bar.bottom = true;
+        Config.options.interactions.deadPixelWorkaround.enable = true;
+        for (const style of cornerStyles) {
+            Config.options.bar.cornerStyle = style;
+            compare(Appearance.sizes.barBottomMargin,
+                    Appearance.sizes.barDeadPixelOverhang,
+                    "the workaround must pull the surface past the edge, "
+                    + "cornerStyle " + style);
+            verify(Appearance.sizes.barBottomMargin < 0,
+                   "a positive bottom margin is the bug: it moves the bar off "
+                   + "the dead row instead of over it, cornerStyle " + style);
+        }
+    }
+
+    // The dead row Hyprland leaves is on the right and bottom screen edges, so
+    // a top-anchored bar has nothing to overhang and keeps the detach margin.
+    function test_aTopBarIsUnaffectedByTheWorkaround() {
+        Config.options.bar.bottom = false;
+        Config.options.interactions.deadPixelWorkaround.enable = true;
+        for (const style of cornerStyles) {
+            Config.options.bar.cornerStyle = style;
+            compare(Appearance.sizes.barBottomMargin,
+                    Appearance.sizes.barDetachMargin,
+                    "a top bar must not overhang, cornerStyle " + style);
+        }
+    }
+
+    function test_withTheWorkaroundOffOnlyM3DetachesFromTheEdge() {
+        Config.options.interactions.deadPixelWorkaround.enable = false;
+        compare(Appearance.sizes.barDeadPixelOverhang, 0,
+                "no overhang while the workaround is off");
+        for (let b = 0; b < 2; ++b) {
+            Config.options.bar.bottom = b === 1;
+            for (const style of cornerStyles) {
+                Config.options.bar.cornerStyle = style;
+                const expected = style === m3CornerStyle
+                    ? Appearance.sizes.hyprlandGapsOut : 0;
+                compare(Appearance.sizes.barDetachMargin, expected,
+                        "detach margin, cornerStyle " + style);
+                compare(Appearance.sizes.barBottomMargin, expected,
+                        "bottom margin, cornerStyle " + style
+                        + ", bottom " + (b === 1));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Describe your changes

Two bar-geometry bugs, both downstream of `131ce1165`'s margin work, both fixed by moving the arithmetic into `Appearance.sizes` where a unit test can evaluate it.

**#98 — `margins.bottom` operator precedence.** `(enable && anchors.bottom) * -1 || cornerStyle === 3 ? 5 : 0` parses as `((A * -1) || (cornerStyle === 3)) ? 5 : 0`, so a live dead-pixel workaround on a bottom bar yielded **+5** instead of −1 for every corner style — pushing the bar off the edge it was meant to overhang, and making Hyprland reserve 5px more with it. Split into `barDetachMargin` (M3's detachment, which is `hyprlandGapsOut` — that is what the `5` always was) and `barDeadPixelOverhang` (the 1px overhang), composed by `barBottomMargin`. They stay alternatives rather than addends, which is the priority the original `||` expressed.

**#99 — standalone badges no longer concentric under Hug.** `barStandalonePillHeight` subtracts one `barPillMargin` and the badge centres in the whole bar; that is only concentric while the group pill's own two insets match, and Hug's stopped matching. Adds `barStandalonePillOffset` (the group pill's centre relative to the bar's, mirrored by `bar.bottom`), applied by TimerPill / PrivacyIndicator / SubmapIndicator on **both** axes — BarGroup insets a horizontal bar's pill along its height and a vertical bar's along its width.

Two commits, one per issue.

## Is it ready? Questions/feedback needed?

Ready. Verification, and what I deliberately left alone, are in the review comment below.

Closes #98
Closes #99