### PR TITLE
fix(settings): a window clear colour that goes opaque never gets its blur back

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -682,6 +682,26 @@ Two non-obvious behaviors have bitten this codebase before and are worth knowing
   publish that takes effect is the settle timer's - which is a guaranteed ~96ms of surface-up-and-
   unblurred on every open. Publish immediately *and* keep the timer. Motivated by 4a1b4f850
   ("fix(blur): stop the compositor frosting drop shadows").
+- **A window's `color` is not just a colour: an alpha of 255 permanently costs that surface its
+  blur.** `QQuickWindow::setColor()` rewrites the window's *requested surface format* whenever the
+  new colour's alpha crosses the 255 boundary - `fmt.setAlphaBufferSize(alpha < 255 ? 8 : -1)` then
+  `QWindow::setFormat(fmt)`, which still mutates `requestedFormat()` long after `create()`.
+  `QWaylandWindow::isOpaque()` is literally `window()->requestedFormat().alphaBufferSize() <= 0`,
+  and the next `setGeometry()`/`setMask()` on an opaque window publishes
+  `wl_surface.set_opaque_region` over the whole surface. **Nothing retracts it** - `setOpaqueArea()`
+  has no caller outside those two `isOpaque()` branches - and Hyprland skips blur behind a
+  client-declared opaque region. So a window colour bound to a transparency-derived token
+  (`colLayer0`) goes opaque once when `appearance.transparency.enable` is switched off and is still
+  declared opaque after it is switched back on: translucent, unblurred, until the shell is reloaded
+  and the window is rebuilt on a fresh surface. That is
+  [#143](https://github.com/XephyLon/immaterial-impulse/issues/143), and note where the fault is not
+  - the QML is fully reactive, the colour really does come back, and no log line mentions any of it.
+  Keep a window's clear colour a **literal** and paint the backdrop with a child `Rectangle`, which
+  is what every other window here already did; `tests/lint_window_clear_color.py` fails the suite on
+  a bound one. The trigger for the latching configure is easy to under-estimate: the transparency
+  toggle makes `PopupBlurThreshold` rewrite `popupBlur.lua` and `hyprctl reload` 400ms later, which
+  reconfigures every window. deba3e3f6 ("fix(settings): keep the window's clear colour constant so
+  the frost survives"), 4a99f2a8b ("test(lint): pin every window's clear colour to a literal").
 - **This whole area is invisible to the test suite.** Quickshell's plugin does not load in
   `qmltestrunner`, so `Region` cannot be constructed there and no test can see whether a region is
   empty, published, or ignored. Every bug in this section was found by looking at the screen, and

--- a/dots/.config/quickshell/imi/ExpandablePanelGallery.qml
+++ b/dots/.config/quickshell/imi/ExpandablePanelGallery.qml
@@ -27,7 +27,16 @@ ShellRoot {
         visible: true
         implicitWidth: 1120
         implicitHeight: 720
-        color: Appearance.colors.colLayer0
+        // Same rule as the Settings window: a window's clear colour is constant
+        // and the backdrop is painted, so an alpha-255 clear colour can never
+        // latch the surface's Wayland opaque region. See AGENT.md.
+        color: "transparent"
+
+        Rectangle {
+            id: galleryBackdrop
+            anchors.fill: parent
+            color: Appearance.colors.colLayer0
+        }
 
         ColumnLayout {
             anchors.fill: parent

--- a/dots/.config/quickshell/imi/modules/imi/settings/Settings.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/Settings.qml
@@ -27,7 +27,14 @@ Scope {
         id: settingsWindow
         visible: GlobalStates.settingsOpen
         title: Translation.tr("Settings")
-        color: Appearance.colors.colLayer0
+        // Constant on purpose, and it must stay constant: a window's clear
+        // colour reaching alpha 255 even once permanently costs the surface its
+        // compositor blur. See AGENT.md's layer-shell section - Qt pushes an
+        // opaque Wayland region on the way to opaque and never retracts it, so
+        // binding this to colLayer0 left Settings unblurred for the rest of the
+        // session after one transparency round trip (#143). The backdrop below
+        // carries the colour instead, where alpha is only ever painted.
+        color: "transparent"
 
         // Fixed size: the layout is designed around these dimensions, and a
         // floating utility window has no reason to be resized.
@@ -43,6 +50,12 @@ Scope {
         onVisibleChanged: {
             if (!visible && GlobalStates.settingsOpen)
                 GlobalStates.settingsOpen = false;
+        }
+
+        Rectangle {
+            id: windowBackdrop
+            anchors.fill: parent
+            color: Appearance.colors.colLayer0
         }
 
         SettingsContent {

--- a/dots/.config/quickshell/imi/tests/lint_window_clear_color.py
+++ b/dots/.config/quickshell/imi/tests/lint_window_clear_color.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Fail if a window's clear colour is bound to an expression instead of a constant.
+
+A `PanelWindow`/`FloatingWindow`/`PopupWindow` `color:` is the QQuickWindow clear
+colour, and Qt treats a change in its *alpha class* as a change to the window's
+requested surface format:
+
+    QQuickWindow::setColor()  ->  fmt.setAlphaBufferSize(alpha < 255 ? 8 : -1)
+                              ->  QWindow::setFormat(fmt)
+
+`QWaylandWindow::isOpaque()` is literally
+`window()->requestedFormat().alphaBufferSize() <= 0`, and the next `setGeometry()`
+or `setMask()` on an opaque window publishes `wl_surface.set_opaque_region` over
+the whole window. Nothing in Qt ever retracts that region when the colour goes
+translucent again - `setOpaqueArea()` has no caller outside those two `isOpaque()`
+branches. Hyprland skips blur behind a client-declared opaque region, so a window
+whose clear colour touches alpha 255 once is unblurred for the rest of the
+process, however translucent it looks afterwards.
+
+That is #143: `Settings.qml` bound its clear colour to `colLayer0`, whose alpha
+collapses to 255 when `appearance.transparency.enable` goes off, so one
+Settings > Transparency round trip cost the Settings window its frost until the
+shell was reloaded and the window rebuilt.
+
+Paint the backdrop with a child `Rectangle` instead and keep the clear colour a
+literal. This check cannot be a QML test: Quickshell's plugin does not load in
+`qmltestrunner`, so no window type here can even be constructed.
+"""
+import re
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# Quickshell window types whose `color` reaches QQuickWindow::setColor.
+WINDOW_TYPES = {"PanelWindow", "FloatingWindow", "PopupWindow"}
+
+# Reviewed exceptions. Adding one means arguing that the latch is harmless for
+# that surface, not that the binding is fine.
+#
+# Background.qml's clear colour flips between "transparent" and an opaque safety
+# tint, so it latches the same way - but it is the bottom-most surface on the
+# screen. A stale opaque region there occludes nothing (there is nothing behind
+# the background layer), and blur behind it has nothing to sample either, so the
+# latch has no visible consequence. Painting the tint as a child instead would
+# mean reordering the wallpaper/parallax/widget stack that surface carries,
+# which is a much larger change than the defect justifies.
+ALLOWED = {"modules/imi/background/Background.qml"}
+
+OBJECT_OPEN = re.compile(r"^\s*(?:[A-Za-z_]\w*\.)*([A-Z]\w*)\s*\{")
+COLOR_BINDING = re.compile(r"^\s*color\s*:\s*(\S.*?)\s*$")
+STRING_LITERAL = re.compile(r'^(?:"[^"]*"|\'[^\']*\')$')
+
+
+def _strip(line):
+    """Drop line comments and string bodies so brace counting stays honest."""
+    line = re.sub(r'"[^"]*"', '""', line)
+    line = re.sub(r"'[^']*'", "''", line)
+    return line.split("//", 1)[0]
+
+
+def offending_bindings(text):
+    """(line number, expression) for every window `color:` that is not a literal."""
+    found = []
+    stack = []
+    for lineno, raw in enumerate(text.splitlines(), 1):
+        code = _strip(raw)
+
+        binding = COLOR_BINDING.match(raw.split("//", 1)[0])
+        if binding and stack and stack[-1] in WINDOW_TYPES:
+            expression = binding.group(1)
+            if not STRING_LITERAL.match(expression):
+                found.append((lineno, expression))
+
+        opened = OBJECT_OPEN.match(code)
+        pending = opened.group(1) if opened else None
+        for char in code:
+            if char == "{":
+                stack.append(pending)
+                pending = None
+            elif char == "}" and stack:
+                stack.pop()
+    return found
+
+
+def scan():
+    offenders = {}
+    for path in sorted(ROOT.rglob("*.qml")):
+        if not path.is_file():
+            continue
+        if str(path.relative_to(ROOT)) in ALLOWED:
+            continue
+        hits = offending_bindings(path.read_text(errors="ignore"))
+        if hits:
+            offenders[str(path.relative_to(ROOT))] = hits
+    return offenders
+
+
+class WindowClearColorLint(unittest.TestCase):
+    def test_the_scanner_sees_a_bound_window_colour(self):
+        self.assertEqual(
+            offending_bindings(
+                'FloatingWindow {\n    color: Appearance.colors.colLayer0\n}\n'),
+            [(2, "Appearance.colors.colLayer0")])
+
+    def test_a_literal_clear_colour_passes(self):
+        self.assertEqual(
+            offending_bindings('PanelWindow {\n    color: "transparent"\n}\n'), [])
+
+    def test_a_nested_rectangle_is_not_the_window(self):
+        self.assertEqual(
+            offending_bindings(
+                'PanelWindow {\n'
+                '    color: "transparent"\n'
+                '    Rectangle {\n'
+                '        color: Appearance.colors.colLayer0\n'
+                '    }\n'
+                '}\n'),
+            [])
+
+    def test_every_reviewed_exception_still_exists(self):
+        for allowed in sorted(ALLOWED):
+            self.assertTrue((ROOT / allowed).is_file(),
+                            f"{allowed} is allowlisted but no longer exists; "
+                            "drop the entry rather than leaving it dangling")
+
+    def test_no_window_binds_its_clear_colour(self):
+        offenders = scan()
+        self.assertEqual(offenders, {}, "\n".join(
+            f"{path}:{lineno}: window clear colour is bound to `{expression}`; "
+            "use a literal and paint the backdrop with a child Rectangle"
+            for path, hits in offenders.items() for lineno, expression in hits))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -125,6 +125,15 @@ if ! python3 "$SCRIPT_DIR/lint_blur_region_pairing.py"; then
     exit 1
 fi
 
+# Static lint: a window's clear colour must be a literal. One that reaches alpha
+# 255 makes Qt declare the Wayland surface opaque, and nothing ever retracts
+# that, so the window loses its compositor blur for the rest of the process.
+echo "Running window clear colour lint..."
+if ! python3 "$SCRIPT_DIR/lint_window_clear_color.py"; then
+    echo "Window clear colour lint failed."
+    exit 1
+fi
+
 # Static lint: StyledText must default to PlainText and every rich-text opt-in
 # must be reviewed - manifest strings are attacker-controlled and the render
 # site is their only defence.


### PR DESCRIPTION
Closes #143.

## The bug

Toggle `appearance.transparency.enable` off and back on with Settings open: the window comes back
translucent but **unblurred**, and stays that way until the shell is reloaded.

## Why

Not a teardown and not a rebuild — nothing in the shell tears down or rebuilds for this window. The
frost is compositor *window* blur (`rules.lua:12`, `no_blur = false` for `org.quickshell`), and the
loss is latched a layer below QML, in Qt's Wayland backend.

`Settings.qml:30` bound the `FloatingWindow`'s clear colour to `Appearance.colors.colLayer0`, whose
alpha collapses to 255 when transparency goes off. `QQuickWindow::setColor()` does not merely store
a colour: when the alpha crosses the 255 boundary it rewrites the window's *requested surface
format* — `fmt.setAlphaBufferSize(alpha < 255 ? 8 : -1)` then `QWindow::setFormat(fmt)`, which still
mutates `requestedFormat()` long after `create()`. `QWaylandWindow::isOpaque()` is exactly
`window()->requestedFormat().alphaBufferSize() <= 0`, and the next `setGeometry()`/`setMask()` on an
opaque window publishes `wl_surface.set_opaque_region` over the whole surface.

**There is no inverse path.** `setOpaqueArea()` has no caller outside those two `isOpaque()`
branches, so the region is never retracted when the colour goes translucent again. Hyprland skips
blur behind a client-declared opaque region, so the window is still *declared* opaque after the
toggle comes back on. A shell reload "fixes" it only by destroying the window and building a fresh
surface.

The configure that publishes the region is readily available: the same toggle makes
`PopupBlurThreshold` rewrite `popupBlur.lua` and fire `hyprctl reload` 400ms later, which
reconfigures every window.

Verified against the installed binaries rather than from memory — `QWaylandWindow::isOpaque`
disassembles to `requestedFormat().alphaBufferSize() <= 0`; `setOpaqueArea` has exactly three call
sites, all inside `setMask`/`setGeometry`, all behind that test; `QQuickWindow::setColor` shows the
two `setAlphaBufferSize` branches followed by `QWindow::setFormat`.

## Scope

A tree-wide scan found only **two** windows binding `color:` to an expression: `Settings.qml` and
`ExpandablePanelGallery.qml` (a dev harness). Every other `PanelWindow`/`FloatingWindow`/
`PopupWindow` already used a literal and painted its backdrop with a child item, so no other shipped
surface can latch. `Background.qml:551` flips between `"transparent"` and an opaque safety tint and
latches identically, but it is the bottom-most surface — a stale opaque region occludes nothing
there and blur behind it has nothing to sample. It is the lint's one documented exception.

## The fix

The clear colour becomes the literal `"transparent"` and a backdrop `Rectangle` carries `colLayer0`.
Painted alpha still goes fully opaque with transparency off, so it looks identical — it just no
longer tells the compositor anything.

`tests/lint_window_clear_color.py` fails the suite on any window type binding `color:` to an
expression. Proven to redden: planting the old binding back on the committed tree gives exit 1 with
`Settings.qml:37: window clear colour is bound to Appearance.colors.colLayer0`.

## Testing

`./tests/run_tests.sh` — 353 passed, 0 failed, all lints including the new one.

Not yet confirmed on screen. The fix only takes effect on a surface created after it, so the shell
must be reloaded before testing or the current Settings surface will look unfixed regardless. Two
things to check: (1) transparency off → on with Settings open keeps the frost, no reload — drag the
window between toggles, since `setGeometry` is what publishes the region; (2) with transparency off
Settings is still fully opaque, which is the one thing this could regress now that the backdrop
supplies what the clear colour used to.

Docs: updated AGENT.md §Layer shell, blur and the compositor
