### PR TITLE
fix(wallpapers): render the still offscreen, and only once per project

### DIFF
--- a/dots/.config/quickshell/imi/scripts/wallpapers/we_still.sh
+++ b/dots/.config/quickshell/imi/scripts/wallpapers/we_still.sh
@@ -26,10 +26,16 @@ GEOMETRY="${3:-}"
 command -v linux-wallpaperengine >/dev/null || { echo "we_still.sh: linux-wallpaperengine not installed" >&2; exit 3; }
 
 # Default to the focused monitor: the greeter fills one screen, and rendering
-# at that size is what makes the result native rather than upscaled.
+# at that size is what makes the result native rather than upscaled. The name
+# is wanted as well as the size - see the render mode below.
+MONITOR_NAME=""
 if [[ -z "$GEOMETRY" ]]; then
-    GEOMETRY="$(hyprctl monitors -j 2>/dev/null \
-        | jq -r 'map(select(.focused)) | .[0] | "\(.width)x\(.height)"' 2>/dev/null || true)"
+    monitor_json="$(hyprctl monitors -j 2>/dev/null \
+        | jq -c 'map(select(.focused)) | .[0] // empty' 2>/dev/null || true)"
+    if [[ -n "$monitor_json" ]]; then
+        MONITOR_NAME="$(jq -r '.name // ""' <<<"$monitor_json" 2>/dev/null || true)"
+        GEOMETRY="$(jq -r '"\(.width)x\(.height)"' <<<"$monitor_json" 2>/dev/null || true)"
+    fi
 fi
 [[ "$GEOMETRY" =~ ^[0-9]+x[0-9]+$ ]] || GEOMETRY="1920x1080"
 WIDTH="${GEOMETRY%x*}"; HEIGHT="${GEOMETRY#*x}"
@@ -38,12 +44,37 @@ TIMEOUT="${WE_STILL_TIMEOUT:-45}"
 DELAY_FRAMES="${WE_STILL_DELAY_FRAMES:-20}"
 
 mkdir -p "$(dirname "$OUT")"
+
 raw="$(mktemp --suffix=-we-still.jpg)"
 cleanup() { rm -f "$raw"; }
 trap cleanup EXIT
 
-# --silent because this runs on every wallpaper switch and a burst of the
-# wallpaper's audio each time would be intolerable.
+# Render mode. --window opens an ordinary floating window: on a compositor it
+# takes focus and covers the screen for the seconds the render takes, which is
+# a visible interruption for a file the user never asked to see being made.
+#
+# --screen-root binds a wlr-layer-shell surface instead, and --layer background
+# puts it on the lowest layer - underneath the shell's own wallpaper, which is
+# opaque and covers it completely. Same frame, no window, no focus change,
+# nothing on screen. It also takes the output's real size, so the geometry is
+# the monitor's by construction rather than by being told.
+#
+# --no-fullscreen-pause is required with it: a background pauses by default
+# while a fullscreen window is active, and a paused renderer never reaches the
+# screenshot frame, so a render started over a fullscreen app would sit there
+# until the timeout and produce nothing.
+#
+# The window path stays for anything without a named output - a non-Hyprland
+# compositor, or an explicit geometry argument asking for a specific size.
+if [[ -n "$MONITOR_NAME" ]]; then
+    render_args=(--screen-root "$MONITOR_NAME" --layer background
+        --no-fullscreen-pause --bg "$PROJECT_ID")
+else
+    render_args=(--window "0x0x${WIDTH}x${HEIGHT}" "$PROJECT_ID")
+fi
+
+# --silent because a burst of the wallpaper's audio while nothing is visible on
+# screen would be worse than the window ever was.
 #
 # setsid + process-group kill because --screenshot does NOT exit once it has
 # written the file: it keeps rendering, so the caller has to notice the file
@@ -51,10 +82,9 @@ trap cleanup EXIT
 # spawns children and a bare `kill` leaves them holding the GPU.
 setsid linux-wallpaperengine \
     --silent \
-    --window "0x0x${WIDTH}x${HEIGHT}" \
     --screenshot "$raw" \
     --screenshot-delay "$DELAY_FRAMES" \
-    "$PROJECT_ID" >/dev/null 2>&1 &
+    "${render_args[@]}" >/dev/null 2>&1 &
 pgid=$!
 
 for _ in $(seq 1 "$TIMEOUT"); do

