### PR TITLE
Reboot after arming BootNext, and disarm it if the reboot fails

### DIFF
--- a/dots/.config/quickshell/imi/modules/common/functions/Session.qml
+++ b/dots/.config/quickshell/imi/modules/common/functions/Session.qml
@@ -37,18 +37,29 @@ Singleton {
         Quickshell.execDetached(["bash", "-c", `systemctl hibernate || loginctl hibernate`]);
     }
 
+    // Order is deliberate: issue the transition FIRST, close windows after. It
+    // used to be the other way round, which meant a transition that did not
+    // happen - a polkit denial, an inhibitor, or a session logind does not
+    // consider "active" and therefore wants admin auth for - had already killed
+    // every one of the user's applications by the time it failed. The user was
+    // left on an empty desktop, still logged in, with nothing on screen
+    // explaining why.
+    //
+    // Reversing it costs nothing. systemd's shutdown sequence SIGTERMs every
+    // process anyway, so applications still get their chance to save;
+    // closeAllWindows() only ever brought that forward by a fraction of a second.
     function poweroff() {
-        closeAllWindows();
         Quickshell.execDetached(["bash", "-c", `systemctl poweroff || loginctl poweroff`]);
+        closeAllWindows();
     }
 
     function reboot() {
-        closeAllWindows();
         Quickshell.execDetached(["bash", "-c", `reboot || loginctl reboot`]);
+        closeAllWindows();
     }
 
     function rebootToFirmware() {
-        closeAllWindows();
         Quickshell.execDetached(["bash", "-c", `systemctl reboot --firmware-setup || loginctl reboot --firmware-setup`]);
+        closeAllWindows();
     }
 }

--- a/dots/.config/quickshell/imi/services/EfiBoot.qml
+++ b/dots/.config/quickshell/imi/services/EfiBoot.qml
@@ -75,17 +75,63 @@ Singleton {
         }
     }
 
+    function notify(title, body) {
+        Quickshell.execDetached(["notify-send", title, body, "-a", "Session"])
+    }
+
     Process {
         id: setNextProc
         command: ["pkexec", "efibootmgr", "-n", root.pendingNum]
         onExited: (exitCode, exitStatus) => {
             if (exitCode === 0) {
-                Session.reboot()
+                // BootNext is now armed in firmware. From here every exit path
+                // must either reboot or clear it again - see rebootProc.
+                rebootProc.running = true
             } else if (exitCode !== 126 && exitCode !== 127) {
                 // 126/127 = polkit dismissal/authorization failure: user's call,
                 // stay quiet. Anything else is a real failure worth surfacing.
-                Quickshell.execDetached(["notify-send", "Reboot cancelled",
-                    `efibootmgr failed to set BootNext (${exitCode})`, "-a", "Session"])
+                root.notify("Reboot cancelled",
+                    `efibootmgr failed to set BootNext (${exitCode})`)
+            }
+        }
+    }
+
+    // Deliberately a Process rather than Session.reboot(). Session.reboot() is
+    // execDetached, which reports nothing back - and once BootNext is armed,
+    // "the reboot silently did not happen" is precisely the state that must not
+    // go unnoticed, because it leaves the machine set to boot another OS at some
+    // unrelated future restart. An exit code is the whole point.
+    //
+    // Nothing tears down the UI first. The session screen has already hidden
+    // itself before rebootInto() is called, and a reboot that fails must leave
+    // the user's session exactly as it was.
+    Process {
+        id: rebootProc
+        command: ["bash", "-c", "reboot || loginctl reboot"]
+        onExited: (exitCode, exitStatus) => {
+            if (exitCode === 0) return // system is going down; nothing left to do
+            // The reboot definitively failed, so the armed BootNext is now a
+            // trap: the next restart, for whatever unrelated reason days later,
+            // would boot the other OS. Clear it. This needs privilege again and
+            // therefore a second polkit prompt - unavoidable, but it only
+            // happens on a path where something has already gone wrong.
+            disarmProc.running = true
+        }
+    }
+
+    Process {
+        id: disarmProc
+        command: ["pkexec", "efibootmgr", "-N"]
+        onExited: (exitCode, exitStatus) => {
+            if (exitCode === 0) {
+                root.notify("Reboot failed",
+                    `Could not reboot into ${root.pendingLabel}. BootNext was cleared, so this machine still boots as usual.`)
+            } else {
+                // Worst case: armed, could not reboot, could not disarm. The
+                // user has to know the exact command, because nothing on screen
+                // will hint that the next restart boots a different OS.
+                root.notify("Reboot failed - BootNext still set",
+                    `Could not reboot into ${root.pendingLabel}, and clearing BootNext failed (${exitCode}). The next restart will boot ${root.pendingLabel}. Run: sudo efibootmgr -N`)
             }
         }
     }

