### PR TITLE
fix(settings): make a ConfigSwitch click an intent, not a write to checked

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
           # skip and the SDR delivery path ships unexercised.
           # qt5compat supplies FastBlur, which WallpaperBlurSurface imports; without
           # it that type is simply "unavailable" and its test fails to compile.
-          sudo apt-get install -y qt6-declarative-dev qml6-module-qttest qml6-module-qtquick qml6-module-qtqml qml6-module-qtquick-controls qml6-module-qtquick-layouts qml6-module-qtqml-workerscript qml6-module-qtquick-window qml6-module-qt5compat-graphicaleffects ffmpeg
+          sudo apt-get install -y qt6-declarative-dev qml6-module-qttest qml6-module-qtquick qml6-module-qtqml qml6-module-qtquick-controls qml6-module-qtquick-templates qml6-module-qtquick-layouts qml6-module-qtqml-workerscript qml6-module-qtquick-window qml6-module-qt5compat-graphicaleffects ffmpeg
 
       # zstd builds the fixture release tarballs in
       # test_wallpaperengine_prebuilt.py and extracts them in the installer under

--- a/AGENT.md
+++ b/AGENT.md
@@ -394,7 +394,34 @@ Consequences for making changes:
 - The settings UI (`modules/imi/settings/pages/*.qml`) is hand-written QML, not generated from the
   schema — every setting needs a corresponding `ConfigSwitch`/`ConfigSpinBox`/`ConfigSelectionArray`/
   etc. row added manually in the relevant page, bound with `checked: Config.options.x.y` /
