### PR TITLE
fix(transparency): the toggle removed the frost but kept the alpha

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -865,10 +865,10 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   `Appearance.qml` already had — a transparency *amount* declared beside `backgroundTransparency`
   / `contentTransparency` that collapses to `0` when the switch is off. Keep new amounts there,
   where "is every one of them gated?" is answerable by looking.
-  13d8a0abe ("feat(plugins): derive desktop-widget opacity from the transparency toggle"),
-  3ed184642 ("fix(plugins): route every widget panel opacity through the derivation"),
-  5ce649746 ("fix(appearance): gate the bar's own opacity on the transparency switch"),
-  535c3b191 ("fix(dropShelf): gate the shelf's frost on the transparency switch").
+  b259288b2 ("feat(plugins): derive desktop-widget opacity from the transparency toggle"),
+  3088bbaed ("fix(plugins): route every widget panel opacity through the derivation"),
+  e4f3a095e ("fix(appearance): gate the bar's own opacity on the transparency switch"),
+  b47935a65 ("fix(dropShelf): gate the shelf's frost on the transparency switch").
 - Desktop plugin delegates are retained for every available manifest and gated through an animated
   `FadeLoader`, rather than repeating only the enabled ids. Removing a model delegate destroys it
   immediately and makes an M3 exit transition impossible; keep disabled loaders dormant until their

--- a/AGENT.md
+++ b/AGENT.md
@@ -854,8 +854,21 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   conditional; `tests/test_widget_transparency_opacity.py` reddens on a call site that reads
   `plugins.blurOpacity` directly. The exemption gates the frost too — a widget excused from the
   opaque default but still denied its blur is exactly the hole this removed.
-  ead4ba6f7 ("feat(plugins): derive desktop-widget opacity from the transparency toggle"),
-  2edab686a ("fix(plugins): route every widget panel opacity through the derivation").
+  **The plugins were not the only ones**, and the audit that found the other two is the point:
+  `Appearance.colors.colBarBackground` thinned the (already gated) `colLayer0` by an ungated
+  `bar.backgroundOpacity`, and `DropShelfPanel` painted an ungated `dropShelf.backgroundOpacity`
+  — the shelf shipped 50% see-through with transparency off, in the default config. Both defaults
+  (`1`, and a panel most people never open) are why nobody reported them. Neither routes through
+  `PluginState`: that function resolves a *per-plugin* opt-out from a manifest seed, so a panel
+  would pass an empty id forever and drag the plugin state store into an unrelated module for a
+  one-line conditional. The generalising abstraction for a non-plugin surface is the one
+  `Appearance.qml` already had — a transparency *amount* declared beside `backgroundTransparency`
+  / `contentTransparency` that collapses to `0` when the switch is off. Keep new amounts there,
+  where "is every one of them gated?" is answerable by looking.
+  13d8a0abe ("feat(plugins): derive desktop-widget opacity from the transparency toggle"),
+  3ed184642 ("fix(plugins): route every widget panel opacity through the derivation"),
+  5ce649746 ("fix(appearance): gate the bar's own opacity on the transparency switch"),
+  535c3b191 ("fix(dropShelf): gate the shelf's frost on the transparency switch").
 - Desktop plugin delegates are retained for every available manifest and gated through an animated
   `FadeLoader`, rather than repeating only the enabled ids. Removing a model delegate destroys it
   immediately and makes an M3 exit transition impossible; keep disabled loaders dormant until their

--- a/AGENT.md
+++ b/AGENT.md
@@ -839,6 +839,23 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   values. Desktop backdrop blur is also per-plugin state: a manifest opts into its default with
   `desktopWidget.blur: true`, while the generated **Blur background** option always lets the user
   override it. Do not make `PluginWidget` blur every plugin unconditionally.
+- **"The frost is gated on the toggle" is not "the surface is gated on the toggle."**
+  `appearance.transparency.enable` removed every desktop widget's blur — `PluginWidget`'s blur
+  `Repeater` reads the flag — while the widgets' panel alpha kept coming from
+  `plugins.blurOpacity` and four hardcoded `0.1` literals, which do not. Turning transparency
+  **off** therefore left fourteen widgets ~10% opaque over a now-**sharp** wallpaper: a worse
+  result than leaving it on, while the dock and the settings window correctly went opaque. Opacity
+  and blur were two settings and only one knew about the switch. The derivation now lives in
+  `PluginState.effectiveBackgroundOpacity(pluginId, base)` — the only place that can see both the
+  toggle and the per-plugin opt-out (`keepTranslucent`), since the generic
+  `designsystem/widgets/Desktop*Widget.qml` have no `PluginWidget` root in scope and a host-side
+  property could never have reached them. When adding anything that paints its own alpha, ask what
+  it looks like with the toggle off, and route it through the derivation rather than repeating the
+  conditional; `tests/test_widget_transparency_opacity.py` reddens on a call site that reads
+  `plugins.blurOpacity` directly. The exemption gates the frost too — a widget excused from the
+  opaque default but still denied its blur is exactly the hole this removed.
+  ead4ba6f7 ("feat(plugins): derive desktop-widget opacity from the transparency toggle"),
+  2edab686a ("fix(plugins): route every widget panel opacity through the derivation").
 - Desktop plugin delegates are retained for every available manifest and gated through an animated
   `FadeLoader`, rather than repeating only the enabled ids. Removing a model delegate destroys it
   immediately and makes an M3 exit transition impossible; keep disabled loaders dormant until their