--- a/dots/.config/quickshell/imi/tests/lint_qml_imports.sh
+++ b/dots/.config/quickshell/imi/tests/lint_qml_imports.sh
@@ -1,44 +1,79 @@
 #!/usr/bin/env bash
 #
-# Regression guard: a .qml that uses the `Appearance` singleton as a bareword
-# (Appearance.colors, Appearance.spacing, ...) MUST import qs.modules.common,
-# where the singleton is declared. The import is NOT transitive through
-# qs.modules.common.widgets. Omitting it throws "ReferenceError: Appearance is
-# not defined" on every binding evaluation; when the missing token feeds a
-# positioner's spacing/margin, the resulting undefined -> NaN geometry thrashes
-# relayout and pegs a core at 100% CPU (see AGENT.md at the repo root). The appearance-token
-# migration introduced exactly this in several files, so this check keeps it
-# from coming back.
+# Regression guard: a .qml that uses a singleton as a bareword MUST import the
+# module that singleton is declared in. QML imports are NOT transitive -
+# `import qs.modules.common` does not bring in `qs.modules.common.functions` -
+# and a missing one is not a load-time error. The bareword simply stays
+# unresolved, and every use throws "ReferenceError: <X> is not defined" when it
+# is evaluated. Inside a signal handler that means the handler silently does
+# nothing at all.
 #
-# Exits non-zero and lists offenders if any file references bareword
-# `Appearance.` without an (unaliased) `import qs.modules.common`.
+# Two real bugs of exactly this shape:
+#
+#   Appearance - the appearance-token migration dropped `import qs.modules.common`
+#                from several files. The undefined token feeds a positioner's
+#                spacing/margin as NaN, relayout thrashes and a core pegs at 100%
+#                CPU (see AGENT.md at the repo root).
+#   Session    - services/EfiBoot.qml called Session.reboot() while importing only
+#                qs.modules.common. "Reboot Into" armed the firmware's BootNext
+#                through pkexec, the reboot call then threw ReferenceError, and
+#                nothing happened - leaving the machine silently configured to
+#                boot a different OS at its next restart, whenever that was (#104).
+#
+# That second one is why this check is now table-driven and scans services/ as
+# well as modules/: the original knew only about Appearance and looked only under
+# modules/, so it missed EfiBoot.qml on both counts.
+#
+# Adding a singleton to CHECKS costs one line and buys a whole class of silent
+# failure. Exits non-zero and lists offenders.
 
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
+# singleton:module-that-declares-it
+CHECKS=(
+    "Appearance:qs.modules.common"
+    "Session:qs.modules.common.functions"
+    "ColorUtils:qs.modules.common.functions"
+    "StringUtils:qs.modules.common.functions"
+)
+
+# services/ is included deliberately: EfiBoot.qml lives there, not under modules/.
+SEARCH_DIRS=("$PROJECT_ROOT/modules" "$PROJECT_ROOT/services")
+
 violations=0
 
