### PR TITLE
fix(install): the RUNPATH repair could never run — patchelf writes in place, and the target is the running shell

### DIFF
--- a/dots/.config/quickshell/imi/tests/test_wallpaperengine_prebuilt.py
+++ b/dots/.config/quickshell/imi/tests/test_wallpaperengine_prebuilt.py
@@ -276,6 +276,96 @@ class WallpaperEnginePrebuiltTest(unittest.TestCase):
         self.assertEqual(self.stamp.read_text().split()[0], "v0.0-test", "stamp not refreshed")
 
 
+
+@unittest.skipUnless(shutil.which("patchelf"), "patchelf not installed")
+class RunpathRepairTests(unittest.TestCase):
+    """ensure_standalone_libs must repair a binary that is currently running.
+
+    patchelf rewrites in place, and the kernel refuses to write to a running
+    executable (ETXTBSY). The shell *is* the binary being repaired, and
+    Settings > Update Dots runs the installer from the shell - so in the only
+    path a user actually takes, the target was always executing and the repair
+    always failed. It failed silently (stderr to /dev/null) and the caller then
+    advised installing patchelf, which was already installed.
+
+    These drive the real functions, lifted out of the script, against a real
+    ELF that is really executing.
+    """
+
+    def setUp(self):
+        self.tmp = pathlib.Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.tmp, True)
+
+        # A real ELF that needs a library only findable via RUNPATH: take a
+        # stock binary and give it a NEEDED entry nothing can resolve yet.
+        self.bin = self.tmp / "quickshell"
+        shutil.copy2(shutil.which("sleep"), self.bin)
+        self.lib_dir = self.tmp / "lib"
+        self.lib_dir.mkdir()
+        soname = "liblinux-wallpaperengine-lib.so"
+        # Any real shared object satisfies ldd under this name.
+        donor = subprocess.run(["bash", "-c", "ldd $(which sleep) | awk '/libc\\.so/{print $3}'"],
+                               capture_output=True, text=True).stdout.strip()
+        self.assertTrue(donor and os.path.exists(donor), "no donor .so found")
+        shutil.copy2(donor, self.lib_dir / soname)
+        subprocess.run(["patchelf", "--add-needed", soname, str(self.bin)], check=True)
+        self.assertIn("not found", self._ldd(), "fixture does not start unresolved")
+
+    def _ldd(self):
+        env = dict(os.environ)
+        env.pop("LD_LIBRARY_PATH", None)
+        return subprocess.run(["ldd", str(self.bin)], capture_output=True,
+                              text=True, env=env).stdout
+
+    def _run_ensure(self):
+        """Run the script's real ensure_standalone_libs against the fixture."""
+        src = SH.read_text()
+        start = src.index("libs_resolve_standalone(){")
+        end = src.index("# Install the wrapper", start)
+        harness = (
+            'set -o pipefail\n'
+            'OPT_LIBS="/opt/linux-wallpaperengine/lib:/opt/linux-wallpaperengine"\n'
+            'say(){ printf "%s\\n" "$*"; }\n'
+            + src[start:end] +
+            f'\nensure_standalone_libs "{self.bin}" "{self.lib_dir}"\n'
+        )
+        return subprocess.run(["bash", "-c", harness], capture_output=True, text=True)
+
+    def test_repairs_a_binary_that_is_not_running(self):
+        proc = self._run_ensure()
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+        self.assertNotIn("not found", self._ldd())
+
+    def test_repairs_a_binary_that_IS_running(self):
+        # The reported case. In-place patchelf returns ETXTBSY here; the repair
+        # has to go through a copy and a rename.
+        running = subprocess.Popen([str(self.bin), "30"],
+                                   env={**os.environ, "LD_LIBRARY_PATH": str(self.lib_dir)})
+        self.addCleanup(running.kill)
+        proc = self._run_ensure()
+        self.assertEqual(proc.returncode, 0,
+                         "repair failed while the target was executing:\n"
+                         + proc.stdout + proc.stderr)
+        self.assertNotIn("not found", self._ldd())
+        self.assertIn("baked the WE runtime lib dirs", proc.stdout)
+
+    def test_the_running_process_survives_the_repair(self):
+        # rename(2) swaps the directory entry; the live process keeps the inode
+        # it already opened. Replacing the file in place would corrupt it.
+        running = subprocess.Popen([str(self.bin), "30"],
+                                   env={**os.environ, "LD_LIBRARY_PATH": str(self.lib_dir)})
+        self.addCleanup(running.kill)
+        self._run_ensure()
+        self.assertIsNone(running.poll(), "the running process died during the repair")
+
+    def test_failure_is_reported_not_swallowed(self):
+        # Silence is what made this look like a missing dependency for months.
+        os.chmod(self.tmp, 0o500)  # no new files beside the target -> mktemp fails
+        self.addCleanup(os.chmod, self.tmp, 0o700)
+        proc = self._run_ensure()
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("could not repair", proc.stdout)
+
 if __name__ == "__main__":
     # A missing zstd is a hard failure, not a skip. These tests exist because
     # this file spent its life reporting success without running; "quietly

