### PR TITLE
fix(desktopMenu): clicks navigate to Settings, Live Wallpaper removed

### DIFF
--- a/dots/.config/quickshell/imi/modules/imi/desktopMenu/DesktopMenu.qml
+++ b/dots/.config/quickshell/imi/modules/imi/desktopMenu/DesktopMenu.qml
@@ -255,7 +255,18 @@ Scope {
                                     }
                                 }
                             }
-                            onClicked: GlobalStates.desktopMenuOpen = false
+                            // Hover opens the quick submenu; a CLICK goes to the
+                            // full Settings page. It used to just close the menu -
+                            // a dead click on a row drawn like a button.
+                            // settingsPage is matched by page NAME in
+                            // SettingsContent (an index here goes stale the day a
+                            // page is inserted - the plugin context menu shipped
+                            // that bug with a hardcoded index).
+                            onClicked: {
+                                GlobalStates.desktopMenuOpen = false
+                                GlobalStates.settingsOpen = true
+                                GlobalStates.settingsPage = "Wallpaper & Desktop"
+                            }
                         }
 
                         // Widgets
@@ -287,6 +298,13 @@ Scope {
                                         submenuCloseTimer.restart()
                                     }
                                 }
+                            }
+                            // Same pattern as Wallpaper & style: hover for the
+                            // quick submenu, click for the full Settings page.
+                            onClicked: {
+                                GlobalStates.desktopMenuOpen = false
+                                GlobalStates.settingsOpen = true
+                                GlobalStates.settingsPage = "Widgets"
                             }
                         }
 
@@ -323,25 +341,11 @@ Scope {
                             }
                         }
 
-                        RippleButton {
-                            implicitHeight: 40
-                            colBackground: "transparent"
-                            colBackgroundHover: Appearance.colors.colLayer2
-                            contentItem: RowLayout {
-                                anchors { fill: parent; leftMargin: Appearance.spacing.space150; rightMargin: Appearance.spacing.space150 }
-                                spacing: Appearance.spacing.space150
-                                MaterialSymbol { text: "animated_images"; iconSize: Appearance.font.pixelSize.larger; color: Appearance.colors.colOnLayer1 }
-                                StyledText { Layout.fillWidth: true; text: "Live Wallpaper"; font.pixelSize: Appearance.font.pixelSize.normal; color: Appearance.colors.colOnLayer1 }
-                                MaterialSymbol { text: "chevron_right"; iconSize: Appearance.font.pixelSize.normal; color: Appearance.colors.colOnLayer1; opacity: 0.4 }
-                            }
-                            onClicked: {
-                                GlobalStates.desktopMenuOpen = false
-                                Wallpapers.openFallbackPicker(
-                                    Appearance.m3colors.darkmode,
-                                    Config.options.wallpaperSelector.liveWallpapersPath ?? ""
-                                )
-                            }
-                        }
+                        // "Live Wallpaper" used to sit here, opening the fallback
+                        // picker at liveWallpapersPath. Removed: live wallpapers
+                        // are picked in the wallpaper selector like everything
+                        // else, and the row duplicated a path already covered by
+                        // Wallpaper & style.
 
                         RippleButton {
                             implicitHeight: 40


### PR DESCRIPTION
The requested desktop right-click menu cleanup:

- **Live Wallpaper removed** — it opened the fallback picker at `liveWallpapersPath`, duplicating a path the wallpaper selector already covers.
- **Wallpaper & style click → Settings, Wallpaper & Desktop page.** The click was previously dead (closed the menu and nothing else) while hover showed the quick submenu. Hover behavior unchanged; click now navigates.
- **Widgets click → Settings, Widgets page.** Same treatment.

Navigation goes through `GlobalStates.settingsPage`, matched by page **name** — an index would go stale the day a page is inserted, and the plugin context menu shipped exactly that bug with a hardcoded `5`.

## Verified live

Deployed to the running shell and driven with ydotool (right-click on the desktop, then clicking each row), screenshot-verified:
- menu shows exactly four rows (thumbnail rail, Wallpaper & style, Widgets, DropShelf, Settings)
- Wallpaper & style click → Settings opened on **Wallpaper & Desktop**, section tree expanded
- Widgets click → Settings opened on the **Widgets** page (Widget settings + Available Widgets)
- DropShelf and Settings rows untouched, submenus still hover-open

Two environment traps burned time and are worth recording: this machine's Lua-mode Hyprland changes `hyprctl dispatch` CLI syntax (CONTRIBUTING already warns exactly this — I guessed anyway, every dispatch silently failed), and ydotool's absolute coordinates map 2:1 to screen pixels here, so every synthetic click landed double-distance until calibrated against `hyprctl cursorpos`.

Docs: not needed — menu row behavior change, no architecture/mechanism change; no new config keys