### PR TITLE
feat(widgets): per-widget grid sizes and a resize handle

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1027,6 +1027,48 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   values. Desktop backdrop blur is also per-plugin state: a manifest opts into its default with
   `desktopWidget.blur: true`, while the generated **Blur background** option always lets the user
   override it. Do not make `PluginWidget` blur every plugin unconditionally.
+- **A manifest's option keys and the host's own per-plugin state are one namespace, so `__` is
+  reserved.** Both land in `pluginOptions[pluginId][key]` in `plugin-state.json`: the manifest's
+  declared options *and* the host's `blurEnabled`/`positionLocked`/`clickThrough`/`keepTranslucent`
+  seeds, plus `__gridSize` (the span a user resized a grid widget to). A manifest declaring a
+  `__`-prefixed key would therefore ship a settings control in Settings > Widgets that writes
+  straight over host state. `PluginValidator.js` rejects it - which is the only defence against an
+  installed third-party plugin, and silent for a bundled one, since a rejected manifest simply does
+  not appear - so `tests/lint_plugin_option_keys.py` is the half that names the file. Anything the
+  host stores per plugin from now on goes under that prefix; anything a manifest may set does not.
+  66c022fbe ("feat(plugins): reserve the `__` option-key prefix for host state").
+- **A widget's grid span is resolved, not read.** `manifest.grid` may offer several spans
+  (`grid.sizes`) with `cols`/`rows` as the default, and the resolution - stored choice, then
+  manifest default, then content-sized - lives in `modules/common/plugins/gridSizes.js` precisely
+  because it is the one testable part (`tests/tst_grid_sizes.qml`; `qmltestrunner` reaches no
+  further into this area). Two of its rules are refusals to repair a manifest, and both exist
+  because the failure is silent and lands on a widget the user already placed: a `sizes` list whose
+  entries disagree with the default, or that holds an unusable entry, is rejected whole, and a
+  stored span the manifest no longer offers falls back to the default. Read the span through
+  `PluginWidget.gridSize`, never `manifest.grid.cols` - the latter is the default, not the size on
+  screen. See `docs/widget-grid.md`. 9c4adcc5f ("feat(plugins): resolve a widget's grid span
+  through a testable module"), 494580b65 ("feat(plugins): resolve a placed widget's span from its
+  stored choice").
+- **What claims a press from a desktop widget's drag-to-move is the nesting, not
+  `preventStealing`.** The resize grip is a `MouseArea` inside `PluginWidget`, which *is* a
+  `MouseArea` (`AbstractWidget`), and a nested area takes the press - the root only ever sees what
+  no child accepted. The flag reads like the load-bearing part and is not: a `MouseArea` steals a
+  child's grab through its `drag` target, and `AbstractWidget` has had none since d2ebb5aeb
+  ("fix(widgetCanvas): compute the drag by hand - MouseArea.drag cannot track it") computed the
+  drag by hand. Measured by planting the removal and re-running the harness, not reasoned about;
+  it stays because it is one `drag.target` binding away from mattering. The corollary for a *new*
+  gesture on a widget: put it in a child area, and score the widget's position as well as its
+  effect, because "it resized" and "it resized without walking" are different results.
+  9c70ac62e ("docs(plugins): say what actually claims the grip's press").
+- **The desktop-widget host is now reachable from a test.** `WidgetResizeGripRuntimeTest.qml`
+  (driven by `tests/test_widget_resize_grip_runtime.py`, headless weston, in `run_tests.sh`) builds
+  real `PluginWidget`s on a real `WidgetCanvas` from synthetic manifests over an inert
+  `{ "type": "Item" }` node and drives them with real mouse events - the same shape as
+  `WidgetInteractionRuntimeTest.qml`. A key event, unlike a mouse event, has no explicit target:
+  `TestCase` sends it to the focused item of *its own* window, so a driver parented outside any
+  window cannot deliver one. What no such harness can answer is the background *layer surface's*
+  keyboard focus, since weston gives it no wlr-layer-shell. 2c8ccae70 ("test(widgets): drive the
+  resize grip with real mouse events").
 - **"The frost is gated on the toggle" is not "the surface is gated on the toggle."**
   `appearance.transparency.enable` removed every desktop widget's blur — `PluginWidget`'s blur
   `Repeater` reads the flag — while the widgets' panel alpha kept coming from

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -240,8 +240,10 @@ bug in anything that qualifies:
   for `ERROR:` - not just `WARN` - before calling the change verified. See AGENT.md's "Where to look
   when something goes wrong" for the cascade format and the `pgrep -af 'qs -c imi'` caveat.
   `DesignSystemCompile.qml` (run by `run_tests.sh`, skipped without `WAYLAND_DISPLAY`) narrows this
-  for the design system, the bundled packages and every settings page - it compiles them, so a bad
-  property on a page nobody opened is caught. Everything else still needs the live load.
+  for the design system, the bundled packages, every settings page and the desktop-widget host
+  (`PluginWidget.qml`, which only compiles once a plugin is enabled on some monitor) - it compiles
+  them, so a bad property on a page nobody opened is caught. Everything else still needs the live
+  load. 494580b65 ("feat(plugins): resolve a placed widget's span from its stored choice").
 - **A new Python check must actually run.** `run_tests.sh` invokes each one as `python3 <file>`, so
   a module of bare `test_*` functions exits zero without executing anything. Either subclass
   `unittest.TestCase` with `unittest.main()`, or end the file with the `contract_runner` block

--- a/docs/widget-grid.md
+++ b/docs/widget-grid.md
@@ -130,9 +130,10 @@ covered by `tests/tst_grid_sizes.qml`):
   positions" each disarm it — the same resolved `interactionLocked` the bundled
   widgets' own grips read.
 
-Growing past the screen edge is not a new rule: the existing position clamp
-(`PluginWidget.applyPersistedPosition`) pulls the widget back inside on the next
-load, exactly as it does for a widget dragged past the edge.
+Growing past the screen edge needs no new rule: committing a span writes plugin state,
+which re-evaluates the widget's persisted position, so the existing clamp
+(`PluginWidget.applyPersistedPosition`) pulls it back inside against its *new* width -
+the same clamp that catches a widget dragged past the edge.
 
 ## Position snapping
 

--- a/docs/widget-grid.md
+++ b/docs/widget-grid.md
@@ -88,6 +88,52 @@ A desktop-widget plugin declares its span with a top-level, optional `grid` fiel
   `Widget.qml` to fill it. When `grid` is absent, the widget keeps the legacy content-sized
   behaviour (its own implicit size).
 
+## Offering more than one size
+
+A manifest may offer several spans instead of one. `cols`/`rows` stay, and become
+the **default**; the spans on offer go in an optional `sizes` array:
+
+```json
+"grid": {
+  "cols": 3, "rows": 2,
+  "sizes": [ { "cols": 3, "rows": 2 }, { "cols": 2, "rows": 2 }, { "cols": 2, "rows": 1 } ]
+}
+```
+
+The host then draws a **resize grip** in the widget's bottom-right corner, visible on
+hover: dragging it previews the nearest offered span live, releasing stores it, and
+Escape cancels back to the span the drag started from. None of that is the plugin's
+code — a manifest opts in by declaring `sizes` and writes no QML for it.
+
+The rules, all of them refusals to guess (`modules/common/plugins/gridSizes.js`,
+covered by `tests/tst_grid_sizes.qml`):
+
+- **`sizes` absent, or offering a single span, means one size and no grip.** That is
+  every plugin shipping today, which is why none of them changed.
+- **`cols`/`rows` must appear in `sizes`.** A default that is not on offer is a
+  manifest bug, and the whole list is rejected rather than honoured — honouring it
+  would resize a widget the user already placed, on upgrade, with nothing reporting
+  why. One unusable entry (a zero, a fraction, an axis above 12) rejects the list the
+  same way, for the same reason: repairing it silently offers a set of spans the
+  author never wrote.
+- **Order is the resize order**, so write them smallest-to-largest or the reverse.
+- **The chosen span is per placed widget**, stored by the host as `"<cols>x<rows>"`
+  under the reserved `__gridSize` key in `plugin-state.json`. A stored span the
+  manifest no longer offers falls back to the default rather than being honoured.
+- **`__` is the host's option-key prefix.** A manifest's `options` and the host's own
+  per-plugin state are one PluginState namespace, so a manifest declaring a
+  `__`-prefixed key would ship a settings control writing over host state. The
+  validator rejects such a manifest and `tests/lint_plugin_option_keys.py` fails the
+  suite on a bundled one.
+- **The grip honours the widget's lock.** A resize changes geometry exactly as a drag
+  does, so a pinned widget, a click-through one, and the global "Lock widget
+  positions" each disarm it — the same resolved `interactionLocked` the bundled
+  widgets' own grips read.
+
+Growing past the screen edge is not a new rule: the existing position clamp
+(`PluginWidget.applyPersistedPosition`) pulls the widget back inside on the next
+load, exactly as it does for a widget dragged past the edge.
+
 ## Position snapping
 
 Grid widgets use the **same fine 12px drag snap** every desktop widget uses (`AbstractWidget`,
@@ -117,6 +163,10 @@ The only test is `size === widgetGridSpanX(cols)` / `widgetGridSpanY(rows)`.
   cell/gap rhythm; do not fight the grid with fractional or off-rhythm sizes.
 - **Cells are wider than tall.** A "2x2" tile is 276x228, not a square. Size for the real
   cell aspect rather than assuming equal width and height.
+- **A widget offering several spans has to fill each of them.** The host swaps the pixel
+  size and nothing else, so a layout that only reads well at the largest span looks
+  broken at the smallest. Switch on the resolved span if the content needs to differ,
+  rather than scaling one layout down.
 - **The `nandoroid-*` widgets already conform.** They define this grid (media = 3x2,
   system monitor = 3x1 / 1x3, currency = 1x1 / 2x1 via their internal `sizeMode`). They are
   content-sized rather than declaring `grid`, but their pixel sizes are exactly on it, so new
@@ -139,9 +189,10 @@ implicitWidth: widgetScreen ? widgetScreen.width : Screen.width
 The manifest's `defaultWidth`/`defaultHeight` then act only as a floor (the host takes
 `Math.max(defaultWidth, content width)`). The bundled `visualizer` is the reference case.
 
-**User-resizable widgets are the other exception.** A `grid` span is a fixed pixel size the host
-assigns, so a widget the user resizes with a drag handle cannot declare one — the span would
-overwrite the dragged size on every load. Such a widget omits `grid` too, keeps its own
+**Freely-resizable widgets are the other exception.** A widget the user resizes to *any* size
+cannot declare a `grid` — the span would overwrite the dragged size on every load. (A widget
+resizing between a fixed set of spans is not this case: that is what `sizes` above is for, and
+the host stores the choice for it.) Such a widget omits `grid` too, keeps its own
 `implicitWidth`/`implicitHeight` bound to a persisted option, and writes the new value back with
 `PluginState.setOption(...)` when the drag ends. The bundled `custom-image` is the reference case:
 it also stays square, which no span can be (the cell is 132x108), and its manifest sets

--- a/dots/.config/quickshell/imi/DesignSystemCompile.qml
+++ b/dots/.config/quickshell/imi/DesignSystemCompile.qml
@@ -44,6 +44,10 @@ ShellRoot {
 
             const paths = designSystem.concat(packages).concat(settingsPages).concat([
                 Quickshell.shellPath("modules/common/plugins/PluginOptions.qml"),
+                // The desktop-widget host. It only compiles once a plugin is
+                // enabled on some monitor, so a bad property on it is invisible
+                // to a shell whose widgets are all off.
+                Quickshell.shellPath("modules/common/plugins/PluginWidget.qml"),
                 Quickshell.shellPath("modules/common/widgets/AutostartApps.qml"),
                 Quickshell.shellPath("modules/common/widgets/WallpaperSubmenu.qml"),
                 // The cheatsheet only compiles when the user presses Super+/,

--- a/dots/.config/quickshell/imi/WidgetResizeGripRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/WidgetResizeGripRuntimeTest.qml
@@ -1,0 +1,307 @@
+import QtQuick
+import QtTest
+import Quickshell
+import qs.modules.common
+import qs.modules.common.plugins
+import qs.modules.common.widgets.widgetCanvas
+
+/**
+ * Drives the grid resize grip with real mouse events, on real `PluginWidget`s.
+ *
+ * The qmltestrunner suite cannot instantiate the host at all (Quickshell's
+ * plugin does not load there), and `tests/test_widget_grip_lock.py` can only
+ * grep the bindings. Neither answers the question this feature turns on:
+ * whether a press on the corner resizes the widget or *walks* it, since
+ * `AbstractWidget`'s drag-to-move is the root MouseArea the grip sits inside.
+ * Only real events can, so the widget's position is scored on every gesture,
+ * not only its span.
+ *
+ * Every check is scored on `PluginState`'s stored `__gridSize` and on the
+ * widget's own x/y, never on the animated width - a half-finished resize
+ * cannot read as a success that way, and there is no Behavior to wait on.
+ *
+ * Two manifests, because most of the assertions are about what does *not*
+ * happen: one offering three spans and one offering a single one. The
+ * single-span widget is the control that keeps "nothing moved, nothing
+ * resized" from being satisfied by a harness that stopped delivering events -
+ * dragging its corner has to move it.
+ *
+ * Run it against a throwaway config:
+ *   XDG_CONFIG_HOME=$(mktemp -d) XDG_STATE_HOME=$(mktemp -d) qs -p WidgetResizeGripRuntimeTest.qml
+ */
+ShellRoot {
+    id: harness
+
+    property int failures: 0
+    readonly property string testScreen: "RESIZE-TEST"
+
+    function check(label, ok) {
+        console.log(`[WidgetResizeGrip] ${label}: ${ok ? "ok" : "FAIL"}`);
+        if (!ok)
+            harness.failures++;
+    }
+
+    // Synthetic manifests: no shipped plugin offers more than one span yet, and
+    // the grip is the host's regardless of what is loaded into it. An `Item`
+    // node draws nothing and takes no input, so every event the harness sends
+    // is answered by the host or by nothing.
+    function manifestFor(id, grid) {
+        return {
+            id: id,
+            name: id,
+            grid: grid,
+            desktopWidget: { type: "Item" }
+        };
+    }
+
+    readonly property var resizableManifest: harness.manifestFor("resize-probe", {
+        cols: 3, rows: 2,
+        sizes: [{ cols: 3, rows: 2 }, { cols: 2, rows: 2 }, { cols: 2, rows: 1 }]
+    })
+    readonly property var fixedManifest: harness.manifestFor("fixed-probe", { cols: 3, rows: 2 })
+
+    FloatingWindow {
+        visible: true
+        implicitWidth: 1200
+        implicitHeight: 700
+        color: "black"
+
+        // Inside the window, unlike the other widget harnesses: a key event has
+        // no explicit target the way a mouse event does - TestCase sends it to
+        // the focused item of *its own* window - so a driver parented outside
+        // any window cannot deliver the Escape this scores.
+        TestCase {
+            id: driver
+            when: false
+            name: "WidgetResizeGripDriver"
+        }
+
+        WidgetCanvas {
+            id: canvas
+            anchors.fill: parent
+
+            PluginWidget {
+                id: resizableWidget
+                manifest: harness.resizableManifest
+                screenName: harness.testScreen
+                screenWidth: 1200
+                screenHeight: 700
+                scaledScreenWidth: 1200
+                scaledScreenHeight: 700
+                wallpaperScale: 1
+            }
+
+            PluginWidget {
+                id: fixedWidget
+                manifest: harness.fixedManifest
+                screenName: harness.testScreen
+                screenWidth: 1200
+                screenHeight: 700
+                scaledScreenWidth: 1200
+                scaledScreenHeight: 700
+                wallpaperScale: 1
+            }
+        }
+    }
+
+    // Both default to the host's generic 100,100, which would stack them and
+    // send every click to whichever was declared last.
+    function placeWidgets() {
+        PluginState.setPosition("resize-probe", harness.testScreen,
+                                { x: 40, y: 40, placementStrategy: "free" });
+        PluginState.setPosition("fixed-probe", harness.testScreen,
+                                { x: 640, y: 400, placementStrategy: "free" });
+    }
+
+    // ---- gestures -------------------------------------------------------
+    //
+    // The grip is 16x16 anchored to the widget's bottom-right with the same
+    // Appearance token the host anchors it with, so a spacing change moves the
+    // gesture too instead of leaving it pointing at bare card.
+    function gripCenter(widget) {
+        const inset = Appearance.spacing.space100 + 8;
+        return { x: widget.x + widget.width - inset, y: widget.y + widget.height - inset };
+    }
+
+    property var pendingGrip: null
+
+    function hoverGrip(widget) {
+        harness.pendingGrip = harness.gripCenter(widget);
+        driver.mouseMove(canvas, harness.pendingGrip.x, harness.pendingGrip.y);
+    }
+
+    function dragPending(dx, dy) {
+        const point = harness.pendingGrip;
+        driver.mousePress(canvas, point.x, point.y, Qt.LeftButton);
+        driver.mouseMove(canvas, point.x + dx / 2, point.y + dy / 2, 20, Qt.LeftButton);
+        driver.mouseMove(canvas, point.x + dx, point.y + dy, 20, Qt.LeftButton);
+        driver.mouseRelease(canvas, point.x + dx, point.y + dy, Qt.LeftButton);
+    }
+
+    function dragPendingWithEscape(dx, dy) {
+        const point = harness.pendingGrip;
+        driver.mousePress(canvas, point.x, point.y, Qt.LeftButton);
+        driver.mouseMove(canvas, point.x + dx, point.y + dy, 20, Qt.LeftButton);
+        driver.keyClick(Qt.Key_Escape);
+        driver.mouseRelease(canvas, point.x + dx, point.y + dy, Qt.LeftButton);
+    }
+
+    function storedSize(id) { return PluginState.option(id, "__gridSize", ""); }
+
+    function snapshot() {
+        return {
+            resizableSize: harness.storedSize("resize-probe"),
+            resizableX: Math.round(resizableWidget.x),
+            resizableY: Math.round(resizableWidget.y),
+            fixedSize: harness.storedSize("fixed-probe"),
+            fixedX: Math.round(fixedWidget.x),
+            fixedY: Math.round(fixedWidget.y)
+        };
+    }
+
+    property var before: null
+
+    function remember() { harness.before = harness.snapshot(); }
+
+    // ---- the checks -----------------------------------------------------
+
+    function scoreResize(label, expected) {
+        const after = harness.snapshot();
+        harness.check(`${label}: stores ${expected}`, after.resizableSize === expected);
+        harness.check(`${label}: the widget stays put`,
+                      after.resizableX === harness.before.resizableX
+                      && after.resizableY === harness.before.resizableY);
+        harness.check(`${label}: the widget is the span it stored`,
+                      Math.round(resizableWidget.width)
+                          === Math.round(Appearance.sizes.widgetGridSpanX(parseInt(expected[0])))
+                      && Math.round(resizableWidget.height)
+                          === Math.round(Appearance.sizes.widgetGridSpanY(parseInt(expected[2]))));
+    }
+
+    function scoreCancelled(label) {
+        const after = harness.snapshot();
+        harness.check(`${label}: stores nothing new`,
+                      after.resizableSize === harness.before.resizableSize);
+        harness.check(`${label}: the widget stays put`,
+                      after.resizableX === harness.before.resizableX
+                      && after.resizableY === harness.before.resizableY);
+        harness.check(`${label}: the widget is back at its stored span`,
+                      Math.round(resizableWidget.width)
+                          === Math.round(Appearance.sizes.widgetGridSpanX(2)));
+    }
+
+    // The control. A widget offering one span has no grip, so the same gesture
+    // on the same corner is a plain drag-to-move - which is also what the
+    // resizable widget must never do.
+    function scoreMoved(label) {
+        const after = harness.snapshot();
+        harness.check(`${label}: stores no span`, after.fixedSize === "");
+        harness.check(`${label}: the widget moved instead`,
+                      after.fixedX !== harness.before.fixedX
+                      || after.fixedY !== harness.before.fixedY);
+    }
+
+    function scoreLocked(label) {
+        const after = harness.snapshot();
+        harness.check(`${label}: stores nothing new`,
+                      after.resizableSize === harness.before.resizableSize);
+        harness.check(`${label}: the widget stays put`,
+                      after.resizableX === harness.before.resizableX
+                      && after.resizableY === harness.before.resizableY);
+    }
+
+    readonly property var steps: [
+        // Shrink 3x2 -> 2x2: 144px in from the right edge, the whole distance
+        // between those two spans.
+        () => harness.remember(),
+        () => harness.hoverGrip(resizableWidget),
+        () => harness.dragPending(-144, 0),
+        () => harness.scoreResize("shrink to 2x2", "2x2"),
+
+        // ...and 2x2 -> 2x1, which only moves vertically.
+        () => harness.remember(),
+        () => harness.hoverGrip(resizableWidget),
+        () => harness.dragPending(0, -120),
+        () => harness.scoreResize("shrink to 2x1", "2x1"),
+
+        // Back out to the largest span, so the cancel below has somewhere to go.
+        () => harness.remember(),
+        () => harness.hoverGrip(resizableWidget),
+        () => harness.dragPending(144, 120),
+        () => harness.scoreResize("grow back to 3x2", "3x2"),
+
+        () => harness.remember(),
+        () => harness.hoverGrip(resizableWidget),
+        () => harness.dragPending(-144, 0),
+        () => harness.scoreResize("shrink to 2x2 again", "2x2"),
+
+        // Escape mid-drag: the release that follows commits nothing and the
+        // widget is back at the span it started the drag from.
+        () => harness.remember(),
+        () => harness.hoverGrip(resizableWidget),
+        () => harness.dragPendingWithEscape(0, -120),
+        () => harness.scoreCancelled("escape cancels"),
+
+        // The control, and the proof the harness is still delivering events.
+        () => harness.remember(),
+        () => harness.hoverGrip(fixedWidget),
+        () => harness.dragPending(-144, 0),
+        () => harness.scoreMoved("a single-span widget has no grip"),
+
+        // Pinned per widget: the grip is disarmed, and so is the drag.
+        () => { harness.remember(); PluginState.setOption("resize-probe", "positionLocked", true); },
+        () => harness.hoverGrip(resizableWidget),
+        () => harness.dragPending(0, -120),
+        () => harness.scoreLocked("a pinned widget does not resize"),
+
+        // Unlocked again: three "nothing happened" phases prove nothing if the
+        // harness quietly stopped delivering events partway.
+        () => { harness.remember(); PluginState.setOption("resize-probe", "positionLocked", false); },
+        () => harness.hoverGrip(resizableWidget),
+        () => harness.dragPending(0, -120),
+        () => harness.scoreResize("unlocked again", "2x1")
+    ]
+
+    property int stepIndex: 0
+
+    // PluginState's FileView load lands asynchronously and replaces the whole
+    // in-memory state, so anything written before it arrives is discarded.
+    // Keep asking until the positions stick and the position Behavior has
+    // finished animating to them.
+    Timer {
+        id: setup
+        interval: 250
+        repeat: true
+        running: true
+        onTriggered: {
+            if (!PluginState.ready || !Config.ready)
+                return;
+            Config.options.background.widgetsLocked = false;
+            if (Math.round(resizableWidget.x) === 40 && Math.round(fixedWidget.x) === 640) {
+                setup.running = false;
+                runner.running = true;
+                return;
+            }
+            harness.placeWidgets();
+        }
+    }
+
+    // One step per tick: the grip only becomes visible once the hover has
+    // animated its opacity off zero, so the hover and the press it enables
+    // cannot share a frame.
+    Timer {
+        id: runner
+        interval: 400
+        repeat: true
+        running: false
+        onTriggered: {
+            if (harness.stepIndex >= harness.steps.length) {
+                runner.running = false;
+                console.log(`[WidgetResizeGrip] failures: ${harness.failures}`);
+                Qt.exit(harness.failures === 0 ? 0 : 1);
+                return;
+            }
+            harness.steps[harness.stepIndex++]();
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/WidgetResizeGripRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/WidgetResizeGripRuntimeTest.qml
@@ -101,6 +101,31 @@ ShellRoot {
                 scaledScreenHeight: 700
                 wallpaperScale: 1
             }
+
+            // The real desktop builds every widget from a Repeater over
+            // PluginManager.availablePlugins, and a manifest crossing a model
+            // boundary is not the object that went in: its nested `sizes` array
+            // arrives as a QVariantList, with the same indices and length but
+            // `Array.isArray` false. Declaring the manifests inline above, the
+            // way the rest of this harness does, never crosses that boundary -
+            // which is exactly how the whole feature came to be inert on the
+            // one path that ships.
+            Repeater {
+                model: [harness.resizableManifest]
+
+                PluginWidget {
+                    required property var modelData
+                    objectName: "modelledWidget"
+                    manifest: modelData
+                    screenName: harness.testScreen + "-MODEL"
+                    screenWidth: 1200
+                    screenHeight: 700
+                    scaledScreenWidth: 1200
+                    scaledScreenHeight: 700
+                    wallpaperScale: 1
+                    visible: false
+                }
+            }
         }
     }
 
@@ -210,7 +235,24 @@ ShellRoot {
                       && after.resizableY === harness.before.resizableY);
     }
 
+    function modelledWidget() {
+        for (const child of canvas.children)
+            if (child.objectName === "modelledWidget") return child;
+        return null;
+    }
+
     readonly property var steps: [
+        // The same manifest, reached the way the desktop reaches it. Scored
+        // first because everything below is meaningless if the spans do not
+        // survive the trip: a widget offering one span has no grip, and
+        // "nothing resized" is what this harness would report.
+        () => {
+            const widget = harness.modelledWidget();
+            harness.check("a manifest through a model still offers its spans",
+                          widget !== null && widget.offeredGridSizes.length === 3
+                          && widget.gridResizable);
+        },
+
         // Shrink 3x2 -> 2x2: 144px in from the right edge, the whole distance
         // between those two spans.
         () => harness.remember(),

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginValidator.js
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginValidator.js
@@ -93,6 +93,14 @@ function validateManifest(manifest) {
             if (optionKeys.has(option.key)) {
                 return { valid: false, error: "Duplicate plugin option key '" + option.key + "'" };
             }
+            // A manifest's options and the host's own per-plugin state share one
+            // PluginState namespace, so a manifest could otherwise declare a
+            // control that writes over host state - `__gridSize`, the span the
+            // user resized the widget to, is the first of those. The prefix is
+            // the host's; nothing under it may come from a manifest.
+            if (option.key.startsWith("__")) {
+                return { valid: false, error: "Plugin option key '" + option.key + "' is reserved: '__' is the host's prefix" };
+            }
             optionKeys.add(option.key);
             if (!["boolean", "choice", "shape", "color", "number", "text"].includes(option.type)) {
                 return { valid: false, error: "Unsupported plugin option type '" + option.type + "'" };

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
@@ -128,8 +128,15 @@ AbstractBackgroundWidget {
     readonly property var offeredGridSizes: GridSizes.offeredSizes(rootWidget.gridSpec)
     readonly property bool gridResizable: rootWidget.offeredGridSizes.length > 1
     // Stored -> manifest default -> null, which is the content-sized path.
-    readonly property var gridSize: GridSizes.resolveSize(rootWidget.gridSpec,
+    readonly property var storedGridSize: GridSizes.resolveSize(rootWidget.gridSpec,
         manifest ? PluginState.option(manifest.id, "__gridSize") : undefined)
+    // The span the grip's drag is currently previewing, null when no resize is
+    // in flight. The widget resizes as the pointer moves, so the size on screen
+    // is the size a release commits - and Escape cancels by clearing this, with
+    // the widget falling straight back to its stored span.
+    property var previewGridSize: null
+    readonly property bool resizingGrid: previewGridSize !== null
+    readonly property var gridSize: previewGridSize ?? storedGridSize
     readonly property int gridCols: gridSize ? gridSize.cols : 0
     readonly property int gridRows: gridSize ? gridSize.rows : 0
     readonly property real gridSpanWidth: gridSize ? Appearance.sizes.widgetGridSpanX(gridCols) : 0
@@ -138,6 +145,34 @@ AbstractBackgroundWidget {
     function commitGridSize(size) {
         if (!manifest || !size) return;
         PluginState.setOption(manifest.id, "__gridSize", GridSizes.formatSize(size));
+    }
+
+    function beginGridResize() {
+        rootWidget.previewGridSize = rootWidget.storedGridSize;
+    }
+
+    // The offered spans measured in pixels, which is where Appearance's
+    // effectiveScale enters: the snap compares the dragged rectangle against
+    // what each span would actually be on this screen, not against cell counts.
+    function previewGridResize(targetWidth, targetHeight) {
+        if (!rootWidget.resizingGrid) return;
+        const nearest = GridSizes.nearestSize(rootWidget.offeredGridSizes.map(size => ({
+            cols: size.cols,
+            rows: size.rows,
+            width: Appearance.sizes.widgetGridSpanX(size.cols),
+            height: Appearance.sizes.widgetGridSpanY(size.rows)
+        })), targetWidth, targetHeight);
+        if (nearest) rootWidget.previewGridSize = nearest;
+    }
+
+    function endGridResize() {
+        const chosen = rootWidget.previewGridSize;
+        rootWidget.previewGridSize = null;
+        rootWidget.commitGridSize(chosen);
+    }
+
+    function cancelGridResize() {
+        rootWidget.previewGridSize = null;
     }
 
     configEntryName: manifest ? "plugin_" + manifest.id : "plugin_unknown"
@@ -284,6 +319,84 @@ AbstractBackgroundWidget {
         gridWidth: rootWidget.gridSpanWidth
         gridHeight: rootWidget.gridSpanHeight
         anchors.centerIn: parent
+    }
+
+    // Resize grip, for a widget whose manifest offers more than one span. It
+    // sits in the host rather than in each plugin, so a manifest opts in by
+    // declaring `grid.sizes` and writes no QML for it.
+    //
+    // Gated on the resolved lock, like the bundled widgets' own grips: a resize
+    // changes the widget's geometry exactly as a drag does, so a widget the
+    // user pinned - or the global "Lock widget positions" - must disarm both.
+    // `visible` is what disarms it, not just what hides it: Qt routes no mouse
+    // events into an invisible item (tests/test_widget_grip_lock.py).
+    Rectangle {
+        id: resizeHandle
+        z: 2
+        implicitWidth: 16
+        implicitHeight: 16
+        radius: Appearance.rounding.unsharpenslight
+        color: Appearance.colors.colOnPrimaryContainer
+        anchors {
+            right: parent.right
+            bottom: parent.bottom
+            margins: Appearance.spacing.space100
+        }
+        opacity: (rootWidget.containsMouse || resizeArea.containsMouse || rootWidget.resizingGrid)
+            ? 0.5 : 0
+        visible: opacity > 0 && rootWidget.gridResizable && !rootWidget.interactionLocked
+
+        Behavior on opacity {
+            NumberAnimation { duration: Appearance.animation.elementMoveFaster.duration }
+        }
+
+        Keys.onEscapePressed: event => {
+            rootWidget.cancelGridResize();
+            event.accepted = true;
+        }
+
+        MouseArea {
+            id: resizeArea
+            anchors.fill: parent
+            hoverEnabled: true
+            acceptedButtons: Qt.LeftButton
+            cursorShape: Qt.SizeFDiagCursor
+            // AbstractWidget's drag-to-move lives on this widget's own root
+            // MouseArea. A nested area takes the press first, and this keeps
+            // the root from stealing the grab back once the pointer moves -
+            // without it, dragging the corner walks the widget instead.
+            preventStealing: true
+
+            // The pointer is tracked in scene coordinates against its position
+            // at the press, because the grip is anchored to a widget that
+            // resizes underneath it: a delta read from this moving item would
+            // fold the resize back into the gesture.
+            property real pressSceneX: 0
+            property real pressSceneY: 0
+            property real pressWidth: 0
+            property real pressHeight: 0
+
+            onPressed: mouse => {
+                const scenePoint = resizeArea.mapToItem(null, mouse.x, mouse.y);
+                resizeArea.pressSceneX = scenePoint.x;
+                resizeArea.pressSceneY = scenePoint.y;
+                resizeArea.pressWidth = rootWidget.width;
+                resizeArea.pressHeight = rootWidget.height;
+                rootWidget.beginGridResize();
+                resizeHandle.forceActiveFocus();
+            }
+            onPositionChanged: mouse => {
+                if (!rootWidget.resizingGrid) return;
+                const scenePoint = resizeArea.mapToItem(null, mouse.x, mouse.y);
+                rootWidget.previewGridResize(
+                    resizeArea.pressWidth + scenePoint.x - resizeArea.pressSceneX,
+                    resizeArea.pressHeight + scenePoint.y - resizeArea.pressSceneY);
+            }
+            // A release after Escape commits nothing: the cancel already
+            // cleared the preview, and endGridResize has nothing to store.
+            onReleased: rootWidget.endGridResize()
+            onCanceled: rootWidget.cancelGridResize()
+        }
     }
 
 }

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
@@ -8,6 +8,7 @@ import qs.modules.common
 import qs.modules.common.widgets
 import qs.modules.imi.background.widgets
 import "../functions/parallax.js" as ParallaxMath
+import "gridSizes.js" as GridSizes
 
 AbstractBackgroundWidget {
     id: rootWidget
@@ -117,11 +118,27 @@ AbstractBackgroundWidget {
     // whole multiple of 12 (cell 132/108, gap 12), so a grid widget still lands
     // flush against its neighbours without a coarse snap that makes it jump.
     // See docs/widget-grid.md.
+    //
+    // A manifest may offer several spans (`grid.sizes`), in which case the one
+    // in use is the user's stored choice. `__gridSize` is host state, not a
+    // plugin setting: the double underscore keeps it out of the manifest's own
+    // options namespace (PluginValidator rejects a manifest key starting with
+    // it) so it never surfaces as a control in Settings > Widgets.
     readonly property var gridSpec: (manifest && manifest.grid) ? manifest.grid : null
-    readonly property int gridCols: gridSpec ? (gridSpec.cols || 1) : 0
-    readonly property int gridRows: gridSpec ? (gridSpec.rows || 1) : 0
-    readonly property real gridSpanWidth: gridSpec ? Appearance.sizes.widgetGridSpanX(gridCols) : 0
-    readonly property real gridSpanHeight: gridSpec ? Appearance.sizes.widgetGridSpanY(gridRows) : 0
+    readonly property var offeredGridSizes: GridSizes.offeredSizes(rootWidget.gridSpec)
+    readonly property bool gridResizable: rootWidget.offeredGridSizes.length > 1
+    // Stored -> manifest default -> null, which is the content-sized path.
+    readonly property var gridSize: GridSizes.resolveSize(rootWidget.gridSpec,
+        manifest ? PluginState.option(manifest.id, "__gridSize") : undefined)
+    readonly property int gridCols: gridSize ? gridSize.cols : 0
+    readonly property int gridRows: gridSize ? gridSize.rows : 0
+    readonly property real gridSpanWidth: gridSize ? Appearance.sizes.widgetGridSpanX(gridCols) : 0
+    readonly property real gridSpanHeight: gridSize ? Appearance.sizes.widgetGridSpanY(gridRows) : 0
+
+    function commitGridSize(size) {
+        if (!manifest || !size) return;
+        PluginState.setOption(manifest.id, "__gridSize", GridSizes.formatSize(size));
+    }
 
     configEntryName: manifest ? "plugin_" + manifest.id : "plugin_unknown"
 
@@ -200,9 +217,9 @@ AbstractBackgroundWidget {
 
     // A declared grid span drives the pixel size directly; otherwise the widget
     // is sized to its content (with any legacy defaultWidth/Height as a floor).
-    width: gridSpec ? gridSpanWidth
+    width: gridSize ? gridSpanWidth
         : Math.max(manifest ? (manifest.defaultWidth || 0) : 0, pluginNode.width)
-    height: gridSpec ? gridSpanHeight
+    height: gridSize ? gridSpanHeight
         : Math.max(manifest ? (manifest.defaultHeight || 0) : 0, pluginNode.height)
 
     // In-shell frost: sample + blur the wallpaper region behind each blur region.

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
@@ -400,8 +400,20 @@ AbstractBackgroundWidget {
             }
             // A release after Escape commits nothing: the cancel already
             // cleared the preview, and endGridResize has nothing to store.
-            onReleased: rootWidget.endGridResize()
-            onCanceled: rootWidget.cancelGridResize()
+            //
+            // The focus the press took for Escape is handed back at the end of
+            // the gesture. Qt would drop it anyway once the grip fades out and
+            // goes invisible, but until then `keyboardFocusRequested` reads a
+            // decorative corner as an editing widget and keeps the whole
+            // background surface asking the compositor for keyboard focus.
+            onReleased: {
+                rootWidget.endGridResize();
+                resizeHandle.focus = false;
+            }
+            onCanceled: {
+                rootWidget.cancelGridResize();
+                resizeHandle.focus = false;
+            }
         }
     }
 

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
@@ -361,10 +361,16 @@ AbstractBackgroundWidget {
             hoverEnabled: true
             acceptedButtons: Qt.LeftButton
             cursorShape: Qt.SizeFDiagCursor
-            // AbstractWidget's drag-to-move lives on this widget's own root
-            // MouseArea. A nested area takes the press first, and this keeps
-            // the root from stealing the grab back once the pointer moves -
-            // without it, dragging the corner walks the widget instead.
+            // What claims the press from AbstractWidget's drag-to-move - which
+            // is this widget's own root MouseArea - is the nesting: an area
+            // inside another takes the press, and the root only sees what no
+            // child accepted. `preventStealing` is not carrying that, and
+            // removing it changes nothing measurable (the runtime harness
+            // passes either way): a MouseArea steals a child's grab through its
+            // `drag` target, and AbstractWidget deliberately has none, having
+            // computed its drag by hand since d2ebb5aeb. It stays because the
+            // bundled grips set it and because that is one binding away from
+            // being untrue again.
             preventStealing: true
 
             // The pointer is tracked in scene coordinates against its position

--- a/dots/.config/quickshell/imi/modules/common/plugins/gridSizes.js
+++ b/dots/.config/quickshell/imi/modules/common/plugins/gridSizes.js
@@ -43,6 +43,27 @@ function defaultSize(grid) {
     return normalizeSize(grid);
 }
 
+// `sizes` as a plain JS array, or null when it is not a list at all.
+//
+// `Array.isArray` is not the test, and assuming it was made the whole `sizes`
+// feature inert on the one path that matters. A JS array reaching a delegate
+// through a `Repeater`'s `model` has crossed into QVariant and back: indices
+// and `length` survive, `Array.isArray` does not - and `Background.qml` builds
+// every desktop widget from exactly such a model, so a manifest declaring
+// three spans arrived offering one, with no error anywhere. Measured against a
+// real shell, because the synthetic manifests the harness declares inline
+// never cross that boundary.
+//
+// Anything without a numeric `length` is still rejected, which is what keeps a
+// malformed `sizes` from being read as an empty list of spans.
+function asSizeList(value) {
+    if (Array.isArray(value)) return value;
+    if (!value || typeof value !== "object" || typeof value.length !== "number") return null;
+    const out = [];
+    for (let index = 0; index < value.length; index++) out.push(value[index]);
+    return out;
+}
+
 function sameSize(a, b) {
     return !!a && !!b && a.cols === b.cols && a.rows === b.rows;
 }
@@ -62,8 +83,8 @@ function offeredSizes(grid) {
     const fallback = defaultSize(grid);
     if (!fallback) return [];
 
-    const declared = grid.sizes;
-    if (!Array.isArray(declared)) return [fallback];
+    const declared = asSizeList(grid.sizes);
+    if (declared === null) return [fallback];
 
     const out = [];
     for (const entry of declared) {
@@ -113,11 +134,12 @@ function resolveSize(grid, stored) {
 // between two spans stable rather than flickering between them. A target that
 // is not a real number yields null - the caller keeps whatever it had.
 function nearestSize(candidates, targetWidth, targetHeight) {
-    if (!Array.isArray(candidates)) return null;
+    const list = asSizeList(candidates);
+    if (list === null) return null;
 
     let best = null;
     let bestDistance = Infinity;
-    for (const candidate of candidates) {
+    for (const candidate of list) {
         const dx = candidate.width - targetWidth;
         const dy = candidate.height - targetHeight;
         const distance = dx * dx + dy * dy;

--- a/dots/.config/quickshell/imi/modules/common/plugins/gridSizes.js
+++ b/dots/.config/quickshell/imi/modules/common/plugins/gridSizes.js
@@ -1,0 +1,130 @@
+.pragma library
+
+// Resolving which component-grid span a placed widget occupies.
+//
+// A manifest's `grid` used to be one constant span (docs/widget-grid.md). It
+// may now also carry a `sizes` array - the spans the widget offers - with
+// `cols`/`rows` staying as the default. Everything here is pure data so it can
+// be driven from a TestCase; the host (PluginWidget) supplies the pixel
+// measurements and does the persisting.
+//
+// The rules that are not obvious:
+//   - a `sizes` list the manifest got wrong is rejected whole, never repaired.
+//     Dropping the bad entry and keeping the rest would silently offer a
+//     different set of spans than the author wrote, and the widget the user
+//     already placed would change size on upgrade for reasons nothing reports.
+//   - a stored span that the manifest no longer offers falls back to the
+//     default rather than being honoured, for the same reason: a widget laid
+//     out into a span its content no longer fills looks broken and is not
+//     traceable to the manifest edit that caused it.
+
+const MIN_CELLS = 1;
+const MAX_CELLS = 12;
+
+function isCellCount(value) {
+    return typeof value === "number" && isFinite(value) && value === Math.floor(value)
+        && value >= MIN_CELLS && value <= MAX_CELLS;
+}
+
+// A span entry, with each axis defaulting to 1 exactly as `grid` itself does.
+// Returns null for anything that is not a usable span, so a caller never has to
+// distinguish "absent" from "malformed" - both mean "do not offer this".
+function normalizeSize(entry) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) return null;
+    const cols = entry.cols === undefined ? 1 : entry.cols;
+    const rows = entry.rows === undefined ? 1 : entry.rows;
+    if (!isCellCount(cols) || !isCellCount(rows)) return null;
+    return { cols: cols, rows: rows };
+}
+
+// The manifest's declared span. Null means the manifest declares no grid at
+// all, which is the legacy content-sized path and not an error.
+function defaultSize(grid) {
+    return normalizeSize(grid);
+}
+
+function sameSize(a, b) {
+    return !!a && !!b && a.cols === b.cols && a.rows === b.rows;
+}
+
+function containsSize(list, size) {
+    for (const entry of list) {
+        if (sameSize(entry, size)) return true;
+    }
+    return false;
+}
+
+// Every span this widget offers, in the manifest's order (which is the resize
+// order). Always at least the default, so a caller can treat the result as the
+// complete answer; a list of one means the widget has a single size and gets no
+// resize handle.
+function offeredSizes(grid) {
+    const fallback = defaultSize(grid);
+    if (!fallback) return [];
+
+    const declared = grid.sizes;
+    if (!Array.isArray(declared)) return [fallback];
+
+    const out = [];
+    for (const entry of declared) {
+        const size = normalizeSize(entry);
+        if (!size) return [fallback];
+        if (!containsSize(out, size)) out.push(size);
+    }
+    if (!containsSize(out, fallback)) return [fallback];
+    return out;
+}
+
+function resizable(grid) {
+    return offeredSizes(grid).length > 1;
+}
+
+// The persisted form, "<cols>x<rows>".
+function formatSize(size) {
+    const normalized = normalizeSize(size);
+    return normalized ? normalized.cols + "x" + normalized.rows : "";
+}
+
+function parseSize(text) {
+    if (typeof text !== "string") return null;
+    const match = /^\s*(\d+)\s*x\s*(\d+)\s*$/.exec(text);
+    if (!match) return null;
+    return normalizeSize({ cols: parseInt(match[1], 10), rows: parseInt(match[2], 10) });
+}
+
+// Stored -> manifest default -> content-sized (null), which is the order
+// PluginWidget applies.
+function resolveSize(grid, stored) {
+    const fallback = defaultSize(grid);
+    if (!fallback) return null;
+
+    const wanted = parseSize(stored);
+    if (wanted && containsSize(offeredSizes(grid), wanted)) return wanted;
+    return fallback;
+}
+
+// The drag snap. `candidates` carry their own pixel measurements because the
+// span-to-pixel conversion is Appearance's (widgetGridSpanX/Y, which also
+// applies effectiveScale) and copying that formula here would be a second one
+// to keep in step: [{ cols, rows, width, height }].
+//
+// Nearest by plain distance in pixels, so both axes count. A tie goes to the
+// earlier candidate, which makes the widget under a pointer sitting exactly
+// between two spans stable rather than flickering between them. A target that
+// is not a real number yields null - the caller keeps whatever it had.
+function nearestSize(candidates, targetWidth, targetHeight) {
+    if (!Array.isArray(candidates)) return null;
+
+    let best = null;
+    let bestDistance = Infinity;
+    for (const candidate of candidates) {
+        const dx = candidate.width - targetWidth;
+        const dy = candidate.height - targetHeight;
+        const distance = dx * dx + dy * dy;
+        if (distance < bestDistance) {
+            bestDistance = distance;
+            best = candidate;
+        }
+    }
+    return best;
+}

--- a/dots/.config/quickshell/imi/tests/imports/qs/modules/common/plugins/gridSizes.js
+++ b/dots/.config/quickshell/imi/tests/imports/qs/modules/common/plugins/gridSizes.js
@@ -1,0 +1,1 @@
+../../../../../../modules/common/plugins/gridSizes.js

--- a/dots/.config/quickshell/imi/tests/lint_plugin_option_keys.py
+++ b/dots/.config/quickshell/imi/tests/lint_plugin_option_keys.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""No bundled manifest may declare an option key under the host's `__` prefix.
+
+A manifest's `options` and the host's own per-plugin state share one PluginState
+namespace (`pluginOptions[pluginId][key]`), and the host now keeps the user's
+chosen grid span there as `__gridSize`. A manifest declaring that key would
+render a settings control in Settings > Widgets that writes straight over it.
+
+PluginValidator.js rejects such a manifest at load, which is the defence for an
+installed third-party plugin. That is silent for a *bundled* one: the widget
+would simply stop appearing, with the reason only in the log. This is the
+greppable half.
+"""
+from pathlib import Path
+import json
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+BUNDLED = ROOT / "modules/common/plugins/bundled"
+RESERVED_PREFIX = "__"
+
+failures = []
+
+for manifest_path in sorted(BUNDLED.glob("*/manifest.json")):
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as error:
+        failures.append(f"{manifest_path.relative_to(ROOT)}: unreadable manifest ({error})")
+        continue
+    for option in manifest.get("options", []) or []:
+        if not isinstance(option, dict):
+            continue
+        key = option.get("key")
+        if isinstance(key, str) and key.startswith(RESERVED_PREFIX):
+            failures.append(
+                f"{manifest_path.relative_to(ROOT)}: option key '{key}' uses the host's "
+                f"'{RESERVED_PREFIX}' prefix, which is reserved for host state")
+
+# The rule is only worth anything while the host enforces it at load too.
+validator = (ROOT / "modules/common/plugins/PluginValidator.js").read_text(encoding="utf-8")
+if 'option.key.startsWith("__")' not in validator:
+    failures.append(
+        "modules/common/plugins/PluginValidator.js: lost its reserved option-key check")
+
+if failures:
+    print("\n".join(failures), file=sys.stderr)
+    sys.exit(1)
+print("Plugin option key lint passed: no manifest claims the host's '__' prefix")

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -211,6 +211,13 @@ if ! python3 "$SCRIPT_DIR/test_widget_grip_lock.py"; then
     exit 1
 fi
 
+# Brings its own headless weston, like the interaction runtime tests above.
+echo "Running widget resize grip runtime tests..."
+if ! python3 "$SCRIPT_DIR/test_widget_resize_grip_runtime.py"; then
+    echo "Widget resize grip runtime tests failed."
+    exit 1
+fi
+
 echo "Running widget group selection tests..."
 if ! python3 "$SCRIPT_DIR/test_widget_group_selection.py"; then
     echo "Widget group selection tests failed."

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -117,6 +117,14 @@ if ! python3 "$SCRIPT_DIR/lint_doc_citations.py"; then
     exit 1
 fi
 
+# Static lint: a manifest's option keys and the host's own per-plugin state
+# share one PluginState namespace, so the `__` prefix is the host's alone.
+echo "Running plugin option key lint..."
+if ! python3 "$SCRIPT_DIR/lint_plugin_option_keys.py"; then
+    echo "Plugin option key lint failed."
+    exit 1
+fi
+
 echo "Running plugin process lifecycle lint..."
 if ! python3 "$SCRIPT_DIR/lint_plugin_processes.py"; then
     echo "Plugin process lifecycle lint failed."

--- a/dots/.config/quickshell/imi/tests/test_widget_grip_lock.py
+++ b/dots/.config/quickshell/imi/tests/test_widget_grip_lock.py
@@ -199,10 +199,13 @@ class TheHostsOwnResizeGrip(unittest.TestCase):
         self.assertRegex(self._grip(), r"visible:[^\n]*rootWidget\.gridResizable")
 
     def test_it_claims_the_press_from_drag_to_move(self):
-        """`AbstractWidget`'s drag-to-move is this widget's own root MouseArea.
-        The nested area takes the press, but without `preventStealing` the root
-        takes the grab back on the first move and the corner walks the widget
-        instead of resizing it.
+        """`AbstractWidget`'s drag-to-move is this widget's own root MouseArea,
+        and what claims the press is the nesting - `WidgetResizeGripRuntimeTest`
+        scores that, and passes with `preventStealing` removed, because a
+        MouseArea steals a child's grab through its `drag` target and
+        AbstractWidget has none. This pins the belt beside the braces: it is one
+        `drag.target` binding away from mattering, and the bundled grips all
+        set it.
         """
         self.assertIn("preventStealing: true", self._grip())
 

--- a/dots/.config/quickshell/imi/tests/test_widget_grip_lock.py
+++ b/dots/.config/quickshell/imi/tests/test_widget_grip_lock.py
@@ -37,6 +37,26 @@ def source(path: Path) -> str:
     return path.read_text(encoding="utf-8")
 
 
+def handle_blocks(text: str):
+    """Every `id: *Handle` block in a file, keyed by id.
+
+    A grip is a `Rectangle` whose `id` ends in `Handle`, holding the `MouseArea`
+    that does the resizing; the block is every line indented at least as far as
+    that `id:`.
+    """
+    blocks = {}
+    for found in re.finditer(r"^(\s*)id: (\w*Handle)$", text, re.M):
+        start = found.end()
+        indent = len(found.group(1))
+        body = []
+        for line in text[start:].splitlines()[1:]:
+            if line.strip() and len(line) - len(line.lstrip()) < indent:
+                break
+            body.append(line)
+        blocks[found.group(2)] = "\n".join(body)
+    return blocks
+
+
 def uncommented(path: Path) -> str:
     """Source with `//` comments stripped.
 
@@ -103,18 +123,7 @@ class EveryGripGatesOnIt(unittest.TestCase):
     invisible item, so hiding the rectangle disarms the area inside it."""
 
     def _handles(self, widget_id):
-        text = source(BUNDLED / widget_id / "Widget.qml")
-        blocks = {}
-        for found in re.finditer(r"^(\s*)id: (\w*Handle)$", text, re.M):
-            start = found.end()
-            indent = len(found.group(1))
-            body = []
-            for line in text[start:].splitlines()[1:]:
-                if line.strip() and len(line) - len(line.lstrip()) < indent:
-                    break
-                body.append(line)
-            blocks[found.group(2)] = "\n".join(body)
-        return blocks
+        return handle_blocks(source(BUNDLED / widget_id / "Widget.qml"))
 
     def test_every_widget_with_a_grip_declares_the_property(self):
         for widget_id in GRIP_WIDGETS:
@@ -159,6 +168,68 @@ class EveryGripGatesOnIt(unittest.TestCase):
             self.assertNotRegex(uncommented(manifest),
                                 r"hostInteractionLocked\s*=[^=]",
                                 manifest.parent.name)
+
+
+class TheHostsOwnResizeGrip(unittest.TestCase):
+    """The grid resize grip is drawn by `PluginWidget` itself, so a manifest
+    opts into it by declaring `grid.sizes` and writes no QML - which also means
+    the sweep over bundled widgets above cannot see it. It is the same gesture
+    under the same lock, so it is pinned here rather than somewhere new."""
+
+    def _grip(self):
+        return handle_blocks(source(HOST))["resizeHandle"]
+
+    def test_the_grip_is_where_this_thinks_it_is(self):
+        """Guards every assertion below: rename it and they all pass on
+        nothing."""
+        self.assertEqual(sorted(handle_blocks(source(HOST))), ["resizeHandle"])
+        self.assertIn("MouseArea", self._grip())
+
+    def test_it_honours_the_hosts_resolved_lock(self):
+        """A resize changes the widget's geometry exactly as a drag does, so
+        every reason the host is locked has to disarm it too."""
+        self.assertIn("!rootWidget.interactionLocked", self._grip())
+
+    def test_it_only_exists_for_a_widget_that_offers_more_than_one_span(self):
+        """Otherwise every grid widget grows a grip that can only ever pick the
+        span it already has."""
+        self.assertIn("rootWidget.gridResizable", self._grip())
+
+    def test_the_gate_is_on_visible_so_the_grip_is_dead_and_not_just_hidden(self):
+        self.assertRegex(self._grip(), r"visible:[^\n]*rootWidget\.gridResizable")
+
+    def test_it_claims_the_press_from_drag_to_move(self):
+        """`AbstractWidget`'s drag-to-move is this widget's own root MouseArea.
+        The nested area takes the press, but without `preventStealing` the root
+        takes the grab back on the first move and the corner walks the widget
+        instead of resizing it.
+        """
+        self.assertIn("preventStealing: true", self._grip())
+
+    def test_the_drag_is_measured_in_scene_coordinates(self):
+        """The grip is anchored to a widget that resizes underneath it while
+        the drag is live, so a delta read from the grip's own frame folds the
+        resize back into the gesture (AGENT.md: a drag cannot be tracked
+        through the item it moves).
+        """
+        self.assertIn("resizeArea.mapToItem(null,", self._grip())
+
+    def test_escape_cancels_the_resize(self):
+        grip = self._grip()
+        self.assertIn("Keys.onEscapePressed", grip)
+        self.assertIn("rootWidget.cancelGridResize()", grip)
+
+    def test_a_release_commits_whatever_the_preview_settled_on(self):
+        """Which is also what makes a release after Escape commit nothing: the
+        cancel cleared the preview, so there is no span left to store. Committing
+        `storedGridSize`, or reading the preview back after clearing it, both
+        read fine and both throw the drag's result away.
+        """
+        body = re.search(r"function endGridResize\(\) \{(.*?)\n    \}",
+                         uncommented(HOST), re.S).group(1)
+        self.assertLess(body.index("previewGridSize = null"),
+                        body.index("commitGridSize("), body)
+        self.assertIn("commitGridSize(chosen)", body)
 
 
 if __name__ == "__main__":

--- a/dots/.config/quickshell/imi/tests/test_widget_group_selection.py
+++ b/dots/.config/quickshell/imi/tests/test_widget_group_selection.py
@@ -166,8 +166,12 @@ class GroupDragIsRigid(unittest.TestCase):
         self.assertIn("function commitPosition()", uncommented(BASE))
         host = uncommented(HOST)
         self.assertIn("function commitPosition()", host)
-        self.assertNotIn("onReleased:", host,
-                         "PluginWidget must not keep a second release path")
+        # Anchored to the host's own scope. A nested MouseArea - the grid
+        # resize grip - releases a gesture of its own that never touches the
+        # widget's position; what must not come back is a handler on the host
+        # itself, shadowing the base class's.
+        self.assertNotRegex(host, r"(?m)^    onReleased:",
+                            "PluginWidget must not keep a second release path")
 
     def test_the_plugin_commit_still_restores_the_binding_and_persists(self):
         """Dropping `restoreXYBinding()` leaves every group member frozen at

--- a/dots/.config/quickshell/imi/tests/test_widget_resize_grip_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_widget_resize_grip_runtime.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Drives the grid resize grip with real mouse events.
+
+`WidgetResizeGripRuntimeTest.qml` builds two real `PluginWidget`s on a real
+`WidgetCanvas` - one whose manifest offers three spans, one that offers a single
+one - and drags the bottom-right corner of each. This module is the driver: it
+stands up a headless weston, points throwaway XDG dirs at it, and fails the
+suite on any check the harness reports.
+
+`test_widget_grip_lock.py` can only grep the bindings, and the qmltestrunner
+suite cannot instantiate the host at all. Neither answers the question this
+feature turns on: whether a press on the corner resizes the widget or *walks*
+it, since `AbstractWidget`'s drag-to-move is the root MouseArea the grip sits
+inside. The harness therefore scores the widget's position on every gesture,
+not only its stored span, and the single-span widget - whose corner must move
+it - is the control that keeps a run where events stopped arriving from reading
+as a pass.
+
+Headless weston rather than the caller's session because the harness opens a
+window. It implements no wlr-layer-shell, so the Escape it delivers proves the
+grip's key handling and not the background surface's keyboard focus, which only
+a real layer surface can answer.
+
+Skips when weston or qs is missing, as in CI.
+"""
+
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HARNESS = ROOT / "WidgetResizeGripRuntimeTest.qml"
+SOCKET = "wayland-imi-widget-resize-grip"
+
+
+def _stop(proc):
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+
+
+def _runtime_available():
+    return shutil.which("qs") is not None and shutil.which("weston") is not None
+
+
+@unittest.skipUnless(_runtime_available(), "needs qs and weston on PATH")
+class WidgetResizeGripRuntimeTest(unittest.TestCase):
+    def setUp(self):
+        self.home = Path(tempfile.mkdtemp(prefix="imi-widget-resize-grip-"))
+        self.addCleanup(shutil.rmtree, self.home, ignore_errors=True)
+
+    def test_the_grip_resizes_without_moving_the_widget(self):
+        env = dict(os.environ)
+        env.setdefault("XDG_RUNTIME_DIR", f"/run/user/{os.getuid()}")
+        env["WAYLAND_DISPLAY"] = SOCKET
+        env.pop("DISPLAY", None)
+
+        weston = subprocess.Popen(
+            ["weston", "--backend=headless", "--renderer=pixman",
+             f"--socket={SOCKET}", "--width=1400", "--height=900"],
+            env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        self.addCleanup(_stop, weston)
+
+        socket_path = Path(env["XDG_RUNTIME_DIR"]) / SOCKET
+        deadline = time.monotonic() + 15
+        while not socket_path.exists() and time.monotonic() < deadline:
+            time.sleep(0.2)
+        self.assertTrue(socket_path.exists(), "headless weston never came up")
+
+        # This box's headless EGL has no driver, so force software rendering.
+        env["LIBGL_ALWAYS_SOFTWARE"] = "1"
+        env["QT_QUICK_BACKEND"] = "software"
+        env["XDG_CONFIG_HOME"] = str(self.home / "config")
+        env["XDG_STATE_HOME"] = str(self.home / "state")
+
+        proc = subprocess.run(["qs", "-p", str(HARNESS)], cwd=str(ROOT), env=env,
+                              capture_output=True, text=True, timeout=180)
+        output = proc.stdout + proc.stderr
+        failed = [line for line in output.splitlines() if "FAIL" in line]
+        self.assertEqual(failed, [], f"harness reported failures:\n{output}")
+        self.assertIn("[WidgetResizeGrip] failures: 0", output,
+                      f"harness did not finish cleanly:\n{output}")
+
+        # A span bound back through the item it sizes shows up here rather than
+        # as a failed check - the widget would still resize, just never settle.
+        self.assertNotIn("Binding loop", output,
+                         f"the host tree grew a binding loop:\n{output}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dots/.config/quickshell/imi/tests/tst_grid_sizes.qml
+++ b/dots/.config/quickshell/imi/tests/tst_grid_sizes.qml
@@ -191,4 +191,41 @@ TestCase {
         compare(GridSizes.nearestSize(undefined, 300, 200), null);
         compare(GridSizes.nearestSize(candidates(), NaN, NaN), null);
     }
+
+    // --- a `sizes` list that has crossed a QML model boundary ---------------
+
+    // What a JS array looks like after a round trip through a Repeater's
+    // `model`: same indices, same length, and `Array.isArray` false. Every
+    // desktop widget is built from such a model (Background.qml), so this is
+    // the shape the host really hands in - not the literal the harnesses
+    // declare inline.
+    function asVariantList(entries) {
+        const like = { length: entries.length };
+        for (let i = 0; i < entries.length; i++) like[i] = entries[i];
+        return like;
+    }
+
+    function test_a_sizes_list_survives_the_model_round_trip() {
+        const grid = { cols: 3, rows: 2, sizes: asVariantList(
+            [{ cols: 3, rows: 2 }, { cols: 2, rows: 2 }, { cols: 2, rows: 1 }]) };
+        verify(!Array.isArray(grid.sizes));
+        compare(GridSizes.offeredSizes(grid).length, 3);
+        verify(GridSizes.resizable(grid));
+    }
+
+    function test_a_sizes_value_that_is_not_a_list_is_still_rejected() {
+        // The point of the relaxation is array-LIKE, not anything at all: a
+        // malformed `sizes` must still fall back to the single declared span
+        // rather than be read as an empty list of spans.
+        compare(GridSizes.offeredSizes({ cols: 2, rows: 2, sizes: 5 }).length, 1);
+        compare(GridSizes.offeredSizes({ cols: 2, rows: 2, sizes: "2x2" }).length, 1);
+        compare(GridSizes.offeredSizes({ cols: 2, rows: 2, sizes: { cols: 2 } }).length, 1);
+    }
+
+    function test_the_snap_takes_a_round_tripped_candidate_list_too() {
+        const list = asVariantList([
+            { cols: 2, rows: 1, width: 276, height: 108 },
+            { cols: 3, rows: 2, width: 420, height: 228 }]);
+        compare(GridSizes.formatSize(GridSizes.nearestSize(list, 420, 228)), "3x2");
+    }
 }

--- a/dots/.config/quickshell/imi/tests/tst_grid_sizes.qml
+++ b/dots/.config/quickshell/imi/tests/tst_grid_sizes.qml
@@ -1,0 +1,181 @@
+import QtTest
+import "../modules/common/plugins/gridSizes.js" as GridSizes
+
+// Resolving a placed widget's component-grid span: what a manifest offers,
+// which one a stored choice resolves to, and which one a drag snaps to.
+//
+// The two rules worth pinning are both about refusing to guess. A `sizes` list
+// whose entries disagree with the manifest's own default is a manifest bug, and
+// honouring it would resize a widget the user already placed; a stored span the
+// manifest no longer offers is the same situation one upgrade later.
+TestCase {
+    name: "GridSizesTest"
+
+    function mediaGrid() {
+        return {
+            cols: 3, rows: 2,
+            sizes: [{ cols: 3, rows: 2 }, { cols: 2, rows: 2 }, { cols: 2, rows: 1 }]
+        };
+    }
+
+    // --- what a manifest offers -------------------------------------------
+
+    function test_no_grid_at_all_is_content_sized() {
+        // Every widget that predates the grid, and every full-bleed one.
+        compare(GridSizes.offeredSizes(undefined).length, 0);
+        compare(GridSizes.defaultSize(undefined), null);
+        compare(GridSizes.resolveSize(undefined, "2x2"), null);
+        compare(GridSizes.resizable(undefined), false);
+    }
+
+    function test_a_malformed_grid_is_content_sized_not_a_default() {
+        const malformed = [null, [2, 2], "2x2", 3, { cols: 0, rows: 2 },
+            { cols: 2.5, rows: 1 }, { cols: 13, rows: 1 }, { cols: "2", rows: 2 }];
+        for (const grid of malformed) {
+            compare(GridSizes.offeredSizes(grid).length, 0,
+                "should offer nothing: " + JSON.stringify(grid));
+        }
+    }
+
+    function test_a_grid_without_sizes_offers_exactly_its_own_span() {
+        // notes, user-card and image-converter all look like this, and none of
+        // them may grow a handle.
+        const offered = GridSizes.offeredSizes({ cols: 2, rows: 2 });
+        compare(offered.length, 1);
+        compare(offered[0].cols, 2);
+        compare(offered[0].rows, 2);
+        compare(GridSizes.resizable({ cols: 2, rows: 2 }), false);
+    }
+
+    function test_each_axis_defaults_to_one_cell() {
+        const offered = GridSizes.offeredSizes({ cols: 3 });
+        compare(offered.length, 1);
+        compare(offered[0].cols, 3);
+        compare(offered[0].rows, 1);
+    }
+
+    function test_declared_sizes_are_offered_in_manifest_order() {
+        const offered = GridSizes.offeredSizes(mediaGrid());
+        compare(offered.length, 3);
+        compare(GridSizes.formatSize(offered[0]), "3x2");
+        compare(GridSizes.formatSize(offered[1]), "2x2");
+        compare(GridSizes.formatSize(offered[2]), "2x1");
+        compare(GridSizes.resizable(mediaGrid()), true);
+    }
+
+    function test_a_default_missing_from_sizes_rejects_the_whole_list() {
+        // The manifest bug this exists for: honouring the list would move the
+        // widget off the span it has always had, on upgrade, with no report.
+        const grid = { cols: 3, rows: 2, sizes: [{ cols: 2, rows: 2 }, { cols: 2, rows: 1 }] };
+        const offered = GridSizes.offeredSizes(grid);
+        compare(offered.length, 1);
+        compare(GridSizes.formatSize(offered[0]), "3x2");
+        compare(GridSizes.resizable(grid), false);
+    }
+
+    function test_one_bad_entry_rejects_the_whole_list() {
+        // Not "drops the bad entry and keeps the rest": the remaining two are
+        // still a usable pair, so a widget would quietly start offering a set
+        // of spans its author never wrote.
+        const grid = { cols: 3, rows: 2,
+            sizes: [{ cols: 3, rows: 2 }, { cols: 2, rows: 2 }, { cols: 0, rows: 4 }] };
+        const offered = GridSizes.offeredSizes(grid);
+        compare(offered.length, 1);
+        compare(GridSizes.formatSize(offered[0]), "3x2");
+        compare(GridSizes.resizable(grid), false);
+    }
+
+    function test_sizes_must_offer_more_than_one_span_to_count() {
+        const grid = { cols: 2, rows: 2, sizes: [{ cols: 2, rows: 2 }] };
+        compare(GridSizes.resizable(grid), false);
+        compare(GridSizes.offeredSizes({ cols: 2, rows: 2, sizes: [] }).length, 1);
+        compare(GridSizes.offeredSizes({ cols: 2, rows: 2, sizes: "2x2" }).length, 1);
+    }
+
+    function test_a_repeated_span_is_offered_once() {
+        // Otherwise the resize walks through the same size twice and reads as
+        // a dead step in the middle of the drag.
+        const grid = { cols: 2, rows: 2, sizes: [{ cols: 2, rows: 2 }, { cols: 2, rows: 2 }, { cols: 2, rows: 1 }] };
+        const offered = GridSizes.offeredSizes(grid);
+        compare(offered.length, 2);
+        compare(GridSizes.formatSize(offered[1]), "2x1");
+    }
+
+    // --- the stored choice -------------------------------------------------
+
+    function test_a_stored_size_that_is_offered_wins() {
+        const resolved = GridSizes.resolveSize(mediaGrid(), "2x1");
+        compare(resolved.cols, 2);
+        compare(resolved.rows, 1);
+    }
+
+    function test_a_stored_size_no_longer_offered_falls_back_to_the_default() {
+        // The manifest changed under an installed widget.
+        compare(GridSizes.formatSize(GridSizes.resolveSize(mediaGrid(), "4x4")), "3x2");
+        compare(GridSizes.formatSize(GridSizes.resolveSize({ cols: 2, rows: 2 }, "3x2")), "2x2");
+    }
+
+    function test_an_unreadable_stored_value_falls_back_to_the_default() {
+        const junk = [undefined, null, "", "2", "2x", "x2", "big", "2x2x2", 22, { cols: 2, rows: 1 }];
+        for (const stored of junk) {
+            compare(GridSizes.formatSize(GridSizes.resolveSize(mediaGrid(), stored)), "3x2",
+                "should fall back: " + JSON.stringify(stored));
+        }
+    }
+
+    function test_a_stored_value_round_trips_through_its_persisted_form() {
+        for (const size of GridSizes.offeredSizes(mediaGrid())) {
+            const text = GridSizes.formatSize(size);
+            compare(GridSizes.formatSize(GridSizes.parseSize(text)), text);
+        }
+        compare(GridSizes.formatSize({ cols: 0, rows: 2 }), "");
+    }
+
+    // --- the drag snap -----------------------------------------------------
+
+    // The media widget's three spans in pixels at scale 1.0, as
+    // Appearance.sizes.widgetGridSpanX/Y measure them.
+    function candidates() {
+        return [
+            { cols: 3, rows: 2, width: 420, height: 228 },
+            { cols: 2, rows: 2, width: 276, height: 228 },
+            { cols: 2, rows: 1, width: 276, height: 108 }
+        ];
+    }
+
+    function test_the_snap_picks_the_span_the_pointer_is_nearest() {
+        compare(GridSizes.formatSize(GridSizes.nearestSize(candidates(), 420, 228)), "3x2");
+        compare(GridSizes.formatSize(GridSizes.nearestSize(candidates(), 280, 220)), "2x2");
+        compare(GridSizes.formatSize(GridSizes.nearestSize(candidates(), 270, 120)), "2x1");
+    }
+
+    function test_dragging_past_the_largest_span_stays_on_it() {
+        compare(GridSizes.formatSize(GridSizes.nearestSize(candidates(), 4000, 4000)), "3x2");
+    }
+
+    function test_dragging_below_the_smallest_span_stays_on_it() {
+        compare(GridSizes.formatSize(GridSizes.nearestSize(candidates(), 0, 0)), "2x1");
+        compare(GridSizes.formatSize(GridSizes.nearestSize(candidates(), -500, -500)), "2x1");
+    }
+
+    function test_the_midpoint_between_two_spans_goes_to_the_earlier_one() {
+        // 276 and 420 are the same height, so the boundary is exactly 348. A
+        // pointer parked there must not flicker between the two.
+        compare(GridSizes.formatSize(GridSizes.nearestSize(candidates(), 348, 228)), "3x2");
+        compare(GridSizes.formatSize(GridSizes.nearestSize(candidates(), 347, 228)), "2x2");
+        compare(GridSizes.formatSize(GridSizes.nearestSize(candidates(), 349, 228)), "3x2");
+    }
+
+    function test_the_boundary_counts_both_axes() {
+        // 276x228 and 276x108 differ only vertically: the boundary is 168.
+        compare(GridSizes.formatSize(GridSizes.nearestSize(candidates(), 276, 168)), "2x2");
+        compare(GridSizes.formatSize(GridSizes.nearestSize(candidates(), 276, 167)), "2x1");
+        compare(GridSizes.formatSize(GridSizes.nearestSize(candidates(), 276, 169)), "2x2");
+    }
+
+    function test_the_snap_answers_nothing_rather_than_guessing() {
+        compare(GridSizes.nearestSize([], 300, 200), null);
+        compare(GridSizes.nearestSize(undefined, 300, 200), null);
+        compare(GridSizes.nearestSize(candidates(), NaN, NaN), null);
+    }
+}

--- a/dots/.config/quickshell/imi/tests/tst_grid_sizes.qml
+++ b/dots/.config/quickshell/imi/tests/tst_grid_sizes.qml
@@ -47,6 +47,19 @@ TestCase {
         compare(GridSizes.resizable({ cols: 2, rows: 2 }), false);
     }
 
+    function test_todays_grid_manifests_keep_the_span_they_have() {
+        // notes, user-card and image-converter are the three manifests that
+        // ship a `grid`, all `{ "cols": 2, "rows": 2 }` with no `sizes`. Every
+        // resolution path has to land back on 2x2 for them - including one
+        // carrying a stored span, which a widget that was never resizable
+        // should never have, but which a preset or a hand-edited state file
+        // can still hand over.
+        const grid = { cols: 2, rows: 2 };
+        compare(GridSizes.formatSize(GridSizes.resolveSize(grid, undefined)), "2x2");
+        compare(GridSizes.formatSize(GridSizes.resolveSize(grid, "3x2")), "2x2");
+        compare(GridSizes.resizable(grid), false);
+    }
+
     function test_each_axis_defaults_to_one_cell() {
         const offered = GridSizes.offeredSizes({ cols: 3 });
         compare(offered.length, 1);

--- a/dots/.config/quickshell/imi/tests/tst_plugin_validator.qml
+++ b/dots/.config/quickshell/imi/tests/tst_plugin_validator.qml
@@ -222,6 +222,31 @@ TestCase {
         compare(result.error, "grid.cols must be an integer between 1 and 12");
     }
 
+    // A manifest's options and the host's own per-plugin state are one
+    // PluginState namespace. `__gridSize` (the span the user resized a widget
+    // to) lives there, so a manifest declaring a `__`-prefixed option would ship
+    // a settings control that writes over host state.
+    function test_rejectsReservedOptionKeyPrefix() {
+        var result = PluginValidator.validateManifest({
+            "id": "reserved_opt",
+            "name": "Reserved Opt",
+            "options": [{ "key": "__gridSize", "type": "boolean", "default": false }],
+            "desktopWidget": { "component": "Widget.qml" }
+        });
+        verify(!result.valid);
+        compare(result.error, "Plugin option key '__gridSize' is reserved: '__' is the host's prefix");
+    }
+
+    function test_acceptsASingleLeadingUnderscore() {
+        var result = PluginValidator.validateManifest({
+            "id": "underscore_opt",
+            "name": "Underscore Opt",
+            "options": [{ "key": "_private", "type": "boolean", "default": false }],
+            "desktopWidget": { "component": "Widget.qml" }
+        });
+        verify(result.valid, "Single underscore should stay valid: " + (result.error ? result.error : ""));
+    }
+
     function test_rejectsNonObjectGrid() {
         var result = PluginValidator.validateManifest({
             "id": "grid_arr",


### PR DESCRIPTION
Steps 1-3 of `docs/superpowers/specs/2026-08-10-media-widget-sizes-design.md`.

A widget's span comes from its manifest, which is a constant, so no placed widget can be resized.
This adds the machinery generically rather than inside one plugin: `notes`, `user-card` and
`image-converter` all declare grids and all had the same one-size limitation.

- `manifest.grid.sizes` — the spans a widget actually has layouts for. **Absent means one size and
  no handle**, which is every shipped manifest today, so nothing changes for any of them.
- `__gridSize` in plugin state, resolved stored → manifest default → content-sized. A stored span the
  manifest no longer offers falls back rather than being honoured.
- The resize grip, shown only when more than one span is offered, previewing live and committing on
  release, Escape cancelling.
- `lint_plugin_option_keys.py` reserves the `__` prefix for host state so a plugin cannot collide.

**Not every widget is resizable, by design.** A widget qualifies only when it has a design per size —
offering a span with no layout behind it is worse than offering nothing.

## Two corrections to the spec

- The spec said the grip must claim the press before drag-to-move, which is true, but the *reason*
  given was wrong: nesting alone claims it, because `AbstractWidget` computes its drag by hand and
  has no `drag` target to steal with. Proved by removing `preventStealing` and watching the runtime
  harness stay green. The flag is kept and the comment rewritten to name the real mechanism.
- The spec said pointer grabs are unreachable from tests. The repo already has a `qs -p` +
  headless-weston pattern that reaches them, so there is now a 22-check runtime harness — including
  *the widget does not move* on every gesture, and a single-span control whose corner must move it.

## Worth a decision

`__gridSize` lives in `pluginOptions`, which presets capture and replace — so a preset now carries
widget sizes as it already carries positions. Confirmed intended.

## Testing

`./tests/run_tests.sh` — **390 passed, 0 failed** (366 baseline; +22 `tst_grid_sizes`, +2 validator).
`DesignSystemCompile` 154 files. Non-vacuity proved on committed trees for all four `gridSizes.js`
mutations, the reserved-prefix lint, the seven grip source pins and the runtime harness — one early
test *was* vacuous under a mutation and was rewritten until it reddened.

Docs: updated AGENT.md §Dynamic/data-driven QML gotchas, docs/widget-grid.md, CONTRIBUTING.md