--- a/sdata/subcmd-install/4.wallpaperengine.sh
+++ b/sdata/subcmd-install/4.wallpaperengine.sh
@@ -151,8 +151,31 @@ ensure_standalone_libs(){
   libs_resolve_standalone "$qs_bin" && return 0
   if command -v patchelf >/dev/null 2>&1; then
     local rp; rp="$(patchelf --print-rpath "$qs_bin" 2>/dev/null || true)"
-    if patchelf --set-rpath "$lib_dir:$OPT_LIBS${rp:+:$rp}" "$qs_bin" 2>/dev/null; then
+    # patchelf rewrites in place, and the kernel refuses to write to a running
+    # executable (ETXTBSY). The shell IS this binary, and Settings > Update Dots
+    # runs the installer *from* the shell - so in the one path a user actually
+    # takes, the target was always executing and this always failed. It failed
+    # silently too: stderr went to /dev/null and the caller then advised
+    # installing patchelf, which was already installed. Only a first install,
+    # with nothing running yet, ever succeeded - so the repair worked exactly
+    # when it was not needed, and not when it was.
+    #
+    # Patch a copy and rename over the original instead. rename(2) swaps the
+    # directory entry; the running process keeps the inode it already opened
+    # and is unaffected, and the next launch picks up the repaired file. The
+    # temporary lives beside the target so the rename stays on one filesystem
+    # (mv across filesystems is copy-then-unlink, which is neither atomic nor
+    # safe against a concurrent exec).
+    local tmp; tmp="$(mktemp "${qs_bin}.patchelf.XXXXXX")" || tmp=""
+    if [[ -n "$tmp" ]] && cp -p "$qs_bin" "$tmp" \
+       && patchelf --set-rpath "$lib_dir:$OPT_LIBS${rp:+:$rp}" "$tmp" \
+       && mv -f "$tmp" "$qs_bin"; then
       say "baked the WE runtime lib dirs into the binary's RUNPATH."
+    else
+      # Surface the reason rather than discarding it - the previous silence is
+      # what made this look like a missing dependency for so long.
+      say "could not repair the binary's RUNPATH with patchelf."
+      [[ -n "$tmp" ]] && rm -f "$tmp"
     fi
   else
     say "patchelf not present; cannot repair the binary's RUNPATH."
@@ -169,7 +192,15 @@ install_wrapper(){
   else
     say "WARNING: binary still needs LD_LIBRARY_PATH. Exporting it as a fallback -"
     say "         apps launched from the shell may load CEF's libEGL/libGLESv2"
-    say "         instead of the system ones. Install patchelf and re-run to fix."
+    say "         instead of the system ones."
+    # Only advise installing patchelf when it is actually missing. Saying it
+    # unconditionally sent someone to install a package they already had, and
+    # then to re-run, which could not have helped either.
+    if command -v patchelf >/dev/null 2>&1; then
+      say "         patchelf is installed but could not repair the binary; see above."
+    else
+      say "         Install patchelf and re-run to fix."
+    fi
     ld_line="export LD_LIBRARY_PATH=\"$lib_dir:$OPT_LIBS\${LD_LIBRARY_PATH:+:\$LD_LIBRARY_PATH}\""
   fi
   local tmp; tmp="$(mktemp)"


### PR DESCRIPTION
Found while checking why installing `patchelf` did not stop the `LD_LIBRARY_PATH` warning.

## The bug

`ensure_standalone_libs` calls `patchelf --set-rpath` **in place**. The kernel refuses to write to a running executable — `ETXTBSY`. The binary being repaired is the shell itself:

```
$ pgrep -x quickshell | xargs -I{} readlink -f /proc/{}/exe
/home/…/.cache/immaterial-impulse/prebuilt/v0.2.2/bin/quickshell

$ grep exec /usr/local/bin/quickshell
exec "/home/…/.cache/immaterial-impulse/prebuilt/v0.2.2/bin/quickshell" "$@"
```

Settings → Update Dots runs the installer **from** the shell, so on the only path a user actually takes, the target is always executing and the repair always fails.

**It failed silently.** `2>/dev/null` swallowed the error, so neither the success nor the "patchelf not present" branch printed, and the caller fell through to:

```
WARNING: binary still needs LD_LIBRARY_PATH. Exporting it as a fallback -
         apps launched from the shell may load CEF's libEGL/libGLESv2
         instead of the system ones. Install patchelf and re-run to fix.
```

on a machine where patchelf **was** installed and re-running could not have helped. Confirmed live: patchelf installed, update run, RUNPATH still `/__w/qs-wallpaperengine/...` (the CI worker's path), fallback still exported.

Only a first install — nothing running yet — ever succeeded. **The repair worked exactly when it was not needed, and not when it was.**

The consequence is the leak the fallback was written to avoid: `LD_LIBRARY_PATH` is inherited by every process the shell spawns, so CEF's bundled `libEGL`/`libGLESv2` shadow the system ones for everything launched from the launcher.

## The fix

Patch a copy, then rename over the original. `rename(2)` swaps the directory entry; the live process keeps the inode it already opened and is unaffected, and the next launch picks up the repaired file.

The temporary is created **beside** the target so the rename stays within one filesystem — `mv` across filesystems is copy-then-unlink, which is neither atomic nor safe against a concurrent `exec`.

Failures are now reported instead of discarded, and installing patchelf is only suggested when it is genuinely missing.

## Verification

Full suite **276 passed, 0 failed**.

The new tests drive the script's real `ensure_standalone_libs` against a real ELF that is really executing — `ETXTBSY` is a kernel behaviour and only a live process reproduces it. Source assertions could not have caught this.

Reverting to the in-place call — the shipped code — gives exactly the bug's signature:

| test | in-place (shipped) | copy+rename (this PR) |
|---|---|---|
| `test_repairs_a_binary_that_is_not_running` | **passes** | passes |
| `test_repairs_a_binary_that_IS_running` | **FAILS** | passes |
| `test_failure_is_reported_not_swallowed` | **FAILS** | passes |
| `test_the_running_process_survives_the_repair` | passes | passes |

That first row passing under the mutation is the point: it is why this survived so long.

The tests skip when `patchelf` is absent rather than silently covering nothing.

## Related

The upstream cause is XephyLon/qs-wallpaperengine#12 — the release binaries carry the CI build directory as their RUNPATH. If that ships `$ORIGIN/../lib`, this repair becomes a no-op and the fallback disappears for everyone. This PR fixes the consumer side, which is needed regardless for binaries already installed.
