### PR TITLE
fix(widgets): sample the desktop frost in the wallpaper's own coordinate space

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1122,6 +1122,49 @@ Sizing is deliberately screen-derived rather than wallpaper-derived: a live WE p
 intrinsic size, and `PreserveAspectCrop` already covers a still, so one rule serves both.
 (feat(background): revive wallpaper parallax, for stills and Wallpaper Engine.)
 
+**A sample rect and the item it samples must be in the same coordinate space —
+and "it samples the real thing" is not evidence that they are.** The desktop
+widgets' frost hands a `sourceRect` to a `ShaderEffectSource` over the wallpaper.
+Every wallpaper layer is declared inside `parallaxViewport`, so all of them are
+viewport-sized and viewport-positioned, while a widget's own x/y are measured
+inside the widget canvas — a screen-sized *sibling* that travels at
+`parallax.widgetsFactor` while the wallpaper travels at 1. That difference is the
+whole effect, so the two frames never agree except at rest, and the frost showed
+the wrong slice of wallpaper on every workspace but the middle one
+([#157](https://github.com/XephyLon/immaterial-impulse/issues/157)). Note which
+half the reasoning got wrong first: the live Wallpaper Engine path samples the
+genuine, already-transformed surface and was assumed immune for that reason — it
+misaligned identically, because sampling a real item fixes nothing when the rect
+handed to it is measured from somewhere else. A reconstruction has the same rule
+plus one more: it must also be the *size* of the thing it stands in for
+(`parallaxWidth x parallaxHeight`, not the screen), or it is a different crop of
+the same file. Both corrections are one function,
+`ParallaxMath.sampleOrigin(canvasOffset, widgetPos, wallpaperOffset)`, kept pure
+beside `widgetOffsets` because nothing about the rendered frost is reachable from
+a test — `qmltestrunner` cannot construct Quickshell types and the software scene
+graph draws no `ShaderEffect`. Feed it the containers' live animating x/y, not the
+parallax targets, or the frost only agrees once the two 600ms pans settle.
+e4ff7abbb ("feat(parallax): work out where a widget's frost must sample the
+wallpaper"), ca667957a ("fix(widgets): sample the desktop frost in the
+wallpaper's own space").
+
+**And ask who is painting the wallpaper before applying any of that.** A video
+wallpaper is drawn by `mpvpaper`, a separate Wayland client on its own layer
+surface, which `parallaxViewport` does not move — so a video neither pans nor
+zooms on screen, and giving its frost the viewport's offset adds travel the
+wallpaper never had, breaking the one case that was right at rest. While
+mpvpaper owns the screen the wallpaper *is* the screen. Two things that look
+like problems there are not: sampling the real player surface is not merely
+declined but unavailable (a `ShaderEffectSource` reaches items in this scene
+graph, and another client's surface is not one), and the still it samples
+instead is not a broken `Image` — `wallpaperPath` already resolves to
+`background.thumbnailPath`, the JPEG first frame `switchwall.sh` extracts with
+ffmpeg. Branch on `videoRevealed` rather than on `wallpaperIsVideo`: during a
+switch cross-fade and on the lock screen the shell draws that thumbnail inside
+the viewport itself, and there the viewport is right again. 918592d33
+("fix(background): frost a video wallpaper against the screen, not the
+viewport").
+
 **A feature that was config-only cannot be revived on its stored values.** The parallax knobs
 shipped for the whole life of this shell with nothing reading them, so every `config.json` holds
 values that predate the feature doing anything - on the author's machine every switch was `false`.

--- a/dots/.config/quickshell/imi/modules/common/functions/parallax.js
+++ b/dots/.config/quickshell/imi/modules/common/functions/parallax.js
@@ -113,3 +113,25 @@ function widgetOffsets(state, factor) {
         y: -overflowY * (f.y - CENTRE) * scale
     };
 }
+
+// Where a desktop widget's frost has to sample the wallpaper.
+//
+// Three items, three positions. The wallpaper sits in a container larger than
+// the screen, placed at `wallpaperOffset` (offsets()); the widget canvas is a
+// screen-sized SIBLING of that container, placed at `canvasOffset`
+// (widgetOffsets()); a widget's own x/y are measured inside the canvas. So a
+// widget's screen position is canvasOffset + widgetPos, and the wallpaper pixel
+// under it is that, measured from where the wallpaper container starts.
+//
+// Both terms are needed and neither cancels the other: the canvas travels at
+// `widgetsFactor` and the wallpaper at 1 - that difference IS the parallax, so
+// they are never the same number except at rest.
+function sampleOrigin(canvasOffset, widgetPos, wallpaperOffset) {
+    canvasOffset = canvasOffset || {};
+    widgetPos = widgetPos || {};
+    wallpaperOffset = wallpaperOffset || {};
+    return {
+        x: number(canvasOffset.x, 0) + number(widgetPos.x, 0) - number(wallpaperOffset.x, 0),
+        y: number(canvasOffset.y, 0) + number(widgetPos.y, 0) - number(wallpaperOffset.y, 0)
+    };
+}

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
@@ -7,6 +7,7 @@ import qs.services
 import qs.modules.common
 import qs.modules.common.widgets
 import qs.modules.imi.background.widgets
+import "../functions/parallax.js" as ParallaxMath
 
 AbstractBackgroundWidget {
     id: rootWidget
@@ -42,6 +43,23 @@ AbstractBackgroundWidget {
     // Background so "blur" frost can sample the animated wallpaper behind each
     // widget. Null when no WE wallpaper is active (static image path).
     property Item weSurfaceItem: null
+
+    // Where the widget canvas and the wallpaper actually are on this monitor,
+    // fed live by Background. Two different positions: the canvas travels at
+    // `parallax.widgetsFactor` and the wallpaper at 1, which is the parallax.
+    // These are the containers' animating x/y rather than the parallax targets,
+    // so the frost stays aligned during a pan and not only once it settles.
+    property real canvasOffsetX: 0
+    property real canvasOffsetY: 0
+    property rect wallpaperRect: Qt.rect(0, 0, 0, 0)
+
+    // This widget's top-left in the wallpaper's own coordinates - the space the
+    // frost samples in. Sampling at the widget's canvas position instead is
+    // issue #157: it happens to be right only where neither pan has moved.
+    readonly property var frostSampleOrigin: ParallaxMath.sampleOrigin(
+        { x: rootWidget.canvasOffsetX, y: rootWidget.canvasOffsetY },
+        { x: rootWidget.x, y: rootWidget.y },
+        { x: rootWidget.wallpaperRect.x, y: rootWidget.wallpaperRect.y })
 
     readonly property bool blurEnabled: manifest
         ? PluginState.option(manifest.id, "blurEnabled", manifest.desktopWidget?.blur === true)
@@ -219,10 +237,10 @@ AbstractBackgroundWidget {
             liveWallpaperActive: rootWidget.liveWallpaperActive
             weSurfaceItem: rootWidget.weSurfaceItem
             cornerRadius: Number(modelData.radius ?? rootWidget.widgetRounding)
-            screenWidth: rootWidget.scaledScreenWidth
-            screenHeight: rootWidget.scaledScreenHeight
-            surfaceX: rootWidget.x + x
-            surfaceY: rootWidget.y + y
+            wallpaperWidth: rootWidget.wallpaperRect.width
+            wallpaperHeight: rootWidget.wallpaperRect.height
+            surfaceX: rootWidget.frostSampleOrigin.x + x
+            surfaceY: rootWidget.frostSampleOrigin.y + y
         }
     }
 

--- a/dots/.config/quickshell/imi/modules/common/widgets/WallpaperBlurSurface.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/WallpaperBlurSurface.qml
@@ -6,15 +6,20 @@ import qs.modules.common
 // the wallpaper region directly behind this surface and blurs it, so the widget
 // reads as frosted glass over the wallpaper.
 //
-// Both wallpaper paths are one shape: a whole-screen item, sampled at this
-// surface's screen rect through a ShaderEffectSource.
+// Both wallpaper paths are one shape: an item covering the whole wallpaper,
+// sampled at this surface's rect through a ShaderEffectSource.
 //
 // - Live Wallpaper Engine wallpaper: the in-shell WallpaperEngineSurface
 //   (weSurfaceItem). WE is now drawn on the background surface itself, so the
 //   old compositor-blur handoff no longer applies - we blur the live frame
 //   ourselves.
-// - Static image wallpaper: a screen-sized Image of the wallpaper, cover-fitted
-//   exactly as the desktop draws it (see wallpaperImage).
+// - Static image wallpaper: an Image of the wallpaper, cover-fitted exactly as
+//   the desktop draws it (see wallpaperImage).
+//
+// The rect and the item it is handed to must be in the SAME space, and that
+// space is the wallpaper's, not the screen's - see surfaceX/surfaceY. The
+// caller owns that conversion (ParallaxMath.sampleOrigin); this component only
+// promises to sample where it is told, in an item of the size it is given.
 Item {
     id: root
 
@@ -26,10 +31,14 @@ Item {
     property real cornerRadius: Appearance.rounding?.verylarge ?? 30
     property int blurRadius: 48
 
-    // Monitor size and this surface's absolute top-left on that monitor, used to
-    // sample exactly the wallpaper slice sitting behind the surface.
-    property real screenWidth: 0
-    property real screenHeight: 0
+    // The size of the wallpaper the frost samples, and this surface's top-left
+    // WITHIN it - not on the monitor. With parallax the wallpaper is drawn in a
+    // container larger than the screen and slid underneath it, so the two are
+    // different by both pans; the static reconstruction below has to be the
+    // same size as that container, or it is a different crop of the same file
+    // than the one on screen. ParallaxMath.sampleOrigin does the conversion.
+    property real wallpaperWidth: 0
+    property real wallpaperHeight: 0
     property real surfaceX: 0
     property real surfaceY: 0
 
@@ -66,8 +75,8 @@ Item {
     // only the sample rect below moves now.
     Image {
         id: wallpaperImage
-        width: root.screenWidth
-        height: root.screenHeight
+        width: root.wallpaperWidth
+        height: root.wallpaperHeight
         source: root.liveWallpaperActive ? "" : root.wallpaperUrl
         fillMode: Image.PreserveAspectCrop
         asynchronous: true
@@ -75,8 +84,8 @@ Item {
         visible: false
     }
 
-    // One sampler for both paths: the source is whole-screen either way, and
-    // the rect is where this surface sits on the monitor.
+    // One sampler for both paths: the source covers the whole wallpaper either
+    // way, and the rect is where this surface sits within it.
     ShaderEffectSource {
         id: wallpaperSample
         anchors.fill: parent

--- a/dots/.config/quickshell/imi/modules/imi/background/Background.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/Background.qml
@@ -1203,6 +1203,19 @@ Variants {
                         weSurfaceItem: (bgRoot.lockWallShown || lockPeelTimer.running)
                             ? lockPeel
                             : (bgRoot.weShown ? weLoader.item : null)
+                        // The frost samples the wallpaper item, so it needs
+                        // both containers' real positions rather than this
+                        // widget's canvas coordinates. Every wallpaper layer -
+                        // the WE surface, the peel, the still - is declared
+                        // inside parallaxViewport and is therefore viewport-
+                        // sized and viewport-positioned; the canvas is a
+                        // sibling that travels further. Read off the items and
+                        // not off parallaxOffsets/widgetParallax so the two
+                        // 600ms pans are followed frame by frame.
+                        canvasOffsetX: widgetCanvas.x
+                        canvasOffsetY: widgetCanvas.y
+                        wallpaperRect: Qt.rect(parallaxViewport.x, parallaxViewport.y,
+                            parallaxViewport.width, parallaxViewport.height)
                     }
                 }
             }

--- a/dots/.config/quickshell/imi/modules/imi/background/Background.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/Background.qml
@@ -1212,10 +1212,24 @@ Variants {
                         // sibling that travels further. Read off the items and
                         // not off parallaxOffsets/widgetParallax so the two
                         // 600ms pans are followed frame by frame.
+                        //
+                        // A video wallpaper is the exception, and it is one of
+                        // ownership rather than of maths: mpvpaper paints it on
+                        // its own layer surface, which this viewport does not
+                        // move, so on screen it neither pans nor zooms. While
+                        // it owns the screen the wallpaper IS the screen, and
+                        // handing the frost the viewport would give it a pan
+                        // the wallpaper never had. videoRevealed is exactly
+                        // "mpvpaper is showing" - the shell's own layers are
+                        // hidden then, and during a switch cross-fade or on the
+                        // lock screen it is false and the viewport is right
+                        // again, so the branch follows whoever is painting.
                         canvasOffsetX: widgetCanvas.x
                         canvasOffsetY: widgetCanvas.y
-                        wallpaperRect: Qt.rect(parallaxViewport.x, parallaxViewport.y,
-                            parallaxViewport.width, parallaxViewport.height)
+                        wallpaperRect: bgRoot.videoRevealed
+                            ? Qt.rect(0, 0, bgRoot.width, bgRoot.height)
+                            : Qt.rect(parallaxViewport.x, parallaxViewport.y,
+                                parallaxViewport.width, parallaxViewport.height)
                     }
                 }
             }

--- a/dots/.config/quickshell/imi/tests/tst_parallax.qml
+++ b/dots/.config/quickshell/imi/tests/tst_parallax.qml
@@ -212,6 +212,74 @@ TestCase {
                      + "desktop than the other");
     }
 
+    // --- Frost sample origin -----------------------------------------------
+    //
+    // A desktop widget's frosted backdrop samples the wallpaper item behind it.
+    // The rect it samples with has to be measured in that item's own space, and
+    // the widget's x/y are measured in the canvas's - two items that are pinned
+    // to different positions on purpose. Getting this wrong is issue #157: the
+    // frost aligned only on the middle workspace, which is the one position
+    // where the canvas is not panned at all.
+
+    function test_sampleOriginIsTheWidgetItselfWhenNothingIsPanned() {
+        // zoom 1: no overflow, so neither the wallpaper nor the canvas has
+        // anywhere to travel and the widget's canvas position IS its position
+        // on the wallpaper. This is the configuration the old, uncorrected
+        // sampling was accidentally right for.
+        const state = baseState({workspaceIndex: 4, overflowX: 0, overflowY: 0});
+        const origin = Parallax.sampleOrigin(
+            Parallax.widgetOffsets(state, 1.2),
+            {x: 420, y: 260},
+            Parallax.offsets(state));
+        compare(origin.x, 420);
+        compare(origin.y, 260);
+    }
+
+    function test_sampleOriginFollowsBothPans() {
+        // Workspace 9 of 10 with a 500px overflow: the wallpaper is slid fully
+        // left (-500) and the canvas is swung half the overflow times the
+        // factor (-500 * 0.5 * 1.2 = -300). The widget is 300px further left
+        // than its canvas x, over a wallpaper that starts 500px further left
+        // still, so the pixel behind it is 200px further INTO the picture.
+        const state = baseState({workspaceIndex: 9, sidebarFraction: 0});
+        const canvas = Parallax.widgetOffsets(state, 1.2);
+        const wallpaper = Parallax.offsets(state);
+        fuzzyCompare(canvas.x, -300, 0.0001);
+        compare(wallpaper.x, -500);
+        const origin = Parallax.sampleOrigin(canvas, {x: 420, y: 260}, wallpaper);
+        fuzzyCompare(origin.x, 620, 0.0001);
+        // Y is parked: the canvas contributes nothing, the wallpaper is centred.
+        fuzzyCompare(origin.y, 260 + 100, 0.0001);
+    }
+
+    // The bug itself. The canvas travels at widgetsFactor and the wallpaper at
+    // 1, so "the widget moved with the wallpaper" is never true off centre -
+    // sampling at the widget's canvas position (the old behaviour) is wrong by
+    // the difference, and correcting for only one of the two pans is still
+    // wrong by the other.
+    function test_theCanvasAndTheWallpaperDoNotTravelTogether() {
+        const state = baseState({workspaceIndex: 9, sidebarFraction: 0});
+        const canvas = Parallax.widgetOffsets(state, 1.2);
+        const wallpaper = Parallax.offsets(state);
+        verify(canvas.x !== wallpaper.x,
+               "the two factors must differ, or there is no parallax to see");
+        const origin = Parallax.sampleOrigin(canvas, {x: 420, y: 260}, wallpaper);
+        verify(origin.x !== 420,
+               "sampling at the widget's canvas position ignores both pans");
+        verify(origin.x !== 420 + canvas.x,
+               "correcting for the canvas alone still ignores the wallpaper");
+        verify(origin.x !== 420 - wallpaper.x,
+               "correcting for the wallpaper alone still ignores the canvas");
+    }
+
+    function test_sampleOriginDoesNotProduceNan() {
+        // Same reason as the offsets above: this feeds a ShaderEffectSource's
+        // sourceRect, and a NaN there samples nothing at all.
+        const origin = Parallax.sampleOrigin(undefined, undefined, undefined);
+        compare(origin.x, 0);
+        compare(origin.y, 0);
+    }
+
     // The wallpaper container is genuinely larger than the screen and *wants*
     // its middle shown, so its own offsets keep the CENTRE parking.
     function test_wallpaperOffsetsStillParkAtCentre() {

--- a/dots/.config/quickshell/imi/tests/tst_wallpaper_blur_sharing.qml
+++ b/dots/.config/quickshell/imi/tests/tst_wallpaper_blur_sharing.qml
@@ -44,8 +44,14 @@ TestCase {
     function buildSurface(index) {
         return createTemporaryObject(surfaceComponent, this, {
             wallpaperSource: wallpaperPath,
-            screenWidth: 5120,
-            screenHeight: 1440,
+            // The wallpaper's size, not the monitor's: with parallax the
+            // wallpaper is drawn `zoom` times the screen (5120x1440 at 107%),
+            // and the reconstruction has to occupy that same space or it is a
+            // different crop of the same file than the one on screen. The
+            // request is unchanged by it - the item's size is not part of a
+            // pixmap cache key, which is what keeps #147 fixed.
+            wallpaperWidth: 5478,
+            wallpaperHeight: 1541,
             surfaceX: 100 + index * 400,
             surfaceY: 220,
             width: 320,


### PR DESCRIPTION
Closes #157. **Stacked on #156** — it needs `ParallaxMath.widgetOffsets` and the canvas offset that
branch publishes. Merge #156 first.

The frosted backdrop inside a desktop widget was shifted relative to the wallpaper whenever parallax
was panned, and aligned exactly on the middle workspace — the resting position.

The wallpaper is drawn in `parallaxViewport`, sized `screen * zoom` and positioned at
`parallaxOffsets`, so a screen pixel shows the viewport pixel at `screenPos - offsets`. The frost
sampled with a rect in **canvas** coordinates. One rule fixes it:

```
sampleOrigin = (canvasOffset + widgetCanvasPos) - wallpaperOffset
```

- **Wallpaper Engine** — origin only; `weSurfaceItem` is already viewport-sized. This path was
  misaligned for *every* WE wallpaper, contradicting a comment I left on the issue saying it was
  healthy.
- **Static image** — same origin, plus the reconstruction `Image` is sized to the viewport rather
  than the screen. The image *request* is untouched, so #147's single shared decode still holds.
- **Video** — see below.

## The issue was wrong about video, in two ways

Both worth recording, because both would have produced a worse fix:

1. It said the frost sampled an `Image` that cannot decode an `.mp4`. It never did:
   `Background.qml:503` already resolves `wallpaperPath` to `thumbnailPath` for a video — the JPEG
   first frame `switchwall.sh` extracts. The *content* was already honest; only the geometry was
   wrong.
2. It suggested sampling the real player surface as the WE path does. That is not merely undesirable,
   it is **impossible**: `mpvpaper` is a separate Wayland client on its own layer surface, and a
   `ShaderEffectSource` can only sample items in this scene graph. WE is different precisely because
   the shell renders it in-process.

And the correction for the other two cases would have **broken** video: `parallaxViewport` does not
move mpvpaper's surface, so a video neither pans nor zooms on screen. Subtracting the viewport offset
would have added travel the wallpaper never had. So while mpvpaper owns the screen the wallpaper rect
is the bare screen — branched on `videoRevealed`, not `wallpaperIsVideo`, because during a switch
cross-fade and on the lock screen the shell draws that thumbnail *inside* the viewport and the
viewport branch is right again.

## Live values, not settled ones

`Background` feeds the containers' animating `x`/`y` rather than the target offsets, so the frost
tracks both 600 ms pans frame by frame instead of only agreeing once they settle.

## Testing

`./tests/run_tests.sh` — **373 passed, 0 failed** (369 on the base branch; +4 new `tst_parallax`
cases): the rest position, a panned position, the two travel factors differing with all three wrong
answers asserted distinct, and a NaN guard. Non-vacuity proved by planting the old origin back — two
cases fail — then reverting.

`PluginWidget`'s change is exercised for real by the existing runtime harnesses, which launch actual
quickshell instances.

Docs: updated AGENT.md §Wallpaper parallax