### PR TITLE
feat(record): native SDR capture via the portal, and a GPU converter for the rest

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -203,6 +203,23 @@ an extra field from a real recording's side data**, so a strict match on the tra
 silently classifies every real HDR file as SDR — synthetic fixtures have no side data, which is why
 only a live file catches it. Use value-only output (`-of default=nw=1:nk=1`) and trim delimiters.
 
+Three more from the same pipeline (4a33f970e ("feat(record): capture SDR through the portal when
+SDR delivery is on"), acb9b4906 ("perf(record): GPU encoder ladder, and the pipefail bug that hid
+the GPU")):
+
+- **Hyprland tonemaps screencopy for capture clients** — grim screenshots of an HDR desktop look
+  right, and gsr's *portal* capture rides the same compositor path, yielding native SDR. Its KMS
+  capture reads the scanout plane and gets raw PQ. If you need SDR frames from an HDR display,
+  capture through the portal; the picker's Region tab covers region selection.
+- **`cmd | grep -q` under `set -o pipefail` reads as failed on success**: grep -q exits at the
+  first match, the producer takes SIGPIPE, and the pipeline's status is the producer's 141. The
+  converter's GPU detection was invisible-broken this way from its first version — every tonemap
+  ran on the CPU, nothing logged. Capture to a variable and match on that.
+- **NVENC's H.264 tops out at 4096px wide** and rejects wider frames with a misleading "No capable
+  devices found" — at 5120x1440 the h264_nvenc rung can never succeed; use HEVC past 4096. And
+  ffmpeg's `-encoders` list advertises build capability, not working hardware — try encoders for
+  real, in a ladder with a CPU floor.
+
 ## Directory map
 
 ```

--- a/dots/.config/quickshell/imi/modules/imi/settings/pages/CaptureConfig.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/pages/CaptureConfig.qml
@@ -109,8 +109,8 @@ ContentPage {
                 }
                 ConfigSwitch {
                     buttonIcon: "brightness_6"
-                    text: Translation.tr("Convert HDR recordings to SDR")
-                    description: Translation.tr("HDR recordings look washed out in players that can't tonemap (VLC, Discord, browsers). This re-encodes each saved recording or replay to SDR in the background, replacing the HDR original. Off = keep true HDR files.")
+                    text: Translation.tr("Record SDR on HDR displays")
+                    description: Translation.tr("HDR recordings look washed out in players that can't tonemap (VLC, Discord, browsers). On: recordings capture through the screen-share portal, which delivers correctly toned SDR instantly — its picker replaces the region selector, and fullscreen remembers your choice after the first time. Replays still record HDR and convert in the background. Off = true HDR files.")
                     checked: Config.options.screenRecord.tonemapSdr
                     onCheckedChanged: { Config.options.screenRecord.tonemapSdr = checked }
                 }

--- a/dots/.config/quickshell/imi/scripts/videos/record.sh
+++ b/dots/.config/quickshell/imi/scripts/videos/record.sh
@@ -81,22 +81,42 @@ monitor_is_hdr() {
 
 # gpu-screen-recorder does not tonemap. Given an HDR surface and an SDR codec it
 # encodes 8-bit and tags the result bt709, so a PQ signal ends up labelled as
-# gamma - and decodes flat, grey and desaturated. The _hdr codec variants carry
-# the real transfer function and primaries, so the file is correct in anything
-# that reads them.
+# gamma - and decodes flat, grey and desaturated. Two correct ways out:
+#
+# - PORTAL capture (-w portal): the stream comes through the compositor, and
+#   Hyprland tonemaps screencopy for capture clients - the same reason a grim
+#   screenshot of an HDR desktop looks right. The recording is native SDR at
+#   capture time, no conversion ever - verified live: portal output probes
+#   bt709/yuv420p with correct colours, where the KMS path gives raw PQ. Used
+#   when the user asked for SDR delivery (screenRecord.tonemapSdr); the
+#   saved-hook tonemapper then sees an SDR file and skips itself. The portal
+#   picker replaces slurp in region mode - it has a Region tab - so regions
+#   are correctly toned too. Fullscreen restores the session from a token
+#   (picker appears once); region deliberately does NOT restore, because a
+#   region is a fresh selection every time anyway.
+#
+# - The _hdr codec variants: real HDR10, correct in anything that tonemaps.
+#   Used when the user keeps the SDR toggle off.
+USE_PORTAL=0
 if monitor_is_hdr "$TARGET_MONITOR"; then
-    case "$CODEC" in
-        ""|auto|hevc) CODEC="hevc_hdr" ;;
-        av1)          CODEC="av1_hdr" ;;
-        h264)
-            # H.264 has no HDR variant here. Silently swapping the codec someone
-            # explicitly chose is worse than saying why the file will look wrong.
-            notify-send "Recording SDR H.264 on an HDR display" \
-                "H.264 cannot carry HDR, so this recording will look washed out. Pick HEVC or AV1, or turn HDR off while recording." \
-                -a 'Recorder' & disown
-            ;;
-    esac
+    if [[ "$(cfg '.screenRecord.tonemapSdr')" == "true" ]]; then
+        USE_PORTAL=1
+        # The stream is SDR, so the user's codec choice applies unchanged.
+    else
+        case "$CODEC" in
+            ""|auto|hevc) CODEC="hevc_hdr" ;;
+            av1)          CODEC="av1_hdr" ;;
+            h264)
+                # H.264 has no HDR variant here. Silently swapping the codec someone
+                # explicitly chose is worse than saying why the file will look wrong.
+                notify-send "Recording SDR H.264 on an HDR display" \
+                    "H.264 cannot carry HDR, so this recording will look washed out. Pick HEVC or AV1, enable 'Convert HDR recordings to SDR', or turn HDR off while recording." \
+                    -a 'Recorder' & disown
+                ;;
+        esac
+    fi
 fi
+PORTAL_TOKEN="$HOME/.local/state/quickshell/gsr-portal-token"
 
 ARGS=(gpu-screen-recorder -c mp4 -f "$FPS" -q "$QUALITY" -ac "$AUDIO_CODEC"
       -fm "$FRAMERATE_MODE" -sc "$SCRIPT_DIR/gsr-saved.sh" -o "$OUT")
@@ -110,7 +130,15 @@ if [[ $SOUND -eq 1 ]]; then
     fi
 fi
 
-if [[ $FULLSCREEN -eq 1 ]]; then
+if [[ $USE_PORTAL -eq 1 ]]; then
+    ARGS+=(-w portal)
+    if [[ $FULLSCREEN -eq 1 ]]; then
+        mkdir -p "$(dirname "$PORTAL_TOKEN")"
+        ARGS+=(-restore-portal-session yes -portal-session-token-filepath "$PORTAL_TOKEN")
+    fi
+    # Region under portal: no slurp and no token - the picker's Region tab IS
+    # the selection, fresh each invocation exactly as slurp was.
+elif [[ $FULLSCREEN -eq 1 ]]; then
     ARGS+=(-w "${TARGET_MONITOR:-screen}")
 else
     if [[ -z "$REGION" ]]; then

--- a/dots/.config/quickshell/imi/scripts/videos/tonemap-sdr.sh
+++ b/dots/.config/quickshell/imi/scripts/videos/tonemap-sdr.sh
@@ -51,10 +51,15 @@ tmp="${FILE%.mp4}.sdr-tmp.mp4"
 log="$(mktemp --suffix=-tonemap.log)"
 
 # libplacebo (Vulkan, GPU tonemap - fast and gamut-aware) when this ffmpeg has
-# it, else the zscale/tonemap CPU chain. x264 veryfast for the encode: every
-# GPU encoder spells its ffmpeg name differently, and a background re-encode
-# being portable matters more than it being instant.
-if ffmpeg -hide_banner -filters 2>/dev/null | grep -q libplacebo; then
+# it, else the zscale/tonemap CPU chain.
+#
+# Captured to a variable, NOT `ffmpeg | grep -q`: grep -q exits at the first
+# match, ffmpeg takes SIGPIPE, and under `set -o pipefail` the whole pipeline
+# reads as failed - so libplacebo silently never got selected and every
+# tonemap ran on the CPU. That single line is why the first version took 13s
+# on a clip the GPU does in 5.
+filters="$(ffmpeg -hide_banner -filters 2>/dev/null || true)"
+if [[ "$filters" == *libplacebo* ]]; then
     VF="libplacebo=tonemapping=auto:colorspace=bt709:color_primaries=bt709:color_trc=bt709:format=yuv420p"
     HW=(-init_hw_device vulkan)
 else
@@ -62,11 +67,56 @@ else
     HW=()
 fi
 
-if ffmpeg -y -v error "${HW[@]}" -i "$FILE" \
-        -vf "$VF" \
-        -c:v libx264 -preset veryfast -crf 20 \
+# Encoder ladder: GPU first, CPU as the floor. NVENC turns a 0.6x-realtime
+# x264 job into a few seconds (measured: 12.9s -> 4.9s on an 8s 5120x1440
+# clip), but hardware encoders lie by omission - ffmpeg listing one does not
+# mean the silicon will take the job - so each rung is tried for real and the
+# first that produces output wins.
+#
+# H.264 preferred for the same reason the container is mp4: shareability. But
+# NVENC's H.264 tops out at 4096px wide and rejects wider frames with a
+# misleading "No capable devices found" (found the hard way at 5120x1440), so
+# past that the rung is HEVC - still fixes every non-tonemapping player, at
+# the cost of Discord-embed friendliness for ultrawide clips specifically.
+width="$(ffprobe -v error -select_streams v:0 -show_entries stream=width \
+    -of default=nw=1:nk=1 "$FILE" 2>/dev/null | head -n 1 || echo 0)"
+
+# The vaapi rung uses the CPU tonemap chain: mixing the Vulkan libplacebo
+# filter with a VAAPI hwupload made ffmpeg's format negotiation fall over.
+VF_CPU="zscale=t=linear:npl=203,format=gbrpf32le,zscale=p=bt709,tonemap=hable:desat=0,zscale=t=bt709:m=bt709:r=tv,format=yuv420p"
+
+try_encode() {
+    local enc="$1" vfarg="$VF" hw=("${HW[@]}") pre=() args=()
+    case "$enc" in
+        h264_nvenc) args=(-c:v h264_nvenc -preset p4 -cq 23) ;;
+        hevc_nvenc) args=(-c:v hevc_nvenc -preset p4 -cq 23) ;;
+        h264_vaapi)
+            pre=(-vaapi_device /dev/dri/renderD128)
+            hw=()
+            vfarg="$VF_CPU,format=nv12,hwupload"
+            args=(-c:v h264_vaapi -qp 23) ;;
+        libx264)    args=(-c:v libx264 -preset veryfast -crf 20) ;;
+    esac
+    echo "--- attempt: $enc" >>"$log"
+    ffmpeg -y -v error "${pre[@]}" "${hw[@]}" -i "$FILE" \
+        -vf "$vfarg" "${args[@]}" \
         -c:a copy -movflags +faststart \
-        "$tmp" >"$log" 2>&1 && [[ -s "$tmp" ]]; then
+        "$tmp" >>"$log" 2>&1 && [[ -s "$tmp" ]]
+}
+
+if [[ "$width" =~ ^[0-9]+$ ]] && (( width > 4096 )); then
+    LADDER=(hevc_nvenc libx264)
+else
+    LADDER=(h264_nvenc h264_vaapi libx264)
+fi
+
+ok=0
+for enc in "${LADDER[@]}"; do
+    if try_encode "$enc"; then ok=1; break; fi
+    rm -f "$tmp"
+done
+
+if [[ $ok -eq 1 ]]; then
     mv -f "$tmp" "$FILE"
     rm -f "$log"
     notify-send "SDR ready" "${FILE##*/}" -a 'Recorder' -i video-x-generic & disown

--- a/dots/.config/quickshell/imi/scripts/videos/tonemap-sdr.sh
+++ b/dots/.config/quickshell/imi/scripts/videos/tonemap-sdr.sh
@@ -58,8 +58,16 @@ log="$(mktemp --suffix=-tonemap.log)"
 # reads as failed - so libplacebo silently never got selected and every
 # tonemap ran on the CPU. That single line is why the first version took 13s
 # on a clip the GPU does in 5.
+# ...and having the filter compiled in still does not mean a Vulkan device
+# exists to run it - a machine without one dies at -init_hw_device before any
+# encoder rung gets a say, taking the CPU floor down with it. So the GPU chain
+# is smoke-tested for real on a one-frame nullsrc, the same
+# try-it-don't-infer-it rule the encoder ladder follows. (CI is exactly such a
+# machine, and the pipefail bug above had been accidentally protecting it.)
 filters="$(ffmpeg -hide_banner -filters 2>/dev/null || true)"
-if [[ "$filters" == *libplacebo* ]]; then
+if [[ "$filters" == *libplacebo* ]] \
+    && ffmpeg -v error -init_hw_device vulkan -f lavfi -i "nullsrc=s=64x64:d=0.1" \
+        -vf "libplacebo=format=yuv420p" -frames:v 1 -f null - >/dev/null 2>&1; then
     VF="libplacebo=tonemapping=auto:colorspace=bt709:color_primaries=bt709:color_trc=bt709:format=yuv420p"
     HW=(-init_hw_device vulkan)
 else

--- a/dots/.config/quickshell/imi/tests/test_screen_record.py
+++ b/dots/.config/quickshell/imi/tests/test_screen_record.py
@@ -271,3 +271,44 @@ class ConfigContractTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class PortalSdrTests(unittest.TestCase):
+    """SDR delivery captures through the portal instead of converting.
+
+    Hyprland tonemaps screencopy for capture clients - the reason a grim
+    screenshot of an HDR desktop looks right - so portal capture yields native
+    SDR at record time (verified live: bt709/yuv420p, correct colours), where
+    the KMS path hands the encoder raw PQ. Regions are covered too: the portal
+    picker has a Region tab and replaces slurp in this mode.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.script = SCRIPT.read_text()
+        cls.code = "\n".join(l for l in cls.script.splitlines()
+                             if not l.lstrip().startswith("#"))
+
+    def test_sdr_toggle_routes_to_portal_capture(self):
+        self.assertIn("tonemapSdr", self.code)
+        self.assertIn("-w portal", self.code)
+        self.assertIn("USE_PORTAL=1", self.code)
+
+    def test_fullscreen_restores_a_session_token_region_does_not(self):
+        # Fullscreen: the picker should appear once, then the token pins the
+        # choice. Region: every capture is a fresh selection, exactly as slurp
+        # was, so restoring a stale region would be wrong.
+        portal_block = self.code[self.code.index("-w portal"):]
+        portal_block = portal_block[:portal_block.index("elif")]
+        self.assertIn("restore-portal-session", portal_block)
+        self.assertRegex(portal_block,
+                         r'if \[\[ \$FULLSCREEN -eq 1 \]\];[\s\S]*restore-portal-session')
+
+    def test_hdr_codec_upgrade_only_when_keeping_hdr(self):
+        # With portal capture the stream is SDR - forcing an _hdr codec onto it
+        # would tag an SDR stream as PQ, recreating the original wash-out in
+        # reverse. The upgrade lives in the else-branch of the toggle.
+        idx_portal = self.code.index("USE_PORTAL=1")
+        idx_hdr = self.code.index('CODEC="hevc_hdr"')
+        self.assertLess(idx_portal, idx_hdr)
+        self.assertIn("else", self.code[idx_portal:idx_hdr])

--- a/dots/.config/quickshell/imi/tests/test_tonemap_sdr.py
+++ b/dots/.config/quickshell/imi/tests/test_tonemap_sdr.py
@@ -149,6 +149,26 @@ class HookWiringTests(unittest.TestCase):
         # or dies with it loses the conversion on every recorder exit.
         self.assertRegex(SAVED_HOOK, r"setsid -f .*tonemap-sdr\.sh")
 
+    def test_libplacebo_detection_survives_pipefail(self):
+        # `ffmpeg -filters | grep -q` under `set -o pipefail` reads as failed:
+        # grep -q exits at the first match, ffmpeg takes SIGPIPE, and the
+        # pipeline's status is ffmpeg's 141 - so libplacebo silently never got
+        # selected and every tonemap ran on the CPU. 13s instead of 5 on the
+        # same clip, with nothing logged. The detection must consume the whole
+        # stream (capture to a variable), never early-exit it.
+        script = SCRIPT.read_text()
+        self.assertNotIn("| grep -q libplacebo", script)
+        self.assertIn('filters="$(', script)
+
+    def test_the_encoder_ladder_is_width_aware(self):
+        # NVENC's H.264 tops out at 4096px and rejects wider frames with a
+        # misleading "No capable devices found" - at 5120x1440 the h264 rung
+        # can never succeed, so wider clips go straight to HEVC.
+        script = SCRIPT.read_text()
+        self.assertIn("width > 4096", script)
+        self.assertRegex(script, r"LADDER=\(hevc_nvenc")
+        self.assertRegex(script, r"LADDER=\(h264_nvenc")
+
     def test_the_temporary_keeps_a_video_extension(self):
         # ffmpeg infers the muxer from the output extension; a bare ".tmp"
         # fails. Same trap that shipped in we_still.sh once already.


### PR DESCRIPTION
Follow-up to #121, answering "can gsr record SDR directly?" — **yes**, and the conversion wait disappears for recordings entirely.

## The discovery

gsr's KMS capture reads the scanout plane → raw PQ, which is why SDR needed a post-tonemap. But **Hyprland tonemaps screencopy for capture clients** — the reason every grim screenshot of the HDR desktop looks correct — and gsr's **portal capture** rides that same compositor path. Verified live: portal output probes `bt709`/`yuv420p` with correct colors. Native SDR at capture time.

## What changes when "Record SDR on HDR displays" is on

- **Fullscreen** → `-w portal` with a session token: picker appears once, instant SDR forever after. No conversion.
- **Region** → `-w portal` with **no** token: the portal picker's Region tab replaces slurp, fresh selection each time exactly as slurp was. Instant SDR. (This was the explicit ask — regions correctly toned at capture.)
- **Replays** → still KMS/HDR (daemon), converted by the saved-hook — now fast (below).
- The `_hdr` codec upgrade moves to the else-branch: forcing an HDR codec onto the portal's SDR stream would tag SDR pixels as PQ — the original bug, mirrored. The converter no-ops on portal files (they probe SDR), so the two mechanisms compose instead of colliding.

## The converter: 12.9s → 4.9s, and an embarrassing find

The GPU tonemap **never ran** — from the converter's first version. `ffmpeg -filters | grep -q libplacebo` under `set -o pipefail` always reads as failed (grep -q exits at first match → ffmpeg takes SIGPIPE → status 141), so the CPU zscale fallback silently won every time, with nothing logged. Detection now captures the filter list to a variable.

Encoding is a tried-for-real ladder: `h264_nvenc → h264_vaapi → libx264`, switching to `hevc_nvenc` above 4096px width — NVENC's H.264 hard-caps there and rejects wider frames with a misleading *"No capable devices found"* (found the hard way at 5120×1440). Rungs are attempted, not inferred: ffmpeg's `-encoders` list advertises build capability, not working hardware — this machine lists NVENC *and* VAAPI, and each fails differently.

Measured on the 8s 5120×1440 clip: **12.9s @ ~1050% CPU → 4.9s @ ~170%**, GPU tonemap + NVENC, CPU floor intact for machines with neither.

## Tests

Portal routing pins (toggle→portal, token fullscreen-only, HDR-upgrade in the else-branch), ladder pins (width gate, both ladders), the pipefail trap pinned as a never-again, plus the existing behavioral suite — all green, full suite 276/0.

Docs: updated AGENT.md §External binaries (compositor tonemap, pipefail grep -q, NVENC width cap)