### PR TITLE
fix(record): recordings on an HDR display are washed out — detect HDR and pick the HDR codec

### DIFF
--- a/dots/.config/quickshell/imi/modules/imi/settings/pages/CaptureConfig.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/pages/CaptureConfig.qml
@@ -63,6 +63,14 @@ ContentPage {
                 ConfigSelectionArray {
                     text: Translation.tr("Codec")
                     icon: "memory"
+                    // No _hdr entries: recording an HDR monitor already picks
+                    // the HDR variant of whichever of these is chosen, so
+                    // listing them would be a second way to say the same thing
+                    // - and one a user could get wrong by selecting HDR on an
+                    // SDR display. H.264 has no HDR variant, so choosing it on
+                    // an HDR monitor notifies at record time instead.
+                    // (ConfigSelectionArray has no `description`; that belongs
+                    // to ConfigSwitch. DesignSystemCompile catches the mix-up.)
                     currentValue: Config.options.screenRecord.codec
                     onSelected: value => { Config.options.screenRecord.codec = value }
                     options: [

--- a/dots/.config/quickshell/imi/scripts/videos/record.sh
+++ b/dots/.config/quickshell/imi/scripts/videos/record.sh
@@ -61,6 +61,43 @@ MIC="$(cfg '.screenRecord.recordMic')"
 
 OUT="$SAVE_DIR/recording_$(date '+%Y-%m-%d_%H.%M.%S').mp4"
 
+# Resolved before the codec, so HDR detection has a monitor to ask about. A
+# region capture is attributed to the focused monitor: slurp can straddle
+# outputs, and short of asking gsr which one it settled on, "the monitor the
+# user was looking at" is the best available answer.
+TARGET_MONITOR="$(hyprctl monitors -j 2>/dev/null | jq -r '.[] | select(.focused == true) | .name' 2>/dev/null)"
+
+# Hyprland's colorManagementPreset is the authoritative HDR signal - its HDR
+# presets are "hdr" and "hdredid". currentFormat is not: XBGR2101010 only says
+# the framebuffer is 10-bit, which is equally true of wide-gamut SDR.
+monitor_is_hdr() {
+    local name="$1"
+    [[ -n "$name" ]] || return 1
+    hyprctl monitors -j 2>/dev/null \
+        | jq -e --arg m "$name" \
+            'any(.[]; .name == $m and ((.colorManagementPreset // "") | startswith("hdr")))' \
+            >/dev/null 2>&1
+}
+
+# gpu-screen-recorder does not tonemap. Given an HDR surface and an SDR codec it
+# encodes 8-bit and tags the result bt709, so a PQ signal ends up labelled as
+# gamma - and decodes flat, grey and desaturated. The _hdr codec variants carry
+# the real transfer function and primaries, so the file is correct in anything
+# that reads them.
+if monitor_is_hdr "$TARGET_MONITOR"; then
+    case "$CODEC" in
+        ""|auto|hevc) CODEC="hevc_hdr" ;;
+        av1)          CODEC="av1_hdr" ;;
+        h264)
+            # H.264 has no HDR variant here. Silently swapping the codec someone
+            # explicitly chose is worse than saying why the file will look wrong.
+            notify-send "Recording SDR H.264 on an HDR display" \
+                "H.264 cannot carry HDR, so this recording will look washed out. Pick HEVC or AV1, or turn HDR off while recording." \
+                -a 'Recorder' & disown
+            ;;
+    esac
+fi
+
 ARGS=(gpu-screen-recorder -c mp4 -f "$FPS" -q "$QUALITY" -ac "$AUDIO_CODEC"
       -fm "$FRAMERATE_MODE" -sc "$SCRIPT_DIR/gsr-saved.sh" -o "$OUT")
 [[ "$CURSOR" == "false" ]] && ARGS+=(-cursor no)
@@ -74,8 +111,7 @@ if [[ $SOUND -eq 1 ]]; then
 fi
 
 if [[ $FULLSCREEN -eq 1 ]]; then
