### PR TITLE
fix(widgets): give every desktop widget's frost one shared wallpaper decode

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,9 @@ jobs:
           # ffmpeg: test_tonemap_sdr.py builds a real HDR10 fixture (libx265)
           # and drives the actual tonemap script; without ffmpeg those tests
           # skip and the SDR delivery path ships unexercised.
-          sudo apt-get install -y qt6-declarative-dev qml6-module-qttest qml6-module-qtquick qml6-module-qtqml qml6-module-qtquick-controls qml6-module-qtquick-layouts qml6-module-qtqml-workerscript qml6-module-qtquick-window ffmpeg
+          # qt5compat supplies FastBlur, which WallpaperBlurSurface imports; without
+          # it that type is simply "unavailable" and its test fails to compile.
+          sudo apt-get install -y qt6-declarative-dev qml6-module-qttest qml6-module-qtquick qml6-module-qtqml qml6-module-qtquick-controls qml6-module-qtquick-layouts qml6-module-qtqml-workerscript qml6-module-qtquick-window qml6-module-qt5compat-graphicaleffects ffmpeg
 
       # zstd builds the fixture release tarballs in
       # test_wallpaperengine_prebuilt.py and extracts them in the installer under

--- a/AGENT.md
+++ b/AGENT.md
@@ -889,6 +889,25 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   3088bbaed ("fix(plugins): route every widget panel opacity through the derivation"),
   e4f3a095e ("fix(appearance): gate the bar's own opacity on the transparency switch"),
   b47935a65 ("fix(dropShelf): gate the shelf's frost on the transparency switch").