--- a/dots/.config/quickshell/imi/scripts/wallpapers/we_still.sh
+++ b/dots/.config/quickshell/imi/scripts/wallpapers/we_still.sh
@@ -23,8 +23,6 @@ GEOMETRY="${3:-}"
 [[ -n "$PROJECT_ID" && -n "$OUT" ]] || { echo "usage: we_still.sh <project-id> <out.jpg> [WxH]" >&2; exit 2; }
 [[ "$PROJECT_ID" =~ ^[0-9]+$ ]] || { echo "we_still.sh: project id must be numeric" >&2; exit 2; }
 
-command -v linux-wallpaperengine >/dev/null || { echo "we_still.sh: linux-wallpaperengine not installed" >&2; exit 3; }
-
 # Default to the focused monitor: the greeter fills one screen, and rendering
 # at that size is what makes the result native rather than upscaled. The name
 # is wanted as well as the size - see the render mode below.
@@ -44,6 +42,30 @@ TIMEOUT="${WE_STILL_TIMEOUT:-45}"
 DELAY_FRAMES="${WE_STILL_DELAY_FRAMES:-20}"
 
 mkdir -p "$(dirname "$OUT")"
+
+# A project's render does not change, so render it once and keep it. Without
+# this the renderer runs on every single wallpaper switch - including switching
+# back to something seen a minute ago - which is several seconds of GPU for a
+# file that is already on disk and identical.
+#
+# The size is checked rather than just the existence: a still cached at the old
+# resolution is exactly the upscaled-thumbnail problem this script exists to
+# fix, so a monitor change has to invalidate it. WE_STILL_FORCE=1 re-renders
+# regardless, for a project whose content was updated in the Workshop.
+still_geometry() {
+    ffprobe -v error -select_streams v -show_entries stream=width,height \
+        -of csv=p=0:s=x "$1" 2>/dev/null || true
+}
+if [[ -z "${WE_STILL_FORCE:-}" && -s "$OUT" ]] \
+    && [[ "$(still_geometry "$OUT")" == "${WIDTH}x${HEIGHT}" ]]; then
+    echo "$OUT"
+    exit 0
+fi
+
+# Checked after the cache, not before: a usable still on disk needs no renderer,
+# and failing here would throw away a good file on a machine that has since
+# dropped the Wallpaper Engine extra.
+command -v linux-wallpaperengine >/dev/null || { echo "we_still.sh: linux-wallpaperengine not installed" >&2; exit 3; }
 
 raw="$(mktemp --suffix=-we-still.jpg)"
 cleanup() { rm -f "$raw"; }

