### PR TITLE
Complete the cheatsheet, and stop the compositor frosting drop shadows

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -632,6 +632,56 @@ Two non-obvious behaviors have bitten this codebase before and are worth knowing
   rather than reached into. Both halves are silent when only one lands: a region without the layer
   rule changes nothing at all, and the layer rule without a region leaves that panel with no blur
   whatsoever. `tests/lint_blur_region_pairing.py` pins the two together.
+- **That whole mechanism applies to layer surfaces only, and a `PopupWindow` is not one.** An
+  `ext-background-effect` region is attached to a layer surface; the tray menu, the dock context
+  menu, the drag-apps popup and the tooltips are xdg-popups, so a `WindowBlurRegion` published from
+  one is accepted and silently does nothing. Popups also carry no namespace of their own - they
+  inherit the rules of the surface they belong to, so the only knob addressed at them is
+  `blur_popups` on the parent's namespace, and turning that off costs the body its blur along with
+  the shadow. Threshold by `ignore_alpha` instead: `colShadow` tops out at 0.3 and fades outward
+  while a panel body sits at `1 - appearance.transparency.backgroundTransparency`, so a value
+  between them blurs one and not the other. Note the failure direction - too high a threshold
+  unblurs the *body*, which looks flat but harmless; too low re-frosts the shadow. Motivated by
+  4a1b4f850 ("fix(blur): stop the compositor frosting drop shadows"), where a region
+  was written, deployed and only shown to be inert by looking at it on screen; a region on a
+  `PopupWindow` now fails `tests/lint_blur_region_pairing.py`. The threshold itself is *generated*,
+  because where it falls moves with the user's transparency setting and a layerrule cannot read
+  one: `services/PopupBlurThreshold.qml` writes
+  `hypr/hyprland/shellOverrides/popupBlur.lua` and `rules.lua` `dofile`s it behind a `pcall` with a
+  fallback for the first run. That rule is applied only to namespaces whose own `blur` is already
+  off, so it reaches their popups and nothing else. Watch which way it fails: too high a threshold
+  unblurs the *body*, which is flat but harmless; too low re-frosts the shadow.
+- **`ignore_alpha` is one value per namespace, shared between a panel and its popups.** It is
+  tempting to raise it on a namespace whose own `blur` is off, on the reasoning that only its popups
+  can be affected. That is wrong: the panel's body is blurred *through the region*, and the region
+  is subject to `ignore_alpha` too, so raising it above the body's alpha unblurs the panel itself.
+  Doing exactly that took the blur off the bar, the dock and both sidebars at once. The threshold
+  has to clear the faintest *panel* body as well as sit above the shadow, and the bar is usually the
+  faintest because it thins `colLayer0` again by `bar.backgroundOpacity`. Motivated by 4a1b4f850
+  ("fix(blur): stop the compositor frosting drop shadows").
+- **`quickshell:popup` is already handled, and adding `blur = false` to it breaks it.** Its two
+  surfaces (`StyledPopupMenu`, `StyledPopup` - `PanelWindow`s despite the name) paint opaque bodies,
+  and the namespace carries `ignore_alpha = 1` from an older tooltip fix. That blurs the opaque body
+  and skips the translucent shadow, which is the whole split the region mechanism exists to produce.
+  Set `blur = false` there and the region becomes the only source of blur, which nothing reaches at
+  alpha 1, so those surfaces go flat.
+- **A blur region is published on the *timer* for panels built by a `LazyLoader`.**
+  `Component.onCompleted` publishes, but there is no layer surface yet at that moment, so the first
+  publish that takes effect is the settle timer's - which is a guaranteed ~96ms of surface-up-and-
+  unblurred on every open. Publish immediately *and* keep the timer. Motivated by 4a1b4f850
+  ("fix(blur): stop the compositor frosting drop shadows").
+- **This whole area is invisible to the test suite.** Quickshell's plugin does not load in
+  `qmltestrunner`, so `Region` cannot be constructed there and no test can see whether a region is
+  empty, published, or ignored. Every bug in this section was found by looking at the screen, and
+  two of them were misattributed first. Deploy, look, and prefer a frame-by-frame capture
+  (`ffmpeg -fps_mode passthrough`) over an impression for anything that lasts under ~200ms.
+- **A stored config value beats the QML default, so changing a default is invisible without a
+  migration.** `Config.qml` defaults only apply to keys that are absent from the user's
+  `config.json`, and every key the shell has ever written is present. Flipping a default therefore
+  changes nothing for anyone who has run the shell - which is a silent no-op, not an error. Pair it
+  with a one-shot migration guarded by its own `migrated*` flag, as `migrateDeadParallaxSwitches`
+  and `migrateSplitCheatsheetButtons` do. Motivated by 65bd7696a ("feat(cheatsheet): draw a chord as
+  one keycap per key").
 - **The region selector intentionally takes exclusive focus.** Dismissable panels normally close
   when `GlobalFocusGrab` is cleared, but the selector first sets
   `GlobalStates.settingsHeldForRegionSelector` so Settings can remain visible in screenshots without

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,36 @@ own repo; the installer pins which revision it builds.
 
 ## [Unreleased]
 
+### Added
+- **The cheatsheet lists every keybind, in columns.** It used to draw only the
+  groups that had sub-groups, silently dropping 28 of the 61 binds on this
+  machine's config, and stacked what was left into one tall column beside an
+  empty screen. Click any shortcut to reassign it: the editor warns before
+  taking a chord that is already in use, and closes itself after five seconds if
+  you opened it by accident.
+- Chords are drawn as one keycap per key, so `SUPER SHIFT ALT R` reads as four
+  keys held together rather than one key with a long name. Existing configs are
+  migrated once, since the old value was the shipped default and there is no
+  setting for it to have been chosen from.
+
+### Fixed
+- **Drop shadows are no longer frosted by the compositor's blur.** The
+  cheatsheet, notification popups, the desktop right-click menu and the tray
+  menu all drew a shadow that the whole-surface blur smeared into a band along
+  their edge — on the cheatsheet this read as having no shadow at all. Each now
+  scopes its blur to the painted body. Notification cards are handled one card
+  at a time so the gaps between them stay sharp. Popups — the tray menu, the
+  dock's context menu, the drag-apps sheet — cannot scope their blur that way at
+  all, so they threshold it by alpha instead, at a point the shell works out
+  from your transparency and bar-opacity settings and keeps up to date as you
+  change them.
+- **Panels no longer flash unblurred as they open.** Anything that opens on
+  demand — the overview, the search bar, the sidebars, the OSDs — showed about
+  a tenth of a second of sharp wallpaper before its blur arrived, because the
+  blur region was only published on a settle timer.
+- The desktop right-click menu and its submenu gained a card to sit on, which is
+  what lets them carry a shadow at all.
+
 ### Changed
 - **The login greeter no longer refreshes through root.** The SDDM theme pin
   moves to imi-sddm-theme v0.3.1, which publishes the greeter's colours,

--- a/dots/.config/hypr/hyprland/rules.lua
+++ b/dots/.config/hypr/hyprland/rules.lua
@@ -185,6 +185,42 @@ hl.layer_rule({ match = { namespace = "quickshell:dock" }, blur = false})
 -- overview itself). See WindowBlurRegion in OnScreenDisplay.qml / Overview.qml.
 hl.layer_rule({ match = { namespace = "quickshell:onScreenDisplay" }, blur = false})
 hl.layer_rule({ match = { namespace = "quickshell:overview" }, blur = false})