-while IFS= read -r -d '' f; do
-    # Bareword `Appearance.` = not preceded by a word char or dot (so an aliased
-    # `C.Appearance.` member access does not count).
-    if ! grep -qP '(?<![\w.])Appearance\.' "$f"; then
-        continue
-    fi
-    # Needs an unaliased `import qs.modules.common` (trailing comment allowed,
-    # but not `import qs.modules.common as X`).
-    if grep -qP '^import qs\.modules\.common(\s*//.*)?\s*$' "$f"; then
-        continue
-    fi
-    echo "  MISSING 'import qs.modules.common': ${f#$PROJECT_ROOT/}"
-    violations=$((violations + 1))
-done < <(find "$PROJECT_ROOT/modules" -name '*.qml' -print0)
+for check in "${CHECKS[@]}"; do
+    singleton="${check%%:*}"
+    module="${check#*:}"
+    # Anchored at both ends, so `import qs.modules.common` cannot satisfy a
+    # requirement for `qs.modules.common.functions`. Trailing comment allowed;
+    # an aliased `... as X` is not.
+    module_escaped="${module//./\\.}"
+
+    while IFS= read -r -d '' f; do
+        # A singleton's own declaration file refers to itself; skip it.
+        [[ "$(basename "$f")" == "$singleton.qml" ]] && continue
+        # Match against CODE only. Prose naming a singleton is not a use of it,
+        # and a lint that cannot tell the difference gets switched off the first
+        # time it fires on a comment explaining why the singleton is not used
+        # here. Strips // line comments and /* */ block comments.
+        code="$(sed 's://.*::' "$f" | sed ':a;N;$!ba;s:/\*[^*]*\*\+\([^/*][^*]*\*\+\)*/::g')"
+        # Bareword `X.` = not preceded by a word char or a dot, so an aliased
+        # `C.Appearance.foo` member access does not count.
+        grep -qP "(?<![\w.])${singleton}\." <<<"$code" || continue
+        grep -qP "^import ${module_escaped}(\s*//.*)?\s*\$" "$f" && continue
+        echo "  MISSING 'import $module' (uses $singleton.*): ${f#$PROJECT_ROOT/}"
+        violations=$((violations + 1))
+    done < <(find "${SEARCH_DIRS[@]}" -name '*.qml' -print0 2>/dev/null)
+done
 
 if [ "$violations" -gt 0 ]; then
-    echo "QML import lint FAILED: $violations file(s) use Appearance.* without importing qs.modules.common" >&2
+    echo "QML import lint FAILED: $violations file(s) use a singleton without importing its declaring module" >&2
     exit 1
 fi
 
-echo "QML import lint passed: all Appearance.* users import qs.modules.common"
+echo "QML import lint passed: all singleton users import the declaring module"
 exit 0

--- a/dots/.config/quickshell/imi/tests/test_efiboot_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_efiboot_contract.py
@@ -43,6 +43,32 @@ def extract_function(name):
     return text[start:i]
 
 
+def strip_comments(text):
+    """Code only. Prose naming a symbol is not a use of it, and several checks
+    below assert a symbol is ABSENT - which a comment explaining its absence
+    would otherwise defeat."""
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.S)
+    return re.sub(r"//.*", "", text)
+
+
+def handler_body(text, proc_id):
+    """The onExited body of the Process with `id: <proc_id>`, by brace matching.
+    Asserting against the whole file cannot tell 'disarm on failure' from
+    'disarm unconditionally' - the strings are identical, only the enclosing
+    handler differs."""
+    start = text.index(f"id: {proc_id}")
+    handler = text.index("onExited:", start)
+    brace = text.index("{", handler)
+    depth, i = 1, brace + 1
+    while depth:
+        if text[i] == "{":
+            depth += 1
+        elif text[i] == "}":
+            depth -= 1
+        i += 1
+    return text[brace:i]
+
+
 class ParserTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -82,9 +108,50 @@ class WiringTests(unittest.TestCase):
         self.service = SERVICE.read_text()
         self.screen = (ROOT / "modules/imi/sessionScreen/SessionScreen.qml").read_text()
 
-    def test_bootnext_via_pkexec_then_reboot(self):
+    def test_bootnext_set_via_pkexec(self):
         self.assertIn('["pkexec", "efibootmgr", "-n", root.pendingNum]', self.service)
