### PR TITLE
fix(sddm): restore the whole matugen block, and only uninstall a theme we installed

### DIFF
--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -288,9 +288,10 @@ if ! python3 "$SCRIPT_DIR/test_kboptions_migration_runtime.py"; then
     exit 1
 fi
 
-# The hook is a path into the theme's directory, and that directory was
-# renamed - a wrong path here means the login screen silently stops following
-# the wallpaper.
+# The block is a set of paths into the theme's directory and at the apply
+# script sudo will accept; the directory was renamed and the script moved. A
+# wrong path here means the login screen silently stops following the
+# wallpaper, and restoring only part of the block is how it stopped last time.
 echo "Running SDDM matugen hook restore tests..."
 if ! python3 "$SCRIPT_DIR/test_sddm_matugen_hook_restore.py"; then
     echo "SDDM matugen hook restore tests failed."

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -298,6 +298,15 @@ if ! python3 "$SCRIPT_DIR/test_sddm_matugen_hook_restore.py"; then
     exit 1
 fi
 
+# Uninstall step 5 hands the machine to the theme's uninstaller, which removes
+# the drop-in carrying Current= along with the theme. Firing it on a theme we
+# did not install is somebody else's login screen.
+echo "Running SDDM uninstall ownership tests..."
+if ! python3 "$SCRIPT_DIR/test_sddm_uninstall_ownership.py"; then
+    echo "SDDM uninstall ownership tests failed."
+    exit 1
+fi
+
 echo "Running SDDM theme source tests..."
 if ! python3 "$SCRIPT_DIR/test_sddm_theme_source.py"; then
     echo "SDDM theme source tests failed."

--- a/dots/.config/quickshell/imi/tests/test_sddm_matugen_hook_restore.py
+++ b/dots/.config/quickshell/imi/tests/test_sddm_matugen_hook_restore.py
@@ -1,22 +1,38 @@
 #!/usr/bin/env python3
-"""`restore_sddm_matugen_hook` must point at the theme that is actually there.
+"""`restore_sddm_matugen_hook` must restore the whole block, pointing at the
+theme that is actually there and at the apply script sudo will actually accept.
 
 We ship our own `~/.config/matugen/config.toml` and deploy it with
-`rsync --delete`, which removes the SDDM theme's `post_hook` on every update -
-so the login screen stops following the wallpaper until the hook is put back.
-`sdata/subcmd-install/3.files-legacy.sh` restores it.
+`rsync --delete`, which removes the SDDM theme's `[templates.iisddmtheme]` block
+on every update - so the login screen stops following the wallpaper until it is
+put back. `sdata/subcmd-install/3.files-legacy.sh` restores it.
 
