### PR TITLE
feat(greeterSync): reactive greeter sync — observe inputs, not borrowed triggers

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -544,6 +544,30 @@ Two non-obvious behaviors have bitten this codebase before and are worth knowing
   racing surface creation. Because clearing the grab also empties its dismissable list, Settings
   must re-register itself when selection ends even though its own `visible` property never changed.
 
+## State propagation is reactive, or it is a bug waiting
+
+**"When X changes, refresh Y" must observe X — a property binding, a `Connections` handler, or an
+explicit completion poke — never piggyback on an unrelated trigger that happens to fire often
+enough.** The shell is an observer system end to end; a consumer wired as a callback of something
+else's event inherits two defect classes at once: it goes stale for every X-change that does not
+happen to fire the borrowed trigger, and it races every asynchronously-produced input it cannot
+wait for.
+
+The worked case is the SDDM greeter sync. Its inputs were refreshed only as a side effect of
+matugen's color generation, so WE scaling changes never reached the login screen, and the
+full-resolution still — grabbed a second *after* the config change that announced it — could be
+produced after the copy and miss the greeter until the next unrelated color event. The fix
+(a605450fd ("feat(greeterSync): observe the greeter's inputs instead of borrowing matugen's
+trigger"); `services/GreeterSync.qml`, spec in
+`docs/superpowers/specs/2026-08-05-reactive-greeter-sync-design.md`)
+observes the greeter-relevant leaves and is poked by the grab's completion, with the expensive side
+gated by an output diff so over-observation costs a hash, not a root copy. That gate is the general
+enabler: make firing cheap, then observe generously — under-observation is the staleness bug,
+over-observation is free.
+
+If you find yourself adding a second caller to an existing hook "because it also needs to run
+then", stop: name the input that actually changed, and observe it.
+
 ## Dynamic/data-driven QML gotchas
 
 Relevant to anything that instantiates QML components from external data (JSON manifests, config

--- a/docs/superpowers/specs/2026-08-05-reactive-greeter-sync-design.md
+++ b/docs/superpowers/specs/2026-08-05-reactive-greeter-sync-design.md
@@ -1,0 +1,75 @@
+# Reactive greeter sync — design
+
+**Status:** approved (option A staged now; option B is a separate future proposal)
+**Repos:** immaterial-impulse (hub), imi-sddm-theme (satellite)
+
+## Problem
+
+The SDDM greeter's inputs — the generated `Settings.qml`, `Colors.qml`, and the wallpaper
+file — are refreshed only as a **side effect of color generation**: matugen's
+`iisddmtheme` post_hook runs `generate_settings.py && sudo …/sddm-theme-apply.sh`.
+The trigger is "matugen ran," not "an input the greeter consumes changed." Two defect
+classes follow, both observed in production:
+
+1. **Staleness.** Any config change that affects `Settings.qml` without changing colors
+   never propagates: WE scaling (reported by the user against imi-sddm-theme#13's
+   subject matter), clock style, lock blur, panel family, quote text. The greeter
+   drifts from the desktop until the next wallpaper/color event.
+2. **The still race.** On a scene switch, matugen fires immediately, but the
+   full-resolution still is grabbed off the live surface ~1s after it settles
+   (`Background.captureGreeterStill`). The root copy can run before the still exists,
+   so the greeter keeps the preview until the *next* color event. The imperative chain
+   cannot express "wait for the still."
+
+## The framing
+
+The shell is already an observer system — QML property bindings are the Observable
+pattern natively. The greeter pipeline is the one consumer wired as a callback of an
+unrelated event instead of an observer of its own inputs. The design choice is only
+*where the observer lives* and *what a firing costs*.
+
+## Options considered
+
+**A. Shell-side observer + user-side diff gate (chosen, staged now).**
+A `GreeterSync` service singleton observes the greeter-relevant leaves
+(`wallpaperEngine.{activeProject,activePath,activeType,activePreview,scaling}`,
+`background.wallpaperPath`) and is poked explicitly by `captureGreeterStill` after a
+successful still write — the grab completion becomes an observed event, which closes
+the race. Debounced (~1.5s), it runs a satellite-owned sync wrapper:
+`generate_settings.py` → hash the greeter-consumed outputs (Settings.qml, Colors.qml,
+the derived still's identity) → compare to the last-applied stamp → `sudo apply` only
+on change. The diff gate is what makes observation cheap to be generous with: an
+over-observed leaf costs a hash, not a root copy. matugen's post_hook keeps firing the
+same wrapper — it *is* the correct observer for "colors changed."
+
+**B. Root out of the hot path (endgame; separate proposal).**
+Install-time: an sddm-readable staging dir (`/var/lib/imi-sddm-theme`, user:sddm);
+theme resolves Settings/Colors/conf/wallpaper from it. Updates become atomic
+user-space writes; the NOPASSWD rule leaves the hot path (install/uninstall only).
+Trust is a wash: root already copies the user's generated QML into the pre-auth
+greeter verbatim, single-user assumption already baked in. Not bundled here because it
+touches install/uninstall/check and login-critical pathing — the class
+imi-sddm-theme's AGENTS.md opens with. Needs its own spec.
+
+**C. systemd user `.path` units** watching config.json + the stills dir. Works with
+the shell stopped, closes the race externally, systemd serializes for free. Passed
+over for now: duplicates the shell's knowledge outside it and still runs root per
+change; composes with B later if wanted.
+
+## Decision
+
+Stage A now. B later as its own proposal. #13 (the scaling mapping) is orthogonal —
+required under every option; reactivity only governs when it refreshes.
+
+## Contracts introduced by A
+
+- **Hub → satellite:** the hub only ever invokes
+  `~/.config/imi-sddm-theme/sddm-theme-sync.sh` (absent = silent no-op, so the hub
+  works on machines without the theme). It never calls the root apply script directly.
+- **Satellite:** the wrapper owns generation, gating, and the privileged call. The
+  matugen post_hook calls the same wrapper. Nothing else calls `sudo` for the theme.
+- **Race closure:** any code that produces a greeter-consumed artifact asynchronously
+  (today: the still grab) must poke `GreeterSync.request()` on completion.
+- **Reactive rule (enforced in AGENT.md):** "when X changes, refresh Y" features must
+  observe X — a binding, a `Connections`, an explicit completion poke — never
+  piggyback on an unrelated trigger because it happens to fire often enough.

--- a/dots/.config/quickshell/imi/modules/imi/background/Background.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/Background.qml
@@ -328,7 +328,17 @@ Variants {
             // Failure is not worth surfacing: the greeter derives this same path,
             // finds nothing, and falls back to the preview - which is what it had
             // before any of this existed.
-            weLoader.item.grabToImage(result => result.saveToFile(target));
+            //
+            // On success, poke the greeter sync: the still is produced
+            // asynchronously, AFTER the config changes that announced the new
+            // wallpaper, so without this the theme apply can copy before the
+            // still exists and the login screen keeps the preview until the
+            // next unrelated color event. The grab's completion is the event
+            // the sync has to observe - see GreeterSync.
+            weLoader.item.grabToImage(result => {
+                if (result.saveToFile(target))
+                    GreeterSync.request();
+            });
         }
 
         // `rendered` flips on the FIRST frame, which can still be warmup or

--- a/dots/.config/quickshell/imi/services/GreeterSync.qml
+++ b/dots/.config/quickshell/imi/services/GreeterSync.qml
@@ -1,0 +1,81 @@
+pragma Singleton
+import qs.modules.common
+import qs.modules.common.functions
+import QtQuick
+import Quickshell
+import Quickshell.Io
+
+// Keeps the SDDM greeter's inputs in step with the desktop, reactively.
+//
+// The greeter used to be refreshed only as a side effect of color generation
+// (matugen's post_hook), so anything that changed the generated Settings.qml
+// without changing colors - WE scaling, clock style - went stale until the
+// next wallpaper switch, and the still grabbed after a scene switch could
+// land AFTER the copy and miss the login screen entirely.
+//
+// This service observes the greeter-relevant config leaves directly, and is
+// poked by Background.captureGreeterStill when a still finishes writing - the
+// grab's completion is an observed event, which is what closes that race.
+//
+// What it runs is the SATELLITE's sync wrapper, not the root apply script:
+// the wrapper generates Settings.qml, hashes the greeter-consumed outputs and
+// only escalates to the privileged copy when something actually changed. That
+// diff gate is what makes observation cheap to be generous with - an
+// over-observed leaf costs a hash, not a root copy. Absent wrapper (machine
+// without the SDDM theme, or a satellite older than the wrapper) = silent
+// no-op; matugen's post_hook still covers those installs the old way.
+Singleton {
+    id: root
+
+    readonly property string syncScript: FileUtils.trimFileProtocol(
+        `${Directories.config}/imi-sddm-theme/sddm-theme-sync.sh`)
+
+    // Public entry point: anything that changes what the greeter shows calls
+    // this. Debounced, because the leaves below often change in bursts (a
+    // wallpaper switch writes four of them back to back).
+    function request() {
+        if (!Config.ready) return;
+        debounce.restart();
+    }
+
+    Timer {
+        id: debounce
+        interval: 1500
+        onTriggered: {
+            // Serialize: a run arriving while one is in flight waits a full
+            // debounce rather than stacking a second wrapper process.
+            if (sync.running) { debounce.restart(); return; }
+            sync.running = true;
+        }
+    }
+
+    Process {
+        id: sync
+        // Existence-checked at fire time, not bound at load: the wrapper
+        // appears when the satellite installs it, which can happen while the
+        // shell is up.
+        command: ["bash", "-c",
+            `[ -f "${root.syncScript}" ] && exec bash "${root.syncScript}" || exit 0`]
+        onExited: exitCode => {
+            if (exitCode !== 0)
+                console.log("[GreeterSync] sync wrapper exited", exitCode);
+        }
+    }
+
+    // The observed leaves. Over-observation is tolerable (the wrapper's diff
+    // gate turns a spurious fire into a hash comparison); UNDER-observation is
+    // the staleness bug this service exists to end, so when in doubt, add the
+    // leaf.
+    Connections {
+        target: Config.options.wallpaperSelector.wallpaperEngine
+        function onActiveProjectChanged() { root.request(); }
+        function onActivePathChanged() { root.request(); }
+        function onActiveTypeChanged() { root.request(); }
+        function onActivePreviewChanged() { root.request(); }
+        function onScalingChanged() { root.request(); }
+    }
+    Connections {
+        target: Config.options.background
+        function onWallpaperPathChanged() { root.request(); }
+    }
+}

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -514,6 +514,12 @@ if ! python3 "$SCRIPT_DIR/test_we_still.py"; then
     exit 1
 fi
 
+echo "Running greeter sync tests..."
+if ! python3 "$SCRIPT_DIR/test_greeter_sync.py"; then
+    echo "Greeter sync tests failed."
+    exit 1
+fi
+
 echo "Running drop shelf summon tests..."
 if ! python3 "$SCRIPT_DIR/test_dropshelf_summon.py"; then
     echo "Drop shelf summon tests failed."

--- a/dots/.config/quickshell/imi/tests/test_greeter_sync.py
+++ b/dots/.config/quickshell/imi/tests/test_greeter_sync.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""The greeter sync observes its inputs; it does not borrow triggers.
+
+The SDDM greeter's inputs were refreshed only as a side effect of matugen's
+color generation, so a WE scaling change never reached the login screen, and
+the still - grabbed a second AFTER the config change announcing it - could be
+produced after the copy and miss the greeter until the next color event.
+
+GreeterSync.qml is the observer; these pin the wiring that would silently
+regress: the observed leaves, the completion poke that closes the still race,
+the debounce, and the privilege boundary (the shell runs the satellite's
+user-side wrapper, never the root apply script).
+
+See docs/superpowers/specs/2026-08-05-reactive-greeter-sync-design.md.
+"""
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SERVICE = (ROOT / "services/GreeterSync.qml").read_text()
+BACKGROUND = (ROOT / "modules/imi/background/Background.qml").read_text()
+
+
+def code_only(text):
+    """Comment lines stripped - assert against THIS, never raw text (the
+    comment explaining a rule necessarily names the thing it forbids)."""
+    return "\n".join(l for l in text.splitlines()
+                     if not l.lstrip().startswith("//"))
+
+
+class ObserverTests(unittest.TestCase):
+    def test_the_greeter_relevant_leaves_are_observed(self):
+        # Under-observation IS the staleness bug this service exists to end.
+        # Scaling is the leaf whose staleness was reported by the user.
+        for handler in ("onScalingChanged", "onActiveProjectChanged",
+                        "onActivePathChanged", "onActiveTypeChanged",
+                        "onActivePreviewChanged", "onWallpaperPathChanged"):
+            self.assertIn(handler, SERVICE, f"leaf no longer observed: {handler}")
+
+    def test_the_still_grab_pokes_the_sync_on_success(self):
+        # The still is produced asynchronously, AFTER the config changes that
+        # announced the wallpaper - the grab's completion is the event that
+        # closes the copy-before-still race, and it must fire only on a write
+        # that actually happened.
+        self.assertRegex(BACKGROUND,
+                         r"if \(result\.saveToFile\(target\)\)\s*\n\s*GreeterSync\.request\(\)")
+
+    def test_requests_are_debounced(self):
+        # A wallpaper switch writes several observed leaves back to back.
+        self.assertRegex(SERVICE, r"Timer \{\s*\n\s*id: debounce\s*\n\s*interval: \d+")
+        self.assertIn("debounce.restart()", SERVICE)
+
+
+class BoundaryTests(unittest.TestCase):
+    def test_the_shell_runs_the_wrapper_not_the_root_script(self):
+        # The satellite owns generation, gating and the privileged call. The
+        # hub invoking the root apply script directly would bypass the diff
+        # gate and put a sudo in the shell's own hot path.
+        code = code_only(SERVICE)
+        self.assertIn("sddm-theme-sync.sh", code)
+        self.assertNotIn("sddm-theme-apply", code)
+        self.assertNotIn("sudo", code)
+
+    def test_a_missing_wrapper_is_a_silent_noop(self):
+        # Machines without the SDDM theme, and satellites older than the
+        # wrapper, must not log an error per wallpaper switch.
+        self.assertRegex(code_only(SERVICE), r'\[ -f "\$\{root\.syncScript\}" \]')
+
+    def test_nothing_fires_before_config_is_ready(self):
+        # Startup writes the observed leaves while the config is still being
+        # loaded; syncing the greeter to a half-loaded config is a downgrade.
+        self.assertIn("if (!Config.ready) return", SERVICE)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Hub half of the reactive greeter sync; the study the user requested is committed as [`docs/superpowers/specs/2026-08-05-reactive-greeter-sync-design.md`](https://github.com/XephyLon/immaterial-impulse/blob/feat/greeter-sync/docs/superpowers/specs/2026-08-05-reactive-greeter-sync-design.md) (options A/B/C; this is option A). Pairs with imi-sddm-theme's `feat/sync-gate`; either merges first — `GreeterSync` silently no-ops while the satellite wrapper is absent.

## What was wrong

The greeter's inputs refreshed only as a **side effect of matugen's color generation**. Two defect classes, both seen in production: staleness (a WE scaling change never reached the login screen — the report behind imi-sddm-theme#13) and the copy-before-still race (the still is grabbed ~1s *after* the config change announcing it, so the apply could run first and the greeter kept the thumbnail until the next unrelated color event).

## What this adds

- `services/GreeterSync.qml` — observes the greeter-relevant leaves (`activeProject/Path/Type/Preview`, `scaling`, `background.wallpaperPath`), debounced and serialized; **poked by `captureGreeterStill` on a successful write**, making the grab's completion an observed event. That is the race closure.
- It fires the satellite's user-side sync wrapper, never the root apply script — the wrapper's diff gate means an over-observed leaf costs a hash, not a root copy, which is what makes generous observation affordable.
- **Enforcement for future agents**: AGENT.md gains *"State propagation is reactive, or it is a bug waiting"* — "when X changes, refresh Y" must observe X (binding, `Connections`, completion poke), never piggyback on an unrelated trigger; a borrowed trigger inherits staleness and races at once. Cited to this branch's feat commit, with the greeter sync as the worked example. `tests/test_greeter_sync.py` pins the wiring: observed leaves, completion poke, debounce, `Config.ready` guard, and the privilege boundary (no `sudo`, no direct apply-script call in the shell).

Full suite green (276 passed, 0 failed; `DesignSystemCompile checked=135 failures=0`).

## Deployment note

New singleton — registers only on a full `qs` restart, not hot reload.

Docs: updated AGENT.md §State propagation is reactive (new), new spec docs/superpowers/specs/2026-08-05-reactive-greeter-sync-design.md