### PR TITLE
fix(background): Wallpaper Engine transition and pending-project state (#94, #92)

### DIFF
--- a/dots/.config/quickshell/imi/modules/imi/background/Background.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/Background.qml
@@ -270,6 +270,32 @@ Variants {
         property real weTransitionProgress: 1.0  // 0 = old still, 1 = new surface
         property bool weTransitioning: false
 
+        // Put the transition back to its resting state: no peel on screen, the
+        // snapshot released, progress at "new surface". Reached from the
+        // watchdog below, and from the two states that make the first frame the
+        // peel is waiting for impossible to ever get.
+        function settleWeTransition() {
+            weTransitionAnim.stop()
+            weTransitionDelay.stop()
+            bgRoot.weTransitionProgress = 1.0
+            bgRoot.weTransitioning = false
+            weOldStill.source = ""
+        }
+        // `failed` latches on a project the renderer cannot draw, and that is
+        // precisely a moment when a transition has just been armed: the switch
+        // snapshots the outgoing frame and then waits on a frame that will never
+        // arrive, since the failure is reported before a texture is ever
+        // acquired. Nothing in the transition's own state can see that, so the
+        // peel used to sit there for the watchdog's whole budget - about nine
+        // seconds of the wallpaper the user just switched *away from*, painted
+        // over the static fallback that weFailed had already revealed
+        // underneath. That fallback exists to avoid exactly this.
+        onWeFailedChanged: if (bgRoot.weFailed) bgRoot.settleWeTransition()
+        // Same hole, different trigger: dropping weActive destroys the surface
+        // the peel samples as its destination, so the frozen still is all that
+        // is left to paint.
+        onWeActiveChanged: if (!bgRoot.weActive) bgRoot.settleWeTransition()
+
         // Switch the WE surface to `path`, animating a shader transition from a
         // snapshot of the current frame into the newly-loaded surface. Called on
         // weProjectPath changes instead of a reactive binding so the old frame can
@@ -353,11 +379,7 @@ Variants {
             running: bgRoot.weTransitioning
             onTriggered: {
                 console.warn("[Background] Wallpaper Engine transition did not finish; settling")
-                weTransitionAnim.stop()
-                weTransitionDelay.stop()
-                bgRoot.weTransitionProgress = 1.0
-                bgRoot.weTransitioning = false
-                weOldStill.source = ""
+                bgRoot.settleWeTransition()
             }
         }
 
@@ -592,7 +614,15 @@ Variants {
                 id: weTransition
                 anchors.fill: parent
                 z: 1
-                visible: bgRoot.weTransitioning
+                // Above the static wallpaper, so its own visibility has to
+                // account for the states that reveal it. `weTransitioning` alone
+                // does not: a failed project and a destroyed WE layer both leave
+                // the peel painting a frozen still of the *previous* project
+                // full-screen over the fallback underneath. Settling on those
+                // two clears this as well, but the guard is what makes it a
+                // property of the shader rather than of getting the handler
+                // ordering right.
+                visible: bgRoot.weTransitioning && !bgRoot.weFailed && weLoader.item !== null
                 property var fromImage: weOldStill
                 property var toImage: weLiveSource
                 property real progress: bgRoot.weTransitionProgress

--- a/dots/.config/quickshell/imi/modules/imi/background/Background.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/Background.qml
@@ -170,11 +170,18 @@ Variants {
             // A switch requested while suppressed could not be applied - the
             // surface only builds a project from updatePaintNode, which does not
             // run for an item that is not being drawn. Apply it now.
-            if (!bgRoot.suppressContents && bgRoot.wePendingProject !== "") {
-                const pending = bgRoot.wePendingProject;
-                bgRoot.wePendingProject = "";
-                bgRoot.loadWeWallpaper(pending);
-            }
+            //
+            // Re-read the request instead of replaying a stashed copy of one.
+            // A stash has to be invalidated by everything that can supersede it:
+            // a switch back to the project already loaded (which loadWeWallpaper
+            // returns on before it could clear anything) and the WE layer being
+            // destroyed and re-syncing on the way back. It was invalidated by
+            // neither, so un-suppressing could load a project the user had
+            // already moved off, silently, while the config said otherwise.
+            // weProjectPath *is* the request and cannot go stale, and
+            // loadWeWallpaper already no-ops when it matches what is loaded.
+            if (!bgRoot.suppressContents)
+                bgRoot.loadWeWallpaper(bgRoot.weProjectPath);
         }
 
         property HyprlandMonitor monitor: Hyprland.monitorFor(modelData)
@@ -260,7 +267,6 @@ Variants {
 
         // WE wallpaper switch transition state.
         property string weLoadedProject: ""     // project currently in the surface
-        property string wePendingProject: ""    // requested while suppressed, not applied yet
         property real weTransitionProgress: 1.0  // 0 = old still, 1 = new surface
         property bool weTransitioning: false
 
@@ -273,11 +279,9 @@ Variants {
             // Nothing draws this item while suppressed, so the surface would never
             // reach updatePaintNode to build the new project - it would sit on the
             // old one with QML believing otherwise, and the transition would hang
-            // waiting for a first frame that cannot arrive. Defer to un-suppress.
-            if (bgRoot.suppressContents) {
-                bgRoot.wePendingProject = path
-                return
-            }
+            // waiting for a first frame that cannot arrive. Drop it; un-suppressing
+            // re-reads weProjectPath and applies whatever it says then.
+            if (bgRoot.suppressContents) return
             const canTransition = bgRoot.weLoadedProject !== "" && weLoader.item.rendered
                 && bgRoot.wallpaperAnimation !== ""
             if (!canTransition) {

--- a/dots/.config/quickshell/imi/tests/test_background_fullscreen_suppression.py
+++ b/dots/.config/quickshell/imi/tests/test_background_fullscreen_suppression.py
@@ -206,6 +206,19 @@ class _QmlSource:
                 return value
         return None
 
+    def function_body(self, name):
+        """The `{ ... }` of `function <name>(...)`, or None.
+
+        A function body is a `js` block whose header carries the declaration,
+        so it is not reachable through `elements()`/`members()` - and pins that
+        follow a call into the function it lands in need it.
+        """
+        declaration = re.compile(r"\bfunction\s+" + re.escape(name) + r"\s*\(")
+        for block in self.blocks:
+            if block.close_at is not None and declaration.search(block.header):
+                return self.code[block.open_at:block.close_at]
+        return None
+
     def element_id(self, block):
         """The block's `id`, as a bare identifier.
 
@@ -381,25 +394,57 @@ class BackgroundSuppressionTests(unittest.TestCase):
                       "Leaving fullscreen must clear suppression directly, not "
                       "through the delay timer.")
 
-    def test_a_switch_requested_while_suppressed_is_deferred(self):
+    def test_a_switch_made_while_suppressed_is_applied_on_the_way_back(self):
         """The surface only builds a project while it is being drawn.
 
-        Declaring `wePendingProject` is not the contract - queueing a switch
-        into it while suppressed, and replaying it on un-suppress, is. Both
-        halves have to be present or a wallpaper change made behind a
-        fullscreen window is simply lost.
+        Both halves have to be present or a wallpaper change made behind a
+        fullscreen window is simply lost: `loadWeWallpaper` must still decline
+        to apply one while suppressed (the surface never reaches
+        updatePaintNode, so it would sit on the old project with QML believing
+        otherwise, and the transition would hang on a first frame that cannot
+        arrive), and un-suppressing must re-apply it.
+
+        This used to name `wePendingProject`, the stash that held the deferred
+        switch. It pins the behaviour rather than the storage now - see the
+        test below for why the storage went away.
         """
-        queued = [m for m in re.finditer(r"wePendingProject\s*=\s*(?!\"\"|'')(\S+)",
-                                         self.qml.code)]
-        self.assertTrue(queued,
-                        "nothing ever queues a switch into wePendingProject, so "
-                        "the deferral cannot happen.")
+        load = self.qml.function_body("loadWeWallpaper")
+        self.assertIsNotNone(load, "loadWeWallpaper should still exist")
+        self.assertIn("suppressContents", load,
+                      "loadWeWallpaper must still refuse to apply a switch while "
+                      "the contents are suppressed.")
         replay = self._handler_body("onSuppressContentsChanged")
-        self.assertIn("wePendingProject", replay,
-                      "un-suppressing must look at the deferred switch.")
         self.assertIn("loadWeWallpaper", replay,
-                      "the deferred switch must actually be replayed, not just "
-                      "cleared.")
+                      "un-suppressing must actually re-apply the switch.")
+
+    def test_the_project_replayed_on_un_suppress_is_the_live_request(self):
+        """Not a stashed copy of one, which nothing could invalidate (#92).
+
+        `wePendingProject` was written in one place and cleared in one place -
+        when it was replayed. Both arms of `loadWeWallpaper`'s first line
+        return *before* the suppression check, so neither could clear a stash
+        that had just been superseded: not a switch back to the project already
+        loaded, and not the WE layer being destroyed and re-syncing
+        `weLoadedProject` on the way back. Un-suppressing then replayed a
+        project the user had already moved off, with `activePath` and
+        `weProjectPath` both saying something else and nothing reconciling them.
+        (`""` also served as both "nothing pending" and a legal project path.)
+
+        Reading `weProjectPath` at replay time deletes the state rather than
+        adding invalidation to it: the request cannot go stale, because it *is*
+        the request. `loadWeWallpaper` already no-ops when it matches what is
+        loaded, so the unconditional call costs nothing.
+        """
+        replay = self._handler_body("onSuppressContentsChanged")
+        call = re.search(r"loadWeWallpaper\s*\(([^)]*)\)", replay)
+        self.assertIsNotNone(call, "un-suppressing must call loadWeWallpaper")
+        argument = call.group(1).strip()
+        self.assertRegex(
+            argument, r"^(?:bgRoot\.)?weProjectPath$",
+            f"un-suppressing replays `{argument}` rather than the live "
+            "weProjectPath. Anything held across the suppression has to be "
+            "invalidated by every route that can supersede it, and the two "
+            "early returns in loadWeWallpaper are not able to.")
 
     def test_transition_cannot_hang_forever(self):
         """A stalled wallpaper transition must settle itself.
@@ -425,18 +470,6 @@ class BackgroundSuppressionTests(unittest.TestCase):
                       "the watchdog must clear the transition it is guarding, "
                       "or the peel shader never comes off screen.")
 
-    def test_fullscreen_test_ignores_maximized(self):
-        """Maximized is not fullscreen; only the polled int tells them apart."""
-        self.assertRegex(self.hyprland_data, r"\bfullscreen\s*>=\s*2",
-                         "HyprlandData must keep testing the fullscreen *mode*, "
-                         "not its truthiness - 1 is maximized.")
-        for name, source in (("Background", self.background),
-                             ("ScreenCorners", self.corners)):
-            self.assertIn("fullscreenByMonitorName", source,
-                          f"{name} should read the polled per-monitor map.")
-            self.assertNotIn("wayland?.fullscreen", source,
-                             f"{name} still uses the toplevel's own fullscreen "
-                             "flag, which is true for maximized windows too.")
 
     def _handler_body(self, handler):
         for child in self.window.children:

--- a/dots/.config/quickshell/imi/tests/test_background_fullscreen_suppression.py
+++ b/dots/.config/quickshell/imi/tests/test_background_fullscreen_suppression.py
@@ -466,10 +466,94 @@ class BackgroundSuppressionTests(unittest.TestCase):
             if child.header.rstrip().endswith("onTriggered:"):
                 fired = self.qml.code[child.open_at:child.close_at]
         self.assertIsNotNone(fired, "the watchdog needs an onTriggered body.")
-        self.assertIn("weTransitioning = false", fired,
+        self.assertIn("weTransitioning = false", self._with_called_bodies(fired),
                       "the watchdog must clear the transition it is guarding, "
                       "or the peel shader never comes off screen.")
 
+    def test_the_transition_overlay_yields_to_the_static_fallback(self):
+        """The peel is drawn above the wallpaper `weFailed` falls back to (#94).
+
+        `weTransition` carries `z: 1`, which puts it over the static `wallpaper`
+        image, and its only visibility term was `weTransitioning`. The way
+        `failed` latches is by loading a project that cannot render, which is
+        exactly when a transition has just been armed - and the renderer reports
+        it from the early-return path before a texture is ever acquired, so
+        `rendered` goes true->false and never comes back. The transition is
+        armed, never starts, and nothing clears it until the watchdog's
+        `wallpaperTransitionDuration + 8000` = 9.2s budget runs out. For all of
+        that time a frozen still of the project the user switched *away from*
+        covers the static fallback that `weFailed` had just revealed underneath.
+
+        Dropping `weActive` mid-transition is the same hole: the surface the
+        peel samples as its destination is destroyed and the still is all that
+        is left to paint.
+
+        Same structural shape as 82f7b29b7 on the static path - never let a
+        shader be the only thing painting the desktop.
+        """
+        shader = None
+        for element in self.qml.elements("ShaderEffect"):
+            if self.qml.element_id(element) == "weTransition":
+                shader = element
+        self.assertIsNotNone(shader, "the WE transition shader should still exist")
+        visible = self.qml.member(shader, "visible") or ""
+        self.assertIn("weFailed", visible,
+                      "the peel stays up over a project the renderer gave up on, "
+                      "hiding the static fallback that failure reveals.")
+        self.assertIn("weLoader.item", visible,
+                      "the peel stays up with its destination surface destroyed, "
+                      "painting the frozen still of the outgoing project alone.")
+
+    def test_a_transition_that_can_never_finish_settles_without_the_watchdog(self):
+        """Both states are known the moment they happen; nothing should wait.
+
+        The watchdog does recover coherent state - the defect is that nothing
+        shortened the wait when the reason the transition will never finish is
+        already known.
+        """
+        for handler, why in (
+                ("onWeFailedChanged",
+                 "a project the renderer gave up on will never produce the "
+                 "first frame the peel is waiting for"),
+                ("onWeActiveChanged",
+                 "a destroyed WE layer takes the peel's destination surface "
+                 "with it")):
+            with self.subTest(handler=handler):
+                body = self.qml.member(self.window, handler)
+                self.assertIsNotNone(
+                    body, f"{handler} should settle the transition: {why}.")
+                self.assertIn(
+                    "weTransitioning = false", self._with_called_bodies(body),
+                    f"{handler} does not settle the transition, so it waits out "
+                    f"the ~9s watchdog instead: {why}.")
+
+    def _with_called_bodies(self, body):
+        """`body`, plus the body of any same-component function it calls.
+
+        The watchdog used to clear the transition inline; it and the two
+        handlers above now share one settle path. Following a call one level
+        deep keeps these pins aimed at what happens rather than at the syntax
+        it happened to be written in.
+        """
+        text = body
+        for name in set(re.findall(r"\b(?:bgRoot\.)?(\w+)\s*\(", body)):
+            called = self.qml.function_body(name)
+            if called:
+                text += called
+        return text
+
+    def test_fullscreen_test_ignores_maximized(self):
+        """Maximized is not fullscreen; only the polled int tells them apart."""
+        self.assertRegex(self.hyprland_data, r"\bfullscreen\s*>=\s*2",
+                         "HyprlandData must keep testing the fullscreen *mode*, "
+                         "not its truthiness - 1 is maximized.")
+        for name, source in (("Background", self.background),
+                             ("ScreenCorners", self.corners)):
+            self.assertIn("fullscreenByMonitorName", source,
+                          f"{name} should read the polled per-monitor map.")
+            self.assertNotIn("wayland?.fullscreen", source,
+                             f"{name} still uses the toplevel's own fullscreen "
+                             "flag, which is true for maximized windows too.")
 
     def _handler_body(self, handler):
         for child in self.window.children:


### PR DESCRIPTION
## Describe your changes

Two defects in `Background.qml`'s Wallpaper Engine state, both in the same area and taken together because they interact.

**#92 — `wePendingProject` was never invalidated.** Written in one place, cleared in one place (when replayed), and both arms of `loadWeWallpaper`'s first line return *before* the suppression check, so neither could clear a stash that had just been superseded. Un-suppressing could load a project the user had already moved off. The stash is removed rather than given invalidation: what un-suppressing wants to apply is always the *current* request, `weProjectPath`, which cannot go stale. That also disposes of the `""`-as-both-sentinel-and-legal-path overload the issue flags.

**#94 — the transition overlay outlived its own destination.** `weTransition` is `z: 1` above the static wallpaper and its only visibility term was `weTransitioning`. A project the renderer gives up on latches `failed` exactly when a transition has just been armed, so the peel painted a frozen still of the *outgoing* project over the static fallback that `weFailed` had just revealed — for the watchdog's full ~9.2s. Fixed on both sides: `visible` gains `!weFailed` and a null check, and `onWeFailedChanged` / `onWeActiveChanged` settle the transition immediately through a shared `settleWeTransition()` that the watchdog now also uses.

Two commits, one per issue.

## Is it ready? Questions/feedback needed?

Ready, with one thing worth your call — see the review comment below: #92's fix deletes state rather than adding invalidation, which is a slightly larger change than the issue proposes.

Refs #92
Refs #94