--- a/dots/.config/quickshell/imi/modules/common/Appearance.qml
+++ b/dots/.config/quickshell/imi/modules/common/Appearance.qml
@@ -42,6 +42,14 @@ Singleton {
     property real autoContentTransparency: 0.9
     property real backgroundTransparency: Config?.options.appearance.transparency.enable ? Config?.options.appearance.transparency.automatic ? autoBackgroundTransparency : Config?.options.appearance.transparency.backgroundTransparency : 0
     property real contentTransparency: Config?.options.appearance.transparency.enable ? Config?.options.appearance.transparency.automatic ? autoContentTransparency : Config?.options.appearance.transparency.contentTransparency : 0
+    // The bar's own opacity is a third gated amount, declared here beside the
+    // other two rather than inlined at colBarBackground: thinning an already
+    // opaque colLayer0 by an ungated `bar.backgroundOpacity` left the bar, the
+    // vertical bar, the pills and the hug corners see-through with transparency
+    // *off* - for everyone who had ever moved that slider and for nobody else,
+    // which is why a default of 1 hid it completely.
+    property real barBackgroundTransparency: Config?.options.appearance.transparency.enable
+        ? 1 - (Config?.options.bar.backgroundOpacity ?? 1) : 0
 
     m3colors: QtObject {
         property bool darkmode: true
@@ -129,9 +137,10 @@ Singleton {
         // The bar's own background chrome (bar/pill fills, hug corners) thins
         // colLayer0 by the user's bar opacity (Config.options.bar.backgroundOpacity,
         // 1 = fully opaque = unchanged). Kept separate from colLayer0 so only the
-        // bar goes translucent, composing with — not overriding — the global
-        // transparency setting colLayer0 already carries.
-        property color colBarBackground: ColorUtils.transparentize(colLayer0, 1 - (Config?.options.bar.backgroundOpacity ?? 1))
+        // bar goes translucent. The amount comes from root.barBackgroundTransparency
+        // rather than from the raw setting, so it genuinely composes with — instead
+        // of reintroducing the translucency colLayer0 has just been made to drop.
+        property color colBarBackground: ColorUtils.transparentize(colLayer0, root.barBackgroundTransparency)
         // Layer 1
         property color colLayer1Base: m3colors.m3surfaceContainerLow
         property color colLayer1: ColorUtils.solveOverlayColor(colLayer0Base, colLayer1Base, 1 - root.contentTransparency);

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginOptions.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginOptions.qml
@@ -38,6 +38,16 @@ ColumnLayout {
         label: "Click through",
         icon: "do_not_touch",
         default: manifest.desktopWidget?.clickThrough === true
+    }, {
+        // Turning transparency off makes every desktop widget's panel fully
+        // opaque (PluginState.effectiveBackgroundOpacity). This is the escape
+        // hatch for a widget whose whole point is to be see-through, and it is
+        // the only way to undo a manifest that ships the exemption on.
+        key: "keepTranslucent",
+        type: "boolean",
+        label: "Stay translucent",
+        icon: "opacity",
+        default: manifest.desktopWidget?.keepTranslucent === true
     }] : []).concat(manifest.options || [])
 
     // Not a pluginOption on purpose: preset application replaces those, and

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginState.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginState.qml
@@ -74,6 +74,37 @@ Singleton {
         return value === undefined ? fallback : value;
     }
 
+    // Desktop-widget panel opacity, resolved against the global transparency
+    // switch. Frost and opacity were two independent settings and only frost
+    // knew about the toggle: PluginWidget's blur Repeater is gated on
+    // `appearance.transparency.enable`, but every widget's panel alpha came
+    // from `plugins.blurOpacity` (or a hardcoded literal), which is not. With
+    // transparency off that combination removed the blur and kept the 10%
+    // panel, leaving each widget a hole onto the sharp wallpaper.
+    //
+    // Lives here rather than in each widget because it is the same derivation
+    // everywhere, and here is the only place that can do both halves of it:
+    // PluginState already reads Config (for the toggle and the configured
+    // opacity) and already owns the per-plugin option the opt-out needs. The
+    // generic designsystem widgets have no PluginWidget root in scope, so a
+    // host-side property could not have reached them; a singleton call can,
+    // with an empty id for a component that has no plugin identity.
+    //
+    // `keepTranslucent` is that opt-out, for a widget whose whole point is to
+    // be see-through. Same shape as blurEnabled/positionLocked/clickThrough:
+    // the manifest seeds the default, PluginState carries the user's override,
+    // so a shipped default stays reversible from Settings > Widgets.
+    function resolveBackgroundOpacity(baseOpacity, transparencyEnabled, keepTranslucent) {
+        return (transparencyEnabled || keepTranslucent) ? baseOpacity : 1;
+    }
+
+    function effectiveBackgroundOpacity(pluginId, baseOpacity, keepTranslucentDefault) {
+        return root.resolveBackgroundOpacity(
+            baseOpacity === undefined ? Config.options.plugins.blurOpacity : baseOpacity,
+            Config.options.appearance.transparency.enable,
+            root.option(pluginId, "keepTranslucent", keepTranslucentDefault === true));
+    }
+
     function presetPersisted(pluginId) {
         return root.state?.presetPersist?.[pluginId] === true;
     }

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginValidator.js
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginValidator.js
@@ -56,7 +56,7 @@ function validateManifest(manifest) {
     // the matching PluginState option, so a non-boolean would slip through as
     // a truthy default nobody can account for later - reject it here instead.
     if (manifest.desktopWidget) {
-        const desktopFlags = ["blur", "locked", "clickThrough"];
+        const desktopFlags = ["blur", "locked", "clickThrough", "keepTranslucent"];
         for (const flag of desktopFlags) {
             if (manifest.desktopWidget[flag] !== undefined
                     && typeof manifest.desktopWidget[flag] !== "boolean") {

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
@@ -62,6 +62,16 @@ AbstractBackgroundWidget {
     clickThrough: manifest
         ? PluginState.option(manifest.id, "clickThrough", manifest.desktopWidget?.clickThrough === true)
         : false
+    // Exempts this widget from the transparency toggle: with transparency off
+    // every other widget's panel is forced fully opaque
+    // (PluginState.effectiveBackgroundOpacity) and loses its frost, which is
+    // the whole point for a widget that is meant to be see-through. Both
+    // halves have to follow the flag together - a translucent panel with the
+    // frost still suppressed is exactly the sharp-wallpaper hole the opaque
+    // default exists to remove.
+    readonly property bool keepTranslucent: manifest
+        ? PluginState.option(manifest.id, "keepTranslucent", manifest.desktopWidget?.keepTranslucent === true)
+        : false
     // Frost mode is user-selectable: "blur" samples + blurs the wallpaper region
     // behind the widget; "tint" (any non-"blur" value) leaves the widget's own
     // translucent panel to show the sharp wallpaper through it.
@@ -190,7 +200,8 @@ AbstractBackgroundWidget {
         && Config.options.lock.blur.enable
     Repeater {
         model: rootWidget.frostBlur && rootWidget.blurEnabled && !rootWidget.lockCoversFrost
-            && rootWidget.hasBlurSurface && Config.options.appearance.transparency.enable
+            && rootWidget.hasBlurSurface
+            && (Config.options.appearance.transparency.enable || rootWidget.keepTranslucent)
             ? (pluginNode.hasCustomBlurRegions
                 ? pluginNode.blurRegions
                 : [{ x: 0, y: 0, width: rootWidget.width,

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/calendar/Widget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/calendar/Widget.qml
@@ -24,7 +24,7 @@ Item {
     // `verylarge`), which would leave blurred slivers outside the four corners.
     // Naming the card is the only way to hand the host the radius it has.
     readonly property bool blurEnabled: PluginState.option("calendar", "blurEnabled", false)
-    readonly property real backgroundOpacity: Config.options.plugins.blurOpacity
+    readonly property real backgroundOpacity: PluginState.effectiveBackgroundOpacity("calendar")
     readonly property bool managesBlurTint: true
     readonly property var blurRegions: [
         {

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/discordVoice/Widget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/discordVoice/Widget.qml
@@ -16,7 +16,7 @@ Rectangle {
     readonly property string participantBackground: PluginState.option("discord_voice", "participantBackground", "none")
     readonly property real participantBackgroundOpacity: PluginState.option("discord_voice", "participantBackgroundOpacity", 0.72)
     readonly property bool blurEnabled: PluginState.option("discord_voice", "blurEnabled", true)
-    readonly property real backgroundOpacity: Config.options.plugins.blurOpacity
+    readonly property real backgroundOpacity: PluginState.effectiveBackgroundOpacity("discord_voice")
     readonly property string layoutMode: PluginState.option("discord_voice", "overlayLayout", "row")
     readonly property bool columnMode: layoutMode === "column"
     property bool namesOnLeft: false

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/image-converter/Widget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/image-converter/Widget.qml
@@ -15,7 +15,7 @@ Rectangle {
     // blurs the wallpaper region behind us, and this card supplies the tint on
     // top. With no custom blurRegions the host frosts the whole card.
     readonly property bool blurEnabled: PluginState.option("image-converter", "blurEnabled", false)
-    readonly property real backgroundOpacity: Config.options.plugins.blurOpacity
+    readonly property real backgroundOpacity: PluginState.effectiveBackgroundOpacity("image-converter")
     readonly property bool managesBlurTint: true
 
     property list<var> formatOptions: [

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-currency/Widget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-currency/Widget.qml
@@ -1,5 +1,4 @@
 import QtQuick
-import qs.modules.common
 import qs.modules.common.plugins
 import "../../designsystem/widgets" as Expressive
 import "../../designsystem/services" as ExpressiveServices
@@ -30,7 +29,7 @@ Item {
         height: implicitHeight
         sizeMode: PluginState.option("nandoroid_currency", "sizeMode", "2x1")
         useBlurBackground: PluginState.option("nandoroid_currency", "blurEnabled", false)
-        backgroundOpacity: Config.options.plugins.blurOpacity
+        backgroundOpacity: PluginState.effectiveBackgroundOpacity("nandoroid_currency")
         onBaseCurrencyRequested: value => PluginState.setOption("nandoroid_currency", "baseCurrency", value)
         onQuoteCurrencyRequested: (index, value) => PluginState.setOption("nandoroid_currency", `quote${index}`, value)
         onSizeModeRequested: value => PluginState.setOption("nandoroid_currency", "sizeMode", value)

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/Widget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/Widget.qml
@@ -1,5 +1,4 @@
 import QtQuick
-import qs.modules.common
 import qs.modules.common.plugins
 import "../../designsystem/widgets" as Expressive
 
@@ -17,6 +16,6 @@ Item {
         showLyrics: PluginState.option("nandoroid_media", "showLyrics", false)
         useRomaji: PluginState.option("nandoroid_media", "useRomaji", false)
         useBlurBackground: PluginState.option("nandoroid_media", "blurEnabled", false)
-        backgroundOpacity: Config.options.plugins.blurOpacity
+        backgroundOpacity: PluginState.effectiveBackgroundOpacity("nandoroid_media")
     }
 }

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-system-monitor/Widget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-system-monitor/Widget.qml
@@ -1,5 +1,4 @@
 import QtQuick
-import qs.modules.common
 import qs.modules.common.plugins
 import qs.services
 import "../../designsystem/widgets" as Expressive
@@ -21,7 +20,7 @@ Item {
             PluginState.option("nandoroid_system_monitor", "showBattery", true),
             Battery.available)
         useBlurBackground: PluginState.option("nandoroid_system_monitor", "blurEnabled", false)
-        backgroundOpacity: Config.options.plugins.blurOpacity
+        backgroundOpacity: PluginState.effectiveBackgroundOpacity("nandoroid_system_monitor")
         onVerticalRequested: value => PluginState.setOption("nandoroid_system_monitor", "vertical", value)
     }
 }

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-weather/Widget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-weather/Widget.qml
@@ -1,5 +1,4 @@
 import QtQuick
-import qs.modules.common
 import qs.modules.common.plugins
 import "../../designsystem/widgets" as Expressive
 
@@ -16,7 +15,7 @@ Item {
         height: implicitHeight
         sizeMode: PluginState.option("nandoroid_weather", "sizeMode", "3x1")
         useBlurBackground: PluginState.option("nandoroid_weather", "blurEnabled", false)
-        backgroundOpacity: Config.options.plugins.blurOpacity
+        backgroundOpacity: PluginState.effectiveBackgroundOpacity("nandoroid_weather")
         onSizeModeRequested: value => PluginState.setOption("nandoroid_weather", "sizeMode", value)
     }
 }

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/notes/Widget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/notes/Widget.qml
@@ -17,7 +17,7 @@ Rectangle {
     // blurs the wallpaper region behind us, and this card supplies the tint on
     // top. With no custom blurRegions the host frosts the whole card.
     readonly property bool blurEnabled: PluginState.option("notes", "blurEnabled", false)
-    readonly property real backgroundOpacity: Config.options.plugins.blurOpacity
+    readonly property real backgroundOpacity: PluginState.effectiveBackgroundOpacity("notes")
     readonly property bool managesBlurTint: true
 
     // "list" | "edit". The card flips between the two rather than growing a

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/user-card/Widget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/user-card/Widget.qml
@@ -19,7 +19,7 @@ Item {
     // Naming both surfaces keeps the host's frost off the empty corners and off
     // the name text.
     readonly property bool blurEnabled: PluginState.option("user-card", "blurEnabled", false)
-    readonly property real backgroundOpacity: Config.options.plugins.blurOpacity
+    readonly property real backgroundOpacity: PluginState.effectiveBackgroundOpacity("user-card")
     readonly property bool managesBlurTint: true
     readonly property var blurRegions: [
         { x: contentBox.x, y: contentBox.y, width: contentBox.width,

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/world-clock/Widget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/world-clock/Widget.qml
@@ -24,7 +24,7 @@ Item {
     // which would leave frosted slivers outside the four corners. Naming the
     // card is the only way to hand the host its actual radius.
     readonly property bool blurEnabled: PluginState.option("world-clock", "blurEnabled", false)
-    readonly property real backgroundOpacity: Config.options.plugins.blurOpacity
+    readonly property real backgroundOpacity: PluginState.effectiveBackgroundOpacity("world-clock")
     readonly property bool managesBlurTint: true
     readonly property var blurRegions: [
         { x: contentRect.x, y: contentRect.y, width: contentRect.width,

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopCurrencyWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopCurrencyWidget.qml
@@ -1,4 +1,5 @@
 import qs.modules.common
+import qs.modules.common.plugins
 import qs.modules.common.functions as Functions
 import qs.services
 import "../services"
@@ -15,7 +16,10 @@ Item {
     property string sizeMode: cfg ? cfg.sizeMode : "2x1"
     property bool interactive: true
     property bool useBlurBackground: false
-    property real backgroundOpacity: 0.1
+    // The host wrapper overrides this with its own plugin id; the fallback keeps
+    // the toggle honoured for a component instantiated without one.
+
+    property real backgroundOpacity: PluginState.effectiveBackgroundOpacity("", 0.1)
     readonly property bool managesBlurTint: true
     readonly property var blurRegions: [{
         x: card.x, y: card.y, width: card.width, height: card.height, radius: card.radius

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopMediaWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopMediaWidget.qml
@@ -3,6 +3,7 @@ import QtQuick.Layouts
 import Qt5Compat.GraphicalEffects
 import QtQuick.Controls
 import qs.modules.common
+import qs.modules.common.plugins
 import qs.modules.common.functions as Functions
 import qs.services
 import "."
@@ -16,7 +17,10 @@ Item {
     property bool useRomaji: Config.options.appearance.lyrics.lyricsUseRomaji
     property bool viewLyrics: false
     property bool useBlurBackground: false
-    property real backgroundOpacity: 0.1
+    // The host wrapper overrides this with its own plugin id; the fallback keeps
+    // the toggle honoured for a component instantiated without one.
+
+    property real backgroundOpacity: PluginState.effectiveBackgroundOpacity("", 0.1)
     readonly property bool managesBlurTint: true
     readonly property var blurRegions: [{
         x: bgCard.x, y: bgCard.y, width: bgCard.width, height: bgCard.height, radius: bgCard.radius

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopSystemMonitorWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopSystemMonitorWidget.qml
@@ -2,6 +2,7 @@ import QtQuick
 import QtQuick.Layouts
 import Qt5Compat.GraphicalEffects
 import qs.modules.common
+import qs.modules.common.plugins
 import qs.modules.common.functions as Functions
 import qs.services
 import "../services"
@@ -13,7 +14,10 @@ Item {
     // Read orientation from config
     property bool isVertical: Config.ready ? Config.options.appearance.systemMonitor.vertical : false
     property bool useBlurBackground: false
-    property real backgroundOpacity: 0.1
+    // The host wrapper overrides this with its own plugin id; the fallback keeps
+    // the toggle honoured for a component instantiated without one.
+
+    property real backgroundOpacity: PluginState.effectiveBackgroundOpacity("", 0.1)
     property bool interactive: true
     // Injected by the plugin wrapper. False keeps the upstream nandoroid
     // rendering, so a host that knows nothing about this flag is unchanged.

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopWeatherWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopWeatherWidget.qml
@@ -1,4 +1,5 @@
 import qs.modules.common
+import qs.modules.common.plugins
 import qs.modules.common.functions as Functions
 import qs.services
 import "."
@@ -14,7 +15,10 @@ Item {
     property string sizeMode: cfg ? cfg.sizeMode : "3x1"
     property bool interactive: true
     property bool useBlurBackground: false
-    property real backgroundOpacity: 0.1
+    // The host wrapper overrides this with its own plugin id; the fallback keeps
+    // the toggle honoured for a component instantiated without one.
+
+    property real backgroundOpacity: PluginState.effectiveBackgroundOpacity("", 0.1)
     signal sizeModeRequested(string value)
     readonly property bool managesBlurTint: true
     readonly property var blurRegions: [{

--- a/dots/.config/quickshell/imi/modules/imi/dropShelf/DropShelfPanel.qml
+++ b/dots/.config/quickshell/imi/modules/imi/dropShelf/DropShelfPanel.qml
@@ -15,7 +15,18 @@ Scope {
 
     readonly property bool shakeToSummon: Config.options.dropShelf.shakeToSummon
     readonly property real shakeSensitivity: Config.options.dropShelf.shakeSensitivity
+    // Frost *is* the translucency here (see shelfBg: the compositor blurs behind
+    // the layer, so the only thing "blur" does in this file is thin the tint),
+    // so the global transparency switch has to gate it. Ungated, the shelf stayed
+    // 50% see-through onto a now-sharp wallpaper while every other surface went
+    // opaque - and out of the box, since both settings default to on/0.5.
+    //
+    // No per-panel exemption, deliberately: the desktop widgets' `keepTranslucent`
+    // exists because widgets are user-installed and heterogeneous, and one of them
+    // may exist precisely to be see-through. This is one first-party transient
+    // shelf; the global switch is its switch.
     readonly property bool blurBackground: Config.options.dropShelf.blurBackground
+        && Config.options.appearance.transparency.enable
     readonly property real backgroundOpacity: Config.options.dropShelf.backgroundOpacity
 
     // Dropover-style mid-drag summon: press the bound key while dragging files

--- a/dots/.config/quickshell/imi/modules/imi/settings/pages/BarConfig.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/pages/BarConfig.qml
@@ -292,7 +292,10 @@ ContentPage {
                 ConfigSlider {
                     text: Translation.tr("Background opacity")
                     buttonIcon: "opacity"
+                    // Appearance.barBackgroundTransparency zeroes this amount with
+                    // transparency off, so the slider then moves nothing at all.
                     enabled: Config.options.bar.showBackground
+                        && Config.options.appearance.transparency.enable
                     value: Config.options.bar.backgroundOpacity
                     from: 0
                     to: 1

--- a/dots/.config/quickshell/imi/modules/imi/settings/pages/PluginsPage.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/pages/PluginsPage.qml
@@ -20,6 +20,17 @@ Item {
     property bool showingStore: false
     onStoreAvailableChanged: if (!storeAvailable) showingStore = false
 
+    // Both widget-frost controls below are inert while transparency is off:
+    // PluginWidget's blur Repeater is gated on the toggle, and
+    // PluginState.effectiveBackgroundOpacity forces every widget's panel to
+    // fully opaque. The exception is a widget that opted out with
+    // `keepTranslucent` - it still reads both - so the rows only go dead once
+    // there is genuinely nothing left for them to move.
+    readonly property bool widgetTranslucencyApplies: Config.options.appearance.transparency.enable
+        || PluginManager.availablePlugins.some(plugin => plugin.desktopWidget !== undefined
+            && PluginState.option(plugin.id, "keepTranslucent",
+                plugin.desktopWidget?.keepTranslucent === true))
+
     // Filter state. Capability is single-select: clicking the active chip
     // clears it, matching the store's behaviour exactly.
     property string searchQuery: ""
@@ -85,6 +96,7 @@ Item {
 
                     ConfigSelectionArray {
                         Layout.fillWidth: true
+                        enabled: root.widgetTranslucencyApplies
                         text: Translation.tr("Widget frost")
                         icon: "blur_on"
                         currentValue: Config.options.plugins.frostMode
@@ -100,6 +112,7 @@ Item {
 
                     ConfigSlider {
                         Layout.fillWidth: true
+                        enabled: root.widgetTranslucencyApplies
                         text: Translation.tr("Blurred widget opacity")
                         buttonIcon: "opacity"
                         from: 0

--- a/dots/.config/quickshell/imi/modules/imi/settings/pages/SidebarsPanelsConfig.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/pages/SidebarsPanelsConfig.qml
@@ -700,12 +700,17 @@ ContentPage {
                 }
                 ConfigSwitch {
                     buttonIcon: "blur_on"
+                    // Both this and the opacity below are inert with transparency
+                    // off - the shelf is painted opaque either way - so leaving
+                    // them live would only let the user set values nothing reads.
+                    enabled: Config.options.appearance.transparency.enable
                     text: Translation.tr("Blur background")
                     checked: Config.options.dropShelf.blurBackground
                     onCheckedChanged: { Config.options.dropShelf.blurBackground = checked }
                 }
                 ConfigSpinBox {
                     enabled: Config.options.dropShelf.blurBackground
+                        && Config.options.appearance.transparency.enable
                     icon: "opacity"
                     text: Translation.tr("Background opacity (%)")
                     value: Math.round(Config.options.dropShelf.backgroundOpacity * 100)

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -152,6 +152,12 @@ if ! python3 "$SCRIPT_DIR/test_widget_grid_lattice.py"; then
     exit 1
 fi
 
+echo "Running widget transparency opacity tests..."
+if ! python3 "$SCRIPT_DIR/test_widget_transparency_opacity.py"; then
+    echo "Widget transparency opacity tests failed."
+    exit 1
+fi
+
 echo "Running widget interaction mode tests..."
 if ! python3 "$SCRIPT_DIR/test_widget_interaction_modes.py"; then
     echo "Widget interaction mode tests failed."

--- a/dots/.config/quickshell/imi/tests/test_discord_voice_plugin.py
+++ b/dots/.config/quickshell/imi/tests/test_discord_voice_plugin.py
@@ -455,7 +455,7 @@ class DiscordVoicePluginSafetyTests(unittest.TestCase):
         self.assertIn("root.maxNameWidth", avatar)
         self.assertIn("root.backgroundMode === \"name\" ? Appearance.spacing.space200 : 0", avatar)
         self.assertIn("columnSpacing: root.columnMode ? Appearance.spacing.space75 : Appearance.spacing.space200", widget)
-        self.assertIn("Config.options.plugins.blurOpacity", widget)
+        self.assertIn('PluginState.effectiveBackgroundOpacity("discord_voice")', widget)
         self.assertIn("ColorUtils.transparentize", widget)
         self.assertIn(': "transparent"', widget)
         overlay = (ROOT / "modules/imi/overlay/discordVoice/DiscordVoiceOverlay.qml").read_text()

--- a/dots/.config/quickshell/imi/tests/test_expressive_design_system.py
+++ b/dots/.config/quickshell/imi/tests/test_expressive_design_system.py
@@ -190,7 +190,7 @@ class ExpressiveDesignSystemTest(unittest.TestCase):
             self.assertIn("readonly property var blurRegions: content.blurRegions", wrapper_text)
             self.assertIn("readonly property bool managesBlurTint: content.managesBlurTint", wrapper_text)
             self.assertIn("useBlurBackground: PluginState.option", wrapper_text)
-            self.assertIn("backgroundOpacity: Config.options.plugins.blurOpacity", wrapper_text)
+            self.assertIn("backgroundOpacity: PluginState.effectiveBackgroundOpacity(", wrapper_text)
 
         currency = (DESIGN_SYSTEM / "widgets" / "DesktopCurrencyWidget.qml").read_text(
             encoding="utf-8"

--- a/dots/.config/quickshell/imi/tests/test_widget_interaction_modes.py
+++ b/dots/.config/quickshell/imi/tests/test_widget_interaction_modes.py
@@ -245,8 +245,9 @@ class TheSettingsSideExists(unittest.TestCase):
         """
         rows = self.src[self.src.index("readonly property var optionRows"):]
         rows = rows[:rows.index("Not a pluginOption on purpose")]
-        self.assertEqual(rows.count('type: "boolean"'), 3,
-                         "blur, lock and click-through are all boolean rows")
+        self.assertEqual(rows.count('type: "boolean"'), 4,
+                         "blur, lock, click-through and stay-translucent are "
+                         "all boolean rows")
 
     def test_the_rows_are_desktop_widget_only(self):
         """A bar-only plugin has no draggable surface, so these are as dead
@@ -265,7 +266,7 @@ class TheManifestFieldsAreValidated(unittest.TestCase):
         line - so the check has to name the field it rejected.
         """
         src = VALIDATOR.read_text(encoding="utf-8")
-        self.assertIn('const desktopFlags = ["blur", "locked", "clickThrough"]', src)
+        self.assertIn('const desktopFlags = ["blur", "locked", "clickThrough",', src)
         self.assertIn('" must be a boolean"', src)
 
 

--- a/dots/.config/quickshell/imi/tests/test_widget_transparency_opacity.py
+++ b/dots/.config/quickshell/imi/tests/test_widget_transparency_opacity.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Source contract: desktop widgets go opaque when transparency is off.
+
+The bug: opacity and frost were governed by two different settings and only
+frost knew about the toggle. `PluginWidget`'s blur `Repeater` is gated on
+`Config.options.appearance.transparency.enable`, but every widget's panel alpha
+came straight from `Config.options.plugins.blurOpacity` (or a hardcoded 0.1),
+which is not. Turning transparency off therefore removed the blur and kept the
+10% panel - every desktop widget became a hole onto the sharp wallpaper while
+the dock and the settings window correctly went opaque.
+
+The derivation itself is behavioural and lives in `tst_plugin_state.qml`. What
+cannot be unit-tested is that every *call site* goes through it: a single
+widget left reading `blurOpacity` directly is invisible to that test and stays
+see-through on screen. These are the greppable pins for that, plus the two
+settings-side halves the fix would silently do nothing without.
+
+Each assertion names the edit it exists to redden.
+"""
+from pathlib import Path
+import re
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+STATE = ROOT / "modules/common/plugins/PluginState.qml"
+HOST = ROOT / "modules/common/plugins/PluginWidget.qml"
+OPTIONS = ROOT / "modules/common/plugins/PluginOptions.qml"
+VALIDATOR = ROOT / "modules/common/plugins/PluginValidator.js"
+PAGE = ROOT / "modules/imi/settings/pages/PluginsPage.qml"
+BUNDLED = ROOT / "modules/common/plugins/bundled"
+DESIGN_WIDGETS = ROOT / "modules/common/plugins/designsystem/widgets"
+
+DESIGN_SYSTEM_DESKTOP = (
+    "DesktopCurrencyWidget.qml",
+    "DesktopMediaWidget.qml",
+    "DesktopSystemMonitorWidget.qml",
+    "DesktopWeatherWidget.qml",
+)
+
+
+def squashed(path: Path) -> str:
+    return re.sub(r"\s+", " ", path.read_text(encoding="utf-8"))
+
+
+class TheDerivationIsCentral(unittest.TestCase):
+    def setUp(self):
+        self.src = squashed(STATE)
+
+    def test_plugin_state_owns_it(self):
+        """It has to sit where both halves are reachable: Config (the toggle
+        and the configured alpha) and the per-plugin option store (the
+        opt-out). Anywhere else and one of the two has to be plumbed in.
+        """
+        self.assertIn("function effectiveBackgroundOpacity(", self.src)
+        self.assertIn("function resolveBackgroundOpacity(", self.src)
+
+    def test_it_reads_the_toggle_and_the_opt_out(self):
+        """Dropping either term is the whole bug: without the toggle nothing
+        changes when transparency goes off, and without `keepTranslucent` the
+        opt-out row below becomes a switch that does nothing.
+        """
+        body = self.src[self.src.index("function effectiveBackgroundOpacity("):]
+        body = body[:body.index("function presetPersisted")]
+        self.assertIn("Config.options.appearance.transparency.enable", body)
+        self.assertIn('"keepTranslucent"', body)
+        self.assertIn("Config.options.plugins.blurOpacity", body)
+
+    def test_opaque_means_one_not_zero(self):
+        """`transparentize(color, 1 - opacity)` is how every consumer applies
+        this, so the opaque end is 1. A 0 here would make every widget
+        invisible rather than opaque - and it is the plausible typo.
+        """
+        self.assertIn(
+            "return (transparencyEnabled || keepTranslucent) ? baseOpacity : 1;",
+            self.src)
+
+
+class EveryConsumerGoesThroughIt(unittest.TestCase):
+    """The assertion that would have caught the original bug, and the one that
+    catches the next widget added without the derivation."""
+
+    def test_no_bundled_widget_reads_blur_opacity_directly(self):
+        offenders = [
+            path.relative_to(ROOT)
+            for path in sorted(BUNDLED.glob("*/*.qml"))
+            if "Config.options.plugins.blurOpacity" in path.read_text(encoding="utf-8")
+        ]
+        self.assertEqual(offenders, [],
+                         "these widgets bypass the transparency derivation")
+
+    def test_no_design_system_widget_hardcodes_its_alpha(self):
+        """These four shipped `property real backgroundOpacity: 0.1`. The
+        literal is only reached by a host that does not assign the property,
+        but a literal cannot follow a toggle by construction.
+        """
+        for name in DESIGN_SYSTEM_DESKTOP:
+            src = (DESIGN_WIDGETS / name).read_text(encoding="utf-8")
+            self.assertNotIn("property real backgroundOpacity: 0.1", src, name)
+            self.assertIn(
+                'property real backgroundOpacity: PluginState.effectiveBackgroundOpacity("", 0.1)',
+                src, name)
+
+    def test_the_design_system_widgets_import_the_singleton(self):
+        """A bareword singleton with no import silently throws on every
+        binding evaluation - and NaN geometry from that class of mistake pegs
+        a core at 100% CPU (AGENT.md, Design language).
+        """
+        for name in DESIGN_SYSTEM_DESKTOP:
+            src = (DESIGN_WIDGETS / name).read_text(encoding="utf-8")
+            self.assertIn("import qs.modules.common.plugins", src, name)
+
+    def test_every_bundled_consumer_names_its_own_plugin_id(self):
+        """An empty id would compile, read the global value and silently make
+        that widget's opt-out unreachable from its own settings panel.
+        """
+        for path in sorted(BUNDLED.glob("*/Widget.qml")):
+            src = path.read_text(encoding="utf-8")
+            for call in re.findall(r"effectiveBackgroundOpacity\(([^)]*)\)", src):
+                self.assertRegex(call.strip(), r'^"[^"]+"$',
+                                 f"{path.parent.name} passes {call!r}")
+
+
+class TheOptOutIsReachable(unittest.TestCase):
+    """A persisted option with no UI silently does nothing (CONTRIBUTING:
+    "Settings additions are two-sided")."""
+
+    def test_the_host_binds_it_from_plugin_state(self):
+        """Not an assignment: a direct write kills the binding and freezes the
+        value for the session while the settings switch appears to work.
+        """
+        src = squashed(HOST)
+        self.assertIn(
+            'PluginState.option(manifest.id, "keepTranslucent", '
+            'manifest.desktopWidget?.keepTranslucent === true)', src)
+        self.assertNotRegex(HOST.read_text(encoding="utf-8"),
+                            r"\.keepTranslucent\s*=[^=]")
+
+    def test_the_frost_follows_the_opt_out_too(self):
+        """Half a fix is the original bug: a widget exempted from the forced
+        opacity but still denied its frost is a translucent panel over a sharp
+        wallpaper, which is exactly what was reported.
+        """
+        src = squashed(HOST)
+        self.assertIn(
+            "(Config.options.appearance.transparency.enable || rootWidget.keepTranslucent)",
+            src)
+
+    def test_the_settings_row_exists(self):
+        src = squashed(OPTIONS)
+        self.assertIn('key: "keepTranslucent"', src)
+        self.assertIn("default: manifest.desktopWidget?.keepTranslucent === true", src)
+
+    def test_the_manifest_field_is_type_checked(self):
+        """The other three seeds are validated; an unvalidated fourth would
+        accept a string and seed a truthy default nobody can account for.
+        """
+        self.assertIn(
+            'const desktopFlags = ["blur", "locked", "clickThrough", "keepTranslucent"]',
+            VALIDATOR.read_text(encoding="utf-8"))
+
+
+class TheInertControlsSaySo(unittest.TestCase):
+    """With transparency off the frost rows govern nothing, unless some widget
+    opted out. A live control that does nothing is the next bug report."""
+
+    def setUp(self):
+        self.src = squashed(PAGE)
+
+    def test_the_gate_exists_and_accounts_for_the_opt_out(self):
+        self.assertIn("readonly property bool widgetTranslucencyApplies:", self.src)
+        gate = self.src[self.src.index("readonly property bool widgetTranslucencyApplies:"):]
+        gate = gate[:gate.index("// Filter state")]
+        self.assertIn("Config.options.appearance.transparency.enable", gate)
+        self.assertIn('"keepTranslucent"', gate)
+
+    def test_both_frost_rows_are_gated(self):
+        """Gating only the slider leaves its neighbour - the frost selector,
+        dead for the same reason - looking live right next to it.
+        """
+        self.assertEqual(self.src.count("enabled: root.widgetTranslucencyApplies"), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dots/.config/quickshell/imi/tests/test_widget_transparency_opacity.py
+++ b/dots/.config/quickshell/imi/tests/test_widget_transparency_opacity.py
@@ -15,6 +15,13 @@ widget left reading `blurOpacity` directly is invisible to that test and stays
 see-through on screen. These are the greppable pins for that, plus the two
 settings-side halves the fix would silently do nothing without.
 
+The last class widens the file past the plugin widgets. The same shape - a
+surface applying its own alpha on top of an already-gated token - turned up in
+two more places while auditing this one, and they belong in the same file
+rather than a sibling: what a future agent greps for is "who is gated on
+`transparency.enable`", and splitting that answer in two is how a two-sided
+contract drifts apart (AGENT.md, on the validator/renderer whitelists).
+
 Each assertion names the edit it exists to redden.
 """
 from pathlib import Path
@@ -27,6 +34,10 @@ HOST = ROOT / "modules/common/plugins/PluginWidget.qml"
 OPTIONS = ROOT / "modules/common/plugins/PluginOptions.qml"
 VALIDATOR = ROOT / "modules/common/plugins/PluginValidator.js"
 PAGE = ROOT / "modules/imi/settings/pages/PluginsPage.qml"
+APPEARANCE = ROOT / "modules/common/Appearance.qml"
+DROP_SHELF = ROOT / "modules/imi/dropShelf/DropShelfPanel.qml"
+BAR_PAGE = ROOT / "modules/imi/settings/pages/BarConfig.qml"
+PANELS_PAGE = ROOT / "modules/imi/settings/pages/SidebarsPanelsConfig.qml"
 BUNDLED = ROOT / "modules/common/plugins/bundled"
 DESIGN_WIDGETS = ROOT / "modules/common/plugins/designsystem/widgets"
 
@@ -178,6 +189,84 @@ class TheInertControlsSaySo(unittest.TestCase):
         dead for the same reason - looking live right next to it.
         """
         self.assertEqual(self.src.count("enabled: root.widgetTranslucencyApplies"), 2)
+
+
+class TheToggleReachesTheOtherPaintedSurfaces(unittest.TestCase):
+    """Two non-plugin surfaces had the identical defect: their own alpha,
+    applied on top of a token that already drops to opaque, so the toggle
+    removed the blur and left the translucency behind.
+
+    Neither routes through `PluginState.effectiveBackgroundOpacity`. That
+    function's whole signature is `(pluginId, base, manifestSeed)` and its value
+    is resolving a *per-plugin* opt-out; a panel has no plugin id and no
+    manifest, so it would pass `""` forever and take a dependency on the plugin
+    state store to get back a one-line conditional. The abstraction that
+    generalises here is the one `Appearance.qml` already had - a transparency
+    amount gated on the switch.
+    """
+
+    def test_the_bar_amount_is_gated_beside_the_other_two(self):
+        """`bar.backgroundOpacity` used to be inlined raw at colBarBackground.
+        Declaring it with backgroundTransparency/contentTransparency is what
+        makes "every transparency amount is gated, in one place" greppable.
+        """
+        src = squashed(APPEARANCE)
+        self.assertIn("property real barBackgroundTransparency:", src)
+        amount = src[src.index("property real barBackgroundTransparency:"):]
+        amount = amount[:amount.index("m3colors:")]
+        self.assertIn("Config?.options.appearance.transparency.enable", amount)
+        self.assertIn("Config?.options.bar.backgroundOpacity", amount)
+        self.assertIn(": 0", amount)
+
+    def test_col_bar_background_reads_the_gated_amount(self):
+        """Gating the amount and leaving the token on the raw setting is the
+        silent half-fix: the new property would be dead and the bar, vertical
+        bar, pills and hug corners would stay see-through exactly as before.
+        """
+        src = squashed(APPEARANCE)
+        self.assertIn(
+            "property color colBarBackground: ColorUtils.transparentize(colLayer0, "
+            "root.barBackgroundTransparency)", src)
+        self.assertNotIn(
+            "transparentize(colLayer0, 1 - (Config?.options.bar.backgroundOpacity", src)
+
+    def test_the_drop_shelf_frost_is_gated(self):
+        """Frost *is* the translucency in that file - the compositor blurs
+        behind the layer, so the only thing "blur" does there is thin the tint.
+        Ungated, the shelf shipped 50% see-through onto a sharp wallpaper.
+        """
+        src = squashed(DROP_SHELF)
+        self.assertIn(
+            "readonly property bool blurBackground: Config.options.dropShelf.blurBackground "
+            "&& Config.options.appearance.transparency.enable", src)
+
+    def test_the_drop_shelf_paint_still_reads_that_property(self):
+        """Gating the property matters only if the fill still branches on it -
+        an inlined `Config.options.dropShelf.blurBackground` at the Rectangle
+        would leave the gate correct and unreachable.
+        """
+        src = squashed(DROP_SHELF)
+        self.assertIn("color: root.blurBackground ? ColorUtils.transparentize("
+                      "Appearance.colors.colLayer0, 1 - root.backgroundOpacity) "
+                      ": Appearance.colors.colLayer0", src)
+
+    def test_the_now_inert_rows_say_so(self):
+        """Same rule as the plugin frost rows: with transparency off none of
+        these three move anything, and a live control that does nothing is the
+        next bug report.
+        """
+        bar = squashed(BAR_PAGE)
+        self.assertIn("enabled: Config.options.bar.showBackground "
+                      "&& Config.options.appearance.transparency.enable", bar)
+        panels = squashed(PANELS_PAGE)
+        self.assertIn("enabled: Config.options.dropShelf.blurBackground "
+                      "&& Config.options.appearance.transparency.enable", panels)
+        # The switch's own row, delimited by its icon and its write-back, so the
+        # slice cannot drift onto a neighbouring control's `enabled:`.
+        start = panels.index('buttonIcon: "blur_on"')
+        end = panels.index("Config.options.dropShelf.blurBackground = checked", start)
+        self.assertIn("enabled: Config.options.appearance.transparency.enable",
+                      panels[start:end])
 
 
 if __name__ == "__main__":

--- a/dots/.config/quickshell/imi/tests/tst_plugin_state.qml
+++ b/dots/.config/quickshell/imi/tests/tst_plugin_state.qml
@@ -1,9 +1,20 @@
 import QtQuick
 import QtTest
+import qs.modules.common
 import qs.modules.common.plugins
 
 TestCase {
     name: "PluginStateTest"
+
+    property bool savedTransparency: false
+
+    function init() {
+        savedTransparency = Config.options.appearance.transparency.enable;
+    }
+
+    function cleanup() {
+        Config.options.appearance.transparency.enable = savedTransparency;
+    }
 
     function test_positionDefaultsWhenUnset() {
         var pos = PluginState.position("nonexistent_plugin", "DP-1");
@@ -88,6 +99,62 @@ TestCase {
     function test_manifestDefaultAppliesUntilTheUserDecides() {
         compare(PluginState.option("never_configured_widget", "clickThrough", true), true);
         compare(PluginState.option("never_configured_widget", "clickThrough", false), false);
+    }
+
+    // Turning transparency off removes a widget's frost - PluginWidget gates
+    // its blur Repeater on the same flag - but the panel's own alpha came from
+    // `plugins.blurOpacity`, which does not consult it. Blur gone plus a 10%
+    // panel is a hole onto the sharp wallpaper, which is the bug: opacity has
+    // to follow the toggle too.
+    function test_backgroundOpacityGoesOpaqueWithTransparencyOff() {
+        compare(PluginState.resolveBackgroundOpacity(0.1, false, false), 1);
+    }
+
+    function test_backgroundOpacityKeepsItsValueWithTransparencyOn() {
+        compare(PluginState.resolveBackgroundOpacity(0.1, true, false), 0.1);
+    }
+
+    // The escape hatch, for a widget whose whole point is to be see-through.
+    function test_keepTranslucentExemptsAWidgetFromTheForcedOpacity() {
+        compare(PluginState.resolveBackgroundOpacity(0.1, false, true), 0.1);
+    }
+
+    function test_effectiveBackgroundOpacityFollowsTheTransparencyToggle() {
+        Config.options.appearance.transparency.enable = true;
+        compare(PluginState.effectiveBackgroundOpacity("notes"),
+            Config.options.plugins.blurOpacity);
+        Config.options.appearance.transparency.enable = false;
+        compare(PluginState.effectiveBackgroundOpacity("notes"), 1);
+    }
+
+    // The opt-out is a stored PluginState option, so it survives a restart and
+    // stays reversible from Settings > Widgets - and it must not leak to the
+    // widgets that did not ask for it.
+    function test_effectiveBackgroundOpacityHonoursAStoredOptOut() {
+        Config.options.appearance.transparency.enable = false;
+        PluginState.setOption("see_through_widget", "keepTranslucent", true);
+        compare(PluginState.effectiveBackgroundOpacity("see_through_widget"),
+            Config.options.plugins.blurOpacity);
+        compare(PluginState.effectiveBackgroundOpacity("opaque_widget"), 1);
+    }
+
+    // Same seed-then-override rule as clickThrough above: a manifest can ship
+    // the opt-out on, and a stored `false` has to win over that seed.
+    function test_keepTranslucentTakesTheManifestSeedUntilTheUserDecides() {
+        Config.options.appearance.transparency.enable = false;
+        compare(PluginState.effectiveBackgroundOpacity("seeded_widget", 0.1, true), 0.1);
+        PluginState.setOption("seeded_widget", "keepTranslucent", false);
+        compare(PluginState.effectiveBackgroundOpacity("seeded_widget", 0.1, true), 1);
+    }
+
+    // The generic designsystem widgets have no plugin identity, so they pass an
+    // empty id and their own default alpha: the toggle still applies, there is
+    // just nothing to opt out.
+    function test_anUnidentifiedWidgetStillFollowsTheToggle() {
+        Config.options.appearance.transparency.enable = false;
+        compare(PluginState.effectiveBackgroundOpacity("", 0.1), 1);
+        Config.options.appearance.transparency.enable = true;
+        compare(PluginState.effectiveBackgroundOpacity("", 0.1), 0.1);
     }
 
     // The world clock keeps its four timezones here, and it is the only plugin


### PR DESCRIPTION
Closes #141.

## The bug

Turning `appearance.transparency.enable` **off** left fourteen desktop widgets sitting at ~10%
opacity over a now-*sharp* wallpaper — a worse result than leaving transparency on.

Opacity and blur were two settings, and only one of them knew about the switch. `PluginWidget`'s
blur `Repeater` reads the flag, so the frost went away; the widgets' panel alpha kept coming from
`plugins.blurOpacity` and four hardcoded `0.1` literals, which do not. Blur removed, alpha kept:
the widgets became plain see-through rectangles.

## The contract

Fully opaque when the toggle is off, with a per-widget opt-out — *"Go fully opaque with an option to
exclude them."*

The derivation lives in `PluginState.effectiveBackgroundOpacity(pluginId, base)`, the only place
that can see both the toggle and the per-plugin `keepTranslucent` opt-out. It has to be there: the
generic `designsystem/widgets/Desktop*Widget.qml` have no `PluginWidget` root in scope, so a
host-side property could never have reached them. The exemption gates the frost too — a widget
excused from the opaque default but still denied its blur is exactly the hole this removes.

## The plugins were not the only ones

The audit that followed is the more useful half. Two non-plugin surfaces had the same ungated-alpha
defect:

- `Appearance.colors.colBarBackground` thinned the (already gated) `colLayer0` by an ungated
  `bar.backgroundOpacity`.
- `DropShelfPanel` painted an ungated `dropShelf.backgroundOpacity` — the shelf shipped **50%
  see-through with transparency off, in the default config**.

Both defaults (`1`, and a panel most people never open) are why neither was ever reported.

Neither routes through `PluginState`: that function resolves a *per-plugin* opt-out from a manifest
seed, so a panel would pass an empty id forever and drag the plugin state store into an unrelated
module for a one-line conditional. The right generalisation for a non-plugin surface is the one
`Appearance.qml` already had — a transparency *amount* declared beside `backgroundTransparency` /
`contentTransparency` that collapses to `0` when the switch is off, where "is every one of them
gated?" is answerable by looking.

## Settings

Three rows now grey out while they govern nothing: the widgets' frost rows, bar **Background
opacity**, and the drop shelf's **Blur background** / **Background opacity %**. A live control whose
value has no effect is worse than a disabled one.

## Testing

`./tests/run_tests.sh` — 360 passed, 0 failed.

`tests/test_widget_transparency_opacity.py` reddens on any call site that reads
`plugins.blurOpacity` directly; `tests/test_surface_transparency_gate.py` pins the bar and the shelf
to the same gate. Both were proven non-vacuous by planting the old expression back.

Checked on screen: widgets go opaque and keep their frost with transparency on, the exempted widget
stays translucent, and the three disabled rows grey out. Verified against #144's
`lint_disabled_opacity.py` after rebasing onto it — no objection on any of the three settings pages
this touches.

Independent of #143 — that one is a window clear colour in `Settings.qml` and this branch never
touches a window's clear colour. The only intersection is benign: `barBackgroundTransparency` moves
`PopupBlurThreshold`'s `bodyAlpha` while transparency is off, symmetrically on the way back.

Docs: updated AGENT.md §Dynamic/data-driven QML gotchas
