### PR TITLE
chore(install): pin Wallpaper Engine prebuilt to v0.2.5 (ffmpeg 9 rebuild)

### DIFF
--- a/sdata/subcmd-install/4.wallpaperengine.sh
+++ b/sdata/subcmd-install/4.wallpaperengine.sh
@@ -41,7 +41,7 @@ set -euo pipefail
 [[ "${INSTALL_WE:-0}" == "1" ]] || { echo "[ImI] Wallpaper Engine: skipped."; exit 0; }
 
 WE_REPO="${WE_REPO:-https://github.com/XephyLon/qs-wallpaperengine}"
-WE_REF="${WE_REF:-v0.2.4}"                       # release tag, so installs take the PREBUILT fast path; any checksum /
+WE_REF="${WE_REF:-v0.2.5}"                       # release tag, so installs take the PREBUILT fast path; any checksum /
                                                  # arch / Qt-too-old / smoke-test failure falls back to a source build, as
                                                  # does a tag whose release has not published yet. Whatever this points at
                                                  # MUST be >= 40427cf, the commit that added


### PR DESCRIPTION
Bumps `WE_REF` v0.2.4 → v0.2.5.

## Why

Arch's ffmpeg `2:9.0` soname bump removes the ffmpeg 8 libraries (`libavcodec.so.62`, `libavformat.so.62`, `libavutil.so.60`, `libswresample.so.6`). The v0.2.4 prebuilt's `liblinux-wallpaperengine-lib.so` links them directly, and it is a load-time dependency of the WE-capable `quickshell` binary — so after a system update the shell fails to start at all:

```
quickshell: error while loading shared libraries: libavcodec.so.62: cannot open shared object file
```

qs-wallpaperengine v0.2.5 is a rebuild-only release ([changelog](https://github.com/XephyLon/qs-wallpaperengine/blob/main/CHANGELOG.md)) produced by the same CI recipe on the updated `archlinux:latest` image; its prebuilt links the ffmpeg 9 sonames (`.63`/`.63`/`.61`/`.7`). Only the WE lib links ffmpeg directly — mpv resolves through its own rebuilt package.

## Notes

- The v0.2.5 release CI is publishing; until its assets land, an install on this pin falls back to the source build (the documented fallback for a not-yet-published tag). Best to run Update Dots after the release shows assets.
- No code changes ride this bump — v0.2.5 is byte-identical source to v0.2.4.

Docs: not needed — version pin bump only; the ffmpeg-soname coupling is documented in the qs-wallpaperengine changelog, and `4.wallpaperengine.sh`'s own pin comment explains the prebuilt/fallback mechanics.