-        self.assertIn("Session.reboot()", self.service)
+
+    def test_reboot_is_observable_not_fire_and_forget(self):
+        # #104: this called Session.reboot(), which is execDetached - no exit
+        # code, so a reboot that never happened could not be detected and the
+        # BootNext just armed could not be rolled back. It was an unresolved
+        # identifier here as well (Session is declared in
+        # qs.modules.common.functions, which this file does not import), so it
+        # threw ReferenceError and did nothing whatsoever. Owning the reboot as
+        # a Process fixes both.
+        self.assertNotIn("Session.reboot()", strip_comments(self.service),
+                         "reboot must not be execDetached: rollback needs an exit code")
+        self.assertRegex(self.service,
+                         r"id:\s*rebootProc\s*\n\s*command:\s*\[[^\]]*reboot[^\]]*\]")
+
+    def test_failed_reboot_clears_bootnext(self):
+        # A failed action must not leave the machine armed to boot another OS.
+        self.assertIn('["pkexec", "efibootmgr", "-N"]', self.service)
+        body = handler_body(strip_comments(self.service), "rebootProc")
+        self.assertIn("disarmProc.running = true", body,
+                      "a non-zero reboot exit must trigger the disarm")
+        self.assertIn("if (exitCode === 0) return", body,
+                      "a successful reboot must not disarm the BootNext it just armed")
+
+    def test_disarm_failure_names_the_manual_command(self):
+        # Armed, could not reboot, could not disarm. Nothing else on screen
+        # would ever hint that the next restart boots a different OS.
+        self.assertIn("efibootmgr -N",
+                      handler_body(strip_comments(self.service), "disarmProc"))
+
+    def test_reboot_command_matches_the_plain_reboot_button(self):
+        # Drift guard. EfiBoot owns its reboot only because it needs the exit
+        # code, not because it wants different semantics from Session.reboot().
+        session = (ROOT / "modules/common/functions/Session.qml").read_text()
+        self.assertIn("reboot || loginctl reboot", self.service)
+        self.assertIn("reboot || loginctl reboot", session)
+
+    def test_import_lint_still_covers_session_and_services(self):
+        # The lint that should have caught #104 knew only about Appearance and
+        # walked only modules/. Narrowing it back reopens the hole silently.
+        lint = (ROOT / "tests/lint_qml_imports.sh").read_text()
+        self.assertIn("Session:qs.modules.common.functions", lint)
+        self.assertRegex(lint, r"SEARCH_DIRS=\([^)]*/services")
 
     def test_polkit_dismissal_stays_quiet(self):
         self.assertIn("exitCode !== 126 && exitCode !== 127", self.service)
@@ -97,6 +164,49 @@ class WiringTests(unittest.TestCase):
         # Session screen closes before pkexec so the polkit dialog gets focus.
         self.assertRegex(self.screen,
                          r"sessionRoot\.hide\(\);\s*\n\s*EfiBoot\.rebootInto")
+
+
+class SessionTransitionOrderTests(unittest.TestCase):
+    """The plain Reboot button does NOT share #104's ReferenceError -
+    SessionScreen.qml imports qs.modules.common.functions correctly - but it did
+    share the shape: closeAllWindows() ran BEFORE the transition was issued, so a
+    transition that never happened had already SIGTERMed every one of the user's
+    applications. Empty desktop, still logged in, nothing explaining why."""
+
+    ORDERED = ("reboot", "poweroff", "rebootToFirmware")
+
+    def setUp(self):
+        self.session = strip_comments(
+            (ROOT / "modules/common/functions/Session.qml").read_text())
+
+    def body(self, name):
+        start = self.session.index(f"function {name}(")
+        brace = self.session.index("{", start)
+        depth, i = 1, brace + 1
+        while depth:
+            if self.session[i] == "{":
+                depth += 1
+            elif self.session[i] == "}":
+                depth -= 1
+            i += 1
+        return self.session[brace:i]
+
+    def test_transition_is_issued_before_windows_are_closed(self):
+        for name in self.ORDERED:
+            with self.subTest(function=name):
+                body = self.body(name)
+                self.assertIn("closeAllWindows()", body)
+                self.assertIn("execDetached", body)
+                self.assertLess(
+                    body.index("execDetached"), body.index("closeAllWindows()"),
+                    f"{name}() must issue the transition before killing the user's windows")
+
+    def test_logout_is_deliberately_left_alone(self):
+        # pkill -i Hyprland does not fail the way a polkit-gated transition can,
+        # so there is no failure path here that could strand the user. Pinned so
+        # a later tidy-up does not "make it consistent" without that argument.
+        body = self.body("logout")
+        self.assertLess(body.index("closeAllWindows()"), body.index("execDetached"))
 
 
 if __name__ == "__main__":

