### PR TITLE
fix(sddm): pass SDDM_REF through so it pins the theme content, not just the installer

### DIFF
--- a/sdata/subcmd-install/5.sddm-theme.sh
+++ b/sdata/subcmd-install/5.sddm-theme.sh
@@ -25,14 +25,19 @@
 # installer at a pinned commit and hand off — so the SDDM theme stays a thin,
 # opt-in bolt-on rather than code we carry and have to maintain.
 #
-# The pin covers the *installer logic*. The theme content is a separate clone
-# the fetched setup.sh performs itself, from the THEME_REPO baked into it — so
-# what lands in /usr/share/sddm/themes is decided by that variable, not by this
-# URL. Pointing this file at the fork while the fork's setup.sh still cloned
+# The theme content is a separate clone the fetched setup.sh performs itself,
+# from the THEME_REPO baked into it — so *which repo* lands in
+# /usr/share/sddm/themes is decided by that variable, not by this URL. Pointing
+# this file at the fork while the fork's setup.sh still cloned
 # 3d3f/ii-sddm-theme installed upstream's theme verbatim, silently undoing
 # every fork change to the theme (the immaterial-impulse config path, the
 # Wallpaper Engine resolution) on each install. Fixed in the fork at 81353f6.
 # If the login theme ever looks like upstream's again, check THEME_REPO first.
+#
+# *Which revision* of it used to be equally out of our hands: that clone had no
+# ref, so SDDM_REF pinned the installer while the theme came from whatever the
+# satellite's default branch was at that moment. IMI_SDDM_THEME_REF below hands
+# the pin through, so the two are one revision (imi-sddm-theme#5).
 #
 # Arch-only: the theme's setup.sh uses pacman. Skipped elsewhere.
 set -euo pipefail

--- a/sdata/subcmd-install/5.sddm-theme.sh
+++ b/sdata/subcmd-install/5.sddm-theme.sh
@@ -74,9 +74,18 @@ fi
 # the run can actually offer, so if the shell config is not there yet it falls
 # back to asking rather than being forced into a state that cannot work.
 echo "[ImI] SDDM theme: handing off to the theme installer (unattended)..."
+# IMI_SDDM_THEME_REF makes SDDM_REF an actual pin. Fetching setup.sh at a ref
+# only ever pinned the *installer*: it then cloned the theme content from
+# whatever the satellite's default branch was at that moment, so this pin could
+# sit unmoved for months while what landed in /usr/share/sddm/themes changed
+# underneath it (imi-sddm-theme#5). Handing the same ref through means the
+# installer and what it installs are one revision. Satellite versions before
+# v0.2.1 ignore this variable, which is why the pin must not be moved backwards
+# past that without also expecting the old behaviour.
 # Optional extra - never let a decline/failure abort the whole install.
 if IMI_SDDM_ASSUME_YES="${IMI_SDDM_ASSUME_YES:-1}" \
    IMI_SDDM_MODE="${IMI_SDDM_MODE:-ii-matugen}" \
+   IMI_SDDM_THEME_REF="${IMI_SDDM_THEME_REF:-$SDDM_REF}" \
      bash "$TMP_SETUP"; then
   # Record that WE installed the theme, so uninstall has evidence rather than
   # an inference. A theme directory only proves *someone* installed one: the

--- a/sdata/subcmd-install/5.sddm-theme.sh
+++ b/sdata/subcmd-install/5.sddm-theme.sh
@@ -56,7 +56,7 @@ fi
 
 SDDM_REPO_RAW="${SDDM_REPO_RAW:-https://raw.githubusercontent.com/XephyLon/imi-sddm-theme}"
 # Pin the installer for reproducibility. Bump this to adopt a newer imi-sddm-theme.
-SDDM_REF="${SDDM_REF:-ac2e7d47f0998442d7baebee7165b4cc28d217d4}"
+SDDM_REF="${SDDM_REF:-800a1c107226cba51475f086d808c0bbcbd75cf9}"
 SETUP_URL="${SDDM_REPO_RAW}/${SDDM_REF}/setup.sh"
 
 echo "[ImI] SDDM theme: fetching imi-sddm-theme installer (${SDDM_REF:0:12})..."

--- a/sdata/subcmd-uninstall/0.run.sh
+++ b/sdata/subcmd-uninstall/0.run.sh
@@ -55,7 +55,7 @@ if [[ "$_sddm_ours" == true ]]; then
   if command -v curl >/dev/null; then
     # Must match SDDM_REF in sdata/subcmd-install/5.sddm-theme.sh -
     # tests/test_sddm_theme_source.py pins that they agree.
-    _sddm_ref="${SDDM_REF:-ac2e7d47f0998442d7baebee7165b4cc28d217d4}"
+    _sddm_ref="${SDDM_REF:-800a1c107226cba51475f086d808c0bbcbd75cf9}"
     _sddm_un="$(mktemp --suffix=-ii-sddm-uninstall.sh)"
     if curl -fsSL "https://raw.githubusercontent.com/XephyLon/imi-sddm-theme/${_sddm_ref}/uninstall.sh" -o "$_sddm_un"; then
       # The theme's uninstaller exits non-zero when it removes nothing (a


### PR DESCRIPTION
Hub half of XephyLon/imi-sddm-theme#5. The satellite half is XephyLon/imi-sddm-theme#9.

`SDDM_REF` chose which `setup.sh` we fetch over `raw.githubusercontent.com`, and that was all it did. The fetched installer then cloned the theme content from the satellite's default branch, so this pin could sit unmoved for months while what actually landed in `/usr/share/sddm/themes` changed underneath it — a pin that looked like one in `repo-status` and in the release docs, but only covered the installer.

This passes the same ref through as `IMI_SDDM_THEME_REF`, so the installer and what it installs are one revision.

### Pin moved

`SDDM_REF` now names **imi-sddm-theme v0.2.1** (`800a1c107226cba51475f086d808c0bbcbd75cf9`), in both files. v0.2.1 is the first revision that reads `IMI_SDDM_THEME_REF`, so until the pin named it the pass-through here had nothing to talk to. Landing them together is what actually closes the hole.

Pinned to the full SHA the tag points at, not the tag — a tag can be force-moved, which would let the theme change under a release that already shipped. Verified as both the tag target and the tip of the satellite's default branch.

### Verification

Full suite **276 passed, 0 failed**. `bash -n` clean. `test_sddm_theme_source.py` (which pins that the two files agree, and that the pin is a full 40-char SHA) passes.

The git mechanics the satellite side relies on were exercised against a fixture repo and against GitHub — a shallow `fetch` of an arbitrary reachable SHA works, and an unfetchable ref fails hard rather than silently falling back to the default branch. Details in XephyLon/imi-sddm-theme#9.

`setup.sh` was not executed anywhere in this work.

### Still wants a real run

This is an installer change, so it deserves a **Settings → Update Dots** with `INSTALL_SDDM=1` to confirm the hand-off end to end. Nothing here is exercised on a default update, since step 5 is skipped unless the SDDM extra is opted into.

