### PR TITLE
fix(install): tmux toggle in both TUIs + fzf cursor restore on load

### DIFF
--- a/dots/.config/quickshell/imi/tests/test_installer_greeting_traps.py
+++ b/dots/.config/quickshell/imi/tests/test_installer_greeting_traps.py
@@ -78,6 +78,17 @@ class TuiCancelMachineryTests(unittest.TestCase):
             r'"\$SETUP_BIN" install "\$\{INSTALL_FLAGS\[@\]\}" --force '
             r'</dev/null >"\$log" 2>&1 &')
 
+    def test_toggle_cursor_restore_binds_the_load_event(self):
+        # The toggle menu re-invokes fzf per toggle and restores the cursor
+        # with pos($pos). That bind must hang off `load`, not `start`: with
+        # piped input, `start` fires before the reader has delivered any
+        # items, so pos() acts on an empty list and silently no-ops — the
+        # cursor snaps back to the top on most toggles, timing-dependent
+        # (measured on fzf 0.74.2: start:pos(3) lands on row 1, load:pos(3)
+        # on row 3). This regressed once already; keep it pinned.
+        self.assertIn('--bind "load:pos($pos)"', TUI)
+        self.assertNotIn('--bind "start:pos', TUI)
+
     def test_esc_and_decline_paths_cancel_cleanly(self):
         self.assertIn("cancelled(){", TUI)
         # Both toggle menus and the fontset picker bail out through cancelled().

--- a/dots/.config/quickshell/imi/tests/test_tmux_dots.py
+++ b/dots/.config/quickshell/imi/tests/test_tmux_dots.py
@@ -22,6 +22,8 @@ TMUX_CONF = ROOT / "dots/.config/tmux/tmux.conf"
 LEGACY = ROOT / "sdata/subcmd-install/3.files-legacy.sh"
 OPTIONS = ROOT / "sdata/subcmd-install/options.sh"
 EXP_YAML = ROOT / "sdata/subcmd-install/3.files-exp.yaml"
+TUI_FZF = ROOT / "sdata/subcmd-install/tui.sh"
+TUI_WHIPTAIL = ROOT / "sdata/subcmd-install/tui-whiptail.sh"
 
 
 def code_only(text):
@@ -88,6 +90,42 @@ class TmuxInstallWiringTests(unittest.TestCase):
         self.assertIsNotNone(match, "tmux entry missing from 3.files-exp.yaml")
         self.assertIn('"plugins"', match.group(1))
         self.assertIn('"matugen.conf"', match.group(1))
+
+
+class TuiTmuxToggleTests(unittest.TestCase):
+    """Both interactive front-ends must surface the tmux component.
+
+    --skip-tmux existing only at flag level is invisible: Update Dots runs the
+    TUI, and a component absent from its menus cannot be chosen or declined
+    there at all.
+    """
+
+    def test_fzf_tui_offers_tmux_and_maps_to_skip_flag(self):
+        tui = code_only(TUI_FZF.read_text())
+        self.assertRegex(tui, r"\[TMUX\]=", "TMUX missing from the fzf STATE/LABELS globals")
+        order_lines = [l for l in tui.splitlines() if re.match(r"\s*ORDER=\(", l)]
+        self.assertTrue(any("TMUX" in l for l in order_lines),
+                        "TMUX not in any fzf toggle ORDER")
+        self.assertRegex(tui, r'"\$TMUX_ON" == on \]\] \|\| INSTALL_FLAGS\+=\(--skip-tmux\)')
+
+    def test_whiptail_tui_offers_tmux_and_maps_to_skip_flag(self):
+        tui = code_only(TUI_WHIPTAIL.read_text())
+        self.assertRegex(tui, r'"TMUX"\s+".*"\s+"\$tmux_state"',
+                         "TMUX row missing from the whiptail checklist")
+        self.assertRegex(
+            tui,
+            r'case "\$COMPONENTS" in\s*\n\s*\*TMUX\*\) : ;;\s*\n\s*\*\) INSTALL_FLAGS\+=\(--skip-tmux\) ;;')
+
+    def test_both_tuis_precheck_ours_but_not_a_foreign_config(self):
+        # The whiptail header's own rule: already-installed components
+        # pre-select so updates reach them. For tmux "installed" means the
+        # deployed config is ours (it sources the matugen theme); a tmux.conf
+        # without that line is the user's own and must default to unticked
+        # rather than being clobbered by rsync --delete.
+        for path in (TUI_FZF, TUI_WHIPTAIL):
+            tui = code_only(path.read_text())
+            self.assertRegex(tui, r"grep -q 'tmux/matugen\\?\.conf'",
+                             f"{path.name}: no ours-vs-foreign detection on tmux.conf")
 
 
 if __name__ == "__main__":

