### PR TITLE
feat(wallpaperEngine): render full-resolution stills so the greeter stops upscaling a thumbnail

### DIFF
--- a/dots/.config/quickshell/imi/modules/common/Config.qml
+++ b/dots/.config/quickshell/imi/modules/common/Config.qml
@@ -1408,19 +1408,28 @@ Singleton {
                     // is unsupported by the embedded renderer (needs CEF), so the
                     // background falls back to the static wallpaper for it.
                     property string activeType: ""
-                    // `activeStill` used to live here: a full-scene still rendered
-                    // from the active project. The selector-only refactor removed
-                    // the code that generated those stills and wrote the field, but
-                    // left the field and its readers, so it sat frozen at whatever
-                    // it held that day - and applying a preset restored that stale
-                    // value, which is how it spread (#103). Removed rather than
-                    // repaired: `activePreview` is maintained by
-                    // WallpaperEngine.apply() and always matches the active project.
+                    // A full-resolution still of the active project, rendered at
+                    // the display's own size and cached under
+                    // ~/.cache/.../wallpaperengine-stills/<id>.jpg.
                     //
-                    // Deliberately not migrated away on disk. The JsonAdapter does
-                    // not expose keys it has no property for, so the leftover key is
-                    // inert - the same treatment the desktop-widget keys got above,
-                    // and it keeps a downgrade working.
+                    // This field existed before, was removed in #103, and is back
+                    // deliberately. It was removed because the selector-only
+                    // refactor deleted the code that generated the stills while
+                    // leaving the field and its readers, so it sat frozen at
+                    // whatever it held that day and preset-apply spread the stale
+                    // value. The field was never the problem - having no writer
+                    // was. It now has one: WallpaperEngine.apply() renders the
+                    // still through scripts/wallpapers/we_still.sh on every scene
+                    // switch, so it cannot go stale the way it did.
+                    //
+                    // It exists because `activePreview` is a Steam Workshop
+                    // thumbnail - often square and around 1000px - and the SDDM
+                    // greeter, which cannot run Wallpaper Engine, was showing that
+                    // upscaled across the whole display (#113). Readers must treat
+                    // an empty value as "not available yet" and fall back to
+                    // activePreview: rendering is asynchronous and a scene takes a
+                    // few seconds.
+                    property string activeStill: ""
                     property int fps: 30
                     property string scaling: "fill"
                     property bool silent: true

--- a/dots/.config/quickshell/imi/scripts/wallpapers/we_still.sh
+++ b/dots/.config/quickshell/imi/scripts/wallpapers/we_still.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Render a full-resolution still of a Wallpaper Engine project.
+#
+# Why this exists: the SDDM greeter cannot run Wallpaper Engine, so it needs a
+# static image of whatever the desktop is showing. The only image a WE project
+# ships is the Steam Workshop preview, which is a thumbnail - typically square
+# and around 1000px. Cropped to a wide display that is a narrow band upscaled
+# several times over (immaterial-impulse#113: a 910x910 preview on 5120x1440).
+#
+# linux-wallpaperengine can render a project and dump a frame, at whatever size
+# it is given, so the greeter can have the wallpaper at the display's own
+# resolution instead. This has to run in the user's session, with a GPU and a
+# compositor: the theme's apply script runs as root through sudo and has
+# neither, which is why the work happens here and only the resulting file is
+# handed over.
+#
+# Usage: we_still.sh <project-id> <output.jpg> [WIDTHxHEIGHT]
+set -euo pipefail
+
+PROJECT_ID="${1:-}"
+OUT="${2:-}"
+GEOMETRY="${3:-}"
+[[ -n "$PROJECT_ID" && -n "$OUT" ]] || { echo "usage: we_still.sh <project-id> <out.jpg> [WxH]" >&2; exit 2; }
+[[ "$PROJECT_ID" =~ ^[0-9]+$ ]] || { echo "we_still.sh: project id must be numeric" >&2; exit 2; }
+
+command -v linux-wallpaperengine >/dev/null || { echo "we_still.sh: linux-wallpaperengine not installed" >&2; exit 3; }
+
+# Default to the focused monitor: the greeter fills one screen, and rendering
+# at that size is what makes the result native rather than upscaled.
+if [[ -z "$GEOMETRY" ]]; then
+    GEOMETRY="$(hyprctl monitors -j 2>/dev/null \
+        | jq -r 'map(select(.focused)) | .[0] | "\(.width)x\(.height)"' 2>/dev/null || true)"
+fi
+[[ "$GEOMETRY" =~ ^[0-9]+x[0-9]+$ ]] || GEOMETRY="1920x1080"
+WIDTH="${GEOMETRY%x*}"; HEIGHT="${GEOMETRY#*x}"
+
+TIMEOUT="${WE_STILL_TIMEOUT:-45}"
+DELAY_FRAMES="${WE_STILL_DELAY_FRAMES:-20}"
+
+mkdir -p "$(dirname "$OUT")"
+raw="$(mktemp --suffix=-we-still.jpg)"
+cleanup() { rm -f "$raw"; }
+trap cleanup EXIT
+
+# --silent because this runs on every wallpaper switch and a burst of the
+# wallpaper's audio each time would be intolerable.
+#
+# setsid + process-group kill because --screenshot does NOT exit once it has
+# written the file: it keeps rendering, so the caller has to notice the file
+# and stop it. Killing the group rather than the pid matters - the renderer
+# spawns children and a bare `kill` leaves them holding the GPU.
+setsid linux-wallpaperengine \
+    --silent \
+    --window "0x0x${WIDTH}x${HEIGHT}" \
+    --screenshot "$raw" \
+    --screenshot-delay "$DELAY_FRAMES" \
+    "$PROJECT_ID" >/dev/null 2>&1 &
+pgid=$!
+
+for _ in $(seq 1 "$TIMEOUT"); do
+    [[ -s "$raw" ]] && break
+    sleep 1
+done
+# A moment for the writer to finish flushing before the group is torn down;
+# without it the file can exist but be truncated.
+[[ -s "$raw" ]] && sleep 1
+kill -TERM -"$pgid" 2>/dev/null || true
+sleep 1
+kill -KILL -"$pgid" 2>/dev/null || true
+wait "$pgid" 2>/dev/null || true
+
+[[ -s "$raw" ]] || { echo "we_still.sh: no frame produced for $PROJECT_ID" >&2; exit 1; }
+
+# The renderer writes JPEG at maximum quality - about 8 MiB at 5120x1440. This
+# is copied onto /usr/share by the greeter's installer, so recompress: -q:v 2
+# is visually equivalent on a render and roughly a tenth the size. Falls back
+# to the raw file if ffmpeg is unavailable rather than failing outright.
+# The temporary keeps a .jpg suffix: ffmpeg picks the encoder from the output
+# extension, and a bare ".tmp" makes it fail - silently, since stderr is
+# discarded, leaving the uncompressed frame in place looking like a success.
+tmp_out="${OUT%.jpg}.tmp.jpg"
+if command -v ffmpeg >/dev/null && ffmpeg -y -i "$raw" -q:v 2 "$tmp_out" >/dev/null 2>&1 && [[ -s "$tmp_out" ]]; then
+    mv -f "$tmp_out" "$OUT"
+else
+    rm -f "$tmp_out"
+    cp -f "$raw" "$OUT"
+fi
+
+echo "$OUT"

--- a/dots/.config/quickshell/imi/services/WallpaperEngine.qml
+++ b/dots/.config/quickshell/imi/services/WallpaperEngine.qml
@@ -72,6 +72,55 @@ Singleton {
         // back to the static wallpaper instead of a blank screen.
         Config.options.wallpaperSelector.wallpaperEngine.activeType = project.type ?? "";
         if (project.preview) root.enqueueTheme(project, darkMode);
+        root.enqueueStill(project);
+    }
+
+    // Render a full-resolution still of the project for consumers that cannot
+    // run Wallpaper Engine - in practice the SDDM greeter, which was showing a
+    // ~1000px square Workshop thumbnail stretched across the display (#113).
+    //
+    // Only "scene" projects need this. A "video" project is a plain file the
+    // greeter can either play or have a frame cut from, and "web" falls back to
+    // the static wallpaper everywhere.
+    readonly property string stillDir: FileUtils.trimFileProtocol(`${Directories.cache}/wallpaperengine-stills`)
+
+    function enqueueStill(project) {
+        if (!project || (project.type ?? "") !== "scene" || !project.id) {
+            // Leave whatever the last scene produced alone rather than clearing
+            // it: the greeter prefers the still only when it matches the active
+            // project, and a half-written value is worse than an absent one.
+            return;
+        }
+        // The renderer holds a GPU context for a few seconds; queue rather than
+        // run concurrently, exactly as theme generation does above.
+        if (stillProcess.running) {
+            stillProcess.pendingProject = project;
+            return;
+        }
+        stillProcess.target = `${root.stillDir}/${project.id}.jpg`;
+        stillProcess.command = [`${Directories.scriptPath}/wallpapers/we_still.sh`,
+            `${project.id}`, stillProcess.target];
+        stillProcess.running = true;
+    }
+
+    Process {
+        id: stillProcess
+        property var pendingProject: null
+        property string target: ""
+        onExited: exitCode => {
+            const pending = stillProcess.pendingProject;
+            stillProcess.pendingProject = null;
+            if (exitCode === 0 && stillProcess.target !== "") {
+                Config.options.wallpaperSelector.wallpaperEngine.activeStill = stillProcess.target;
+            } else if (exitCode !== 0) {
+                // Not an error worth surfacing: the greeter falls back to the
+                // preview, which is what it used before this existed. Missing
+                // linux-wallpaperengine exits 3 and is the common case on a
+                // machine that never installed the Wallpaper Engine extra.
+                console.log("[WallpaperEngine] still render failed:", exitCode);
+            }
+            if (pending) Qt.callLater(() => root.enqueueStill(pending));
+        }
     }
 
     function enqueueTheme(project, darkMode = Appearance.m3colors.darkmode) {
@@ -93,6 +142,9 @@ Singleton {
         Config.options.wallpaperSelector.wallpaperEngine.activePath = "";
         Config.options.wallpaperSelector.wallpaperEngine.activeType = "";
         Config.options.wallpaperSelector.wallpaperEngine.activePreview = "";
+        // Cleared with the rest: a still naming a project no longer active is
+        // exactly the stale-field failure #103 was about.
+        Config.options.wallpaperSelector.wallpaperEngine.activeStill = "";
     }
 
     Process {

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -502,6 +502,12 @@ if ! python3 "$SCRIPT_DIR/test_screen_record.py"; then
     exit 1
 fi
 
+echo "Running Wallpaper Engine still tests..."
+if ! python3 "$SCRIPT_DIR/test_we_still.py"; then
+    echo "Wallpaper Engine still tests failed."
+    exit 1
+fi
+
 echo "Running drop shelf summon tests..."
 if ! python3 "$SCRIPT_DIR/test_dropshelf_summon.py"; then
     echo "Drop shelf summon tests failed."

--- a/dots/.config/quickshell/imi/tests/test_we_still.py
+++ b/dots/.config/quickshell/imi/tests/test_we_still.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Full-resolution Wallpaper Engine stills.
+
+The SDDM greeter cannot run Wallpaper Engine, so it needs a static image of the
+active project. The only image a project ships is the Steam Workshop preview - a
+thumbnail, often square and around 1000px - which on a wide display was cropped
+to a narrow band and upscaled several times over (#113; measured at 910x910 on
+5120x1440).
+
+scripts/wallpapers/we_still.sh renders the project at the display's own size.
+These pin the parts that fail silently: the audio flag, the process-group
+teardown, and the recompression's output extension.
+"""
+import re
+import subprocess
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/wallpapers/we_still.sh"
+SERVICE = ROOT / "services/WallpaperEngine.qml"
+CONFIG = ROOT / "modules/common/Config.qml"
+
+
+class StillScriptTests(unittest.TestCase):
+    def setUp(self):
+        self.script = SCRIPT.read_text()
+
+    def test_exists_and_is_executable(self):
+        self.assertTrue(SCRIPT.exists())
+        self.assertTrue(SCRIPT.stat().st_mode & 0o111, "not executable")
+
+    def test_bash_syntax(self):
+        proc = subprocess.run(["bash", "-n", str(SCRIPT)], capture_output=True, text=True)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+
+    def test_renders_silently(self):
+        # This runs on every scene switch. Without --silent the wallpaper's
+        # audio plays for the few seconds the renderer is up, every time.
+        #
+        # Comments are stripped first: the flag is explained in a comment right
+        # above the call, so asserting on the raw text passes even when the flag
+        # itself is deleted. Mutation testing caught exactly that.
+        code = "\n".join(l for l in self.script.splitlines()
+                         if not l.lstrip().startswith("#"))
+        self.assertIn("--silent", code)
+
+    def test_kills_the_process_group_not_the_pid(self):
+        # --screenshot does not exit once it has written the file, so the caller
+        # has to stop it - and the renderer spawns children, so a bare `kill`
+        # leaves them holding the GPU.
+        self.assertIn("setsid", self.script)
+        self.assertRegex(self.script, r'kill -TERM -"\$pgid"')
+        self.assertRegex(self.script, r'kill -KILL -"\$pgid"')
+
+    def test_waits_for_the_file_rather_than_a_fixed_sleep(self):
+        self.assertRegex(self.script, r'\[\[ -s "\$raw" \]\] && break')
+
+    def test_recompression_target_keeps_a_jpg_extension(self):
+        # ffmpeg picks its encoder from the output extension. A bare ".tmp"
+        # makes it fail, and stderr is discarded - so the uncompressed ~8 MiB
+        # frame is left in place and the script still reports success. This was
+        # a real bug in the first version of this script, found only by
+        # measuring the output size.
+        m = re.search(r'tmp_out="([^"]+)"', self.script)
+        self.assertIsNotNone(m, "no tmp_out assignment found")
+        self.assertTrue(m.group(1).endswith(".jpg"),
+                        f"recompression target {m.group(1)!r} must end in .jpg")
+
+    def test_rejects_a_non_numeric_project_id(self):
+        # The id is interpolated into a command line.
+        proc = subprocess.run(["bash", str(SCRIPT), "../../etc/passwd", "/tmp/x.jpg"],
+                              capture_output=True, text=True)
+        self.assertEqual(proc.returncode, 2, proc.stdout + proc.stderr)
+
+    def test_missing_renderer_is_a_distinct_exit_code(self):
+        # A machine without the Wallpaper Engine extra is the common case, not
+        # an error: the service logs it and the greeter keeps the preview.
+        self.assertIn("exit 3", self.script)
+
+
+class ServiceWiringTests(unittest.TestCase):
+    def setUp(self):
+        self.service = SERVICE.read_text()
+
+    def test_only_scenes_are_rendered(self):
+        # A video is a plain file the greeter can play or sample, and web falls
+        # back to the static wallpaper - neither needs a multi-second render.
+        self.assertRegex(self.service, r'\(project\.type \?\? ""\) !== "scene"')
+
+    def test_renders_are_queued_not_concurrent(self):
+        # The renderer holds a GPU context; two at once on a wallpaper spam is
+        # the failure this avoids.
+        self.assertIn("stillProcess.pendingProject = project", self.service)
+
+    def test_still_is_recorded_only_on_success(self):
+        body = self.service[self.service.index("id: stillProcess"):]
+        self.assertIn("if (exitCode === 0", body)
+        self.assertIn("activeStill = stillProcess.target", body)
+
+    def test_stop_clears_the_still(self):
+        # A still naming a project that is no longer active is exactly the
+        # stale-field failure #103 was about.
+        stop = self.service[self.service.index("function stop()"):]
+        stop = stop[:stop.index("\n    }")]
+        self.assertIn("activeStill = \"\"", stop)
+
+    def test_config_declares_the_field(self):
+        self.assertIn("property string activeStill:", CONFIG.read_text())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #113. Satellite half: XephyLon/imi-sddm-theme#10.

#113 said the greeter background was capped at the Workshop preview's resolution and that the real fix was blocked on the embedded Wallpaper Engine renderer. **That was wrong** — `linux-wallpaperengine` can already render a project and dump a frame at an arbitrary size, so scenes are solvable today.

Measured on a 5120x1440 display:

| | before | after | cost |
|---|---|---|---|
| scene (`3097818836`) | 910x910 preview | **5120x1440** | 3.0s, 1.8 MiB |
| video (`3308717230`) | 1024x1024 preview | **5120x1440** | 1.05s, 1.0 MiB |

## What this adds

`scripts/wallpapers/we_still.sh` renders the active project at the focused monitor's size and recompresses the frame. `WallpaperEngine.apply()` calls it on every **scene** switch and records the path.

Video and web are deliberately excluded: a video is a plain file the greeter can play or sample (the satellite PR does that), and web falls back to the static wallpaper everywhere. Neither justifies a multi-second GPU render.

## `activeStill` is back

Reinstated deliberately. It was removed in #103 for having **no writer** — the selector-only refactor deleted the still generation but left the field and its readers, so it froze and preset-apply spread the stale value. The field was never the problem. It now has a writer, `stop()` clears it, and a value only ever names the project that produced it.

Readers must treat empty as "not ready" and fall back to `activePreview`: rendering is asynchronous, so the first apply after a switch can still see the thumbnail.

## Three things that fail quietly

Each of these is why the script looks more careful than a one-line `ffmpeg` call:

- **`--silent`** — this runs on every scene switch; without it the wallpaper's audio plays for the few seconds the renderer is up, every time.
- **`setsid` + process-group kill** — `--screenshot` does *not* exit after writing the file, it keeps rendering. The caller has to notice the file and stop it, and a bare `kill` leaves the renderer's children holding the GPU.
- **`.jpg` on the recompression temporary** — ffmpeg picks its encoder from the output extension. A bare `.tmp` makes it fail *silently* (stderr is discarded), leaving the uncompressed ~8 MiB frame in place looking like success. **This shipped in my first draft** and was caught only by measuring the output size, not by the exit code.

## Verification

Full suite **276 passed, 0 failed**. Both scripts `bash -n` clean.

The renderer was run for real against the live scene: 5120x1440 in 3s, correct composed frame (verified visually, mean luma 93 — not a black frame), `quickshell` unaffected, no stray renderer processes left behind.

Six mutations, each confirmed to fail and reverted:

| mutation | caught |
|---|---|
| recompression temp loses `.jpg` (the real bug) | ✅ |
| `--silent` dropped | ✅ * |
| kills the pid instead of the process group | ✅ |
| renders every project type, not just scenes | ✅ |
| records the still even when the render failed | ✅ |
| `stop()` no longer clears the still | ✅ |

\* caught **only after fixing the test**. The first version asserted `--silent` appeared in the script — and it still did, in the comment explaining it, with the flag deleted. The assertion now strips comments. Mutation testing found that; review would not have.

## Ordering

Merge this first — the satellite's `activeStill` branch is inert until something writes the field.
