### PR TITLE
fix(install): the RUNPATH repair missed the bundled libraries — DT_RUNPATH is not transitive

### DIFF
--- a/dots/.config/quickshell/imi/tests/test_wallpaperengine_prebuilt.py
+++ b/dots/.config/quickshell/imi/tests/test_wallpaperengine_prebuilt.py
@@ -336,6 +336,31 @@ class RunpathRepairTests(unittest.TestCase):
         self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
         self.assertNotIn("not found", self._ldd())
 
+    def test_repairs_a_dependency_of_a_dependency(self):
+        # DT_RUNPATH is NOT transitive. The executable's RUNPATH resolves its
+        # own direct needs and nothing further: a bundled library's own needs
+        # are searched using *that library's* RUNPATH. Repairing only the binary
+        # therefore left the shell unable to start unaided, and the
+        # LD_LIBRARY_PATH fallback - which IS transitive, which is precisely why
+        # it worked where the RUNPATH did not - stayed in the wrapper.
+        #
+        # Build that shape: the bundled lib needs a second lib that only the
+        # sibling directory can supply, and give it a RUNPATH that resolves
+        # nothing, exactly as the shipped one does.
+        inner = "libwe-inner-dep.so"
+        shutil.copy2(self.lib_dir / "liblinux-wallpaperengine-lib.so",
+                     self.lib_dir / inner)
+        subprocess.run(["patchelf", "--add-needed", inner,
+                        str(self.lib_dir / "liblinux-wallpaperengine-lib.so")], check=True)
+        subprocess.run(["patchelf", "--set-rpath", "/nonexistent/builder/path",
+                        str(self.lib_dir / "liblinux-wallpaperengine-lib.so")], check=True)
+        self.assertIn("not found", self._ldd(), "fixture does not reproduce the shape")
+
+        proc = self._run_ensure()
+        self.assertEqual(proc.returncode, 0,
+                         "transitive dependency left unresolved:\n" + proc.stdout + proc.stderr)
+        self.assertNotIn("not found", self._ldd())
+
     def test_repairs_a_binary_that_IS_running(self):
         # The reported case. In-place patchelf returns ETXTBSY here; the repair
         # has to go through a copy and a rename.

--- a/sdata/subcmd-install/4.wallpaperengine.sh
+++ b/sdata/subcmd-install/4.wallpaperengine.sh
@@ -146,37 +146,65 @@ libs_resolve_standalone(){
   ! env -u LD_LIBRARY_PATH ldd "$qs_bin" 2>/dev/null | grep -q "not found"
 }
 
