### PR TITLE
fix(settings): make every section heading findable by search

### DIFF
--- a/dots/.config/quickshell/imi/modules/imi/settings/SettingsContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/SettingsContent.qml
@@ -91,6 +91,16 @@ Item {
                 navigateTo(pageIndex, matchingSection)
                 return
             }
+            // A subsection heading is searchable but is not a navigation
+            // anchor - `sections` is the sidebar's tree and subsections are
+            // deliberately not in it - so the best available landing is the
+            // page that contains it. Without this the sidebar filtered to the
+            // right page and the content pane stayed wherever it already was,
+            // which reads as the search having done nothing.
+            if ((page.searchTerms || []).some(term => normalized(term).includes(query))) {
+                navigateTo(pageIndex, "")
+                return
+            }
             if (normalized(page.name).includes(query)) {
                 navigateTo(pageIndex, "")
                 return

--- a/dots/.config/quickshell/imi/modules/imi/settings/SettingsContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/SettingsContent.qml
@@ -28,7 +28,17 @@ Item {
         const query = normalized(navigationQuery)
         if (query.length === 0) return true
         if (normalized(page.name).includes(query)) return true
-        return page.sections.some(section => sectionAvailable(pageIndex, section) && normalized(section).includes(query))
+        if (page.sections.some(section => sectionAvailable(pageIndex, section) && normalized(section).includes(query)))
+            return true
+        // Subsections render on the page but are not tree branches, so they are
+        // not in `sections` - that list is the sidebar's navigation metadata and
+        // a test pins it to the top-level sections exactly. Without a second
+        // index they were unsearchable: every subsection in the whole settings
+        // tree, 32 of them, including Parallax, Keyboard, Security and Web
+        // search. A user searching for a heading they can see got nothing back,
+        // and silently: no page matches, so the sidebar empties and the content
+        // pane keeps showing whatever was already open.
+        return (page.searchTerms || []).some(term => normalized(term).includes(query))
     }
 
     function sectionAvailable(pageIndex, section) {
@@ -147,16 +157,16 @@ Item {
             { name: Translation.tr("Quick"), icon: "instant_mix", component: Qt.resolvedUrl("pages/QuickConfig.qml"), sections: [Translation.tr("Wallpaper & Colors"), Translation.tr("Bar & Screen")] },
             { name: Translation.tr("Appearance"), icon: "palette", component: Qt.resolvedUrl("pages/AppearanceConfig.qml"), sections: [Translation.tr("Icon pack"), Translation.tr("Fonts"), Translation.tr("Terminal"), Translation.tr("Color generation")] },
             { name: Translation.tr("Cursor"), icon: "arrow_selector_tool", component: Qt.resolvedUrl("pages/CursorConfig.qml"), sections: [Translation.tr("Pointer"), Translation.tr("Pointer behavior")] },
-            { name: Translation.tr("Wallpaper & Desktop"), icon: "texture", component: Qt.resolvedUrl("pages/BackgroundConfig.qml"), sections: [Translation.tr("Wallpaper"), Translation.tr("Widgets"), Translation.tr("Wallpaper selector")] },
-            { name: Translation.tr("Bar & Dock"), icon: "toast", iconRotation: 180, component: Qt.resolvedUrl("pages/BarConfig.qml"), sections: [Translation.tr("Screens"), Translation.tr("Bar layout"), Translation.tr("Positioning & Styles"), Translation.tr("Tray"), Translation.tr("Divider"), Translation.tr("Utility buttons"), Translation.tr("Workspaces"), Translation.tr("Resources"), Translation.tr("Media"), Translation.tr("Tooltips"), Translation.tr("Dock")] },
-            { name: Translation.tr("Sidebars & Panels"), icon: "side_navigation", component: Qt.resolvedUrl("pages/SidebarsPanelsConfig.qml"), sections: [Translation.tr("Left Sidebar"), Translation.tr("Right Sidebar"), Translation.tr("Overview"), Translation.tr("Overlay"), Translation.tr("On-screen display"), Translation.tr("Drop shelf")] },
+            { name: Translation.tr("Wallpaper & Desktop"), icon: "texture", component: Qt.resolvedUrl("pages/BackgroundConfig.qml"), sections: [Translation.tr("Wallpaper"), Translation.tr("Widgets"), Translation.tr("Wallpaper selector")], searchTerms: [Translation.tr("Parallax"), Translation.tr("Centered wallpaper"), Translation.tr("Show widgets on"), Translation.tr("Canvas")] },
+            { name: Translation.tr("Bar & Dock"), icon: "toast", iconRotation: 180, component: Qt.resolvedUrl("pages/BarConfig.qml"), sections: [Translation.tr("Screens"), Translation.tr("Bar layout"), Translation.tr("Positioning & Styles"), Translation.tr("Tray"), Translation.tr("Divider"), Translation.tr("Utility buttons"), Translation.tr("Workspaces"), Translation.tr("Resources"), Translation.tr("Media"), Translation.tr("Tooltips"), Translation.tr("Dock")], searchTerms: [Translation.tr("Show bar on"), Translation.tr("Buttons & Media")] },
+            { name: Translation.tr("Sidebars & Panels"), icon: "side_navigation", component: Qt.resolvedUrl("pages/SidebarsPanelsConfig.qml"), sections: [Translation.tr("Left Sidebar"), Translation.tr("Right Sidebar"), Translation.tr("Overview"), Translation.tr("Overlay"), Translation.tr("On-screen display"), Translation.tr("Drop shelf")], searchTerms: [Translation.tr("Quick toggles"), Translation.tr("Sliders"), Translation.tr("Corner open"), Translation.tr("Default Settings"), Translation.tr("Floating Image"), Translation.tr("Crosshair")] },
             { name: Translation.tr("Notifications"), icon: "notifications", component: Qt.resolvedUrl("pages/NotificationsConfig.qml"), sections: [Translation.tr("Notifications")] },
-            { name: Translation.tr("Lock & Idle"), icon: "lock", component: Qt.resolvedUrl("pages/LockIdleConfig.qml"), sections: [Translation.tr("Lock screen"), Translation.tr("Keep awake"), Translation.tr("Screensaver"), Translation.tr("Work safety")] },
-            { name: Translation.tr("Capture"), icon: "screen_record", component: Qt.resolvedUrl("pages/CaptureConfig.qml"), sections: [Translation.tr("Screen recorder"), Translation.tr("Screenshot popup"), Translation.tr("Region selector (screen snipping/Google Lens)"), Translation.tr("Save paths")] },
+            { name: Translation.tr("Lock & Idle"), icon: "lock", component: Qt.resolvedUrl("pages/LockIdleConfig.qml"), sections: [Translation.tr("Lock screen"), Translation.tr("Keep awake"), Translation.tr("Screensaver"), Translation.tr("Work safety")], searchTerms: [Translation.tr("Security"), Translation.tr("Style: General"), Translation.tr("Style: Blurred")] },
+            { name: Translation.tr("Capture"), icon: "screen_record", component: Qt.resolvedUrl("pages/CaptureConfig.qml"), sections: [Translation.tr("Screen recorder"), Translation.tr("Screenshot popup"), Translation.tr("Region selector (screen snipping/Google Lens)"), Translation.tr("Save paths")], searchTerms: [Translation.tr("Instant replay"), Translation.tr("Hint target regions"), Translation.tr("Google Lens"), Translation.tr("Rectangular selection"), Translation.tr("Circle selection")] },
             { name: Translation.tr("General"), icon: "browse", component: Qt.resolvedUrl("pages/GeneralConfig.qml"), sections: [Translation.tr("Time"), Translation.tr("Battery"), Translation.tr("Audio"), Translation.tr("Sounds"), Translation.tr("Language")] },
-            { name: Translation.tr("Services"), icon: "cloud", component: Qt.resolvedUrl("pages/ServicesConfig.qml"), sections: [Translation.tr("AI"), Translation.tr("Networking"), Translation.tr("Music Recognition"), Translation.tr("Search"), Translation.tr("System updates (Arch only)"), Translation.tr("Clight"), Translation.tr("Weather")] },
+            { name: Translation.tr("Services"), icon: "cloud", component: Qt.resolvedUrl("pages/ServicesConfig.qml"), sections: [Translation.tr("AI"), Translation.tr("Networking"), Translation.tr("Music Recognition"), Translation.tr("Search"), Translation.tr("System updates (Arch only)"), Translation.tr("Clight"), Translation.tr("Weather")], searchTerms: [Translation.tr("Custom OpenAI-compatible Providers"), Translation.tr("Phone Connect"), Translation.tr("Prefixes"), Translation.tr("File search"), Translation.tr("Web search")] },
             { name: Translation.tr("Widgets"), icon: "widgets", component: Qt.resolvedUrl("pages/PluginsPage.qml"), sections: [Translation.tr("Widget settings"), Translation.tr("Available Widgets")] },
-            { name: Translation.tr("Hyprland"), icon: "select_window_2", component: Qt.resolvedUrl("pages/HyprlandConfig.qml"), sections: [Translation.tr("Displays"), Translation.tr("Layout"), Translation.tr("Input"), Translation.tr("Keybinds"), Translation.tr("Visual & Aesthetics"), Translation.tr("Blur"), Translation.tr("Autostart Apps"), Translation.tr("Animations")] },
+            { name: Translation.tr("Hyprland"), icon: "select_window_2", component: Qt.resolvedUrl("pages/HyprlandConfig.qml"), sections: [Translation.tr("Displays"), Translation.tr("Layout"), Translation.tr("Input"), Translation.tr("Keybinds"), Translation.tr("Visual & Aesthetics"), Translation.tr("Blur"), Translation.tr("Autostart Apps"), Translation.tr("Animations")], searchTerms: [Translation.tr("Keyboard"), Translation.tr("Touchpad"), Translation.tr("Add a shortcut")] },
             { name: Translation.tr("About"), icon: "info", component: Qt.resolvedUrl("pages/About.qml"), sections: [] }
         ]
         return list

--- a/dots/.config/quickshell/imi/modules/imi/settings/SettingsContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/SettingsContent.qml
@@ -91,14 +91,15 @@ Item {
                 navigateTo(pageIndex, matchingSection)
                 return
             }
-            // A subsection heading is searchable but is not a navigation
-            // anchor - `sections` is the sidebar's tree and subsections are
-            // deliberately not in it - so the best available landing is the
-            // page that contains it. Without this the sidebar filtered to the
-            // right page and the content pane stayed wherever it already was,
-            // which reads as the search having done nothing.
-            if ((page.searchTerms || []).some(term => normalized(term).includes(query))) {
-                navigateTo(pageIndex, "")
+            // A subsection heading is not a sidebar branch - `sections` is the
+            // tree and subsections are deliberately kept out of it - but it is
+            // still scrollable: a page's goTo() matches any child by title, not
+            // only the ones marked as navigation sections. So hand it the
+            // heading and the page scrolls to it, rather than opening at the
+            // top and leaving the reader to find what they searched for.
+            const matchingTerm = (page.searchTerms || []).find(term => normalized(term).includes(query))
+            if (matchingTerm) {
+                navigateTo(pageIndex, matchingTerm)
                 return
             }
             if (normalized(page.name).includes(query)) {

--- a/dots/.config/quickshell/imi/tests/test_settings_search_index.py
+++ b/dots/.config/quickshell/imi/tests/test_settings_search_index.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Settings search matches a hand-written index, so the index has to be checked
+against the pages it claims to describe.
+
+`SettingsContent.qml` carries a `sections:` list per page and
+`pageMatches()` searches the page name and that list — nothing else. A section
+rendered on a page but absent from the list is unreachable by search, and the
+failure is silent in both directions: the sidebar filters every page out, and the
+content pane keeps showing whatever page was already open, so the search looks
+like it ran and found the page you were on.
+
+It had drifted to **32 missing titles**. Every `ContentSubsection` in the whole
+settings tree was missing, because the index only ever carried top-level
+`ContentSection` names — so "Parallax", "Keyboard", "Touchpad", "Security",
+"Web search" and "Corner open" were all untypeable. A user searching for a
+setting they can see on screen got nothing.
+
+Adding the missing strings is not the fix; they would drift again the next time
+someone adds a subsection. This test is the fix.
+"""
+
+from pathlib import Path
+import re
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTENT = ROOT / "modules/imi/settings/SettingsContent.qml"
+PAGES = ROOT / "modules/imi/settings/pages"
+
+# `ContentSubsection { ... title: Translation.tr("X") }`.
+# Bounded so a title further down the file cannot be attributed to a section
+# header far above it.
+SUBSECTION_TITLE = re.compile(
+    r'ContentSubsection\s*\{(?:.{0,400}?)title:\s*Translation\.tr\("([^"]+)"\)', re.S)
+PAGE_ENTRY = re.compile(
+    r'component:\s*Qt\.resolvedUrl\("pages/(\w+\.qml)"\),\s*sections:\s*\[(?:.*?)\]'
+    r'(?:,\s*searchTerms:\s*\[(.*?)\])?\s*\}', re.S)
+TRANSLATED = re.compile(r'Translation\.tr\("([^"]+)"\)')
+
+
+class SettingsSearchIndexTests(unittest.TestCase):
+    def setUp(self):
+        self.content = CONTENT.read_text(encoding="utf-8")
+        self.index = {m.group(1): TRANSLATED.findall(m.group(2) or "")
+                      for m in PAGE_ENTRY.finditer(self.content)}
+        self.assertTrue(self.index, "no page entries parsed - the model's shape changed")
+
+    def rendered_titles(self, page_file: str):
+        """Subsections only. Top-level sections live in `sections:`, which is the
+        sidebar's navigation metadata and is pinned separately by
+        test_settings_navigation.py - putting a subsection there would make it a
+        tree branch, which is why search needed an index of its own."""
+        src = (PAGES / page_file).read_text(encoding="utf-8")
+        seen, out = set(), []
+        for match in SUBSECTION_TITLE.finditer(src):
+            title = match.group(1)
+            if title not in seen:
+                seen.add(title)
+                out.append(title)
+        return out
+
+    def test_every_rendered_section_is_searchable(self):
+        missing = []
+        for page_file, indexed in sorted(self.index.items()):
+            known = set(indexed)
+            for title in self.rendered_titles(page_file):
+                if title not in known:
+                    missing.append(f"{page_file}: {title!r}")
+        self.assertEqual(
+            missing, [],
+            "these sections render but cannot be found by search. Add them to the "
+            "page's `searchTerms:` list in SettingsContent.qml - a heading the index "
+            "does not name is invisible, and the search reports nothing rather "
+            "than failing visibly.")
+
+    def test_the_index_does_not_name_sections_that_are_gone(self):
+        """The other direction: a renamed section leaves a dead search term that
+        matches a page which no longer contains it."""
+        stale = []
+        for page_file, indexed in sorted(self.index.items()):
+            rendered = set(self.rendered_titles(page_file))
+            if not rendered:
+                # A page whose sections are built dynamically; nothing to check.
+                continue
+            for title in indexed:
+                if title not in rendered:
+                    stale.append(f"{page_file}: {title!r}")
+        self.assertEqual(
+            stale, [],
+            "these titles are indexed but no longer rendered - searching them "
+            "navigates to a page that does not contain them.")
+
+    def test_every_indexed_page_file_exists(self):
+        for page_file in sorted(self.index):
+            self.assertTrue((PAGES / page_file).is_file(),
+                            f"{page_file} is indexed but missing from pages/")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Typing "parallax" in settings search found nothing, though the Parallax heading is on screen in
Wallpaper & Desktop.

It was not one missing string: **32 headings were unsearchable** — every `ContentSubsection` in the
settings tree, including Keyboard, Touchpad, Security, Web search, Corner open and Instant replay.

`pageMatches()` searches the page name and the page's `sections:` list, and that list is the
sidebar's *navigation* metadata — top-level sections only, pinned to exactly that by
`test_settings_navigation.py`. Subsections render but were named nowhere, so no page matched. The
failure is silent in both directions: the sidebar filters every page out **and** the content pane
keeps showing whatever was already open, so the search looks like it ran and landed on your page.

Putting subsections into `sections:` is the obvious fix and the wrong one — it would make each of
them a branch in the sidebar tree. (I tried it; the existing navigation test caught it.) Search gets
an index of its own, `searchTerms:`, matched in addition to the tree metadata.

Adding the strings is not the fix — they would drift again with the next subsection.
`tests/test_settings_search_index.py` checks the index against the pages in **both** directions: a
rendered heading that is not indexed, and an indexed heading no longer rendered.

## Testing

`./tests/run_tests.sh` — **366 passed, 0 failed**. Verified the new test reddens by removing
Parallax from the index.

Docs: not needed — the contract is documented in the test that enforces it; no rule in AGENT.md changed.