### PR TITLE
fix(bar): a tray menu on the shared card killed the shell

### DIFF
--- a/dots/.config/hypr/hyprland/rules.lua
+++ b/dots/.config/hypr/hyprland/rules.lua
@@ -217,7 +217,12 @@ local popup_blur_threshold = (ok and type(generated) == "number") and generated 
 -- which is what PopupBlurThreshold computes. Getting that backwards unblurs
 -- the panels themselves.
 for _, ns in ipairs({ "quickshell:bar", "quickshell:verticalBar", "quickshell:dock",
-                      "quickshell:sidebarLeft", "quickshell:sidebarRight" }) do
+                      "quickshell:sidebarLeft", "quickshell:sidebarRight",
+                      -- The bar popup overlay: one always-mapped surface whose
+                      -- card hosts every bar popup's content, so the menus those
+                      -- popups open are now xdg-popups of *this* surface and
+                      -- inherit its threshold rather than the bar's.
+                      "quickshell:barPopup" }) do
     hl.layer_rule({ match = { namespace = ns }, ignore_alpha = popup_blur_threshold })
 end
 

--- a/dots/.config/quickshell/imi/modules/common/widgets/StyledPopup.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/StyledPopup.qml
@@ -33,6 +33,20 @@ QtObject {
     // binding rather than close the popup.
     signal dismissRequested()
 
+    // Raised by the overlay immediately *before* it unparents this popup's
+    // content from the card. Anything holding a reference to the window the
+    // content is currently in - a menu anchored to it, say - has to let go here:
+    // once the reparent starts, Qt tears the item's window association down and
+    // re-evaluates every binding that read it, with the item half destroyed.
+    signal aboutToRelease()
+
+    // Windows that belong to this popup but are not the card: a tray item's
+    // context menu is a real window of its own, opened from content sitting on
+    // the shared card. The overlay's focus grab has to count them as inside, or
+    // opening one reads as a click outside the card and dismisses the popup that
+    // owns it.
+    property var extraGrabWindows: []
+
     onPopupVisibleChanged: {
         // A click-toggled popup's widget never reports hover (a RippleButton has
         // no containsMouse; the plugin adapters set hoverEnabled: false), so

--- a/dots/.config/quickshell/imi/modules/imi/bar/BarPopupOverlay.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/BarPopupOverlay.qml
@@ -50,13 +50,24 @@ Scope {
                 right: true
             }
 
-            // Reused deliberately rather than minting a namespace: rules.lua
-            // gives quickshell:popup ignore_alpha = 1, which blurs the card's
-            // opaque body and skips its translucent shadow. A new namespace
-            // would fall through to the catch-all 0.05, under which this
-            // surface's transparent pixels ask the compositor to blur the
-            // entire screen.
-            WlrLayershell.namespace: "quickshell:popup"
+            // Its own namespace, listed in rules.lua's computed-threshold loop
+            // beside the bar and the dock. quickshell:popup was reused at first
+            // because its ignore_alpha = 1 blurs the card's opaque body and
+            // skips its translucent shadow - but a tray item's context menu is
+            // an xdg-popup of whatever surface it was opened from, and popups
+            // inherit the parent surface's rules. Once tray items moved onto
+            // this card their menus inherited that 1, and a translucent menu
+            // body sits below it: the menu stopped being blurred at all.
+            //
+            // The computed threshold serves both, which the constant cannot:
+            // it is above the shadow and below the faintest body, so the opaque
+            // card blurs, its shadow stays sharp, this surface's transparent
+            // pixels are left alone, and the popups opened from the card are
+            // blurred like the ones opened from the bar always were. A
+            // namespace absent from that loop is the real hazard - it falls
+            // through to the catch-all 0.05, under which the transparent pixels
+            // ask the compositor to blur the whole screen.
+            WlrLayershell.namespace: "quickshell:barPopup"
             WlrLayershell.layer: WlrLayer.Overlay
 
             mask: Region {
@@ -280,6 +291,11 @@ Scope {
 
             function release(popup) {
                 if (!popup) return;
+                // Before the reparent, not after: setParentItem() runs
+                // derefWindow(), which re-evaluates every binding that read the
+                // old window while the item is mid-teardown. A tray menu
+                // anchored to that window segfaulted the shell there.
+                popup.aboutToRelease();
                 const content = popup.contentItem;
                 if (content) {
                     content.anchors.centerIn = null;
@@ -335,7 +351,8 @@ Scope {
                     && card.width > Appearance.sizes.elevationMargin * 2
                 windows: [
                     overlayWindow,
-                    overlayWindow.current?.hoverTarget?.QsWindow?.window
+                    overlayWindow.current?.hoverTarget?.QsWindow?.window,
+                    ...(overlayWindow.current?.extraGrabWindows ?? [])
                 ].filter(window => window)
                 onCleared: overlayWindow.current?.dismissRequested()
             }

--- a/dots/.config/quickshell/imi/modules/imi/bar/SysTray.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/SysTray.qml
@@ -29,7 +29,18 @@ Item {
         if (unpinnedItems.length == 0) root.closeOverflowMenu()
     }
 
-    function grabFocus() { focusGrab.active = true }
+    function grabFocus() {
+        // Only one focus grab can be held at a time. While the overflow's
+        // content sits on the shared card, the overlay is already holding one
+        // that covers the bar, the card and this menu (it publishes the menu
+        // through extraGrabWindows) - arming a second makes the compositor drop
+        // one of the two, and whichever loses raises cleared, which closed a
+        // tray menu about half a second after it opened. The overlay's grab
+        // dismisses the menu and the overflow together in that case.
+        if (overflowPopup.surfaceWindow)
+            return;
+        focusGrab.active = true
+    }
     function setExtraWindowAndGrabFocus(window) {
         if (root.activeMenu && root.activeMenu !== window) {
             if (typeof root.activeMenu.close === "function")

--- a/dots/.config/quickshell/imi/modules/imi/bar/SysTray.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/SysTray.qml
@@ -119,6 +119,16 @@ Item {
                 // Bound, not assignable - so the overlay's grab asks rather
                 // than writes, and this clears the flag the binding reads.
                 onDismissRequested: root.trayOverflowOpen = false
+                extraGrabWindows: root.activeMenu ? [root.activeMenu] : []
+                // The overflow's delegates own tray menus anchored to whatever
+                // window the card is on. Let them go before the card unparents.
+                onAboutToRelease: {
+                    if (root.activeMenu) {
+                        root.activeMenu.close()
+                        root.activeMenu = null
+                    }
+                    root.trayOverflowOpen = false
+                }
 
                 GridLayout {
                     id: trayOverflowLayout

--- a/dots/.config/quickshell/imi/modules/imi/bar/SysTrayItem.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/SysTrayItem.qml
@@ -78,7 +78,7 @@ MouseArea {
             trayItemMenuHandle: root.item.menu
             trayItemId: root.item.id
             anchor {
-                window: root.QsWindow.window
+                window: root.QsWindow?.window ?? null
                 item: root
                 gravity: Config.options.bar.vertical
                     ? (Config.options.bar.bottom ? Edges.Left : Edges.Right)

--- a/dots/.config/quickshell/imi/tests/lint_bar_popup_overlay_static.py
+++ b/dots/.config/quickshell/imi/tests/lint_bar_popup_overlay_static.py
@@ -68,9 +68,10 @@ for axis in ("width", "height"):
             f"never collapses the card back to {axis} 0; an exited card must build an empty "
             "input region, and an opacity-0 card still publishes a full-size one")
 
-if 'WlrLayershell.namespace: "quickshell:popup"' not in code:
+if 'WlrLayershell.namespace: "quickshell:barPopup"' not in code:
     failures.append(
-        'does not reuse the quickshell:popup namespace; a new one falls through to the '
+        'does not use the quickshell:barPopup namespace, which rules.lua gives the computed '
+        'popup-blur threshold; a namespace outside that loop falls through to the '
         "catch-all ignore_alpha and asks the compositor to blur the whole screen")
 
 if "WindowBlurRegion" in code:


### PR DESCRIPTION
Right-clicking a tray icon inside the overflow popup **segfaulted the whole shell**. Shipped in
0.23.0 — this wants a 0.23.1.

Three defects, all the same root cause: the morphing card hosts content that used to live in a
window of its own, and a tray menu is a real window opened *from* that content.

## The crash

```
PopupAnchor::setWindow(QObject*)
QQuickItem::window() const          <- SEGV
QQuickMouseArea::itemChange(...)
QQuickItemPrivate::derefWindow()
QQuickItem::setParentItem(QQuickItem*)
```

That `setParentItem` is the overlay's `release()` doing `content.parent = null`. Qt runs
`derefWindow()` inside it, which re-evaluates every binding that read the item's window while the
item is half torn down — and `SysTrayItem`'s menu anchor read `root.QsWindow.window` unguarded.

A per-popup window was destroyed whole, so that binding never re-evaluated with a live menu
attached. A shared card unparents instead, and does it while the menu is open.

`StyledPopup` gains `aboutToRelease()`, raised *before* the reparent rather than after, and SysTray
closes its menus on it. The anchor binding is guarded too, since a null window is now a state it can
legitimately see.

## The overflow closed itself when a menu opened

The overlay's focus grab counts a click outside the card as a dismissal, and a tray menu is a window
of its own. SysTray's old grab listed it explicitly; the shared grab could not know about it.
`StyledPopup` gains `extraGrabWindows` for exactly this, and SysTray publishes its open menu there.

## The menu closed itself half a second later

With that fixed, opening a menu still armed SysTray's *own* grab while the overlay's was already
active. Only one focus grab is held at a time, so the compositor drops one and whichever loses
raises `cleared`. The recording put it at ~0.5s after opening, twice — a handoff, not a timer.

SysTray declines to arm while the overflow's content is on the card. A pinned tray icon is
unaffected: no card, so `surfaceWindow` is null and the old grab arms exactly as before.

## The menu lost its blur

Popups are xdg-popups of the surface they were opened from and inherit its rules, so tray menus used
to inherit `quickshell:bar`'s computed threshold. Opened from the card they inherited
`quickshell:popup`'s `ignore_alpha = 1`, which no translucent body reaches.

The overlay takes its own namespace, `quickshell:barPopup`, added to rules.lua's threshold loop —
which is above the shadow and below the faintest body, so it serves the opaque card and its
translucent child popups at once. `lint_bar_popup_overlay_static.py` pins the new namespace and says
why a namespace outside that loop is the hazard.

## Testing

`./tests/run_tests.sh` — 364 passed, 0 failed.

All four confirmed on screen by the user: no crash, the overflow stays open, the menu stays open, and
the menu is blurred (visible in the recording — the wallpaper behind it is blurred while open and
sharp in the frame after it closes).

Docs: not needed — the mechanisms are documented at their call sites; AGENT.md's layer-shell section already covers input regions and popup rule inheritance.