--- a/dots/.config/quickshell/imi/tests/test_we_still.py
+++ b/dots/.config/quickshell/imi/tests/test_we_still.py
@@ -11,8 +11,11 @@ scripts/wallpapers/we_still.sh renders the project at the display's own size.
 These pin the parts that fail silently: the audio flag, the process-group
 teardown, and the recompression's output extension.
 """
+import os
 import re
+import shutil
 import subprocess
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -25,6 +28,12 @@ CONFIG = ROOT / "modules/common/Config.qml"
 class StillScriptTests(unittest.TestCase):
     def setUp(self):
         self.script = SCRIPT.read_text()
+        # Comments are stripped for anything asserting a flag is *used*: every
+        # flag here is explained in a comment right above the call, so matching
+        # the raw text passes even when the flag itself is deleted. Mutation
+        # testing caught exactly that on --silent.
+        self.code = "\n".join(l for l in self.script.splitlines()
+                              if not l.lstrip().startswith("#"))
 
     def test_exists_and_is_executable(self):
         self.assertTrue(SCRIPT.exists())
@@ -35,15 +44,30 @@ class StillScriptTests(unittest.TestCase):
         self.assertEqual(proc.returncode, 0, proc.stderr)
 
     def test_renders_silently(self):
-        # This runs on every scene switch. Without --silent the wallpaper's
-        # audio plays for the few seconds the renderer is up, every time.
-        #
-        # Comments are stripped first: the flag is explained in a comment right
-        # above the call, so asserting on the raw text passes even when the flag
-        # itself is deleted. Mutation testing caught exactly that.
-        code = "\n".join(l for l in self.script.splitlines()
-                         if not l.lstrip().startswith("#"))
-        self.assertIn("--silent", code)
+        # Nothing is visible on screen while this runs, so a burst of the
+        # wallpaper's audio would be the only sign it happened at all.
+        self.assertIn("--silent", self.code)
+
+    def test_renders_beneath_the_shell_rather_than_in_a_window(self):
+        # --window opens an ordinary floating window: it takes focus and covers
+        # the screen for the seconds the render takes. --screen-root binds a
+        # layer-shell surface and --layer background puts it under the shell's
+        # own (opaque) wallpaper, so the render is not visible and does not
+        # touch focus. Losing either flag puts the window back.
+        self.assertIn("--screen-root", self.code)
+        self.assertIn("--layer background", self.code)
+
+    def test_does_not_pause_behind_a_fullscreen_window(self):
+        # A background pauses by default while a fullscreen window is active.
+        # Paused, it never reaches the screenshot frame - so a render started
+        # over a fullscreen app would sit until the timeout and produce
+        # nothing. Only matters in layer-shell mode, which is now the default.
+        self.assertIn("--no-fullscreen-pause", self.code)
+
+    def test_window_mode_survives_as_a_fallback(self):
+        # Not every caller has a named output: a non-Hyprland compositor, or an
+        # explicit geometry argument asking for a size that is not a monitor's.
+        self.assertIn("--window", self.code)
 
     def test_kills_the_process_group_not_the_pid(self):
         # --screenshot does not exit once it has written the file, so the caller
@@ -77,6 +101,100 @@ class StillScriptTests(unittest.TestCase):
         # A machine without the Wallpaper Engine extra is the common case, not
         # an error: the service logs it and the greeter keeps the preview.
         self.assertIn("exit 3", self.script)
+
+
+def _make_jpeg(path, width, height):
+    """A real JPEG of a known size - the cache check reads the file's geometry."""
+    subprocess.run(
+        ["ffmpeg", "-y", "-f", "lavfi", "-i", f"color=c=red:s={width}x{height}",
+         "-frames:v", "1", str(path)],
+        capture_output=True, check=True)
+
+
+@unittest.skipUnless(shutil.which("ffmpeg") and shutil.which("ffprobe"),
+                     "ffmpeg/ffprobe required to build and measure the fixture")
+class StillCacheTests(unittest.TestCase):
+    """A cached still is reused instead of re-rendered.
+
+    Every one of these runs the real script. They reach the cache branch and
+    return before the renderer is ever consulted, so they pass on a machine
+    with no linux-wallpaperengine - which is what CI is.
+    """
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp, True)
+        self.out = Path(self.tmp) / "3097818836.jpg"
+
+        # A stub renderer shadowing the real one. Whether it ran is the actual
+        # question these tests ask - "is linux-wallpaperengine installed" is
+        # not, and answering it by emptying PATH silently fails on a developer
+        # machine where the real binary sits in /usr/bin and gets found anyway.
+        # It renders nothing, so a cache miss ends in the no-frame path.
+        self.stub_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.stub_dir, True)
+        self.marker = Path(self.stub_dir) / "ran"
+        stub = Path(self.stub_dir) / "linux-wallpaperengine"
+        stub.write_text(f'#!/usr/bin/env bash\ntouch {self.marker}\nexit 0\n')
+        stub.chmod(0o755)
+
+    def run_script(self, geometry="800x600", env=None):
+        return subprocess.run(
+            ["bash", str(SCRIPT), "3097818836", str(self.out), geometry],
+            capture_output=True, text=True,
+            # A miss waits for a frame the stub never writes, so cap the wait.
+            env={**os.environ, **(env or {}),
+                 "PATH": f"{self.stub_dir}:{os.environ['PATH']}",
+                 "WE_STILL_TIMEOUT": "1"})
+
+    def rendered(self):
+        return self.marker.exists()
+
+    def test_a_matching_still_is_reused(self):
+        # The whole point: switching back to a scene seen a minute ago must not
+        # spend several seconds of GPU reproducing a file already on disk.
+        _make_jpeg(self.out, 800, 600)
+        before = self.out.stat().st_mtime_ns
+        proc = self.run_script()
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertFalse(self.rendered(), "renderer ran despite a usable cache")
+        self.assertEqual(self.out.stat().st_mtime_ns, before, "still was rewritten")
+        self.assertEqual(proc.stdout.strip(), str(self.out))
+
+    def test_reuse_does_not_need_the_renderer_installed(self):
+        # The cache check sits ahead of the availability guard on purpose: a
+        # good still on disk must not be thrown away by a machine that has
+        # since dropped the Wallpaper Engine extra.
+        #
+        # Asserted as an ordering rather than by running with the renderer
+        # removed: it lives in /usr/bin, so any PATH narrow enough to hide it
+        # also hides bash and ffprobe, and the test then passes or fails for
+        # reasons that have nothing to do with the branch under test.
+        script = SCRIPT.read_text()
+        self.assertLess(script.index("WE_STILL_FORCE"),
+                        script.index("linux-wallpaperengine not installed"),
+                        "availability guard runs before the cache check")
+
+    def test_a_still_at_the_wrong_size_is_not_reused(self):
+        # A still cached at the old resolution is precisely the upscaled
+        # thumbnail this script exists to avoid, so a monitor change has to
+        # invalidate it.
+        _make_jpeg(self.out, 640, 480)
+        self.run_script(geometry="800x600")
+        self.assertTrue(self.rendered(), "stale-size still was accepted")
+
+    def test_force_bypasses_the_cache(self):
+        # For a project whose content was updated in the Workshop, where the
+        # size still matches but the render no longer does.
+        _make_jpeg(self.out, 800, 600)
+        self.run_script(env={"WE_STILL_FORCE": "1"})
+        self.assertTrue(self.rendered(), "WE_STILL_FORCE did not force a render")
+
+    def test_an_empty_still_is_not_reused(self):
+        # A truncated write must not be mistaken for a cache hit.
+        self.out.write_bytes(b"")
+        self.run_script()
+        self.assertTrue(self.rendered(), "empty still was accepted as a cache hit")
 
 
 class ServiceWiringTests(unittest.TestCase):


