### PR TITLE
fix(cheatsheet): let the screen's width decide the column count too

### DIFF
--- a/dots/.config/quickshell/imi/modules/imi/cheatsheet/Cheatsheet.qml
+++ b/dots/.config/quickshell/imi/modules/imi/cheatsheet/Cheatsheet.qml
@@ -196,6 +196,14 @@ Scope { // Scope
                             // growing past the screen, minus the toolbar and
                             // padding - what decides the column count.
                             maxContentHeight: (cheatsheetRoot.screen?.height ?? 1080) - 220
+                            // And the room across. Columns trade height for
+                            // width, so a screen with height to spare but not
+                            // width was asked for more columns than fit and the
+                            // outer ones ran off both edges.
+                            maxContentWidth: (cheatsheetRoot.screen?.width ?? 1920)
+                                - Appearance.sizes.elevationMargin * 2
+                                - cheatsheetBackground.padding * 2
+                                - Appearance.spacing.space250 * 2
                             onEditRequested: bindingData => {
                                 cheatsheetRoot.editingBinding = bindingData;
                             }

--- a/dots/.config/quickshell/imi/modules/imi/cheatsheet/CheatsheetKeybinds.qml
+++ b/dots/.config/quickshell/imi/modules/imi/cheatsheet/CheatsheetKeybinds.qml
@@ -29,6 +29,11 @@ Item {
     // Set by the cheatsheet to the height it may use before growing past the
     // screen; 0 means "unknown", which falls back to a sane budget.
     property real maxContentHeight: 0
+    // The width the card may use before it runs off the screen. Columns trade
+    // height for width, so the row budget alone can ask for more columns than
+    // there is room for - on a small display that pushed the card past both
+    // screen edges and simply cut the outer columns off.
+    property real maxContentWidth: 0
     // Deliberately budgets less height than there is. Filling the screen
     // vertically is what the single column already did; the point of columns is
     // to trade height for width on a display that has width to spare. Two
@@ -37,8 +42,33 @@ Item {
     readonly property real rowHeight: 30
     readonly property int availableRows: Math.max(
         8, Math.floor((root.maxContentHeight > 0 ? root.maxContentHeight : 900) * 0.66 / root.rowHeight))
+    // Ceiling on the column count, lowered until the laid-out row fits the
+    // width budget. Measured rather than predicted: a column is as wide as its
+    // widest section, which is not known until the text has been shaped.
+    readonly property int maxColumns: 4
+    property int columnCap: root.maxColumns
     readonly property var columns: CheatsheetLayout.balance(
-        root.sections, CheatsheetLayout.columnCount(root.sections, root.availableRows, 4))
+        root.sections, CheatsheetLayout.columnCount(root.sections, root.availableRows, root.columnCap))
+
+    function fitToWidth() {
+        if (root.maxContentWidth <= 0 || root.columnCap <= 1)
+            return;
+        if (root.implicitWidth > root.maxContentWidth)
+            root.columnCap -= 1;
+    }
+
+    // Only ever shrinks, so this settles: each drop narrows the row, and the
+    // guard stops at a single column. Anything that changes what is being laid
+    // out starts the search again from the top.
+    onImplicitWidthChanged: Qt.callLater(root.fitToWidth)
+    onMaxContentWidthChanged: {
+        root.columnCap = root.maxColumns;
+        Qt.callLater(root.fitToWidth);
+    }
+    onSectionsChanged: {
+        root.columnCap = root.maxColumns;
+        Qt.callLater(root.fitToWidth);
+    }
     implicitWidth: row.implicitWidth + padding * 2
     implicitHeight: row.implicitHeight + padding * 2
     // Excellent symbol explaination and source :

--- a/dots/.config/quickshell/imi/tests/test_cheatsheet_width_budget.py
+++ b/dots/.config/quickshell/imi/tests/test_cheatsheet_width_budget.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""The cheatsheet's column count has to answer to the screen's width, not only
+its height.
+
+`columnCount` picks columns from a *row* budget - how many keybind rows fit
+vertically before the card grows past the screen. Columns trade height for
+width, so on a display with height to spare but not width it asked for four
+columns and the outer two ran off both edges, cut off rather than wrapped.
+
+Width cannot be predicted the way rows can: a column is as wide as its widest
+section, which is not known until the text has been shaped. So the cap is
+measured and lowered. That makes the loop the thing worth pinning - it must only
+ever shrink, and it must stop.
+"""
+
+from pathlib import Path
+import re
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+KEYBINDS = ROOT / "modules/imi/cheatsheet/CheatsheetKeybinds.qml"
+CHEATSHEET = ROOT / "modules/imi/cheatsheet/Cheatsheet.qml"
+
+
+class CheatsheetWidthBudgetTests(unittest.TestCase):
+    def setUp(self):
+        self.keybinds = KEYBINDS.read_text(encoding="utf-8")
+        self.cheatsheet = CHEATSHEET.read_text(encoding="utf-8")
+
+    def test_the_window_hands_down_a_width_budget(self):
+        self.assertIn("maxContentWidth:", self.cheatsheet,
+                      "Cheatsheet.qml must pass a width budget, or nothing bounds the columns")
+        self.assertIn("screen?.width", self.cheatsheet,
+                      "the budget has to come from the screen the cheatsheet is on")
+
+    def test_the_column_cap_is_measured_against_that_budget(self):
+        self.assertIn("property real maxContentWidth", self.keybinds)
+        self.assertIn("property int columnCap", self.keybinds)
+        self.assertRegex(
+            self.keybinds,
+            r"columnCount\(root\.sections, root\.availableRows, root\.columnCap\)",
+            "the cap has to reach columnCount, or lowering it changes nothing")
+
+    def test_the_fit_loop_only_shrinks_and_terminates(self):
+        body = re.search(r"function fitToWidth\(\)\s*\{(.*?)\n    \}", self.keybinds, re.S)
+        self.assertIsNotNone(body, "fitToWidth must exist")
+        body = body.group(1)
+
+        # Only ever downward. An increment inside the loop, with implicitWidth
+        # feeding back into it, is how this oscillates forever instead of
+        # settling.
+        self.assertIn("columnCap -= 1", body)
+        self.assertNotIn("columnCap += 1", body)
+        # And a floor, or a card wider than any single column recurses to zero
+        # columns and lays out nothing at all.
+        self.assertIn("columnCap <= 1", body)
+
+    def test_a_changed_layout_starts_the_search_again(self):
+        # Shrink-only means the cap can never recover on its own: rotate to a
+        # wider screen, or change the keybind list, and it would stay at
+        # whatever the narrowest case needed.
+        for trigger in ("onMaxContentWidthChanged", "onSectionsChanged"):
+            self.assertIn(trigger, self.keybinds, f"{trigger} must reset the cap")
+        resets = re.findall(r"columnCap = root\.maxColumns", self.keybinds)
+        self.assertGreaterEqual(len(resets), 2,
+                                "both triggers must reset the cap to the maximum")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The cheatsheet ran off both screen edges on a smaller display — the leftmost group rendered as
"tilities", cut off rather than wrapped or scrolled.

## Why

`columnCount` picks columns from a **row** budget: how many keybind rows fit vertically before the
card grows past the bottom of the screen. Columns trade height for width, so a display with height
to spare but not width was asked for four columns and the outer two had nowhere to go. Nothing in
the layout ever consulted the screen's width.

## The fix

Width cannot be derived the way rows can — a column is as wide as its widest section, and that is
not known until the text has been shaped. So the cap is *measured*: lay out, compare against a
budget the window hands down from its screen, drop a column if it does not fit.

The loop only ever shrinks and floors at one column, so it settles rather than oscillating against
its own `implicitWidth`. Anything that changes what is being laid out — a different screen, a
different keybind list — resets the cap, since shrink-only means it could otherwise never recover
after a narrow case.

## Testing

`./tests/run_tests.sh` — 364 passed, 0 failed.

`tests/test_cheatsheet_width_budget.py` pins the parts that make it terminate: the cap reaching
`columnCount`, the decrement having no matching increment, the floor at one column, and both reset
triggers. Proven to redden by pointing `columnCount` back at the constant 4.

## Not covered

If a *single* column is still wider than the screen it will clip. Fixing that means horizontal
scrolling, and `StyledFlickable` is vertical-only, so it needs new machinery — and the choice
between clipping and scrolling is a design decision rather than a bug fix. Worth its own issue if it
turns out to be reachable on a real display.

Not verified on screen: the reporting display is not this machine, and the fix is a layout change
whose effect is only visible at a width where four columns do not fit.

Docs: not needed — the width budget is documented where it is declared, and no rule in AGENT.md changed.