-  `onCheckedChanged: Config.options.x.y = checked`.
+  `onToggleRequested: Config.options.x.y = !Config.options.x.y` — see the next two points for why
+  the write-back is not hung on the control's own `changed` signal.
+- **A control writes back by changing the config, never by assigning to its own bound property.**
+  Assigning to a property that carries a binding *destroys the binding*, and in this codebase that
+  is how a settings toggle silently detaches from the config it is showing. `ConfigSwitch` answered
+  its own click with `onClicked: checked = !checked` while all 159 call sites bound
+  `checked: Config.options.x.y`. From the first click onward the switch showed local state: nothing
+  external could move it again — not a preset, not a hand-edited `config.json`, not a migration —
+  while the page's own `onCheckedChanged` kept writing through, so the *setting* changed and the
+  *switch* lied about it, and the next click on a switch that looked on wrote `!off` = on.
+  Restarting rebuilt the component and with it the binding, which is exactly why it read as a
+  refresh bug rather than a broken control
+  ([#158](https://github.com/XephyLon/immaterial-impulse/issues/158)). The click is now an intent —
+  `toggleRequested()` — and the call site flips the value at its source. A rewritten call site must
+  not read the widget's own state: reading `checked` to decide what to write puts the coupling
+  straight back. Three things fell out of it, all of them evidence of the same bug being routed
+  around locally: the `if (checked === Config.options.x.y) return` echo guards a dozen handlers
+  carried existed only because the write came back through the binding and re-fired the handler, and
+  an intent fires once per click, so they are gone; the four
+  `Binding { property: "checked"; restoreMode: RestoreBinding }` blocks were four call sites
+  restoring the binding the click had destroyed, so they are gone too; and the inner `StyledSwitch`
+  is now `checkable: false`, because a QQC2 `Switch` moves its own `checked` on a click or a thumb
+  drag and would show a flip the call site declined. `tests/lint_config_switch_intent.py` fails the
+  suite on an assignment to `checked` in the widget or at any call site (and on an
+  `onCheckedChanged` write-back, which is now a dead switch), and
+  `tests/tst_config_switch_binding.qml` delivers a real click to a model of the shape and writes the
+  source externally afterwards. 69c15279a ("fix(widgets): make a ConfigSwitch click an intent, not a
+  write to `checked`").
 - **A ranged control writes back from `onValueModified`, never `onValueChanged`.** `ConfigSpinBox`
   and `ConfigSlider` are the two controls with a `from`/`to`, and their `value` changes for reasons
   that are not edits: QQC2 bounds `SpinBox.value` to `[from, to]` when the component completes,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,8 +188,18 @@ filed for, and rebuilt a subprocess renderer the embedded one exists to replace.
 A new persisted option needs both halves, or it silently does nothing:
 1. The schema property in `Config.qml` (inside the correct nested `JsonObject`).
 2. A corresponding row in the relevant `modules/imi/settings/pages/*.qml` file, wired with
-   `checked`/`value`/`currentValue` reading from `Config.options....` and an `on*Changed` handler
-   writing back to it.
+   `checked`/`value`/`currentValue` reading from `Config.options....` and a handler writing back to
+   it — but read both exceptions below before picking which handler.
+
+**Exception — `ConfigSwitch` writes back from `onToggleRequested`, never `onCheckedChanged`.**
+`checked` is a pure binding on the config value and only ever follows it; a click raises an intent
+instead, and the call site flips the value at its source
+(`onToggleRequested: Config.options.x.y = !Config.options.x.y`). The handler must not read the
+widget's own `checked` to decide what to write — that is the coupling this removed. The old shape
+(`onClicked: checked = !checked` in the widget, `onCheckedChanged` write-back at the call site)
+destroyed the binding on the first click, so the switch detached from the config and then lied
+about it for the rest of the session (#158). `tests/lint_config_switch_intent.py` fails the suite on
+either half of it. See AGENT.md's Config section.
 
 **Exception — `ConfigSpinBox` and `ConfigSlider` write back from `onValueModified`, not
 `onValueChanged`.** Their `value` also changes when the control is merely built (QQC2 clamps it to

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginOptions.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginOptions.qml
@@ -113,10 +113,8 @@ ColumnLayout {
             buttonIcon: "push_pin"
             text: Translation.tr("Keep settings across presets")
             checked: PluginState.presetPersisted(root.manifest.id)
-            onCheckedChanged: {
-                if (checked !== PluginState.presetPersisted(root.manifest.id))
-                    PluginState.setPresetPersist(root.manifest.id, checked);
-            }
+            onToggleRequested: PluginState.setPresetPersist(root.manifest.id,
+                !PluginState.presetPersisted(root.manifest.id))
         }
 
         Repeater {
@@ -166,10 +164,8 @@ ColumnLayout {
                     buttonIcon: optionLoader.optionData.icon || "tune"
                     text: optionLoader.optionData.label
                     checked: PluginState.option(root.manifest.id, optionLoader.optionData.key, optionLoader.optionData.default)
-                    onCheckedChanged: {
-                        if (checked !== PluginState.option(root.manifest.id, optionLoader.optionData.key, optionLoader.optionData.default))
-                            PluginState.setOption(root.manifest.id, optionLoader.optionData.key, checked);
-                    }
+                    onToggleRequested: PluginState.setOption(root.manifest.id, optionLoader.optionData.key,
+                        !PluginState.option(root.manifest.id, optionLoader.optionData.key, optionLoader.optionData.default))
                 }
             }
 

--- a/dots/.config/quickshell/imi/modules/common/widgets/AutostartApps.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/AutostartApps.qml
@@ -54,9 +54,7 @@ ColumnLayout {
                 buttonIcon: "check"
                 text: Translation.tr("Enable")
                 checked: Config.options.hyprland.autostartApps.enable
-                onCheckedChanged: {
-                    Config.options.hyprland.autostartApps.enable = checked
-                }
+                onToggleRequested: Config.options.hyprland.autostartApps.enable = !Config.options.hyprland.autostartApps.enable
             }
         }
 

--- a/dots/.config/quickshell/imi/modules/common/widgets/ConfigSwitch.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/ConfigSwitch.qml
@@ -30,6 +30,19 @@ RippleButton {
     // switch is the last thing in this component, so anything a call site
     // appends to its own row can only land beyond it.
     property alias trailingContent: trailingRow.data
+    // A click is an intent to flip, not a state change of its own. Assigning to
+    // `checked` from a handler destroys the call site's `checked:` binding on
+    // the very first click, after which nothing external - a preset, a
+    // hand-edited config, a migration - can move the switch again, while the
+    // row's own write-back keeps working: the setting changes and the switch
+    // lies (#158). The call site owns the value and flips it at the source;
+    // `checked` here only ever follows it back.
+    //
+    // A signal of its own rather than AbstractButton's inherited `toggled()`:
+    // RippleButton declares `property bool toggled` (its "draw me as active"
+    // flag), which shadows that signal, so `onToggled` at a call site would be
+    // the property's change handler rather than this.
+    signal toggleRequested()
     colBackgroundHover: "transparent"
 
     // Nothing in here dims itself on `enabled`. RippleButton already applies the
@@ -43,7 +56,7 @@ RippleButton {
     implicitHeight: contentItem.implicitHeight + 8 
     font.pixelSize: Appearance.font.pixelSize.small
 
-    onClicked: checked = !checked
+    onClicked: root.toggleRequested()
 
     contentItem: ColumnLayout {
         spacing: 0
@@ -103,6 +116,12 @@ RippleButton {
                 id: switchWidget
                 down: root.down
                 Layout.fillWidth: false
+                // A Switch is checkable by default and moves its own `checked`
+                // on a click or a thumb drag, so it would show the flip even
+                // where the call site declines the intent - and stay wrong
+                // until the config next changed. Non-checkable it still emits
+                // `clicked`, and its `checked` stays a picture of the row's.
+                checkable: false
                 checked: root.checked
                 onClicked: root.clicked()
             }

--- a/dots/.config/quickshell/imi/modules/common/widgets/KeybindEditor.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/KeybindEditor.qml
@@ -181,7 +181,7 @@ ColumnLayout {
             buttonIcon: "warning"
             text: Translation.tr("Assign it anyway — both shortcuts will fire on this chord")
             checked: root.acknowledgedChord === root.capturedIdentity
-            onClicked: {
+            onToggleRequested: {
                 root.acknowledgedChord = (root.acknowledgedChord === root.capturedIdentity)
                     ? "" : root.capturedIdentity;
             }

--- a/dots/.config/quickshell/imi/modules/common/widgets/WallpaperSubmenu.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/WallpaperSubmenu.qml
@@ -149,7 +149,7 @@ Item {
                     buttonIcon: "check"
                     text: Translation.tr("Centered wallpaper")
                     checked: Config.options.background.centeredWallpaper
-                    onCheckedChanged: Config.options.background.centeredWallpaper = checked
+                    onToggleRequested: Config.options.background.centeredWallpaper = !Config.options.background.centeredWallpaper
                 }
 
                 ConfigSwitch {
@@ -158,7 +158,7 @@ Item {
                     text: Translation.tr("Only when locked")
                     checked: Config.options.background.centeredWallpaperOnlyWhenLocked
                     enabled: Config.options.background.centeredWallpaper
-                    onCheckedChanged: Config.options.background.centeredWallpaperOnlyWhenLocked = checked
+                    onToggleRequested: Config.options.background.centeredWallpaperOnlyWhenLocked = !Config.options.background.centeredWallpaperOnlyWhenLocked
                 }
 
                 ConfigSelectionShapeArray {

--- a/dots/.config/quickshell/imi/modules/common/widgets/WidgetsSubmenu.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/WidgetsSubmenu.qml
@@ -34,7 +34,7 @@ Item {
             buttonIcon: "lock"
             text: Translation.tr("Lock widget positions")
             checked: Config.options.background.widgetsLocked
-            onCheckedChanged: Config.options.background.widgetsLocked = checked
+            onToggleRequested: Config.options.background.widgetsLocked = !Config.options.background.widgetsLocked
         }
 
         Rectangle {
@@ -55,7 +55,7 @@ Item {
                 buttonIcon: modelData.icon
                 text: modelData.name
                 checked: Config.options.background.widgets[modelData.key].enable
-                onCheckedChanged: Config.options.background.widgets[modelData.key].enable = checked
+                onToggleRequested: Config.options.background.widgets[modelData.key].enable = !Config.options.background.widgets[modelData.key].enable
             }
         }
     }

--- a/dots/.config/quickshell/imi/modules/imi/settings/pages/AppearanceConfig.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/pages/AppearanceConfig.qml
@@ -277,8 +277,8 @@ ContentPage {
                     text: Translation.tr("Background pattern")
                     description: Translation.tr("Show an image behind Kitty terminal content")
                     checked: Config.options.appearance.terminal.background.enabled
-                    onCheckedChanged: {
-                        Config.options.appearance.terminal.background.enabled = checked
+                    onToggleRequested: {
+                        Config.options.appearance.terminal.background.enabled = !Config.options.appearance.terminal.background.enabled
                         page.scheduleTerminalBackgroundApply()
                     }
                 }
@@ -371,19 +371,19 @@ ContentPage {
                     buttonIcon: "hardware"
                     text: Translation.tr("Shell & utilities")
                     checked: Config.options.appearance.wallpaperTheming.enableAppsAndShell
-                    onCheckedChanged: { Config.options.appearance.wallpaperTheming.enableAppsAndShell = checked }
+                    onToggleRequested: Config.options.appearance.wallpaperTheming.enableAppsAndShell = !Config.options.appearance.wallpaperTheming.enableAppsAndShell
                 }
                 ConfigSwitch {
                     buttonIcon: "tv_options_input_settings"
                     text: Translation.tr("Qt apps")
                     checked: Config.options.appearance.wallpaperTheming.enableQtApps
-                    onCheckedChanged: { Config.options.appearance.wallpaperTheming.enableQtApps = checked }
+                    onToggleRequested: Config.options.appearance.wallpaperTheming.enableQtApps = !Config.options.appearance.wallpaperTheming.enableQtApps
                 }
                 ConfigSwitch {
                     buttonIcon: "terminal"
                     text: Translation.tr("Terminal")
                     checked: Config.options.appearance.wallpaperTheming.enableTerminal
-                    onCheckedChanged: { Config.options.appearance.wallpaperTheming.enableTerminal = checked }
+                    onToggleRequested: Config.options.appearance.wallpaperTheming.enableTerminal = !Config.options.appearance.wallpaperTheming.enableTerminal
                 }
                 ConfigRow {
                     uniform: true
@@ -391,7 +391,7 @@ ContentPage {
                         buttonIcon: "dark_mode"
                         text: Translation.tr("Force dark mode in terminal")
                         checked: Config.options.appearance.wallpaperTheming.terminalGenerationProps.forceDarkMode
-                        onCheckedChanged: { Config.options.appearance.wallpaperTheming.terminalGenerationProps.forceDarkMode = checked }
+                        onToggleRequested: Config.options.appearance.wallpaperTheming.terminalGenerationProps.forceDarkMode = !Config.options.appearance.wallpaperTheming.terminalGenerationProps.forceDarkMode
                     }
                 }
                 ConfigSpinBox {

--- a/dots/.config/quickshell/imi/modules/imi/settings/pages/BackgroundConfig.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/pages/BackgroundConfig.qml
@@ -199,18 +199,6 @@ ContentPage {
                 }
             }
 
-            Connections {
-                target: Config.options.background
-                function onLockWallChanged() {
-                    syncWallpaperSwitch.checked = Qt.binding(() => Config.options.background.lockWall === ""
-                        && Config.options.background.lockWallEngine === "")
-                }
-                function onLockWallEngineChanged() {
-                    syncWallpaperSwitch.checked = Qt.binding(() => Config.options.background.lockWall === ""
-                        && Config.options.background.lockWallEngine === "")
-                }
-            }
-        
             ContentSubsection {
                 title: Translation.tr("Parallax")
                 Layout.fillWidth: true

--- a/dots/.config/quickshell/imi/modules/imi/settings/pages/BackgroundConfig.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/pages/BackgroundConfig.qml
@@ -158,11 +158,12 @@ ContentPage {
                     text: Translation.tr("Use same wallpaper for both")
                     checked: Config.options.background.lockWall === ""
                         && Config.options.background.lockWallEngine === ""
-                    onCheckedChanged: {
-                        if (checked) {
-                            Config.options.background.lockWall = "";
-                            Config.options.background.lockWallEngine = "";
-                        }
+                    // One-way: clearing both paths is what "same wallpaper"
+                    // means, and there is no stored lockscreen wallpaper to put
+                    // back, so a click while it is already on stays a no-op.
+                    onToggleRequested: {
+                        Config.options.background.lockWall = "";
+                        Config.options.background.lockWallEngine = "";
                     }
                 }
 
@@ -170,9 +171,7 @@ ContentPage {
                     buttonIcon: "preview"
                     text: Translation.tr("Preview wallpaper")
                     checked: Config.options.background.enableWallpaperPreview
-                    onCheckedChanged: {
-                        Config.options.background.enableWallpaperPreview = checked;
-                    }
+                    onToggleRequested: Config.options.background.enableWallpaperPreview = !Config.options.background.enableWallpaperPreview
                 }
 
                 ConfigSpinBox {
@@ -222,9 +221,7 @@ ContentPage {
                         buttonIcon: "animation"
                         text: Translation.tr("Enable")
                         checked: Config.options.background.parallax.enable
-                        onClicked: {
-                            Config.options.background.parallax.enable = !Config.options.background.parallax.enable;
-                        }
+                        onToggleRequested: Config.options.background.parallax.enable = !Config.options.background.parallax.enable
                     }
                     ConfigSpinBox {
                         Layout.fillWidth: true
@@ -248,9 +245,7 @@ ContentPage {
                         enabled: Config.options.background.parallax.enable
                         text: Translation.tr("Follow workspaces")
                         checked: Config.options.background.parallax.enableWorkspace
-                        onClicked: {
-                            Config.options.background.parallax.enableWorkspace = !Config.options.background.parallax.enableWorkspace;
-                        }
+                        onToggleRequested: Config.options.background.parallax.enableWorkspace = !Config.options.background.parallax.enableWorkspace
                     }
                     ConfigSwitch {
                         Layout.fillWidth: true
@@ -258,9 +253,7 @@ ContentPage {
                         enabled: Config.options.background.parallax.enable
                         text: Translation.tr("Follow sidebars")
                         checked: Config.options.background.parallax.enableSidebar
-                        onClicked: {
-                            Config.options.background.parallax.enableSidebar = !Config.options.background.parallax.enableSidebar;
-                        }
+                        onToggleRequested: Config.options.background.parallax.enableSidebar = !Config.options.background.parallax.enableSidebar
                     }
                     ConfigSwitch {
                         Layout.fillWidth: true
@@ -268,9 +261,7 @@ ContentPage {
                         enabled: Config.options.background.parallax.enable
                         text: Translation.tr("Move desktop widgets")
                         checked: Config.options.background.parallax.enableWidgets
-                        onClicked: {
-                            Config.options.background.parallax.enableWidgets = !Config.options.background.parallax.enableWidgets;
-                        }
+                        onToggleRequested: Config.options.background.parallax.enableWidgets = !Config.options.background.parallax.enableWidgets
                     }
                     ConfigSwitch {
                         Layout.fillWidth: true
@@ -278,9 +269,7 @@ ContentPage {
                         enabled: Config.options.background.parallax.enable
                         text: Translation.tr("Pan vertically")
                         checked: Config.options.background.parallax.vertical
-                        onClicked: {
-                            Config.options.background.parallax.vertical = !Config.options.background.parallax.vertical;
-                        }
+                        onToggleRequested: Config.options.background.parallax.vertical = !Config.options.background.parallax.vertical
                     }
                     ConfigSwitch {
                         Layout.fillWidth: true
@@ -288,9 +277,7 @@ ContentPage {
                         enabled: Config.options.background.parallax.enable && !Config.options.background.parallax.vertical
                         text: Translation.tr("Pan vertically on portrait wallpapers")
                         checked: Config.options.background.parallax.autoVertical
-                        onClicked: {
-                            Config.options.background.parallax.autoVertical = !Config.options.background.parallax.autoVertical;
-                        }
+                        onToggleRequested: Config.options.background.parallax.autoVertical = !Config.options.background.parallax.autoVertical
                     }
                 }
             }
@@ -305,18 +292,14 @@ ContentPage {
                         buttonIcon: "check"
                         text: Translation.tr("Enable")
                         checked: Config.options.background.centeredWallpaper
-                        onClicked: {
-                            Config.options.background.centeredWallpaper = !Config.options.background.centeredWallpaper;
-                        }
+                        onToggleRequested: Config.options.background.centeredWallpaper = !Config.options.background.centeredWallpaper
                     }
                     ConfigSwitch {
                         Layout.fillWidth: true
                         buttonIcon: "lock"
                         text: Translation.tr("Show only when locked")
                         checked: Config.options.background.centeredWallpaperOnlyWhenLocked
-                        onCheckedChanged: {
-                            Config.options.background.centeredWallpaperOnlyWhenLocked = checked;
-                        }
+                        onToggleRequested: Config.options.background.centeredWallpaperOnlyWhenLocked = !Config.options.background.centeredWallpaperOnlyWhenLocked
                         enabled: Config.options.background.centeredWallpaper
                     }
                 }
@@ -390,18 +373,14 @@ ContentPage {
                         buttonIcon: "grid_4x4"
                         text: Translation.tr("Show alignment grid while dragging")
                         checked: Config.options.background.showGrid
-                        onCheckedChanged: {
-                            Config.options.background.showGrid = checked;
-                        }
+                        onToggleRequested: Config.options.background.showGrid = !Config.options.background.showGrid
                     }
                     ConfigSwitch {
                         Layout.fillWidth: true
                         buttonIcon: "align_horizontal_center"
                         text: Translation.tr("Show snap lines when dropping")
                         checked: Config.options.background.showSnapLines
-                        onCheckedChanged: {
-                            Config.options.background.showSnapLines = checked;
-                        }
+                        onToggleRequested: Config.options.background.showSnapLines = !Config.options.background.showSnapLines
                     }
                 }
             }
@@ -417,36 +396,28 @@ ContentPage {
                     buttonIcon: "ad"
                     text: Translation.tr('Use system file picker')
                     checked: Config.options.wallpaperSelector.useSystemFileDialog
-                    onCheckedChanged: {
-                        Config.options.wallpaperSelector.useSystemFileDialog = checked;
-                    }
+                    onToggleRequested: Config.options.wallpaperSelector.useSystemFileDialog = !Config.options.wallpaperSelector.useSystemFileDialog
                 }
 
                 ConfigSwitch {
                     buttonIcon: "home"
                     text: Translation.tr('Show home directory in quick access')
                     checked: Config.options.wallpaperSelector.showHomePath
-                    onCheckedChanged: {
-                        Config.options.wallpaperSelector.showHomePath = checked;
-                    }
+                    onToggleRequested: Config.options.wallpaperSelector.showHomePath = !Config.options.wallpaperSelector.showHomePath
                 }
 
                 ConfigSwitch {
                     buttonIcon: "done"
                     text: Translation.tr('Close after selection')
                     checked: Config.options.wallpaperSelector.closeAfterSelection
-                    onCheckedChanged: {
-                        Config.options.wallpaperSelector.closeAfterSelection = checked;
-                    }
+                    onToggleRequested: Config.options.wallpaperSelector.closeAfterSelection = !Config.options.wallpaperSelector.closeAfterSelection
                 }
 
                 ConfigSwitch {
                     buttonIcon: "blur_on"
                     text: Translation.tr('Show blur background')
                     checked: Config.options.wallpaperSelector.showBlurBackground
-                    onCheckedChanged: {
-                        Config.options.wallpaperSelector.showBlurBackground = checked;
-                    }
+                    onToggleRequested: Config.options.wallpaperSelector.showBlurBackground = !Config.options.wallpaperSelector.showBlurBackground
                 }
 
                 ConfigSpinBox {
@@ -477,9 +448,7 @@ ContentPage {
                     buttonIcon: "search"
                     text: Translation.tr('Always show search bar')
                     checked: Config.options.wallpaperSelector.showSearchbar
-                    onCheckedChanged: {
-                        Config.options.wallpaperSelector.showSearchbar = checked;
-                    }
+                    onToggleRequested: Config.options.wallpaperSelector.showSearchbar = !Config.options.wallpaperSelector.showSearchbar
                 }
                 ConfigTextArea {
                     id: userPathField

--- a/dots/.config/quickshell/imi/modules/imi/settings/pages/BarConfig.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/pages/BarConfig.qml
@@ -122,15 +122,14 @@ ContentPage {
                             anchors { fill: parent; margins: Appearance.spacing.space100 }
                             buttonIcon: "tv_displays"
                             text: Translation.tr("All")
-                            onCheckedChanged: {
-                                if (checked) Config.options.bar.screenList = []
-                            }
-
-                            Binding {
-                                target: allSwitchItem
-                                property: "checked"
-                                value: Config.options.bar.screenList.length === 0
-                                restoreMode: Binding.RestoreBinding
+                            checked: Config.options.bar.screenList.length === 0
+                            // One-way: an empty list *is* "every screen", so a
+                            // click while it is already on has nothing to mean -
+                            // "no screens" is the state ScreenSelection refuses
+                            // to represent.
+                            onToggleRequested: {
+                                if (Config.options.bar.screenList.length > 0)
+                                    Config.options.bar.screenList = []
                             }
                         }
                     }
@@ -157,27 +156,21 @@ ContentPage {
                                 anchors { fill: parent; margins: Appearance.spacing.space100 }
                                 buttonIcon: "monitor"
                                 text: monitorRow.modelData.name
-                                onCheckedChanged: {
+                                checked: ScreenSelection.includes(Config.options.bar.screenList, monitorRow.modelData.name)
+                                onToggleRequested: {
                                     const allNames = Hyprland.monitors.values.map(m => m.name)
+                                    const shown = ScreenSelection.includes(
+                                        Config.options.bar.screenList, monitorRow.modelData.name)
                                     const result = ScreenSelection.toggle(
                                         Config.options.bar.screenList, allNames,
-                                        monitorRow.modelData.name, checked)
-                                    if (!result.accepted) {
-                                        // Unchecking the last screen would empty the
-                                        // list, which means "every screen" - the bar
-                                        // would come back on everywhere. Put the
-                                        // switch back rather than bounce it.
-                                        checked = true
-                                        return
-                                    }
+                                        monitorRow.modelData.name, !shown)
+                                    // Unchecking the last screen would empty the
+                                    // list, which means "every screen" - the bar
+                                    // would come back on everywhere. Leaving the
+                                    // config alone leaves the switch on, since
+                                    // that is what it is bound to.
+                                    if (!result.accepted) return
                                     Config.options.bar.screenList = result.list
-                                }
-
-                                Binding {
-                                    target: switchItem
-                                    property: "checked"
-                                    value: Config.options.bar.screenList.length === 0 || Config.options.bar.screenList.includes(monitorRow.modelData.name)
-                                    restoreMode: Binding.RestoreBinding
                                 }
                             }
                         }
@@ -268,7 +261,7 @@ ContentPage {
                         text: Translation.tr("Show Background")
                         enabled: Config.options.bar.cornerStyle === 0 || Config.options.bar.cornerStyle === 1
                         checked: Config.options.bar.showBackground
-                        onCheckedChanged: { Config.options.bar.showBackground = checked; }
+                        onToggleRequested: Config.options.bar.showBackground = !Config.options.bar.showBackground
                     }
                     ConfigSelectionArray {
                         text: Translation.tr("Autohide")
@@ -287,7 +280,7 @@ ContentPage {
                     enabled: Config.options.bar.showBackground
                         && (Config.options.bar.cornerStyle === 0 || Config.options.bar.cornerStyle === 1)
                     checked: Config.options.bar.shadow
-                    onCheckedChanged: { Config.options.bar.shadow = checked; }
+                    onToggleRequested: Config.options.bar.shadow = !Config.options.bar.shadow
                 }
                 ConfigSlider {
                     text: Translation.tr("Background opacity")
@@ -309,7 +302,7 @@ ContentPage {
                     text: Translation.tr("Auto-dismiss popups on hide")
                     enabled: Config.options.bar.autoHide.enable
                     checked: Config.options.bar.autoHide.dismissPopups
-                    onCheckedChanged: { Config.options.bar.autoHide.dismissPopups = checked; }
+                    onToggleRequested: Config.options.bar.autoHide.dismissPopups = !Config.options.bar.autoHide.dismissPopups
                 }
             }
         }
@@ -323,12 +316,12 @@ ContentPage {
                 ConfigSwitch {
                     buttonIcon: "keep"; text: Translation.tr("Make icons pinned by default")
                     checked: Config.options.tray.invertPinnedItems
-                    onCheckedChanged: { Config.options.tray.invertPinnedItems = checked; }
+                    onToggleRequested: Config.options.tray.invertPinnedItems = !Config.options.tray.invertPinnedItems
                 }
                 ConfigSwitch {
                     buttonIcon: "colors"; text: Translation.tr("Tint icons")
                     checked: Config.options.tray.monochromeIcons
-                    onCheckedChanged: { Config.options.tray.monochromeIcons = checked; }
+                    onToggleRequested: Config.options.tray.monochromeIcons = !Config.options.tray.monochromeIcons
                 }
             }
         }
@@ -377,13 +370,13 @@ ContentPage {
                         buttonIcon: "screenshot_region"
                         text: Translation.tr("Screen snip")
                         checked: Config.options.bar.utilButtons.showScreenSnip
-                        onCheckedChanged: { Config.options.bar.utilButtons.showScreenSnip = checked }
+                        onToggleRequested: Config.options.bar.utilButtons.showScreenSnip = !Config.options.bar.utilButtons.showScreenSnip
                     }
                     ConfigSwitch {
                         buttonIcon: "colorize"
                         text: Translation.tr("Color picker")
                         checked: Config.options.bar.utilButtons.showColorPicker
-                        onCheckedChanged: { Config.options.bar.utilButtons.showColorPicker = checked }
+                        onToggleRequested: Config.options.bar.utilButtons.showColorPicker = !Config.options.bar.utilButtons.showColorPicker
                     }
                 }
                 ConfigRow {
@@ -392,13 +385,13 @@ ContentPage {
                         buttonIcon: "keyboard"
                         text: Translation.tr("Keyboard toggle")
                         checked: Config.options.bar.utilButtons.showKeyboardToggle
-                        onCheckedChanged: { Config.options.bar.utilButtons.showKeyboardToggle = checked }
+                        onToggleRequested: Config.options.bar.utilButtons.showKeyboardToggle = !Config.options.bar.utilButtons.showKeyboardToggle
                     }
                     ConfigSwitch {
                         buttonIcon: "mic"
                         text: Translation.tr("Mic toggle")
                         checked: Config.options.bar.utilButtons.showMicToggle
-                        onCheckedChanged: { Config.options.bar.utilButtons.showMicToggle = checked }
+                        onToggleRequested: Config.options.bar.utilButtons.showMicToggle = !Config.options.bar.utilButtons.showMicToggle
                     }
                 }
                 ConfigRow {
@@ -407,13 +400,13 @@ ContentPage {
                         buttonIcon: "dark_mode"
                         text: Translation.tr("Dark/Light toggle")
                         checked: Config.options.bar.utilButtons.showDarkModeToggle
-                        onCheckedChanged: { Config.options.bar.utilButtons.showDarkModeToggle = checked }
+                        onToggleRequested: Config.options.bar.utilButtons.showDarkModeToggle = !Config.options.bar.utilButtons.showDarkModeToggle
                     }
                     ConfigSwitch {
                         buttonIcon: "speed"
                         text: Translation.tr("Performance Profile")
                         checked: Config.options.bar.utilButtons.showPerformanceProfileToggle
-                        onCheckedChanged: { Config.options.bar.utilButtons.showPerformanceProfileToggle = checked }
+                        onToggleRequested: Config.options.bar.utilButtons.showPerformanceProfileToggle = !Config.options.bar.utilButtons.showPerformanceProfileToggle
                     }
                 }
                 ConfigRow {
@@ -422,13 +415,13 @@ ContentPage {
                         buttonIcon: "screen_record"
                         text: Translation.tr("Record Screen")
                         checked: Config.options.bar.utilButtons.showScreenRecord
-                        onCheckedChanged: { Config.options.bar.utilButtons.showScreenRecord = checked }
+                        onToggleRequested: Config.options.bar.utilButtons.showScreenRecord = !Config.options.bar.utilButtons.showScreenRecord
                     }
                     ConfigSwitch {
                         buttonIcon: "imagesmode"
                         text: Translation.tr("Wallpapers Toggle")
                         checked: Config.options.bar.utilButtons.showWallpaperToggle
-                        onCheckedChanged: { Config.options.bar.utilButtons.showWallpaperToggle = checked }
+                        onToggleRequested: Config.options.bar.utilButtons.showWallpaperToggle = !Config.options.bar.utilButtons.showWallpaperToggle
                     }
                 }
             }
@@ -441,7 +434,7 @@ ContentPage {
                 ConfigSwitch {
                     buttonIcon: "counter_1"; text: Translation.tr("Always show numbers")
                     checked: Config.options.bar.workspaces.alwaysShowNumbers
-                    onCheckedChanged: { Config.options.bar.workspaces.alwaysShowNumbers = checked; }
+                    onToggleRequested: Config.options.bar.workspaces.alwaysShowNumbers = !Config.options.bar.workspaces.alwaysShowNumbers
                 }
                 ConfigSelectionArray {
                     text: Translation.tr("Numbers style")
@@ -459,12 +452,12 @@ ContentPage {
                 ConfigSwitch {
                     buttonIcon: "award_star"; text: Translation.tr("Show app icons")
                     checked: Config.options.bar.workspaces.showAppIcons
-                    onCheckedChanged: { Config.options.bar.workspaces.showAppIcons = checked; }
+                    onToggleRequested: Config.options.bar.workspaces.showAppIcons = !Config.options.bar.workspaces.showAppIcons
                 }
                 ConfigSwitch {
                     buttonIcon: "monitor"; text: Translation.tr("Show workspaces from all monitors")
                     checked: Config.options.bar.workspaces.showAllMonitors
-                    onCheckedChanged: { Config.options.bar.workspaces.showAllMonitors = checked; }
+                    onToggleRequested: Config.options.bar.workspaces.showAllMonitors = !Config.options.bar.workspaces.showAllMonitors
                 }
                 ConfigSpinBox {
                     icon: "view_column"; text: Translation.tr("Workspaces shown")
@@ -499,13 +492,13 @@ ContentPage {
                         buttonIcon: "planner_review"
                         text: Translation.tr("CPU")
                         checked: Config.options.bar.resources.alwaysShowCpu
-                        onCheckedChanged: { Config.options.bar.resources.alwaysShowCpu = checked }
+                        onToggleRequested: Config.options.bar.resources.alwaysShowCpu = !Config.options.bar.resources.alwaysShowCpu
                     }
                     ConfigSwitch {
                         buttonIcon: "thermostat"
                         text: Translation.tr("CPU Temperature")
                         checked: Config.options.bar.resources.alwaysShowCpuTemp
-                        onCheckedChanged: { Config.options.bar.resources.alwaysShowCpuTemp = checked }
+                        onToggleRequested: Config.options.bar.resources.alwaysShowCpuTemp = !Config.options.bar.resources.alwaysShowCpuTemp
                     }
                 }
                 ConfigRow {
@@ -514,13 +507,13 @@ ContentPage {
                         buttonIcon: "memory"
                         text: Translation.tr("RAM")
                         checked: Config.options.bar.resources.alwaysShowRam
-                        onCheckedChanged: { Config.options.bar.resources.alwaysShowRam = checked }
+                        onToggleRequested: Config.options.bar.resources.alwaysShowRam = !Config.options.bar.resources.alwaysShowRam
                     }
                     ConfigSwitch {
                         buttonIcon: "monitor"
                         text: Translation.tr("GPU")
                         checked: Config.options.bar.resources.alwaysShowGpu
-                        onCheckedChanged: { Config.options.bar.resources.alwaysShowGpu = checked }
+                        onToggleRequested: Config.options.bar.resources.alwaysShowGpu = !Config.options.bar.resources.alwaysShowGpu
                     }
                 }
                 ConfigRow {
@@ -529,7 +522,7 @@ ContentPage {
                         buttonIcon: "storage"
                         text: Translation.tr("Disk")
                         checked: Config.options.bar.resources.alwaysShowDisk
-                        onCheckedChanged: { Config.options.bar.resources.alwaysShowDisk = checked }
+                        onToggleRequested: Config.options.bar.resources.alwaysShowDisk = !Config.options.bar.resources.alwaysShowDisk
                     }
                 }
                 ConfigRow {
@@ -538,19 +531,19 @@ ContentPage {
                         buttonIcon: "swap_horiz"
                         text: Translation.tr("Swap")
                         checked: Config.options.bar.resources.alwaysShowSwap
-                        onCheckedChanged: { Config.options.bar.resources.alwaysShowSwap = checked }
+                        onToggleRequested: Config.options.bar.resources.alwaysShowSwap = !Config.options.bar.resources.alwaysShowSwap
                     }
                     ConfigSwitch {
                         buttonIcon: "thermostat"
                         text: Translation.tr("GPU Temperature")
                         checked: Config.options.bar.resources.alwaysShowGpuTemp
-                        onCheckedChanged: { Config.options.bar.resources.alwaysShowGpuTemp = checked }
+                        onToggleRequested: Config.options.bar.resources.alwaysShowGpuTemp = !Config.options.bar.resources.alwaysShowGpuTemp
                     }
                     ConfigSwitch {
                         buttonIcon: "memory"
                         text: Translation.tr("VRAM")
                         checked: Config.options.bar.resources.alwaysShowVram
-                        onCheckedChanged: { Config.options.bar.resources.alwaysShowVram = checked }
+                        onToggleRequested: Config.options.bar.resources.alwaysShowVram = !Config.options.bar.resources.alwaysShowVram
                     }
                 }
                 ConfigSelectionArray {
@@ -566,7 +559,7 @@ ContentPage {
                 ConfigSwitch {
                     buttonIcon: "decimal_increase"; text: Translation.tr("Show Percentage")
                     checked: Config.options.bar.resources.showValue
-                    onCheckedChanged: { Config.options.bar.resources.showValue = checked; }
+                    onToggleRequested: Config.options.bar.resources.showValue = !Config.options.bar.resources.showValue
                 }
                 ConfigSpinBox {
                     icon: "av_timer"
@@ -611,12 +604,12 @@ ContentPage {
                 ConfigSwitch {
                     buttonIcon: "keep"; text: Translation.tr("Pin media controls")
                     checked: Config.options.bar.media.alwaysVisible
-                    onCheckedChanged: { Config.options.bar.media.alwaysVisible = checked; }
+                    onToggleRequested: Config.options.bar.media.alwaysVisible = !Config.options.bar.media.alwaysVisible
                 }
                 ConfigSwitch {
                     buttonIcon: "titlecase"; text: Translation.tr("Show only title")
                     checked: Config.options.bar.media.onlyTitle
-                    onCheckedChanged: { Config.options.bar.media.onlyTitle = checked; }
+                    onToggleRequested: Config.options.bar.media.onlyTitle = !Config.options.bar.media.onlyTitle
                 }
                 ConfigSpinBox {
                     icon: "width"
@@ -639,7 +632,7 @@ ContentPage {
                 ConfigSwitch {
                     buttonIcon: "ads_click"; text: Translation.tr("Click to show")
                     checked: Config.options.bar.tooltips.clickToShow
-                    onCheckedChanged: { Config.options.bar.tooltips.clickToShow = checked; }
+                    onToggleRequested: Config.options.bar.tooltips.clickToShow = !Config.options.bar.tooltips.clickToShow
                 }
             }
         }
@@ -654,25 +647,25 @@ ContentPage {
                     buttonIcon: "check"
                     text: Translation.tr("Enable")
                     checked: Config.options.dock.enable
-                    onCheckedChanged: { Config.options.dock.enable = checked }
+                    onToggleRequested: Config.options.dock.enable = !Config.options.dock.enable
                 }
                 ConfigSwitch {
                     buttonIcon: "background_dot_small"
                     text: Translation.tr("Background")
                     checked: Config.options.dock.showBackground
-                    onCheckedChanged: { Config.options.dock.showBackground = checked }
+                    onToggleRequested: Config.options.dock.showBackground = !Config.options.dock.showBackground
                 }
                 ConfigSwitch {
                     buttonIcon: "highlight_mouse_cursor"
                     text: Translation.tr("Hover to reveal")
                     checked: Config.options.dock.hoverToReveal
-                    onCheckedChanged: { Config.options.dock.hoverToReveal = checked }
+                    onToggleRequested: Config.options.dock.hoverToReveal = !Config.options.dock.hoverToReveal
                 }
                 ConfigSwitch {
                     buttonIcon: "push_pin"
                     text: Translation.tr("Pinned on startup")
                     checked: Config.options.dock.pinnedOnStartup
-                    onCheckedChanged: { Config.options.dock.pinnedOnStartup = checked }
+                    onToggleRequested: Config.options.dock.pinnedOnStartup = !Config.options.dock.pinnedOnStartup
                 }
             }
 
@@ -684,25 +677,25 @@ ContentPage {
                         buttonIcon: "music_note"
                         text: Translation.tr("Media Player")
                         checked: Config.options.dock.showMedia
-                        onCheckedChanged: { Config.options.dock.showMedia = checked }
+                        onToggleRequested: Config.options.dock.showMedia = !Config.options.dock.showMedia
                     }
                     ConfigSwitch {
                         buttonIcon: "keep"
                         text: Translation.tr("Show Pin Button")
                         checked: Config.options.dock.showPinButton
-                        onCheckedChanged: { Config.options.dock.showPinButton = checked }
+                        onToggleRequested: Config.options.dock.showPinButton = !Config.options.dock.showPinButton
                     }
                     ConfigSwitch {
                         buttonIcon: "apps"
                         text: Translation.tr("Show Apps Button")
                         checked: Config.options.dock.showAppsButton
-                        onCheckedChanged: { Config.options.dock.showAppsButton = checked }
+                        onToggleRequested: Config.options.dock.showAppsButton = !Config.options.dock.showAppsButton
                     }
                     ConfigSwitch {
                         buttonIcon: "colors"
                         text: Translation.tr("Tint app icons")
                         checked: Config.options.dock.monochromeIcons
-                        onCheckedChanged: { Config.options.dock.monochromeIcons = checked }
+                        onToggleRequested: Config.options.dock.monochromeIcons = !Config.options.dock.monochromeIcons
                     }
                 }
             }

--- a/dots/.config/quickshell/imi/modules/imi/settings/pages/CaptureConfig.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/pages/CaptureConfig.qml
@@ -93,26 +93,26 @@ ContentPage {
                     buttonIcon: "volume_up"
                     text: Translation.tr("Record desktop audio")
                     checked: Config.options.screenRecord.recordAudio
-                    onCheckedChanged: { Config.options.screenRecord.recordAudio = checked }
+                    onToggleRequested: Config.options.screenRecord.recordAudio = !Config.options.screenRecord.recordAudio
                 }
                 ConfigSwitch {
                     buttonIcon: "mic"
                     text: Translation.tr("Merge microphone into the audio track")
                     checked: Config.options.screenRecord.recordMic
-                    onCheckedChanged: { Config.options.screenRecord.recordMic = checked }
+                    onToggleRequested: Config.options.screenRecord.recordMic = !Config.options.screenRecord.recordMic
                 }
                 ConfigSwitch {
                     buttonIcon: "point_scan"
                     text: Translation.tr("Show cursor")
                     checked: Config.options.screenRecord.showCursor
-                    onCheckedChanged: { Config.options.screenRecord.showCursor = checked }
+                    onToggleRequested: Config.options.screenRecord.showCursor = !Config.options.screenRecord.showCursor
                 }
                 ConfigSwitch {
                     buttonIcon: "brightness_6"
                     text: Translation.tr("Record SDR on HDR displays")
                     description: Translation.tr("HDR recordings look washed out in players that can't tonemap (VLC, Discord, browsers). On: fullscreen recordings capture through the screen-share portal — correctly toned SDR instantly, with a one-time approval it remembers. Region recordings and replays record HDR and convert to SDR in the background a few seconds after saving. Off = true HDR files.")
                     checked: Config.options.screenRecord.tonemapSdr
-                    onCheckedChanged: { Config.options.screenRecord.tonemapSdr = checked }
+                    onToggleRequested: Config.options.screenRecord.tonemapSdr = !Config.options.screenRecord.tonemapSdr
                 }
             }
 
@@ -123,7 +123,7 @@ ContentPage {
                         buttonIcon: "replay"
                         text: Translation.tr("Enable (keep the last moments in a buffer)")
                         checked: Config.options.screenRecord.replay.enable
-                        onCheckedChanged: { Config.options.screenRecord.replay.enable = checked }
+                        onToggleRequested: Config.options.screenRecord.replay.enable = !Config.options.screenRecord.replay.enable
                     }
                     ConfigSpinBox {
                         icon: "history"
@@ -138,7 +138,7 @@ ContentPage {
                         buttonIcon: "save"
                         text: Translation.tr("Buffer on disk instead of RAM")
                         checked: Config.options.screenRecord.replay.storage === "disk"
-                        onCheckedChanged: { Config.options.screenRecord.replay.storage = checked ? "disk" : "ram" }
+                        onToggleRequested: Config.options.screenRecord.replay.storage = Config.options.screenRecord.replay.storage === "disk" ? "ram" : "disk"
                     }
                     ConfigTextArea {
                         id: replayPathField
@@ -178,7 +178,7 @@ ContentPage {
                     text: Translation.tr("Show result popup")
                     description: Translation.tr("Preview with save/edit/discard after every screenshot")
                     checked: Config.options.screenshotResult.enable
-                    onCheckedChanged: Config.options.screenshotResult.enable = checked
+                    onToggleRequested: Config.options.screenshotResult.enable = !Config.options.screenshotResult.enable
                 }
                 ConfigSpinBox {
                     enabled: Config.options.screenshotResult.enable
@@ -205,25 +205,19 @@ ContentPage {
                         buttonIcon: "select_window"
                         text: Translation.tr('Windows')
                         checked: Config.options.regionSelector.targetRegions.windows
-                        onCheckedChanged: {
-                            Config.options.regionSelector.targetRegions.windows = checked;
-                        }
+                        onToggleRequested: Config.options.regionSelector.targetRegions.windows = !Config.options.regionSelector.targetRegions.windows
                     }
                     ConfigSwitch {
                         buttonIcon: "right_panel_open"
                         text: Translation.tr('Layers')
                         checked: Config.options.regionSelector.targetRegions.layers
-                        onCheckedChanged: {
-                            Config.options.regionSelector.targetRegions.layers = checked;
-                        }
+                        onToggleRequested: Config.options.regionSelector.targetRegions.layers = !Config.options.regionSelector.targetRegions.layers
                     }
                     ConfigSwitch {
                         buttonIcon: "nearby"
                         text: Translation.tr('Content')
                         checked: Config.options.regionSelector.targetRegions.content
-                        onCheckedChanged: {
-                            Config.options.regionSelector.targetRegions.content = checked;
-                        }
+                        onToggleRequested: Config.options.regionSelector.targetRegions.content = !Config.options.regionSelector.targetRegions.content
                     }
                 }
             }
@@ -254,9 +248,7 @@ ContentPage {
                         buttonIcon: "point_scan"
                         text: Translation.tr("Show aim lines")
                         checked: Config.options.regionSelector.rect.showAimLines
-                        onCheckedChanged: {
-                            Config.options.regionSelector.rect.showAimLines = checked;
-                        }
+                        onToggleRequested: Config.options.regionSelector.rect.showAimLines = !Config.options.regionSelector.rect.showAimLines
                     }
                 }
             }

--- a/dots/.config/quickshell/imi/modules/imi/settings/pages/GeneralConfig.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/pages/GeneralConfig.qml
@@ -148,9 +148,7 @@ ContentPage {
                     buttonIcon: "pace"
                     text: Translation.tr("Second precision")
                     checked: Config.options.time.secondPrecision
-                    onCheckedChanged: {
-                        Config.options.time.secondPrecision = checked;
-                    }
+                    onToggleRequested: Config.options.time.secondPrecision = !Config.options.time.secondPrecision
                 }
                 ConfigSelectionArray {
                     text: Translation.tr("First day of week")
@@ -227,9 +225,7 @@ ContentPage {
                         buttonIcon: "pause"
                         text: Translation.tr("Automatic suspend")
                         checked: Config.options.battery.automaticSuspend
-                        onCheckedChanged: {
-                            Config.options.battery.automaticSuspend = checked;
-                        }
+                        onToggleRequested: Config.options.battery.automaticSuspend = !Config.options.battery.automaticSuspend
                     }
                     ConfigSpinBox {
                         enabled: Config.options.battery.automaticSuspend
@@ -269,9 +265,7 @@ ContentPage {
                     buttonIcon: "hearing"
                     text: Translation.tr("Earbang protection")
                     checked: Config.options.audio.protection.enable
-                    onCheckedChanged: {
-                        Config.options.audio.protection.enable = checked;
-                    }
+                    onToggleRequested: Config.options.audio.protection.enable = !Config.options.audio.protection.enable
                 }
                 ConfigRow {
                     enabled: Config.options.audio.protection.enable
@@ -311,17 +305,13 @@ ContentPage {
                     text: Translation.tr("Battery")
                     enabled: Battery.available
                     checked: Config.options.sounds.battery
-                    onCheckedChanged: {
-                        Config.options.sounds.battery = checked;
-                    }
+                    onToggleRequested: Config.options.sounds.battery = !Config.options.sounds.battery
                 }
                 ConfigSwitch {
                     buttonIcon: "av_timer"
                     text: Translation.tr("Pomodoro")
                     checked: Config.options.sounds.pomodoro
-                    onCheckedChanged: {
-                        Config.options.sounds.pomodoro = checked;
-                    }
+                    onToggleRequested: Config.options.sounds.pomodoro = !Config.options.sounds.pomodoro
                 }
             }
         }

--- a/dots/.config/quickshell/imi/modules/imi/settings/pages/HyprlandConfig.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/pages/HyprlandConfig.qml
@@ -107,9 +107,9 @@ ContentPage {
                         buttonIcon: "tv_off"
                         text: Translation.tr("Enabled")
                         checked: !(monitorConfig.monitors[monitorCanvas.selectedIndex]?.disabled ?? false)
-                        onCheckedChanged: {
-                            if (checked === !(monitorConfig.monitors[monitorCanvas.selectedIndex]?.disabled ?? false)) return
-                            monitorConfig.updateMonitor(monitorCanvas.selectedIndex, { disabled: !checked })
+                        onToggleRequested: {
+                            const disabled = monitorConfig.monitors[monitorCanvas.selectedIndex]?.disabled ?? false
+                            monitorConfig.updateMonitor(monitorCanvas.selectedIndex, { disabled: !disabled })
                             monitorConfig.applyAndSave(monitorCanvas.selectedIndex)
                         }
                     }
@@ -265,10 +265,10 @@ ContentPage {
                         buttonIcon: "numbers"
                         text: Translation.tr("Numlock by default")
                         checked: Config.options.hyprland.input.numlock
-                        onCheckedChanged: {
-                            if (checked === Config.options.hyprland.input.numlock) return
-                            Config.options.hyprland.input.numlock = checked
-                            HyprlandConfig.set("input:numlock_by_default", checked ? 1 : 0)
+                        onToggleRequested: {
+                            const next = !Config.options.hyprland.input.numlock
+                            Config.options.hyprland.input.numlock = next
+                            HyprlandConfig.set("input:numlock_by_default", next ? 1 : 0)
                         }
                     }
 
@@ -320,10 +320,10 @@ ContentPage {
                         buttonIcon: "swap_vert"
                         text: Translation.tr("Natural scroll")
                         checked: Config.options.hyprland.input.touchpad.naturalScroll
-                        onCheckedChanged: {
-                            if (checked === Config.options.hyprland.input.touchpad.naturalScroll) return
-                            Config.options.hyprland.input.touchpad.naturalScroll = checked
-                            HyprlandConfig.set("input:touchpad:natural_scroll", checked ? 1 : 0)
+                        onToggleRequested: {
+                            const next = !Config.options.hyprland.input.touchpad.naturalScroll
+                            Config.options.hyprland.input.touchpad.naturalScroll = next
+                            HyprlandConfig.set("input:touchpad:natural_scroll", next ? 1 : 0)
                         }
                     }
 
@@ -331,10 +331,10 @@ ContentPage {
                         buttonIcon: "keyboard_hide"
                         text: Translation.tr("Disable while typing")
                         checked: Config.options.hyprland.input.touchpad.disableWhileTyping
-                        onCheckedChanged: {
-                            if (checked === Config.options.hyprland.input.touchpad.disableWhileTyping) return
-                            Config.options.hyprland.input.touchpad.disableWhileTyping = checked
-                            HyprlandConfig.set("input:touchpad:disable_while_typing", checked ? 1 : 0)
+                        onToggleRequested: {
+                            const next = !Config.options.hyprland.input.touchpad.disableWhileTyping
+                            Config.options.hyprland.input.touchpad.disableWhileTyping = next
+                            HyprlandConfig.set("input:touchpad:disable_while_typing", next ? 1 : 0)
                         }
                     }
 
@@ -342,10 +342,10 @@ ContentPage {
                         buttonIcon: "touch_app"
                         text: Translation.tr("Clickfinger behavior")
                         checked: Config.options.hyprland.input.touchpad.clickfingerBehavior
-                        onCheckedChanged: {
-                            if (checked === Config.options.hyprland.input.touchpad.clickfingerBehavior) return
-                            Config.options.hyprland.input.touchpad.clickfingerBehavior = checked
-                            HyprlandConfig.set("input:touchpad:clickfinger_behavior", checked ? 1 : 0)
+                        onToggleRequested: {
+                            const next = !Config.options.hyprland.input.touchpad.clickfingerBehavior
+                            Config.options.hyprland.input.touchpad.clickfingerBehavior = next
+                            HyprlandConfig.set("input:touchpad:clickfinger_behavior", next ? 1 : 0)
                         }
                     }
 
@@ -696,10 +696,10 @@ ContentPage {
                     text: Translation.tr("Blur")
                     infoText: Translation.tr("Enable kawase window background blur.")
                     checked: Config.options.hyprland.decoration.blur.enabled
-                    onCheckedChanged: {
-                        if (checked === Config.options.hyprland.decoration.blur.enabled) return
-                        Config.options.hyprland.decoration.blur.enabled = checked
-                        HyprlandConfig.set("decoration:blur:enabled", checked ? 1 : 0)
+                    onToggleRequested: {
+                        const next = !Config.options.hyprland.decoration.blur.enabled
+                        Config.options.hyprland.decoration.blur.enabled = next
+                        HyprlandConfig.set("decoration:blur:enabled", next ? 1 : 0)
                     }
                 }
 
@@ -734,10 +734,10 @@ ContentPage {
                     text: Translation.tr("Ignore Window Opacity")
                     infoText: Translation.tr("Blur behind a window even where the window itself is translucent.")
                     checked: Config.options.hyprland.decoration.blur.ignoreOpacity
-                    onCheckedChanged: {
-                        if (checked === Config.options.hyprland.decoration.blur.ignoreOpacity) return
-                        Config.options.hyprland.decoration.blur.ignoreOpacity = checked
-                        HyprlandConfig.set("decoration:blur:ignore_opacity", checked ? 1 : 0)
+                    onToggleRequested: {
+                        const next = !Config.options.hyprland.decoration.blur.ignoreOpacity
+                        Config.options.hyprland.decoration.blur.ignoreOpacity = next
+                        HyprlandConfig.set("decoration:blur:ignore_opacity", next ? 1 : 0)
                     }
                 }
 
@@ -746,10 +746,10 @@ ContentPage {
                     text: Translation.tr("Extra Optimizations")
                     infoText: Translation.tr("Enable further optimizations to the blur. Recommended.")
                     checked: Config.options.hyprland.decoration.blur.newOptimizations
-                    onCheckedChanged: {
-                        if (checked === Config.options.hyprland.decoration.blur.newOptimizations) return
-                        Config.options.hyprland.decoration.blur.newOptimizations = checked
-                        HyprlandConfig.set("decoration:blur:new_optimizations", checked ? 1 : 0)
+                    onToggleRequested: {
+                        const next = !Config.options.hyprland.decoration.blur.newOptimizations
+                        Config.options.hyprland.decoration.blur.newOptimizations = next
+                        HyprlandConfig.set("decoration:blur:new_optimizations", next ? 1 : 0)
                     }
                 }
 
@@ -758,10 +758,10 @@ ContentPage {
                     text: Translation.tr("X-Ray (Skip Tiled Windows)")
                     infoText: Translation.tr("Floating windows ignore tiled windows in their blur, so they blur the wallpaper instead.")
                     checked: Config.options.hyprland.decoration.blur.xray
-                    onCheckedChanged: {
-                        if (checked === Config.options.hyprland.decoration.blur.xray) return
-                        Config.options.hyprland.decoration.blur.xray = checked
-                        HyprlandConfig.set("decoration:blur:xray", checked ? 1 : 0)
+                    onToggleRequested: {
+                        const next = !Config.options.hyprland.decoration.blur.xray
+                        Config.options.hyprland.decoration.blur.xray = next
+                        HyprlandConfig.set("decoration:blur:xray", next ? 1 : 0)
                     }
                 }
 
@@ -840,10 +840,10 @@ ContentPage {
                     text: Translation.tr("Blur Special Workspace")
                     infoText: Translation.tr("Blur behind the special workspace. Expensive.")
                     checked: Config.options.hyprland.decoration.blur.special
-                    onCheckedChanged: {
-                        if (checked === Config.options.hyprland.decoration.blur.special) return
-                        Config.options.hyprland.decoration.blur.special = checked
-                        HyprlandConfig.set("decoration:blur:special", checked ? 1 : 0)
+                    onToggleRequested: {
+                        const next = !Config.options.hyprland.decoration.blur.special
+                        Config.options.hyprland.decoration.blur.special = next
+                        HyprlandConfig.set("decoration:blur:special", next ? 1 : 0)
                     }
                 }
 
@@ -852,10 +852,10 @@ ContentPage {
                     text: Translation.tr("Blur Popups")
                     infoText: Translation.tr("Blur popups such as right-click menus.")
                     checked: Config.options.hyprland.decoration.blur.popups
-                    onCheckedChanged: {
-                        if (checked === Config.options.hyprland.decoration.blur.popups) return
-                        Config.options.hyprland.decoration.blur.popups = checked
-                        HyprlandConfig.set("decoration:blur:popups", checked ? 1 : 0)
+                    onToggleRequested: {
+                        const next = !Config.options.hyprland.decoration.blur.popups
+                        Config.options.hyprland.decoration.blur.popups = next
+                        HyprlandConfig.set("decoration:blur:popups", next ? 1 : 0)
                     }
                 }
 
@@ -878,10 +878,10 @@ ContentPage {
                     text: Translation.tr("Blur Input Methods")
                     infoText: Translation.tr("Blur input methods, such as fcitx5.")
                     checked: Config.options.hyprland.decoration.blur.inputMethods
-                    onCheckedChanged: {
-                        if (checked === Config.options.hyprland.decoration.blur.inputMethods) return
-                        Config.options.hyprland.decoration.blur.inputMethods = checked
-                        HyprlandConfig.set("decoration:blur:input_methods", checked ? 1 : 0)
+                    onToggleRequested: {
+                        const next = !Config.options.hyprland.decoration.blur.inputMethods
+                        Config.options.hyprland.decoration.blur.inputMethods = next
+                        HyprlandConfig.set("decoration:blur:input_methods", next ? 1 : 0)
                     }
                 }
 
@@ -921,10 +921,10 @@ ContentPage {
                     buttonIcon: "check"
                     text: Translation.tr("Enable")
                     checked: Config.options.hyprland.animations.enable
-                    onCheckedChanged: {
-                        if (checked === Config.options.hyprland.animations.enable) return
-                        Config.options.hyprland.animations.enable = checked
-                        HyprlandConfig.set("animations:enabled", checked ? 1 : 0)
+                    onToggleRequested: {
+                        const next = !Config.options.hyprland.animations.enable
+                        Config.options.hyprland.animations.enable = next
+                        HyprlandConfig.set("animations:enabled", next ? 1 : 0)
                     }
                 }
                 ConfigSelectionArray {

--- a/dots/.config/quickshell/imi/modules/imi/settings/pages/LockIdleConfig.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/pages/LockIdleConfig.qml
@@ -52,32 +52,32 @@ ContentPage {
                     buttonIcon: "water_drop"
                     text: Translation.tr("Use Hyprlock (instead of Quickshell)")
                     checked: Config.options.lock.useHyprlock
-                    onCheckedChanged: { Config.options.lock.useHyprlock = checked }
+                    onToggleRequested: Config.options.lock.useHyprlock = !Config.options.lock.useHyprlock
                 }
                 ConfigSwitch {
                     buttonIcon: "account_circle"
                     text: Translation.tr("Launch on startup")
                     checked: Config.options.lock.launchOnStartup
-                    onCheckedChanged: { Config.options.lock.launchOnStartup = checked }
+                    onToggleRequested: Config.options.lock.launchOnStartup = !Config.options.lock.launchOnStartup
                 }
                 ConfigSwitch {
                     buttonIcon: "widgets"
                     text: Translation.tr("Show Widgets")
                     checked: Config.options.lock.showWidgets
-                    onCheckedChanged: { Config.options.lock.showWidgets = checked }
+                    onToggleRequested: Config.options.lock.showWidgets = !Config.options.lock.showWidgets
                 }
                 ConfigSwitch {
                     buttonIcon: "tools_installation_kit"
                     text: Translation.tr("Show Toolbars")
                     checked: Config.options.lock.showToolbars
-                    onCheckedChanged: { Config.options.lock.showToolbars = checked }
+                    onToggleRequested: Config.options.lock.showToolbars = !Config.options.lock.showToolbars
                 }
                 ConfigSwitch {
                     buttonIcon: "music_note"
                     enabled: Config.options.lock.showToolbars
                     text: Translation.tr("Show media player info")
                     checked: Config.options.lock.showMedia
-                    onCheckedChanged: { Config.options.lock.showMedia = checked }
+                    onToggleRequested: Config.options.lock.showMedia = !Config.options.lock.showMedia
                 }
             }
 
@@ -88,13 +88,13 @@ ContentPage {
                         buttonIcon: "settings_power"
                         text: Translation.tr("Require password to power off/restart")
                         checked: Config.options.lock.security.requirePasswordToPower
-                        onCheckedChanged: { Config.options.lock.security.requirePasswordToPower = checked }
+                        onToggleRequested: Config.options.lock.security.requirePasswordToPower = !Config.options.lock.security.requirePasswordToPower
                     }
                     ConfigSwitch {
                         buttonIcon: "key_vertical"
                         text: Translation.tr("Also unlock keyring")
                         checked: Config.options.lock.security.unlockKeyring
-                        onCheckedChanged: { Config.options.lock.security.unlockKeyring = checked }
+                        onToggleRequested: Config.options.lock.security.unlockKeyring = !Config.options.lock.security.unlockKeyring
                     }
                 }
             }
@@ -106,19 +106,19 @@ ContentPage {
                         buttonIcon: "center_focus_weak"
                         text: Translation.tr("Center clock")
                         checked: Config.options.lock.centerClock
-                        onCheckedChanged: { Config.options.lock.centerClock = checked }
+                        onToggleRequested: Config.options.lock.centerClock = !Config.options.lock.centerClock
                     }
                     ConfigSwitch {
                         buttonIcon: "info"
                         text: Translation.tr('Show "Locked" text')
                         checked: Config.options.lock.showLockedText
-                        onCheckedChanged: { Config.options.lock.showLockedText = checked }
+                        onToggleRequested: Config.options.lock.showLockedText = !Config.options.lock.showLockedText
                     }
                     ConfigSwitch {
                         buttonIcon: "shapes"
                         text: Translation.tr("Use varying shapes for password characters")
                         checked: Config.options.lock.materialShapeChars
-                        onCheckedChanged: { Config.options.lock.materialShapeChars = checked }
+                        onToggleRequested: Config.options.lock.materialShapeChars = !Config.options.lock.materialShapeChars
                     }
                 }
             }
@@ -130,7 +130,7 @@ ContentPage {
                         buttonIcon: "blur_on"
                         text: Translation.tr("Enable blur")
                         checked: Config.options.lock.blur.enable
-                        onCheckedChanged: { Config.options.lock.blur.enable = checked }
+                        onToggleRequested: Config.options.lock.blur.enable = !Config.options.lock.blur.enable
                     }
                     ConfigSpinBox {
                         icon: "deblur"
@@ -161,7 +161,7 @@ ContentPage {
                     text: Translation.tr("Keep awake while an external monitor is connected")
                     description: Translation.tr("Combines with the \"Keep awake\" quick toggle: the system stays awake while either is active")
                     checked: Config.options.idleInhibitor.autoOnExternalMonitor
-                    onCheckedChanged: { Config.options.idleInhibitor.autoOnExternalMonitor = checked }
+                    onToggleRequested: Config.options.idleInhibitor.autoOnExternalMonitor = !Config.options.idleInhibitor.autoOnExternalMonitor
                 }
             }
         }
@@ -176,7 +176,7 @@ ContentPage {
                     buttonIcon: "bedtime"
                     text: Translation.tr("Enable OLED screensaver")
                     checked: Config.options.screensaver.enable
-                    onCheckedChanged: { Config.options.screensaver.enable = checked }
+                    onToggleRequested: Config.options.screensaver.enable = !Config.options.screensaver.enable
                 }
                 ConfigSelectionArray {
                     text: Translation.tr("Mode")
@@ -200,17 +200,13 @@ ContentPage {
                     buttonIcon: "assignment"
                     text: Translation.tr("Hide clipboard images copied from sussy sources")
                     checked: Config.options.workSafety.enable.clipboard
-                    onCheckedChanged: {
-                        Config.options.workSafety.enable.clipboard = checked;
-                    }
+                    onToggleRequested: Config.options.workSafety.enable.clipboard = !Config.options.workSafety.enable.clipboard
                 }
                 ConfigSwitch {
                     buttonIcon: "wallpaper"
                     text: Translation.tr("Hide sussy/anime wallpapers")
                     checked: Config.options.workSafety.enable.wallpaper
-                    onCheckedChanged: {
-                        Config.options.workSafety.enable.wallpaper = checked;
-                    }
+                    onToggleRequested: Config.options.workSafety.enable.wallpaper = !Config.options.workSafety.enable.wallpaper
                 }
             }
         }

--- a/dots/.config/quickshell/imi/modules/imi/settings/pages/NotificationsConfig.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/pages/NotificationsConfig.qml
@@ -87,7 +87,7 @@ ContentPage {
                     buttonIcon: "counter_2"
                     text: Translation.tr("Unread indicator: show count")
                     checked: Config.options.bar.indicators.notifications.showUnreadCount
-                    onCheckedChanged: { Config.options.bar.indicators.notifications.showUnreadCount = checked; }
+                    onToggleRequested: Config.options.bar.indicators.notifications.showUnreadCount = !Config.options.bar.indicators.notifications.showUnreadCount
                 }
                 ConfigSpinBox {
                     icon: "av_timer"

--- a/dots/.config/quickshell/imi/modules/imi/settings/pages/PluginsPage.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/pages/PluginsPage.qml
@@ -501,15 +501,17 @@ Item {
 
                                     property bool isEnabled: Config.options.plugins.enabled.includes(modelData.id)
                                     checked: isEnabled
-                                    onCheckedChanged: {
+                                    onToggleRequested: {
+                                        // Whole-list assignment: JsonAdapter
+                                        // lists only persist when replaced.
                                         let newList = [];
                                         for (let i = 0; i < Config.options.plugins.enabled.length; i++) {
                                             newList.push(Config.options.plugins.enabled[i]);
                                         }
-                                        if (checked && !isEnabled) {
-                                            newList.push(modelData.id);
-                                        } else if (!checked && isEnabled) {
-                                            newList = newList.filter(id => id !== modelData.id);
+                                        if (configSwitch.isEnabled) {
+                                            newList = newList.filter(id => id !== configSwitch.modelData.id);
+                                        } else {
+                                            newList.push(configSwitch.modelData.id);
                                         }
                                         Config.setNestedValue("plugins.enabled", newList);
                                     }

--- a/dots/.config/quickshell/imi/modules/imi/settings/pages/QuickConfig.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/pages/QuickConfig.qml
@@ -293,14 +293,14 @@ ContentPage {
                     buttonIcon: "motion_mode"
                     text: Translation.tr("Transparency")
                     checked: Config.options.appearance.transparency.enable
-                    onCheckedChanged: { Config.options.appearance.transparency.enable = checked; }
+                    onToggleRequested: Config.options.appearance.transparency.enable = !Config.options.appearance.transparency.enable
                 }
                 ConfigSwitch {
                     buttonIcon: "autofps_select"
                     enabled: Config.options.appearance.transparency.enable
                     text: Translation.tr("Automatic")
                     checked: Config.options.appearance.transparency.automatic
-                    onCheckedChanged: { Config.options.appearance.transparency.automatic = checked; }
+                    onToggleRequested: Config.options.appearance.transparency.automatic = !Config.options.appearance.transparency.automatic
                 }
             }
 
@@ -352,9 +352,7 @@ ContentPage {
                     ? Translation.tr("Applies the accent color to your RGB hardware whenever the palette changes")
                     : Translation.tr("The openrgb command was not found — install OpenRGB to use this")
                 checked: Config.options.appearance.openrgb.enable
-                onCheckedChanged: {
-                    Config.options.appearance.openrgb.enable = checked;
-                }
+                onToggleRequested: Config.options.appearance.openrgb.enable = !Config.options.appearance.openrgb.enable
             }
 
             ConfigSelectionArray {
@@ -382,9 +380,7 @@ ContentPage {
                         ? Translation.tr("Follow the screen only while a fullscreen app runs; otherwise use the accent")
                         : Translation.tr("The grim command was not found — install grim to sample the monitor")
                     checked: Config.options.appearance.openrgb.monitorFullscreenOnly
-                    onCheckedChanged: {
-                        Config.options.appearance.openrgb.monitorFullscreenOnly = checked;
-                    }
+                    onToggleRequested: Config.options.appearance.openrgb.monitorFullscreenOnly = !Config.options.appearance.openrgb.monitorFullscreenOnly
                 }
 
                 ConfigSwitch {
@@ -392,9 +388,7 @@ ContentPage {
                     text: Translation.tr("Smooth transitions")
                     description: Translation.tr("Blend toward the sampled color instead of snapping on scene cuts")
                     checked: Config.options.appearance.openrgb.monitorSmooth
-                    onCheckedChanged: {
-                        Config.options.appearance.openrgb.monitorSmooth = checked;
-                    }
+                    onToggleRequested: Config.options.appearance.openrgb.monitorSmooth = !Config.options.appearance.openrgb.monitorSmooth
                 }
 
                 ConfigSwitch {
@@ -404,22 +398,13 @@ ContentPage {
                     text: Translation.tr("Include GPU lighting")
                     description: Translation.tr("GPU RGB writes ride the graphics i2c bus and can stutter games — off is safer")
                     checked: gpuIncluded
-                    onCheckedChanged: {
-                        if (checked === gpuIncluded)
-                            return;
+                    onToggleRequested: {
                         // Whole-list assignment: JsonAdapter lists only
                         // persist when replaced, never when mutated.
                         let types = (Config.options.appearance.openrgb.monitorExcludedTypes ?? []).filter(t => t !== "GPU");
-                        if (!checked)
+                        if (gpuAmbientSwitch.gpuIncluded)
                             types = types.concat(["GPU"]);
                         Config.options.appearance.openrgb.monitorExcludedTypes = types;
-                    }
-
-                    Binding {
-                        target: gpuAmbientSwitch
-                        property: "checked"
-                        value: gpuAmbientSwitch.gpuIncluded
-                        restoreMode: Binding.RestoreBinding
                     }
                 }
 
@@ -500,24 +485,13 @@ ContentPage {
                             ? Translation.tr("%1 — %2 devices").arg(modelData.type).arg(modelData.count)
                             : modelData.type
                         checked: syncedNow
-                        onCheckedChanged: {
-                            if (checked === syncedNow)
-                                return;
+                        onToggleRequested: {
                             // Whole-list assignment: JsonAdapter lists only
                             // persist when replaced, never when mutated.
-                            let excluded = (Config.options.appearance.openrgb.excludedDevices ?? []).filter(n => n !== modelData.name);
-                            if (!checked)
-                                excluded = excluded.concat([modelData.name]);
+                            let excluded = (Config.options.appearance.openrgb.excludedDevices ?? []).filter(n => n !== deviceSwitch.modelData.name);
+                            if (deviceSwitch.syncedNow)
+                                excluded = excluded.concat([deviceSwitch.modelData.name]);
                             Config.options.appearance.openrgb.excludedDevices = excluded;
-                        }
-
-                        // Re-sync the switch with config after external edits
-                        // without losing the binding on manual toggles.
-                        Binding {
-                            target: deviceSwitch
-                            property: "checked"
-                            value: deviceSwitch.syncedNow
-                            restoreMode: Binding.RestoreBinding
                         }
                     }
                 }

--- a/dots/.config/quickshell/imi/modules/imi/settings/pages/ServicesConfig.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/pages/ServicesConfig.qml
@@ -115,12 +115,12 @@ ContentPage {
                                         ? Translation.tr("Enable %1").arg(Config.options.ai.customProviders[index].name)
                                         : Translation.tr("Enable provider %1").arg(index + 1)
                                     checked: Config.options.ai.customProviders[index].enabled
-                                    onCheckedChanged: {
+                                    onToggleRequested: {
+                                        // Whole-list assignment: JsonAdapter
+                                        // lists only persist when replaced.
                                         let providers = [...Config.options.ai.customProviders];
-                                        if (providers[index].enabled !== checked) {
-                                            providers[index].enabled = checked;
-                                            Config.options.ai.customProviders = providers;
-                                        }
+                                        providers[index].enabled = !providers[index].enabled;
+                                        Config.options.ai.customProviders = providers;
                                     }
                                 }
 
@@ -263,9 +263,7 @@ ContentPage {
                         buttonIcon: "mobile"
                         text: Translation.tr("Show your phone (via KDE Connect or Valent)")
                         checked: Config.options.networking.phoneConnect.enable
-                        onCheckedChanged: {
-                            Config.options.networking.phoneConnect.enable = checked;
-                        }
+                        onToggleRequested: Config.options.networking.phoneConnect.enable = !Config.options.networking.phoneConnect.enable
                     }
                     ConfigSpinBox {
                         icon: "av_timer"
@@ -324,9 +322,7 @@ ContentPage {
                 ConfigSwitch {
                     text: Translation.tr("Use Levenshtein distance-based algorithm instead of fuzzy")
                     checked: Config.options.search.sloppy
-                    onCheckedChanged: {
-                        Config.options.search.sloppy = checked;
-                    }
+                    onToggleRequested: Config.options.search.sloppy = !Config.options.search.sloppy
                 }
             }
 
@@ -486,9 +482,7 @@ ContentPage {
                         buttonIcon: "folder_open"
                         text: Translation.tr("Enable file/folder search")
                         checked: Config.options.search.fileSearch.enable
-                        onCheckedChanged: {
-                            Config.options.search.fileSearch.enable = checked;
-                        }
+                        onToggleRequested: Config.options.search.fileSearch.enable = !Config.options.search.fileSearch.enable
                     }
                     ConfigTextArea {
                         id: fileSearchRootField
@@ -549,9 +543,7 @@ ContentPage {
                     buttonIcon: "update"
                     text: Translation.tr("Enable update checks")
                     checked: Config.options.updates.enableCheck
-                    onCheckedChanged: {
-                        Config.options.updates.enableCheck = checked;
-                    }
+                    onToggleRequested: Config.options.updates.enableCheck = !Config.options.updates.enableCheck
                 }
 
                 ConfigSpinBox {
@@ -580,22 +572,14 @@ ContentPage {
                     buttonIcon: "handshake"
                     text: Translation.tr("Cooperate with the Clight daemon")
                     checked: Config.options.light.clight.enable
-                    onCheckedChanged: {
-                        Config.options.light.clight.enable = checked;
-                    }
+                    onToggleRequested: Config.options.light.clight.enable = !Config.options.light.clight.enable
                 }
                 ConfigSwitch {
                     visible: Clight.available
                     buttonIcon: "brightness_auto"
                     text: Translation.tr("Automatic brightness calibration")
                     checked: Clight.autoCalibration
-                    onCheckedChanged: {
-                        // Daemon state round-trips through the poll, so the
-                        // binding refresh re-fires this handler; only a real
-                        // change may reach the daemon.
-                        if (checked !== Clight.autoCalibration)
-                            Clight.setAutoCalibration(checked);
-                    }
+                    onToggleRequested: Clight.setAutoCalibration(!Clight.autoCalibration)
                 }
                 ConfigSpinBox {
                     visible: Clight.available
@@ -675,17 +659,13 @@ ContentPage {
                     buttonIcon: "assistant_navigation"
                     text: Translation.tr("Enable GPS based location")
                     checked: Config.options.bar.weather.enableGPS
-                    onCheckedChanged: {
-                        Config.options.bar.weather.enableGPS = checked;
-                    }
+                    onToggleRequested: Config.options.bar.weather.enableGPS = !Config.options.bar.weather.enableGPS
                 }
                 ConfigSwitch {
                     buttonIcon: "thermometer"
                     text: Translation.tr("Fahrenheit unit")
                     checked: Config.options.bar.weather.useUSCS
-                    onCheckedChanged: {
-                        Config.options.bar.weather.useUSCS = checked;
-                    }
+                    onToggleRequested: Config.options.bar.weather.useUSCS = !Config.options.bar.weather.useUSCS
                 }
                 ConfigSpinBox {
                     icon: "av_timer"

--- a/dots/.config/quickshell/imi/modules/imi/settings/pages/SidebarsPanelsConfig.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/pages/SidebarsPanelsConfig.qml
@@ -84,13 +84,13 @@ ContentPage {
                                 buttonIcon: "check"
                                 text: Translation.tr("Enable")
                                 checked: Config.options.sidebar.media.enable
-                                onCheckedChanged: { Config.options.sidebar.media.enable = checked }
+                                onToggleRequested: Config.options.sidebar.media.enable = !Config.options.sidebar.media.enable
                             }
                             ConfigSwitch {
                                 buttonIcon: "radio_button_partial"
                                 text: Translation.tr("Follow Album Colors")
                                 checked: Config.options.sidebar.media.artColors
-                                onCheckedChanged: { Config.options.sidebar.media.artColors = checked }
+                                onToggleRequested: Config.options.sidebar.media.artColors = !Config.options.sidebar.media.artColors
                             }
                         }
                     }
@@ -198,7 +198,7 @@ ContentPage {
                             buttonIcon: "translate"
                             text: Translation.tr("Enable Translator")
                             checked: Config.options.sidebar.translator.enable
-                            onCheckedChanged: { Config.options.sidebar.translator.enable = checked }
+                            onToggleRequested: Config.options.sidebar.translator.enable = !Config.options.sidebar.translator.enable
                         }
                     }
                 }
@@ -215,27 +215,21 @@ ContentPage {
                     buttonIcon: "planner_banner_ad_pt"
                     text: Translation.tr('Banner')
                     checked: Config.options.sidebar.banner
-                    onCheckedChanged: {
-                        Config.options.sidebar.banner = checked;
-                    }
+                    onToggleRequested: Config.options.sidebar.banner = !Config.options.sidebar.banner
                 }
 
                 ConfigSwitch {
                     buttonIcon: "music_note"
                     text: Translation.tr('Media Player')
                     checked: Config.options.sidebar.mediaPlayer
-                    onCheckedChanged: {
-                        Config.options.sidebar.mediaPlayer = checked;
-                    }
+                    onToggleRequested: Config.options.sidebar.mediaPlayer = !Config.options.sidebar.mediaPlayer
                 }
 
                 ConfigSwitch {
                     buttonIcon: "memory"
                     text: Translation.tr('Keep right sidebar loaded')
                     checked: Config.options.sidebar.keepRightSidebarLoaded
-                    onCheckedChanged: {
-                        Config.options.sidebar.keepRightSidebarLoaded = checked;
-                    }
+                    onToggleRequested: Config.options.sidebar.keepRightSidebarLoaded = !Config.options.sidebar.keepRightSidebarLoaded
                 }
             }
 
@@ -285,9 +279,7 @@ ContentPage {
                         buttonIcon: "check"
                         text: Translation.tr("Enable")
                         checked: Config.options.sidebar.quickSliders.enable
-                        onCheckedChanged: {
-                            Config.options.sidebar.quickSliders.enable = checked;
-                        }
+                        onToggleRequested: Config.options.sidebar.quickSliders.enable = !Config.options.sidebar.quickSliders.enable
                     }
 
                     ConfigSwitch {
@@ -295,9 +287,7 @@ ContentPage {
                         text: Translation.tr("Brightness")
                         enabled: Config.options.sidebar.quickSliders.enable
                         checked: Config.options.sidebar.quickSliders.showBrightness
-                        onCheckedChanged: {
-                            Config.options.sidebar.quickSliders.showBrightness = checked;
-                        }
+                        onToggleRequested: Config.options.sidebar.quickSliders.showBrightness = !Config.options.sidebar.quickSliders.showBrightness
                     }
 
                     ConfigSwitch {
@@ -305,9 +295,7 @@ ContentPage {
                         text: Translation.tr("Volume")
                         enabled: Config.options.sidebar.quickSliders.enable
                         checked: Config.options.sidebar.quickSliders.showVolume
-                        onCheckedChanged: {
-                            Config.options.sidebar.quickSliders.showVolume = checked;
-                        }
+                        onToggleRequested: Config.options.sidebar.quickSliders.showVolume = !Config.options.sidebar.quickSliders.showVolume
                     }
 
                     ConfigSwitch {
@@ -315,9 +303,7 @@ ContentPage {
                         text: Translation.tr("Microphone")
                         enabled: Config.options.sidebar.quickSliders.enable
                         checked: Config.options.sidebar.quickSliders.showMic
-                        onCheckedChanged: {
-                            Config.options.sidebar.quickSliders.showMic = checked;
-                        }
+                        onToggleRequested: Config.options.sidebar.quickSliders.showMic = !Config.options.sidebar.quickSliders.showMic
                     }
                 }
             }
@@ -330,38 +316,38 @@ ContentPage {
                         buttonIcon: "check"
                         text: Translation.tr("Enable")
                         checked: Config.options.sidebar.cornerOpen.enable
-                        onCheckedChanged: { Config.options.sidebar.cornerOpen.enable = checked }
+                        onToggleRequested: Config.options.sidebar.cornerOpen.enable = !Config.options.sidebar.cornerOpen.enable
                     }
                     ConfigSwitch {
                         buttonIcon: "highlight_mouse_cursor"
                         text: Translation.tr("Hover to trigger")
                         checked: Config.options.sidebar.cornerOpen.clickless
-                        onCheckedChanged: { Config.options.sidebar.cornerOpen.clickless = checked }
+                        onToggleRequested: Config.options.sidebar.cornerOpen.clickless = !Config.options.sidebar.cornerOpen.clickless
                     }
                     ConfigSwitch {
                         buttonIcon: "vertical_align_bottom"
                         text: Translation.tr("Place at bottom")
                         checked: Config.options.sidebar.cornerOpen.bottom
-                        onCheckedChanged: { Config.options.sidebar.cornerOpen.bottom = checked }
+                        onToggleRequested: Config.options.sidebar.cornerOpen.bottom = !Config.options.sidebar.cornerOpen.bottom
                     }
                     ConfigSwitch {
                         buttonIcon: "unfold_more_double"
                         text: Translation.tr("Value scroll")
                         checked: Config.options.sidebar.cornerOpen.valueScroll
-                        onCheckedChanged: { Config.options.sidebar.cornerOpen.valueScroll = checked }
+                        onToggleRequested: Config.options.sidebar.cornerOpen.valueScroll = !Config.options.sidebar.cornerOpen.valueScroll
                     }
                     ConfigSwitch {
                         buttonIcon: "visibility"
                         text: Translation.tr("Visualize region")
                         checked: Config.options.sidebar.cornerOpen.visualize
-                        onCheckedChanged: { Config.options.sidebar.cornerOpen.visualize = checked }
+                        onToggleRequested: Config.options.sidebar.cornerOpen.visualize = !Config.options.sidebar.cornerOpen.visualize
                     }
                     ConfigSwitch {
                         enabled: Config.options.sidebar.cornerOpen.clickless
                         buttonIcon: "ads_click"
                         text: Translation.tr("Force hover at absolute corner")
                         checked: Config.options.sidebar.cornerOpen.clicklessCornerEnd
-                        onCheckedChanged: { Config.options.sidebar.cornerOpen.clicklessCornerEnd = checked }
+                        onToggleRequested: Config.options.sidebar.cornerOpen.clicklessCornerEnd = !Config.options.sidebar.cornerOpen.clicklessCornerEnd
                     }
                     ConfigSpinBox {
                         enabled: Config.options.sidebar.cornerOpen.clickless
@@ -399,17 +385,13 @@ ContentPage {
                     buttonIcon: "check"
                     text: Translation.tr("Enable")
                     checked: Config.options.overview.enable
-                    onCheckedChanged: {
-                        Config.options.overview.enable = checked;
-                    }
+                    onToggleRequested: Config.options.overview.enable = !Config.options.overview.enable
                 }
                 ConfigSwitch {
                     buttonIcon: "center_focus_strong"
                     text: Translation.tr("Center icons")
                     checked: Config.options.overview.centerIcons
-                    onCheckedChanged: {
-                        Config.options.overview.centerIcons = checked;
-                    }
+                    onToggleRequested: Config.options.overview.centerIcons = !Config.options.overview.centerIcons
                 }
                 ConfigSpinBox {
                     icon: "loupe"
@@ -535,17 +517,13 @@ ContentPage {
                     buttonIcon: "high_density"
                     text: Translation.tr("Enable opening zoom animation")
                     checked: Config.options.overlay.openingZoomAnimation
-                    onCheckedChanged: {
-                        Config.options.overlay.openingZoomAnimation = checked;
-                    }
+                    onToggleRequested: Config.options.overlay.openingZoomAnimation = !Config.options.overlay.openingZoomAnimation
                 }
                 ConfigSwitch {
                     buttonIcon: "texture"
                     text: Translation.tr("Darken screen")
                     checked: Config.options.overlay.darkenScreen
-                    onCheckedChanged: {
-                        Config.options.overlay.darkenScreen = checked;
-                    }
+                    onToggleRequested: Config.options.overlay.darkenScreen = !Config.options.overlay.darkenScreen
                 }
             }
 
@@ -671,13 +649,13 @@ ContentPage {
                     buttonIcon: "swipe_up"
                     text: Translation.tr("Reveal when dragging files onto the bar")
                     checked: Config.options.dropShelf.dragToBarReveal
-                    onCheckedChanged: { Config.options.dropShelf.dragToBarReveal = checked }
+                    onToggleRequested: Config.options.dropShelf.dragToBarReveal = !Config.options.dropShelf.dragToBarReveal
                 }
                 ConfigSwitch {
                     buttonIcon: "gesture"
                     text: Translation.tr("Shake cursor (while dragging) to summon")
                     checked: Config.options.dropShelf.shakeToSummon
-                    onCheckedChanged: { Config.options.dropShelf.shakeToSummon = checked }
+                    onToggleRequested: Config.options.dropShelf.shakeToSummon = !Config.options.dropShelf.shakeToSummon
                 }
                 ConfigSpinBox {
                     enabled: Config.options.dropShelf.shakeToSummon
@@ -706,7 +684,7 @@ ContentPage {
                     enabled: Config.options.appearance.transparency.enable
                     text: Translation.tr("Blur background")
                     checked: Config.options.dropShelf.blurBackground
-                    onCheckedChanged: { Config.options.dropShelf.blurBackground = checked }
+                    onToggleRequested: Config.options.dropShelf.blurBackground = !Config.options.dropShelf.blurBackground
                 }
                 ConfigSpinBox {
                     enabled: Config.options.dropShelf.blurBackground

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/Anime.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/Anime.qml
@@ -509,8 +509,12 @@ Item {
 
                     hoverEnabled: true
                     PointingHandInteraction {}
+                    // The switch is disabled on zerochan but this area is not,
+                    // so it carries the same gate rather than relying on a
+                    // handler that would have run after the visual moved.
                     onPressed: {
-                        nsfwSwitch.checked = !nsfwSwitch.checked
+                        if (Booru.currentProvider === "zerochan") return;
+                        Persistent.states.booru.allowNsfw = !Persistent.states.booru.allowNsfw;
                     }
 
                     RowLayout {
@@ -532,10 +536,11 @@ Item {
                             scale: 0.6
                             Layout.alignment: Qt.AlignVCenter
                             checked: (Persistent.states.booru.allowNsfw && Booru.currentProvider !== "zerochan")
-                            onCheckedChanged: {
-                                if (!nsfwSwitch.enabled) return;
-                                Persistent.states.booru.allowNsfw = checked;
-                            }
+                            // Same rule as ConfigSwitch: `checked` is a binding
+                            // on the stored value and only follows it. A Switch
+                            // moving its own `checked` would destroy that.
+                            checkable: false
+                            onClicked: Persistent.states.booru.allowNsfw = !Persistent.states.booru.allowNsfw
                         }
                     }
 

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/iconPicker/IconPickerDialog.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/iconPicker/IconPickerDialog.qml
@@ -77,9 +77,7 @@ WindowDialog {
             buttonIcon: "colors"
             text: Translation.tr("Colorize")
             checked: Config.options.custom.colorizeIcon
-            onCheckedChanged: {
-                Config.options.custom.colorizeIcon = checked
-            }
+            onToggleRequested: Config.options.custom.colorizeIcon = !Config.options.custom.colorizeIcon
         }
 
         Item {

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/nightLight/NightLightDialog.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/nightLight/NightLightDialog.qml
@@ -45,9 +45,7 @@ WindowDialog {
             buttonIcon: "check"
             text: Translation.tr("Enable now")
             checked: Hyprsunset.temperatureActive
-            onCheckedChanged: {
-                Hyprsunset.toggleTemperature(checked)
-            }
+            onToggleRequested: Hyprsunset.toggleTemperature(!Hyprsunset.temperatureActive)
         }
 
         ConfigSwitch {
@@ -59,9 +57,7 @@ WindowDialog {
             buttonIcon: "night_sight_auto"
             text: Translation.tr("Automatic")
             checked: Config.options.light.night.automatic
-            onCheckedChanged: {
-                Config.options.light.night.automatic = checked;
-            }
+            onToggleRequested: Config.options.light.night.automatic = !Config.options.light.night.automatic
         }
 
         WindowDialogSlider {
@@ -105,9 +101,9 @@ WindowDialog {
             buttonIcon: "filter"
             text: Translation.tr("Content adjustment")
             checked: HyprlandAntiFlashbangShader.enabled
-            onCheckedChanged: {
-                if (checked) HyprlandAntiFlashbangShader.enable()
-                else HyprlandAntiFlashbangShader.disable()
+            onToggleRequested: {
+                if (HyprlandAntiFlashbangShader.enabled) HyprlandAntiFlashbangShader.disable()
+                else HyprlandAntiFlashbangShader.enable()
             }
             StyledToolTip {
                 textFormat: Text.StyledText
@@ -124,9 +120,7 @@ WindowDialog {
             buttonIcon: "light_mode"
             text: Translation.tr("Brightness adjustment")
             checked: Config.options.light.antiFlashbang.enable
-            onCheckedChanged: {
-                Config.options.light.antiFlashbang.enable = checked;
-            }
+            onToggleRequested: Config.options.light.antiFlashbang.enable = !Config.options.light.antiFlashbang.enable
             StyledToolTip {
                 textFormat: Text.StyledText
                 text: Translation.tr("Adapts the <b>display (physical screen) brightness</b><br><br>Pros: Less expensive, retains colors<br>Cons: Not immediately responsive<br><br><i>Adjusts display brightness after each Hyprland IPC event</i>")

--- a/dots/.config/quickshell/imi/tests/lint_config_switch_intent.py
+++ b/dots/.config/quickshell/imi/tests/lint_config_switch_intent.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+#
+# Regression guard: a ConfigSwitch click is an INTENT, never a write to
+# `checked`.
+#
+# `ConfigSwitch.qml` used to answer its own click with `checked = !checked`,
+# and every settings page binds that same property:
+#
+#     ConfigSwitch {
+#         checked: Config.options.x.y
+#         onCheckedChanged: Config.options.x.y = checked
+#     }
+#
+# An imperative assignment to a bound property destroys the binding. From the
+# first click onward the switch showed local state - no preset, hand-edited
+# config or migration could move it again - while the row's write-back kept
+# working, so the setting changed and the switch lied about it. The next click
+# on a switch that looked on then wrote `!off` = on. 159 call sites had it
+# (#158), and every one of them looked correct in isolation, which is why this
+# is a check rather than a note: the idiom comes back one switch at a time.
+#
+# The shape that works keeps `checked` a pure binding and expresses the click
+# as `toggleRequested()`, which the call site answers by flipping the value at
+# its source:
+#
+#     ConfigSwitch {
+#         checked: Config.options.x.y
+#         onToggleRequested: Config.options.x.y = !Config.options.x.y
+#     }
+#
+# So, enforced here:
+#   1. ConfigSwitch.qml assigns to `checked` nowhere, declares
+#      `signal toggleRequested()`, and raises it from `onClicked`.
+#   2. Its inner StyledSwitch is `checkable: false`. A QQC2 Switch moves its own
+#      `checked` on a click or a thumb drag, which would show a flip the call
+#      site may decline and leave it wrong until the config next changed.
+#   3. No ConfigSwitch call site assigns to `checked`, drives it through a
+#      `Binding` object, or takes the write-back on `onCheckedChanged` /
+#      overrides `onClicked` (which would swallow the intent).
+#
+# Exits non-zero listing offenders. Wired into run_tests.sh / CI.
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+MODULES = ROOT / "modules"
+WIDGET = MODULES / "common/widgets/ConfigSwitch.qml"
+
+# The number of call sites when this check landed. It is a floor, not a pin:
+# the point is that a reformat or a parser slip cannot leave the scan matching
+# nothing while still reporting success.
+MINIMUM_CALL_SITES = 150
+
+ASSIGNS_CHECKED = re.compile(r"\bchecked\s*=(?![=~])")
+
+
+def mask(source):
+    """Blank out comments and string literals so braces inside them don't count."""
+    out = list(source)
+    i, n = 0, len(source)
+    while i < n:
+        char = source[i]
+        if char == "/" and source[i + 1:i + 2] == "/":
+            end = source.find("\n", i)
+            end = n if end < 0 else end
+        elif char == "/" and source[i + 1:i + 2] == "*":
+            end = source.find("*/", i + 2)
+            end = n if end < 0 else end + 2
+        elif char in "\"'`":
+            end = i + 1
+            while end < n:
+                if source[end] == "\\":
+                    end += 2
+                    continue
+                if source[end] == char:
+                    end += 1
+                    break
+                end += 1
+        else:
+            i += 1
+            continue
+        for position in range(i, min(end, n)):
+            out[position] = " "
+        i = end
+    return "".join(out)
+
+
+def blocks(masked):
+    """(start, end) of every `ConfigSwitch { ... }` in a masked source."""
+    found = []
+    for match in re.finditer(r"\bConfigSwitch\s*\{", masked):
+        depth, index = 0, match.end() - 1
+        while index < len(masked):
+            if masked[index] == "{":
+                depth += 1
+            elif masked[index] == "}":
+                depth -= 1
+                if depth == 0:
+                    break
+            index += 1
+        found.append((match.start(), index + 1))
+    return found
+
+
+def top_level_members(masked, start, end):
+    """Property/handler names bound directly on the block, not on a child."""
+    body_start = masked.index("{", start) + 1
+    body_end = end - 1
+    names = {}
+    for match in re.finditer(r"[A-Za-z_][A-Za-z0-9_.]*\s*:", masked[body_start:body_end]):
+        position = body_start + match.start()
+        nested = (masked.count("{", body_start, position) - masked.count("}", body_start, position)
+                  or masked.count("[", body_start, position) - masked.count("]", body_start, position)
+                  or masked.count("(", body_start, position) - masked.count(")", body_start, position))
+        if nested:
+            continue
+        names.setdefault(match.group()[:-1].strip(), masked[:position].count("\n") + 1)
+    return names
+
+
+def check_the_widget(violations):
+    source = WIDGET.read_text(encoding="utf-8")
+    masked = mask(source)
+    if ASSIGNS_CHECKED.search(masked):
+        line = masked[:ASSIGNS_CHECKED.search(masked).start()].count("\n") + 1
+        violations.append((WIDGET.name, line,
+                           "ConfigSwitch assigns to `checked`, which destroys "
+                           "the call site's binding on the first click"))
+    if not re.search(r"^\s*signal\s+toggleRequested\s*\(\s*\)", source, re.M):
+        violations.append((WIDGET.name, 0,
+                           "ConfigSwitch no longer declares `signal toggleRequested()`"))
+    if not re.search(r"^\s*onClicked:\s*root\.toggleRequested\(\)", source, re.M):
+        violations.append((WIDGET.name, 0,
+                           "ConfigSwitch's click no longer raises toggleRequested()"))
+    if not re.search(r"^\s*checkable:\s*false", source, re.M):
+        violations.append((WIDGET.name, 0,
+                           "the inner StyledSwitch is checkable again, so it "
+                           "moves its own `checked` on click and drag"))
+
+
+def main():
+    if not WIDGET.exists():
+        print(f"ConfigSwitch intent lint FAILED: {WIDGET} is missing - this "
+              "check no longer guards anything.", file=sys.stderr)
+        return 1
+
+    violations = []
+    check_the_widget(violations)
+
+    call_sites = 0
+    for path in sorted(MODULES.rglob("*.qml")):
+        source = path.read_text(encoding="utf-8")
+        if "ConfigSwitch" not in source:
+            continue
+        masked = mask(source)
+        for start, end in blocks(masked):
+            call_sites += 1
+            relative = path.relative_to(MODULES)
+            line = masked[:start].count("\n") + 1
+            body = masked[start:end]
+            members = top_level_members(masked, start, end)
+            if ASSIGNS_CHECKED.search(body):
+                violations.append((relative, line,
+                                   "assigns to `checked` - that is the binding "
+                                   "destroyed by hand"))
+            if re.search(r'property:\s*"checked"', body):
+                violations.append((relative, line,
+                                   "drives `checked` through a Binding object - "
+                                   "a plain `checked:` binding survives a click now"))
+            if "onCheckedChanged" in members:
+                violations.append((relative, members["onCheckedChanged"],
+                                   "writes back from onCheckedChanged - `checked` "
+                                   "no longer moves on a click, so this is a dead "
+                                   "switch. Use onToggleRequested"))
+            if "onClicked" in members:
+                violations.append((relative, members["onClicked"],
+                                   "overrides onClicked, which is where the base "
+                                   "raises the intent. Use onToggleRequested"))
+
+    if call_sites < MINIMUM_CALL_SITES:
+        print(f"ConfigSwitch intent lint FAILED: found only {call_sites} call "
+              f"sites (expected at least {MINIMUM_CALL_SITES}) - the scan is "
+              "matching almost nothing and would pass vacuously.",
+              file=sys.stderr)
+        return 1
+
+    if violations:
+        print("ConfigSwitch intent lint FAILED: a click is an intent, not a "
+              "write to `checked` - assigning to a bound property destroys the "
+              "binding and detaches the switch from the config (#158):",
+              file=sys.stderr)
+        for relative, line, detail in violations:
+            print(f"  {relative}:{line}: {detail}", file=sys.stderr)
+        return 1
+
+    print(f"ConfigSwitch intent lint passed ({call_sites} call sites)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -99,6 +99,15 @@ if ! python3 "$SCRIPT_DIR/lint_disabled_opacity.py"; then
     exit 1
 fi
 
+# Static lint: a ConfigSwitch click is an intent. Assigning to `checked` - in
+# the widget or at a call site - destroys the binding every settings page hangs
+# on it, and the switch silently detaches from the config it is showing.
+echo "Running ConfigSwitch intent lint..."
+if ! python3 "$SCRIPT_DIR/lint_config_switch_intent.py"; then
+    echo "ConfigSwitch intent lint failed."
+    exit 1
+fi
+
 echo "Running shell name lint..."
 if ! python3 "$SCRIPT_DIR/lint_shell_name.py"; then
     echo "Shell name lint failed."

--- a/dots/.config/quickshell/imi/tests/test_clight_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_clight_contract.py
@@ -169,7 +169,8 @@ def test_clight_enable_setting_has_both_halves():
 
     page = SERVICES_PAGE.read_text()
     assert "checked: Config.options.light.clight.enable" in page
-    assert "Config.options.light.clight.enable = checked;" in page
+    assert ("onToggleRequested: Config.options.light.clight.enable = "
+            "!Config.options.light.clight.enable" in page)
 
 
 def test_settings_temperature_spinboxes_write_from_value_modified():
@@ -179,10 +180,19 @@ def test_settings_temperature_spinboxes_write_from_value_modified():
             r"onValueModified: \{\s*\n\s*Clight\." + setter + r"\(newValue\);", page
         ), f"{setter} must be driven from onValueModified(newValue)"
     # The daemon-state switch must not echo poll refreshes back at the daemon.
+    # It used to need an `if (checked !== Clight.autoCalibration)` guard for
+    # that, because the write came back through the binding and re-fired the
+    # handler. A ConfigSwitch click is an intent now (#158) - it fires once per
+    # click and never on a state change - so the guard has nothing to suppress
+    # and is gone. What has to hold instead: the daemon call reads the daemon's
+    # own state rather than the widget's, and hangs off the intent.
     assert re.search(
-        r"if \(checked !== Clight\.autoCalibration\)\s*\n\s*Clight\.setAutoCalibration\(checked\);",
-        page,
-    ), "auto-calibration switch would loop daemon state through onCheckedChanged"
+        r"onToggleRequested: Clight\.setAutoCalibration\(!Clight\.autoCalibration\)", page
+    ), "auto-calibration must ask the daemon for the opposite of what it reports"
+    assert "onCheckedChanged" not in page, (
+        "a ConfigSwitch write-back on onCheckedChanged is a dead switch now - "
+        "`checked` no longer moves on a click"
+    )
 
 
 if __name__ == "__main__":

--- a/dots/.config/quickshell/imi/tests/test_widget_transparency_opacity.py
+++ b/dots/.config/quickshell/imi/tests/test_widget_transparency_opacity.py
@@ -265,7 +265,7 @@ class TheToggleReachesTheOtherPaintedSurfaces(unittest.TestCase):
         # The switch's own row, delimited by its icon and its write-back, so the
         # slice cannot drift onto a neighbouring control's `enabled:`.
         start = panels.index('buttonIcon: "blur_on"')
-        end = panels.index("Config.options.dropShelf.blurBackground = checked", start)
+        end = panels.index("onToggleRequested: Config.options.dropShelf.blurBackground", start)
         self.assertIn("enabled: Config.options.appearance.transparency.enable",
                       panels[start:end])
 

--- a/dots/.config/quickshell/imi/tests/tst_config_switch_binding.qml
+++ b/dots/.config/quickshell/imi/tests/tst_config_switch_binding.qml
@@ -1,0 +1,181 @@
+import QtQuick
+import QtQuick.Controls
+import QtTest
+
+// A settings toggle has to survive being clicked: `checked` is bound to a
+// config value, and a preset, a hand-edited config.json or a migration must
+// still be able to move it afterwards. `ConfigSwitch` used to answer its own
+// click with `checked = !checked`, which destroys that binding on the first
+// click - the setting kept changing while the switch showed stale local state,
+// and a click on a switch that looked on wrote `!off` = on (#158).
+//
+// The real widget cannot be instantiated here (it reaches StyledText, whose
+// `font.variableAxes` needs a newer Qt than the suite runs against, and
+// Appearance/Config are Quickshell singletons), so this rebuilds its exact
+// three-part shape out of plain QtQuick.Controls: a row-sized AbstractButton
+// standing in for the RippleButton root, an inner Switch standing in for
+// StyledSwitch, and a `source` property standing in for the config leaf.
+//
+// The old idiom is modelled beside the new one on purpose. Proving it detaches
+// is what makes a green result here mean something: without it, a harness that
+// simply never breaks a binding would pass either way.
+TestCase {
+    id: testCase
+    name: "ConfigSwitchBindingTest"
+    when: windowShown
+    visible: true
+    width: 200
+    height: 40
+
+    // ConfigSwitch as it was: the click writes the property the call site bound.
+    Component {
+        id: detachingSwitch
+        Item {
+            id: host
+            property bool source: false
+            property alias control: row
+            property alias handle: handle
+            anchors.fill: parent
+
+            AbstractButton {
+                id: row
+                anchors.fill: parent
+                checked: host.source
+                onClicked: checked = !checked
+                onCheckedChanged: host.source = checked
+
+                Switch {
+                    id: handle
+                    anchors.right: parent.right
+                    width: 60
+                    height: parent.height
+                    checked: row.checked
+                    onClicked: row.clicked()
+                }
+            }
+        }
+    }
+
+    // ConfigSwitch as it is: the click is an intent the call site answers by
+    // flipping the value at its source.
+    Component {
+        id: intentSwitch
+        Item {
+            id: host
+            property bool source: false
+            property alias control: row
+            property alias handle: handle
+            anchors.fill: parent
+
+            AbstractButton {
+                id: row
+                signal toggleRequested
+                anchors.fill: parent
+                checked: host.source
+                onClicked: row.toggleRequested()
+                onToggleRequested: host.source = !host.source
+
+                Switch {
+                    id: handle
+                    anchors.right: parent.right
+                    width: 60
+                    height: parent.height
+                    checkable: false
+                    checked: row.checked
+                    onClicked: row.clicked()
+                }
+            }
+        }
+    }
+
+    // A switch the call site refuses to move - "use the same wallpaper for
+    // both" is on when two paths are empty and clearing them is all a click can
+    // do, so a click while it is already on means nothing.
+    Component {
+        id: decliningSwitch
+        Item {
+            id: host
+            property bool source: true
+            property alias control: row
+            property alias handle: handle
+            anchors.fill: parent
+
+            AbstractButton {
+                id: row
+                signal toggleRequested
+                anchors.fill: parent
+                checked: host.source
+                onClicked: row.toggleRequested()
+                onToggleRequested: {}
+
+                Switch {
+                    id: handle
+                    anchors.right: parent.right
+                    width: 60
+                    height: parent.height
+                    checkable: false
+                    checked: row.checked
+                    onClicked: row.clicked()
+                }
+            }
+        }
+    }
+
+    // The bug, so the rest of this file cannot pass vacuously. One click and
+    // the switch stops answering to the value it was bound to.
+    function test_theOldIdiomDetachesOnTheFirstClick() {
+        const host = createTemporaryObject(detachingSwitch, testCase);
+        mouseClick(host.control, 10, 20);
+        compare(host.source, true, "the click still writes the value");
+
+        host.source = false;
+        compare(host.control.checked, true,
+                "assigning to `checked` from onClicked is supposed to destroy "
+                + "the binding - if this now follows the source, the harness is "
+                + "no longer able to detect the bug it is guarding");
+    }
+
+    function test_theBindingSurvivesAClickOnTheRow() {
+        const host = createTemporaryObject(intentSwitch, testCase);
+        mouseClick(host.control, 10, 20);
+        compare(host.source, true, "the click flips the value at its source");
+        compare(host.control.checked, true, "and the switch follows it");
+
+        host.source = false;
+        compare(host.control.checked, false,
+                "an external write - a preset, a config edit - must still move "
+                + "the switch after it has been clicked");
+        host.source = true;
+        compare(host.control.checked, true, "and back again");
+    }
+
+    function test_theBindingSurvivesAClickOnTheSwitchItself() {
+        const host = createTemporaryObject(intentSwitch, testCase);
+        mouseClick(host.handle, 30, 20);
+        compare(host.source, true, "clicking the handle reaches the row");
+        compare(host.handle.checked, true, "the handle draws the new state");
+
+        host.source = false;
+        compare(host.handle.checked, false,
+                "the handle is a picture of the row's `checked`, so it has to "
+                + "follow an external write too");
+    }
+
+    // The handle is where this goes wrong if it stays checkable: a QQC2 Switch
+    // moves its own `checked` on click, so it would show a flip that never
+    // happened and stay wrong until the config next changed.
+    function test_aDeclinedIntentLeavesTheHandleWhereItWas() {
+        const host = createTemporaryObject(decliningSwitch, testCase);
+        mouseClick(host.handle, 30, 20);
+        compare(host.control.checked, true, "nothing moved the value");
+        compare(host.handle.checked, true,
+                "so the handle must not have moved either");
+    }
+
+    function test_aDeclinedIntentOnTheRowLeavesNothingLookingFlipped() {
+        const host = createTemporaryObject(decliningSwitch, testCase);
+        mouseClick(host.control, 10, 20);
+        compare(host.control.checked, true);
+        compare(host.handle.checked, true);
+    }
+}


### PR DESCRIPTION
Closes #158.

Applying a preset changed the settings but not the toggles, and then clicking a switch that *looked*
on turned the setting on. Restarting fixed it.

`ConfigSwitch` did `onClicked: checked = !checked`, and every page binds `checked: Config.options.x`.
Assigning to a bound property from a handler **destroys the binding**, so from the first click the
switch showed local state and nothing external could move it again. The page's own
`onCheckedChanged` still wrote, so the setting changed and the switch lied.

The click is now an intent — `toggleRequested()` — and `checked` stays a pure binding that follows
config forever. Call sites write the config and never read the widget: **0 of 158 sites read
`checked`.**

## Two things found by probing rather than reasoning

- **A new signal was not a preference.** `ConfigSwitch` is a `RippleButton`, which declares a
  `property bool toggled` — that *shadows* `AbstractButton.toggled()`, so `onToggled` at a call site
  would bind the property's change handler and `root.toggled()` is not callable. Reuse was
  unavailable, not merely inferior.
- **The inner `StyledSwitch` needed `checkable: false`.** A QQC2 `Switch` moves its own `checked` on
  click *and* on a thumb drag, so where a call site declines the intent the switch showed a flip that
  never happened. Measured under `qmltestrunner` with `mouseClick` and a drag.

## Verifying nothing inverted

The risk here is a silently inverted toggle, which would be worse than the bug. Every mechanical site
was checked by re-parsing both trees and asserting the new handler is the exact negation of the bound
expression — **123 verified, 0 problems** — with the remaining 36 read individually. Independently
re-checked before merge: 128 exact negations, the rest multi-line handlers inspected by hand.

Sites deliberately not forced into the pattern: Hyprland's 12 (write config *and* `hyprctl`, now
computing `next` once so the two cannot disagree), the string-valued replay storage, whole-list
reassignments, and the genuinely one-way switches.

## Three existing workarounds for this bug, now removable

Found while rewriting, each a separate attempt to fight the detachment: two `Binding { property:
"checked"; restoreMode: RestoreBinding }` blocks — one commented *"re-sync the switch with config
after external edits without losing the binding on manual toggles"*, which is this bug described
exactly — and a `Connections` block re-installing `Qt.binding()` on every change. All deleted.

Also fixed the shell's only bare `StyledSwitch` (`sidebarLeft/Anime.qml`), which had the bug twice;
on zerochan the switch is disabled but the row's MouseArea is not, so a press moved the visual while
the write-back declined it.

## Testing

`./tests/run_tests.sh` — **373 passed, 0 failed** (366 baseline).

- `tests/lint_config_switch_intent.py` — the base may not assign to `checked`; no call site may
  assign to it, bind it through a `Binding`, take `onCheckedChanged`, or override `onClicked`. It
  refuses to report success below 150 call sites, so it cannot pass by finding nothing.
- `tests/tst_config_switch_binding.qml` — a real `TestCase` that clicks the row, clicks the handle,
  then writes the source externally. It **also models the old idiom and asserts that one detaches**,
  so the file cannot pass vacuously.

Two existing tests were re-anchored rather than loosened, and the commits say so.

Docs: updated AGENT.md §The Config system, CONTRIBUTING.md §Settings additions are two-sided