-The hook is a path, and the theme's directory name changed: it installs as
-`imi-sddm-theme` now, and installs from before that rename are still under
-`ii-sddm-theme` until the theme's own installer migrates them. So the restore
-has to resolve the name rather than hardcode it, and it has to prefer the new
-one - during a migrating update both directories exist for a moment, and a hook
-written against the one about to be deleted is broken the instant the migration
-finishes.
+Three things have to be right, and each has been wrong:
+
+1. **The whole block, not just the hook.** The restore used to write a bare
+   `post_hook` under `[config]`, which is worse than writing nothing: the hook
+   fires - now after every matugen run, not just this template's - while the
+   `input_path`/`output_path` pair that regenerates `Colors.qml` is gone, so
+   there is nothing for it to publish. The greeter's palette froze and the
+   function reported success (issue #101). Its guard (`grep ^post_hook`) then
+   matched its own half-restore forever, so it never corrected the state it had
+   created.
+
+2. **The theme's directory name.** It installs as `imi-sddm-theme` now, and
+   installs from before that rename are still under `ii-sddm-theme` until the
+   theme's own installer migrates them. During a migrating update both exist for
+   a moment, and a block written against the one about to be deleted is broken
+   the instant the migration finishes.
+
+3. **The apply script's path.** It is installed root-owned at
+   `/usr/local/lib/<theme>/`, because the NOPASSWD sudoers rule names it and
+   sudo matches by path - a rule pointing anywhere the user can write is
+   equivalent to `NOPASSWD: ALL`. A hook naming any other location prompts for a
+   password from a backgrounded hook, which is a hang rather than an error.
 
 Hermetic: sources just this function out of 3.files-legacy.sh (the file is
 meant to be sourced by ./setup and has a procedural body) and runs it against a
-sandbox HOME.
+sandbox HOME, with the privileged directory rewritten into that sandbox.
 """
 
 import subprocess
@@ -35,6 +51,13 @@ SCRIPT = ROOT / "sdata/subcmd-install/3.files-legacy.sh"
 FUNCTION = "restore_sddm_matugen_hook"
 
 BASE_CONF = "[config]\nreload_apps = true\n"
+BLOCK_HEADER = "[templates.iisddmtheme]"
+
+# The apply script's real home. The harness rewrites this to reach the sandbox;
+# test_the_privileged_path_is_where_we_think_it_is keeps the rewrite honest, so
+# a change to the install path fails loudly instead of silently exercising the
+# real /usr/local/lib.
+PRIV_LITERAL = "/usr/local/lib/${theme_name}"
 
 
 def _extract_function(text, name):
@@ -56,44 +79,166 @@ class SddmMatugenHookRestoreTest(unittest.TestCase):
         (self.config / "matugen").mkdir(parents=True)
         self.matugen_conf = self.config / "matugen/config.toml"
         self.matugen_conf.write_text(BASE_CONF)
+        # Stands in for /usr/local/lib.
+        self.priv = self.home / "usr-local-lib"
+        self.priv.mkdir()
 
-    def install_theme(self, name, with_generate_settings=True):
+    def install_theme(self, name, with_generate_settings=True,
+                      privileged_apply=True, legacy_apply=False):
+        """Lay out an install the way the theme's setup.sh leaves one.
+
+        `SddmColors.qml` is the template's input_path and the marker the restore
+        keys off; the apply script is *not* in this directory on a current
+        install, it is root-owned under the privileged directory.
+        """
         theme = self.config / name
         theme.mkdir(parents=True)
-        (theme / "sddm-theme-apply.sh").write_text("#!/bin/sh\n")
+        (theme / "SddmColors.qml").write_text("// stub\n")
         if with_generate_settings:
             (theme / "generate_settings.py").write_text("# stub\n")
+        if privileged_apply:
+            priv_theme = self.priv / name
+            priv_theme.mkdir(parents=True)
+            (priv_theme / "sddm-theme-apply.sh").write_text("#!/bin/sh\n")
+        if legacy_apply:
+            (theme / "sddm-theme-apply.sh").write_text("#!/bin/sh\n")
+
+    def apply_path(self, name):
+        return f"{self.priv}/{name}/sddm-theme-apply.sh"
 
     def run_restore(self):
+        function = self.function.replace(PRIV_LITERAL, f"{self.priv}/${{theme_name}}")
         script = textwrap.dedent(f"""\
             #!/usr/bin/env bash
             set -uo pipefail
             XDG_CONFIG_HOME="{self.config}"
             STY_BLUE=""; STY_RST=""
-            {self.function}
+            {function}
             {FUNCTION}
             """)
         path = self.home / "drive.sh"
         path.write_text(script)
         proc = subprocess.run(["bash", str(path)], capture_output=True, text=True)
         self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.stdout = proc.stdout
         return self.matugen_conf.read_text()
+
+    def block_of(self, conf):
+        """The [templates.iisddmtheme] body as key -> value."""
+        body, seen = {}, False
+        for line in conf.splitlines():
+            if line.strip() == BLOCK_HEADER:
+                seen = True
+                continue
+            if seen and line.startswith("["):
+                break
+            if seen and "=" in line:
+                key, _, value = line.partition("=")
+                body[key.strip()] = value.strip().strip("'")
+        self.assertTrue(seen, f"no {BLOCK_HEADER} block in:\n{conf}")
+        return body
+
+    # --- the whole block, not just the hook (#101) --------------------------
+
+    def test_the_template_block_is_restored_in_full(self):
+        """A post_hook with no input_path/output_path regenerates nothing: the
+        hook fires and publishes a Colors.qml nobody wrote."""
+        self.install_theme("imi-sddm-theme")
+        block = self.block_of(self.run_restore())
+        self.assertEqual(block["input_path"],
+                         "~/.config/imi-sddm-theme/SddmColors.qml")
+        self.assertEqual(block["output_path"],
+                         "~/.config/imi-sddm-theme/Colors.qml")
+        self.assertIn("post_hook", block)
+
+    def test_the_hook_lives_under_the_template_not_under_config(self):
+        """A `[config] post_hook` is global - it runs after every matugen
+        invocation, dragging a sudo call along with it."""
+        self.install_theme("imi-sddm-theme")
+        conf = self.run_restore()
+        head = conf.split(BLOCK_HEADER)[0]
+        self.assertNotIn("post_hook", head)
+
+    def test_a_stray_global_post_hook_is_cleaned_up(self):
+        """The state the old restore left on every machine it ran on. Left in
+        place alongside a correct block it runs the apply script twice per
+        wallpaper change, once of them outside the template."""
+        self.matugen_conf.write_text(
+            "[config]\n"
+            "post_hook = 'python3 ~/.config/imi-sddm-theme/generate_settings.py"
+            " && sudo ~/.config/imi-sddm-theme/sddm-theme-apply.sh &'\n"
+            "reload_apps = true\n")
+        self.install_theme("imi-sddm-theme")
+        conf = self.run_restore()
+        self.assertEqual(conf.count("post_hook"), 1, conf)
+        self.assertEqual(conf.count("sddm-theme-apply.sh"), 1, conf)
+        self.assertIn("stray global matugen post_hook", self.stdout)
+        self.assertIn("reload_apps = true", conf)
+
+    def test_a_post_hook_that_is_not_ours_is_left_alone(self):
+        """Only a global hook naming the theme's apply script is ours to
+        delete; the user's own belongs to them."""
+        self.matugen_conf.write_text("[config]\npost_hook = 'notify-send hi'\n")
+        self.install_theme("imi-sddm-theme")
+        conf = self.run_restore()
+        self.assertIn("post_hook = 'notify-send hi'", conf)
+
+    def test_the_guard_is_the_block_not_the_word_post_hook(self):
+        """`grep ^post_hook` matched the old version's own half-restore, so it
+        could never tell "the theme's block survived" from "only the bare hook I
+        wrote last time is here" - and never repaired the latter."""
+        self.matugen_conf.write_text(
+            "[config]\npost_hook = 'sudo /somewhere/sddm-theme-apply.sh &'\n")
+        self.install_theme("imi-sddm-theme")
+        self.block_of(self.run_restore())
+
+    # --- the apply script's path --------------------------------------------
+
+    def test_the_hook_calls_the_privileged_apply_script(self):
+        """sudo matches the NOPASSWD rule by path. The in-home path is not what
+        the rule names any more, and a password prompt from a backgrounded hook
+        is a hang, not a message."""
+        self.install_theme("imi-sddm-theme")
+        hook = self.block_of(self.run_restore())["post_hook"]
+        self.assertIn(f"sudo {self.apply_path('imi-sddm-theme')}", hook)
+        self.assertIn("python3 ~/.config/imi-sddm-theme/generate_settings.py", hook)
+
+    def test_an_install_predating_the_move_keeps_the_in_home_path(self):
+        """Those installs' sudoers rule still names the in-config copy;
+        rewriting the hook to a path that does not exist there would break a
+        working install."""
+        self.install_theme("imi-sddm-theme", privileged_apply=False,
+                           legacy_apply=True)
+        hook = self.block_of(self.run_restore())["post_hook"]
+        self.assertIn("sudo ~/.config/imi-sddm-theme/sddm-theme-apply.sh", hook)
+
+    def test_no_apply_script_anywhere_means_no_block(self):
+        """A block whose hook names a path that does not exist is not an
+        improvement on no block."""
+        self.install_theme("imi-sddm-theme", privileged_apply=False)
+        self.assertEqual(self.run_restore(), BASE_CONF)
+
+    def test_the_privileged_path_is_where_we_think_it_is(self):
+        """This literal is what the harness rewrites into the sandbox."""
+        self.assertIn(PRIV_LITERAL, self.function)
+
+    # --- resolving the theme's name -----------------------------------------
 
     def test_the_current_name_is_used(self):
         self.install_theme("imi-sddm-theme")
         conf = self.run_restore()
-        self.assertIn("~/.config/imi-sddm-theme/sddm-theme-apply.sh", conf)
-        self.assertNotIn("ii-sddm-theme/", conf.replace("imi-sddm-theme/", ""))
+        self.assertIn("~/.config/imi-sddm-theme/SddmColors.qml", conf)
+        self.assertNotIn("~/.config/ii-sddm-theme/", conf)
 
-    def test_an_unmigrated_install_still_gets_its_hook(self):
+    def test_an_unmigrated_install_still_gets_its_block(self):
         """Pre-rename installs exist until the theme's installer migrates them,
-        and they need the hook restored just as much."""
+        and they need the block restored just as much."""
         self.install_theme("ii-sddm-theme")
         conf = self.run_restore()
-        self.assertIn("~/.config/ii-sddm-theme/sddm-theme-apply.sh", conf)
+        self.assertIn("~/.config/ii-sddm-theme/SddmColors.qml", conf)
 
     def test_with_both_present_the_current_name_wins(self):
-        """A migrating update has both on disk at once. Writing the hook
+        """A migrating update has both on disk at once. Writing the block
         against the directory about to be removed breaks it immediately."""
         self.install_theme("ii-sddm-theme")
         self.install_theme("imi-sddm-theme")
@@ -101,26 +246,35 @@ class SddmMatugenHookRestoreTest(unittest.TestCase):
         self.assertIn("~/.config/imi-sddm-theme/", conf)
         self.assertNotIn("~/.config/ii-sddm-theme/", conf)
 
+    def test_the_theme_is_detected_by_the_templates_input_file(self):
+        """sddm-theme-apply.sh used to be the marker and is not installed in the
+        config directory at all any more, so that marker matches nothing on a
+        current install - the restore would silently never run."""
+        detection = self.function.split("for theme_name in")[1][:400]
+        self.assertIn("SddmColors.qml", detection)
+
+    # --- modes, idempotency, no-ops -----------------------------------------
+
     def test_the_matugen_only_mode_gets_no_generate_settings_call(self):
         """generate_settings.py ships only with the ii+matugen mode; calling it
         where it does not exist makes the hook fail every wallpaper change."""
         self.install_theme("imi-sddm-theme", with_generate_settings=False)
-        conf = self.run_restore()
-        self.assertIn("sudo ~/.config/imi-sddm-theme/sddm-theme-apply.sh", conf)
-        self.assertNotIn("generate_settings.py", conf)
+        hook = self.block_of(self.run_restore())["post_hook"]
+        self.assertEqual(hook, f"sudo {self.apply_path('imi-sddm-theme')} &")
 
-    def test_no_theme_means_no_hook(self):
+    def test_no_theme_means_no_block(self):
         self.assertEqual(self.run_restore(), BASE_CONF)
 
-    def test_an_existing_hook_is_not_duplicated(self):
+    def test_an_existing_block_is_not_duplicated(self):
         self.install_theme("imi-sddm-theme")
         first = self.run_restore()
-        self.assertEqual(first.count("post_hook"), 1)
+        self.assertEqual(first.count(BLOCK_HEADER), 1)
         self.assertEqual(self.run_restore(), first)
 
     def test_the_trailing_ampersand_survives(self):
-        """The hook ends in `&`, and `&` in a sed replacement means the whole
-        match - unescaped it expands to the literal text it was replacing."""
+        """The hook ends in `&` so matugen does not block on it. It has been
+        eaten before: `&` in a sed replacement means the whole match, which is
+        why the block is appended rather than spliced in."""
         self.install_theme("imi-sddm-theme")
         conf = self.run_restore()
         self.assertIn("sddm-theme-apply.sh &'", conf)

--- a/dots/.config/quickshell/imi/tests/test_sddm_uninstall_ownership.py
+++ b/dots/.config/quickshell/imi/tests/test_sddm_uninstall_ownership.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Uninstall step 5 must only remove an SDDM theme we installed.
+
+`sdata/subcmd-uninstall/0.run.sh` hands the machine to the theme's own
+uninstaller, which removes the theme directory, the drop-in carrying `Current=`,
+the user's `~/.config/<theme>` directory, its fonts, its matugen block and its
+`/etc/sudoers.d` rule.
+
+It used to decide that on nothing but a directory existing - *either* name:
+
+    if [[ -d .../imi-sddm-theme || -d .../ii-sddm-theme ]]; then
+
+`ii-sddm-theme` is upstream 3d3f/ii-sddm-theme's install name. Somebody who
+installed upstream's theme themselves, years before ImI, then installed ImI
+without the SDDM extra (`INSTALL_SDDM=0`, the default), had all of the above
+deleted by an ImI uninstall - and losing the theme directory while a `Current=`
+in `kde_settings.conf` or `/etc/sddm.conf` still names it is a machine with no
+graphical login. Step 4, immediately below, already models the right shape:
+prove ownership, don't infer it (issue #100).
+
+So install step 5 now records a marker on a successful hand-off, and uninstall
+fires on evidence: the marker, or the current theme name, which only this fork
+installs. A bare pre-fork directory is reported, never acted on.
+
+Hermetic: the gate is extracted from 0.run.sh with the themes directory
+rewritten into a tempdir, and driven for each combination. Nothing runs the real
+uninstaller and nothing looks at /usr/share.
+"""
+import re
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve()
+while not (ROOT / "sdata").exists():
+    if ROOT.parent == ROOT:
+        raise AssertionError("could not locate the repo root")
+    ROOT = ROOT.parent
+
+UNINSTALL = ROOT / "sdata/subcmd-uninstall/0.run.sh"
+INSTALL_5 = ROOT / "sdata/subcmd-install/5.sddm-theme.sh"
+UNINSTALL_TEXT = UNINSTALL.read_text(encoding="utf-8")
+INSTALL_5_TEXT = INSTALL_5.read_text(encoding="utf-8")
+
+THEMES_DIR = "/usr/share/sddm/themes"
+MARKER_REL = "immaterial-impulse/sddm-theme-installed"
+
+# Everything from the marker path down to the end of the ownership decision.
+GATE = re.search(r'^_sddm_marker=.*?^fi$', UNINSTALL_TEXT, re.M | re.S)
+assert GATE, "could not extract the step-5 ownership gate — did it move?"
+GATE_TEXT = GATE.group(0)
+
+
+class SddmUninstallOwnershipTest(unittest.TestCase):
+
+    def decide(self, *, marker=False, imi_dir=False, legacy_dir=False):
+        """Run the gate; return (fires, stdout)."""
+        tmp = Path(tempfile.mkdtemp(prefix="imi-sddm-own-"))
+        self.addCleanup(__import__("shutil").rmtree, tmp, ignore_errors=True)
+        themes, state = tmp / "themes", tmp / "state"
+        themes.mkdir()
+        (state / "immaterial-impulse").mkdir(parents=True)
+        if imi_dir:
+            (themes / "imi-sddm-theme").mkdir()
+        if legacy_dir:
+            (themes / "ii-sddm-theme").mkdir()
+        if marker:
+            (state / MARKER_REL).write_text("ref=deadbeef\n")
+
+        gate = GATE_TEXT.replace(THEMES_DIR, str(themes))
+        script = tmp / "drive.sh"
+        script.write_text(textwrap.dedent(f"""\
+            #!/usr/bin/env bash
+            set -uo pipefail
+            XDG_STATE_HOME="{state}"
+            STY_YELLOW=""; STY_CYAN=""; STY_RST=""
+            {gate}
+            printf 'DECISION=%s\\n' "$_sddm_ours"
+            """))
+        proc = subprocess.run(["bash", str(script)], capture_output=True, text=True)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn("DECISION=", proc.stdout)
+        fires = proc.stdout.rsplit("DECISION=", 1)[1].strip() == "true"
+        return fires, proc.stdout
+
+    # --- the case that cost somebody their login screen ---------------------
+
+    def test_a_foreign_pre_fork_install_is_never_touched(self):
+        """Upstream's theme, installed by the user, with no record of ours."""
+        fires, out = self.decide(legacy_dir=True)
+        self.assertFalse(fires)
+        self.assertIn("ii-sddm-theme", out)
+        self.assertIn("no record that we installed it", out)
+
+    def test_the_untouched_case_says_what_it_found_and_why_it_stopped(self):
+        """Silence would read as "there was no SDDM theme". The hint has to name
+        the directory and warn that deleting it while a Current= names it is the
+        login-blocking case."""
+        _, out = self.decide(legacy_dir=True)
+        self.assertIn("Leaving it alone", out)
+        self.assertIn("no graphical login", out)
+
+    def test_nothing_installed_at_all_is_silent(self):
+        fires, out = self.decide()
+        self.assertFalse(fires)
+        self.assertEqual(out.strip(), "DECISION=false")
+
+    # --- the cases that are ours --------------------------------------------
+
+    def test_our_own_theme_name_is_enough(self):
+        """Installs predating the marker have nothing else, and only this fork
+        installs under imi-sddm-theme."""
+        fires, _ = self.decide(imi_dir=True)
+        self.assertTrue(fires)
+
+    def test_the_marker_authorises_the_pre_fork_name(self):
+        """We installed it before the theme renamed itself and its migration has
+        not run since - still ours, and the only evidence that says so."""
+        fires, _ = self.decide(marker=True, legacy_dir=True)
+        self.assertTrue(fires)
+
+    def test_the_marker_alone_does_not_fire(self):
+        """A marker with no theme on disk means it is already gone."""
+        fires, _ = self.decide(marker=True)
+        self.assertFalse(fires)
+
+    def test_a_migrating_install_with_both_names_fires(self):
+        fires, _ = self.decide(marker=True, imi_dir=True, legacy_dir=True)
+        self.assertTrue(fires)
+
+    # --- the two halves have to agree ---------------------------------------
+
+    def test_install_step_5_writes_the_marker_the_uninstaller_reads(self):
+        self.assertIn(MARKER_REL.split("/")[-1], INSTALL_5_TEXT)
+        self.assertIn('${XDG_STATE_HOME:-$HOME/.local/state}/immaterial-impulse',
+                      INSTALL_5_TEXT)
+        self.assertIn('${XDG_STATE_HOME:-$HOME/.local/state}/immaterial-impulse/'
+                      + MARKER_REL.split("/")[-1], UNINSTALL_TEXT)
+
+    def test_the_marker_is_only_written_on_a_successful_handoff(self):
+        """A declined or failed theme install must not leave a marker claiming
+        we installed something."""
+        handoff = INSTALL_5_TEXT.split("handing off to the theme installer")[1]
+        marker_at = handoff.index("sddm-theme-installed")
+        else_at = handoff.index("\nelse\n")
+        self.assertLess(marker_at, else_at,
+                        "the marker is written outside the success branch")
+
+    def test_the_marker_is_removed_only_when_the_uninstall_succeeded(self):
+        """The theme's uninstaller exits non-zero when it removes nothing, so a
+        declined uninstall must leave the marker in place."""
+        self.assertIn('if bash "$_sddm_un"; then', UNINSTALL_TEXT)
+        after = UNINSTALL_TEXT.split('if bash "$_sddm_un"; then')[1]
+        self.assertLess(after.index('rm -f "$_sddm_marker"'), after.index("else"))
+
+    def test_the_handoff_is_gated_on_the_decision(self):
+        """The gate is worthless if the fetch-and-run below is not inside it."""
+        after = UNINSTALL_TEXT.split(GATE_TEXT, 1)[1]
+        self.assertIn('if [[ "$_sddm_ours" == true ]]; then',
+                      after[:after.index("uninstall.sh")])
+
+    def test_the_themes_directory_is_where_we_think_it_is(self):
+        """This literal is what the harness rewrites into the sandbox."""
+        self.assertIn(f"{THEMES_DIR}/imi-sddm-theme", GATE_TEXT)
+        self.assertIn(f"{THEMES_DIR}/ii-sddm-theme", GATE_TEXT)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sdata/subcmd-install/3.files-legacy.sh
+++ b/sdata/subcmd-install/3.files-legacy.sh
@@ -5,51 +5,92 @@
 
 #####################################################################################
 # The loop above deploys dots/.config/* with rsync --delete, and the SDDM login
-# theme keeps its trigger *inside* one of those files: its installer appends a
-# `post_hook` to ~/.config/matugen/config.toml so the greeter's background and
-# colors are regenerated on every wallpaper change. We ship our own
-# config.toml without that line, so each update deleted the hook and the login
-# screen quietly froze at whatever it looked like when the theme was installed.
+# theme keeps its integration *inside* one of those files: its installer appends
+# a `[templates.iisddmtheme]` block to ~/.config/matugen/config.toml so the
+# greeter's colors are regenerated on every wallpaper change. We ship our own
+# config.toml without that block, so each update deleted it and the login screen
+# quietly froze at whatever it looked like when the theme was installed.
 #
-# Put it back if the theme is installed. Idempotent, and it re-derives the mode
-# rather than assuming: generate_settings.py is only present for the
-# ii+matugen mode, which additionally syncs the shell's own settings.
+# The block is one unit and has to be restored as one. An earlier version of
+# this function put back only the `post_hook`, under [config] rather than under
+# the template, which is worse than not restoring anything: the hook fires (now
+# after *every* matugen run, not just this template's) while the input_path /
+# output_path pair that actually regenerates Colors.qml is gone, so nothing is
+# produced for it to publish. The greeter's palette stayed frozen and the
+# function reported success. See issue #101.
+#
+# Idempotent, and it re-derives the mode rather than assuming:
+# generate_settings.py is only present for the ii+matugen mode, which
+# additionally syncs the shell's own settings.
 restore_sddm_matugen_hook(){
   local matugen_conf="${XDG_CONFIG_HOME}/matugen/config.toml"
 
   # The theme installs as imi-sddm-theme; installs from before that rename are
   # still under ii-sddm-theme until the theme's own installer migrates them, so
-  # restore the hook for whichever is actually there. Preferring the new name
-  # matters: during a migrating update both directories exist for a moment, and
-  # pointing the hook at the one about to be deleted would break it again.
+  # restore for whichever is actually there. Preferring the new name matters:
+  # during a migrating update both directories exist for a moment, and pointing
+  # at the one about to be deleted would break it again.
+  #
+  # SddmColors.qml is the marker rather than sddm-theme-apply.sh: the apply
+  # script no longer lives here. It is installed root-owned under
+  # /usr/local/lib because a NOPASSWD sudoers rule names it and sudo matches by
+  # path. SddmColors.qml is the template's input_path, so it is exactly the file
+  # whose absence would make the block pointless.
   local theme_name theme_dir=""
   for theme_name in imi-sddm-theme ii-sddm-theme; do
-    if [[ -f "${XDG_CONFIG_HOME}/${theme_name}/sddm-theme-apply.sh" ]]; then
+    if [[ -f "${XDG_CONFIG_HOME}/${theme_name}/SddmColors.qml" ]]; then
       theme_dir="${XDG_CONFIG_HOME}/${theme_name}"
       break
     fi
   done
 
   [[ -n "$theme_dir" && -f "$matugen_conf" ]] || return 0
-  grep -q '^post_hook' "$matugen_conf" && return 0
+
+  # Guard on the block, not on `^post_hook`. The old guard could not tell "the
+  # theme's block survived" from "only the bare hook I restored last time is
+  # here", so it never noticed - or corrected - the half-restored state it had
+  # created itself.
+  grep -q '^\[templates\.iisddmtheme\]' "$matugen_conf" && return 0
+
+  # The apply script's path is what the sudoers rule names, and sudo matches by
+  # path: a hook naming any other location prompts for a password from a
+  # backgrounded hook and never completes. Prefer the root-owned location, fall
+  # back to the in-config one for installs made before that move.
+  local apply_script=""
+  if [[ -f "/usr/local/lib/${theme_name}/sddm-theme-apply.sh" ]]; then
+    apply_script="/usr/local/lib/${theme_name}/sddm-theme-apply.sh"
+  elif [[ -f "${theme_dir}/sddm-theme-apply.sh" ]]; then
+    apply_script="~/.config/${theme_name}/sddm-theme-apply.sh"
+  else
+    return 0
+  fi
 
   local hook
   if [[ -f "${theme_dir}/generate_settings.py" ]]; then
-    hook="python3 ~/.config/${theme_name}/generate_settings.py && sudo ~/.config/${theme_name}/sddm-theme-apply.sh &"
+    hook="python3 ~/.config/${theme_name}/generate_settings.py && sudo ${apply_script} &"
   else
-    hook="sudo ~/.config/${theme_name}/sddm-theme-apply.sh &"
+    hook="sudo ${apply_script} &"
   fi
 
-  # Belongs under [config]; matugen reads it from there.
-  # The hook ends in `&` to background it, and `&` in a sed replacement means
-  # "the whole match" - unescaped it expands to the literal text [config].
-  local hook_sed="${hook//&/\\&}"
-  if grep -q '^\[config\]' "$matugen_conf"; then
-    sed -i "0,/^\[config\]/s|^\[config\]|[config]\npost_hook = '${hook_sed}'|" "$matugen_conf"
-  else
-    printf '[config]\npost_hook = %s\n' "'${hook}'" >> "$matugen_conf"
+  # Drop a stray global post_hook left by the earlier half-restore. Left in
+  # place it would keep running the apply script (and a sudo call) after every
+  # matugen invocation, on top of the template's own hook. Only ours is touched:
+  # the line has to name the theme's apply script.
+  if grep -qE "^post_hook[[:space:]]*=.*sddm-theme-apply\.sh" "$matugen_conf"; then
+    sed -i -E "/^post_hook[[:space:]]*=.*sddm-theme-apply\.sh/d" "$matugen_conf"
+    echo -e "${STY_BLUE}[$0]: removed a stray global matugen post_hook for the SDDM theme (it fired on every run and regenerated nothing).${STY_RST}"
   fi
-  echo -e "${STY_BLUE}[$0]: restored the SDDM theme's matugen post_hook (our config.toml sync removes it).${STY_RST}"
+
+  # Same shape the theme's own setup.sh writes, so a later re-run of the theme
+  # installer replaces this block rather than appending a second one.
+  cat >> "$matugen_conf" <<EOF
+
+[templates.iisddmtheme]
+input_path = '~/.config/${theme_name}/SddmColors.qml'
+output_path = '~/.config/${theme_name}/Colors.qml'
+post_hook = '${hook}'
+EOF
+  echo -e "${STY_BLUE}[$0]: restored the SDDM theme's [templates.iisddmtheme] matugen block (our config.toml sync removes it).${STY_RST}"
 }
 
 # MISC (For dots/.config/* but not quickshell, not fish, not Hyprland, not fontconfig)

--- a/sdata/subcmd-install/5.sddm-theme.sh
+++ b/sdata/subcmd-install/5.sddm-theme.sh
@@ -51,7 +51,7 @@ fi
 
 SDDM_REPO_RAW="${SDDM_REPO_RAW:-https://raw.githubusercontent.com/XephyLon/imi-sddm-theme}"
 # Pin the installer for reproducibility. Bump this to adopt a newer imi-sddm-theme.
-SDDM_REF="${SDDM_REF:-cd56fcdcd70a0800918262e6cba2ebcc5aa9b447}"
+SDDM_REF="${SDDM_REF:-ac2e7d47f0998442d7baebee7165b4cc28d217d4}"
 SETUP_URL="${SDDM_REPO_RAW}/${SDDM_REF}/setup.sh"
 
 echo "[ImI] SDDM theme: fetching imi-sddm-theme installer (${SDDM_REF:0:12})..."

--- a/sdata/subcmd-install/5.sddm-theme.sh
+++ b/sdata/subcmd-install/5.sddm-theme.sh
@@ -75,8 +75,24 @@ fi
 # back to asking rather than being forced into a state that cannot work.
 echo "[ImI] SDDM theme: handing off to the theme installer (unattended)..."
 # Optional extra - never let a decline/failure abort the whole install.
-IMI_SDDM_ASSUME_YES="${IMI_SDDM_ASSUME_YES:-1}" \
-IMI_SDDM_MODE="${IMI_SDDM_MODE:-ii-matugen}" \
-  bash "$TMP_SETUP" \
-  || echo "[ImI] SDDM theme: theme installer exited non-zero (declined or error)."
+if IMI_SDDM_ASSUME_YES="${IMI_SDDM_ASSUME_YES:-1}" \
+   IMI_SDDM_MODE="${IMI_SDDM_MODE:-ii-matugen}" \
+     bash "$TMP_SETUP"; then
+  # Record that WE installed the theme, so uninstall has evidence rather than
+  # an inference. A theme directory only proves *someone* installed one: the
+  # pre-fork name (ii-sddm-theme) is upstream 3d3f/ii-sddm-theme's install name,
+  # and a user who installed that on their own years ago would have had their
+  # working login screen handed to our uninstaller on the strength of a
+  # directory existing. See issue #100.
+  #
+  # State, not config: it describes what this machine had done to it, and it
+  # must survive the dots sync in step 3, which rsync --delete's ~/.config.
+  _sddm_marker_dir="${XDG_STATE_HOME:-$HOME/.local/state}/immaterial-impulse"
+  if mkdir -p "$_sddm_marker_dir" 2>/dev/null; then
+    printf 'ref=%s\ninstalled=%s\n' "$SDDM_REF" "$(date -Is)" \
+      > "$_sddm_marker_dir/sddm-theme-installed" 2>/dev/null || true
+  fi
+else
+  echo "[ImI] SDDM theme: theme installer exited non-zero (declined or error)."
+fi
 echo "[ImI] SDDM theme: done."

--- a/sdata/subcmd-uninstall/0.run.sh
+++ b/sdata/subcmd-uninstall/0.run.sh
@@ -18,9 +18,39 @@ pause
 
 # Step 5: the imi-sddm-theme SDDM login theme (if present). Hand off to the
 # theme's own uninstaller, pinned to the same commit our installer used - it
-# removes both the current and the pre-rename name. Detect either, since an
-# install that predates the rename has not been migrated yet.
-if [[ -d /usr/share/sddm/themes/imi-sddm-theme || -d /usr/share/sddm/themes/ii-sddm-theme ]]; then
+# removes both the current and the pre-rename name.
+#
+# Only when it is ours to remove. This used to fire on either directory
+# existing, and "ii-sddm-theme" is upstream 3d3f/ii-sddm-theme's install name -
+# so a user who installed upstream's theme themselves, years before ImI, then
+# installed ImI *without* the SDDM extra (INSTALL_SDDM=0, the default), had
+# their working login screen handed to our uninstaller by an ImI uninstall. It
+# removes the theme directory, the drop-in carrying their Current=, their
+# config dir, fonts, matugen block and sudoers rule - none of which we created.
+# Losing the directory while Current= still names it is the login-blocking case.
+# Step 4 below already models the right shape: prove ownership, don't infer it.
+# See issue #100.
+#
+# Two forms of evidence, in order of strength:
+#   - the marker install step 5 writes on a successful hand-off. Definitive,
+#     and the only thing that can authorise removing the legacy name.
+#   - /usr/share/sddm/themes/imi-sddm-theme. Installs predating the marker have
+#     nothing else, and this name is ours: only this fork installs under it.
+# A bare legacy directory is never enough, and is reported instead of acted on.
+_sddm_marker="${XDG_STATE_HOME:-$HOME/.local/state}/immaterial-impulse/sddm-theme-installed"
+_sddm_ours=false
+if [[ -d /usr/share/sddm/themes/imi-sddm-theme ]]; then
+  _sddm_ours=true
+elif [[ -f "$_sddm_marker" && -d /usr/share/sddm/themes/ii-sddm-theme ]]; then
+  # We installed it before the theme renamed itself, and its migration has not
+  # run since. Still ours.
+  _sddm_ours=true
+elif [[ -d /usr/share/sddm/themes/ii-sddm-theme ]]; then
+  printf "${STY_YELLOW}Found /usr/share/sddm/themes/ii-sddm-theme, the pre-fork name, with no record that we installed it.${STY_RST}\n"
+  printf "${STY_YELLOW}Leaving it alone - it is most likely upstream 3d3f/ii-sddm-theme, installed by you. To remove it, use its own uninstaller; deleting the directory while a Current= still names it will leave you with no graphical login.${STY_RST}\n"
+fi
+
+if [[ "$_sddm_ours" == true ]]; then
   printf "${STY_CYAN}Undo install step 5 (imi-sddm-theme SDDM login theme)...\n${STY_RST}"
   if command -v curl >/dev/null; then
     # Must match SDDM_REF in sdata/subcmd-install/5.sddm-theme.sh -
@@ -28,9 +58,16 @@ if [[ -d /usr/share/sddm/themes/imi-sddm-theme || -d /usr/share/sddm/themes/ii-s
     _sddm_ref="${SDDM_REF:-cd56fcdcd70a0800918262e6cba2ebcc5aa9b447}"
     _sddm_un="$(mktemp --suffix=-ii-sddm-uninstall.sh)"
     if curl -fsSL "https://raw.githubusercontent.com/XephyLon/imi-sddm-theme/${_sddm_ref}/uninstall.sh" -o "$_sddm_un"; then
-      bash "$_sddm_un" || printf "${STY_YELLOW}imi-sddm-theme uninstaller exited non-zero; remove it manually if needed.${STY_RST}\n"
+      # The theme's uninstaller exits non-zero when it removes nothing (a
+      # decline, or no terminal to ask on), so the marker only goes away when
+      # the thing it records is actually gone.
+      if bash "$_sddm_un"; then
+        rm -f "$_sddm_marker"
+      else
+        printf "${STY_YELLOW}imi-sddm-theme uninstaller exited non-zero; remove it manually if needed.${STY_RST}\n"
+      fi
     else
-      printf "${STY_YELLOW}Could not fetch the imi-sddm-theme uninstaller. Remove manually: /usr/share/sddm/themes/{imi,ii}-sddm-theme, /etc/sddm.conf.d/{imi,ii}-sddm-theme.conf, ~/.config/{imi,ii}-sddm-theme, its /etc/sudoers.d rule and its fonts.${STY_RST}\n"
+      printf "${STY_YELLOW}Could not fetch the imi-sddm-theme uninstaller. Remove manually: /usr/share/sddm/themes/imi-sddm-theme, /etc/sddm.conf.d/zz-imi-sddm-theme.conf, ~/.config/imi-sddm-theme, /usr/local/lib/imi-sddm-theme, its /etc/sudoers.d rule and its fonts.${STY_RST}\n"
     fi
     rm -f "$_sddm_un"
   else

--- a/sdata/subcmd-uninstall/0.run.sh
+++ b/sdata/subcmd-uninstall/0.run.sh
@@ -55,7 +55,7 @@ if [[ "$_sddm_ours" == true ]]; then
   if command -v curl >/dev/null; then
     # Must match SDDM_REF in sdata/subcmd-install/5.sddm-theme.sh -
     # tests/test_sddm_theme_source.py pins that they agree.
-    _sddm_ref="${SDDM_REF:-cd56fcdcd70a0800918262e6cba2ebcc5aa9b447}"
+    _sddm_ref="${SDDM_REF:-ac2e7d47f0998442d7baebee7165b4cc28d217d4}"
     _sddm_un="$(mktemp --suffix=-ii-sddm-uninstall.sh)"
     if curl -fsSL "https://raw.githubusercontent.com/XephyLon/imi-sddm-theme/${_sddm_ref}/uninstall.sh" -o "$_sddm_un"; then
       # The theme's uninstaller exits non-zero when it removes nothing (a


### PR DESCRIPTION
Closes #101. Closes #100.

Two halves of the same subject: what the dots sync does to the SDDM theme's matugen integration, and what the uninstaller does to an SDDM theme that may not be ours.

## #101 — the matugen block was restored in pieces

`restore_sddm_matugen_hook` exists because install step 3 deploys `dots/.config/matugen/config.toml` with `rsync --delete`, wiping the `[templates.iisddmtheme]` block the theme's installer appends there. It put back only the `post_hook`, and under `[config]` rather than under the template.

That is worse than restoring nothing: the hook still fires — now after *every* matugen invocation, dragging a `sudo` call with it — while the `input_path`/`output_path` pair that regenerates `Colors.qml` is gone. Nothing produces the file the hook is meant to publish, so the greeter's palette freezes on every ImI update while the function reports success. Its guard (`grep ^post_hook`) matched its own half-restore, so the bad state was permanent once created.

Now: the guard is the block header; the full block is written in the same shape `setup.sh` writes; and a stray global `post_hook` naming the theme's apply script is deleted first (that line is on every machine this ran on). A `post_hook` that doesn't name the apply script is the user's and is left alone.

Two further defects surfaced while fixing it, both from the theme's recent history:

- **The detection marker no longer existed.** It keyed off `~/.config/<theme>/sddm-theme-apply.sh`, and that file is not installed there any more — the apply script is now root-owned at `/usr/local/lib/<theme>/`, because a NOPASSWD sudoers rule names it and sudo matches by path. On any current install the marker matched nothing and the restore silently never ran. It now keys off `SddmColors.qml`, the template's own `input_path`.
- **The restored hook named a path sudo would not accept.** Same reason. A password prompt from a hook backgrounded with `&` is a hang, not an error. The privileged path is preferred, with the in-config one kept as a fallback for installs predating the move, whose sudoers rule still names it.

## #100 — uninstall step 5 fired on somebody else's theme

It gated on a directory existing, under either name. `ii-sddm-theme` is upstream `3d3f/ii-sddm-theme`'s install name, so a user who installed upstream's theme themselves, then installed ImI *without* the SDDM extra (`INSTALL_SDDM=0`, the default), had their theme directory, drop-in, config dir, fonts, matugen block and sudoers rule deleted by an ImI uninstall. Losing the directory while a `Current=` still names it is the login-blocking case.

Step 4 immediately below already models the right shape — prove ownership, don't infer it. Step 5 now does the same:

- install step 5 writes a marker on a successful hand-off, under `XDG_STATE_HOME` so the dots sync (which `rsync --delete`s `~/.config`) can't erase the record. Written only in the success branch.
- uninstall fires on the marker, or on `/usr/share/sddm/themes/imi-sddm-theme` — our name, only this fork installs under it. Installs predating the marker still uninstall cleanly.
- the marker alone authorises the pre-fork name (we installed it before the rename and the migration hasn't run).
- a bare pre-fork directory with no marker is **reported, never acted on**, including the warning that deleting it while a `Current=` names it costs the user their login screen.

The marker is removed only when the theme's uninstaller succeeds — newly meaningful, since that uninstaller used to exit 0 when it removed nothing (fixed in the satellite PR). The manual-removal hint also still named pre-rename paths and omitted `/usr/local/lib/imi-sddm-theme`.

## Tests

`260 passed, 0 failed`.

- `test_sddm_matugen_hook_restore.py` — extended. Its existing cases pinned the half-restore as correct (they asserted the in-home hook path and never checked that `input_path`/`output_path` came back), so those assertions are replaced rather than kept; that was the test being wrong, not the change being a regression. 13 of the 17 cases fail against the previous implementation.
- `test_sddm_uninstall_ownership.py` — new. Drives the ownership gate for every combination of marker / current name / pre-fork name, and pins that install and uninstall agree on the marker path. Fails loudly against the previous implementation.

## Not done here

`SDDM_REF` and `WE_REF` are untouched. The pin needs to move for the satellite fixes to reach anyone — the SHA is in the comment below.