### PR DESCRIPTION
Follow-up to #117. The still rendering worked, but the method was intrusive in two ways, both reported after using it:

- **it took over the screen** — `--window` opens an ordinary floating window, which takes focus and covers whatever was in front of it for the three seconds the render takes;
- **it did it every time** — including switching back to a scene seen a minute ago, re-rendering a file already on disk byte for byte.

## Offscreen

`--screen-root` binds a wlr-layer-shell surface instead of a window, and `--layer background` puts it on the lowest layer — underneath the shell's own wallpaper, which is opaque and covers it completely.

Verified on a live session mid-render:

```
windows named wallpaperengine: 0
active window:  unchanged
DP-1 level=0  linux-wallpaperengine     <- render
DP-1 level=1  quickshell:background     <- covers it
```

…and the frame still comes out at 5120x1440. That an occluded background layer keeps rendering at all was the part worth checking rather than assuming.

`--no-fullscreen-pause` is required alongside it: a background pauses by default while a fullscreen window is active, and a paused renderer never reaches the screenshot frame — a render started over a fullscreen app would sit until the timeout and produce nothing. In window mode the question never arose.

The window path stays as the fallback for anything without a named output: a non-Hyprland compositor, or an explicit geometry argument asking for a size that is not a monitor's.

## Cached

A project's render does not change, so it is kept and reused.

| | before | after |
|---|---|---|
| first apply | 3.20s | 3.20s |
| every apply after | 3.20s | **0.044s** |

The cached file's *size* is checked, not just its existence — a still cached at the old resolution is exactly the upscaled-thumbnail problem #113 was about, so a monitor change invalidates it. `WE_STILL_FORCE=1` re-renders regardless, for a project updated in the Workshop at unchanged dimensions.

The cache check sits ahead of the "is the renderer installed" guard deliberately: a usable still needs no renderer, and failing there would discard a good file on a machine that has since dropped the extra.

## Testing

Full suite green (276 passed, 0 failed). Each of the three commits passes its own tests, so the history bisects.

Mutation-tested — dropping `--layer background`, `--no-fullscreen-pause`, `--screen-root`, `--silent`, the size comparison, the `WE_STILL_FORCE` bypass, or the cache branch entirely each fail the suite.

One mutation survives and is equivalent rather than uncovered: swapping `-s` for `-e` on the cached file lets an empty file past the existence check, but `ffprobe` then reports no geometry, the comparison fails, and the cache misses anyway. `-s` is kept because it avoids spawning `ffprobe` on a zero-byte file.

Worth flagging about the tests themselves: the first version of the cache tests tried to simulate "no renderer" by narrowing `PATH`. `linux-wallpaperengine` lives in `/usr/bin`, so any `PATH` narrow enough to hide it also hides `bash` and `ffprobe` — those tests silently ran the *real* renderer and passed for the wrong reason. They now shadow it with a stub that records whether it ran, which is the actual question.

## Not addressed

Rendering a scene through a second process at all remains the wrong shape; the right fix is the shell owning the Wallpaper Engine texture, at which point a still is a framebuffer read and costs nothing. That is the parked embed work, unchanged by this.