### PR TITLE
feat(record): opt-in SDR tonemap after every save

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,10 @@ jobs:
       - name: Install Qt6 Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y qt6-declarative-dev qml6-module-qttest qml6-module-qtquick qml6-module-qtqml qml6-module-qtquick-controls qml6-module-qtquick-layouts qml6-module-qtqml-workerscript qml6-module-qtquick-window
+          # ffmpeg: test_tonemap_sdr.py builds a real HDR10 fixture (libx265)
+          # and drives the actual tonemap script; without ffmpeg those tests
+          # skip and the SDR delivery path ships unexercised.
+          sudo apt-get install -y qt6-declarative-dev qml6-module-qttest qml6-module-qtquick qml6-module-qtqml qml6-module-qtquick-controls qml6-module-qtquick-layouts qml6-module-qtqml-workerscript qml6-module-qtquick-window ffmpeg
 
       # zstd builds the fixture release tarballs in
       # test_wallpaperengine_prebuilt.py and extracts them in the installer under

--- a/AGENT.md
+++ b/AGENT.md
@@ -193,6 +193,15 @@ The authoritative signal is Hyprland's `colorManagementPreset` (`hdr`/`hdredid`)
 `currentFormat`: a wide-gamut SDR monitor also reports `XBGR2101010`. H.264 cannot carry HDR at all,
 so an explicit H.264 choice is respected and explained rather than silently overridden.
 (307c8b4ae ("fix(record): pick the HDR codec when capturing an HDR monitor").)