+- **N widgets each asking the image reader for the same wallpaper is N serialized decodes, not
+  one.** Qt runs a single pixmap-reader thread, so per-widget image loads queue behind each other —
+  which is why the desktop widgets' frost came back one widget at a time, ~0.6s apart, after
+  anything that rebuilt the blur surfaces
+  ([#147](https://github.com/XephyLon/immaterial-impulse/issues/147)). Note the asymmetry that
+  names the cause: losing the frost was atomic because it is a property change, getting it back was
+  serial because it waits on a decode. What decides whether two `Image`s share one decode is the
+  whole **request**, and more of it than is obvious: url, `sourceSize`, `sourceClipRect`, *and* the
+  aspect flags a `PreserveAspectCrop`/`Fit` fill mode puts in the request — an otherwise identical
+  `Stretch` image of the same file is a different request and decodes again (measured; it is what
+  made a correct fix look broken from a test). `cache: false` opts out of sharing entirely. So a
+  per-widget `sourceClipRect`, which is the natural way to write "the slice of wallpaper behind
+  this widget", is exactly what makes every widget pay for its own full-resolution decode — and it
+  re-pays on every pixel of a drag, since the rect tracks the widget's position. Take the slice
+  with a `ShaderEffectSource`'s `sourceRect` over a shared, unclipped, cached `Image` instead: the
+  rect is free to move, and matching the request Background's own wallpaper `Image` makes means a
+  surface built while that wallpaper is on screen needs no decode at all.
+  33139b688 ("fix(widgets): give every desktop widget's frost one shared wallpaper decode"),
+  e15b9f166 ("test(widgets): pin the desktop frost to one shared wallpaper request").
 - Desktop plugin delegates are retained for every available manifest and gated through an animated
   `FadeLoader`, rather than repeating only the enabled ids. Removing a model delegate destroys it
   immediately and makes an M3 exit transition impossible; keep disabled loaders dormant until their

--- a/dots/.config/quickshell/imi/modules/common/widgets/WallpaperBlurSurface.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/WallpaperBlurSurface.qml
@@ -6,11 +6,15 @@ import qs.modules.common
 // the wallpaper region directly behind this surface and blurs it, so the widget
 // reads as frosted glass over the wallpaper.
 //
-// - Static image wallpaper: load + clip the image region behind the surface.
-// - Live Wallpaper Engine wallpaper: sample the in-shell WallpaperEngineSurface
-//   (weSurfaceItem) at this surface's screen rect. WE is now drawn on the
-//   background surface itself, so the old compositor-blur handoff no longer
-//   applies - we blur the live frame ourselves.
+// Both wallpaper paths are one shape: a whole-screen item, sampled at this
+// surface's screen rect through a ShaderEffectSource.
+//
+// - Live Wallpaper Engine wallpaper: the in-shell WallpaperEngineSurface
+//   (weSurfaceItem). WE is now drawn on the background surface itself, so the
+//   old compositor-blur handoff no longer applies - we blur the live frame
+//   ourselves.
+// - Static image wallpaper: a screen-sized Image of the wallpaper, cover-fitted
+//   exactly as the desktop draws it (see wallpaperImage).
 Item {
     id: root
 
@@ -23,7 +27,7 @@ Item {
     property int blurRadius: 48
 
     // Monitor size and this surface's absolute top-left on that monitor, used to
-    // clip out exactly the wallpaper slice sitting behind the surface.
+    // sample exactly the wallpaper slice sitting behind the surface.
     property real screenWidth: 0
     property real screenHeight: 0
     property real surfaceX: 0
@@ -39,55 +43,48 @@ Item {
         radius: root.cornerRadius
     }
 
-    // ---- Live Wallpaper Engine path: sample the WE surface at our screen rect.
+    // ---- Static image path: the whole wallpaper, laid out exactly as the
+    // desktop draws it, so the slice behind this surface is just a sub-rect.
+    //
+    // Asking for the plain file - no sourceSize, no sourceClipRect, cache on -
+    // is the fix for #147, not an oversight. Those are the request parameters a
+    // QQuickPixmap cache key is built from, so the per-surface clip rect this
+    // used to carry gave every surface a key of its own, and `cache: false`
+    // stopped even identical requests from being shared: eight widgets meant
+    // sixteen full-resolution decodes of one file queued on Qt's single
+    // pixmap-reader thread, and the frost came back one widget at a time, ~0.6s
+    // apart. Sharing the key means every surface - and Background's own
+    // wallpaper Image, which asks for it the same way - waits on one decode, and
+    // a surface created after that decode is Ready in the frame it is built. It
+    // also stops a drag re-requesting the wallpaper on every pixel of travel:
+    // only the sample rect below moves now.
+    Image {
+        id: wallpaperImage
+        width: root.screenWidth
+        height: root.screenHeight
+        source: root.liveWallpaperActive ? "" : root.wallpaperUrl
+        fillMode: Image.PreserveAspectCrop
+        asynchronous: true
+        cache: true
+        visible: false
+    }
+
+    // One sampler for both paths: the source is whole-screen either way, and
+    // the rect is where this surface sits on the monitor.
     ShaderEffectSource {
-        id: liveSample
+        id: wallpaperSample
         anchors.fill: parent
         visible: false
         live: true
         hideSource: false
-        sourceItem: root.liveWallpaperActive ? root.weSurfaceItem : null
-        sourceRect: root.liveWallpaperActive
-            ? Qt.rect(root.surfaceX, root.surfaceY, Math.max(1, root.width), Math.max(1, root.height))
-            : Qt.rect(0, 0, 0, 0)
-    }
-
-    // ---- Static image path: natural size probe + clipped cover sample.
-    Image {
-        id: wallpaperMetadata
-        source: root.liveWallpaperActive ? "" : root.wallpaperUrl
-        asynchronous: true
-        cache: false
-        visible: false
-    }
-
-    Image {
-        id: wallpaperSample
-        anchors.fill: parent
-        source: root.liveWallpaperActive ? "" : root.wallpaperUrl
-        fillMode: Image.PreserveAspectCrop
-        asynchronous: true
-        cache: false
-        visible: false
-
-        readonly property real srcW: wallpaperMetadata.sourceSize.width
-        readonly property real srcH: wallpaperMetadata.sourceSize.height
-        readonly property real coverScale: (srcW > 0 && srcH > 0
-                && root.screenWidth > 0 && root.screenHeight > 0)
-            ? Math.max(root.screenWidth / srcW, root.screenHeight / srcH)
-            : 0
-        sourceClipRect: coverScale > 0
-            ? Qt.rect(
-                (srcW - root.screenWidth / coverScale) / 2 + root.surfaceX / coverScale,
-                (srcH - root.screenHeight / coverScale) / 2 + root.surfaceY / coverScale,
-                Math.max(1, root.width / coverScale),
-                Math.max(1, root.height / coverScale))
-            : Qt.rect(0, 0, 0, 0)
+        sourceItem: root.liveWallpaperActive ? root.weSurfaceItem : wallpaperImage
+        sourceRect: Qt.rect(root.surfaceX, root.surfaceY,
+            Math.max(1, root.width), Math.max(1, root.height))
     }
 
     FastBlur {
         anchors.fill: parent
-        source: root.liveWallpaperActive ? liveSample : wallpaperSample
+        source: wallpaperSample
         radius: root.blurRadius
         layer.enabled: true
         layer.effect: OpacityMask {

--- a/dots/.config/quickshell/imi/modules/common/widgets/WallpaperBlurSurface.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/WallpaperBlurSurface.qml
@@ -37,6 +37,12 @@ Item {
         ? "file://" + root.wallpaperSource.split('/').map(s => encodeURIComponent(s)).join('/')
         : ""
 
+    // Load state of the static sample. The cascade this component exists to
+    // avoid is only observable as *when* each surface's wallpaper arrives, and
+    // nothing else about the frost is reachable from a test - see
+    // tests/tst_wallpaper_blur_sharing.qml.
+    readonly property int sampleStatus: wallpaperImage.status
+
     readonly property Rectangle _mask: Rectangle {
         width: root.width
         height: root.height

--- a/dots/.config/quickshell/imi/tests/imports/qs/modules/common/widgets/WallpaperBlurSurface.qml
+++ b/dots/.config/quickshell/imi/tests/imports/qs/modules/common/widgets/WallpaperBlurSurface.qml
@@ -1,0 +1,1 @@
+../../../../../../modules/common/widgets/WallpaperBlurSurface.qml

--- a/dots/.config/quickshell/imi/tests/imports/qs/modules/common/widgets/qmldir
+++ b/dots/.config/quickshell/imi/tests/imports/qs/modules/common/widgets/qmldir
@@ -1,2 +1,3 @@
 module qs.modules.common.widgets
 LiveDesktopEntry 1.0 LiveDesktopEntry.qml
+WallpaperBlurSurface 1.0 WallpaperBlurSurface.qml

--- a/dots/.config/quickshell/imi/tests/tst_wallpaper_blur_sharing.qml
+++ b/dots/.config/quickshell/imi/tests/tst_wallpaper_blur_sharing.qml
@@ -1,0 +1,81 @@
+import QtQuick
+import QtTest
+import qs.modules.common.widgets
+
+// Desktop widget frost used to come back one widget at a time after anything
+// that rebuilt the blur surfaces (#147): each surface asked for the wallpaper
+// with request parameters of its own (a per-surface `sourceClipRect`, and
+// `cache: false`), so no two requests could be shared and Qt's single
+// pixmap-reader thread served them one after another - eight widgets, sixteen
+// full-resolution decodes, ~0.6s each.
+//
+// Nothing about the rendered frost is reachable from a test: Quickshell's
+// plugin does not load in qmltestrunner and the software scene graph draws no
+// ShaderEffect. What *is* reachable is the load state that ordered the cascade,
+// and it is the whole mechanism: a surface that shares the wallpaper request is
+// Ready the moment it is built, and one that does not has to wait for a decode.
+TestCase {
+    name: "WallpaperBlurSharingTest"
+
+    readonly property string wallpaperPath:
+        Qt.resolvedUrl("fixtures/colorful_64.png").toString().replace("file://", "")
+
+    // Stands in for Background.qml's own wallpaper Image, which has already
+    // decoded the file by the time any desktop widget is built. Declared with
+    // exactly that image's request parameters, because every one of them is part
+    // of the cache key: a bare path rather than the file:// URL the surface
+    // builds, no sourceSize, no sourceClipRect, and PreserveAspectCrop - a fill
+    // mode that preserves aspect sets flags in the request, so the same file
+    // asked for with the default Stretch is a different request and decodes
+    // again.
+    Image {
+        id: backgroundWallpaper
+        fillMode: Image.PreserveAspectCrop
+        cache: true
+        asynchronous: true
+        visible: false
+    }
+
+    Component {
+        id: surfaceComponent
+        WallpaperBlurSurface {}
+    }
+
+    function buildSurface(index) {
+        return createTemporaryObject(surfaceComponent, this, {
+            wallpaperSource: wallpaperPath,
+            screenWidth: 5120,
+            screenHeight: 1440,
+            surfaceX: 100 + index * 400,
+            surfaceY: 220,
+            width: 320,
+            height: 200
+        });
+    }
+
+    function test_everySurfaceSharesTheWallpaperTheDesktopAlreadyDecoded() {
+        backgroundWallpaper.source = wallpaperPath;
+        tryVerify(() => backgroundWallpaper.status === Image.Ready, 5000,
+            "the stand-in background wallpaper never loaded");
+
+        // Eight surfaces at eight different places on the monitor: the desktop
+        // the cascade was measured on. Under the old shape each one issues its
+        // own clipped decode and is still Loading here.
+        for (let i = 0; i < 8; i++) {
+            const surface = buildSurface(i);
+            compare(surface.sampleStatus, Image.Ready,
+                "surface " + i + " had to wait for a decode of its own");
+        }
+    }
+
+    // The live Wallpaper Engine path samples the WE surface instead, so it must
+    // not ask the image reader for anything at all - a live project has no file
+    // to decode, and requesting the last static wallpaper behind it would put
+    // the queue back for the path that never had it.
+    function test_theLiveWallpaperPathRequestsNoImage() {
+        const surface = buildSurface(0);
+        surface.liveWallpaperActive = true;
+        compare(surface.sampleStatus, Image.Null,
+            "the live path still requested a static wallpaper");
+    }
+}


### PR DESCRIPTION
Closes #147.

Desktop widget frost came back **one widget at a time** after anything that rebuilt the blur
surfaces — the transparency toggle is the easy trigger. Roughly 0.6 s apart, ~3.6 s end to end on an
eight-widget desktop. Present for weeks, not a regression.

The loss was atomic and the return was serialized, and that asymmetry is the diagnosis: losing the
frost is a property change, restoring it waits on an image decode.

## Cause

Every `WallpaperBlurSurface` owned two `Image`s pointed at the full wallpaper file, both
`asynchronous: true` and `cache: false`. A `QQuickPixmap` cache key is
`(url, sourceSize, sourceClipRect, frame, provider options)` — so the per-surface `sourceClipRect`
was itself part of the key, and `cache: false` stopped even identical requests being shared. Eight
widgets meant sixteen full-resolution decodes of one 5120×1440 file queued on Qt's single
pixmap-reader thread.

Measured, 8 surfaces: before, `s0@75 s7@250 s6@427 … s1@1256` ms — 78 ms per decode, one surface
arriving every ~166 ms. After, all eight `Ready` together at 76 ms. One decode.

Two things the issue got wrong, both load-bearing:

- **`cache: true` is not half a fix and the metadata probe does not need hoisting.** Drop the clip
  rect *and* enable the cache and every surface makes one identical request. `wallpaperMetadata`
  then has nothing left to do — an unclipped screen-sized `PreserveAspectCrop` image does the cover
  fit itself, so the `sourceSize` probe and the `coverScale` arithmetic delete rather than move.
- **Fill mode is part of the request.** `PreserveAspectCrop` sets aspect flags in the provider
  options, so the same file requested with the default `Stretch` decodes again. `Background.qml`'s
  own wallpaper is `PreserveAspectCrop` too, so the surfaces now attach to its existing decode at
  0 ms.

Also unreported and now gone: the clip rect tracked `rootWidget.x/y` live, so every pixel of a
widget drag issued a fresh full-resolution request.

## Why not hoist the wallpaper into Background

That was the obvious "unify both paths" move and it is reachable — one `WidgetCanvas`, one
`Repeater`, one `bgRoot.wallpaperPath` per screen. It was not taken: it couples a
`modules/common/widgets` component to *which* of Background's five wallpaper layers is currently
painting (static, mid-transition, centred, video, lock peel). Getting that wrong frosts a widget
against nothing and no test can see it. Sharing the request reaches zero extra decodes anyway, and
both paths still end up on one `ShaderEffectSource`, which was the actual point.

## Testing

`./tests/run_tests.sh` — **364 passed, 0 failed** (360 on the base commit; the +4 is the new test).

`tests/tst_wallpaper_blur_sharing.qml` builds eight real surfaces after a stand-in Background
wallpaper has loaded and requires each to be `Ready` the frame it is built. Non-vacuity proven on a
committed tree: the full old shape fails with `surface 0 had to wait for a decode of its own`, and
so does the one-character mutation `cache: true` → `false`.

Rendering equivalence was measured rather than assumed. `QT_QPA_PLATFORM=offscreen` loads the
software scene graph and draws no `ShaderEffect` at all, so the committed component was rendered
against the old clip-rect shape under a private headless weston with real GL: max per-channel
difference 1/255, rising to 4/255 where the cover fit has to scale.

Confirmed on screen by the user, on both the static and live Wallpaper Engine paths.

Docs: updated AGENT.md §Dynamic/data-driven QML gotchas