+-- The cheatsheet has drawn a StyledRectangularShadow all along; the
+-- whole-surface blur was frosting it, which is why the card read as having no
+-- shadow at all. See WindowBlurRegion in Cheatsheet.qml.
+hl.layer_rule({ match = { namespace = "quickshell:cheatsheet" }, blur = false})
+-- Notification popups: each card carries its own shadow, so the whole-surface
+-- blur frosted every one of them. The shell publishes a region per card
+-- instead, leaving the gaps between them unblurred. See WindowBlurRegion in
+-- NotificationPopup.qml.
+hl.layer_rule({ match = { namespace = "quickshell:notificationPopup" }, blur = false})
+-- The popups those surfaces open (the tray menu, the dock's context menu, the
+-- drag-apps sheet, every tooltip) draw shadows too, and blur_popups above
+-- frosts them the same way. The fix above does not reach them: an
+-- ext-background-effect region belongs to a layer surface, and a popup is an
+-- xdg-popup, so a region published from one is accepted and does nothing.
+-- Popups carry no namespace of their own either - they inherit their parent
+-- surface's rules, which is why this is keyed on the parents.
+--
+-- So threshold by alpha instead: below `ignore_alpha` a pixel is left
+-- unblurred, and the shadow and the body sit at different alphas. Where the
+-- line falls depends on the user's transparency setting, which a layerrule
+-- cannot read, so the shell computes it and writes it out - see
+-- services/PopupBlurThreshold.qml. The fallback covers the first run, before
+-- the shell has ever written the file.
+local ok, generated = pcall(dofile, os.getenv("HOME") .. "/.config/hypr/hyprland/shellOverrides/popupBlur.lua")
+local popup_blur_threshold = (ok and type(generated) == "number") and generated or 0.6
+
+-- Keyed on the parent surfaces. Their own bodies are blurred through a
+-- region, and a region is subject to ignore_alpha too, so the threshold has
+-- to stay below the faintest body among them as well as above the shadow -
+-- which is what PopupBlurThreshold computes. Getting that backwards unblurs
+-- the panels themselves.
+for _, ns in ipairs({ "quickshell:bar", "quickshell:verticalBar", "quickshell:dock",
+                      "quickshell:sidebarLeft", "quickshell:sidebarRight" }) do
+    hl.layer_rule({ match = { namespace = ns }, ignore_alpha = popup_blur_threshold })
+end
+
 hl.layer_rule({ match = { namespace = "quickshell:verticalBar" }, animation = "slide"})
 hl.layer_rule({ match = { namespace = "quickshell:osk" }, order = -1})
 -- Quickshell: waffles

--- a/dots/.config/quickshell/imi/modules/common/Config.qml
+++ b/dots/.config/quickshell/imi/modules/common/Config.qml
@@ -74,6 +74,18 @@ Singleton {
         root.setNestedValue("background.parallax.migratedFromDeadCode", true);
     }
 