+The capture fix only moves the wash-out to the consumer's machine — a correct HDR10 file still
+renders flat in anything that does not tonemap (VLC defaults, Discord, browsers). Delivery is the
+opt-in `screenRecord.tonemapSdr`: `scripts/videos/tonemap-sdr.sh`, invoked from the `gsr-saved.sh`
+hook on every save (recordings *and* replays — replays never pass through `record.sh`), probes and
+tonemaps to bt709 in the background, replacing the file atomically (d7113f84c ("feat(record):
+opt-in SDR tonemap after every save")). Probe trap from that commit: ffprobe's **CSV output grows
+an extra field from a real recording's side data**, so a strict match on the transfer value
+silently classifies every real HDR file as SDR — synthetic fixtures have no side data, which is why
+only a live file catches it. Use value-only output (`-of default=nw=1:nk=1`) and trim delimiters.
 
 ## Directory map
 

--- a/dots/.config/quickshell/imi/modules/common/Config.qml
+++ b/dots/.config/quickshell/imi/modules/common/Config.qml
@@ -1340,6 +1340,15 @@ Singleton {
                 property bool recordMic: false // merge the mic into the audio track
                 property bool showCursor: true
                 property string framerateMode: "vfr" // cfr | vfr | content
+                // Recordings made on an HDR display are stored as real HDR10
+                // (the _hdr codec variants; see scripts/videos/record.sh). That
+                // is correct in HDR-aware players and washed out everywhere
+                // else - VLC's defaults, Discord embeds, browsers, editors,
+                // none of which tonemap. This switch trades the HDR away after
+                // the fact: when a save lands, the file is tonemapped to bt709
+                // SDR in the background and replaced. Default off - "preserve
+                // HDR" was the explicit choice when HDR recording was added.
+                property bool tonemapSdr: false
                 property JsonObject replay: JsonObject {
                     property bool enable: false // instant-replay ring buffer daemon
                     property int duration: 120 // seconds kept in the buffer

--- a/dots/.config/quickshell/imi/modules/imi/settings/pages/CaptureConfig.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/pages/CaptureConfig.qml
@@ -107,6 +107,13 @@ ContentPage {
                     checked: Config.options.screenRecord.showCursor
                     onCheckedChanged: { Config.options.screenRecord.showCursor = checked }
                 }
+                ConfigSwitch {
+                    buttonIcon: "brightness_6"
+                    text: Translation.tr("Convert HDR recordings to SDR")
+                    description: Translation.tr("HDR recordings look washed out in players that can't tonemap (VLC, Discord, browsers). This re-encodes each saved recording or replay to SDR in the background, replacing the HDR original. Off = keep true HDR files.")
+                    checked: Config.options.screenRecord.tonemapSdr
+                    onCheckedChanged: { Config.options.screenRecord.tonemapSdr = checked }
+                }
             }
 
             ContentSubsection {

--- a/dots/.config/quickshell/imi/scripts/videos/gsr-saved.sh
+++ b/dots/.config/quickshell/imi/scripts/videos/gsr-saved.sh
@@ -11,3 +11,15 @@ case "$type" in
     *) title="Saved" ;;
 esac
 notify-send "$title" "${path##*/}" -a 'Recorder' -i video-x-generic & disown
+
+# A save landing is the event the SDR delivery observes - recordings and
+# replays alike, which is exactly why it hangs off this hook rather than off
+# record.sh (replays never pass through record.sh). Detached: this hook runs
+# inside gsr's process context, and a re-encode must not block or die with it.
+# The tonemap script decides for itself whether to act (toggle + HDR probe),
+# keeping this hook dumb.
+case "$type" in
+    regular|replay)
+        setsid -f bash "$(dirname "$0")/tonemap-sdr.sh" "$path" >/dev/null 2>&1
+        ;;
+esac

--- a/dots/.config/quickshell/imi/scripts/videos/tonemap-sdr.sh
+++ b/dots/.config/quickshell/imi/scripts/videos/tonemap-sdr.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Tonemap an HDR recording to SDR, in place - the delivery half of HDR capture.
+#
+# Recording on an HDR display stores real HDR10 (record.sh picks the _hdr
+# codec variants), which is correct in HDR-aware players and washed out in
+# everything that does not tonemap - VLC's defaults, Discord embeds, browsers,
+# editors. gpu-screen-recorder cannot tonemap at capture time, so when the
+# user opts in (screenRecord.tonemapSdr) this runs after the save lands,
+# invoked by gsr-saved.sh: probe, tonemap to bt709, atomically replace.
+#
+# Usage: tonemap-sdr.sh <file.mp4>
+# Exits 0 without touching the file when: the toggle is off, the file is
+# already SDR, or the probe fails. The original is replaced only by a rename
+# of a fully-written temporary, so an interrupted run leaves it intact.
+set -euo pipefail
+
+FILE="${1:-}"
+[[ -f "$FILE" ]] || exit 0
+
+CONFIG_FILE="${XDG_CONFIG_HOME:-$HOME/.config}/immaterial-impulse/config.json"
+enabled="$(jq -r '.screenRecord.tonemapSdr // false' "$CONFIG_FILE" 2>/dev/null)"
+[[ "$enabled" == "true" ]] || exit 0
+
+# smpte2084 = HDR10 PQ, arib-std-b67 = HLG. Anything else is already SDR (or
+# unreadable, in which case leaving it alone is the only correct move).
+#
+# default=nw=1:nk=1, not csv: on a real gpu-screen-recorder file the CSV row
+# grows an extra field from the stream's side data (content light level), so
+# the value comes back as "smpte2084," and a strict match silently classifies
+# every real HDR recording as SDR. The synthetic test fixture has no side
+# data, which is why only the live file caught this.
+transfer="$(ffprobe -v error -select_streams v:0 \
+    -show_entries stream=color_transfer -of default=nw=1:nk=1 "$FILE" 2>/dev/null \
+    | head -n 1 || true)"
+# Belt and braces: trim any delimiter an output format sneaks in, so a future
+# probe-format change degrades to a wrong-looking value rather than a silent
+# every-file-is-SDR skip.
+transfer="${transfer%%[,$'\r']*}"
+case "$transfer" in
+    smpte2084|arib-std-b67) ;;
+    *) exit 0 ;;
+esac
+
+notify-send "Tonemapping to SDR" "${FILE##*/} - the HDR original will be replaced" \
+    -a 'Recorder' & disown
+
+# The temporary MUST end in .mp4: ffmpeg infers the muxer from the output
+# extension, and a bare ".tmp" fails - silently, if stderr is ever discarded.
+# Same trap that shipped in we_still.sh once already.
+tmp="${FILE%.mp4}.sdr-tmp.mp4"
+log="$(mktemp --suffix=-tonemap.log)"
+
+# libplacebo (Vulkan, GPU tonemap - fast and gamut-aware) when this ffmpeg has
+# it, else the zscale/tonemap CPU chain. x264 veryfast for the encode: every
+# GPU encoder spells its ffmpeg name differently, and a background re-encode
+# being portable matters more than it being instant.
+if ffmpeg -hide_banner -filters 2>/dev/null | grep -q libplacebo; then
+    VF="libplacebo=tonemapping=auto:colorspace=bt709:color_primaries=bt709:color_trc=bt709:format=yuv420p"
+    HW=(-init_hw_device vulkan)
+else
+    VF="zscale=t=linear:npl=203,format=gbrpf32le,zscale=p=bt709,tonemap=hable:desat=0,zscale=t=bt709:m=bt709:r=tv,format=yuv420p"
+    HW=()
+fi
+
+if ffmpeg -y -v error "${HW[@]}" -i "$FILE" \
+        -vf "$VF" \
+        -c:v libx264 -preset veryfast -crf 20 \
+        -c:a copy -movflags +faststart \
+        "$tmp" >"$log" 2>&1 && [[ -s "$tmp" ]]; then
+    mv -f "$tmp" "$FILE"
+    rm -f "$log"
+    notify-send "SDR ready" "${FILE##*/}" -a 'Recorder' -i video-x-generic & disown
+else
+    rm -f "$tmp"
+    notify-send "Tonemap failed - HDR original kept" \
+        "${FILE##*/} (details: $log)" -a 'Recorder' -u critical & disown
+    exit 1
+fi

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -508,6 +508,12 @@ if ! python3 "$SCRIPT_DIR/test_screen_record.py"; then
     exit 1
 fi
 
