### PR TITLE
chore(install): pin Wallpaper Engine prebuilt to v0.2.6 (occlusion pauses playback)

### DIFF
--- a/dots/.config/quickshell/imi/modules/imi/background/WallpaperEngineLayer.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/WallpaperEngineLayer.qml
@@ -35,13 +35,15 @@ WallpaperEngineSurface {
         // is the half QML cannot otherwise reach: suppressing the contents stops
         // Qt drawing the surface, but the WE thread keeps producing frames
         // behind it. Same dynamic-binding treatment as audioEnabled, and for the
-        // same reason - it only exists on qs-wallpaperengine builds newer than
-        // the one currently pinned, so on today's binary this is a no-op and the
-        // pause still comes from WE's own detector.
+        // same reason - the property only exists on WE-capable builds, so a
+        // stock binary degrades to no pause instead of a load error.
         //
-        // Scope: this does not reach mpv. A video wallpaper keeps decoding,
-        // because only WE's private setPause() stops that. What it drops is the
-        // blit, the fence, the publish, the repaint and the surface commit.
+        // Since qs-wallpaperengine v0.2.6 it reaches mpv too: the renderer
+        // forwards the flag into WE's own pause machinery, so video decode
+        // stops while the output is covered (qs-wallpaperengine#19 - before
+        // that, a 7680x2160 software-decoded video kept ~180% CPU behind a
+        // fullscreen game). On v0.2.2-v0.2.5 the same binding only drops the
+        // blit, fence, publish, repaint and surface commit.
         if ("occluded" in root) {
             root.occluded = Qt.binding(() => root.covered);
         }

--- a/sdata/subcmd-install/4.wallpaperengine.sh
+++ b/sdata/subcmd-install/4.wallpaperengine.sh
@@ -41,7 +41,7 @@ set -euo pipefail
 [[ "${INSTALL_WE:-0}" == "1" ]] || { echo "[ImI] Wallpaper Engine: skipped."; exit 0; }
 
 WE_REPO="${WE_REPO:-https://github.com/XephyLon/qs-wallpaperengine}"
-WE_REF="${WE_REF:-v0.2.5}"                       # release tag, so installs take the PREBUILT fast path; any checksum /
+WE_REF="${WE_REF:-v0.2.6}"                       # release tag, so installs take the PREBUILT fast path; any checksum /
                                                  # arch / Qt-too-old / smoke-test failure falls back to a source build, as
                                                  # does a tag whose release has not published yet. Whatever this points at
                                                  # MUST be >= 40427cf, the commit that added


### PR DESCRIPTION
Bumps `WE_REF` v0.2.5 → v0.2.6 and updates `WallpaperEngineLayer.qml`'s scope comment.

## Why

[qs-wallpaperengine v0.2.6](https://github.com/XephyLon/qs-wallpaperengine/blob/main/CHANGELOG.md) closes [qs-wallpaperengine#19](https://github.com/XephyLon/qs-wallpaperengine/issues/19): the shell's covered→`occluded` binding now pauses WE playback itself — mpv stops decoding while a fullscreen window covers the output. Before, occlusion only stopped the blit/publish half, and a software-decoded video (e.g. 7680×2160 h264, wider than NVDEC's 4096 h264 cap) kept a measured constant ~180% CPU running against the game. Measured with the fix: ~250% → ~1.5% CPU on occlude, full-rate resume on uncover.

No shell code change needed — the existing `covered` binding already forwards into the surface's `occluded`; the new behavior rides the pin. The layer's comment described the old limitation ("this does not reach mpv") as permanent; it now documents both sides of the pin.

## Notes

- The v0.2.6 release CI is publishing; until assets land, installs on this pin fall back to the source build (documented fallback). Best to Update Dots after assets show.

Docs: not needed — version pin bump; the behavior change is documented in the qs-wallpaperengine changelog and in `WallpaperEngineLayer.qml`'s updated comment in this PR.