### PR TITLE
fix(record): drop portal capture — xdph returns an empty restore token

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -209,8 +209,13 @@ the GPU")):
 
 - **Hyprland tonemaps screencopy for capture clients** — grim screenshots of an HDR desktop look
   right, and gsr's *portal* capture rides the same compositor path, yielding native SDR. Its KMS
-  capture reads the scanout plane and gets raw PQ. If you need SDR frames from an HDR display,
-  capture through the portal; the picker's Region tab covers region selection.
+  capture reads the scanout plane and gets raw PQ. **But do not route recording through the portal
+  on this stack**: `xdg-desktop-portal-hyprland` (1.4.1) returns an **empty restore token** — gsr
+  logs `saved restore token to cache ()` — so `-restore-portal-session` is a no-op and the picker
+  prompts on *every* recording. Shipped and reverted the same day ("fix(record): regions never
+  touch the portal - one selection, ever", then the removal citing this entry): SDR delivery lives
+  in the post-save GPU converter instead. Revisit portal capture only after verifying a **non-empty**
+  token actually round-trips on the installed xdph.
 - **`cmd | grep -q` under `set -o pipefail` reads as failed on success**: grep -q exits at the
   first match, the producer takes SIGPIPE, and the pipeline's status is the producer's 141. The
   converter's GPU detection was invisible-broken this way from its first version — every tonemap

--- a/dots/.config/quickshell/imi/modules/imi/settings/pages/CaptureConfig.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/pages/CaptureConfig.qml
@@ -109,8 +109,8 @@ ContentPage {
                 }
                 ConfigSwitch {
                     buttonIcon: "brightness_6"
-                    text: Translation.tr("Record SDR on HDR displays")
-                    description: Translation.tr("HDR recordings look washed out in players that can't tonemap (VLC, Discord, browsers). On: fullscreen recordings capture through the screen-share portal — correctly toned SDR instantly, with a one-time approval it remembers. Region recordings and replays record HDR and convert to SDR in the background a few seconds after saving. Off = true HDR files.")
+                    text: Translation.tr("Convert HDR recordings to SDR")
+                    description: Translation.tr("HDR recordings look washed out in players that can't tonemap (VLC, Discord, browsers). On: every recording and replay is converted to SDR on the GPU a few seconds after saving, with a notification when ready. Off = true HDR files for HDR-aware players.")
                     checked: Config.options.screenRecord.tonemapSdr
                     onCheckedChanged: { Config.options.screenRecord.tonemapSdr = checked }
                 }

--- a/dots/.config/quickshell/imi/scripts/videos/record.sh
+++ b/dots/.config/quickshell/imi/scripts/videos/record.sh
@@ -81,37 +81,29 @@ monitor_is_hdr() {
 
 # gpu-screen-recorder does not tonemap. Given an HDR surface and an SDR codec it
 # encodes 8-bit and tags the result bt709, so a PQ signal ends up labelled as
-# gamma - and decodes flat, grey and desaturated. Two correct ways out:
+# gamma - and decodes flat, grey and desaturated. So an HDR monitor is always
+# captured with an _hdr codec variant - real HDR10, correct in anything that
+# tonemaps - and SDR delivery (screenRecord.tonemapSdr) happens AFTER the
+# save: the saved-hook converter tonemaps on the GPU a few seconds later.
 #
-# - PORTAL capture (-w portal), FULLSCREEN ONLY: the stream comes through the
-#   compositor, and Hyprland tonemaps screencopy for capture clients - the
-#   same reason a grim screenshot of an HDR desktop looks right. Native SDR at
-#   capture time, no conversion ever - verified live: portal output probes
-#   bt709/yuv420p with correct colours, where the KMS path gives raw PQ. The
-#   session restores from a token, so the picker appears exactly once.
-#
-# - Regions NEVER go through the portal. The first version routed them to the
-#   portal picker's Region tab - and the recorder overlay's "Record Region"
-#   already runs the shell's own region selector first, so the user picked a
-#   region and was then prompted to pick again. One selection UX everywhere:
-#   regions always come from the shell's selector (or slurp), capture via KMS
-#   as real HDR, and the saved-hook converter delivers SDR a few seconds
-#   later on the GPU. The codec is forced to an HDR variant in that case even
-#   if the user chose H.264: the converter re-encodes to H.264 anyway, and
-#   honouring the choice at capture would bake the wash-out in before the
-#   converter ever saw the file.
-#
-# - The _hdr codec variants: real HDR10, correct in anything that tonemaps.
-#   Used when the user keeps the SDR toggle off.
-USE_PORTAL=0
+# Portal capture (-w portal) is deliberately NOT used, twice over. It would
+# give native SDR at capture time - the stream comes through the compositor,
+# which tonemaps screencopy for capture clients - but it prompts:
+#   - routed regions through the portal picker after the shell's own region
+#     selector had already run, so the user selected twice;
+#   - and for fullscreen, session restore turned out to be a no-op on this
+#     stack: gpu-screen-recorder requests persistence correctly, and
+#     xdg-desktop-portal-hyprland (1.4.1) returns an EMPTY restore token
+#     ("saved restore token to cache ()" in gsr's log), so the picker appears
+#     on every single recording. Zero prompts beats zero conversion.
+# If xdph ever returns real tokens, fullscreen portal capture becomes worth
+# revisiting - the compositor tonemap itself was verified working.
 if monitor_is_hdr "$TARGET_MONITOR"; then
     if [[ "$(cfg '.screenRecord.tonemapSdr')" == "true" ]]; then
-        if [[ $FULLSCREEN -eq 1 ]]; then
-            USE_PORTAL=1
-            # The stream is SDR, so the user's codec choice applies unchanged.
-        else
-            CODEC="hevc_hdr"
-        fi
+        # The converter re-encodes to H.264 anyway, so the capture codec must
+        # carry HDR even under an explicit H.264 choice - honouring it here
+        # would bake the wash-out in before the converter ever saw the file.
+        CODEC="hevc_hdr"
     else
         case "$CODEC" in
             ""|auto|hevc) CODEC="hevc_hdr" ;;
@@ -126,8 +118,6 @@ if monitor_is_hdr "$TARGET_MONITOR"; then
         esac
     fi
 fi
-PORTAL_TOKEN="$HOME/.local/state/quickshell/gsr-portal-token"
-
 ARGS=(gpu-screen-recorder -c mp4 -f "$FPS" -q "$QUALITY" -ac "$AUDIO_CODEC"
       -fm "$FRAMERATE_MODE" -sc "$SCRIPT_DIR/gsr-saved.sh" -o "$OUT")
 [[ "$CURSOR" == "false" ]] && ARGS+=(-cursor no)
@@ -140,13 +130,7 @@ if [[ $SOUND -eq 1 ]]; then
     fi
 fi
 
-if [[ $USE_PORTAL -eq 1 ]]; then
-    # Fullscreen only (see the routing above) - the token means the picker
-    # appears once, ever, and never mid-flow.
-    ARGS+=(-w portal)
-    mkdir -p "$(dirname "$PORTAL_TOKEN")"
-    ARGS+=(-restore-portal-session yes -portal-session-token-filepath "$PORTAL_TOKEN")
-elif [[ $FULLSCREEN -eq 1 ]]; then
+if [[ $FULLSCREEN -eq 1 ]]; then
     ARGS+=(-w "${TARGET_MONITOR:-screen}")
 else
     if [[ -z "$REGION" ]]; then

--- a/dots/.config/quickshell/imi/tests/test_screen_record.py
+++ b/dots/.config/quickshell/imi/tests/test_screen_record.py
@@ -273,17 +273,15 @@ if __name__ == "__main__":
     unittest.main()
 
 
-class PortalSdrTests(unittest.TestCase):
-    """SDR delivery: portal for fullscreen, shell selector + convert for regions.
+class SdrRoutingTests(unittest.TestCase):
+    """SDR delivery is post-save conversion; the portal is deliberately absent.
 
-    Hyprland tonemaps screencopy for capture clients, so portal capture yields
-    native SDR at record time (verified live: bt709/yuv420p) where the KMS
-    path hands the encoder raw PQ. Portal is FULLSCREEN ONLY: the recorder
-    overlay's "Record Region" runs the shell's own region selector first, and
-    the first version then routed the capture through the portal picker - the
-    user selected a region and was immediately prompted to select again.
-    Regions therefore never touch the portal: shell selector (or slurp), KMS
-    HDR capture, GPU-converted to SDR by the saved-hook seconds later.
+    Portal capture would give native SDR (the compositor tonemaps screencopy),
+    but it prompts: it double-prompted regions after the shell's own selector,
+    and for fullscreen xdg-desktop-portal-hyprland (1.4.1) returns an EMPTY
+    restore token - gsr logs `saved restore token to cache ()` - so the picker
+    appeared on every recording. Zero prompts beats zero conversion; delivery
+    lives in the saved-hook converter instead.
     """
 
     @classmethod
@@ -292,44 +290,22 @@ class PortalSdrTests(unittest.TestCase):
         cls.code = "\n".join(l for l in cls.script.splitlines()
                              if not l.lstrip().startswith("#"))
 
-    def test_sdr_toggle_routes_fullscreen_to_portal(self):
-        self.assertIn("tonemapSdr", self.code)
-        self.assertIn("-w portal", self.code)
-        # The gate: portal only inside the FULLSCREEN branch of the toggle.
+    def test_nothing_routes_through_the_portal(self):
+        # Reintroducing -w portal reintroduces a picker prompt somewhere,
+        # until the day xdph returns real restore tokens.
+        self.assertNotIn("-w portal", self.code)
+        self.assertNotIn("restore-portal-session", self.code)
+
+    def test_sdr_mode_forces_an_hdr_capture_codec(self):
+        # The converter re-encodes to H.264 anyway; honouring an explicit
+        # H.264 choice at capture would bake the wash-out in before the
+        # converter ever saw the file.
         toggle = self.code[self.code.index("tonemapSdr"):]
-        toggle = toggle[:toggle.index("PORTAL_TOKEN=")]
-        self.assertRegex(toggle,
-                         r'if \[\[ \$FULLSCREEN -eq 1 \]\];[\s\S]*?USE_PORTAL=1')
+        toggle = toggle[:toggle.index("ARGS=")]
+        self.assertRegex(toggle, r'CODEC="hevc_hdr"')
 
-    def test_regions_never_prompt_twice(self):
-        # A region invocation must not reach the portal picker: the selection
-        # already happened in the shell's selector (or happens once in slurp).
-        # USE_PORTAL=1 appearing outside the FULLSCREEN guard would put the
-        # second prompt back.
-        self.assertEqual(self.code.count("USE_PORTAL=1"), 1)
-        portal_block = self.code[self.code.index("-w portal"):]
-        portal_block = portal_block[:portal_block.index("elif")]
-        self.assertNotIn("slurp", portal_block)
-        self.assertNotIn("REGION", portal_block)
-
-    def test_sdr_region_forces_an_hdr_codec_for_the_converter(self):
-        # Honouring an explicit H.264 choice at capture would bake the
-        # wash-out in before the converter ever saw the file - the converter
-        # re-encodes to H.264 anyway, so the capture codec must carry HDR.
-        toggle = self.code[self.code.index("tonemapSdr"):]
-        toggle = toggle[:toggle.index("PORTAL_TOKEN=")]
-        self.assertRegex(toggle, r'else\s*\n\s*CODEC="hevc_hdr"')
-
-    def test_fullscreen_portal_restores_a_session_token(self):
-        # The picker should appear exactly once, ever - and never mid-flow.
-        portal_block = self.code[self.code.index("-w portal"):]
-        portal_block = portal_block[:portal_block.index("elif")]
-        self.assertIn("restore-portal-session", portal_block)
-
-    def test_hdr_codec_upgrade_only_when_keeping_hdr(self):
-        # With portal capture the stream is SDR - forcing an _hdr codec onto it
-        # would tag SDR pixels as PQ, recreating the original wash-out in
-        # reverse.
-        idx_portal = self.code.index("USE_PORTAL=1")
-        idx_hdr = self.code.index('CODEC="hevc_hdr" ;;')
-        self.assertLess(idx_portal, idx_hdr)
+    def test_selection_ux_is_untouched(self):
+        # Fullscreen: no prompt at all. Region: the shell selector or slurp,
+        # exactly once.
+        self.assertIn('-w "${TARGET_MONITOR:-screen}"', self.script)
+        self.assertIn("slurp", self.code)


### PR DESCRIPTION
Report: **Record Screen** from the overlay pops the portal picker. Investigation shows it always will: the token file was 0 bytes after an approved recording, and gsr's log has the smoking gun — `saved restore token to cache ()`. gsr requests persistence correctly; **xdg-desktop-portal-hyprland 1.4.1 returns an empty restore token**, so `-restore-portal-session` is a no-op on this stack and the "picker once, ever" design was never achievable. Verified live twice, the second with a completed, approved recording.

A picker on every recording is a worse regression than the conversion wait ever was. Portal capture is removed entirely:

| path | capture | prompts | SDR delivery |
|---|---|---|---|
| fullscreen | KMS, HDR | **zero** | GPU convert, ~5s/8s clip, notification |
| region | KMS, HDR | shell selector once | GPU convert |
| replay | KMS, HDR | zero | GPU convert |

Also tried and rejected: wf-recorder as an SDR-mode capture (screencopy = compositor-tonemapped, promptless) — its VAAPI encode is broken against current ffmpeg (`hwupload` device-ref failure), and CPU encode at 5120×1440@60 is exactly the cost gsr was adopted to escape.

What survives: the SDR toggle (now honest again: "Convert HDR recordings to SDR"), the GPU converter with its width-aware NVENC ladder, the forced-HDR capture codec under the toggle. AGENT.md's compositor-tonemap entry now carries the empty-token finding and a hard precondition for ever revisiting: a **non-empty** token must demonstrably round-trip first.

Net UX across the whole saga: identical prompts to the pre-SDR world (none beyond region selection), correct colors everywhere, ~5s background wait when the toggle is on.

Tests: portal-absence pinned (`-w portal` reintroduction fails the suite until the precondition is met), codec force pinned, selection UX pinned. Full suite 276/0.

Docs: updated AGENT.md §External binaries (empty-token finding, portal precondition)