### PR TITLE
chore(install): pin Wallpaper Engine to v0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,23 @@ The version is stored in `VERSION` (a symlink to the shell's
 About page can read it). The companion `qs-wallpaperengine` is versioned in its
 own repo; the installer pins which revision it builds.
 
+## [Unreleased]
+
+### Fixed
+- **Video wallpapers no longer leak ~10 MB of memory per minute.** The shell
+  grew by roughly 14 GB/day with any Wallpaper Engine *video* wallpaper active
+  (scene wallpapers were fine) — an upstream mpv bug: its `vo=libmpv` render
+  path creates one GL fence per rendered frame and never deletes it, and each
+  one pins ~5 KB of driver memory for the life of the process
+  ([qs-wallpaperengine#16](https://github.com/XephyLon/qs-wallpaperengine/issues/16)).
+  The embedded engine is bumped to
+  [qs-wallpaperengine v0.2.4](https://github.com/XephyLon/qs-wallpaperengine/releases/tag/v0.2.4),
+  which caps the fences (measured: 10.2 MB/min → 0.6 MB/min, flat after
+  warm-up) and also stops a needless per-frame PulseAudio enumeration when
+  wallpaper audio is off. Run **Settings → Update Dots** and restart the shell
+  to pick up the new prebuilt; an already-bloated shell only returns the
+  memory on restart.
+
 ## [0.18.1] — 2026-08-06
 
 ### Fixed

--- a/sdata/subcmd-install/4.wallpaperengine.sh
+++ b/sdata/subcmd-install/4.wallpaperengine.sh
@@ -41,7 +41,7 @@ set -euo pipefail
 [[ "${INSTALL_WE:-0}" == "1" ]] || { echo "[ImI] Wallpaper Engine: skipped."; exit 0; }
 
 WE_REPO="${WE_REPO:-https://github.com/XephyLon/qs-wallpaperengine}"
-WE_REF="${WE_REF:-v0.2.3}"                       # release tag, so installs take the PREBUILT fast path; any checksum /
+WE_REF="${WE_REF:-v0.2.4}"                       # release tag, so installs take the PREBUILT fast path; any checksum /
                                                  # arch / Qt-too-old / smoke-test failure falls back to a source build, as
                                                  # does a tag whose release has not published yet. Whatever this points at
                                                  # MUST be >= 40427cf, the commit that added


### PR DESCRIPTION
## Summary

- bump `WE_REF` default `v0.2.3` → `v0.2.4` (the one pin site in `4.wallpaperengine.sh`)
- changelog entry for the user-facing fix

## Why

v0.2.4 carries the fix for [qs-wallpaperengine#16](https://github.com/XephyLon/qs-wallpaperengine/issues/16): mpv's `vo=libmpv` leaks one GL fence per rendered video frame (~5 KB driver memory each → ~10 MB/min at 30 fps), so any **video** wallpaper grew the shell ~14 GB/day until restart. The release also always passes `--noautomute`, ending a needless per-frame PulseAudio enumeration when wallpaper audio is off ([qs-wallpaperengine#17](https://github.com/XephyLon/qs-wallpaperengine/pull/17)).

Measured (this machine): embedded harness slope **10.2 MB/min → 0.6 MB/min** on the same wallpaper; 12-min standalone repro flat (~56 KB/min) after warm-up. Scene wallpapers were never affected.

The v0.2.4 release workflow is building the prebuilt now; if an install runs before the artifact lands, the installer's existing source-build fallback covers it.

## Tests

- `python3 dots/.config/quickshell/imi/tests/test_wallpaperengine_prebuilt.py` — OK
- verification of the fix itself lives in qs-wallpaperengine (`test/test_fence_cap_patch.py`, harness + standalone-repro measurements in #16)

Docs: not needed — user-facing behavior and the measured scope are documented in CHANGELOG.md; the invariant lives in qs-wallpaperengine's patch comment; no durable contributor rule changed.