### PR TITLE
feat(background): revive wallpaper parallax, for stills and Wallpaper Engine

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -829,6 +829,30 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   binding to track it - and prefer extracting it into a reusable, testable component over
   re-inlining the same fix at each call site.
 
+**Wallpaper parallax is one oversized viewport, not a per-layer effect.**
+`Background.qml` draws every wallpaper layer inside `parallaxViewport`, an item sized to
+`screen * parallax.workspaceZoom` whose `x`/`y` are the effect; the maths lives in
+`modules/common/functions/parallax.js` so it can be tested without a compositor. Keep new wallpaper
+layers **inside** that viewport and `anchors.fill: parent` - that is the only reason Wallpaper
+Engine parallaxes at all, since the WE surface, the frozen switch stills and the peel shaders are
+all sized to the same item and therefore pan together. Anything that must stay screen-sized (the
+widget canvas, the desktop right-click area) is a *sibling* of the viewport and needs its own copy
+of the `suppressContents` fullscreen gate, which the viewport carries for its own children.
+Sizing is deliberately screen-derived rather than wallpaper-derived: a live WE project reports no
+intrinsic size, and `PreserveAspectCrop` already covers a still, so one rule serves both.
+(feat(background): revive wallpaper parallax, for stills and Wallpaper Engine.)
+
+**A feature that was config-only cannot be revived on its stored values.** The parallax knobs
+shipped for the whole life of this shell with nothing reading them, so every `config.json` holds
+values that predate the feature doing anything - on the author's machine every switch was `false`.
+Turning the code back on against those values ships the feature dead for everyone who has ever
+written a config, which is everyone, and no unit test sees it: the QML default says `true`, the
+stored config says `false`, and the adapter's answer is the one that runs. Reviving dead config
+therefore needs a one-shot migration with a marker (`migrateDeadParallaxSwitches`), and a runtime
+test that seeds a real config directory. Reset only the switches - a tuned number is a plausible
+preference and usually cannot disable the feature by itself.
+(fix(config): revive the parallax switches every stored config turned off.)
+
 **Treat repeated binding exceptions as potential resource runaways, not harmless log noise.** A
 sidebar media-player binding called `filterDuplicatePlayers()` without defining the helper in that
 component. The visible log only gained an occasional `ReferenceError` when MPRIS state changed, but

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ own repo; the installer pins which revision it builds.
 
 ## [Unreleased]
 
+### Added
+- **Wallpaper parallax is back, and it works with live wallpapers too.** The
+  wallpaper drifts as you move between workspaces, nudges when a sidebar opens,
+  and the desktop widgets travel a little further than it does so they read as
+  sitting in front of it. Portrait wallpapers pan down instead of across, and
+  vertical panning can be forced for any wallpaper. Wallpaper Engine projects
+  parallax exactly like stills, cross-fades included. Controls live under
+  Settings → Desktop → Parallax; the zoom there is the room the effect has to
+  move in.
+- Existing configs are migrated once: the knobs had been carried since
+  dots-hyprland with nothing reading them, so whatever they held was a leftover
+  rather than a preference and would have left the revived effect switched off.
+
 ## [0.21.0] — 2026-08-09
 
 ### Added

--- a/dots/.config/quickshell/imi/ParallaxMigrationRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/ParallaxMigrationRuntimeTest.qml
@@ -1,0 +1,86 @@
+import QtQuick
+import Quickshell
+import qs.modules.common
+
+/**
+ * Drives Config.qml's one-shot parallax revival against a real config.json.
+ *
+ * Wallpaper parallax was config-only for this shell's whole life - the knobs
+ * came over from dots-hyprland but their consumer went with the ii->pC theme
+ * swap - so every stored value predates the feature doing anything. Reviving
+ * it against those values would ship it switched off for everyone who has ever
+ * written a config, which is everyone, and no unit test sees that: the logic
+ * reads correctly in isolation and only fails against an on-disk config the
+ * adapter has already merged over the QML defaults.
+ *
+ * Launched once per case by tests/test_parallax_migration_runtime.py, which
+ * seeds a throwaway XDG_CONFIG_HOME and reads config.json afterwards. Never
+ * point it at a real config directory - it writes config.json.
+ *
+ *   PARALLAX_EXPECT=on XDG_CONFIG_HOME=$(mktemp -d) qs -p ParallaxMigrationRuntimeTest.qml
+ */
+ShellRoot {
+    id: harness
+
+    property int failures: 0
+    property int elapsed: 0
+
+    // "on"  - the switches must end up true (the migration ran)
+    // "off" - they must be left alone (the marker said it already ran)
+    readonly property string expected: Quickshell.env("PARALLAX_EXPECT") ?? "on"
+
+    function check(label, ok) {
+        console.log(`[Parallax] ${label}: ${ok ? "ok" : "FAIL"}`);
+        if (!ok)
+            harness.failures++;
+    }
+
+    function finish() {
+        console.log(`[Parallax] failures: ${harness.failures}`);
+        Qt.exit(harness.failures === 0 ? 0 : 1);
+    }
+
+    Timer {
+        id: waitForConfig
+        interval: 250
+        repeat: true
+        running: true
+        onTriggered: {
+            harness.elapsed += waitForConfig.interval;
+            if (!Config.ready) {
+                if (harness.elapsed >= 15000) {
+                    harness.check("the config becomes ready", false);
+                    harness.finish();
+                }
+                return;
+            }
+            waitForConfig.running = false;
+
+            const parallax = Config.options.background.parallax;
+            const wantOn = harness.expected === "on";
+            harness.check(`enable is ${wantOn}, got ${parallax.enable}`,
+                          parallax.enable === wantOn);
+            harness.check(`enableWorkspace is ${wantOn}, got ${parallax.enableWorkspace}`,
+                          parallax.enableWorkspace === wantOn);
+            harness.check(`enableSidebar is ${wantOn}, got ${parallax.enableSidebar}`,
+                          parallax.enableSidebar === wantOn);
+            harness.check(`enableWidgets is ${wantOn}, got ${parallax.enableWidgets}`,
+                          parallax.enableWidgets === wantOn);
+            // Tuned numbers are never reset - only the switches are, because a
+            // number cannot turn the effect off on its own.
+            harness.check(`workspaceZoom survives, got ${parallax.workspaceZoom}`,
+                          Math.abs(parallax.workspaceZoom - 1.42) < 0.001);
+            harness.check("the marker is set", parallax.migratedFromDeadCode === true);
+
+            // The config write is debounced; give it a moment before the
+            // caller reads the file back.
+            settle.running = true;
+        }
+    }
+
+    Timer {
+        id: settle
+        interval: 1500
+        onTriggered: harness.finish()
+    }
+}

