### PR TITLE
fix(bar): an auto-hidden bar could not be revealed from the screen edge

### DIFF
--- a/dots/.config/quickshell/imi/modules/common/Appearance.qml
+++ b/dots/.config/quickshell/imi/modules/common/Appearance.qml
@@ -563,8 +563,20 @@ Singleton {
         // bar away from the edge it was meant to overhang and making Hyprland
         // reserve 5px more with it. They live here so the arithmetic is one
         // expression a test can read rather than three inline ternaries.
-        property real barDetachMargin: Config?.options.bar.cornerStyle === 3
+        // The visual gap a detached bar style (cornerStyle 3) leaves against the
+        // screen edge.
+        property real barDetachGap: Config?.options.bar.cornerStyle === 3
             ? root.sizes.hyprlandGapsOut : 0
+        // With auto-hide on, that gap cannot be left outside the surface: the
+        // reveal strip lives inside the window, so a detached surface leaves a
+        // band the pointer can never reach - hovering it reaches whatever is
+        // behind the bar instead, and hiding looks wrong because the bar slides
+        // up inside a surface that already starts below the edge. So the
+        // surface takes the edge and the *content* carries the gap. Identical
+        // to look at, and no surface reconfiguration to do it.
+        property real barDetachInset: (Config?.options.bar.autoHide.enable ?? false)
+            ? root.sizes.barDetachGap : 0
+        property real barDetachMargin: root.sizes.barDetachGap - root.sizes.barDetachInset
         // One physical pixel, not a design token - it is the width of the row
         // the compositor leaves out, so it does not scale with anything.
         property real barDeadPixelOverhang: Config?.options.interactions.deadPixelWorkaround.enable

--- a/dots/.config/quickshell/imi/modules/imi/bar/Bar.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/Bar.qml
@@ -205,13 +205,30 @@ Scope {
                         bottomMargin: (Config.options.interactions.deadPixelWorkaround.enable && barRoot.anchors.bottom) * 1
                     }
 
+                    // The window's input region, and the only thing that can
+                    // reveal an auto-hidden bar: the pointer has to land inside
+                    // it for hoverRegion to see anything at all.
+                    //
+                    // Kept inside the surface on purpose. Anchoring this to
+                    // barContent with negative margins was the obvious way to
+                    // write it, but while the bar is hidden barContent sits at
+                    // y = -barHeight, so the published rect began roughly a
+                    // whole bar height *above* the surface and the compositor
+                    // was left to clamp it. The reveal strip is only
+                    // hoverRegionWidth (2px by default) tall once clamped, so
+                    // an off-by-one there costs half of it - and the row that
+                    // goes missing is y = 0, the screen edge, which is exactly
+                    // where a pointer thrown at the top of the screen lands.
                     Item {
                         id: hoverMaskRegion
-                        anchors {
-                            fill: barContent
-                            topMargin: -Config.options.bar.autoHide.hoverRegionWidth
-                            bottomMargin: -Config.options.bar.autoHide.hoverRegionWidth
-                        }
+                        readonly property real reveal: Config.options.bar.autoHide.hoverRegionWidth
+                        readonly property real rawTop: barContent.y - reveal
+                        readonly property real rawBottom: barContent.y + barContent.height + reveal
+
+                        x: 0
+                        width: parent.width
+                        y: Math.max(0, rawTop)
+                        height: Math.max(0, Math.min(parent.height, rawBottom) - y)
                     }
 
                     RoundCorner {

--- a/dots/.config/quickshell/imi/modules/imi/bar/Bar.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/Bar.qml
@@ -65,7 +65,20 @@ Scope {
                 // Overlay layer only while special workspace sits on top of a fullscreen window on this monitor,
                 // else Top layer so fullscreen apps cover the bar as normal (Hyprland buries Top layer under fullscreen+special).
                 WlrLayershell.layer: (monitorHasFullscreen && monitorHasSpecialOpen) ? WlrLayer.Overlay : WlrLayer.Top
-                implicitHeight: Appearance.sizes.barHeight + Appearance.rounding.screenRounding
+                // A detached bar style (cornerStyle 3) holds the surface off the
+                // screen edge by barDetachMargin. That gap is not part of the
+                // surface, so with auto-hide on it is a band the pointer can
+                // never reach: the reveal strip lives *inside* the window, and
+                // hovering the gap reaches whatever is behind it instead. It
+                // also made hiding look wrong - the bar slid up inside a
+                // surface that already started below the edge, so the gap above
+                // it never moved.
+                //
+                // While auto-hide is on the surface takes the edge and the
+                // content carries the gap instead, which looks identical and
+                // costs no surface reconfiguration.
+                readonly property real detachInset: Appearance.sizes.barDetachInset
+                implicitHeight: Appearance.sizes.barHeight + Appearance.rounding.screenRounding + detachInset
                 // When Overlay-layer, bar shares a layer with the screen-corner click zones (ScreenCorners.qml)
                 // and same-layer overlap is resolved by stacking, not layer priority - bar was winning and
                 // swallowing the tiny corner-open hit rects. Carve them out of the bar's own mask so clicks
@@ -268,7 +281,8 @@ Scope {
                             left: parent.left
                             top: parent.top
                             bottom: undefined
-                            topMargin: (Config?.options.bar.autoHide.enable && !mustShow) ? -Appearance.sizes.barHeight : 0
+                            topMargin: (Config?.options.bar.autoHide.enable && !mustShow)
+                                ? -Appearance.sizes.barHeight : barRoot.detachInset
                             bottomMargin: (Config.options.interactions.deadPixelWorkaround.enable && barRoot.anchors.bottom) * -1
                             rightMargin: (Config.options.interactions.deadPixelWorkaround.enable && barRoot.anchors.right) * -1
                         }
@@ -294,7 +308,8 @@ Scope {
                             PropertyChanges {
                                 target: barContent
                                 anchors.topMargin: 0
-                                anchors.bottomMargin: (Config?.options.bar.autoHide.enable && !mustShow) ? -Appearance.sizes.barHeight : 0
+                                anchors.bottomMargin: (Config?.options.bar.autoHide.enable && !mustShow)
+                                    ? -Appearance.sizes.barHeight : barRoot.detachInset
                             }
                         }
                     }

--- a/dots/.config/quickshell/imi/modules/imi/bar/Bar.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/Bar.qml
@@ -235,7 +235,14 @@ Scope {
                     Item {
                         id: hoverMaskRegion
                         readonly property real reveal: Config.options.bar.autoHide.hoverRegionWidth
-                        readonly property real rawTop: barContent.y - reveal
+                        // The detach inset counts as the bar's own space, not a
+                        // gap outside it. Leaving it out made the strip start
+                        // below the edge whenever the bar was *shown*, so a
+                        // pointer resting on row 0 revealed the bar, fell
+                        // outside the strip the moment it appeared, and hid it
+                        // again - a reveal/hide oscillation for as long as the
+                        // pointer stayed on the edge.
+                        readonly property real rawTop: barContent.y - reveal - Appearance.sizes.barDetachInset
                         readonly property real rawBottom: barContent.y + barContent.height + reveal
 
                         x: 0

--- a/dots/.config/quickshell/imi/tests/test_bar_hover_region.py
+++ b/dots/.config/quickshell/imi/tests/test_bar_hover_region.py
@@ -47,11 +47,27 @@ class BarHoverRegionTests(unittest.TestCase):
         self.assertRegex(self.block, r"height:\s*Math\.max\(0,",
                          "a negative height is not a small region, it is an invalid one")
 
+    def test_the_strip_covers_the_detach_inset_in_both_states(self):
+        """Otherwise revealing the bar moves the strip out from under the pointer.
+
+        With auto-hide on, a detached style's gap is carried by the content, so
+        a *shown* bar sits `barDetachInset` down from the surface edge. Compute
+        the strip from `barContent.y` alone and it then starts below row 0 - so
+        a pointer resting on the screen edge reveals the bar, is immediately
+        outside the strip, and hides it again. Reveal, hide, reveal: the stutter
+        was that loop running as fast as the animation allowed.
+
+        The inset is the bar's own space, not a gap outside it, so the strip has
+        to span it in both states.
+        """
+        self.assertIn("barContent.y - reveal - Appearance.sizes.barDetachInset", self.block,
+                      "the strip must reach the surface edge while the bar is shown, "
+                      "or revealing it takes the strip out from under the pointer")
+
     def test_the_strip_still_covers_the_reveal_width_either_side(self):
         # Clamping must not quietly drop the overshoot that makes the strip
         # reachable before the bar has finished sliding in.
         self.assertIn("hoverRegionWidth", self.block)
-        self.assertIn("barContent.y - reveal", self.block)
         self.assertIn("barContent.y + barContent.height + reveal", self.block)
 
 

--- a/dots/.config/quickshell/imi/tests/test_bar_hover_region.py
+++ b/dots/.config/quickshell/imi/tests/test_bar_hover_region.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""The auto-hidden bar's reveal strip is the window's whole input region, and it
+has to stay inside the window.
+
+While the bar is hidden its content sits at `y = -barHeight`. Anchoring the mask
+item to that content with negative margins - the obvious way to write "the bar
+plus a couple of pixels either side" - published a rect starting roughly a whole
+bar height above the surface and left the compositor to clamp it. What survives
+clamping is only `hoverRegionWidth` tall (2px by default), so an off-by-one
+costs half the strip, and the row that goes missing is `y = 0`: the screen edge,
+which is where a pointer thrown at the top of the screen actually lands.
+
+Clamping is therefore not a tidy-up. It is the difference between the strip
+being reachable and not.
+"""
+
+from pathlib import Path
+import re
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BAR = ROOT / "modules/imi/bar/Bar.qml"
+
+
+class BarHoverRegionTests(unittest.TestCase):
+    def setUp(self):
+        self.bar = BAR.read_text(encoding="utf-8")
+        block = re.search(r"Item \{\s*\n\s*id: hoverMaskRegion(.*?)\n                    \}",
+                          self.bar, re.S)
+        self.assertIsNotNone(block, "hoverMaskRegion must exist - it is the bar's input region")
+        self.block = block.group(1)
+
+    def test_the_strip_is_not_anchored_to_the_offscreen_content(self):
+        # `fill: barContent` with negative margins is the shape that put the
+        # rect outside the surface.
+        self.assertNotIn("fill: barContent", self.block)
+        self.assertNotRegex(self.block, r"topMargin:\s*-",
+                            "a negative top margin puts the region above the surface")
+        self.assertNotRegex(self.block, r"bottomMargin:\s*-")
+
+    def test_the_strip_is_clamped_into_the_window(self):
+        self.assertIn("Math.max(0,", self.block,
+                      "the top edge has to clamp at 0 or the rect starts outside the surface")
+        self.assertIn("Math.min(parent.height,", self.block,
+                      "the bottom edge has to clamp at the surface height, for a bottom bar")
+        self.assertRegex(self.block, r"height:\s*Math\.max\(0,",
+                         "a negative height is not a small region, it is an invalid one")
+
+    def test_the_strip_still_covers_the_reveal_width_either_side(self):
+        # Clamping must not quietly drop the overshoot that makes the strip
+        # reachable before the bar has finished sliding in.
+        self.assertIn("hoverRegionWidth", self.block)
+        self.assertIn("barContent.y - reveal", self.block)
+        self.assertIn("barContent.y + barContent.height + reveal", self.block)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dots/.config/quickshell/imi/tests/tst_bar_geometry.qml
+++ b/dots/.config/quickshell/imi/tests/tst_bar_geometry.qml
@@ -15,17 +15,20 @@ TestCase {
     property int savedCornerStyle: 0
     property bool savedBottom: false
     property bool savedDeadPixel: false
+    property bool savedAutoHide: false
 
     function initTestCase() {
         savedCornerStyle = Config.options.bar.cornerStyle;
         savedBottom = Config.options.bar.bottom;
         savedDeadPixel = Config.options.interactions.deadPixelWorkaround.enable;
+        savedAutoHide = Config.options.bar.autoHide.enable;
     }
 
     function cleanupTestCase() {
         Config.options.bar.cornerStyle = savedCornerStyle;
         Config.options.bar.bottom = savedBottom;
         Config.options.interactions.deadPixelWorkaround.enable = savedDeadPixel;
+        Config.options.bar.autoHide.enable = savedAutoHide;
     }
 
     // BarGroup.qml paints its background inset by the edge-side margin at the
@@ -103,6 +106,59 @@ TestCase {
         Config.options.bar.bottom = true;
         compare(Appearance.sizes.barStandalonePillOffset, -top,
                 "the shift must follow the bar to the other monitor edge");
+    }
+
+    // A detached bar style holds the surface off the screen edge. With auto-hide
+    // on that gap is not a gap - it is a band of the screen the bar's surface
+    // does not cover, and the reveal strip lives inside the surface. Hovering it
+    // reached whatever was behind the bar, so an auto-hidden detached bar could
+    // not be brought back from the very edge at all; and hiding looked wrong,
+    // because the bar slid up inside a surface that already began below the
+    // edge, leaving the band above it untouched.
+    //
+    // The gap has to survive - it is the style - so it moves from the surface's
+    // margin to an inset on the content. These two therefore always sum to the
+    // gap, whichever side is carrying it.
+    function test_autoHideMovesTheDetachGapOffTheSurface() {
+        Config.options.bar.bottom = false;
+        Config.options.interactions.deadPixelWorkaround.enable = false;
+        for (const style of cornerStyles) {
+            Config.options.bar.cornerStyle = style;
+            const gap = Appearance.sizes.barDetachGap;
+
+            Config.options.bar.autoHide.enable = false;
+            compare(Appearance.sizes.barDetachInset, 0,
+                    "nothing is inset while the surface keeps the gap, cornerStyle " + style);
+            compare(Appearance.sizes.barDetachMargin, gap,
+                    "the surface carries the whole gap, cornerStyle " + style);
+
+            Config.options.bar.autoHide.enable = true;
+            compare(Appearance.sizes.barDetachMargin, 0,
+                    "an auto-hidden bar's surface must reach the edge, cornerStyle " + style);
+            compare(Appearance.sizes.barDetachInset, gap,
+                    "the content must take on the gap the surface gave up, cornerStyle " + style);
+            compare(Appearance.sizes.barDetachMargin + Appearance.sizes.barDetachInset, gap,
+                    "the gap changed size instead of moving, cornerStyle " + style);
+
+            // Every later test in this case reads these same tokens, and
+            // auto-hide changes what they mean.
+            Config.options.bar.autoHide.enable = false;
+        }
+    }
+
+    // The bottom margin falls through to the detach margin on a top bar, so it
+    // inherits the move rather than needing its own rule - and must not go
+    // negative doing it.
+    function test_theBottomMarginFollowsTheDetachMargin() {
+        Config.options.bar.bottom = false;
+        Config.options.interactions.deadPixelWorkaround.enable = false;
+        Config.options.bar.cornerStyle = m3CornerStyle;
+        Config.options.bar.autoHide.enable = true;
+        compare(Appearance.sizes.barBottomMargin, Appearance.sizes.barDetachMargin,
+                "a top bar's bottom margin must still track the detach margin");
+        verify(Appearance.sizes.barBottomMargin >= 0,
+               "the surface must not be pulled off the opposite edge");
+        Config.options.bar.autoHide.enable = false;
     }
 
     // Bar.qml's `margins.bottom` used to read


### PR DESCRIPTION
With auto-hide on, throwing the pointer at the very edge of the screen the bar lives on did not
bring it back — the whole edge, not just the corners. Hiding also looked wrong: the bar appeared to
slide up, but the band above it never moved.

## Why

The detached bar style (`cornerStyle 3`) holds the *surface* off the screen edge by
`barDetachMargin`. That is the style working as intended — until auto-hide is on, when the gap stops
being a gap and becomes a band of screen the bar's surface does not cover at all.

Measured on the reporting machine: `quickshell:bar` at `xywh 0 5 5120 63`. The top five rows belonged
to no bar surface. The reveal strip is the window's input region, so a pointer landing there reached
whatever was behind the bar; and the bar slid up inside a surface that already began below the edge,
which is why the band above it never moved.

## The fix, in three steps

Each of the first two was necessary and neither was sufficient — the third is a regression the second
introduced, caught by the reporter noticing a stutter I had already recorded and misread as noise.

1. **Keep the strip inside the surface.** The mask item was anchored to the bar content with negative
   margins, so while hidden it published a rect starting roughly a whole bar height *above* the
   surface and left the compositor to clamp it. What survives clamping is only `hoverRegionWidth`
   tall — 2px by default — so an off-by-one costs half of it, and the row that goes missing is `y=0`.
2. **Let the surface reach the edge.** The gap has to survive, since it is the style, so it moves:
   the surface takes the edge and the content carries the inset. Identical to look at, and no surface
   reconfiguration to do it — the window grows by exactly what it stopped being pushed down by. After
   this, `xywh 0 0 5120 68`.
3. **Span the inset in the strip.** With the content inset, a *shown* bar sits 5px down, so a strip
   computed from `barContent.y` alone began below row 0. A pointer on the edge revealed the bar, was
   immediately outside the strip that revealed it, and hid it again — reveal, hide, reveal, as fast
   as the animation allowed. The inset is the bar's own space, not a gap outside it.

The arithmetic for (2) lives in `Appearance` rather than `Bar.qml`, because an existing contract
admits only a bare token name in those margins — a rule that exists because inline arithmetic there
once turned the dead-pixel workaround's `-1` into `+5`. My first attempt violated it and the test
caught it. `barBottomMargin` already falls through to `barDetachMargin`, so it inherits this rather
than needing its own case.

## Testing

`./tests/run_tests.sh` — **366 passed, 0 failed** (364 on main; the +2 are the new geometry cases).

- `tst_bar_geometry.qml` pins that the margin and the inset always **sum to the gap**, across every
  corner style — the gap may move but not change size. Reddens if `barDetachMargin` collapses back to
  the raw gap. Writing it also surfaced a state leak: the new case left `autoHide` on and broke a
  later test in the same case, now reset explicitly.
- `tests/test_bar_hover_region.py` pins the clamp, the overshoot it must not drop, and the inset the
  strip has to span — with the oscillation written out so it is not reintroduced. Reddens on the old
  anchored shape.

Confirmed on screen by the user: reveals from row 0, hides clear of the edge, no stutter along the
top.

Docs: not needed — the mechanism is documented at the tokens it splits and at the strip it computes; no rule in AGENT.md changed.