--- a/sdata/subcmd-install/tui-whiptail.sh
+++ b/sdata/subcmd-install/tui-whiptail.sh
@@ -54,6 +54,16 @@ sddm_state=OFF
 [[ -d /usr/share/sddm/themes/imi-sddm-theme || -d /usr/share/sddm/themes/ii-sddm-theme ]] && sddm_state=ON
 plymouth_state=OFF
 [[ -d /usr/share/plymouth/themes/immaterial-impulse ]] && plymouth_state=ON
+# tmux pre-selects when the deployed config is ours (it sources the matugen
+# theme) or when the machine has no tmux config at all (matching the install
+# pipeline's install-by-default). A tmux.conf WITHOUT that line is the user's
+# own config: its step syncs with rsync --delete, so it defaults to unticked
+# rather than silently clobbering their setup on an update.
+tmux_state=ON
+tmux_conf="${XDG_CONFIG_HOME:-$HOME/.config}/tmux/tmux.conf"
+if [[ -f "$tmux_conf" ]] && ! grep -q 'tmux/matugen\.conf' "$tmux_conf"; then
+  tmux_state=OFF
+fi
 
 COMPONENTS=$(whiptail --title "Immaterial Impulse Installer" \
   --checklist "Select components (space to toggle, enter to confirm).\nAlready-installed components are pre-selected so updates reach them:" 18 74 6 \
@@ -62,6 +72,7 @@ COMPONENTS=$(whiptail --title "Immaterial Impulse Installer" \
   "WE" "Wallpaper Engine (builds a custom quickshell)" "$we_state" \
   "SDDM" "SDDM login theme - imi-sddm-theme (Arch only)" "$sddm_state" \
   "PLYMOUTH" "Plymouth boot splash (Arch only)" "$plymouth_state" \
+  "TMUX" "tmux config (themed status bar, fish default)" "$tmux_state" \
   3>&1 1>&2 2>&3)
 ret=$?
 [[ $ret -eq 0 ]] || cancelled
@@ -115,6 +126,11 @@ case "$COMPONENTS" in
   *) INSTALL_FLAGS+=(--skip-alldeps) ;;
 esac
 
+case "$COMPONENTS" in
+  *TMUX*) : ;;
+  *) INSTALL_FLAGS+=(--skip-tmux) ;;
+esac
+
 if [[ "$FONTSET_CHOICE" != "none" ]]; then
   INSTALL_FLAGS+=(--fontset "$FONTSET_CHOICE")
 fi
@@ -125,6 +141,7 @@ Dependencies: $(case "$COMPONENTS" in *DEPS*) echo "yes";; *) echo "no (--skip-a
 Wallpaper Engine: $(case "$COMPONENTS" in *WE*) echo "yes (INSTALL_WE=1)";; *) echo "no";; esac)
 SDDM login theme: $(case "$COMPONENTS" in *SDDM*) echo "yes (INSTALL_SDDM=1)";; *) echo "no";; esac)
 Plymouth splash: $(case "$COMPONENTS" in *PLYMOUTH*) echo "yes (INSTALL_PLYMOUTH=1)";; *) echo "no";; esac)
