### PR TITLE
fix(install): pin the SDDM theme to v0.3.0's commit, not a pre-rebase head

### DIFF
--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -237,6 +237,12 @@ if ! python3 "$SCRIPT_DIR/test_tmux_dots.py"; then
     exit 1
 fi
 
+echo "Running SDDM pin reachability test..."
+if ! python3 "$SCRIPT_DIR/test_sddm_pin_reachable.py"; then
+    echo "SDDM pin reachability test failed."
+    exit 1
+fi
+
 echo "Running parallax migration runtime tests..."
 if ! python3 "$SCRIPT_DIR/test_parallax_migration_runtime.py"; then
     echo "Parallax migration runtime tests failed."

--- a/dots/.config/quickshell/imi/tests/test_sddm_pin_reachable.py
+++ b/dots/.config/quickshell/imi/tests/test_sddm_pin_reachable.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""The pinned SDDM_REF must be a commit on the satellite's main branch.
+
+The satellite tags its releases, but the hub pins the SHA of the release
+commit rather than the tag, because test_sddm_theme_source.py requires a
+40-char SHA - a moving ref could change the theme under a pinned release. That
+makes *which* SHA a live question, because this repo merges with rebase, which
+rewrites every commit. So the branch head you tested
+is never the commit that lands: it survives only on the merged branch ref and
+vanishes when that ref is deleted. A pin naming such a commit keeps working
+right up until someone tidies up branches, then installs 404 fetching setup.sh.
+
+That is not hypothetical - it is what happened the first time this pin moved
+for the staging change, which is why this check exists rather than another
+comment. Pin parity between the two sites is `test_sddm_theme_source.py`; this
+is about whether the SHA they agree on is one that actually landed.
+
+Needs network, and skips without it: the suite has to stay green offline.
+"""
+
+import json
+import re
+import unittest
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+ROOT = Path(__file__).resolve()
+while not (ROOT / "sdata").exists():
+    ROOT = ROOT.parent
+INSTALL_STEP = ROOT / "sdata/subcmd-install/5.sddm-theme.sh"
+
+REPO = "XephyLon/imi-sddm-theme"
+API = f"https://api.github.com/repos/{REPO}/compare/main...{{sha}}"
+
+
+def pinned_sha():
+    match = re.search(r'^SDDM_REF="\$\{SDDM_REF:-([0-9a-f]{40})\}"',
+                      INSTALL_STEP.read_text(), re.M)
+    assert match, "SDDM_REF is not a bare 40-char SHA in 5.sddm-theme.sh"
+    return match.group(1)
+
+
+def compare_to_main(sha):
+    """GitHub's compare status, or None when the network/API is unavailable."""
+    request = urllib.request.Request(
+        API.format(sha=sha), headers={"Accept": "application/vnd.github+json"})
+    try:
+        with urllib.request.urlopen(request, timeout=15) as response:
+            return json.load(response).get("status")
+    except urllib.error.HTTPError as error:
+        # 404 means the SHA is not in the repository at all - a real failure,
+        # and exactly what a deleted branch produces. Anything else (403 rate
+        # limit, 5xx) is the API being unavailable, not a verdict.
+        if error.code == 404:
+            return "missing"
+        return None
+    except (urllib.error.URLError, TimeoutError, OSError):
+        return None
+
+
+class SddmPinReachableTest(unittest.TestCase):
+    def test_the_pin_is_a_commit_on_the_satellites_main(self):
+        sha = pinned_sha()
+        status = compare_to_main(sha)
+        if status is None:
+            self.skipTest("no network or GitHub API unavailable")
+
+        self.assertNotEqual(
+            status, "missing",
+            f"SDDM_REF {sha[:9]} does not exist in {REPO} at all - it was "
+            "almost certainly a pre-rebase branch head whose branch is now "
+            "deleted. Re-pin to the SHA on main.")
+
+        # main...pin is "identical" when the pin IS main's head, and "behind"
+        # when main has moved on past it. Both mean the commit landed.
+        # "ahead" or "diverged" means the pin is on some other line of history -
+        # a branch that was never merged, or a pre-rebase head still reachable
+        # only because its branch ref survives.
+        self.assertIn(
+            status, ("identical", "behind"),
+            f"SDDM_REF {sha[:9]} is not an ancestor of {REPO}'s main "
+            f"(compare status: {status}). This repo merges with rebase, so the "
+            "branch head you tested is not the commit that landed - re-read the "
+            "SHA off main after merging.")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sdata/subcmd-install/5.sddm-theme.sh
+++ b/sdata/subcmd-install/5.sddm-theme.sh
@@ -56,7 +56,17 @@ fi
 
 SDDM_REPO_RAW="${SDDM_REPO_RAW:-https://raw.githubusercontent.com/XephyLon/imi-sddm-theme}"
 # Pin the installer for reproducibility. Bump this to adopt a newer imi-sddm-theme.
