### PR TITLE
fix(sidebarRight): hide the empty-notification shape when the list is cramped (#87)

### DIFF
--- a/dots/.config/quickshell/imi/modules/common/functions/placeholderFit.js
+++ b/dots/.config/quickshell/imi/modules/common/functions/placeholderFit.js
@@ -1,0 +1,31 @@
+.pragma library
+
+// A PagePlaceholder centres its column in whatever space the page gives it,
+// and a page shorter than that column does not clip it - the column simply
+// draws outside the container it belongs to. The right sidebar's notification
+// list is the case that forced this (#87): it shares the sidebar column with a
+// fixed-height bottom widget group, so on a short screen it is squeezed until
+// the placeholder's shape sits above the list's own top edge, outside the
+// rounded rectangle that is supposed to hold it.
+//
+// The shape is both the tallest part of a placeholder and the part carrying
+// the least information, so it is what gives way first - the text alone still
+// says what the empty state is.
+
+// Whether the shape still fits above the labels within `availableHeight`.
+//
+// `iconHeight` is the shape's own implicit height and `textHeights` are the
+// visible labels' - never the column's own implicit height, which excludes an
+// invisible child. Deciding from that would drop the shape, free its height,
+// find there is room again, put it back, and oscillate forever.
+//
+// A page with no height yet has not been laid out; it is not "too short". A
+// placeholder built before its first layout pass would otherwise start without
+// its shape and pop it in, which reads as a glitch rather than as a fit.
+function iconFits(availableHeight, iconHeight, textHeights, spacing) {
+    if (!(availableHeight > 0))
+        return true;
+    const text = (textHeights || []).reduce(
+        (total, height) => total + height + spacing, 0);
+    return availableHeight >= iconHeight + text;
+}

--- a/dots/.config/quickshell/imi/modules/common/widgets/PagePlaceholder.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/PagePlaceholder.qml
@@ -2,6 +2,7 @@ import QtQuick
 import QtQuick.Layouts
 import qs.modules.common
 import qs.modules.common.widgets
+import "../functions/placeholderFit.js" as PlaceholderFit
 
 Item {
     id: root
@@ -12,6 +13,24 @@ Item {
     property alias description: widgetDescriptionText.text
     property alias shape: shapeWidget.shape
     property alias descriptionHorizontalAlignment: widgetDescriptionText.horizontalAlignment
+
+    // Drop the shape rather than let it draw outside the page when the page is
+    // too short to hold the whole column - placeholderFit.js has the reasoning
+    // for why the shape is what gives way. Off by default: a page with room to
+    // spare wants it, since an empty state is mostly that shape. Only a page
+    // squeezed by a sibling of fixed height needs this.
+    property bool dropIconWhenCramped: false
+    readonly property var textHeights: {
+        const heights = [];
+        if (widgetNameText.visible)
+            heights.push(widgetNameText.implicitHeight);
+        if (widgetDescriptionText.visible)
+            heights.push(widgetDescriptionText.implicitHeight);
+        return heights;
+    }
+    readonly property bool iconShown: !root.dropIconWhenCramped
+        || PlaceholderFit.iconFits(root.height, shapeWidget.implicitHeight,
+                                   root.textHeights, column.spacing)
 
     opacity: shown ? 1 : 0
     visible: opacity > 0
@@ -26,11 +45,18 @@ Item {
     }
 
     ColumnLayout {
+        id: column
         anchors.centerIn: parent
         spacing: Appearance.spacing.space100
+        // Only while measuring. A description wraps to this column's width, so
+        // leaving that width to the children would let dropping the shape
+        // narrow the column, reflow the description, change the height being
+        // measured, and feed straight back into the decision that dropped it.
+        width: root.dropIconWhenCramped ? root.width : column.implicitWidth
 
         MaterialShapeWrappedMaterialSymbol {
             id: shapeWidget
+            visible: root.iconShown
             Layout.alignment: Qt.AlignHCenter
             padding: Appearance.spacing.space150
             iconSize: 56

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/notifications/NotificationList.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/notifications/NotificationList.qml
@@ -30,13 +30,25 @@ Item {
         popup: false
     }
 
-    // Placeholder when list is empty
-    PagePlaceholder {
-        shown: Notifications.list.length === 0
-        icon: "notifications_active"
-        description: Translation.tr("Nothing")
-        shape: MaterialShape.Shape.Ghostish
-        descriptionHorizontalAlignment: Text.AlignHCenter
+    // Placeholder when list is empty. Given the list's area rather than the
+    // whole column: the status row along the bottom is not space the empty
+    // state can use, and the placeholder decides whether its shape fits from
+    // the height it is handed.
+    Item {
+        anchors.fill: listview
+
+        PagePlaceholder {
+            // This list shares the sidebar column with a bottom widget group of
+            // fixed height (see BottomWidgetGroup.expandedHeight), so on a short
+            // screen it is squeezed until the shape reaches past the top of the
+            // rounded container holding it - which does not clip (#87).
+            dropIconWhenCramped: true
+            shown: Notifications.list.length === 0
+            icon: "notifications_active"
+            description: Translation.tr("Nothing")
+            shape: MaterialShape.Shape.Ghostish
+            descriptionHorizontalAlignment: Text.AlignHCenter
+        }
     }
 
     ButtonGroup {

--- a/dots/.config/quickshell/imi/tests/test_shared_widget_contracts.py
+++ b/dots/.config/quickshell/imi/tests/test_shared_widget_contracts.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python3
 """Structural guarantees for shared settings controls."""
 
+import re
 from pathlib import Path
 import unittest
 
 
 ROOT = Path(__file__).resolve().parents[1]
+PLACEHOLDER = ROOT / "modules/common/widgets/PagePlaceholder.qml"
+NOTIFICATION_LIST = ROOT / "modules/imi/sidebarRight/notifications/NotificationList.qml"
 
 
 class SharedWidgetContractsTest(unittest.TestCase):
@@ -14,6 +17,61 @@ class SharedWidgetContractsTest(unittest.TestCase):
             encoding="utf-8"
         )
         self.assertNotIn("Layout.bottomMargin", source)
+
+    def test_the_placeholder_shape_is_gated_on_the_tested_fit_rule(self):
+        """`tst_placeholder_fit.qml` proves the arithmetic; this proves it is used.
+
+        The widget cannot be instantiated by the QML suite (StyledText assigns
+        `font.variableAxes`, which needs Qt 6.7 while the suite runs against the
+        distribution Qt), so the decision lives in placeholderFit.js and the
+        unit test drives it directly. That test goes vacuous the moment
+        PagePlaceholder stops asking it, which nothing else would notice.
+        """
+        source = PLACEHOLDER.read_text(encoding="utf-8")
+        self.assertIn("placeholderFit.js", source,
+                      "PagePlaceholder no longer imports the fit rule the unit "
+                      "test exercises.")
+        self.assertRegex(
+            source, r"iconShown:[^\n]*(\n[^\n]*)*?iconFits\(",
+            "PagePlaceholder computes `iconShown` without calling iconFits(), "
+            "so the tested rule is not what decides whether the shape is drawn.")
+        self.assertRegex(
+            source, r"id:\s*shapeWidget\s*\n\s*visible:\s*root\.iconShown\b",
+            "the shape is not gated on iconShown, so it is drawn outside a page "
+            "too short to hold it regardless of what the rule says.")
+
+    def test_the_placeholder_measures_the_children_not_the_column(self):
+        """A column's implicitHeight excludes an invisible child.
+
+        Deciding from it would drop the shape, free its height, find there is
+        room again, put it back, and oscillate - a relayout loop, which in this
+        codebase means a pegged core rather than a wrong pixel.
+        """
+        source = PLACEHOLDER.read_text(encoding="utf-8")
+        call = re.search(r"iconFits\((.*?)\)", source, re.S)
+        self.assertIsNotNone(call, "PagePlaceholder should call iconFits()")
+        self.assertNotIn("column.implicitHeight", call.group(1),
+                         "measuring the column feeds the shape's own visibility "
+                         "back into the decision that hides it.")
+        self.assertIn("shapeWidget.implicitHeight", call.group(1),
+                      "the shape's own implicit height is the term that does not "
+                      "move when it is hidden.")
+
+    def test_the_notification_placeholder_opts_in_and_gets_the_lists_area(self):
+        """#87: the squeezed page, and the only one that opts in.
+
+        The status row along the bottom is not space the empty state can use,
+        so a placeholder filling the whole column would measure room it does
+        not have and keep a shape that overlaps the buttons.
+        """
+        source = NOTIFICATION_LIST.read_text(encoding="utf-8")
+        self.assertIn("dropIconWhenCramped: true", source,
+                      "the notification list's placeholder no longer opts in, so "
+                      "its shape draws outside the container again.")
+        self.assertRegex(
+            source, r"anchors\.fill:\s*listview",
+            "the placeholder must be given the list's area, not the whole "
+            "column - otherwise it measures the status row's height as free.")
 
 
 if __name__ == "__main__":

--- a/dots/.config/quickshell/imi/tests/tst_placeholder_fit.qml
+++ b/dots/.config/quickshell/imi/tests/tst_placeholder_fit.qml
@@ -1,0 +1,65 @@
+import QtTest
+import "../modules/common/functions/placeholderFit.js" as PlaceholderFit
+
+// The empty-state placeholder's shape is dropped rather than drawn outside a
+// page too short to hold it (#87). The widget itself cannot be instantiated
+// here - it reaches StyledText, whose `font.variableAxes` needs Qt 6.7 while
+// the suite runs against the distribution Qt - so the decision lives in a
+// library function and this is where it is exercised.
+TestCase {
+    name: "PlaceholderFitTest"
+
+    readonly property real iconHeight: 80   // 56px symbol + space150 padding
+    readonly property real lineHeight: 20
+    readonly property real spacing: 8       // space100, the column's own
+
+    function fits(availableHeight, textHeights) {
+        return PlaceholderFit.iconFits(availableHeight, iconHeight,
+                                       textHeights, spacing);
+    }
+
+    function test_aPageWithRoomKeepsItsShape() {
+        verify(fits(400, [lineHeight]));
+        verify(fits(400, []));
+    }
+
+    // The whole point: a page shorter than the column does not clip it, so
+    // there is no such thing as "it overflows a little".
+    function test_aPageTooShortDropsTheShape() {
+        verify(!fits(60, []));
+        verify(!fits(100, [lineHeight]));
+    }
+
+    // 80 + 8 + 20 = 108 exactly. Off by one either way is a shape drawn one
+    // pixel outside the container, or dropped with a pixel to spare.
+    function test_theBoundaryIsExactFit() {
+        compare(fits(108, [lineHeight]), true, "an exact fit still fits");
+        compare(fits(107, [lineHeight]), false, "one pixel short does not");
+    }
+
+    // The spacing above each label is part of what the shape has to leave
+    // behind, so a title *and* a description cost more than either alone.
+    function test_everyVisibleLabelCostsItsOwnSpacing() {
+        const one = [lineHeight];
+        const two = [lineHeight, lineHeight];
+        verify(fits(108, one));
+        verify(!fits(108, two));
+        verify(fits(136, two), "80 + 2 * (8 + 20) = 136");
+    }
+
+    // A placeholder built before its first layout pass has height 0, which is
+    // "not measured yet", not "too short". Reading it as too short would drop
+    // the shape on construction and pop it back in a frame later.
+    function test_anUnlaidOutPageIsNotTreatedAsTooShort() {
+        verify(fits(0, [lineHeight]));
+        verify(fits(-1, [lineHeight]));
+        verify(fits(NaN, [lineHeight]));
+        verify(fits(undefined, [lineHeight]));
+    }
+
+    function test_noLabelsIsJustTheShape() {
+        compare(fits(80, []), true);
+        compare(fits(79, []), false);
+        compare(fits(80, undefined), true, "an absent list reads as no labels");
+    }
+}


### PR DESCRIPTION
## Describe your changes

Implements your call on #87 — *"I'll just hide the notification icon when covered by too many things."*

`PagePlaceholder` centres its column with `anchors.centerIn` on a page that does not clip, so a page shorter than the column draws it **outside** the container rather than cropping it. The right sidebar's notification list shares its column with `BottomWidgetGroup`'s fixed 352px, so on a short screen it is squeezed until the 56px shape reaches above the rounded container's top edge.

The shape is the tallest part of a placeholder and the part carrying the least information, so it is what gives way — `"Nothing"` on its own still reads as an empty state. **Opt-in** via `dropIconWhenCramped`, set only by the notification list; the other five placeholders are byte-for-byte unaffected.

The fit rule lives in `modules/common/functions/placeholderFit.js` (same shape as `screenSelection.js`) because the widget cannot be instantiated by the QML suite — `StyledText` assigns `font.variableAxes`, which is Qt 6.7, and the suite runs against the distribution Qt 6.4. `tst_placeholder_fit.qml` drives it directly; three pins in `test_shared_widget_contracts.py` keep that from going vacuous.

## Is it ready? Questions/feedback needed?

Ready. One thing I deliberately left alone is the reporter's *second* complaint — details in the review comment below.

Closes #87