+tmux config: $(case "$COMPONENTS" in *TMUX*) echo "yes";; *) echo "no (--skip-tmux)";; esac)
 Fontset: ${FONTSET_CHOICE}
 fcitx5 IME: $(case "$EXTRAS" in *FCITX5*) echo "yes";; *) echo "no";; esac)
 

--- a/sdata/subcmd-install/tui.sh
+++ b/sdata/subcmd-install/tui.sh
@@ -145,10 +145,14 @@ fzf_toggle(){
     header="$(banner)"$'\n'"${C_DIM}  Enter = toggle · ESC = cancel${C_RST}"$'\n'"  ${C_BOLD}${title}${C_RST}"
     local pick
     # Re-invoking fzf per toggle otherwise snaps the cursor back to the top;
-    # start:pos($pos) restores it to the row that was just acted on.
+    # pos($pos) restores it to the row that was just acted on. It must hang off
+    # the `load` event, not `start`: with piped input, `start` fires before the
+    # reader has delivered any items, so pos() acts on an empty list and
+    # silently no-ops (measured on fzf 0.74.2 - start:pos(3) lands on row 1,
+    # load:pos(3) on row 3). `load` fires once the input stream is complete.
     pick=$(printf '%s\n' "${lines[@]}" \
       | fzf "${FZF_COMMON[@]}" --with-nth='2..' --delimiter=$'\t' \
-            --bind "start:pos($pos)" \
+            --bind "load:pos($pos)" \
             --header="$header" --prompt='select ▸ ')
     [[ $? -eq 0 ]] || return 130
     key=${pick%%$'\t'*}

--- a/sdata/subcmd-install/tui.sh
+++ b/sdata/subcmd-install/tui.sh
@@ -178,17 +178,28 @@ build_sysinfo
 
 # --- 1. Component toggles ----------------------------------------------------
 # Core config is always installed (never --skip-allfiles), so it is not a toggle.
-declare -A STATE=( [DEPS]=on [WE]=off [SDDM]=off )
+# tmux pre-selects when the deployed config is ours (it sources the matugen
+# theme) or when the machine has no tmux config at all (matching the install
+# pipeline's install-by-default). A tmux.conf WITHOUT that line is the user's
+# own config: its step syncs with rsync --delete, so it defaults to off rather
+# than silently clobbering their setup on an update.
+tmux_state=on
+tmux_conf="${XDG_CONFIG_HOME:-$HOME/.config}/tmux/tmux.conf"
+if [[ -f "$tmux_conf" ]] && ! grep -q 'tmux/matugen\.conf' "$tmux_conf"; then
+  tmux_state=off
+fi
+declare -A STATE=( [DEPS]=on [WE]=off [SDDM]=off [TMUX]="$tmux_state" )
 declare -A LABELS=(
   [DEPS]="Dependencies"
   [WE]="Wallpaper Engine  ${C_DIM}(builds a custom quickshell)${C_RST}"
   [SDDM]="SDDM login theme  ${C_DIM}(imi-sddm-theme · Arch only)${C_RST}"
+  [TMUX]="tmux config  ${C_DIM}(themed status bar, fish default)${C_RST}"
 )
-ORDER=(DEPS WE SDDM)
+ORDER=(DEPS WE SDDM TMUX)
 fzf_toggle "Components  (Core config is always installed)" || cancelled
 # Snapshot immediately: fzf_toggle works on the shared STATE global, which the
 # extras step reuses, so read the component decisions out now.
-DEPS_ON="${STATE[DEPS]}"; WE_ON="${STATE[WE]}"; SDDM_ON="${STATE[SDDM]}"
+DEPS_ON="${STATE[DEPS]}"; WE_ON="${STATE[WE]}"; SDDM_ON="${STATE[SDDM]}"; TMUX_ON="${STATE[TMUX]}"
 
 # --- 2. Fontset picker over dots-extra/fontsets ------------------------------
 fontset_lines(){
@@ -222,6 +233,7 @@ INSTALL_FLAGS=()
 # first prompt and silently abort, installing nothing. So SDDM is handled as a
 # post-install step below (mirroring the fcitx5 extra), on the clean terminal.
 [[ "$DEPS_ON" == on ]] || INSTALL_FLAGS+=(--skip-alldeps)
+[[ "$TMUX_ON" == on ]] || INSTALL_FLAGS+=(--skip-tmux)
 [[ "$FONTSET_CHOICE" != "none" ]] && INSTALL_FLAGS+=(--fontset "$FONTSET_CHOICE")
 
 # --- Quiet-mode install runner (fancy ASCII progress bar) --------------------
@@ -397,6 +409,7 @@ ${C_DIM}  ───────────────────────�
   Dependencies     $(yn "$DEPS_ON")$([[ "$DEPS_ON" == on ]] || echo "  ${C_DIM}(--skip-alldeps)${C_RST}")
   Wallpaper Engine $(yn "$WE_ON")$([[ "$WE_ON" == on ]] && echo "  ${C_DIM}(INSTALL_WE=1)${C_RST}")
   SDDM login theme $(yn "$SDDM_ON")$([[ "$SDDM_ON" == on ]] && echo "  ${C_DIM}(INSTALL_SDDM=1)${C_RST}")
+  tmux config      $(yn "$TMUX_ON")$([[ "$TMUX_ON" == on ]] || echo "  ${C_DIM}(--skip-tmux)${C_RST}")
   Fontset          ${FONTSET_CHOICE}
   fcitx5 IME       $(yn "$FCITX5_ON")
   Output           $([[ "$VERBOSE_ON" == on ]] && echo "verbose ${C_DIM}(raw stream)${C_RST}" || echo "quiet ${C_DIM}(progress bar)${C_RST}")


### PR DESCRIPTION
Two installer-TUI fixes, both user-reported.

## tmux is now a component in both front-ends

`--skip-tmux` (added with the tmux dots in #131) existed only at `options.sh` flag level — the interactive front-ends, which is what Update Dots actually runs, never offered tmux at all.

Both TUIs now list a **tmux config** toggle. Pre-selection follows the whiptail header's existing rule (already-installed components pre-select so updates reach them), with one refinement: "installed" for tmux means the deployed `tmux.conf` is ours, detected by its matugen-theme source line. A `tmux.conf` **without** that line is the user's own config — the tmux step syncs with `rsync --delete`, so that case defaults to unticked instead of clobbering their setup on an update. No `tmux.conf` at all pre-selects, matching the pipeline's install-by-default.

## fzf toggle cursor restore actually works now

b670ddc88 bound `pos($pos)` to fzf's `start` event, which fires before the piped-in menu items have been read — `pos()` acts on an empty list and silently no-ops, so the cursor still snapped to the top after most toggles (timing-dependent, hence "fixed" looking right at the time). Measured on fzf 0.74.2: `start:pos(3)` lands on row 1, `load:pos(3)` on row 3. Now bound to `load`, which fires once the input stream is complete.

Verified by driving the real menu under tmux: toggling rows 2 and 4 leaves the pointer on the toggled row through the redraw, and ESC still cancels cleanly with no install.

## Tests

- `test_tmux_dots.py`: three new tests — TMUX in the fzf STATE/ORDER globals mapped to `--skip-tmux`, TMUX row + case mapping in the whiptail checklist, and the ours-vs-foreign `tmux.conf` detection present in both front-ends.
- `test_installer_greeting_traps.py`: pins `load:pos` and rejects any return of `start:pos` (regressed once already). Proven non-vacuous: the check fails against the pre-fix `tui.sh`.

Full suite green (314 QML + python checks).

Docs: not needed — installer TUI internals; the pre-selection rule and the load-vs-start trap are documented in the scripts' own comments and pinned by the tests above.