### PR TITLE
fix(background): stop parallax pushing the widget canvas off the screen

### DIFF
--- a/dots/.config/quickshell/imi/modules/common/functions/parallax.js
+++ b/dots/.config/quickshell/imi/modules/common/functions/parallax.js
@@ -85,3 +85,31 @@ function offsets(state) {
 function widgetOffset(wallpaperOffset, factor) {
     return number(wallpaperOffset, 0) * number(factor, 0);
 }
+
+// The same travel, measured from the centre rather than from the edge.
+//
+// `offsets()` is written for the wallpaper container, which is genuinely larger
+// than the screen: parking an axis at CENTRE shows the middle of the picture,
+// which is what you want. The widget canvas is *screen-sized*, so the identical
+// arithmetic means something else entirely - half the overflow of static shift,
+// pushing the canvas off the screen and taking that strip of desktop with it.
+//
+// It is worst on the axis that does not travel at all. `vertical: false` sends
+// workspace movement to x and parks y at CENTRE, so with the shipped 107% zoom
+// and 1.2 factor a 1440-tall screen loses its bottom 60px permanently, to buy
+// motion that never happens.
+//
+// Subtracting CENTRE makes the resting position 0 on both axes: the canvas
+// covers the screen exactly when nothing is panned, and swings symmetrically
+// either side of that when something is. A parked axis contributes nothing.
+function widgetOffsets(state, factor) {
+    state = state || {};
+    const f = fractions(state);
+    const scale = number(factor, 0);
+    const overflowX = Math.max(0, number(state.overflowX, 0));
+    const overflowY = Math.max(0, number(state.overflowY, 0));
+    return {
+        x: -overflowX * (f.x - CENTRE) * scale,
+        y: -overflowY * (f.y - CENTRE) * scale
+    };
+}

--- a/dots/.config/quickshell/imi/modules/imi/background/Background.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/Background.qml
@@ -1125,12 +1125,16 @@ Variants {
             // Screen-sized regardless of the zoom, so a widget dragged to a
             // corner stays where the user put it rather than being placed
             // against an overscanned canvas they cannot see the edges of.
-            x: (Config.options.background.parallax.enableWidgets ?? true)
-                ? ParallaxMath.widgetOffset(bgRoot.parallaxOffsets.x, Config.options.background.parallax.widgetsFactor ?? 0)
-                : 0
-            y: (Config.options.background.parallax.enableWidgets ?? true)
-                ? ParallaxMath.widgetOffset(bgRoot.parallaxOffsets.y, Config.options.background.parallax.widgetsFactor ?? 0)
-                : 0
+            // Centre-relative, not edge-relative: this canvas is screen-sized,
+            // so the wallpaper's own offsets would shift it off the screen by
+            // half the zoom overflow and make that strip of desktop
+            // unreachable - permanently on whichever axis is not travelling.
+            // See ParallaxMath.widgetOffsets.
+            readonly property var widgetParallax: (Config.options.background.parallax.enableWidgets ?? true)
+                ? ParallaxMath.widgetOffsets(bgRoot.parallaxState, Config.options.background.parallax.widgetsFactor ?? 0)
+                : ({ x: 0, y: 0 })
+            x: widgetParallax.x
+            y: widgetParallax.y
             Behavior on x {
                 enabled: bgRoot.parallaxEnabled
                 NumberAnimation { duration: 600; easing.type: Easing.OutCubic }

--- a/dots/.config/quickshell/imi/tests/tst_parallax.qml
+++ b/dots/.config/quickshell/imi/tests/tst_parallax.qml
@@ -176,4 +176,51 @@ TestCase {
         compare(o.x, 0);
         compare(o.y, 0);
     }
+
+    // The widget canvas is screen-sized, so the wallpaper's edge-relative
+    // offsets mean something different there: half the zoom overflow of static
+    // shift, which pushes the canvas off the screen and makes that strip of
+    // desktop unreachable. Worst on the axis that never travels - with
+    // vertical: false, y parks at CENTRE and the bottom of the screen is lost
+    // permanently to motion that does not happen.
+    function test_widgetOffsetsRestAtZeroOnAParkedAxis() {
+        const state = {
+            vertical: false, enableWorkspace: true, enableSidebar: false,
+            workspaceIndex: 1, totalWorkspaces: 5,
+            overflowX: 358, overflowY: 100.8
+        };
+        const widget = Parallax.widgetOffsets(state, 1.2);
+        compare(widget.y, 0,
+                "a parked axis must not shift the canvas at all");
+        verify(widget.x !== 0, "the travelling axis must still travel");
+    }
+
+    function test_widgetOffsetsAreSymmetricAboutTheCentre() {
+        const base = {
+            vertical: false, enableWorkspace: true, enableSidebar: false,
+            totalWorkspaces: 5, overflowX: 358, overflowY: 100.8
+        };
+        const first = Parallax.widgetOffsets(
+            Object.assign({}, base, { workspaceIndex: 0 }), 1.2);
+        const last = Parallax.widgetOffsets(
+            Object.assign({}, base, { workspaceIndex: 4 }), 1.2);
+        const middle = Parallax.widgetOffsets(
+            Object.assign({}, base, { workspaceIndex: 2 }), 1.2);
+        compare(middle.x, 0, "the middle workspace is the resting position");
+        fuzzyCompare(first.x, -last.x, 0.001,
+                     "the swing must be even either side, or one edge loses more "
+                     + "desktop than the other");
+    }
+
+    // The wallpaper container is genuinely larger than the screen and *wants*
+    // its middle shown, so its own offsets keep the CENTRE parking.
+    function test_wallpaperOffsetsStillParkAtCentre() {
+        const state = {
+            vertical: false, enableWorkspace: true, enableSidebar: false,
+            workspaceIndex: 1, totalWorkspaces: 5,
+            overflowX: 358, overflowY: 100.8
+        };
+        compare(Parallax.offsets(state).y, -50.4,
+                "the wallpaper must still be centred on its parked axis");
+    }
 }


### PR DESCRIPTION
Part of #154.

Desktop widgets could not be placed in the bottom ~60px of the screen, and the placement lattice
stopped there too — in the shipped configuration, with vertical parallax **off**.

## Why

`offsets()` is written for the wallpaper container, which is genuinely larger than the screen:
parking an axis at `CENTRE` shows the middle of the picture, which is what you want. The widget
canvas is **screen-sized**, so the same arithmetic means something else entirely — half the zoom
overflow of static shift, which moves the canvas off the screen and takes that strip of desktop with
it.

It is worst on the axis that never travels:

```js
let x = vertical ? CENTRE : workspace;
let y = vertical ? workspace : CENTRE;   // 0.5, not 0
```

`vertical` only chooses which axis *workspace movement* uses. With `vertical: false`, y parks at
`CENTRE`, so with the shipped `workspaceZoom: 107%` and `widgetsFactor: 1.2` a 1440-tall screen
loses:

- `overflowY = 1440 * 0.07 = 100.8`
- `offsets.y = -100.8 * 0.5 = -50.4`
- canvas `y = -50.4 * 1.2 = -60.5`

60px of desktop, permanently, to buy motion that does not happen. That the boundary landed near the
dock's top edge is a coincidence of this screen's height, and is why it was first reported as the
dock blocking placement.

## The fix

`widgetOffsets()` measures from the centre: the canvas covers the screen exactly when nothing is
panned, and swings evenly either side when something is. A parked axis contributes nothing.

The wallpaper's own `offsets()` is unchanged — for the wallpaper, `CENTRE` parking is correct — and a
test pins that it still behaves that way, so the two uses cannot be conflated again.

## Not covered

The **travelling** axis still loses a strip while panned. That one is the price of the effect rather
than a defect; clamping the drag against the screen instead of the canvas is #154's remaining half,
and a per-widget parallax opt-out is planned separately.

## Testing

`./tests/run_tests.sh` — **369 passed, 0 failed** (366 on main; the +3 are the new cases).

`tst_parallax.qml` gains: a parked axis rests at zero, the swing is symmetric about the middle
workspace, and the wallpaper still parks at centre. Verified they redden by putting the arithmetic
back to edge-relative — two of the three fail.

Confirmed working on screen by the user.

Docs: not needed — the distinction is documented at `widgetOffsets` itself, and no rule in AGENT.md changed.