--- a/dots/.config/quickshell/imi/modules/common/Config.qml
+++ b/dots/.config/quickshell/imi/modules/common/Config.qml
@@ -51,6 +51,29 @@ Singleton {
             "notes": "notes"
         })
 
+    // Wallpaper parallax was config-only for the whole life of this shell: the
+    // knobs were carried over from dots-hyprland but the code that read them
+    // went with the ii->pC theme swap, so nothing has consumed them since.
+    // Whatever an existing config.json holds for them is therefore a leftover,
+    // not a preference - it was never possible to see what it did. Reviving the
+    // feature against those values ships it switched off for everyone who has
+    // ever written a config, which is everyone.
+    //
+    // So the stored block is cleared exactly once, letting the QML defaults
+    // apply, and the marker keeps a later deliberate "off" from being undone.
+    // Only the switches are reset: workspaceZoom and widgetsFactor are numbers
+    // a user could plausibly have tuned, and neither of them can turn the
+    // effect off on its own.
+    function migrateDeadParallaxSwitches() {
+        if (root.options.background.parallax.migratedFromDeadCode)
+            return;
+        root.setNestedValue("background.parallax.enable", true);
+        root.setNestedValue("background.parallax.enableWorkspace", true);
+        root.setNestedValue("background.parallax.enableSidebar", true);
+        root.setNestedValue("background.parallax.enableWidgets", true);
+        root.setNestedValue("background.parallax.migratedFromDeadCode", true);
+    }
+
     function migrateDesktopWidgetsToPlugins() {
         if (root.options.plugins.migratedDesktopWidgets)
             return;
@@ -402,6 +425,7 @@ Singleton {
             root.migrateUpstreamKeys(text());
             root.ready = true;
             root.clearStaleKbOptions();
+            root.migrateDeadParallaxSwitches();
             root.migrateDesktopWidgetsToPlugins();
             root.migrateDesktopWidgetOptionsToPlugins();
         }
@@ -883,12 +907,22 @@ Singleton {
                 property string thumbnailPath: ""
                 property bool hideWhenFullscreen: true
                 property JsonObject parallax: JsonObject {
+                    property bool enable: true
                     property bool vertical: false
-                    property bool autoVertical: false
+                    property bool autoVertical: true // Pan vertically on a portrait wallpaper
                     property bool enableWorkspace: true
-                    property real workspaceZoom: 1.0 // Relative to wallpaper size
+                    // How much larger than the screen the wallpaper is drawn.
+                    // This IS the effect's headroom: at 1.0 there is no overflow
+                    // to pan across and every other knob here does nothing, which
+                    // is why the revived default overscans. It also costs - the
+                    // Wallpaper Engine surface renders at this size - so it is
+                    // deliberately modest.
+                    property real workspaceZoom: 1.1
                     property bool enableSidebar: true
+                    property bool enableWidgets: true
                     property real widgetsFactor: 1.2
+                    // Set once by migrateDeadParallaxSwitches; see there.
+                    property bool migratedFromDeadCode: false
                 }
             }
 

--- a/dots/.config/quickshell/imi/modules/common/functions/parallax.js
+++ b/dots/.config/quickshell/imi/modules/common/functions/parallax.js
@@ -1,0 +1,87 @@
+.pragma library
+
+// Wallpaper parallax maths.
+//
+// The whole effect is one idea: draw the wallpaper larger than the screen, then
+// choose which part of that overflow is visible. Everything here works in
+// fractions of the overflow - 0 is the left/top edge of the picture, 1 the
+// right/bottom edge, 0.5 dead centre - and only the last step turns them into
+// pixels. Background.qml feeds live state in and applies the result; it makes
+// no positioning decisions of its own, which is what lets this be tested
+// without a compositor.
+//
+// Nothing here may return NaN. Background.qml binds these straight to x/y, and
+// a NaN there does not misplace the wallpaper, it stops the item rendering
+// entirely - so every input is defaulted rather than trusted.
+
+const CENTRE = 0.5;
+
+function clamp01(value) {
+    if (!isFinite(value)) return CENTRE;
+    return Math.max(0, Math.min(1, value));
+}
+
+function number(value, fallback) {
+    return (typeof value === "number" && isFinite(value)) ? value : fallback;
+}
+
+// Where this workspace sits along the pan, 0..1.
+//
+// Divided by (total - 1) rather than by total: the pan runs between the first
+// and last workspace, so the last one reaches the far edge of the picture
+// instead of stopping one step short. One workspace has nowhere to pan and
+// stays centred - which is also the divide-by-zero guard.
+function workspaceFraction(workspaceIndex, totalWorkspaces) {
+    const total = number(totalWorkspaces, 1);
+    if (total <= 1) return CENTRE;
+    return clamp01(number(workspaceIndex, 0) / (total - 1));
+}
+
+// Fractions for both axes, given the full parallax state.
+//
+// Sidebars always act on X even in vertical mode: they are horizontal surfaces
+// sliding in from the left and right edges whichever way the workspaces pan, so
+// moving the wallpaper vertically for them would not read as the same effect.
+function fractions(state) {
+    state = state || {};
+    const vertical = !!state.vertical;
+    const workspace = state.enableWorkspace === false
+        ? CENTRE
+        : workspaceFraction(state.workspaceIndex, state.totalWorkspaces);
+
+    let x = vertical ? CENTRE : workspace;
+    let y = vertical ? workspace : CENTRE;
+
+    if (state.enableSidebar !== false) {
+        const nudge = number(state.sidebarFraction, 0);
+        if (state.sidebarRightOpen) x += nudge;
+        if (state.sidebarLeftOpen) x -= nudge;
+    }
+
+    return { x: clamp01(x), y: clamp01(y) };
+}
+
+// Fractions turned into the pixel offsets the wallpaper container is placed at.
+//
+// Negative: the container is bigger than the screen and slides underneath it,
+// so showing the right-hand end of the picture means moving the container left.
+function offsets(state) {
+    state = state || {};
+    const f = fractions(state);
+    const overflowX = Math.max(0, number(state.overflowX, 0));
+    const overflowY = Math.max(0, number(state.overflowY, 0));
+    return {
+        x: -overflowX * f.x,
+        y: -overflowY * f.y
+    };
+}
+
+// How far the desktop widgets travel for a given wallpaper offset.
+//
+// A factor above 1 moves the widgets further than the wallpaper, which is what
+// reads as depth; equal factors would glue them to the picture and the effect
+// disappears. Kept as its own function because the widget layer is a sibling of
+// the wallpaper container, not a child, so it cannot inherit the offset.
+function widgetOffset(wallpaperOffset, factor) {
+    return number(wallpaperOffset, 0) * number(factor, 0);
+}

--- a/dots/.config/quickshell/imi/modules/imi/background/Background.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/Background.qml
@@ -6,6 +6,7 @@ import qs.modules.common
 import qs.modules.common.widgets
 import qs.modules.common.widgets.widgetCanvas
 import qs.modules.common.functions as CF
+import "../../common/functions/parallax.js" as ParallaxMath
 import QtQuick
 import QtQuick.Layouts
 import Qt5Compat.GraphicalEffects
@@ -185,6 +186,67 @@ Variants {
         }
 
         property HyprlandMonitor monitor: Hyprland.monitorFor(modelData)
+
+        // ---- Wallpaper parallax -------------------------------------------
+        //
+        // The wallpaper is drawn into a container larger than the screen and
+        // that container is slid around underneath it. Doing it with ONE
+        // container, rather than teaching each layer to offset itself, is what
+        // makes this work for Wallpaper Engine as well as stills: the WE
+        // surface, the frozen stills and the transition shaders all stay
+        // `anchors.fill: parent` inside it, so they pan together and the
+        // cross-fade keeps lining up mid-pan.
+        //
+        // The container is sized off the SCREEN rather than off the wallpaper's
+        // own pixels. A live WE project has no intrinsic size to scale from, and
+        // for stills `PreserveAspectCrop` already covers whatever it is given -
+        // so one rule serves both, and the zoom means the same thing either way.
+        readonly property bool parallaxEnabled: (Config.options.background.parallax.enable ?? true)
+            && !GlobalStates.screenLocked
+        // Locked: the lock screen has its own framing (and its own blur zoom),
+        // and a wallpaper that slides while the session is locked reads as the
+        // session still being live.
+        readonly property real parallaxZoom: bgRoot.parallaxEnabled
+            ? Math.max(1, Config.options.background.parallax.workspaceZoom ?? 1)
+            : 1
+        readonly property real parallaxWidth: bgRoot.width * bgRoot.parallaxZoom
+        readonly property real parallaxHeight: bgRoot.height * bgRoot.parallaxZoom
+
+        // Portrait wallpapers have vertical room to spare and no horizontal
+        // story to tell, so they pan down the picture instead of across it.
+        // Only stills can be measured this way - a WE project reports nothing -
+        // so a live wallpaper follows the explicit switch alone.
+        readonly property bool parallaxVertical: {
+            if (Config.options.background.parallax.vertical) return true;
+            if (!(Config.options.background.parallax.autoVertical ?? false)) return false;
+            if (bgRoot.weActive) return false;
+            return bgRoot.wallpaperIsPortrait;
+        }
+        // Written by the wallpaper Image as it loads, rather than read off it by
+        // id: the still's intrinsic size is only known once the source resolves,
+        // and a binding reaching forward into a layer declared further down the
+        // file resolves to nothing at all - it did, silently, and only a live
+        // load surfaced the ReferenceError.
+        property bool wallpaperIsPortrait: false
+
+        readonly property int parallaxWorkspaceChunk: Config.options?.bar.workspaces.shown ?? 10
+        readonly property var parallaxState: ({
+            workspaceIndex: (bgRoot.monitor?.activeWorkspace?.id ?? 1) - 1,
+            totalWorkspaces: bgRoot.parallaxWorkspaceChunk,
+            vertical: bgRoot.parallaxVertical,
+            enableWorkspace: Config.options.background.parallax.enableWorkspace ?? true,
+            enableSidebar: Config.options.background.parallax.enableSidebar ?? true,
+            sidebarLeftOpen: GlobalStates.sidebarLeftOpen,
+            sidebarRightOpen: GlobalStates.sidebarRightOpen,
+            // A sidebar is worth about half a workspace step, so opening one
+            // reads as a nudge rather than as a workspace change.
+            sidebarFraction: 0.5 / Math.max(1, bgRoot.parallaxWorkspaceChunk - 1),
+            overflowX: Math.max(0, bgRoot.parallaxWidth - bgRoot.width),
+            overflowY: Math.max(0, bgRoot.parallaxHeight - bgRoot.height)
+        })
+        readonly property var parallaxOffsets: bgRoot.parallaxEnabled
+            ? ParallaxMath.offsets(bgRoot.parallaxState)
+            : ({ x: 0, y: 0 })
 
         property string effectiveWallpaperPath: {
             if (GlobalStates.screenLocked && Config.options.background.lockWall !== "")
@@ -586,11 +648,39 @@ Variants {
             }
         }
 
+        // The wallpaper layers, and the parallax viewport they live in. It is
+        // deliberately NOT anchored: it is drawn larger than the screen and its
+        // x/y ARE the effect (see parallaxOffsets). At zoom 1 it is exactly
+        // screen-sized at 0,0, so the feature collapses back to the old
+        // geometry rather than to a special case.
+        //
+        // One viewport for every layer is what makes Wallpaper Engine parallax
+        // for free: the WE surface, the frozen stills and the peel shaders all
+        // stay `anchors.fill: parent` inside it, so they pan together and the
+        // cross-fade keeps lining up mid-pan.
         Item {
-            anchors.fill: parent
+            id: parallaxViewport
+            width: bgRoot.parallaxWidth
+            height: bgRoot.parallaxHeight
+            x: bgRoot.parallaxOffsets.x
+            y: bgRoot.parallaxOffsets.y
             // Everything the background draws hangs off here, so this is what
             // `hideWhenFullscreen` switches off - see suppressContents above.
             visible: !bgRoot.suppressContents
+
+            // Slower than a workspace switch on purpose: the wallpaper trails
+            // the workspace animation rather than racing it, which is what reads
+            // as distance instead of as a second window sliding. Not an
+            // Appearance token - those are tuned for UI elements and made the
+            // wallpaper snap.
+            Behavior on x {
+                enabled: bgRoot.parallaxEnabled
+                NumberAnimation { duration: 600; easing.type: Easing.OutCubic }
+            }
+            Behavior on y {
+                enabled: bgRoot.parallaxEnabled
+                NumberAnimation { duration: 600; easing.type: Easing.OutCubic }
+            }
 
             // Live Wallpaper Engine layer - bottom of the stack. When active it
             // is the wallpaper; the static-image layers below are hidden. Loaded
@@ -725,6 +815,12 @@ Variants {
                 onStatusChanged: {
                     if (status === Image.Ready && bgRoot.transitionProgress === 0.0) {
                         transitionAnim.restart()
+                    }
+                    // Feeds parallax.autoVertical. Both dimensions read 0 until
+                    // the source resolves, so the guard keeps a not-yet-loaded
+                    // image from looking square and flipping the pan axis.
+                    if (status === Image.Ready && implicitWidth > 0 && implicitHeight > 0) {
+                        bgRoot.wallpaperIsPortrait = implicitHeight > implicitWidth
                     }
                 }
             }
@@ -1008,85 +1104,120 @@ Variants {
                 }
             }
 
-            WidgetCanvas {
-                id: widgetCanvas
-                anchors.fill: parent
-                // Above the WE wallpaper-switch transition (weTransition, z 1) so the
-                // desktop widgets/plugins stay visible while wallpapers cross-fade.
-                z: 2
-                // The desktop is the canvas the marquee exists for: rubber-band
-                // several widgets, then drag any of them to move the cluster.
-                selectionEnabled: true
+        } // parallaxViewport
 
-                transitions: Transition {
-                    PropertyAnimation {
-                        properties: "width,height"
-                        duration: Appearance.animation.elementMove.duration
-                        easing.type: Appearance.animation.elementMove.type
-                        easing.bezierCurve: Appearance.animation.elementMove.bezierCurve
-                    }
-                    AnchorAnimation {
-                        duration: Appearance.animation.elementMove.duration
-                        easing.type: Appearance.animation.elementMove.type
-                        easing.bezierCurve: Appearance.animation.elementMove.bezierCurve
-                    }
+        WidgetCanvas {
+            id: widgetCanvas
+            width: bgRoot.width
+            height: bgRoot.height
+            // Moved out of the viewport, so it needs its own copy of the
+            // fullscreen gate the viewport carries - without this the
+            // desktop widgets would stay on screen under a fullscreen
+            // window while the wallpaper behind them vanished.
+            visible: !bgRoot.suppressContents
+            // Widget parallax. The canvas is a SIBLING of the wallpaper
+            // viewport, not a child, so it cannot inherit the pan - and it
+            // must not: matching the wallpaper exactly would glue the
+            // widgets to the picture and there would be no effect to see.
+            // Travelling further than the wallpaper (factor > 1) is what
+            // reads as the widgets sitting in front of it.
+            //
+            // Screen-sized regardless of the zoom, so a widget dragged to a
+            // corner stays where the user put it rather than being placed
+            // against an overscanned canvas they cannot see the edges of.
+            x: (Config.options.background.parallax.enableWidgets ?? true)
+                ? ParallaxMath.widgetOffset(bgRoot.parallaxOffsets.x, Config.options.background.parallax.widgetsFactor ?? 0)
+                : 0
+            y: (Config.options.background.parallax.enableWidgets ?? true)
+                ? ParallaxMath.widgetOffset(bgRoot.parallaxOffsets.y, Config.options.background.parallax.widgetsFactor ?? 0)
+                : 0
+            Behavior on x {
+                enabled: bgRoot.parallaxEnabled
+                NumberAnimation { duration: 600; easing.type: Easing.OutCubic }
+            }
+            Behavior on y {
+                enabled: bgRoot.parallaxEnabled
+                NumberAnimation { duration: 600; easing.type: Easing.OutCubic }
+            }
+            // Above the WE wallpaper-switch transition (weTransition, z 1) so the
+            // desktop widgets/plugins stay visible while wallpapers cross-fade.
+            z: 2
+            // The desktop is the canvas the marquee exists for: rubber-band
+            // several widgets, then drag any of them to move the cluster.
+            selectionEnabled: true
+
+            transitions: Transition {
+                PropertyAnimation {
+                    properties: "width,height"
+                    duration: Appearance.animation.elementMove.duration
+                    easing.type: Appearance.animation.elementMove.type
+                    easing.bezierCurve: Appearance.animation.elementMove.bezierCurve
                 }
-                Repeater {
-                    model: PluginManager.availablePlugins
+                AnchorAnimation {
+                    duration: Appearance.animation.elementMove.duration
+                    easing.type: Appearance.animation.elementMove.type
+                    easing.bezierCurve: Appearance.animation.elementMove.bezierCurve
+                }
+            }
+            Repeater {
+                model: PluginManager.availablePlugins
 
-                    FadeLoader {
-                        id: pluginLoader
+                FadeLoader {
+                    id: pluginLoader
 
-                        required property var modelData
-                        shown: modelData.desktopWidget !== undefined
-                            && modelData.startupSafe !== false
-                            && Config.options.plugins.enabled.includes(modelData.id)
-                        // Keep the loader untransformed. Hyprland derives live
-                        // background blur from this surface's alpha map; wrapping
-                        // plugin widgets in a Scale transform offsets that map
-                        // from the live Wallpaper Engine layer beneath it.
-                        enterDuration: Appearance.animation.elementMoveEnter.duration
-                        enterEasingCurve: Appearance.animation.elementMoveEnter.bezierCurve
-                        exitDuration: Appearance.animation.elementMoveExit.duration
-                        exitEasingCurve: Appearance.animation.elementMoveExit.bezierCurve
+                    required property var modelData
+                    shown: modelData.desktopWidget !== undefined
+                        && modelData.startupSafe !== false
+                        && Config.options.plugins.enabled.includes(modelData.id)
+                    // Keep the loader untransformed. Hyprland derives live
+                    // background blur from this surface's alpha map; wrapping
+                    // plugin widgets in a Scale transform offsets that map
+                    // from the live Wallpaper Engine layer beneath it.
+                    enterDuration: Appearance.animation.elementMoveEnter.duration
+                    enterEasingCurve: Appearance.animation.elementMoveEnter.bezierCurve
+                    exitDuration: Appearance.animation.elementMoveExit.duration
+                    exitEasingCurve: Appearance.animation.elementMoveExit.bezierCurve
 
-                        sourceComponent: PluginWidget {
-                            manifest: pluginLoader.modelData
-                            screenName: bgRoot.screen.name
-                            screenWidth: bgRoot.screen.width
-                            screenHeight: bgRoot.screen.height
-                            scaledScreenWidth: bgRoot.screen.width
-                            scaledScreenHeight: bgRoot.screen.height
-                            wallpaperScale: 1
-                            // Use the exact source resolved by this background,
-                            // including lock wallpaper and video thumbnails.
-                            wallpaperPath: bgRoot.wallpaperPath
-                            wallpaperSafetyTriggered: bgRoot.wallpaperSafetyTriggered
-                            // Live surface for in-shell "blur" frost. During lock
-                            // and the lock<->WE peel, frost against the peel itself
-                            // so it tracks the exact lock background (avoids the WE
-                            // flashing through the frost before the unlock peel
-                            // catches up). Otherwise the live WE, or null (=> static
-                            // image path) when no WE is active.
-                            weSurfaceItem: (bgRoot.lockWallShown || lockPeelTimer.running)
-                                ? lockPeel
-                                : (bgRoot.weShown ? weLoader.item : null)
-                        }
+                    sourceComponent: PluginWidget {
+                        manifest: pluginLoader.modelData
+                        screenName: bgRoot.screen.name
+                        screenWidth: bgRoot.screen.width
+                        screenHeight: bgRoot.screen.height
+                        scaledScreenWidth: bgRoot.screen.width
+                        scaledScreenHeight: bgRoot.screen.height
+                        wallpaperScale: 1
+                        // Use the exact source resolved by this background,
+                        // including lock wallpaper and video thumbnails.
+                        wallpaperPath: bgRoot.wallpaperPath
+                        wallpaperSafetyTriggered: bgRoot.wallpaperSafetyTriggered
+                        // Live surface for in-shell "blur" frost. During lock
+                        // and the lock<->WE peel, frost against the peel itself
+                        // so it tracks the exact lock background (avoids the WE
+                        // flashing through the frost before the unlock peel
+                        // catches up). Otherwise the live WE, or null (=> static
+                        // image path) when no WE is active.
+                        weSurfaceItem: (bgRoot.lockWallShown || lockPeelTimer.running)
+                            ? lockPeel
+                            : (bgRoot.weShown ? weLoader.item : null)
                     }
                 }
             }
+        }
 
-            MouseArea {
-                id: desktopRightClickArea
-                anchors.fill: parent
-                z: -2
-                acceptedButtons: Qt.RightButton
-                onClicked: (mouse) => {
-                    GlobalStates.desktopMenuScreen = bgRoot.screen
-                    GlobalStates.desktopMenuX = mouse.x
-                    GlobalStates.desktopMenuY = mouse.y
-                    GlobalStates.desktopMenuOpen = true
-                }
+        MouseArea {
+            id: desktopRightClickArea
+            // Kept off while the contents are suppressed, which the removed
+            // wrapper used to do for it: a right-click desktop menu opening
+            // behind a fullscreen window is not a desktop the user can see.
+            visible: !bgRoot.suppressContents
+            anchors.fill: parent
+            z: -2
+            acceptedButtons: Qt.RightButton
+            onClicked: (mouse) => {
+                GlobalStates.desktopMenuScreen = bgRoot.screen
+                GlobalStates.desktopMenuX = mouse.x
+                GlobalStates.desktopMenuY = mouse.y
+                GlobalStates.desktopMenuOpen = true
             }
         }
     }

--- a/dots/.config/quickshell/imi/modules/imi/settings/pages/BackgroundConfig.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/pages/BackgroundConfig.qml
@@ -224,6 +224,89 @@ ContentPage {
             }
         
             ContentSubsection {
+                title: Translation.tr("Parallax")
+                Layout.fillWidth: true
+
+                GroupedList {
+                    ConfigSwitch {
+                        Layout.fillWidth: true
+                        buttonIcon: "animation"
+                        text: Translation.tr("Enable")
+                        checked: Config.options.background.parallax.enable
+                        onClicked: {
+                            Config.options.background.parallax.enable = !Config.options.background.parallax.enable;
+                        }
+                    }
+                    ConfigSpinBox {
+                        Layout.fillWidth: true
+                        enabled: Config.options.background.parallax.enable
+                        text: Translation.tr("Zoom (%)")
+                        // The zoom IS the room the pan happens in: at 100% the
+                        // wallpaper is exactly screen-sized and every switch
+                        // below it does nothing, so the floor is 100 rather
+                        // than something that silently disables the feature.
+                        from: 100
+                        to: 150
+                        stepSize: 1
+                        value: Math.round(Config.options.background.parallax.workspaceZoom * 100)
+                        onValueModified: newValue => {
+                            Config.options.background.parallax.workspaceZoom = newValue / 100;
+                        }
+                    }
+                    ConfigSwitch {
+                        Layout.fillWidth: true
+                        buttonIcon: "view_carousel"
+                        enabled: Config.options.background.parallax.enable
+                        text: Translation.tr("Follow workspaces")
+                        checked: Config.options.background.parallax.enableWorkspace
+                        onClicked: {
+                            Config.options.background.parallax.enableWorkspace = !Config.options.background.parallax.enableWorkspace;
+                        }
+                    }
+                    ConfigSwitch {
+                        Layout.fillWidth: true
+                        buttonIcon: "dock_to_right"
+                        enabled: Config.options.background.parallax.enable
+                        text: Translation.tr("Follow sidebars")
+                        checked: Config.options.background.parallax.enableSidebar
+                        onClicked: {
+                            Config.options.background.parallax.enableSidebar = !Config.options.background.parallax.enableSidebar;
+                        }
+                    }
+                    ConfigSwitch {
+                        Layout.fillWidth: true
+                        buttonIcon: "widgets"
+                        enabled: Config.options.background.parallax.enable
+                        text: Translation.tr("Move desktop widgets")
+                        checked: Config.options.background.parallax.enableWidgets
+                        onClicked: {
+                            Config.options.background.parallax.enableWidgets = !Config.options.background.parallax.enableWidgets;
+                        }
+                    }
+                    ConfigSwitch {
+                        Layout.fillWidth: true
+                        buttonIcon: "swap_vert"
+                        enabled: Config.options.background.parallax.enable
+                        text: Translation.tr("Pan vertically")
+                        checked: Config.options.background.parallax.vertical
+                        onClicked: {
+                            Config.options.background.parallax.vertical = !Config.options.background.parallax.vertical;
+                        }
+                    }
+                    ConfigSwitch {
+                        Layout.fillWidth: true
+                        buttonIcon: "auto_awesome"
+                        enabled: Config.options.background.parallax.enable && !Config.options.background.parallax.vertical
+                        text: Translation.tr("Pan vertically on portrait wallpapers")
+                        checked: Config.options.background.parallax.autoVertical
+                        onClicked: {
+                            Config.options.background.parallax.autoVertical = !Config.options.background.parallax.autoVertical;
+                        }
+                    }
+                }
+            }
+
+            ContentSubsection {
                 title: Translation.tr("Centered wallpaper")
                 Layout.fillWidth: true
 

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -237,6 +237,12 @@ if ! python3 "$SCRIPT_DIR/test_tmux_dots.py"; then
     exit 1
 fi
 
+echo "Running parallax migration runtime tests..."
+if ! python3 "$SCRIPT_DIR/test_parallax_migration_runtime.py"; then
+    echo "Parallax migration runtime tests failed."
+    exit 1
+fi
+
 echo "Running Prism Launcher instance tests..."
 if ! python3 "$SCRIPT_DIR/test_prism_instances.py"; then
     echo "Prism Launcher instance tests failed."

--- a/dots/.config/quickshell/imi/tests/test_parallax_migration_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_parallax_migration_runtime.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""The one-shot parallax revival, against a real config.json.
+
+Wallpaper parallax was config-only for this shell's whole life: the knobs came
+over from dots-hyprland but the code reading them left with the ii->pC theme
+swap, so nothing has consumed them since. Every value an existing config
+carries therefore predates the feature doing anything - it was never possible
+to see what it did - and reviving the effect against those values would ship it
+switched off for everyone who has ever written a config, which is everyone.
+
+None of that is reachable from a unit test. The failure lives in the merge: the
+QML defaults say true, the stored config says false, and the adapter's answer
+is the one the shell runs on. So this launches a real shell against a seeded
+throwaway config directory and reads the file back afterwards.
+
+Needs a Wayland session and `qs` on PATH, so it skips in CI the same way the
+other runtime harnesses do.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HARNESS = ROOT / "ParallaxMigrationRuntimeTest.qml"
+SHIPPED_DEFAULT = ROOT / "defaults/config.json"
+
+# A zoom nobody would pick by accident, so its survival is unambiguous.
+TUNED_ZOOM = 1.42
+
+
+def _runtime_available():
+    return bool(os.environ.get("WAYLAND_DISPLAY")) and shutil.which("qs") is not None
+
+
+@unittest.skipUnless(_runtime_available(),
+                     "needs a Wayland session and qs on PATH")
+class ParallaxMigrationRuntimeTest(unittest.TestCase):
+    def setUp(self):
+        self.home = Path(tempfile.mkdtemp(prefix="imi-parallax-runtime-"))
+        self.addCleanup(shutil.rmtree, self.home, ignore_errors=True)
+        self.config_home = self.home / "config"
+        self.shell_config = self.config_home / "immaterial-impulse"
+        self.shell_config.mkdir(parents=True)
+
+    @property
+    def config_file(self):
+        return self.shell_config / "config.json"
+
+    def seed(self, parallax):
+        config = json.loads(SHIPPED_DEFAULT.read_text())
+        # Keep the other migrations out of this one's way.
+        config["migratedUpstreamSchema"] = True
+        config.setdefault("background", {})["parallax"] = parallax
+        self.config_file.write_text(json.dumps(config, indent=2))
+
+    def launch(self, expected):
+        env = dict(os.environ)
+        env["XDG_CONFIG_HOME"] = str(self.config_home)
+        env["XDG_STATE_HOME"] = str(self.home / "state")
+        env["XDG_CACHE_HOME"] = str(self.home / "cache")
+        env["XDG_DATA_HOME"] = str(self.home / "data")
+        env["PARALLAX_EXPECT"] = expected
+        proc = subprocess.run(["qs", "-p", str(HARNESS)], cwd=str(ROOT), env=env,
+                              capture_output=True, text=True, timeout=180)
+        output = proc.stdout + proc.stderr
+        failed = [line for line in output.splitlines() if "FAIL" in line]
+        self.assertEqual(failed, [], f"harness reported failures:\n{output}")
+        self.assertIn("[Parallax] failures: 0", output,
+                      f"harness did not finish cleanly:\n{output}")
+        return output
+
+    def stored(self):
+        return json.loads(self.config_file.read_text())["background"]["parallax"]
+
+    def test_dead_era_switches_are_turned_back_on(self):
+        # Exactly the shape found on the author's machine: every switch off,
+        # a hand-tuned zoom, and no marker.
+        self.seed({
+            "vertical": False,
+            "autoVertical": False,
+            "enableWorkspace": False,
+            "enableSidebar": False,
+            "workspaceZoom": TUNED_ZOOM,
+            "widgetsFactor": 1.2,
+        })
+        self.launch("on")
+        stored = self.stored()
+        self.assertTrue(stored["enableWorkspace"])
+        self.assertTrue(stored["enableSidebar"])
+        self.assertTrue(stored["enable"])
+        self.assertTrue(stored["migratedFromDeadCode"])
+
+    def test_a_tuned_zoom_is_never_reset(self):
+        # The switches are leftovers; the numbers might not be. A zoom cannot
+        # turn the effect off on its own, so there is no reason to touch it.
+        self.seed({
+            "enableWorkspace": False,
+            "workspaceZoom": TUNED_ZOOM,
+            "widgetsFactor": 1.2,
+        })
+        self.launch("on")
+        self.assertAlmostEqual(self.stored()["workspaceZoom"], TUNED_ZOOM, places=3)
+
+    def test_a_deliberate_off_survives_once_the_marker_is_set(self):
+        # After the migration has run, "off" is a real preference and must
+        # stick - otherwise every launch overrides the user.
+        self.seed({
+            "enable": False,
+            "enableWorkspace": False,
+            "enableSidebar": False,
+            "enableWidgets": False,
+            "workspaceZoom": TUNED_ZOOM,
+            "widgetsFactor": 1.2,
+            "migratedFromDeadCode": True,
+        })
+        self.launch("off")
+        stored = self.stored()
+        self.assertFalse(stored["enable"])
+        self.assertFalse(stored["enableWorkspace"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dots/.config/quickshell/imi/tests/tst_parallax.qml
+++ b/dots/.config/quickshell/imi/tests/tst_parallax.qml
@@ -1,0 +1,179 @@
+import QtTest
+import "../modules/common/functions/parallax.js" as Parallax
+
+// The wallpaper parallax maths, kept out of Background.qml so it can be tested
+// without a compositor. Background.qml only feeds live state in and applies the
+// pixel offsets it gets back - every decision about WHERE the wallpaper sits is
+// made here.
+//
+// The effect is one pan across an overscanned wallpaper: the picture is drawn
+// larger than the screen, and these fractions choose which part of the overflow
+// is on screen. 0 is the left/top edge of the picture, 1 the right/bottom, 0.5
+// centred (which is also the neutral position when nothing is driving an axis).
+TestCase {
+    name: "ParallaxTest"
+
+    function baseState(overrides) {
+        const state = {
+            workspaceIndex: 0,
+            totalWorkspaces: 10,
+            vertical: false,
+            enableWorkspace: true,
+            enableSidebar: true,
+            sidebarLeftOpen: false,
+            sidebarRightOpen: false,
+            sidebarFraction: 0.05,
+            overflowX: 500,
+            overflowY: 200
+        };
+        for (const key in overrides)
+            state[key] = overrides[key];
+        return state;
+    }
+
+    // --- Workspace parallax ------------------------------------------------
+
+    function test_first_workspace_sits_at_the_start_of_the_picture() {
+        compare(Parallax.fractions(baseState({workspaceIndex: 0})).x, 0);
+    }
+
+    function test_last_workspace_sits_at_the_end_of_the_picture() {
+        compare(Parallax.fractions(baseState({workspaceIndex: 9})).x, 1);
+    }
+
+    function test_middle_workspace_is_proportional() {
+        // 5 of 10 workspaces -> 5/9 of the way across, not 0.5: the pan runs
+        // between workspace centres, so the last workspace can reach the edge.
+        const f = Parallax.fractions(baseState({workspaceIndex: 5})).x;
+        fuzzyCompare(f, 5 / 9, 0.0001);
+    }
+
+    function test_a_single_workspace_stays_centred() {
+        // Nothing to pan across; dividing by (total - 1) would be a divide by
+        // zero and put the wallpaper at NaN, which renders as nothing at all.
+        compare(Parallax.fractions(baseState({totalWorkspaces: 1})).x, 0.5);
+    }
+
+    function test_workspace_parallax_off_leaves_the_axis_centred() {
+        const f = Parallax.fractions(baseState({workspaceIndex: 9, enableWorkspace: false}));
+        compare(f.x, 0.5);
+    }
+
+    function test_workspace_index_beyond_the_count_is_clamped() {
+        // Hyprland IDs can exceed the shown chunk (workspace 12 of 10 shown).
+        compare(Parallax.fractions(baseState({workspaceIndex: 30})).x, 1);
+    }
+
+    function test_negative_workspace_index_is_clamped() {
+        compare(Parallax.fractions(baseState({workspaceIndex: -3})).x, 0);
+    }
+
+    // --- Sidebar parallax --------------------------------------------------
+
+    function test_right_sidebar_pushes_the_view_right() {
+        const closed = Parallax.fractions(baseState({workspaceIndex: 4})).x;
+        const open = Parallax.fractions(baseState({workspaceIndex: 4, sidebarRightOpen: true})).x;
+        verify(open > closed);
+        fuzzyCompare(open - closed, 0.05, 0.0001);
+    }
+
+    function test_left_sidebar_pushes_the_view_left() {
+        const closed = Parallax.fractions(baseState({workspaceIndex: 4})).x;
+        const open = Parallax.fractions(baseState({workspaceIndex: 4, sidebarLeftOpen: true})).x;
+        verify(open < closed);
+        fuzzyCompare(closed - open, 0.05, 0.0001);
+    }
+
+    function test_both_sidebars_open_cancel_out() {
+        const neither = Parallax.fractions(baseState({workspaceIndex: 4})).x;
+        const both = Parallax.fractions(baseState({
+            workspaceIndex: 4, sidebarLeftOpen: true, sidebarRightOpen: true})).x;
+        fuzzyCompare(both, neither, 0.0001);
+    }
+
+    function test_sidebar_nudge_alone_moves_a_centred_wallpaper() {
+        // With workspace parallax off, the sidebars are still a reason to move:
+        // this is what makes the effect visible to someone using one workspace.
+        const f = Parallax.fractions(baseState({
+            enableWorkspace: false, sidebarRightOpen: true})).x;
+        fuzzyCompare(f, 0.55, 0.0001);
+    }
+
+    function test_sidebar_parallax_off_ignores_open_sidebars() {
+        const f = Parallax.fractions(baseState({
+            workspaceIndex: 4, enableSidebar: false, sidebarRightOpen: true})).x;
+        fuzzyCompare(f, Parallax.fractions(baseState({workspaceIndex: 4})).x, 0.0001);
+    }
+
+    function test_sidebar_nudge_cannot_push_past_the_edge() {
+        // At the last workspace the view is already at the far edge; a further
+        // nudge must clamp rather than expose the void beyond the picture.
+        const f = Parallax.fractions(baseState({
+            workspaceIndex: 9, sidebarRightOpen: true})).x;
+        compare(f, 1);
+    }
+
+    // --- Vertical parallax -------------------------------------------------
+
+    function test_vertical_mode_moves_the_workspace_pan_to_the_y_axis() {
+        const f = Parallax.fractions(baseState({workspaceIndex: 9, vertical: true}));
+        compare(f.y, 1);
+        // X stops tracking workspaces, but sidebars still live on X - they are
+        // horizontal surfaces whichever way the workspaces pan.
+        compare(f.x, 0.5);
+    }
+
+    function test_vertical_mode_still_honours_the_sidebars_horizontally() {
+        const f = Parallax.fractions(baseState({
+            workspaceIndex: 9, vertical: true, sidebarRightOpen: true}));
+        fuzzyCompare(f.x, 0.55, 0.0001);
+        compare(f.y, 1);
+    }
+
+    function test_horizontal_mode_leaves_y_centred() {
+        compare(Parallax.fractions(baseState({workspaceIndex: 9})).y, 0.5);
+    }
+
+    // --- Pixel offsets -----------------------------------------------------
+
+    function test_offsets_are_negative_because_the_picture_slides_left() {
+        // The container is larger than the screen and slides under it, so a
+        // fraction of 1 means "shifted fully left/up", i.e. negative.
+        const o = Parallax.offsets(baseState({workspaceIndex: 9}));
+        compare(o.x, -500);
+        compare(o.y, -100); // y centred: half of 200
+    }
+
+    function test_no_overflow_means_no_movement() {
+        // zoom 1.0 leaves nothing to pan across. Every fraction must still map
+        // to 0 rather than NaN, or the wallpaper vanishes on a default config.
+        const o = Parallax.offsets(baseState({workspaceIndex: 9, overflowX: 0, overflowY: 0}));
+        compare(o.x, 0);
+        compare(o.y, 0);
+    }
+
+    function test_widget_offset_scales_the_wallpaper_offset() {
+        // Widgets travel further than the wallpaper (factor > 1), which is what
+        // reads as depth rather than as the widgets being glued to the picture.
+        compare(Parallax.widgetOffset(-500, 1.2), -600);
+        compare(Parallax.widgetOffset(-500, 0), 0);
+    }
+
+    function test_widget_offset_is_zero_when_the_wallpaper_has_not_moved() {
+        compare(Parallax.widgetOffset(0, 1.2), 0);
+    }
+
+    // --- Guards ------------------------------------------------------------
+
+    function test_missing_state_does_not_produce_nan() {
+        // Config reads can arrive undefined during startup, before Config.ready.
+        // A NaN here propagates into x/y and the wallpaper disappears, so every
+        // field falls back rather than trusting the caller.
+        const f = Parallax.fractions({});
+        verify(!isNaN(f.x));
+        verify(!isNaN(f.y));
+        const o = Parallax.offsets({});
+        compare(o.x, 0);
+        compare(o.y, 0);
+    }
+}


### PR DESCRIPTION
All four effects asked for: **workspace**, **sidebar**, **widget** and **vertical** parallax — working for static wallpapers and Wallpaper Engine alike.

## Why it was dead

Worth stating, since the repo's rule is to find out why something went before putting it back. Parallax wasn't removed on purpose: the knobs came over from dots-hyprland and their consumer lived in the `ii` theme's `Background.qml`, which `bb6e174be` ("Supersede dots-hyprland ii with the pC theme") replaced wholesale. The config survived, the code didn't. No prior decision argues against reviving it.

## How it works

One viewport, not a per-layer effect. Every wallpaper layer is drawn inside `parallaxViewport`, sized to `screen × zoom`, and that item's `x`/`y` are the effect. That single choice is why **Wallpaper Engine parallaxes at all** — the WE surface, the frozen switch stills and the peel shaders are all `anchors.fill` inside the same item, so they pan together and a cross-fade still lines up mid-pan. No layer needed teaching about parallax individually.

Sizing is screen-derived, not wallpaper-derived: a live WE project reports no intrinsic size, and `PreserveAspectCrop` already covers a still, so one rule serves both and the zoom means the same thing either way. At zoom 1 the viewport is exactly screen-sized at 0,0 — the feature collapses to the old geometry rather than to a special case.

The maths lives in `modules/common/functions/parallax.js` so it can be tested without a compositor. Parallax is off while locked (the lock screen has its own framing and blur zoom).

## The part that would have shipped it broken

Every existing `config.json` already carries these knobs — and since nothing has ever read them, whatever they hold is a leftover, not a preference. On my machine **every switch was `false`** with a hand-tuned zoom of 1.07. Turning the code back on against that ships the feature silently dead for everyone who has ever written a config, which is everyone. No unit test sees this: the QML default says true, the stored config says false, and the adapter's answer is what runs.

So there's a one-shot migration with a marker (a later deliberate "off" sticks), resetting only the switches — `workspaceZoom` and `widgetsFactor` are numbers someone could plausibly have tuned and neither can disable the effect alone.

## Verification

- 23 unit tests on the maths: the pan divides by `total - 1` so the last workspace reaches the edge, single-workspace and zero-overflow cases stay centred instead of going NaN, sidebar nudges cancel and clamp, vertical mode moves workspaces to Y while leaving sidebars on X. Proven able to fail — dividing by `total` instead trips five of them.
- 3 runtime tests launching a real shell against a seeded config directory: dead-era switches revived, tuned zoom untouched, deliberate off preserved after the marker.
- Live load of `Background.qml` clean (`Configuration Loaded`, no `ERROR`, no `WARN scene`) — which is how I caught two real bugs the green suite didn't: a forward `id` reference that silently resolved to nothing, and a duplicate `onStatusChanged`.
- Geometry measured end to end against real Hyprland state at 5120×1440, zoom 1.1: viewport 5632×1584, overflow 512×144, workspace 0 → offset 0, workspace 5 → −512, right sidebar → −64 (= 0.5 of a workspace step with 5 shown).

Full suite green, 337 tests.

**What I can't verify from here is how it feels.** The numbers are right; whether 1.1 zoom and the 600ms trail read well on your desktop is a judgement call — both are one-line changes if it's too much or too little.

Docs: updated AGENT.md (the viewport rule for future wallpaper layers, and the general trap of reviving config-only features) plus CHANGELOG under Unreleased.