### PR TITLE
feat(search): launch Minecraft modpacks from the search bar

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -112,6 +112,17 @@ or use a worktree, validate headlessly, then perform one controlled live load.
   recreated the same way scene components are — don't assume editing a singleton always produces
   an immediately-visible fresh instance; when in doubt, verify with a temporary `console.log` in an
   `onXChanged` handler (see CONTRIBUTING.md's verification workflow).
+- **A singleton is constructed on first use, so a service whose only caller is a lazily-evaluated
+  binding does not start when you think it does.** Anything a singleton kicks off at construction
+  — a detection `Process`, a poll timer, a file read — is deferred until something actually reads
+  one of its properties. `PrismLauncher` is reached only from `LauncherSearch`'s `results` binding,
+  which does not evaluate until the user types, so its "run at startup" detection had in fact not
+  started when the first query was answered: measured, the first search came back with no modpacks
+  and only the second had them. If a service must be warm before its first consumer runs, construct
+  it explicitly from a `Component.onCompleted` that does run early — reading any property is what
+  constructs it. This is separate from the reactive-observation rule below: the binding was correctly
+  reactive, it just had nothing to observe yet. (feat(search): launch Minecraft modpacks from the
+  search bar.)
 
 ### Where to look when something goes wrong
 
@@ -294,6 +305,11 @@ services/                  Singletons wrapping external state/processes - one pe
                               scripts/hyprland/keybind_overrides.py. Never edits user keybind
                               files; refuses to touch a hand-edited shim (content hash). See
                               docs/proposals/keyboard-shortcuts-editor.md
+  PrismLauncher.qml            Prism Launcher modpacks for the launcher search, enumerated by
+                              scripts/prism/list_instances.py. Feature-detected (native binary or
+                              flatpak): without Prism the script never runs, `available` stays
+                              false, and the '%' prefix plus its settings row disappear. Launches
+                              by instance FOLDER name, which is not the display name
   Notifications.qml            org.freedesktop.Notifications server + notification history
   Notes.qml                    The note store: a JSON array in Directories.notesPath. Sole owner -
                               the bundled `notes` desktop plugin (one instance per monitor) and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ The version is stored in `VERSION` (a symlink to the shell's
 About page can read it). The companion `qs-wallpaperengine` is versioned in its
 own repo; the installer pins which revision it builds.
 
+## [Unreleased]
+
+### Added
+- **Launch Minecraft modpacks from the search bar.** Press Super, type a pack
+  name and hit Enter: Prism Launcher instances now appear in the launcher
+  results alongside apps, each with its own pack icon, Minecraft version and
+  mod loader. A `%` prefix lists every instance for browsing, configurable
+  under Settings → Services → Prefixes. Feature-detected end to end — on a
+  machine without Prism Launcher nothing runs, the prefix stays an ordinary
+  character, and the settings row is hidden.
+
 ## [0.20.1] — 2026-08-08
 
 ### Fixed

--- a/dots/.config/quickshell/imi/modules/common/Config.qml
+++ b/dots/.config/quickshell/imi/modules/common/Config.qml
@@ -1271,6 +1271,7 @@ Singleton {
                     property string shellCommand: "$"
                     property string webSearch: "?"
                     property string file: "~" // File/folder search
+                    property string prism: "%" // Prism Launcher modpacks; inert without Prism installed
                 }
                 property JsonObject fileSearch: JsonObject {
                     property bool enable: true

--- a/dots/.config/quickshell/imi/modules/common/models/LauncherSearchResult.qml
+++ b/dots/.config/quickshell/imi/modules/common/models/LauncherSearchResult.qml
@@ -2,7 +2,10 @@ import QtQuick
 import Quickshell
 
 QtObject {
-    enum IconType { Material, Text, System, None }
+    // System looks `iconName` up in the icon theme; File treats it as a path on
+    // disk, for sources that ship their own artwork rather than a themed icon
+    // (Prism modpack icons live under the launcher's own data directory).
+    enum IconType { Material, Text, System, None, File }
     enum FontType { Normal, Monospace }
 
     // General stuff

--- a/dots/.config/quickshell/imi/modules/imi/overview/SearchItem.qml
+++ b/dots/.config/quickshell/imi/modules/imi/overview/SearchItem.qml
@@ -147,6 +147,8 @@ RippleButton {
                     return bigTextComponent
                 case LauncherSearchResult.IconType.System:
                     return iconImageComponent
+                case LauncherSearchResult.IconType.File:
+                    return fileImageComponent
                 case LauncherSearchResult.IconType.None:
                     return null
                 default:
@@ -160,6 +162,23 @@ RippleButton {
                 source: Quickshell.iconPath(root.iconName, "image-missing")
                 width: 35
                 height: 35
+            }
+        }
+
+        Component {
+            id: fileImageComponent
+            Image {
+                source: root.iconName.length > 0 ? Qt.resolvedUrl("file://" + root.iconName) : ""
+                width: 35
+                height: 35
+                // Modpack art is arbitrary user-supplied PNG/WebP at whatever
+                // resolution the pack shipped, so it is scaled down rather
+                // than trusted to fit, and sourceSize keeps the decode at
+                // display size instead of holding a 512px image per result.
+                fillMode: Image.PreserveAspectFit
+                sourceSize.width: 35
+                sourceSize.height: 35
+                asynchronous: true
             }
         }
 

--- a/dots/.config/quickshell/imi/modules/imi/settings/pages/ServicesConfig.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/pages/ServicesConfig.qml
@@ -453,6 +453,29 @@ ContentPage {
                             }
                         }
                     }
+
+                    // Only shown where Prism Launcher exists: the prefix does
+                    // nothing without it, and a dead setting reads as a broken
+                    // one. PrismLauncher.available comes from that service's
+                    // own startup detection, so this row appears on machines
+                    // that can use it and nowhere else.
+                    ConfigRow {
+                        uniform: true
+                        visible: PrismLauncher.available
+                        ConfigTextArea {
+                            Layout.fillWidth: true
+                            buttonIcon: "stadia_controller"
+                            fieldWidth: 100
+                            text: Translation.tr("Modpacks")
+                            value: Config.options.search.prefix.prism
+                            onValueChanged: {
+                                Config.options.search.prefix.prism = value;
+                            }
+                        }
+                        Item {
+                            Layout.fillWidth: true
+                        }
+                    }
                 }
             }
             ContentSubsection {

--- a/dots/.config/quickshell/imi/scripts/prism/list_instances.py
+++ b/dots/.config/quickshell/imi/scripts/prism/list_instances.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""List Prism Launcher instances as JSON for the launcher search.
+
+Emits one object per instance on stdout, most recently launched first:
+
+    {"id", "name", "icon", "minecraftVersion", "loader",
+     "lastLaunchTime", "totalTimePlayed", "launch": [argv...]}
+
+`id` is the instance FOLDER name, which is what `prismlauncher --launch`
+takes; `name` is the display name from instance.cfg, which the user can
+rename independently. The two are not interchangeable.
+
+Errors are never fatal: a machine with no Prism, a half-written mmc-pack.json
+or an unreadable instance directory produces fewer entries, not a failure -
+the caller is a search bar, and a stack trace there costs the user every other
+result too.
+"""
+
+import argparse
+import json
+import os
+import shlex
+import sys
+from pathlib import Path
+
+# uid -> display name. Prism identifies the mod loader by the component uid in
+# mmc-pack.json; the cachedName field is absent on instances that have never
+# been launched, so the uid is the reliable half.
+LOADER_UIDS = {
+    "net.minecraftforge": "Forge",
+    "net.neoforged": "NeoForge",
+    "net.fabricmc.fabric-loader": "Fabric",
+    "org.quiltmc.quilt-loader": "Quilt",
+    "com.mumfrey.liteloader": "LiteLoader",
+}
+
+MINECRAFT_UID = "net.minecraft"
+
+# Prism stores instance icons under icons/<iconKey>.<ext>, but iconKey may also
+# name a built-in with no file on disk (e.g. "flame", "default").
+ICON_EXTENSIONS = (".png", ".webp", ".jpg", ".jpeg", ".svg", ".gif", ".ico")
+
+
+def parse_instance_cfg(path):
+    """Parse Prism's instance.cfg into a dict.
+
+    Deliberately not configparser: these files are only key=value pairs, but
+    values legitimately contain '=' (Env={}, JavaPath, renamed instances), and
+    MultiMC-era files have no section header at all. Splitting on the first '='
+    handles every real case without configparser's interpolation and
+    header requirements.
+    """
+    values = {}
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return values
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith(("#", ";", "[")):
+            continue
+        key, sep, value = line.partition("=")
+        if sep:
+            values[key.strip()] = value.strip()
+    return values
+
+
+def read_pack(path):
+    """Minecraft version and loader name from mmc-pack.json."""
+    try:
+        with path.open(encoding="utf-8") as handle:
+            pack = json.load(handle)
+    except (OSError, ValueError):
+        return "", ""
+    version, loader = "", ""
+    for component in pack.get("components", []):
+        if not isinstance(component, dict):
+            continue
+        uid = component.get("uid", "")
+        if uid == MINECRAFT_UID:
+            version = str(component.get("version", ""))
+        elif uid in LOADER_UIDS:
+            loader = LOADER_UIDS[uid]
+    return version, loader
+
+
+def resolve_icon(icons_dir, icon_key):
+    """Absolute path to the instance's icon file, or "" when there is none.
+
+    Returning "" rather than a guessed path matters: the search item renders
+    whatever it is handed, so a path to a nonexistent file shows a broken
+    image where a Material symbol fallback belongs.
+    """
+    if not icon_key:
+        return ""
+    for extension in ICON_EXTENSIONS:
+        candidate = icons_dir / f"{icon_key}{extension}"
+        if candidate.is_file():
+            return str(candidate)
+    return ""
+
+
+def to_int(value):
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def collect(data_dir, launcher_argv):
+    instances_dir = data_dir / "instances"
+    icons_dir = data_dir / "icons"
+    try:
+        entries = sorted(instances_dir.iterdir())
+    except OSError:
+        return []
+
+    out = []
+    for entry in entries:
+        config_path = entry / "instance.cfg"
+        if not config_path.is_file():
+            continue
+        config = parse_instance_cfg(config_path)
+        version, loader = read_pack(entry / "mmc-pack.json")
+        out.append({
+            "id": entry.name,
+            "name": config.get("name") or entry.name,
+            "icon": resolve_icon(icons_dir, config.get("iconKey", "")),
+            "minecraftVersion": version,
+            "loader": loader,
+            "lastLaunchTime": to_int(config.get("lastLaunchTime")),
+            "totalTimePlayed": to_int(config.get("totalTimePlayed")),
+            "launch": launcher_argv + ["--launch", entry.name],
+        })
+
+    # Most recently launched first; never-launched instances (timestamp 0)
+    # therefore sort last, with a name tiebreak so the order is stable rather
+    # than filesystem-dependent.
+    out.sort(key=lambda i: (-i["lastLaunchTime"], i["name"].lower()))
+    return out
+
+
+def default_data_dir():
+    xdg_data = os.environ.get("XDG_DATA_HOME") or str(Path.home() / ".local/share")
+    native = Path(xdg_data) / "PrismLauncher"
+    if native.is_dir():
+        return native
+    return Path.home() / ".var/app/org.prismlauncher.PrismLauncher/data/PrismLauncher"
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--data-dir", default=None,
+                        help="Prism data directory (default: XDG, then flatpak)")
+    parser.add_argument("--launcher", default="prismlauncher",
+                        help="launcher command; split with shell quoting rules "
+                             "so 'flatpak run org.prismlauncher.PrismLauncher' works")
+    args = parser.parse_args()
+
+    data_dir = Path(args.data_dir) if args.data_dir else default_data_dir()
+    json.dump(collect(data_dir, shlex.split(args.launcher)), sys.stdout)
+    sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/dots/.config/quickshell/imi/services/LauncherSearch.qml
+++ b/dots/.config/quickshell/imi/services/LauncherSearch.qml
@@ -26,6 +26,29 @@ Singleton {
             FileSearch.reset();
     }
 
+    // One shape for a modpack result, built in both places that need it: the
+    // prefix branch (which lists every instance) and the default results
+    // (which mixes matching instances in with apps, so Super + a pack name is
+    // enough - the prefix is for browsing, not a requirement).
+    function makePrismResult(instance) {
+        const versionLine = [instance.minecraftVersion, instance.loader].filter(part => part.length > 0).join(" · ");
+        return resultComp.createObject(null, {
+            id: instance.id,
+            name: instance.name,
+            comment: versionLine,
+            verb: Translation.tr("Play"),
+            type: Translation.tr("Modpack"),
+            // Prism writes instance icons as files, so the icon is a path, not
+            // an icon-theme name; empty means the pack uses a Prism built-in
+            // with nothing on disk, and the Material fallback covers it.
+            iconName: instance.icon.length > 0 ? instance.icon : "stadia_controller",
+            iconType: instance.icon.length > 0 ? LauncherSearchResult.IconType.File : LauncherSearchResult.IconType.Material,
+            execute: () => {
+                PrismLauncher.launch(instance);
+            }
+        });
+    }
+
     function ensurePrefix(prefix) {
         if ([Config.options.search.prefix.action, Config.options.search.prefix.app, Config.options.search.prefix.clipboard, Config.options.search.prefix.emojis, Config.options.search.prefix.symbols, Config.options.search.prefix.math, Config.options.search.prefix.shellCommand, Config.options.search.prefix.webSearch,].some(i => root.query.startsWith(i))) {
             root.query = prefix + root.query.slice(1);
@@ -78,6 +101,9 @@ Singleton {
 
     Component.onCompleted: {
         keywordHarvester.startHarvesting();
+        // Constructs the Prism service so its detection runs now rather than
+        // on the user's first keystroke - see the note on reload().
+        PrismLauncher.reload();
     }
 
 
@@ -411,6 +437,13 @@ Singleton {
                         })]
                 });
             }).filter(Boolean);
+        } else if (PrismLauncher.available && root.query.startsWith(Config.options.search.prefix.prism ?? "%")) {
+            // Prism Launcher modpacks. Gated on `available` rather than only on
+            // the prefix: without Prism installed the prefix is a normal
+            // character again, so typing it still reaches the default results
+            // instead of dead-ending in an empty branch.
+            const searchString = StringUtils.cleanPrefix(root.query, Config.options.search.prefix.prism ?? "%");
+            return PrismLauncher.fuzzyQuery(searchString).map(instance => root.makePrismResult(instance)).filter(Boolean);
         } else if (root.query.startsWith(Config.options.search.prefix.symbols)) {
             // Material Symbols
             const searchString = StringUtils.cleanPrefix(root.query, Config.options.search.prefix.symbols);
@@ -482,6 +515,13 @@ Singleton {
                 })
             });
         });
+        // Matching modpacks, mixed into the default results so the prefix is
+        // optional. Unprefixed only - a query carrying some other source's
+        // prefix is not asking for packs.
+        const prismResultObjects = PrismLauncher.available
+            ? PrismLauncher.fuzzyQuery(StringUtils.cleanPrefix(root.query, Config.options.search.prefix.app)).map(instance => root.makePrismResult(instance)).filter(Boolean)
+            : [];
+
         ////////////////// Settings search //////////////////
         const settingsQuery = root.query.toLowerCase().trim();
 
@@ -573,6 +613,11 @@ Singleton {
 
         //////////////// Apps //////////////////
         result = result.concat(appResultObjects);
+        //////////////// Modpacks //////////////
+        // Ahead of settings and actions, behind apps: launching a pack is the
+        // same kind of intent as launching an app, and a pack name is specific
+        // enough that a match is rarely accidental. Inert without Prism.
+        result = result.concat(prismResultObjects);
         ////////////// Settings ////////////////
         result = result.concat(settingsResults);
         ////////// Launcher actions ////////////

--- a/dots/.config/quickshell/imi/services/PrismLauncher.qml
+++ b/dots/.config/quickshell/imi/services/PrismLauncher.qml
@@ -1,0 +1,121 @@
+pragma Singleton
+
+import qs.modules.common
+import qs.modules.common.functions
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import ".."
+
+/**
+ * Prism Launcher instances, for launching a modpack straight from the search
+ * bar.
+ *
+ * Feature-detected end to end: a machine without Prism never spawns the
+ * enumeration script, `available` stays false, and every consumer (the search
+ * prefix, its settings row) hides itself. That is the whole reason detection
+ * lives here rather than in Config - the shell ships to machines that have no
+ * Minecraft on them at all, and an always-present prefix for a launcher you
+ * do not own is clutter, not a feature.
+ */
+Singleton {
+    id: root
+
+    // Native install first, flatpak second - matching list_instances.py's own
+    // data-dir preference, so the binary we launch and the instances we list
+    // always come from the same install.
+    readonly property string flatpakId: "org.prismlauncher.PrismLauncher"
+    property string launcherCommand: ""
+    readonly property bool available: root.launcherCommand !== ""
+
+    property var instances: []
+
+    // Instance names are what the user types, so that is what gets prepped.
+    // Rebuilt only when the instance list actually changes - Fuzzy.prepare is
+    // not free and a search bar calls fuzzyQuery on every keystroke.
+    readonly property var preppedNames: root.instances.map(instance => ({
+        name: Fuzzy.prepare(`${instance.name} `),
+        entry: instance
+    }))
+
+    function fuzzyQuery(search: string): var {
+        if (search.length === 0)
+            return root.instances;
+        return Fuzzy.go(search, root.preppedNames, {
+            all: true,
+            key: "name"
+        }).map(result => result.obj.entry);
+    }
+
+    function launch(instance) {
+        if (!instance?.launch?.length)
+            return;
+        Quickshell.execDetached(instance.launch);
+    }
+
+    // Also the instantiation hook, and that is the more important half. A QML
+    // singleton is constructed on first use, and the only other thing that
+    // reaches this one is the results binding inside LauncherSearch - so
+    // without an early caller, detection would not even START until the user's
+    // first keystroke, and their first query would silently have no modpacks
+    // in it. Calling this from LauncherSearch's Component.onCompleted
+    // constructs the singleton (which starts detection); the body no-ops on
+    // that first call, because `available` is still false until detection
+    // answers a moment later.
+    function reload() {
+        if (root.available)
+            instanceLister.running = true;
+    }
+
+    // Detection runs once at startup. `command -v` covers the native binary;
+    // the flatpak check is a directory test rather than `flatpak info` because
+    // the latter costs hundreds of milliseconds on a cold flatpak store and
+    // this runs on every shell start, on machines that will never need it.
+    Process {
+        id: detector
+        running: true
+        command: ["bash", "-c",
+            `if command -v prismlauncher >/dev/null 2>&1; then echo prismlauncher; ` +
+            `elif [ -d "$HOME/.var/app/${root.flatpakId}" ]; then echo "flatpak run ${root.flatpakId}"; fi`]
+        stdout: SplitParser {
+            onRead: data => {
+                const found = data.trim();
+                if (found.length === 0)
+                    return;
+                root.launcherCommand = found;
+                instanceLister.running = true;
+            }
+        }
+    }
+
+    Process {
+        id: instanceLister
+        command: ["python3", Quickshell.shellPath("scripts/prism/list_instances.py"),
+            "--launcher", root.launcherCommand]
+        stdout: StdioCollector {
+            onStreamFinished: {
+                try {
+                    root.instances = JSON.parse(text);
+                } catch (error) {
+                    // A parse failure means no modpack results this session,
+                    // not a broken search bar: every other result source is
+                    // independent of this one.
+                    console.warn("[PrismLauncher] could not parse instance list:", error);
+                    root.instances = [];
+                }
+            }
+        }
+    }
+
+    // Instances change when the user installs, renames or plays a pack - all
+    // of which rewrite instance.cfg. Re-reading on every search keystroke
+    // would spawn a process per character; re-reading when the launcher opens
+    // is both cheap and exactly when a stale list would be visible.
+    Connections {
+        target: GlobalStates
+        function onOverviewOpenChanged() {
+            if (GlobalStates.overviewOpen)
+                root.reload();
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/tests/imports/qs/services/PrismLauncher.qml
+++ b/dots/.config/quickshell/imi/tests/imports/qs/services/PrismLauncher.qml
@@ -1,0 +1,1 @@
+../../../../services/PrismLauncher.qml

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -237,6 +237,12 @@ if ! python3 "$SCRIPT_DIR/test_tmux_dots.py"; then
     exit 1
 fi
 
+echo "Running Prism Launcher instance tests..."
+if ! python3 "$SCRIPT_DIR/test_prism_instances.py"; then
+    echo "Prism Launcher instance tests failed."
+    exit 1
+fi
+
 echo "Running wallpaper thumbnail fallback tests..."
 if ! python3 "$SCRIPT_DIR/test_thumbnail_fallback.py"; then
     echo "Wallpaper thumbnail fallback tests failed."

--- a/dots/.config/quickshell/imi/tests/test_prism_instances.py
+++ b/dots/.config/quickshell/imi/tests/test_prism_instances.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Prism Launcher instance enumeration for the launcher search.
+
+scripts/prism/list_instances.py walks a Prism data directory and emits the
+JSON the PrismLauncher service turns into search results. Everything here is
+pure filesystem parsing, so it is tested against fixture trees rather than the
+author's real install - which also pins the cases a real install happens not
+to have right now (a renamed instance, a missing icon, a Fabric pack, a
+flatpak layout).
+"""
+
+import json
+import pathlib
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve()
+while not (ROOT / "sdata").exists():
+    ROOT = ROOT.parent
+SCRIPT = ROOT / "dots/.config/quickshell/imi/scripts/prism/list_instances.py"
+
+
+def write(path, text):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+
+
+def make_instance(instances_dir, folder, *, name=None, icon_key=None,
+                  last_launch=None, played=None, components=None):
+    """Write a minimal but realistic Prism instance into `instances_dir`."""
+    cfg = ["[General]", "ConfigVersion=1.3", "InstanceType=OneSix"]
+    if name is not None:
+        cfg.append(f"name={name}")
+    if icon_key is not None:
+        cfg.append(f"iconKey={icon_key}")
+    if last_launch is not None:
+        cfg.append(f"lastLaunchTime={last_launch}")
+    if played is not None:
+        cfg.append(f"totalTimePlayed={played}")
+    write(instances_dir / folder / "instance.cfg", "\n".join(cfg) + "\n")
+    if components is not None:
+        write(instances_dir / folder / "mmc-pack.json",
+              json.dumps({"components": components, "formatVersion": 1}))
+
+
+def run(data_dir, *, launcher="prismlauncher"):
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--data-dir", str(data_dir),
+         "--launcher", launcher],
+        capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout)
+
+
+class InstanceEnumerationTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = pathlib.Path(tempfile.mkdtemp())
+        self.data = self.tmp / "PrismLauncher"
+        self.instances = self.data / "instances"
+        self.instances.mkdir(parents=True)
+        self.addCleanup(shutil.rmtree, self.tmp)
+
+    def test_reads_name_and_launch_id_separately(self):
+        # The launch ID is the FOLDER name; `name` is the display name a user
+        # can rename freely. Conflating them launches the wrong pack, or
+        # nothing at all.
+        make_instance(self.instances, "cottage-witch-1", name="Cottage Witch")
+        out = run(self.data)
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0]["id"], "cottage-witch-1")
+        self.assertEqual(out[0]["name"], "Cottage Witch")
+
+    def test_folder_name_is_the_fallback_display_name(self):
+        make_instance(self.instances, "No Name Here")
+        out = run(self.data)
+        self.assertEqual(out[0]["name"], "No Name Here")
+
+    def test_directories_without_instance_cfg_are_skipped(self):
+        # instgroups.json and stray directories live alongside instances.
+        make_instance(self.instances, "real", name="Real")
+        (self.instances / "not-an-instance").mkdir()
+        write(self.instances / "instgroups.json", '{"groups":{}}')
+        out = run(self.data)
+        self.assertEqual([i["id"] for i in out], ["real"])
+
+    def test_sorted_by_most_recently_launched(self):
+        make_instance(self.instances, "old", name="Old", last_launch=1000)
+        make_instance(self.instances, "new", name="New", last_launch=9000)
+        make_instance(self.instances, "never", name="Never")
+        out = run(self.data)
+        # Never-launched sorts last rather than first: a missing timestamp is
+        # not a recent one.
+        self.assertEqual([i["name"] for i in out], ["New", "Old", "Never"])
+
+    def test_icon_resolves_to_a_real_file_of_any_extension(self):
+        make_instance(self.instances, "a", name="A", icon_key="curseforge_x")
+        make_instance(self.instances, "b", name="B", icon_key="modrinth_y")
+        write(self.data / "icons/curseforge_x.png", "")
+        write(self.data / "icons/modrinth_y.webp", "")
+        out = {i["name"]: i for i in run(self.data)}
+        self.assertTrue(out["A"]["icon"].endswith("/icons/curseforge_x.png"))
+        self.assertTrue(out["B"]["icon"].endswith("/icons/modrinth_y.webp"))
+
+    def test_missing_icon_file_yields_empty_icon_not_a_broken_path(self):
+        # iconKey often names a Prism built-in ("flame", "default") with no
+        # file on disk. Handing the UI a path that does not exist renders a
+        # broken-image box; empty lets it fall back to a Material symbol.
+        make_instance(self.instances, "a", name="A", icon_key="flame")
+        out = run(self.data)
+        self.assertEqual(out[0]["icon"], "")
+
+    def test_version_and_loader_come_from_mmc_pack(self):
+        make_instance(self.instances, "a", name="A", components=[
+            {"uid": "org.lwjgl3", "version": "3.3.1"},
+            {"uid": "net.minecraft", "version": "1.19.2"},
+            {"uid": "net.minecraftforge", "version": "43.2.0"},
+        ])
+        out = run(self.data)
+        self.assertEqual(out[0]["minecraftVersion"], "1.19.2")
+        self.assertEqual(out[0]["loader"], "Forge")
+
+    def test_every_known_loader_is_named(self):
+        loaders = {
+            "net.fabricmc.fabric-loader": "Fabric",
+            "org.quiltmc.quilt-loader": "Quilt",
+            "net.neoforged": "NeoForge",
+            "com.mumfrey.liteloader": "LiteLoader",
+        }
+        for uid, expected in loaders.items():
+            with self.subTest(uid=uid):
+                folder = uid.replace(".", "-")
+                make_instance(self.instances, folder, name=folder, components=[
+                    {"uid": "net.minecraft", "version": "1.20.1"},
+                    {"uid": uid, "version": "1.0"},
+                ])
+                out = {i["name"]: i for i in run(self.data)}
+                self.assertEqual(out[folder]["loader"], expected)
+
+    def test_vanilla_instance_has_no_loader(self):
+        make_instance(self.instances, "a", name="A", components=[
+            {"uid": "net.minecraft", "version": "1.20.1"},
+        ])
+        self.assertEqual(run(self.data)[0]["loader"], "")
+
+    def test_unreadable_mmc_pack_does_not_drop_the_instance(self):
+        # A half-written or hand-edited pack file must cost that instance its
+        # version line, not its presence in the launcher.
+        make_instance(self.instances, "a", name="A")
+        write(self.instances / "a/mmc-pack.json", "{ not json")
+        out = run(self.data)
+        self.assertEqual(out[0]["name"], "A")
+        self.assertEqual(out[0]["minecraftVersion"], "")
+
+    def test_launch_command_carries_the_instance_id(self):
+        make_instance(self.instances, "cottage-witch-1", name="Cottage Witch")
+        out = run(self.data)
+        self.assertEqual(out[0]["launch"],
+                         ["prismlauncher", "--launch", "cottage-witch-1"])
+
+    def test_flatpak_launcher_is_passed_through_verbatim(self):
+        # The service decides native vs flatpak; the script must not rewrite
+        # whatever it is handed, or a flatpak install launches nothing.
+        make_instance(self.instances, "a", name="A")
+        out = run(self.data, launcher="flatpak run org.prismlauncher.PrismLauncher")
+        self.assertEqual(out[0]["launch"], [
+            "flatpak", "run", "org.prismlauncher.PrismLauncher",
+            "--launch", "a"])
+
+    def test_missing_data_dir_is_empty_output_not_an_error(self):
+        # Feature detection lives in the service, but the script is what runs
+        # on a machine where Prism was uninstalled between the two.
+        out = run(self.tmp / "does-not-exist")
+        self.assertEqual(out, [])
+
+    def test_instance_cfg_without_a_section_header_still_parses(self):
+        # Older MultiMC-era configs have no [General] header.
+        write(self.instances / "legacy/instance.cfg",
+              "name=Legacy Pack\nlastLaunchTime=5\n")
+        out = run(self.data)
+        self.assertEqual(out[0]["name"], "Legacy Pack")
+
+    def test_values_containing_equals_are_not_truncated(self):
+        make_instance(self.instances, "a", name="A=B=C")
+        self.assertEqual(run(self.data)[0]["name"], "A=B=C")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Press Super, type a pack name, hit Enter. Prism Launcher instances appear in the launcher results next to apps, each with its own pack art, Minecraft version and mod loader.