+    // splitButtons shipped as false, so every existing config has a stored
+    // false that would beat the new default and leave chords drawn as one wide
+    // keycap. Nobody chose that value - there is no setting for it in the UI,
+    // so the only way to have set it deliberately is by hand, and this runs
+    // once either way.
+    function migrateSplitCheatsheetButtons() {
+        if (root.options.cheatsheet.migratedSplitButtons)
+            return;
+        root.setNestedValue("cheatsheet.splitButtons", true);
+        root.setNestedValue("cheatsheet.migratedSplitButtons", true);
+    }
+
     function migrateDesktopWidgetsToPlugins() {
         if (root.options.plugins.migratedDesktopWidgets)
             return;
@@ -426,6 +438,7 @@ Singleton {
             root.ready = true;
             root.clearStaleKbOptions();
             root.migrateDeadParallaxSwitches();
+            root.migrateSplitCheatsheetButtons();
             root.migrateDesktopWidgetsToPlugins();
             root.migrateDesktopWidgetOptionsToPlugins();
         }
@@ -749,7 +762,14 @@ Singleton {
                 // 10:  | 11:  | 12:  | 13:  | 14: 󱄛
                 property string superKey: ""
                 property bool useMacSymbol: false
-                property bool splitButtons: false
+                // One keycap per key. Off, a chord is drawn as a single wide
+                // keycap reading "SUPER SHIFT ALT R", which looks like one key
+                // with a long name rather than four keys held together.
+                property bool splitButtons: true
+                // Whether the stored config has been moved off the old default.
+                // Without this the change above is invisible to anyone who has
+                // ever run the shell, because a stored value beats a QML one.
+                property bool migratedSplitButtons: false
                 property bool useMouseSymbol: false
                 property bool useFnSymbol: false
                 property JsonObject fontSize: JsonObject {

--- a/dots/.config/quickshell/imi/modules/common/functions/cheatsheetLayout.js
+++ b/dots/.config/quickshell/imi/modules/common/functions/cheatsheetLayout.js
@@ -1,0 +1,83 @@
+.pragma library
+
+// Turning the parsed keybind tree into cheatsheet columns.
+//
+// Two jobs, and the first one is a bug fix. The renderer used to draw only a
+// group's `children`, so any group holding keybinds at its OWN level drew
+// nothing at all - on this machine that silently dropped 48 keybinds
+// (Utilities, Screen, Media, plus the tree root's own). `sections()` flattens
+// the tree into every node that actually has keybinds, so a group is rendered
+// for what it holds rather than for where it sits.
+//
+// The second is layout. Columns used to come from the tree's top-level
+// children, which is an authoring detail of keybinds.lua, not a layout
+// decision: it produced one tall column beside three-quarters of empty screen.
+// `balance()` packs the flattened sections into a chosen number of columns,
+// shortest-column-first, so the card grows sideways instead of downwards.
+
+// Every node carrying keybinds, depth-first, with its display name.
+//
+// A node with keybinds AND children yields its own section first, then its
+// children - that is the order they were authored in. Unnamed nodes (the tree
+// root, and the anonymous groups keybinds.lua uses purely for grouping) keep
+// their keybinds but contribute no heading, since inventing one would be
+// worse than the blank the author chose.
+function sections(node) {
+    const out = [];
+    if (!node) return out;
+
+    const keybinds = node.keybinds || [];
+    if (keybinds.length > 0) {
+        out.push({
+            name: node.name || "",
+            keybinds: keybinds,
+            // What the column packer measures. Rows plus a heading if there is
+            // one; the caller scales it by real row height.
+            weight: keybinds.length + (node.name ? 1 : 0)
+        });
+    }
+    for (const child of (node.children || [])) {
+        for (const section of sections(child)) out.push(section);
+    }
+    return out;
+}
+
+// Pack sections into `count` columns, keeping author order within a column.
+//
+// Shortest-column-first rather than an even split by index: sections vary from
+// 2 to 15 rows, so splitting by count alone leaves one column twice the height
+// of its neighbour. Greedy is not optimal packing, but it is stable - the same
+// input always produces the same layout, which matters more here than a
+// perfect balance nobody can perceive.
+function balance(sectionList, count) {
+    const columns = [];
+    const heights = [];
+    for (let i = 0; i < Math.max(1, count); i++) {
+        columns.push([]);
+        heights.push(0);
+    }
+    for (const section of (sectionList || [])) {
+        let target = 0;
+        for (let i = 1; i < heights.length; i++) {
+            if (heights[i] < heights[target]) target = i;
+        }
+        columns[target].push(section);
+        heights[target] += section.weight;
+    }
+    return columns;
+}
+
+// How many columns to ask for, given how much vertical room there is.
+//
+// Derived from the content rather than fixed: the point is to stop growing
+// downwards past the screen. Start at one column and add columns until the
+// tallest would fit, capped so a short keybind list does not fan out into
+// slivers.
+function columnCount(sectionList, availableRows, maxColumns) {
+    const list = sectionList || [];
+    if (list.length === 0) return 1;
+    const total = list.reduce((sum, section) => sum + section.weight, 0);
+    const rows = Math.max(1, availableRows || 1);
+    const cap = Math.max(1, Math.min(maxColumns || 4, list.length));
+    return Math.max(1, Math.min(cap, Math.ceil(total / rows)));
+}

--- a/dots/.config/quickshell/imi/modules/common/widgets/KeybindEditor.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/KeybindEditor.qml
@@ -46,8 +46,15 @@ ColumnLayout {
     readonly property bool chordChanged: capture.hasChord && root.bindingData !== null
         && HyprlandKeybindOverrides.identityFor(capture.mods, capture.key)
            !== HyprlandKeybindOverrides.identityFor(root.bindingData.mods, root.bindingData.key)
+    // Acknowledging a conflict is per-chord: capturing a different one has to
+    // re-ask, or a stale "yes" from an earlier attempt would carry over.
+    property string acknowledgedChord: ""
+    readonly property string capturedIdentity: capture.hasChord
+        ? HyprlandKeybindOverrides.identityFor(capture.mods, capture.key) : ""
+    readonly property bool conflictAcknowledged: root.conflicts.length === 0
+        || (root.capturedIdentity.length > 0 && root.acknowledgedChord === root.capturedIdentity)
     readonly property bool canApply: root.writable && root.chordChanged
-        && root.conflicts.length === 0
+        && root.conflictAcknowledged
         && (root.bindingData.editable || root.bindingData.added)
 
     function apply() {
@@ -161,6 +168,46 @@ ColumnLayout {
                 wrapMode: Text.Wrap
             }
         }
+
+        // A conflict used to disable Apply outright, which left no way to
+        // deliberately move a chord onto one already in use - and no
+        // explanation, just a dead button. It is a warning to confirm now.
+        // Hyprland keeps both binds; the shell cannot remove someone else's,
+        // so say what will actually happen rather than implying a swap.
+        ConfigSwitch {
+            id: conflictConfirm
+            Layout.fillWidth: true
+            visible: root.conflicts.length > 0
+            buttonIcon: "warning"
+            text: Translation.tr("Assign it anyway — both shortcuts will fire on this chord")
+            checked: root.acknowledgedChord === root.capturedIdentity
+            onClicked: {
+                root.acknowledgedChord = (root.acknowledgedChord === root.capturedIdentity)
+                    ? "" : root.capturedIdentity;
+            }
+        }
+    }
+
+    // Auto-cancel. A click on a chord row opens this, and a misclick on a dense
+    // list is easy - without a way out that costs nothing, the editor is a trap
+    // that has to be dismissed deliberately. Any interaction cancels the
+    // countdown: it only fires when the editor was opened and then ignored.
+    Timer {
+        id: idleCancel
+        interval: 5000
+        running: root.bindingData !== null && !capture.hasChord
+            && !capture.activeFocus && capture.pendingMods.length === 0
+        onTriggered: root.done()
+    }
+
+    StyledText {
+        Layout.fillWidth: true
+        visible: idleCancel.running
+        horizontalAlignment: Text.AlignHCenter
+        text: Translation.tr("Closing in %1s — press a shortcut to edit it")
+            .arg(Math.ceil(idleCancel.interval / 1000))
+        color: Appearance.colors.colSubtext
+        font.pixelSize: Appearance.font.pixelSize.smaller
     }
 
     RowLayout {

--- a/dots/.config/quickshell/imi/modules/common/widgets/NotificationGroup.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/NotificationGroup.qml
@@ -131,6 +131,11 @@ MouseArea { // Notification group area
         }
     }
 
+    // The painted card, published so the popup window can scope the
+    // compositor's blur to the cards and leave the gaps - and the shadow
+    // below - alone. See WindowBlurRegion in NotificationPopup.qml.
+    readonly property Item blurItem: background
+
     StyledRectangularShadow {
         target: background
         visible: popup

--- a/dots/.config/quickshell/imi/modules/common/widgets/NotificationListView.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/NotificationListView.qml
@@ -12,6 +12,34 @@ StyledListView { // Scrollable window
 
     spacing: Appearance.spacing.space50
 
+    // The painted card of every realized delegate, for a caller that needs the
+    // list's painted area rather than its bounding box - the popup window's
+    // blur region (see NotificationPopup.qml). The bounding box would swallow
+    // the gaps between cards, and blurring a gap frosts bare wallpaper exactly
+    // where the card's shadow falls.
+    //
+    // Recomputed on membership changes only: a Region tracks its item's
+    // geometry itself, so cards resizing or sliding need no rebuild.
+    property var cardItems: []
+
+    function refreshCardItems(): void {
+        let items = [];
+        const children = root.contentItem?.children ?? [];
+        for (let i = 0; i < children.length; i++) {
+            // contentItem also holds children that are not delegates (the
+            // highlight items a ListView makes), which have no card.
+            const card = children[i]?.blurItem ?? null;
+            if (card)
+                items.push(card);
+        }
+        root.cardItems = items;
+    }
+
+    // Delegates are built a beat after the count changes, so read the children
+    // once the current pass of the event loop has created them.
+    onCountChanged: Qt.callLater(root.refreshCardItems)
+    Component.onCompleted: Qt.callLater(root.refreshCardItems)
+
     model: ScriptModel {
         values: root.popup ? Notifications.popupAppNameList : Notifications.appNameList
     }

--- a/dots/.config/quickshell/imi/modules/common/widgets/WindowBlurRegion.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/WindowBlurRegion.qml
@@ -33,6 +33,56 @@ Item {
         radius: root.regionRadius
     }
 
+    // A body whose rects are not known until runtime: the notification stack
+    // paints one card per app and they come and go. A declared Region cannot
+    // express that - `regions` is a default list filled at construction, and
+    // Repeater only produces Items - so build the children here and assign the
+    // list, which Quickshell's Region does accept.
+    //
+    // Callers use either this or regionItem/region, not both.
+    property var regionItems: []
+    property int regionItemsRadius: 0
+
+    Component {
+        id: subRegionComponent
+        Region {}
+    }
+
+    property var subRegions: []
+
+    function rebuildFromItems() {
+        // regionItems defaults to [], so this handler fires once at
+        // construction for EVERY instance, including the great majority that
+        // use regionItem and never touch the dynamic path. Assigning an empty
+        // list to their region's children wipes the declared region and the
+        // panel loses its blur entirely - which is what happened to the bar,
+        // the overview and the sidebars. Leave the declared region alone
+        // unless this instance is actually using regionItems.
+        if (root.subRegions.length === 0 && (root.regionItems?.length ?? 0) === 0)
+            return;
+
+        // Nothing else owns these, so they have to be torn down explicitly or
+        // every card that ever appeared leaks a Region.
+        for (const stale of root.subRegions)
+            if (stale)
+                stale.destroy();
+
+        let built = [];
+        for (const item of (root.regionItems ?? [])) {
+            if (!item)
+                continue;
+            built.push(subRegionComponent.createObject(root, {
+                item: item,
+                radius: root.regionItemsRadius
+            }));
+        }
+        root.subRegions = built;
+        root.region.regions = built;
+        root.republish();
+    }
+
+    onRegionItemsChanged: root.rebuildFromItems()
+
     function republish() {
         if (!root.targetWindow)
             return;
@@ -40,7 +90,7 @@ Item {
         root.targetWindow.BackgroundEffect.blurRegion = root.region;
     }
 
-    onRegionChanged: settleTimer.restart()
+    onRegionChanged: root.publishNow()
 
     Timer {
         id: settleTimer
@@ -49,18 +99,29 @@ Item {
         onTriggered: root.republish()
     }
 
+    // Publish at once and schedule the settle as well, rather than only
+    // scheduling it. The timer exists for a region dropped mid-(re)configure,
+    // which is a race worth re-covering - but waiting on it is a guaranteed
+    // 96ms of surface-up-and-unblurred, which on a panel that opens on demand
+    // is a visible flash of sharp wallpaper before the blur lands. Measured at
+    // 7 frames of a 60fps capture on the overview and the search bar.
+    function publishNow(): void {
+        root.republish();
+        settleTimer.restart();
+    }
+
     Connections {
         target: root.targetWindow ?? null
         ignoreUnknownSignals: true
         function onVisibleChanged() {
             if (root.targetWindow.visible)
-                settleTimer.restart();
+                root.publishNow();
         }
         function onWidthChanged() {
-            settleTimer.restart();
+            root.publishNow();
         }
         function onHeightChanged() {
-            settleTimer.restart();
+            root.publishNow();
         }
     }
 

--- a/dots/.config/quickshell/imi/modules/imi/cheatsheet/Cheatsheet.qml
+++ b/dots/.config/quickshell/imi/modules/imi/cheatsheet/Cheatsheet.qml
@@ -71,6 +71,16 @@ Scope { // Scope
                 }
             }
 
+            // Scope the compositor's blur to the painted card so the drop
+            // shadow below stays crisp instead of being frosted along with it
+            // (#82, #89); pairs with rules.lua turning the layerrule blur off
+            // for this namespace.
+            WindowBlurRegion {
+                targetWindow: cheatsheetRoot
+                regionItem: cheatsheetBackground
+                regionRadius: cheatsheetBackground.radius
+            }
+
             // Background
             StyledRectangularShadow {
                 target: cheatsheetBackground

--- a/dots/.config/quickshell/imi/modules/imi/cheatsheet/Cheatsheet.qml
+++ b/dots/.config/quickshell/imi/modules/imi/cheatsheet/Cheatsheet.qml
@@ -182,6 +182,10 @@ Scope { // Scope
                         }
 
                         CheatsheetKeybinds {
+                            // The room the card may use before it starts
+                            // growing past the screen, minus the toolbar and
+                            // padding - what decides the column count.
+                            maxContentHeight: (cheatsheetRoot.screen?.height ?? 1080) - 220
                             onEditRequested: bindingData => {
                                 cheatsheetRoot.editingBinding = bindingData;
                             }
@@ -209,7 +213,12 @@ Scope { // Scope
                         property real padding: Appearance.spacing.space300
                         width: Math.min(560, keybindEditorScrim.width - Appearance.spacing.space800)
                         height: keybindEditorContent.implicitHeight + padding * 2
-                        color: Appearance.colors.colLayer1
+                        // colLayer1 carries the user's global transparency, which
+                        // is right for a panel resting on the shell background and
+                        // wrong for a modal resting on a dense keybind table: the
+                        // rows underneath read straight through the dialog. The
+                        // *Base* colour is the same surface, opaque.
+                        color: Appearance.colors.colLayer1Base
                         border.width: 1
                         border.color: Appearance.colors.colLayer0Border
                         radius: Appearance.rounding.normal

--- a/dots/.config/quickshell/imi/modules/imi/cheatsheet/CheatsheetKeybinds.qml
+++ b/dots/.config/quickshell/imi/modules/imi/cheatsheet/CheatsheetKeybinds.qml
@@ -5,6 +5,7 @@ import qs.modules.common
 import qs.modules.common.widgets
 import QtQuick
 import QtQuick.Layouts
+import "../../common/functions/cheatsheetLayout.js" as CheatsheetLayout
 
 Item {
     id: root
@@ -16,6 +17,28 @@ Item {
     property real spacing: Appearance.spacing.space250
     property real titleSpacing: Appearance.spacing.space100
     property real padding: Appearance.spacing.space50
+
+    // Every node that actually holds keybinds, flattened out of the tree. The
+    // renderer used to walk `children` only, so a group holding binds at its
+    // own level drew nothing - 48 of them on this machine.
+    readonly property var sections: CheatsheetLayout.sections(root.keybinds)
+    // Rough row budget: how many keybind rows fit in the space the cheatsheet
+    // may occupy before it starts growing past the screen. Approximate on
+    // purpose - it only decides how many columns to ask for, and being one out
+    // costs a slightly taller card, not a broken layout.
+    // Set by the cheatsheet to the height it may use before growing past the
+    // screen; 0 means "unknown", which falls back to a sane budget.
+    property real maxContentHeight: 0
+    // Deliberately budgets less height than there is. Filling the screen
+    // vertically is what the single column already did; the point of columns is
+    // to trade height for width on a display that has width to spare. Two
+    // thirds keeps the card comfortably clear of the screen edges and, on this
+    // 5120x1440 desktop, turns two tall columns into three shorter ones.
+    readonly property real rowHeight: 30
+    readonly property int availableRows: Math.max(
+        8, Math.floor((root.maxContentHeight > 0 ? root.maxContentHeight : 900) * 0.66 / root.rowHeight))
+    readonly property var columns: CheatsheetLayout.balance(
+        root.sections, CheatsheetLayout.columnCount(root.sections, root.availableRows, 4))
     implicitWidth: row.implicitWidth + padding * 2
     implicitHeight: row.implicitHeight + padding * 2
     // Excellent symbol explaination and source :
@@ -86,15 +109,15 @@ Item {
         spacing: root.spacing
         
         Repeater {
-            model: keybinds.children
-            
-            delegate: Column { // Keybind sections
+            model: root.columns
+
+            delegate: Column { // One balanced column of sections
                 spacing: root.spacing
                 required property var modelData
                 anchors.top: row.top
 
                 Repeater {
-                    model: modelData.children
+                    model: modelData
 
                     delegate: Item { // Section with real keybinds
                         id: keybindSection
@@ -109,6 +132,7 @@ Item {
                             
                             StyledText {
                                 id: sectionTitle
+                                visible: text.length > 0
                                 font {
                                     family: Appearance.font.family.title
                                     pixelSize: Appearance.font.pixelSize.title
@@ -158,9 +182,39 @@ Item {
                                         return result;
                                     }
                                     delegate: Item {
+                                        id: keybindCell
                                         required property var modelData
                                         implicitWidth: keybindLoader.implicitWidth
                                         implicitHeight: keybindLoader.implicitHeight
+
+                                        // Only chords open the editor. Comment cells and
+                                        // documentation rows are text, and highlighting
+                                        // them would promise a click that does nothing.
+                                        readonly property bool editable: keybindCell.modelData.type === "keys"
+                                            && keybindCell.modelData.binding !== undefined
+                                            && !(keybindCell.modelData.binding?.flags?.documentation ?? false)
+
+                                        // The keycaps are drawings of keys, not controls, so
+                                        // the row needs its own hover to show where the click
+                                        // target is.
+                                        //
+                                        // It fills the grid CELL rather than the keycap Row:
+                                        // a Row positions its children, so a child anchored to
+                                        // fill it corrupts the row's layout, and padding the
+                                        // fill outwards with a negative margin overflows into
+                                        // the neighbouring cell instead of being clipped -
+                                        // which drew the hovered row on top of the one above.
+                                        Rectangle {
+                                            anchors.fill: parent
+                                            z: -1
+                                            radius: Appearance.rounding.small
+                                            visible: keybindCellHover.hovered && keybindCell.editable
+                                            color: Appearance.colors.colLayer1Hover
+                                        }
+
+                                        HoverHandler {
+                                            id: keybindCellHover
+                                        }
 
                                         Loader {
                                             id: keybindLoader
@@ -173,8 +227,15 @@ Item {
                                                 id: keysRow
                                                 spacing: Appearance.spacing.space50
 
-                                                HoverHandler {
-                                                    id: keysRowHover
+                                                // The whole chord is the edit
+                                                // affordance, not just the pencil:
+                                                // a hover-only target on a dense
+                                                // list is hard to find and
+                                                // impossible to discover.
+                                                TapHandler {
+                                                    acceptedButtons: Qt.LeftButton
+                                                    enabled: keybindCell.editable
+                                                    onTapped: root.editRequested(keybindCell.modelData.binding)
                                                 }
 
                                                 Repeater {
@@ -201,8 +262,8 @@ Item {
                                                     id: editBindingButton
                                                     // Space is always reserved so hovering cannot
                                                     // reflow the grid; only the icon fades in.
-                                                    visible: modelData.binding?.removable ?? false
-                                                    opacity: (keysRowHover.hovered || editBindingButton.hovered) ? 1 : 0
+                                                    visible: keybindCell.editable
+                                                    opacity: (keybindCellHover.hovered || editBindingButton.hovered) ? 1 : 0
                                                     enabled: opacity > 0
                                                     anchors.verticalCenter: parent.verticalCenter
                                                     implicitWidth: 22

--- a/dots/.config/quickshell/imi/modules/imi/notificationPopup/NotificationPopup.qml
+++ b/dots/.config/quickshell/imi/modules/imi/notificationPopup/NotificationPopup.qml
@@ -43,6 +43,18 @@ Scope {
             item: listview.contentItem
         }
 
+        // Every popup card already draws a StyledRectangularShadow; the
+        // catch-all whole-surface blur was frosting all of them (#82, #89).
+        // Scope the blur to the cards themselves - not the list's bounding
+        // box, which would take in the gaps between cards and frost bare
+        // wallpaper right where each shadow falls. Pairs with rules.lua
+        // turning the layerrule blur off for this namespace.
+        WindowBlurRegion {
+            targetWindow: root
+            regionItems: listview.cardItems
+            regionItemsRadius: Appearance.rounding.normal
+        }
+
         color: "transparent"
         implicitWidth: Appearance.sizes.notificationPopupWidth
 

--- a/dots/.config/quickshell/imi/scripts/hyprland/get_keybinds.py
+++ b/dots/.config/quickshell/imi/scripts/hyprland/get_keybinds.py
@@ -28,6 +28,45 @@ content_lines = []
 reading_line = 0
 
 
+def parse_pseudo_bind(text):
+    """Split a hand-written cheatsheet bind line into (mods, key).
+
+    These are documentation rows, not real binds: `--#/#` marks one conceptual
+    shortcut standing in for a family of real ones that cannot be listed
+    individually (Hash for workspaces 1-9, the four arrows, both Page keys).
+    They are written in Hyprland's own config syntax:
+
+        bind = SUPER, Hash,,          -> (["SUPER"], "Hash")
+        bind = SUPER+ALT, Hash,,      -> (["SUPER", "ALT"], "Hash")
+        bind = SUPER + <arrows>,,     -> (["SUPER"], "<arrows>")
+        binde = SUPER, ;/',,          -> (["SUPER"], ";/'")
+
+    Unparsed, the whole literal string became the key and rendered as one very
+    wide keycap reading `bind = SUPER, Hash,,` - config syntax, trailing commas
+    and all, on screen.
+    """
+    rest = re.sub(r'^bind[a-z]*\s*=\s*', '', text.strip())
+    rest = rest.rstrip(",").strip()
+    if not rest:
+        return [], text.strip()
+
+    if "," in rest:
+        # `MODS, KEY` - the common form.
+        mod_part, key_part = rest.split(",", 1)
+    elif " + " in rest:
+        # `MODS + KEY` with no comma; the key is whatever follows the last
+        # separator, since mods are always single tokens.
+        mod_part, key_part = rest.rsplit(" + ", 1)
+    else:
+        return [], rest
+
+    mods = [m.strip() for m in re.split(r'[+\s]+', mod_part) if m.strip()]
+    key = key_part.strip().rstrip(",").strip()
+    if not key:
+        return [], mod_part.strip()
+    return mods, key
+
+
 class KeyBinding(dict):
     def __init__(self, mods, key, dispatcher, params, comment, flags=None, submap=""):
         self["mods"]       = mods
@@ -222,8 +261,14 @@ def get_binds_recursive(current_content: Section, scope: int) -> Section:
                 # It's a descriptive placeholder like "bind = SUPER + ←/→ -- Focus in direction"
                 # Extract key hint from before " -- "
                 key_hint = rest.split(" -- ")[0].strip()
-                # Build a synthetic KeyBinding for display
-                kb = KeyBinding([], key_hint, "comment", "", comment_part)
+                # Split the config syntax into mods and key so it renders as
+                # keycaps rather than as a literal `bind = SUPER, Hash,,`.
+                # Flagged documentation so the cheatsheet can say these stand
+                # for several real binds and cannot be reassigned - one of
+                # them is not a chord the shell could rebind even in principle.
+                mods, key = parse_pseudo_bind(key_hint)
+                kb = KeyBinding(mods, key, "comment", "", comment_part,
+                                flags={"documentation": True})
                 current_content["keybinds"].append(kb)
             reading_line += 1
             continue

--- a/dots/.config/quickshell/imi/services/PopupBlurThreshold.qml
+++ b/dots/.config/quickshell/imi/services/PopupBlurThreshold.qml
@@ -1,0 +1,120 @@
+pragma Singleton
+pragma ComponentBehavior: Bound
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import qs.modules.common
+import qs.modules.common.functions
+
+/**
+ * Publishes the alpha threshold Hyprland should use when blurring the shell's
+ * popups, as a Lua file rules.lua reads.
+ *
+ * Popups cannot scope their blur the way panels do. A panel turns the
+ * whole-surface blur off and publishes an ext-background-effect region over its
+ * painted body, so the compositor never touches the shadow in its elevation
+ * margin. That mechanism is for layer surfaces, and a PopupWindow is an
+ * xdg-popup: a region published from one is accepted and does nothing. The only
+ * knob aimed at popups is `blur_popups` on the parent surface's namespace, and
+ * turning it off costs the body its blur along with the shadow.
+ *
+ * What is left is `ignore_alpha`, which skips blur for pixels below a
+ * threshold. The shadow and the body sit at different alphas, so a value
+ * between them blurs one and not the other - but where "between" is depends on
+ * the user's transparency setting, and a layerrule is static Lua that cannot
+ * read it. Hence this: the shell computes the threshold and writes it out, and
+ * rules.lua reads the file with a fallback for the first run.
+ */
+Singleton {
+    id: root
+
+    // colShadow is m3shadow transparentized 0.7, and StyledRectangularShadow
+    // fades outward from there, so this is the shadow's ceiling rather than its
+    // typical value.
+    readonly property real shadowPeakAlpha: 0.3
+
+    // The faintest body the threshold has to stay below.
+    //
+    // Not just the popups'. `ignore_alpha` is a single value per namespace,
+    // shared between a popup's blur and its parent panel's, because the panel
+    // is blurred through a region and a region is subject to ignore_alpha too.
+    // So this has to clear the *panels* as well, and the bar is the faintest of
+    // them: it thins colLayer0 further by its own background opacity. Set this
+    // above the bar's body and the bar loses its blur.
+    readonly property real bodyAlpha: (1 - Appearance.backgroundTransparency)
+        * Math.min(1, Config.options.bar.backgroundOpacity ?? 1)
+
+    /**
+     * Midway between the two, which is the most forgiving spot: it tolerates
+     * the most drift in either direction before one of them lands on the wrong
+     * side.
+     *
+     * The `bodyAlpha - 0.05` clamp is for the case where the user has turned
+     * transparency up so far that the body is fainter than the shadow's ceiling
+     * and no threshold separates them. Then the choice is which one to get
+     * wrong, and this keeps the body blurred: losing the blur is the change
+     * people notice, and a frosted shadow on a nearly-invisible body is not.
+     */
+    readonly property real threshold: Math.max(
+        0.02,
+        Math.min(root.bodyAlpha - 0.05,
+                 (root.shadowPeakAlpha + root.bodyAlpha) / 2))
+
+    readonly property string path: FileUtils.trimFileProtocol(
+        `${Directories.config}/hypr/hyprland/shellOverrides/popupBlur.lua`)
+
+    // Rounded before it is written and before it is compared, so a float that
+    // wobbles in the last decimal place cannot cause a write, and every write
+    // costs a Hyprland config reload.
+    readonly property string rendered: `-- Written by the shell (services/PopupBlurThreshold.qml). Do not edit.
+-- The alpha below which Hyprland leaves the shell's popups unblurred, so a
+-- popup's drop shadow stays crisp while its body still gets a backdrop.
+return ${root.threshold.toFixed(3)}
+`
+
+    property string lastWritten: ""
+
+    /**
+     * Nothing reads this singleton's properties, and a QML singleton is built
+     * on first use, so without a call from shell.qml it would never start and
+     * the file would never be written. Doubles as the seed of the file.
+     */
+    function load(): void {
+        reader.reload();
+    }
+
+    function publish(): void {
+        if (root.rendered === root.lastWritten)
+            return;
+        root.lastWritten = root.rendered;
+        writer.setText(root.rendered);
+    }
+
+    FileView {
+        id: writer
+        path: root.path
+        printErrors: true
+        onSaved: Quickshell.execDetached(["hyprctl", "reload"])
+    }
+
+    onRenderedChanged: republishDebounce.restart()
+
+    // Dragging the transparency slider walks through every value on the way,
+    // and each one would otherwise be a file write plus a compositor reload.
+    Timer {
+        id: republishDebounce
+        interval: 400
+        onTriggered: root.publish()
+    }
+
+    FileView {
+        id: reader
+        path: root.path
+        printErrors: false
+        onLoaded: {
+            root.lastWritten = reader.text();
+            root.publish();
+        }
+        onLoadFailed: root.publish()
+    }
+}

--- a/dots/.config/quickshell/imi/shell.qml
+++ b/dots/.config/quickshell/imi/shell.qml
@@ -57,6 +57,7 @@ ShellRoot {
         WallpaperEngine.load()
         Updates.load()
         OpenRgb.load()
+        PopupBlurThreshold.load() // writes the popup blur threshold rules.lua reads
         LyricsService.restartLyrics()
     }
     

--- a/dots/.config/quickshell/imi/tests/lint_blur_region_pairing.py
+++ b/dots/.config/quickshell/imi/tests/lint_blur_region_pairing.py
@@ -33,6 +33,8 @@ BLUR_DISABLED = re.compile(
     r'namespace\s*=\s*"([^"]+)"[^}]*}\s*,\s*blur\s*=\s*false')
 PUBLISHES_REGION = re.compile(r'\bWindowBlurRegion\s*\{')
 DECLARES_NAMESPACE = re.compile(r'WlrLayershell\.namespace:\s*"([^"]+)"')
+IS_POPUP_WINDOW = re.compile(r'\bPopupWindow\s*\{')
+IS_PANEL_WINDOW = re.compile(r'\bPanelWindow\s*\{')
 
 
 def namespaces_with_blur_disabled():
@@ -53,6 +55,40 @@ def namespaces_publishing_a_region():
         if not DECLARES_NAMESPACE.search(text):
             found.setdefault(f"<no namespace in {rel}>", rel)
     return found
+
+
+class PopupBlurRegionLint(unittest.TestCase):
+    """A region published from a PopupWindow is accepted and does nothing.
+
+    ext_background_effect binds a region to a *layer surface*. A PopupWindow is
+    an xdg-popup, so `BackgroundEffect.blurRegion` on one is set without error,
+    without warning, and without effect - the popup goes on being blurred whole
+    by `blur_popups`, shadow and all.
+
+    This cost a full write-deploy-look cycle on the tray menu before the
+    inertness was visible, and nothing in the QML or the compositor says a word
+    about it. Popups threshold their blur with `ignore_alpha` on the parent
+    surface's namespace instead; see services/PopupBlurThreshold.qml.
+    """
+
+    def test_no_popup_window_publishes_a_blur_region(self):
+        offenders = []
+        for path in sorted(MODULES.rglob("*.qml")):
+            if path == WIDGET_DEFINITION:
+                continue
+            text = path.read_text(errors="ignore")
+            if not PUBLISHES_REGION.search(text):
+                continue
+            # A file holding both is not automatically wrong - the region may
+            # belong to the PanelWindow - but it is worth a human look, and no
+            # file does it today.
+            if IS_POPUP_WINDOW.search(text) and not IS_PANEL_WINDOW.search(text):
+                offenders.append(str(path.relative_to(ROOT)))
+        self.assertEqual(
+            offenders, [],
+            "these publish a WindowBlurRegion from a PopupWindow, where it has "
+            "no effect at all:\n  " + "\n  ".join(offenders)
+            + "\nUse ignore_alpha on the parent surface's namespace instead.")
 
 
 class BlurRegionPairingLint(unittest.TestCase):

--- a/dots/.config/quickshell/imi/tests/test_get_keybinds.py
+++ b/dots/.config/quickshell/imi/tests/test_get_keybinds.py
@@ -187,12 +187,21 @@ def main():
                       comments == ["Focus in direction", "Focus down"],
                       f"got {comments}")
                 synthetic = focus["keybinds"][0] if focus["keybinds"] else None
-                check("--#/# synthetic bind uses 'comment' dispatcher",
+                # This used to assert mods == [] and key == "SUPER + Arrows",
+                # which pinned the defect rather than the behaviour: the whole
+                # config-syntax string was kept as the key, and the cheatsheet
+                # rendered it verbatim as one wide keycap reading
+                # `bind = SUPER, Hash,,`. The line is documentation for a family
+                # of real binds, so it is split like any other chord and flagged
+                # so the UI does not offer to rebind something that has no
+                # single chord behind it.
+                check("--#/# synthetic bind is split into mods and key",
                       synthetic is not None
                       and synthetic["dispatcher"] == "comment"
-                      and synthetic["mods"] == []
-                      and synthetic["key"] == "SUPER + Arrows"
-                      and synthetic["params"] == "",
+                      and synthetic["mods"] == ["SUPER"]
+                      and synthetic["key"] == "Arrows"
+                      and synthetic["params"] == ""
+                      and synthetic["flags"].get("documentation") is True,
                       f"got {synthetic}")
 
         # --- Apps section: exec autogen + blacklist + multiline -------------

--- a/dots/.config/quickshell/imi/tests/tst_cheatsheet_layout.qml
+++ b/dots/.config/quickshell/imi/tests/tst_cheatsheet_layout.qml
@@ -1,0 +1,129 @@
+import QtTest
+import "../modules/common/functions/cheatsheetLayout.js" as Layout
+
+// Flattening the keybind tree into cheatsheet sections, and packing those into
+// columns. Both used to be implicit in the renderer's structure, which is how
+// 48 keybinds went missing: it drew a group's `children` and never the group's
+// own `keybinds`, so any node holding binds directly rendered nothing.
+TestCase {
+    name: "CheatsheetLayoutTest"
+
+    function tree() {
+        // The real shape on this machine: the root holds binds AND groups, two
+        // anonymous groups exist purely for grouping, and one named section is
+        // empty.
+        return {
+            name: "",
+            keybinds: new Array(20).fill({}),
+            children: [
+                { name: "Utilities", keybinds: new Array(14).fill({}), children: [] },
+                { name: "Screen", keybinds: new Array(2).fill({}), children: [] },
+                { name: "Media", keybinds: new Array(12).fill({}), children: [] },
+                { name: "", keybinds: [], children: [
+                    { name: "Window", keybinds: new Array(15).fill({}), children: [] },
+                    { name: "Workspace", keybinds: new Array(5).fill({}), children: [] },
+                    { name: "Virtual machines", keybinds: [], children: [] }
+                ]},
+                { name: "", keybinds: [], children: [
+                    { name: "Session", keybinds: new Array(2).fill({}), children: [] },
+                    { name: "Apps", keybinds: new Array(11).fill({}), children: [] }
+                ]}
+            ]
+        };
+    }
+
+    // --- flattening --------------------------------------------------------
+
+    function test_a_group_with_its_own_keybinds_becomes_a_section() {
+        // The bug. Utilities/Screen/Media hold binds at their own level and
+        // have no children, so the old renderer drew nothing for them.
+        const names = Layout.sections(tree()).map(s => s.name);
+        verify(names.indexOf("Utilities") >= 0);
+        verify(names.indexOf("Screen") >= 0);
+        verify(names.indexOf("Media") >= 0);
+    }
+
+    function test_no_keybind_is_dropped() {
+        const total = Layout.sections(tree())
+            .reduce((sum, s) => sum + s.keybinds.length, 0);
+        compare(total, 20 + 14 + 2 + 12 + 15 + 5 + 2 + 11);
+    }
+
+    function test_the_roots_own_keybinds_survive_without_inventing_a_heading() {
+        const root = Layout.sections(tree())[0];
+        compare(root.name, "");
+        compare(root.keybinds.length, 20);
+    }
+
+    function test_an_empty_named_section_is_not_rendered() {
+        // "Virtual machines" has no binds; a bare heading over nothing is what
+        // the screenshot showed and it reads as a broken section.
+        const names = Layout.sections(tree()).map(s => s.name);
+        compare(names.indexOf("Virtual machines"), -1);
+    }
+
+    function test_author_order_is_preserved() {
+        const names = Layout.sections(tree()).map(s => s.name).filter(n => n.length > 0);
+        compare(names, ["Utilities", "Screen", "Media", "Window",
+                        "Workspace", "Session", "Apps"]);
+    }
+
+    function test_an_empty_tree_is_no_sections_not_a_crash() {
+        compare(Layout.sections(null).length, 0);
+        compare(Layout.sections({}).length, 0);
+    }
+
+    // --- packing -----------------------------------------------------------
+
+    function test_every_section_lands_in_exactly_one_column() {
+        const list = Layout.sections(tree());
+        const columns = Layout.balance(list, 3);
+        let packed = 0;
+        for (const column of columns) packed += column.length;
+        compare(packed, list.length);
+    }
+
+    function test_columns_are_balanced_by_height_not_by_count() {
+        // Splitting by index would put the 20-row root and the 15-row Window
+        // section together and leave a stub column beside them.
+        const columns = Layout.balance(Layout.sections(tree()), 3);
+        const heights = columns.map(c => c.reduce((sum, s) => sum + s.weight, 0));
+        const tallest = Math.max.apply(null, heights);
+        const shortest = Math.min.apply(null, heights);
+        verify(tallest - shortest <= 20); // no column is double another
+    }
+
+    function test_packing_is_stable() {
+        const a = Layout.balance(Layout.sections(tree()), 3).map(c => c.map(s => s.name).join(","));
+        const b = Layout.balance(Layout.sections(tree()), 3).map(c => c.map(s => s.name).join(","));
+        compare(a, b);
+    }
+
+    function test_one_column_is_the_floor() {
+        compare(Layout.balance(Layout.sections(tree()), 0).length, 1);
+        compare(Layout.balance(Layout.sections(tree()), -3).length, 1);
+    }
+
+    // --- choosing the column count ----------------------------------------
+
+    function test_more_content_than_height_asks_for_more_columns() {
+        const list = Layout.sections(tree()); // 88 rows of weight
+        verify(Layout.columnCount(list, 30, 4) > 1);
+        compare(Layout.columnCount(list, 1000, 4), 1); // all of it fits in one
+    }
+
+    function test_the_cap_is_respected() {
+        compare(Layout.columnCount(Layout.sections(tree()), 5, 3), 3);
+    }
+
+    function test_a_short_list_never_fans_out_into_slivers() {
+        // Two sections cannot become four columns, however little room there is.
+        const two = [{name: "a", keybinds: [], weight: 3},
+                     {name: "b", keybinds: [], weight: 3}];
+        compare(Layout.columnCount(two, 1, 4), 2);
+    }
+
+    function test_no_sections_is_one_column() {
+        compare(Layout.columnCount([], 10, 4), 1);
+    }
+}


### PR DESCRIPTION
## The cheatsheet was hiding half its own content

It drew a group's `children` and never the group's own `keybinds`, so any node
holding binds directly rendered nothing — 28 of 61 binds missing on this
machine, including all of Utilities, Screen and Media. What survived was
stacked into one tall column beside three-quarters of empty screen, because
columns came from the tree's top-level children, which is an authoring detail
of `keybinds.lua` rather than a layout decision.

Sections are now flattened out of the tree and packed shortest-column-first.
Clicking any chord opens the editor; it warns before taking a chord already in
use, and closes itself after five seconds if you opened it by accident. Chords
render as one keycap per key — `SUPER SHIFT ALT R` was previously a single wide
keycap, which reads as one key with an improbable name.

## Drop shadows were being frosted by the compositor

Same defect as #82 and #89, on the surfaces that hadn't been ported. The
cheatsheet's case was the confusing one: it had always drawn a
`StyledRectangularShadow`, and the whole-surface blur smeared it into a band
along the card's edge, which read as having no shadow at all.

Two of these needed something the existing pattern didn't cover:

- **Notifications** are a dynamic stack with no fixed set of rects. The list's
  bounding box is the tempting shortcut and it is wrong — it takes in the gaps
  between cards, and blurring a gap frosts bare wallpaper exactly where each
  card's shadow falls. `WindowBlurRegion` accepts a list of items and builds the
  child regions itself.
- **The tray menu** is an xdg-popup, so a region published from it is accepted
  and does nothing. It thresholds by `ignore_alpha` instead, at a point the
  shell computes from the transparency and bar-opacity settings and rewrites
  when they change — a layerrule cannot read either.

Two bugs in `WindowBlurRegion` itself came out of this and are fixed here:
`regionItems` defaulting to `[]` wiped the declared region of every instance
using `regionItem`, and a region was only published on the settle timer, so
every `LazyLoader` panel flashed ~96 ms of sharp wallpaper on open.

## What is not here

An earlier version of this branch also gave the desktop right-click menu a
container card, and scoped blur on `quickshell:popup`. Both were reverted after
testing and the reverts are not in the history — the branch was reshaped, so the
files are untouched rather than changed-and-changed-back.

The desktop menu was a misreading of "right-click menus", which meant the tray
and context menus. `quickshell:popup` already worked: its bodies are opaque and
it carries `ignore_alpha = 1`, which blurs the body and skips the shadow —
adding `blur = false` made the region the only blur source and flattened those
surfaces.

Follow-ups: #140 (morphing hover overlay), #141 (transparency toggle leaves
elements translucent), #142 (desktop menu polish, including per-section shadows
for it).

## Testing

353 tests green. Both lints pass at every commit individually, so there is no
point in the history where one half of the blur pairing landed without the
other.

Verified on screen, since none of this area is reachable by the suite —
Quickshell's plugin does not load in `qmltestrunner`, so `Region` cannot be
constructed there: cheatsheet layout, hover, click-to-edit, the opaque editor,
the tray menu, notification popups, and the open-flash fix confirmed frame by
frame from a 60 fps capture.

Docs: updated AGENT.md §Panels and windows (regions are inert on popups;
ignore_alpha is shared between a panel and its popups; quickshell:popup is
already handled; LazyLoader panels must publish on show; none of it is
test-visible), and CHANGELOG.md