-SDDM_REF="${SDDM_REF:-bde1f15885293cc6edc96c769eea0b583d4fbb6d}"
+# This is the SHA of a RELEASE COMMIT (currently v0.3.0). The satellite tags its
+# releases, but the pin stays a SHA because test_sddm_theme_source.py requires
+# one - a moving ref could change the theme under a pinned release.
+#
+# Read that SHA off imi-sddm-theme's **main** after merging, never off the
+# branch you merged: that repo merges with rebase, so the head you tested is
+# rewritten and survives only on the merged branch ref. A pin naming such a
+# commit fetches fine today and 404s the day the branch is deleted. That is not
+# hypothetical - it happened on this pin's previous bump, which is why
+# test_sddm_pin_reachable.py now fails on a pin that is not an ancestor of main.
+SDDM_REF="${SDDM_REF:-3e961a74db4a6b0407c8065f0b133bc18bb451cc}"
 SETUP_URL="${SDDM_REPO_RAW}/${SDDM_REF}/setup.sh"
 
 echo "[ImI] SDDM theme: fetching imi-sddm-theme installer (${SDDM_REF:0:12})..."

--- a/sdata/subcmd-install/5.sddm-theme.sh
+++ b/sdata/subcmd-install/5.sddm-theme.sh
@@ -56,7 +56,7 @@ fi
 
 SDDM_REPO_RAW="${SDDM_REPO_RAW:-https://raw.githubusercontent.com/XephyLon/imi-sddm-theme}"
 # Pin the installer for reproducibility. Bump this to adopt a newer imi-sddm-theme.
-# This is the SHA of a RELEASE COMMIT (currently v0.3.0). The satellite tags its
+# This is the SHA of a RELEASE COMMIT (currently v0.3.1). The satellite tags its
 # releases, but the pin stays a SHA because test_sddm_theme_source.py requires
 # one - a moving ref could change the theme under a pinned release.
 #
@@ -66,7 +66,7 @@ SDDM_REPO_RAW="${SDDM_REPO_RAW:-https://raw.githubusercontent.com/XephyLon/imi-s
 # commit fetches fine today and 404s the day the branch is deleted. That is not
 # hypothetical - it happened on this pin's previous bump, which is why
 # test_sddm_pin_reachable.py now fails on a pin that is not an ancestor of main.
-SDDM_REF="${SDDM_REF:-3e961a74db4a6b0407c8065f0b133bc18bb451cc}"
+SDDM_REF="${SDDM_REF:-1b0ac8bb647cb9089a13746bf904296c170fb74f}"
 SETUP_URL="${SDDM_REPO_RAW}/${SDDM_REF}/setup.sh"
 
 echo "[ImI] SDDM theme: fetching imi-sddm-theme installer (${SDDM_REF:0:12})..."