-    MONITOR="$(hyprctl monitors -j | jq -r '.[] | select(.focused == true) | .name')"
-    ARGS+=(-w "${MONITOR:-screen}")
+    ARGS+=(-w "${TARGET_MONITOR:-screen}")
 else
     if [[ -z "$REGION" ]]; then
         if ! REGION="$(slurp)"; then

--- a/dots/.config/quickshell/imi/services/ScreenRecord.qml
+++ b/dots/.config/quickshell/imi/services/ScreenRecord.qml
@@ -5,6 +5,7 @@ import Quickshell.Io
 import Quickshell.Hyprland
 import qs.modules.common
 import qs.modules.common.functions
+import qs.services
 import qs
 
 /**
@@ -67,6 +68,29 @@ Singleton {
         return dir.startsWith("~") ? Directories.home.replace("file://", "") + dir.slice(1) : dir
     }
 
+    // gpu-screen-recorder does not tonemap. Given an HDR surface and an SDR
+    // codec it encodes 8-bit and tags the result bt709, so a PQ signal is
+    // labelled as gamma and decodes flat, grey and desaturated. The _hdr
+    // variants carry the real transfer function and primaries instead.
+    //
+    // colorManagementPreset is the authoritative signal - Hyprland's HDR
+    // presets are "hdr" and "hdredid". currentFormat is not: XBGR2101010 only
+    // means a 10-bit framebuffer, which wide-gamut SDR also has. Kept in step
+    // with scripts/videos/record.sh, which does the same for one-shot
+    // recordings; test_screen_record.py pins that the two agree.
+    function hdrCodecFor(codec, monitorName) {
+        const mons = HyprlandData.monitors ?? []
+        const mon = (monitorName && monitorName !== "screen")
+            ? mons.find(m => m.name === monitorName)
+            : mons.find(m => m.focused)
+        if (!(mon?.colorManagementPreset ?? "").startsWith("hdr")) return codec
+        if (codec === "auto" || codec === "hevc") return "hevc_hdr"
+        if (codec === "av1") return "av1_hdr"
+        // h264 has no HDR variant; leave the explicit choice alone rather than
+        // swapping the codec out from under whoever picked it.
+        return codec
+    }
+
     function replayArgs() {
         const o = root.opts
         let args = ["gpu-screen-recorder",
@@ -82,7 +106,8 @@ Singleton {
             "-cursor", o.showCursor ? "yes" : "no",
             "-sc", `${Directories.scriptPath}/videos/gsr-saved.sh`,
             "-o", root.replayDir]
-        if (o.codec !== "auto") args.push("-k", o.codec)
+        const codec = root.hdrCodecFor(o.codec, o.replay.monitor)
+        if (codec !== "auto") args.push("-k", codec)
         if (o.recordAudio) args.push("-a", o.recordMic ? "default_output|default_input" : "default_output")
         return args
     }

--- a/dots/.config/quickshell/imi/tests/test_screen_record.py
+++ b/dots/.config/quickshell/imi/tests/test_screen_record.py
@@ -104,6 +104,103 @@ class ServiceTests(unittest.TestCase):
         self.assertIn("_screenRecord: ScreenRecord", shell)
 
 
+class HdrCodecTests(unittest.TestCase):
+    """gpu-screen-recorder does not tonemap.
+
+    Handed an HDR surface with an SDR codec it encodes 8-bit and tags the file
+    bt709, so a PQ signal ends up labelled as gamma and decodes flat and grey.
+    These run the real script against stub hyprctl/gpu-screen-recorder binaries
+    and read back the argv it built, rather than asserting on source text - the
+    mapping is a behaviour, and a source grep would pass on a script that
+    computed the codec correctly and then forgot to pass it.
+    """
+
+    def run_record(self, preset, codec="auto"):
+        """Run record.sh --fullscreen against a monitor whose CM preset is
+        `preset`, and return the argv it handed to gpu-screen-recorder."""
+        import os
+        import shutil
+        import tempfile
+
+        tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, tmp, True)
+        bindir = tmp / "bin"
+        bindir.mkdir()
+        argv_file = tmp / "argv"
+
+        monitors = json.dumps([{
+            "name": "DP-1", "focused": True,
+            "colorManagementPreset": preset,
+            "currentFormat": "XBGR2101010",
+        }])
+        (bindir / "hyprctl").write_text(
+            "#!/usr/bin/env bash\ncat <<'MONEOF'\n" + monitors + "\nMONEOF\n")
+        # Records argv and exits, so record.sh's `wait` returns immediately.
+        (bindir / "gpu-screen-recorder").write_text(
+            '#!/usr/bin/env bash\nprintf "%s\\n" "$@" > "' + str(argv_file) + '"\n')
+        for noop in ("notify-send", "slurp"):
+            (bindir / noop).write_text("#!/usr/bin/env bash\nexit 0\n")
+        for f in bindir.iterdir():
+            f.chmod(0o755)
+
+        home = tmp / "home"
+        (home / ".config/immaterial-impulse").mkdir(parents=True)
+        (home / ".config/immaterial-impulse/config.json").write_text(
+            json.dumps({"screenRecord": {"codec": codec, "savePath": str(tmp / "out")}}))
+
+        env = dict(os.environ)
+        env["PATH"] = str(bindir) + os.pathsep + env["PATH"]
+        env["HOME"] = str(home)
+        env["XDG_CONFIG_HOME"] = str(home / ".config")
+        env["XDG_RUNTIME_DIR"] = str(tmp)
+        subprocess.run(["bash", str(RECORD_SH), "--fullscreen"],
+                       env=env, capture_output=True, text=True, timeout=60)
+        self.assertTrue(argv_file.exists(), "gpu-screen-recorder was never invoked")
+        return argv_file.read_text().split("\n")
+
+    def codec_of(self, argv):
+        return argv[argv.index("-k") + 1] if "-k" in argv else None
+
+    def test_hdr_monitor_upgrades_auto_to_hevc_hdr(self):
+        # The reported bug: on an HDR display "auto" produced 8-bit bt709 HEVC.
+        self.assertEqual(self.codec_of(self.run_record("hdredid")), "hevc_hdr")
+
+    def test_plain_hdr_preset_also_counts(self):
+        # Hyprland has two HDR presets; matching "hdredid" alone misses one.
+        self.assertEqual(self.codec_of(self.run_record("hdr")), "hevc_hdr")
+
+    def test_sdr_monitor_is_left_alone(self):
+        # 10-bit is not HDR: wide-gamut SDR reports the same currentFormat,
+        # which is why the preset and not the format is the signal.
+        self.assertIsNone(self.codec_of(self.run_record("srgb")))
+        self.assertEqual(self.codec_of(self.run_record("srgb", codec="hevc")), "hevc")
+
+    def test_explicit_codecs_map_to_their_hdr_variants(self):
+        self.assertEqual(self.codec_of(self.run_record("hdredid", codec="hevc")), "hevc_hdr")
+        self.assertEqual(self.codec_of(self.run_record("hdredid", codec="av1")), "av1_hdr")
+
+    def test_h264_is_not_silently_swapped(self):
+        # H.264 has no HDR variant. Changing the codec someone explicitly chose
+        # is worse than telling them why the file will look wrong.
+        self.assertEqual(self.codec_of(self.run_record("hdredid", codec="h264")), "h264")
+
+    def test_replay_path_agrees_with_the_script(self):
+        # Two capture paths, one behaviour. The replay daemon lives in QML and
+        # would otherwise drift out of step with record.sh silently.
+        qml = SERVICE.read_text()
+        self.assertIn("hdrCodecFor", qml)
+        self.assertIn('startsWith("hdr")', qml)
+        for expected in ('return "hevc_hdr"', 'return "av1_hdr"'):
+            self.assertIn(expected, qml)
+        self.assertIn("root.hdrCodecFor(o.codec, o.replay.monitor)", qml,
+                      "replayArgs must route its codec through the HDR mapping")
+
+    def test_service_imports_the_module_declaring_HyprlandData(self):
+        # #104 was exactly this shape: a singleton used without importing the
+        # module that declares it throws ReferenceError at the call site.
+        self.assertIn("import qs.services", SERVICE.read_text())
+
+
 class WiringTests(unittest.TestCase):
     def test_keybinds(self):
         keybinds = (ROOT.parents[1] / "hypr/hyprland/keybinds.lua").read_text()


### PR DESCRIPTION
Recordings on an HDR display came out washed out — flat, grey, desaturated.

## Cause

`gpu-screen-recorder` does not tonemap. Handed an HDR surface with an SDR codec it encodes 8-bit and tags the output bt709, so a PQ signal ends up labelled as gamma. Decoding it as gamma is what produces the washed-out look.

`ffprobe` on a recording from a 5120x1440 HDR display:

```
codec_name=hevc      profile=Main       pix_fmt=yuv420p
color_range=tv       color_space=bt709
color_transfer=bt709 color_primaries=bt709
(no mastering metadata)
```

Meanwhile the display reports `currentFormat = XBGR2101010`, `colorManagementPreset = hdredid`.

Nothing in the shell ever passed `-k` unless the user had explicitly chosen a codec, so the default `auto` always landed on an SDR encoder — **and there was no way to get a correct recording through the UI at all**, since the codec list offers only `h264 | hevc | av1` and none of gsr's `_hdr` variants.

## Fix

Detect HDR and select the matching codec, on **both** capture paths — the one-shot script and the replay daemon, which had the same defect.

`colorManagementPreset` is the signal, **not** `currentFormat`. Hyprland's HDR presets are `hdr` and `hdredid`; `XBGR2101010` only means a 10-bit framebuffer, which wide-gamut SDR also has. Keying on the format would misfire on 10-bit SDR.

| chosen | on HDR |
|---|---|
| `auto`, `hevc` | `hevc_hdr` |
| `av1` | `av1_hdr` |
| `h264` | left alone + notification |

H.264 has no HDR variant here. Swapping out a codec someone explicitly picked is worse than telling them why the file will look wrong, so it notifies instead.

`ScreenRecord.qml` also gains `import qs.services` for `HyprlandData` — QML imports are not transitive, and that exact omission is what #104 turned out to be.

## Verification

Full suite **276 passed, 0 failed**, DesignSystemCompile 0 failures.

The new tests run `record.sh` against stub `hyprctl`/`gpu-screen-recorder` binaries and read back the argv it built, rather than asserting on source text — the mapping is a behaviour, and a source grep would pass on a script that computed the codec correctly and then forgot to pass it.

Seven mutations, each confirmed to turn the file red and each reverted:

| mutation | caught |
|---|---|
| HDR detection disabled | 3 tests |
| keyed on `currentFormat` instead of the preset | 3 |
| matches `hdredid` only, missing plain `hdr` | 1 |
| `h264` silently swapped | 1 |
| `av1` not upgraded | 1 |
| codec computed but never passed | 5 |
| replay path bypasses the mapping | 1 |

## Known limits

- **Region captures are attributed to the focused monitor.** `slurp` can straddle outputs; short of asking gsr which one it settled on there is no better answer. On a mixed HDR/SDR multi-monitor setup a region on the *other* screen could get the wrong codec.
- **Colour range is untouched.** The sample was `color_range=tv`. That is a separate axis from the transfer function and I had no evidence it was wrong, so I did not change it.
- **The output is now genuinely HDR**, which is correct but means players that ignore the metadata will still show it flat. That is the intended trade — chosen deliberately over an ffmpeg tonemap post-pass, which would make every save slow and CPU-bound.