Part of the dots rather than a plugin, and feature-detected end to end: on a machine without Prism Launcher the script never runs, the prefix is an ordinary character again, and the settings row is hidden.

## How it works

- `scripts/prism/list_instances.py` walks the Prism data directory (native or flatpak) and emits JSON per instance.
- `services/PrismLauncher.qml` detects the launcher, runs that script, and exposes the instances plus a fuzzy query. Re-reads when the launcher opens — installing, renaming or playing a pack all rewrite `instance.cfg`.
- `LauncherSearch` mixes matching packs into the default results, and a new `%` prefix lists them all for browsing. The prefix is configurable under Settings → Services → Prefixes.
- `IconType.File` renders the pack's own artwork; Prism stores icons as files, which the icon-theme lookup behind `IconType.System` can't find.

## Two things worth a reviewer's attention

**Launch id ≠ display name.** Prism launches by folder name while `instance.cfg` carries a display name the user can rename freely. Three instances on my machine already disagree — *Steller: The Rise of the Kingdom* lives in `Steller- The Rise of the Kingdom`. Conflating them launches the wrong pack or nothing, so they're kept separate and pinned by test.

**A lazily-constructed singleton doesn't start when it looks like it does.** `PrismLauncher` is only reached from `LauncherSearch`'s results binding, which doesn't evaluate until the user types — so its startup detection hadn't started when the first query was answered. Measured: first search had no modpacks, second did. Fixed by constructing it from `LauncherSearch.Component.onCompleted`; written up in AGENT.md since it generalises to any service like this.

## Verification

15 new tests in `test_prism_instances.py` against fixture trees, covering the cases my real install happens not to have: a renamed instance, a missing icon file, every loader, a corrupt `mmc-pack.json`, a header-less MultiMC config, a flatpak launcher, and a missing data dir. Full suite green (314 QML + python checks).

Verified live in a real `qs` instance: detection finds the native binary, all 10 instances enumerate, `%` lists them (first result *Cottage Witch*, type Modpack, verb Play, "1.19.2 · Forge", file icon resolved), and typing `cottage` unprefixed puts the pack in the default results. Degradation checked too — with `available` false, `%` falls through to Command/Math/Web search as normal.

Docs: updated AGENT.md §Directory map (PrismLauncher service) and §Runtime model (singleton construction timing), plus CHANGELOG under Unreleased.