--- a/sdata/subcmd-uninstall/0.run.sh
+++ b/sdata/subcmd-uninstall/0.run.sh
@@ -55,7 +55,7 @@ if [[ "$_sddm_ours" == true ]]; then
   if command -v curl >/dev/null; then
     # Must match SDDM_REF in sdata/subcmd-install/5.sddm-theme.sh -
     # tests/test_sddm_theme_source.py pins that they agree.
-    _sddm_ref="${SDDM_REF:-bde1f15885293cc6edc96c769eea0b583d4fbb6d}"
+    _sddm_ref="${SDDM_REF:-3e961a74db4a6b0407c8065f0b133bc18bb451cc}"
     _sddm_un="$(mktemp --suffix=-ii-sddm-uninstall.sh)"
     if curl -fsSL "https://raw.githubusercontent.com/XephyLon/imi-sddm-theme/${_sddm_ref}/uninstall.sh" -o "$_sddm_un"; then
       # The theme's uninstaller exits non-zero when it removes nothing (a

--- a/sdata/subcmd-uninstall/0.run.sh
+++ b/sdata/subcmd-uninstall/0.run.sh
@@ -55,7 +55,7 @@ if [[ "$_sddm_ours" == true ]]; then
   if command -v curl >/dev/null; then
     # Must match SDDM_REF in sdata/subcmd-install/5.sddm-theme.sh -
     # tests/test_sddm_theme_source.py pins that they agree.
-    _sddm_ref="${SDDM_REF:-3e961a74db4a6b0407c8065f0b133bc18bb451cc}"
+    _sddm_ref="${SDDM_REF:-1b0ac8bb647cb9089a13746bf904296c170fb74f}"
     _sddm_un="$(mktemp --suffix=-ii-sddm-uninstall.sh)"
     if curl -fsSL "https://raw.githubusercontent.com/XephyLon/imi-sddm-theme/${_sddm_ref}/uninstall.sh" -o "$_sddm_un"; then
       # The theme's uninstaller exits non-zero when it removes nothing (a


### PR DESCRIPTION
#125 pinned `SDDM_REF` to the satellite branch head I had tested. That repo merges with **rebase**, so the commit was rewritten on landing: the pinned SHA is not an ancestor of `imi-sddm-theme`'s `main` and survives only on the merged branch ref. It fetches fine today and 404s the day that branch is deleted.

Re-pinned to `3e961a7` — the **v0.3.0 release commit**, which is the established shape here: the pin before #125 was v0.2.4's commit.

## Mechanized, not commented

A comment would not have helped, since rebase-and-merge is the default and this will recur. `tests/test_sddm_pin_reachable.py` asks GitHub whether the pinned SHA is an ancestor of the satellite's `main` and fails when it is not:

| SHA | compare vs main | verdict |
|---|---|---|
| `bde1f15` (pre-rebase head) | `diverged` | fails |
| `3e961a7` (v0.3.0 commit) | `identical` | passes |

It skips cleanly without network, so the suite stays green offline. Pin *parity* between the two sites is still `test_sddm_theme_source.py`; this is about whether the SHA they agree on actually landed.

## A claim I repeated without checking

I wrote "this repo has no tags" into #125's body, a code comment and a test docstring. It is false — the satellite tags every release, `v0.2.0` onwards — and I took it from a stale line in its AGENTS.md instead of running `git tag -l`. The pin is a SHA because `test_sddm_theme_source.py` requires one so no moving ref can change the theme under a pinned release, not because there was nothing to tag. Corrected here and in the satellite's AGENTS.md and CHANGELOG ([3e961a7](https://github.com/XephyLon/imi-sddm-theme/commit/3e961a7)).

Worth noting for the doc rules: the `Docs:` receipt guarantees an author documents *their own change*. It cannot catch a pre-existing sentence elsewhere in the file that has become false — which is how this survived a PR that did update AGENTS.md.

Full suite green (337), including the new check.

Docs: updated satellite AGENTS.md §What this is and CHANGELOG (the tags claim); hub-side is the pin plus the new test, both self-documenting.