+echo "Running SDR tonemap tests..."
+if ! python3 "$SCRIPT_DIR/test_tonemap_sdr.py"; then
+    echo "SDR tonemap tests failed."
+    exit 1
+fi
+
 echo "Running Wallpaper Engine still tests..."
 if ! python3 "$SCRIPT_DIR/test_we_still.py"; then
     echo "Wallpaper Engine still tests failed."

--- a/dots/.config/quickshell/imi/tests/test_tonemap_sdr.py
+++ b/dots/.config/quickshell/imi/tests/test_tonemap_sdr.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""SDR delivery for HDR recordings: opt-in, probe-gated, atomic.
+
+record.sh stores real HDR10 on an HDR display - correct in HDR-aware players,
+washed out in everything that does not tonemap (VLC defaults, Discord,
+browsers). tonemap-sdr.sh is the delivery half: invoked by gsr-saved.sh when a
+save lands, it acts only when the user opted in AND the file is actually HDR,
+and replaces the file only by renaming a fully-written temporary.
+
+Behavioural tests drive the real script against a real (tiny) HDR10 clip with
+a sandboxed XDG_CONFIG_HOME; the failure-path test stubs ffmpeg/ffprobe via
+PATH. notify-send is stubbed throughout.
+"""
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/videos/tonemap-sdr.sh"
+SAVED_HOOK = (ROOT / "scripts/videos/gsr-saved.sh").read_text()
+
+HAVE_FFMPEG = bool(shutil.which("ffmpeg") and shutil.which("ffprobe"))
+
+
+def encoders():
+    if not HAVE_FFMPEG:
+        return ""
+    return subprocess.run(["ffmpeg", "-hide_banner", "-encoders"],
+                          capture_output=True, text=True).stdout
+
+
+def make_clip(path, hdr):
+    # x265 writes the VUI from its own params and ignores ffmpeg's -color_*
+    # flags, so the HDR tagging must go through -x265-params or the fixture
+    # probes as "unknown" - which it did on this test's first run.
+    color = (["-pix_fmt", "yuv420p10le", "-x265-params",
+              "colorprim=bt2020:transfer=smpte2084:colormatrix=bt2020nc"]
+             if hdr else ["-pix_fmt", "yuv420p"])
+    codec = "libx265" if hdr else "libx264"
+    subprocess.run(
+        ["ffmpeg", "-y", "-v", "error", "-f", "lavfi",
+         "-i", "testsrc2=s=64x64:d=0.3:r=10", "-c:v", codec, *color, str(path)],
+        capture_output=True, check=True)
+
+
+def transfer_of(path):
+    return subprocess.run(
+        ["ffprobe", "-v", "error", "-select_streams", "v:0",
+         "-show_entries", "stream=color_transfer", "-of", "csv=p=0", str(path)],
+        capture_output=True, text=True).stdout.strip()
+
+
+class SandboxedRun:
+    def __init__(self, enabled, stub_dir=None):
+        self.tmp = Path(tempfile.mkdtemp())
+        conf = self.tmp / "config/immaterial-impulse"
+        conf.mkdir(parents=True)
+        (conf / "config.json").write_text(
+            '{"screenRecord": {"tonemapSdr": %s}}' % ("true" if enabled else "false"))
+        stubs = self.tmp / "bin"
+        stubs.mkdir()
+        (stubs / "notify-send").write_text("#!/usr/bin/env bash\nexit 0\n")
+        (stubs / "notify-send").chmod(0o755)
+        path = f"{stubs}:{os.environ['PATH']}"
+        if stub_dir:
+            path = f"{stub_dir}:{path}"
+        self.env = {**os.environ, "XDG_CONFIG_HOME": str(self.tmp / "config"),
+                    "PATH": path}
+
+    def run(self, target):
+        return subprocess.run(["bash", str(SCRIPT), str(target)],
+                              env=self.env, capture_output=True, text=True)
+
+
+@unittest.skipUnless(HAVE_FFMPEG and "libx265" in encoders(),
+                     "ffmpeg with libx265 required to build the HDR fixture")
+class TonemapBehaviourTests(unittest.TestCase):
+    def setUp(self):
+        self.dir = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.dir, True)
+        self.clip = self.dir / "rec.mp4"
+
+    def test_hdr_clip_becomes_bt709_when_enabled(self):
+        make_clip(self.clip, hdr=True)
+        self.assertEqual(transfer_of(self.clip), "smpte2084", "fixture is not HDR")
+        proc = SandboxedRun(enabled=True).run(self.clip)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(transfer_of(self.clip), "bt709",
+                         "file was not tonemapped to SDR")
+
+    def test_toggle_off_leaves_the_file_alone(self):
+        make_clip(self.clip, hdr=True)
+        before = self.clip.stat().st_mtime_ns
+        SandboxedRun(enabled=False).run(self.clip)
+        self.assertEqual(self.clip.stat().st_mtime_ns, before,
+                         "acted despite the toggle being off")
+
+    def test_sdr_input_is_never_reencoded(self):
+        # Double-tonemapping an SDR file darkens it; the probe is the guard.
+        make_clip(self.clip, hdr=False)
+        before = self.clip.stat().st_mtime_ns
+        proc = SandboxedRun(enabled=True).run(self.clip)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(self.clip.stat().st_mtime_ns, before,
+                         "re-encoded an already-SDR file")
+
+    def test_a_failed_encode_keeps_the_hdr_original(self):
+        # Losing the only copy of a recording to a failed conversion is the
+        # one outcome strictly worse than a washed-out embed. Stub ffprobe to
+        # claim HDR and ffmpeg to fail; the original must survive, and the
+        # temporary must not linger.
+        make_clip(self.clip, hdr=True)
+        original = self.clip.read_bytes()
+        stubs = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, stubs, True)
+        # The trailing comma reproduces what a real gpu-screen-recorder file's
+        # side data does to CSV probing - the shape that made the first version
+        # of the script silently classify every real HDR recording as SDR. If
+        # parsing regresses to a strict match, this stub makes the script skip,
+        # ffmpeg never runs, and the "failed encode" assertions below fail.
+        (stubs / "ffprobe").write_text("#!/usr/bin/env bash\necho 'smpte2084,'\n")
+        (stubs / "ffmpeg").write_text("#!/usr/bin/env bash\nexit 1\n")
+        for s in ("ffprobe", "ffmpeg"):
+            (stubs / s).chmod(0o755)
+        proc = SandboxedRun(enabled=True, stub_dir=stubs).run(self.clip)
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertEqual(self.clip.read_bytes(), original, "original was damaged")
+        self.assertEqual(list(self.dir.glob("*sdr-tmp*")), [], "temporary left behind")
+
+    def test_a_missing_file_is_a_quiet_noop(self):
+        proc = SandboxedRun(enabled=True).run(self.dir / "gone.mp4")
+        self.assertEqual(proc.returncode, 0)
+
+
+class HookWiringTests(unittest.TestCase):
+    def test_saves_and_replays_trigger_it_screenshots_do_not(self):
+        # Replays never pass through record.sh, which is why the delivery hangs
+        # off the saved-hook: a save landing is the observed event.
+        hook = "\n".join(l for l in SAVED_HOOK.splitlines()
+                         if not l.lstrip().startswith("#"))
+        self.assertIn("regular|replay", hook)
+        self.assertIn("tonemap-sdr.sh", hook)
+
+    def test_the_hook_detaches_the_reencode(self):
+        # The hook runs inside gsr's process context; a re-encode that blocks
+        # or dies with it loses the conversion on every recorder exit.
+        self.assertRegex(SAVED_HOOK, r"setsid -f .*tonemap-sdr\.sh")
+
+    def test_the_temporary_keeps_a_video_extension(self):
+        # ffmpeg infers the muxer from the output extension; a bare ".tmp"
+        # fails. Same trap that shipped in we_still.sh once already.
+        script = SCRIPT.read_text()
+        import re
+        m = re.search(r'tmp="\$\{FILE%\.mp4\}([^"]+)"', script)
+        self.assertIsNotNone(m, "no temporary assignment found")
+        self.assertTrue(m.group(1).endswith(".mp4"),
+                        f"temporary {m.group(1)!r} must end in .mp4")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes out the gpu-screen-recorder washed-out-colors thread. Diagnosis first, since the report arrived after the 0.16.0 capture fix:

## The capture side is already correct

All existing washed-out recordings **predate the fix** — nothing had been recorded since. A fresh test clip probes as genuine HDR10 (`hevc`, `yuv420p10le`, `bt2020`, `smpte2084`) and displays correctly in HDR-aware players. What remains is **delivery**: that correct file renders flat in everything that does not tonemap — VLC defaults, Discord embeds, browsers, editors — and that happens on the consumer's machine, out of our reach at capture time.

Frame-level proof (same frame, naive decode vs tonemap) confirmed the wash-out is purely a decode-side artifact.

## What this adds

A Settings switch, **default off** ("preserve HDR" was the explicit earlier choice): *Convert HDR recordings to SDR*. When on, each saved recording **or replay** is tonemapped to bt709 in the background and replaced, with start/finish notifications.

- Hangs off the `gsr-saved.sh` hook — a save landing is the observed event (per the reactive rule), and replays never pass through `record.sh`, so one hook covers both. Detached with `setsid`: the hook runs inside gsr's process context.
- The script gates itself: toggle off / already-SDR / unreadable probe → silent no-op. The original is only ever replaced by renaming a fully-written temporary — a failed encode keeps the HDR file and notifies critically.
- libplacebo (Vulkan GPU tonemap) when available, zscale chain otherwise; x264 veryfast for portability. Measured live at full 5120×1440: 8s clip → 12.9s wall, output visually matching the reference tonemap.

## The bug the live test caught

The first version silently skipped **every real HDR recording**: ffprobe's CSV output grows an extra field from a real file's side data (content light level), so the transfer probed as `smpte2084,` and the strict match classified it as SDR. The synthetic x265 fixture has no side data — sandbox green, production dead. Fixed with value-only probe output plus delimiter trimming, and the failure-path test's stub now emits the comma shape so a regression to strict matching fails the suite.

## Testing

8 tests driving the **real script**: real HDR10 fixture (x265 — which needed `-x265-params` for the tagging, its own small trap) → becomes bt709; toggle-off untouched; SDR input never re-encoded; failed encode keeps the original byte-identical with no temp left; missing file quiet; hook wiring pins. ffmpeg added to CI so these run there rather than skipping. Full suite 276/0.

Docs: updated AGENT.md §External binaries (HDR delivery + the ffprobe side-data trap)