### PR TITLE
fix(record): restore fullscreen portal SDR — the token was config-gated, not missing

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -209,13 +209,19 @@ the GPU")):
 
 - **Hyprland tonemaps screencopy for capture clients** — grim screenshots of an HDR desktop look
   right, and gsr's *portal* capture rides the same compositor path, yielding native SDR. Its KMS
-  capture reads the scanout plane and gets raw PQ. **But do not route recording through the portal
-  on this stack**: `xdg-desktop-portal-hyprland` (1.4.1) returns an **empty restore token** — gsr
-  logs `saved restore token to cache ()` — so `-restore-portal-session` is a no-op and the picker
-  prompts on *every* recording. Shipped and reverted the same day ("fix(record): regions never
-  touch the portal - one selection, ever", then the removal citing this entry): SDR delivery lives
-  in the post-save GPU converter instead. Revisit portal capture only after verifying a **non-empty**
-  token actually round-trips on the installed xdph.
+  capture reads the scanout plane and gets raw PQ. **Portal restore tokens are opt-in and default
+  OFF**: xdph only issues one when the share picker's "Allow a restore token" checkbox is ticked
+  (`src/portals/Screencopy.cpp` gates `restore_data` on the picker's `r` flag), and
+  `screencopy:allow_token_by_default = true` — shipped in `dots/.config/hypr/xdph.conf` — is what
+  pre-checks it. Without that, `-restore-portal-session` is a silent no-op and the picker prompts
+  on **every** recording; gsr's log line `saved restore token to cache ()` in that state is gsr
+  echoing its own empty cache buffer, **not** an xdph response — an earlier version of this entry
+  misread it as "xdph returns an empty token" and portal capture was removed on that misdiagnosis
+  ("fix(record): drop portal capture - xdph returns an empty restore token"), then restored with
+  the shipped config once a 22-byte token was demonstrated round-tripping live: second recording
+  produced frames within one second, zero interaction. Lesson: a log line about a cache is
+  evidence about the cache, not about the peer — read the source of *both* sides before blaming
+  either.
 - **`cmd | grep -q` under `set -o pipefail` reads as failed on success**: grep -q exits at the
   first match, the producer takes SIGPIPE, and the pipeline's status is the producer's 141. The
   converter's GPU detection was invisible-broken this way from its first version — every tonemap

--- a/dots/.config/hypr/xdph.conf
+++ b/dots/.config/hypr/xdph.conf
@@ -1,0 +1,21 @@
+# xdg-desktop-portal-hyprland configuration.
+#
+# allow_token_by_default pre-checks the share picker's "Allow a restore token"
+# checkbox. Without it the checkbox defaults OFF, no restore token is ever
+# issued, and every portal screen capture re-prompts the picker - which is
+# exactly what happened to SDR screen recording: gpu-screen-recorder requests
+# session persistence correctly, but persistence cannot work if the portal
+# never hands out a token. (The gsr log line "saved restore token to cache ()"
+# in that state is gsr echoing its own empty cache, not an xdph response.)
+#
+# With this set, the picker appears ONCE for fullscreen SDR recording, the
+# token is stored, and every later recording starts silently. Verified live:
+# 22-byte token issued, second recording produced frames within 1 second with
+# no interaction.
+#
+# Scope note: this only controls whether the OPTION is pre-checked for portal
+# clients that request persistence; one-off shares (browser meetings etc.)
+# behave as before unless the app itself asks to be remembered.
+screencopy {
+    allow_token_by_default = true
+}

--- a/dots/.config/quickshell/imi/modules/imi/settings/pages/CaptureConfig.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/pages/CaptureConfig.qml
@@ -109,8 +109,8 @@ ContentPage {
                 }
                 ConfigSwitch {
                     buttonIcon: "brightness_6"
-                    text: Translation.tr("Convert HDR recordings to SDR")
-                    description: Translation.tr("HDR recordings look washed out in players that can't tonemap (VLC, Discord, browsers). On: every recording and replay is converted to SDR on the GPU a few seconds after saving, with a notification when ready. Off = true HDR files for HDR-aware players.")
+                    text: Translation.tr("Record SDR on HDR displays")
+                    description: Translation.tr("HDR recordings look washed out in players that can't tonemap (VLC, Discord, browsers). On: fullscreen recordings capture through the screen-share portal — correctly toned SDR instantly, with a one-time approval it remembers. Region recordings and replays record HDR and convert to SDR in the background a few seconds after saving. Off = true HDR files.")
                     checked: Config.options.screenRecord.tonemapSdr
                     onCheckedChanged: { Config.options.screenRecord.tonemapSdr = checked }
                 }

--- a/dots/.config/quickshell/imi/scripts/videos/record.sh
+++ b/dots/.config/quickshell/imi/scripts/videos/record.sh
@@ -81,29 +81,48 @@ monitor_is_hdr() {
 
 # gpu-screen-recorder does not tonemap. Given an HDR surface and an SDR codec it
 # encodes 8-bit and tags the result bt709, so a PQ signal ends up labelled as
-# gamma - and decodes flat, grey and desaturated. So an HDR monitor is always
-# captured with an _hdr codec variant - real HDR10, correct in anything that
-# tonemaps - and SDR delivery (screenRecord.tonemapSdr) happens AFTER the
-# save: the saved-hook converter tonemaps on the GPU a few seconds later.
+# gamma - and decodes flat, grey and desaturated. Two correct ways out:
 #
-# Portal capture (-w portal) is deliberately NOT used, twice over. It would
-# give native SDR at capture time - the stream comes through the compositor,
-# which tonemaps screencopy for capture clients - but it prompts:
-#   - routed regions through the portal picker after the shell's own region
-#     selector had already run, so the user selected twice;
-#   - and for fullscreen, session restore turned out to be a no-op on this
-#     stack: gpu-screen-recorder requests persistence correctly, and
-#     xdg-desktop-portal-hyprland (1.4.1) returns an EMPTY restore token
-#     ("saved restore token to cache ()" in gsr's log), so the picker appears
-#     on every single recording. Zero prompts beats zero conversion.
-# If xdph ever returns real tokens, fullscreen portal capture becomes worth
-# revisiting - the compositor tonemap itself was verified working.
+# - PORTAL capture (-w portal), FULLSCREEN ONLY: the stream comes through the
+#   compositor, and Hyprland tonemaps screencopy for capture clients - the
+#   same reason a grim screenshot of an HDR desktop looks right. Native SDR at
+#   capture time, no conversion ever - verified live: portal output probes
+#   bt709/yuv420p with correct colours, where the KMS path gives raw PQ. The
+#   session restores from a token, so the picker appears exactly once.
+#
+#   THE TOKEN DEPENDS ON A SHIPPED CONFIG. xdph only issues restore tokens
+#   when the picker's "Allow a restore token" checkbox is ticked, and that
+#   checkbox defaults OFF - which made restore a silent no-op, the picker
+#   prompt on every recording, and got misdiagnosed as xdph lacking the
+#   feature entirely. dots/.config/hypr/xdph.conf ships
+#   `screencopy:allow_token_by_default = true` to pre-check it. Verified end
+#   to end with it set: 22-byte token issued on the approved first run, the
+#   second recording produced frames within one second with no interaction.
+#   If the picker reappears on every fullscreen recording, check that
+#   xdph.conf is in place and the portal was restarted since it landed.
+#
+# - Regions NEVER go through the portal. The first version routed them to the
+#   portal picker's Region tab - and the recorder overlay's "Record Region"
+#   already runs the shell's own region selector first, so the user picked a
+#   region and was then prompted to pick again. One selection UX everywhere:
+#   regions always come from the shell's selector (or slurp), capture via KMS
+#   as real HDR, and the saved-hook converter delivers SDR a few seconds
+#   later on the GPU. The codec is forced to an HDR variant in that case even
+#   if the user chose H.264: the converter re-encodes to H.264 anyway, and
+#   honouring the choice at capture would bake the wash-out in before the
+#   converter ever saw the file.
+#
+# - The _hdr codec variants: real HDR10, correct in anything that tonemaps.
+#   Used when the user keeps the SDR toggle off.
+USE_PORTAL=0
 if monitor_is_hdr "$TARGET_MONITOR"; then
     if [[ "$(cfg '.screenRecord.tonemapSdr')" == "true" ]]; then
-        # The converter re-encodes to H.264 anyway, so the capture codec must
-        # carry HDR even under an explicit H.264 choice - honouring it here
-        # would bake the wash-out in before the converter ever saw the file.
-        CODEC="hevc_hdr"
+        if [[ $FULLSCREEN -eq 1 ]]; then
+            USE_PORTAL=1
+            # The stream is SDR, so the user's codec choice applies unchanged.
+        else
+            CODEC="hevc_hdr"
+        fi
     else
         case "$CODEC" in
             ""|auto|hevc) CODEC="hevc_hdr" ;;
@@ -118,6 +137,8 @@ if monitor_is_hdr "$TARGET_MONITOR"; then
         esac
     fi
 fi
+PORTAL_TOKEN="$HOME/.local/state/quickshell/gsr-portal-token"
+
 ARGS=(gpu-screen-recorder -c mp4 -f "$FPS" -q "$QUALITY" -ac "$AUDIO_CODEC"
       -fm "$FRAMERATE_MODE" -sc "$SCRIPT_DIR/gsr-saved.sh" -o "$OUT")
 [[ "$CURSOR" == "false" ]] && ARGS+=(-cursor no)
@@ -130,7 +151,13 @@ if [[ $SOUND -eq 1 ]]; then
     fi
 fi
 
-if [[ $FULLSCREEN -eq 1 ]]; then
+if [[ $USE_PORTAL -eq 1 ]]; then
+    # Fullscreen only (see the routing above) - the token means the picker
+    # appears once, ever, and never mid-flow.
+    ARGS+=(-w portal)
+    mkdir -p "$(dirname "$PORTAL_TOKEN")"
+    ARGS+=(-restore-portal-session yes -portal-session-token-filepath "$PORTAL_TOKEN")
+elif [[ $FULLSCREEN -eq 1 ]]; then
     ARGS+=(-w "${TARGET_MONITOR:-screen}")
 else
     if [[ -z "$REGION" ]]; then

--- a/dots/.config/quickshell/imi/tests/test_screen_record.py
+++ b/dots/.config/quickshell/imi/tests/test_screen_record.py
@@ -274,14 +274,16 @@ if __name__ == "__main__":
 
 
 class SdrRoutingTests(unittest.TestCase):
-    """SDR delivery is post-save conversion; the portal is deliberately absent.
+    """SDR delivery: portal for fullscreen, shell selector + convert for regions.
 
-    Portal capture would give native SDR (the compositor tonemaps screencopy),
-    but it prompts: it double-prompted regions after the shell's own selector,
-    and for fullscreen xdg-desktop-portal-hyprland (1.4.1) returns an EMPTY
-    restore token - gsr logs `saved restore token to cache ()` - so the picker
-    appeared on every recording. Zero prompts beats zero conversion; delivery
-    lives in the saved-hook converter instead.
+    Hyprland tonemaps screencopy for capture clients, so portal capture yields
+    native SDR at record time (bt709/yuv420p, verified live) where KMS hands
+    the encoder raw PQ. Portal is FULLSCREEN ONLY: routing regions through the
+    picker double-prompted after the shell's own selector. And the fullscreen
+    token has a shipped precondition - xdph issues restore tokens only when
+    the picker's checkbox is ticked, which dots/.config/hypr/xdph.conf
+    pre-checks via allow_token_by_default. Without it the picker prompts on
+    EVERY recording (that shipped once, misdiagnosed as an xdph limitation).
     """
 
     @classmethod
@@ -290,22 +292,42 @@ class SdrRoutingTests(unittest.TestCase):
         cls.code = "\n".join(l for l in cls.script.splitlines()
                              if not l.lstrip().startswith("#"))
 
-    def test_nothing_routes_through_the_portal(self):
-        # Reintroducing -w portal reintroduces a picker prompt somewhere,
-        # until the day xdph returns real restore tokens.
-        self.assertNotIn("-w portal", self.code)
-        self.assertNotIn("restore-portal-session", self.code)
-
-    def test_sdr_mode_forces_an_hdr_capture_codec(self):
-        # The converter re-encodes to H.264 anyway; honouring an explicit
-        # H.264 choice at capture would bake the wash-out in before the
-        # converter ever saw the file.
+    def test_sdr_toggle_routes_fullscreen_to_portal(self):
+        self.assertIn("tonemapSdr", self.code)
+        self.assertIn("-w portal", self.code)
         toggle = self.code[self.code.index("tonemapSdr"):]
-        toggle = toggle[:toggle.index("ARGS=")]
-        self.assertRegex(toggle, r'CODEC="hevc_hdr"')
+        toggle = toggle[:toggle.index("PORTAL_TOKEN=")]
+        self.assertRegex(toggle,
+                         r'if \[\[ \$FULLSCREEN -eq 1 \]\];[\s\S]*?USE_PORTAL=1')
 
-    def test_selection_ux_is_untouched(self):
-        # Fullscreen: no prompt at all. Region: the shell selector or slurp,
-        # exactly once.
-        self.assertIn('-w "${TARGET_MONITOR:-screen}"', self.script)
-        self.assertIn("slurp", self.code)
+    def test_regions_never_prompt_twice(self):
+        # The overlay's Record Region runs the shell selector first; a portal
+        # picker after it is the double prompt this arrangement exists to end.
+        self.assertEqual(self.code.count("USE_PORTAL=1"), 1)
+        portal_block = self.code[self.code.index("-w portal"):]
+        portal_block = portal_block[:portal_block.index("elif")]
+        self.assertNotIn("slurp", portal_block)
+        self.assertNotIn("REGION", portal_block)
+
+    def test_fullscreen_portal_restores_a_session_token(self):
+        portal_block = self.code[self.code.index("-w portal"):]
+        portal_block = portal_block[:portal_block.index("elif")]
+        self.assertIn("restore-portal-session", portal_block)
+
+    def test_the_token_precondition_ships_with_the_dots(self):
+        # xdph only issues tokens when allow_token_by_default pre-checks the
+        # picker box. Portal fullscreen without this file regresses to a
+        # prompt per recording - the exact failure that got portal capture
+        # removed once already.
+        xdph = ROOT.parents[1] / "hypr/xdph.conf"
+        self.assertTrue(xdph.exists(), f"missing {xdph}")
+        conf = "\n".join(l for l in xdph.read_text().splitlines()
+                          if not l.lstrip().startswith("#"))
+        self.assertIn("allow_token_by_default = true", conf)
+
+    def test_sdr_region_forces_an_hdr_capture_codec(self):
+        # The converter re-encodes to H.264 anyway; honouring an explicit
+        # H.264 choice at capture would bake the wash-out in first.
+        toggle = self.code[self.code.index("tonemapSdr"):]
+        toggle = toggle[:toggle.index("PORTAL_TOKEN=")]
+        self.assertRegex(toggle, r'else\s*\n\s*CODEC="hevc_hdr"')


### PR DESCRIPTION
Reverses #124's removal on new evidence, meeting the exact precondition #124 set.

## The correction

Source analysis of xdph v1.4.1 (and gsr master): restore tokens are **fully implemented but opt-in** — issued only when the share picker's "Allow a restore token" checkbox is ticked, default off. The `saved restore token to cache ()` log line that convicted xdph was actually **gsr echoing its own empty cache buffer** (`src/capture/portal.c` seeds it with `""`; the truthiness check lets it through). Nobody's bug; a default nobody flipped. The withheld upstream issue draft documents all of it with file:line receipts.

## The fix

`dots/.config/hypr/xdph.conf` ships `screencopy { allow_token_by_default = true }` (installer uses the `.new`-sidecar sync, so user-modified files are never clobbered). Precondition from #124 — *a non-empty token demonstrably round-trips* — **met live before committing**: 22-byte token on the approved first run; second recording produced frames in **1 second with zero interaction**.

record.sh and the settings text return to the 0.17.5 shape: portal **fullscreen only** (regions never touch it — #123's reasoning stands), token restore, instant SDR. Regions/replays keep the GPU converter.

| path | prompts | SDR |
|---|---|---|
| fullscreen | picker **once, ever** (pre-ticked) | **instant** |
| region | shell selector once | GPU convert ~5s |
| replay | zero | GPU convert |

## Docs & tests

AGENT.md's misdiagnosis entry rewritten with the mechanism, the shipped config, and the lesson (*a log line about a cache is evidence about the cache, not the peer*). Tests re-pin fullscreen-only portal routing **plus** the new precondition: the suite fails if `xdph.conf` stops shipping `allow_token_by_default` while portal routing exists. Full suite green (one unrelated migration-timing flake passed on isolated rerun).

Deployment note: the portal must be restarted once after the config lands (`systemctl --user restart xdg-desktop-portal-hyprland`) — already done on this machine, where the token is live.

Docs: updated AGENT.md §External binaries (misdiagnosis corrected, token mechanism + precondition)