+# Rewrite one ELF's RUNPATH. $1=file, $2=new RUNPATH. Returns 0 on success.
+#
+# patchelf rewrites in place, and the kernel refuses to write to a running
+# executable (ETXTBSY). The shell IS the binary being repaired, and Settings >
+# Update Dots runs the installer *from* the shell - so in the one path a user
+# actually takes, the target was always executing and this always failed. The
+# same hazard applies to the bundled .so files, which the running process has
+# mapped.
+#
+# Patch a copy and rename over the original instead. rename(2) swaps the
+# directory entry; the running process keeps the inode it already opened and is
+# unaffected, and the next launch picks up the repaired file. The temporary
+# lives beside the target so the rename stays on one filesystem - mv across
+# filesystems is copy-then-unlink, which is neither atomic nor safe against a
+# concurrent exec.
+set_runpath(){
+  local target="$1" rpath="$2" tmp
+  tmp="$(mktemp "${target}.patchelf.XXXXXX")" || return 1
+  if cp -p "$target" "$tmp" \
+     && patchelf --set-rpath "$rpath" "$tmp" \
+     && mv -f "$tmp" "$target"; then
+    return 0
+  fi
+  rm -f "$tmp"
+  return 1
+}
+
 ensure_standalone_libs(){
   local qs_bin="$1" lib_dir="$2"
   libs_resolve_standalone "$qs_bin" && return 0
   if command -v patchelf >/dev/null 2>&1; then
     local rp; rp="$(patchelf --print-rpath "$qs_bin" 2>/dev/null || true)"
-    # patchelf rewrites in place, and the kernel refuses to write to a running
-    # executable (ETXTBSY). The shell IS this binary, and Settings > Update Dots
-    # runs the installer *from* the shell - so in the one path a user actually
-    # takes, the target was always executing and this always failed. It failed
-    # silently too: stderr went to /dev/null and the caller then advised
-    # installing patchelf, which was already installed. Only a first install,
-    # with nothing running yet, ever succeeded - so the repair worked exactly
-    # when it was not needed, and not when it was.
-    #
-    # Patch a copy and rename over the original instead. rename(2) swaps the
-    # directory entry; the running process keeps the inode it already opened
-    # and is unaffected, and the next launch picks up the repaired file. The
-    # temporary lives beside the target so the rename stays on one filesystem
-    # (mv across filesystems is copy-then-unlink, which is neither atomic nor
-    # safe against a concurrent exec).
-    local tmp; tmp="$(mktemp "${qs_bin}.patchelf.XXXXXX")" || tmp=""
-    if [[ -n "$tmp" ]] && cp -p "$qs_bin" "$tmp" \
-       && patchelf --set-rpath "$lib_dir:$OPT_LIBS${rp:+:$rp}" "$tmp" \
-       && mv -f "$tmp" "$qs_bin"; then
+    if set_runpath "$qs_bin" "$lib_dir:$OPT_LIBS${rp:+:$rp}"; then
       say "baked the WE runtime lib dirs into the binary's RUNPATH."
     else
       # Surface the reason rather than discarding it - the previous silence is
       # what made this look like a missing dependency for so long.
       say "could not repair the binary's RUNPATH with patchelf."
-      [[ -n "$tmp" ]] && rm -f "$tmp"
     fi
+
+    # DT_RUNPATH is NOT transitive. The executable's RUNPATH resolves its own
+    # direct dependencies and nothing else: liblinux-wallpaperengine-lib.so's
+    # own needs (libcef.so beside it, libkissfft-float.so from the /opt runtime)
+    # are searched using *that library's* RUNPATH, which is the builder's
+    # directory and exists nowhere. So repairing only the binary left the shell
+    # still unable to start unaided, and the LD_LIBRARY_PATH fallback - which IS
+    # transitive, and is exactly why it worked where the RUNPATH did not - stayed
+    # in the wrapper.
+    #
+    # $ORIGIN first so a library finds its siblings wherever the prebuilt tree
+    # is unpacked, then the /opt runtime for what is not bundled.
+    local so
+    for so in "$lib_dir"/*.so*; do
+      [[ -f "$so" ]] || continue
+      libs_resolve_standalone "$so" && continue
+      local so_rp; so_rp="$(patchelf --print-rpath "$so" 2>/dev/null || true)"
+      set_runpath "$so" "\$ORIGIN:$OPT_LIBS${so_rp:+:$so_rp}" \
+        || say "could not repair $(basename "$so")'s RUNPATH."
+    done
   else
     say "patchelf not present; cannot repair the binary's RUNPATH."
   fi


### PR DESCRIPTION
Follow-up to #115, found by checking whether that fix actually worked on a real machine. It did what it claimed and the problem it was written to solve remained.

## What #115 achieved, and what it missed

After v0.16.0 the log finally reads:

```
[ImI] Wallpaper Engine: baked the WE runtime lib dirs into the binary's RUNPATH.
```

That line had never appeared before — the repair genuinely works now. But the very next lines still say:

```
WARNING: binary still needs LD_LIBRARY_PATH. Exporting it as a fallback -
         patchelf is installed but could not repair the binary; see above.
```

Two dependencies were still unresolved:

```
$ env -u LD_LIBRARY_PATH ldd .../bin/quickshell
    libkissfft-float.so.131 => not found
    libcef.so => not found
```

`libcef.so` **is** in the bundled lib directory. It was still not found.

## Cause

**`DT_RUNPATH` is not transitive.** The executable's RUNPATH resolves the executable's own direct dependencies and nothing further. `liblinux-wallpaperengine-lib.so`'s needs are searched using *its* RUNPATH — and that is a builder path too:

```
$ patchelf --print-rpath .../lib/liblinux-wallpaperengine-lib.so
/__w/qs-wallpaperengine/.../build/lib:/__w/.../cef/.../Release:
```

`libcef.so` sits beside it (and correctly carries `$ORIGIN`); `libkissfft-float.so.131` lives in `/opt/linux-wallpaperengine/lib`.

`LD_LIBRARY_PATH` **is** transitive. That is exactly why the fallback worked where the RUNPATH did not — and why this went unnoticed for so long: the fallback was quietly covering for it, which is also the leak it was supposed to avoid.

## Fix

Every bundled `.so` that cannot resolve on its own gets `$ORIGIN:/opt/linux-wallpaperengine/...` — `$ORIGIN` first so a library finds its siblings wherever the prebuilt tree is unpacked, then the `/opt` runtime for what is not bundled.

Verified against the real installed tree before changing anything: patching the binary alone leaves two unresolved; patching the library as well resolves everything.

The copy-and-rename from #115 is factored out into `set_runpath` and reused — the running process has these libraries mapped, so writing to them in place carries the same hazard as writing to the executable.

## Verification

Full suite **276 passed, 0 failed**.

The new test builds the shape that survived #115: a bundled library needing a second library, with a RUNPATH that resolves nothing — as the shipped one has.

| mutation | result |
|---|---|
| library loop removed (repair the binary only — i.e. #115's behaviour) | **FAILS** |
| library RUNPATH written without `$ORIGIN` | **FAILS** |

That first row is the point: this PR's test fails against the code that is currently on `main`.

## Relationship to the upstream fix

XephyLon/qs-wallpaperengine#13 sets `$ORIGIN/../lib` on the **binary** at packaging time. That is also incomplete for the same reason and wants the same treatment for the bundled libraries — I will follow up there. This PR is needed regardless, since binaries already installed carry the old RUNPATHs.