--- a/dots/.config/quickshell/imi/tests/test_efiboot_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_efiboot_contract.py
@@ -124,6 +124,17 @@ class WiringTests(unittest.TestCase):
         self.assertRegex(self.service,
                          r"id:\s*rebootProc\s*\n\s*command:\s*\[[^\]]*reboot[^\]]*\]")
 
+    def test_arming_bootnext_is_followed_by_the_reboot(self):
+        # The one edge #104 actually broke. The cases either side of it pin that
+        # rebootProc exists and that it behaves correctly once it runs - but
+        # nothing pinned that anything *starts* it, which is precisely the state
+        # the bug left behind: pkexec returned 0, the success branch threw before
+        # reaching the reboot, and BootNext stayed armed. Replacing this
+        # assignment with a no-op keeps every other case in this file green.
+        body = handler_body(strip_comments(self.service), "setNextProc")
+        self.assertIn("rebootProc.running = true", body,
+                      "a successful pkexec must start the reboot it just armed BootNext for")
+
     def test_failed_reboot_clears_bootnext(self):
         # A failed action must not leave the machine armed to boot another OS.
         self.assertIn('["pkexec", "efibootmgr", "-N"]', self.service)


### PR DESCRIPTION
## Describe your changes

Closes #104.

The cause is an **unresolved identifier, not a race.** `EfiBoot.qml` called `Session.reboot()` while importing only `qs.modules.common` and `qs`. `Session` is declared in `qs.modules.common.functions`, QML imports are not transitive, so the bareword never resolved — the call threw `ReferenceError` inside `onExited` and the handler stopped there. `pkexec` had already succeeded, so `BootNext` stayed armed, and no notification fired because the existing `else if` only reports a *non-zero* exit while the exit code was `0`.

The issue's leading suspicion — `closeAllWindows()` tearing down the shell before `execDetached` lands — **does not hold**; evidence in the comment below.

Four commits:

1. **`fix(efiboot)`** — the reboot becomes a `Process` with an observable exit code, deliberately not `Session.reboot()`. Once `BootNext` is armed, "the reboot silently did not happen" is exactly the state that must not go unnoticed, and `execDetached` reports nothing back, so there is no way to know a rollback is needed. On a non-zero exit the `BootNext` is cleared with `pkexec efibootmgr -N`; if that also fails, the notification names the entry that will boot and the exact command to fix it.
2. **`fix(session)`** — separate defect found on the way. `reboot()` / `poweroff()` / `rebootToFirmware()` killed every one of the user's windows *before* issuing the transition, so a transition that failed left an empty desktop, still logged in, with nothing explaining why. Order reversed.
3. **`test(lint)`** — the import lint that should have caught this knew only about `Appearance` and walked only `modules/`. It missed `EfiBoot.qml` on both axes. Now table-driven and scans `services/`.
4. **`test(efiboot)`** — extends `test_efiboot_contract.py` (7 new cases, 14 total).

### Verification

Root cause confirmed under `qmltestrunner`, not by reading. Every new assertion proven by mutation — ten breakages, each seen to fail, each reverted. Full suite **260 passed, 0 failed** before each commit.

## Is it ready? Questions/feedback needed?

Ready to review. Not merged, nothing tagged, `WE_REF`/`SDDM_REF` untouched.

**One thing needs you on real hardware:** I could not test that the reboot now actually happens — that requires an actual reboot of your live desktop. Everything here is static analysis plus runtime QML checks. Details of exactly what remains unconfirmed are in the comment below.
