### PR TITLE
fix(record): regions never touch the portal — one selection, ever

### DIFF
--- a/dots/.config/quickshell/imi/modules/imi/settings/pages/CaptureConfig.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/pages/CaptureConfig.qml
@@ -110,7 +110,7 @@ ContentPage {
                 ConfigSwitch {
                     buttonIcon: "brightness_6"
                     text: Translation.tr("Record SDR on HDR displays")
-                    description: Translation.tr("HDR recordings look washed out in players that can't tonemap (VLC, Discord, browsers). On: recordings capture through the screen-share portal, which delivers correctly toned SDR instantly — its picker replaces the region selector, and fullscreen remembers your choice after the first time. Replays still record HDR and convert in the background. Off = true HDR files.")
+                    description: Translation.tr("HDR recordings look washed out in players that can't tonemap (VLC, Discord, browsers). On: fullscreen recordings capture through the screen-share portal — correctly toned SDR instantly, with a one-time approval it remembers. Region recordings and replays record HDR and convert to SDR in the background a few seconds after saving. Off = true HDR files.")
                     checked: Config.options.screenRecord.tonemapSdr
                     onCheckedChanged: { Config.options.screenRecord.tonemapSdr = checked }
                 }

--- a/dots/.config/quickshell/imi/scripts/videos/record.sh
+++ b/dots/.config/quickshell/imi/scripts/videos/record.sh
@@ -83,25 +83,35 @@ monitor_is_hdr() {
 # encodes 8-bit and tags the result bt709, so a PQ signal ends up labelled as
 # gamma - and decodes flat, grey and desaturated. Two correct ways out:
 #
-# - PORTAL capture (-w portal): the stream comes through the compositor, and
-#   Hyprland tonemaps screencopy for capture clients - the same reason a grim
-#   screenshot of an HDR desktop looks right. The recording is native SDR at
+# - PORTAL capture (-w portal), FULLSCREEN ONLY: the stream comes through the
+#   compositor, and Hyprland tonemaps screencopy for capture clients - the
+#   same reason a grim screenshot of an HDR desktop looks right. Native SDR at
 #   capture time, no conversion ever - verified live: portal output probes
-#   bt709/yuv420p with correct colours, where the KMS path gives raw PQ. Used
-#   when the user asked for SDR delivery (screenRecord.tonemapSdr); the
-#   saved-hook tonemapper then sees an SDR file and skips itself. The portal
-#   picker replaces slurp in region mode - it has a Region tab - so regions
-#   are correctly toned too. Fullscreen restores the session from a token
-#   (picker appears once); region deliberately does NOT restore, because a
-#   region is a fresh selection every time anyway.
+#   bt709/yuv420p with correct colours, where the KMS path gives raw PQ. The
+#   session restores from a token, so the picker appears exactly once.
+#
+# - Regions NEVER go through the portal. The first version routed them to the
+#   portal picker's Region tab - and the recorder overlay's "Record Region"
+#   already runs the shell's own region selector first, so the user picked a
+#   region and was then prompted to pick again. One selection UX everywhere:
+#   regions always come from the shell's selector (or slurp), capture via KMS
+#   as real HDR, and the saved-hook converter delivers SDR a few seconds
+#   later on the GPU. The codec is forced to an HDR variant in that case even
+#   if the user chose H.264: the converter re-encodes to H.264 anyway, and
+#   honouring the choice at capture would bake the wash-out in before the
+#   converter ever saw the file.
 #
 # - The _hdr codec variants: real HDR10, correct in anything that tonemaps.
 #   Used when the user keeps the SDR toggle off.
 USE_PORTAL=0
 if monitor_is_hdr "$TARGET_MONITOR"; then
     if [[ "$(cfg '.screenRecord.tonemapSdr')" == "true" ]]; then
-        USE_PORTAL=1
-        # The stream is SDR, so the user's codec choice applies unchanged.
+        if [[ $FULLSCREEN -eq 1 ]]; then
+            USE_PORTAL=1
+            # The stream is SDR, so the user's codec choice applies unchanged.
+        else
+            CODEC="hevc_hdr"
+        fi
     else
         case "$CODEC" in
             ""|auto|hevc) CODEC="hevc_hdr" ;;
@@ -131,13 +141,11 @@ if [[ $SOUND -eq 1 ]]; then
 fi
 
 if [[ $USE_PORTAL -eq 1 ]]; then
+    # Fullscreen only (see the routing above) - the token means the picker
+    # appears once, ever, and never mid-flow.
     ARGS+=(-w portal)
-    if [[ $FULLSCREEN -eq 1 ]]; then
-        mkdir -p "$(dirname "$PORTAL_TOKEN")"
-        ARGS+=(-restore-portal-session yes -portal-session-token-filepath "$PORTAL_TOKEN")
-    fi
-    # Region under portal: no slurp and no token - the picker's Region tab IS
-    # the selection, fresh each invocation exactly as slurp was.
+    mkdir -p "$(dirname "$PORTAL_TOKEN")"
+    ARGS+=(-restore-portal-session yes -portal-session-token-filepath "$PORTAL_TOKEN")
 elif [[ $FULLSCREEN -eq 1 ]]; then
     ARGS+=(-w "${TARGET_MONITOR:-screen}")
 else

--- a/dots/.config/quickshell/imi/tests/test_screen_record.py
+++ b/dots/.config/quickshell/imi/tests/test_screen_record.py
@@ -274,13 +274,16 @@ if __name__ == "__main__":
 
 
 class PortalSdrTests(unittest.TestCase):
-    """SDR delivery captures through the portal instead of converting.
+    """SDR delivery: portal for fullscreen, shell selector + convert for regions.
 
-    Hyprland tonemaps screencopy for capture clients - the reason a grim
-    screenshot of an HDR desktop looks right - so portal capture yields native
-    SDR at record time (verified live: bt709/yuv420p, correct colours), where
-    the KMS path hands the encoder raw PQ. Regions are covered too: the portal
-    picker has a Region tab and replaces slurp in this mode.
+    Hyprland tonemaps screencopy for capture clients, so portal capture yields
+    native SDR at record time (verified live: bt709/yuv420p) where the KMS
+    path hands the encoder raw PQ. Portal is FULLSCREEN ONLY: the recorder
+    overlay's "Record Region" runs the shell's own region selector first, and
+    the first version then routed the capture through the portal picker - the
+    user selected a region and was immediately prompted to select again.
+    Regions therefore never touch the portal: shell selector (or slurp), KMS
+    HDR capture, GPU-converted to SDR by the saved-hook seconds later.
     """
 
     @classmethod
@@ -289,26 +292,44 @@ class PortalSdrTests(unittest.TestCase):
         cls.code = "\n".join(l for l in cls.script.splitlines()
                              if not l.lstrip().startswith("#"))
 
-    def test_sdr_toggle_routes_to_portal_capture(self):
+    def test_sdr_toggle_routes_fullscreen_to_portal(self):
         self.assertIn("tonemapSdr", self.code)
         self.assertIn("-w portal", self.code)
-        self.assertIn("USE_PORTAL=1", self.code)
+        # The gate: portal only inside the FULLSCREEN branch of the toggle.
+        toggle = self.code[self.code.index("tonemapSdr"):]
+        toggle = toggle[:toggle.index("PORTAL_TOKEN=")]
+        self.assertRegex(toggle,
+                         r'if \[\[ \$FULLSCREEN -eq 1 \]\];[\s\S]*?USE_PORTAL=1')
 
-    def test_fullscreen_restores_a_session_token_region_does_not(self):
-        # Fullscreen: the picker should appear once, then the token pins the
-        # choice. Region: every capture is a fresh selection, exactly as slurp
-        # was, so restoring a stale region would be wrong.
+    def test_regions_never_prompt_twice(self):
+        # A region invocation must not reach the portal picker: the selection
+        # already happened in the shell's selector (or happens once in slurp).
+        # USE_PORTAL=1 appearing outside the FULLSCREEN guard would put the
+        # second prompt back.
+        self.assertEqual(self.code.count("USE_PORTAL=1"), 1)
+        portal_block = self.code[self.code.index("-w portal"):]
+        portal_block = portal_block[:portal_block.index("elif")]
+        self.assertNotIn("slurp", portal_block)
+        self.assertNotIn("REGION", portal_block)
+
+    def test_sdr_region_forces_an_hdr_codec_for_the_converter(self):
+        # Honouring an explicit H.264 choice at capture would bake the
+        # wash-out in before the converter ever saw the file - the converter
+        # re-encodes to H.264 anyway, so the capture codec must carry HDR.
+        toggle = self.code[self.code.index("tonemapSdr"):]
+        toggle = toggle[:toggle.index("PORTAL_TOKEN=")]
+        self.assertRegex(toggle, r'else\s*\n\s*CODEC="hevc_hdr"')
+
+    def test_fullscreen_portal_restores_a_session_token(self):
+        # The picker should appear exactly once, ever - and never mid-flow.
         portal_block = self.code[self.code.index("-w portal"):]
         portal_block = portal_block[:portal_block.index("elif")]
         self.assertIn("restore-portal-session", portal_block)
-        self.assertRegex(portal_block,
-                         r'if \[\[ \$FULLSCREEN -eq 1 \]\];[\s\S]*restore-portal-session')
 
     def test_hdr_codec_upgrade_only_when_keeping_hdr(self):
         # With portal capture the stream is SDR - forcing an _hdr codec onto it
-        # would tag an SDR stream as PQ, recreating the original wash-out in
-        # reverse. The upgrade lives in the else-branch of the toggle.
+        # would tag SDR pixels as PQ, recreating the original wash-out in
+        # reverse.
         idx_portal = self.code.index("USE_PORTAL=1")
-        idx_hdr = self.code.index('CODEC="hevc_hdr"')
+        idx_hdr = self.code.index('CODEC="hevc_hdr" ;;')
         self.assertLess(idx_portal, idx_hdr)
-        self.assertIn("else", self.code[idx_portal:idx_hdr])


### PR DESCRIPTION
UX fix for #122's SDR routing, reported live: the recorder overlay's **Record Region** runs the shell's own region selector, and record.sh then discarded that geometry and routed the capture through the portal picker — select a region, get told to select again. **The double prompt was my routing, not a gsr limitation** — gsr only needs the portal for tonemapping, and only fullscreen needs the portal at all.

New rule, one selection everywhere:

| flow | selection | capture | SDR delivery |
|---|---|---|---|
| fullscreen | none | portal (token — picker once, ever, never mid-flow) | instant |
| region (overlay or slurp) | shell selector / slurp, once | KMS, HDR | GPU convert, ~seconds after save |
| replay | none | KMS, HDR | GPU convert |

One subtlety: SDR-mode regions force `hevc_hdr` at capture even if the user's codec is H.264 — the converter re-encodes to H.264 anyway, and honouring the choice at capture would bake the wash-out in before the converter ever saw the file.

Pins rewritten to the new routing: `USE_PORTAL=1` appears exactly once and only inside the fullscreen guard, the portal block contains no region/slurp handling, the region codec force, and the token. Full suite 276/0.

Also noting for the record: this closes the "wf-recorder fallback" question — the speed reason gsr was chosen survives intact (GPU encode everywhere, replay buffer native), and the UX regression is gone.

Docs: not needed — routing fix within behavior documented in #122; AGENT.md's portal/tonemap facts unchanged