### PR TITLE
feat(widgets): a shared settings section, and a per-widget parallax opt-out

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1029,8 +1029,12 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   override it. Do not make `PluginWidget` blur every plugin unconditionally.
 - **A manifest's option keys and the host's own per-plugin state are one namespace, so `__` is
   reserved.** Both land in `pluginOptions[pluginId][key]` in `plugin-state.json`: the manifest's
-  declared options *and* the host's `blurEnabled`/`positionLocked`/`clickThrough`/`keepTranslucent`
-  seeds, plus `__gridSize` (the span a user resized a grid widget to). A manifest declaring a
+  declared options *and* the host's `blurEnabled`/`positionLocked`/`clickThrough`/
+  `keepTranslucent`/`followParallax` seeds, plus `__gridSize` (the span a user resized a grid
+  widget to) and a `migrations` map beside them for one-shot store migrations. Note the five
+  behaviour seeds are deliberately *unprefixed*: the prefix earns its place on `__gridSize`
+  because that key is not a row a plugin could plausibly declare, while the toggles are, and
+  renaming five live keys would need its own migration for no user-visible gain. A manifest declaring a
   `__`-prefixed key would therefore ship a settings control in Settings > Widgets that writes
   straight over host state. `PluginValidator.js` rejects it - which is the only defence against an
   installed third-party plugin, and silent for a bundled one, since a rejected manifest simply does
@@ -1049,6 +1053,51 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   screen. See `docs/widget-grid.md`. 9c4adcc5f ("feat(plugins): resolve a widget's grid span
   through a testable module"), 494580b65 ("feat(plugins): resolve a placed widget's span from its
   stored choice").
+- **`Array.isArray` is false for an array that has crossed a QML `model`, and the length is
+  still right.** A JS array reaching a delegate through a `Repeater`'s `model` goes into
+  QVariant and comes back as a list wrapper: indices and `length` survive, the `Array.isArray`
+  brand does not. `gridSizes.js` gated a manifest's whole `grid.sizes` list on that check, and
+  `Background.qml` builds *every* desktop widget from such a model — so a manifest declaring
+  three spans reached the host offering one, with no grip, no size row and nothing in the log.
+  The runtime harness passed throughout because it declares its synthetic manifests inline on
+  the harness root, which never crosses a model; it now builds one widget through a `Repeater`
+  as well. When validating data that arrives through a delegate, test for array-*likeness*
+  (`typeof value.length === "number"`), and get one test onto the path that actually ships.
+  109e6d897 ("fix(plugins): a manifest's grid.sizes survives the model boundary").
+- **A widget's settings page shows the plugin's own options first and the host's in a
+  "Widget behaviour" `ContentSubsection` below.** `PluginOptions.qml` used to concatenate its
+  synthesized host rows in *front* of `manifest.options`, so every widget's page opened with
+  four identical switches and the settings the user came for sat below them, reading as if the
+  plugin had declared the switches too. The two groups share one delegate and must not be
+  rejoined into one model (`tests/test_plugin_options_sections.py`). A host row that cannot
+  apply is **omitted, not disabled** — `hasBlurSurface` for a bar-only plugin, and the Size row
+  for a manifest offering a single span; the greying-out in that file is for a row that is
+  *temporarily* inert (`enabledWhen`), which is a different thing.
+  a03f1b266 ("feat(plugins): show a widget's own options above the host's"),
+  008e51dc9 ("feat(plugins): offer a resizable widget's span as a settings row").
+- **A desktop widget opts out of the parallax pan by cancelling it, not by being offset less.**
+  The widget canvas is one item whose `x`/`y` *are* the widget parallax (`Background.qml`), so
+  every widget on it travels because its parent does. `followParallax: false` therefore adds
+  `-canvas.x` to the widget's placement — `ParallaxMath.parallaxCancel`, beside `widgetOffset`
+  so it is testable — and the two summing to zero is what holds the widget still. The half that
+  is not on screen: the drag runs in canvas coordinates while `PluginState` holds *placement*
+  coordinates, and the gap between them is exactly the cancellation, so `commitPosition`
+  subtracts it back out. Storing the drawn coordinate walks an opted-out widget by a whole pan
+  on every drag, silently, because it looks right until the pan next changes. Anything else
+  that reads a widget's `x` and means "where the user put it" has the same subtraction to do.
+  95f851c28 ("feat(plugins): let a widget opt out of the desktop's parallax pan").
+- **A per-plugin key can be a retired manifest option for one widget and a live setting for
+  another, so migrate on what the manifest says, not on the key name.** `sizeMode` was a
+  manifest *option* on weather and currency, which `__gridSize` took over; `world-clock` and
+  `calendar` declare no `grid` and drive a `sizeMode` of their own from their own toggles. A
+  pass keyed on the name emptied those two widgets' options and reset them - the migration's
+  own failure mode aimed at the wrong widgets, found by running it against a seeded
+  `plugin-state.json` rather than by reading it. It now acts only where the manifest offers
+  more than one span. The marker (`migrations.migratedSizeMode`) is subject to AGENT.md's usual
+  warning - it records that the pass *ran*, not that it saw the user's data - so `PluginManager`
+  drives it on a settle timer rather than on the first non-empty manifest list, and the pass
+  returns without marking on an empty one. See `docs/widget-grid.md`.
+  db3a7d009 ("refactor(plugins): retire sizeMode in favour of the host's __gridSize").
 - **What claims a press from a desktop widget's drag-to-move is the nesting, not
   `preventStealing`.** The resize grip is a `MouseArea` inside `PluginWidget`, which *is* a
   `MouseArea` (`AbstractWidget`), and a nested area takes the press - the root only ever sees what

--- a/docs/superpowers/specs/2026-08-10-widget-common-settings-design.md
+++ b/docs/superpowers/specs/2026-08-10-widget-common-settings-design.md
@@ -1,6 +1,6 @@
 # Common per-widget settings — design
 
-**Status:** design, not implemented
+**Status:** landed — see "As it landed" at the end for the three places reality differed
 **Scope:** `modules/common/plugins/` (`PluginOptions`, `PluginWidget`, `PluginState`), the bundled
 weather and currency manifests, `modules/imi/settings/pages/PluginsPage.qml`
 
@@ -132,3 +132,39 @@ with the drag handle, and a parallax opt-out actually holding still while worksp
 
 Step 1 is worth looking at on screen before 2-4 exist, since it changes every widget's settings page
 and nothing else.
+
+---
+
+## As it landed
+
+Three places the implementation had to differ from the design above. Recorded here
+rather than silently, because each one is a thing the next person would otherwise
+re-derive.
+
+1. **A prerequisite bug: `grid.sizes` did not survive the model boundary.** `offeredSizes`
+   gated the list on `Array.isArray`, which is false for an array that has crossed a
+   `Repeater`'s `model` — and `Background.qml` builds every desktop widget from such a
+   model. So a manifest declaring several spans reached the host offering one, and steps
+   3 and 4 were both dead on arrival until it was fixed. The runtime harness had missed
+   it because it declares its manifests inline on the harness root, a path that never
+   crosses a model.
+
+2. **Weather and currency lost their own resize grips, which the design did not mention.**
+   Retiring `sizeMode` leaves the host's generic grip in the same bottom-right corner
+   their `swap_horiz` chips occupied, so keeping both would stack two controls on one
+   spot — and theirs gated on a legacy `cfg.locked` rather than the host's resolved lock,
+   staying live on a widget the user had pinned. Their `sizeModeRequested` signal and
+   `getModeForWidth` helper went with them.
+
+3. **The migration is scoped by the manifest, not by the key name.** §2 describes reading
+   "a stored `sizeMode`", which is not enough: `world-clock` and `calendar` declare no
+   `grid` and drive a `sizeMode` of their own from their own toggles, so for them the key
+   is a live setting. A pass keyed on the name emptied their options and reset both
+   widgets. It now acts only where the manifest offers more than one span. The
+   `migratedSizeMode` marker is kept as designed, but is belt-and-braces rather than the
+   load-bearing part — deleting the old key is what makes the pass one-shot — and it is
+   fired on a settle timer, because a marker records that a pass ran, not that it saw the
+   user's data, and manifests load one `FileView` at a time.
+
+The settings-search note in §5 did not apply: this branch's tree has no `searchTerms` in
+`SettingsContent.qml` and no `tests/test_settings_search_index.py`.

--- a/docs/superpowers/specs/2026-08-10-widget-common-settings-design.md
+++ b/docs/superpowers/specs/2026-08-10-widget-common-settings-design.md
@@ -1,0 +1,134 @@
+# Common per-widget settings — design
+
+**Status:** design, not implemented
+**Scope:** `modules/common/plugins/` (`PluginOptions`, `PluginWidget`, `PluginState`), the bundled
+weather and currency manifests, `modules/imi/settings/pages/PluginsPage.qml`
+
+Paths are relative to `dots/.config/quickshell/imi/` unless written repo-relative.
+
+## Problem
+
+Every desktop widget's settings page opens with the same four rows — **Blur background**, **Lock
+position**, **Click through**, **Stay translucent** — synthesized by `PluginOptions.qml` and
+concatenated in front of whatever the plugin itself declares. They are host behaviours, not plugin
+settings; the manifest only seeds their defaults.
+
+Two more are arriving: a **size** and a **follow parallax** opt-out. Six identical rows in front of
+every widget's own two or three options is the bloat this design exists to remove.
+
+There is also a duplicate. Size already exists twice:
+
+- `sizeMode` — a plugin-declared `choice` option on `nandoroid-weather` and `nandoroid-currency`,
+  stored at `PluginState.option(id, "sizeMode")`, values `"3x1"`, `"2x1"`, `"2x2"`, `"1x3"`. The
+  widget reads it and picks a layout.
+- `__gridSize` — host-owned, declared through `manifest.grid.sizes`, driven by the resize handle,
+  same `"<cols>x<rows>"` string format.
+
+Two mechanisms, one concept, one format. They must become one before a third widget picks a side.
+
+## Settled input
+
+- Not every widget is resizable. A widget is resizable **only** when it has a design per size —
+  currency and weather do, most do not. Offering a size where there is no layout for it is worse
+  than offering nothing.
+- Presets capture widget sizes, as they already capture positions. Intended.
+
+---
+
+## 1. Two kinds of setting, shown as two kinds
+
+`PluginOptions` stops concatenating. It renders:
+
+1. **The widget's own options** — `manifest.options`, first, because that is what the user opened
+   the page for.
+2. **A shared section beneath them**, titled "Widget behaviour", holding every host row. It is a
+   `ContentSubsection`, so it reads as a group rather than as more of the widget's settings — and,
+   per the settings-search contract, its title goes in `searchTerms:`.
+
+Nothing is hidden and no row moves between widgets: the same rows appear for every widget, which is
+the point. What changes is that they stop being mistaken for the widget's own settings, and stop
+pushing the widget's actual options below the fold.
+
+Rows that cannot apply are omitted rather than disabled — `hasBlurSurface` already does this for
+bar-only plugins, and **Size** follows the same rule: absent unless the manifest offers more than
+one span. A disabled control that can never enable is noise; the existing greying-out is for rows
+that are *temporarily* inert (transparency off), which is a different thing.
+
+## 2. Size, unified
+
+`__gridSize` wins, because it is host-owned and the resize handle needs it. `sizeMode` is retired.
+
+- `nandoroid-weather` and `nandoroid-currency` drop their `sizeMode` option from `manifest.options`
+  and declare `grid.sizes` instead, listing the spans they actually have layouts for.
+- Their `Widget.qml` reads the resolved span from the host rather than `PluginState.option(id,
+  "sizeMode")`. The widget still chooses its own layout from the span — the host owns *which size*,
+  the widget owns *what that size looks like*.
+- **Migration.** A stored `sizeMode` is read once, mapped to `__gridSize` if it names an offered
+  span, and the old key deleted. Without this, upgrading resets both widgets to their default size,
+  which is a visible change to a setting the user chose. The migration is keyed by a
+  `migratedSizeMode` flag in the same store, matching how `Config.qml` guards its one-shot
+  migrations — a stored value beats a default, so a migration that runs twice is not idempotent by
+  accident.
+
+The **Size** row in the shared section and the drag handle are two faces of one value. The row is
+what makes it discoverable and keyboard-reachable; the handle is what makes it quick.
+
+## 3. Follow parallax
+
+New host row, `followParallax`, default **true**, seeded by `manifest.desktopWidget.followParallax`.
+
+When false, the widget is excluded from the canvas's parallax translation and stays where it was put
+relative to the screen.
+
+**This is not a position offset.** The canvas is one item and its `x`/`y` carry the pan, so a widget
+opting out must cancel it — `x: -canvas.widgetParallax.x` relative to its own placement, which means
+`PluginWidget` needs the canvas's current offset. `AbstractWidget` already finds its canvas
+(`findCanvas`), so the value is reachable; the arithmetic belongs in `ParallaxMath` beside
+`widgetOffsets` so it is testable.
+
+Note what this does *not* fix: the reachable-area question in
+[#154](https://github.com/XephyLon/immaterial-impulse/issues/154). A widget that opts out still has
+its drag clamped to the canvas, so it still cannot be dropped in the strip the pan has moved off
+screen. Opting out changes where a widget *stays*, not where it may be *placed*. #154's remaining
+half — clamping against the screen rather than the canvas — is what fixes placement, and it is
+independent of this.
+
+## 4. Where the state lives
+
+All host rows are `pluginOptions` entries, like the four that exist today. Two consequences worth
+stating rather than discovering:
+
+- **Presets capture them.** Confirmed intended. A preset therefore carries sizes, parallax opt-outs
+  and blur choices, and "Keep settings across presets" is the existing escape hatch.
+- **The `__` prefix is reserved** for host state and rejected by `lint_plugin_option_keys.py`, so a
+  plugin cannot collide with `__gridSize`. `followParallax` and the four existing rows do **not**
+  carry the prefix, which is an inconsistency worth resolving one way or the other. Recommendation:
+  leave them unprefixed. The prefix earns its place on `__gridSize` because that key is *not* a row
+  a plugin could plausibly declare; the behaviour toggles are. Renaming four live keys would need
+  its own migration for no user-visible gain.
+
+## 5. Testing
+
+Testable, and extracted for it:
+
+- The `sizeMode` → `__gridSize` migration: mapping, the not-an-offered-span case, the run-twice case.
+  Pure, driven from a QML `TestCase`.
+- The parallax cancellation arithmetic, in `ParallaxMath` beside `widgetOffsets`.
+- A static check that `PluginOptions` renders the plugin's own options and the shared section as
+  separate groups, so a future edit cannot quietly concatenate them again.
+- The settings-search index test already added covers the new subsection title automatically.
+
+Not testable, needs the screen: the shared section's appearance and ordering, the Size row agreeing
+with the drag handle, and a parallax opt-out actually holding still while workspaces change.
+
+## 6. Landing plan
+
+1. `PluginOptions` splits into the widget's own options and a shared "Widget behaviour" section. No
+   new rows — reviewable as a pure presentation change against the four that exist.
+2. `followParallax` row + the cancellation in `PluginWidget`, with its `ParallaxMath` helper.
+3. Size row, shown only when the manifest offers more than one span.
+4. `sizeMode` migration + weather and currency moved onto `grid.sizes`.
+5. `docs/widget-grid.md` and AGENT.md.
+
+Step 1 is worth looking at on screen before 2-4 exist, since it changes every widget's settings page
+and nothing else.

--- a/docs/widget-grid.md
+++ b/docs/widget-grid.md
@@ -105,6 +105,27 @@ hover: dragging it previews the nearest offered span live, releasing stores it, 
 Escape cancels back to the span the drag started from. None of that is the plugin's
 code — a manifest opts in by declaring `sizes` and writes no QML for it.
 
+It also draws a **Size row** in Settings > Widgets, under "Widget behaviour". The row
+and the grip are two faces of one value, not two settings: both read and write
+`__gridSize`, and the row's chips are spelled by `gridSizes.formatSize` so there is one
+string format rather than two. The grip is what makes a resize quick; the row is what
+makes it discoverable and reachable from the keyboard. The row is **omitted** — not
+shown disabled — for a manifest naming a single span.
+
+**Only declare `sizes` for a widget that has a design per size.** Most widgets have one
+layout, and the host swaps the pixel size and nothing else: offering a span a widget has
+no layout for is worse than offering no choice at all. `nandoroid-weather` (1x1 / 2x1 /
+3x1) and `nandoroid-currency` (1x1 / 2x1) qualify because each span is a different
+layout inside the widget; nothing else bundled does.
+
+Such a widget reads the resolved span back from the host as `hostGridSize`
+(`"<cols>x<rows>"`, declared as a `property string` on its `Widget.qml` root and bound
+by `PluginNode`), and switches its layout on it. **The host owns which size a widget is;
+the widget owns what that size looks like.** It tracks the grip's live preview, so a
+drag reshapes the content as it goes rather than on release. A widget must not persist a
+size of its own alongside this — that is what `sizeMode` was, and it is retired
+(db3a7d009 ("refactor(plugins): retire sizeMode in favour of the host's __gridSize")).
+
 The rules, all of them refusals to guess (`modules/common/plugins/gridSizes.js`,
 covered by `tests/tst_grid_sizes.qml`):
 
@@ -129,6 +150,17 @@ covered by `tests/tst_grid_sizes.qml`):
   does, so a pinned widget, a click-through one, and the global "Lock widget
   positions" each disarm it — the same resolved `interactionLocked` the bundled
   widgets' own grips read.
+- **`Array.isArray(manifest.grid.sizes)` is not the test, and assuming it was made
+  this whole feature inert.** A JS array reaching a delegate through a `Repeater`'s
+  `model` has crossed into QVariant and back: its indices and `length` survive,
+  `Array.isArray` does not. `Background.qml` builds every desktop widget from exactly
+  such a model, so a manifest declaring three spans arrived at the host offering one —
+  no grip, no row, no error. `gridSizes.asSizeList` accepts anything array-*like* (and
+  still rejects a number, a string or a plain object, so a malformed `sizes` cannot be
+  read as an empty list of spans). The reason nobody saw it: the runtime harness
+  declared its synthetic manifests inline on the harness root, a path that never
+  crosses a model, so it now also builds one widget through a `Repeater`.
+  109e6d897 ("fix(plugins): a manifest's grid.sizes survives the model boundary").
 
 Growing past the screen edge needs no new rule: committing a span writes plugin state,
 which re-evaluates the widget's persisted position, so the existing clamp
@@ -169,10 +201,12 @@ The only test is `size === widgetGridSpanX(cols)` / `widgetGridSpanY(rows)`.
   broken at the smallest. Switch on the resolved span if the content needs to differ,
   rather than scaling one layout down.
 - **The `nandoroid-*` widgets already conform.** They define this grid (media = 3x2,
-  system monitor = 3x1 / 1x3, currency = 1x1 / 2x1 via their internal `sizeMode`). They are
-  content-sized rather than declaring `grid`, but their pixel sizes are exactly on it, so new
-  `grid` widgets tile flush beside them. `clock` is exempt by decision: its shape places neatly
-  without a span, so it stays content-sized behind `defaultWidth`/`defaultHeight`.
+  system monitor = 3x1 / 1x3). Media and the system monitor are content-sized rather than
+  declaring `grid`, but their pixel sizes are exactly on it, so new `grid` widgets tile
+  flush beside them; weather (1x1 / 2x1 / 3x1) and currency (1x1 / 2x1) declare
+  `grid.sizes` and take their size from the host. `clock` is exempt by decision: its shape
+  places neatly without a span, so it stays content-sized behind
+  `defaultWidth`/`defaultHeight`.
 
 ## Widgets that cannot use the grid
 
@@ -210,6 +244,22 @@ literal, and `tests/test_widget_grid_lattice.py` enforces exactly that, with the
 named in one place. A manifest's `defaultWidth`/`defaultHeight` floor is a size too: make it
 the smallest span the widget can actually take, or the floor pins the widget off-grid no
 matter what the QML says.
+
+**A widget-owned `sizeMode` is not the same thing as the retired manifest option, and a
+migration keyed on the name alone destroys it.** `world-clock` and `calendar` declare no
+`grid` and drive a `sizeMode` of their own from their own toggles, so for them the key is
+a live setting; weather and currency declared one as a manifest *option*, which is what
+`__gridSize` took over. The `sizeMode` → `__gridSize` migration therefore acts only where
+the manifest offers more than one span — measured against a real shell, a pass keyed on
+the key name emptied world-clock's and calendar's options and reset both widgets, which is
+the migration's own failure mode aimed at the wrong widgets. The migration maps the stored
+value onto `__gridSize` (dropping a mode the manifest does not offer, exactly as
+`resolveSize` refuses a stored span no longer on offer), deletes the old key so it is
+idempotent on its own, and is marked done under `migrations.migratedSizeMode` in
+`plugin-state.json`. It is driven by `PluginManager` on a settle timer rather than fired
+on the first non-empty manifest list, because a marker records that a pass *ran*, not
+that it saw anything, and manifests load one FileView at a time.
+db3a7d009 ("refactor(plugins): retire sizeMode in favour of the host's __gridSize").
 
 **Name a size mode after the shape it really is.** `world-clock`'s wide mode was called `"4x1"`
 while being 420px — which is `spanX(3)`, three columns — and `calendar`'s was `"1x2"` while

--- a/dots/.config/quickshell/imi/WidgetParallaxOptOutRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/WidgetParallaxOptOutRuntimeTest.qml
@@ -1,0 +1,246 @@
+import QtQuick
+import QtTest
+import Quickshell
+import qs.modules.common
+import qs.modules.common.plugins
+import qs.modules.common.widgets.widgetCanvas
+
+/**
+ * Drives the `followParallax` opt-out on real `PluginWidget`s.
+ *
+ * The desktop's widget parallax is the canvas's own `x`/`y` (Background.qml),
+ * so every widget on it travels whether or not it wants to. Opting out is a
+ * cancellation rather than a smaller offset, and the arithmetic is unit-tested
+ * in `tst_parallax.qml` - what needs a real host is the pair of consequences
+ * that arithmetic has for a widget's *stored* position:
+ *
+ *   - the widget must hold its place on screen (canvas.x + widget.x) while the
+ *     canvas pans, which nothing but a live tree can show;
+ *   - dragging it while the canvas is panned must store where it was PLACED,
+ *     not where it was drawn. Storing the drawn coordinate folds the pan into
+ *     the saved position, so the widget walks by a whole pan every time it is
+ *     moved - and it walks silently, because it looks right until the pan
+ *     changes.
+ *
+ * The following widget is the control throughout: three "it did not move"
+ * checks prove nothing if the harness stopped delivering events.
+ *
+ * Position Behaviors are switched off (`animateXPos`/`animateYPos`) so a score
+ * reads a settled coordinate rather than a frame of an animation. The
+ * cancellation is a binding, not a transition - the animation is the same one
+ * every widget already has.
+ *
+ * Run it against a throwaway config:
+ *   XDG_CONFIG_HOME=$(mktemp -d) XDG_STATE_HOME=$(mktemp -d) qs -p WidgetParallaxOptOutRuntimeTest.qml
+ */
+ShellRoot {
+    id: harness
+
+    property int failures: 0
+    readonly property string testScreen: "PARALLAX-TEST"
+
+    function check(label, ok) {
+        console.log(`[WidgetParallax] ${label}: ${ok ? "ok" : "FAIL"}`);
+        if (!ok)
+            harness.failures++;
+    }
+
+    // Synthetic manifests, because the opt-out is the host's regardless of what
+    // is loaded into it. An `Item` node draws nothing and takes no input, so
+    // every event the harness sends is answered by the host or by nothing; the
+    // `grid` gives each probe a body big enough to press.
+    function manifestFor(id, follows) {
+        return {
+            id: id,
+            name: id,
+            grid: { cols: 2, rows: 1 },
+            desktopWidget: follows ? { type: "Item" }
+                                   : { type: "Item", followParallax: false }
+        };
+    }
+
+    readonly property var followManifest: harness.manifestFor("follow-probe", true)
+    readonly property var holdManifest: harness.manifestFor("hold-probe", false)
+
+    FloatingWindow {
+        visible: true
+        implicitWidth: 1200
+        implicitHeight: 700
+        color: "black"
+
+        TestCase {
+            id: driver
+            when: false
+            name: "WidgetParallaxDriver"
+        }
+
+        WidgetCanvas {
+            id: canvas
+            width: 1200
+            height: 700
+
+            PluginWidget {
+                id: followWidget
+                manifest: harness.followManifest
+                screenName: harness.testScreen
+                screenWidth: 1200
+                screenHeight: 700
+                scaledScreenWidth: 1200
+                scaledScreenHeight: 700
+                wallpaperScale: 1
+                animateXPos: false
+                animateYPos: false
+            }
+
+            PluginWidget {
+                id: holdWidget
+                manifest: harness.holdManifest
+                screenName: harness.testScreen
+                screenWidth: 1200
+                screenHeight: 700
+                scaledScreenWidth: 1200
+                scaledScreenHeight: 700
+                wallpaperScale: 1
+                animateXPos: false
+                animateYPos: false
+            }
+        }
+    }
+
+    function placeWidgets() {
+        PluginState.setPosition("follow-probe", harness.testScreen,
+                                { x: 120, y: 120, placementStrategy: "free" });
+        PluginState.setPosition("hold-probe", harness.testScreen,
+                                { x: 600, y: 360, placementStrategy: "free" });
+    }
+
+    // What the user sees: the canvas carries the pan, so a widget's place on
+    // screen is the sum. This is the only coordinate the opt-out promises
+    // anything about.
+    function screenX(widget) { return Math.round(canvas.x + widget.x); }
+    function screenY(widget) { return Math.round(canvas.y + widget.y); }
+
+    function pan(dx, dy) {
+        canvas.x = dx;
+        canvas.y = dy;
+    }
+
+    function storedX(id) { return Math.round(PluginState.position(id, harness.testScreen).x); }
+    function storedY(id) { return Math.round(PluginState.position(id, harness.testScreen).y); }
+
+    // Snapped to the shared 12px lattice by AbstractWidget, so every gesture
+    // here is a whole number of steps and the expected result is exact.
+    function dragWidget(widget, dx, dy) {
+        const x = widget.x + widget.width / 2;
+        const y = widget.y + widget.height / 2;
+        driver.mouseMove(canvas, x, y);
+        driver.mousePress(canvas, x, y, Qt.LeftButton);
+        driver.mouseMove(canvas, x + dx / 2, y + dy / 2, 20, Qt.LeftButton);
+        driver.mouseMove(canvas, x + dx, y + dy, 20, Qt.LeftButton);
+        driver.mouseRelease(canvas, x + dx, y + dy, Qt.LeftButton);
+    }
+
+    readonly property var steps: [
+        () => {
+            harness.check("unpanned: the follower is where it was placed",
+                          harness.screenX(followWidget) === 120 && harness.screenY(followWidget) === 120);
+            harness.check("unpanned: the opted-out widget is where it was placed",
+                          harness.screenX(holdWidget) === 600 && harness.screenY(holdWidget) === 360);
+            harness.check("unpanned: nothing is cancelling anything",
+                          Math.round(holdWidget.x) === 600 && Math.round(holdWidget.y) === 360);
+        },
+
+        () => harness.pan(-180, -60),
+        () => {
+            // The control. Without this, "the other one held still" is also
+            // what a canvas that never moved would report.
+            harness.check("panned: the follower travels with the canvas",
+                          harness.screenX(followWidget) === -60 && harness.screenY(followWidget) === 60);
+            harness.check("panned: the opted-out widget holds its screen place",
+                          harness.screenX(holdWidget) === 600 && harness.screenY(holdWidget) === 360);
+            harness.check("panned: it holds it by cancelling, not by not moving",
+                          Math.round(holdWidget.x) === 780 && Math.round(holdWidget.y) === 420);
+        },
+
+        // Dragged while the canvas is panned: the drag is in canvas
+        // coordinates and the store is in placement coordinates, and the gap
+        // between them is exactly the cancellation.
+        () => harness.dragWidget(holdWidget, 48, 24),
+        () => {
+            harness.check("dragged while panned: stores the placement, not the drawn position",
+                          harness.storedX("hold-probe") === 648
+                          && harness.storedY("hold-probe") === 384);
+            harness.check("dragged while panned: lands where the pointer left it",
+                          harness.screenX(holdWidget) === 648 && harness.screenY(holdWidget) === 384);
+        },
+
+        // The drift check, and the reason commitPosition subtracts: a widget
+        // that stored its drawn coordinate would now be one pan further along,
+        // every time.
+        () => harness.dragWidget(holdWidget, 48, 24),
+        () => {
+            harness.check("dragged twice: each drag moves it by the drag alone",
+                          harness.storedX("hold-probe") === 696
+                          && harness.storedY("hold-probe") === 408);
+        },
+
+        () => harness.pan(0, 0),
+        () => {
+            harness.check("pan released: the follower comes back",
+                          harness.screenX(followWidget) === 120 && harness.screenY(followWidget) === 120);
+            harness.check("pan released: the opted-out widget has not moved at all",
+                          harness.screenX(holdWidget) === 696 && harness.screenY(holdWidget) === 408);
+        },
+
+        // Turning it back on from the settings row: the widget rejoins the pan
+        // from where it is, without its stored position changing.
+        () => { PluginState.setOption("hold-probe", "followParallax", true); },
+        () => harness.pan(-180, -60),
+        () => {
+            harness.check("opt-in again: it travels with the canvas",
+                          harness.screenX(holdWidget) === 516 && harness.screenY(holdWidget) === 348);
+            harness.check("opt-in again: its stored position is untouched",
+                          harness.storedX("hold-probe") === 696
+                          && harness.storedY("hold-probe") === 408);
+        }
+    ]
+
+    property int stepIndex: 0
+
+    // PluginState's FileView load lands asynchronously and replaces the whole
+    // in-memory state, so anything written before it arrives is discarded.
+    Timer {
+        id: setup
+        interval: 250
+        repeat: true
+        running: true
+        onTriggered: {
+            if (!PluginState.ready || !Config.ready)
+                return;
+            Config.options.background.widgetsLocked = false;
+            if (Math.round(followWidget.x) === 120 && Math.round(holdWidget.x) === 600) {
+                setup.running = false;
+                runner.running = true;
+                return;
+            }
+            harness.placeWidgets();
+        }
+    }
+
+    Timer {
+        id: runner
+        interval: 300
+        repeat: true
+        running: false
+        onTriggered: {
+            if (harness.stepIndex >= harness.steps.length) {
+                runner.running = false;
+                console.log(`[WidgetParallax] failures: ${harness.failures}`);
+                Qt.exit(harness.failures === 0 ? 0 : 1);
+                return;
+            }
+            harness.steps[harness.stepIndex]();
+            harness.stepIndex++;
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/modules/common/functions/parallax.js
+++ b/dots/.config/quickshell/imi/modules/common/functions/parallax.js
@@ -135,3 +135,20 @@ function sampleOrigin(canvasOffset, widgetPos, wallpaperOffset) {
         y: number(canvasOffset.y, 0) + number(widgetPos.y, 0) - number(wallpaperOffset.y, 0)
     };
 }
+
+// What a single widget adds to its own placement to opt OUT of the pan.
+//
+// This is not the same kind of quantity as widgetOffset above, and the
+// difference is the whole reason it needs a function: the widget canvas is one
+// item whose x/y ARE the pan, so a widget cannot decline to travel by being
+// given a smaller offset - it is already moving because its parent is. It has
+// to cancel the canvas's offset instead, and the two summing to zero is what
+// leaves it at the same place on screen while its neighbours slide.
+//
+// Following is the default, so anything other than an explicit `false` follows:
+// a widget whose flag has not loaded yet must move with the rest rather than
+// pinning itself against a canvas offset it has not seen.
+function parallaxCancel(canvasOffset, follows) {
+    if (follows === false) return -number(canvasOffset, 0);
+    return 0;
+}

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginManager.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginManager.qml
@@ -153,6 +153,27 @@ Singleton {
         }
         root.availablePlugins = loaded.sort((a, b) => a.name.localeCompare(b.name));
         root.manifestsMap = map;
+        sizeModeMigrationTimer.restart();
+    }
+
+    // The `sizeMode` -> `__gridSize` retirement needs the manifests - they are
+    // what say which spans are on offer - which is why it is driven from here
+    // rather than from the store it rewrites. It waits for the manifest loads
+    // to settle: every manifest FileView triggers its own rebuild, so a pass
+    // fired on the first non-empty list would run, and burn its marker, before
+    // the two widgets that stored a `sizeMode` had been read - losing exactly
+    // the size this exists to keep. Long enough to cover the bundled sweep and
+    // the installed scan behind it.
+    Timer {
+        id: sizeModeMigrationTimer
+        interval: 1500
+        repeat: false
+        onTriggered: PluginState.migrateSizeModes(root.availablePlugins)
+    }
+
+    Connections {
+        target: PluginState
+        function onReadyChanged() { sizeModeMigrationTimer.restart() }
     }
 
     function scanInstalledPlugins() {

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginNode.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginNode.qml
@@ -52,6 +52,12 @@ Item {
     property real gridWidth: 0
     property real gridHeight: 0
     readonly property bool hasGrid: gridWidth > 0 && gridHeight > 0
+    // The same span as a "<cols>x<rows>" string, for a widget that has a
+    // different LAYOUT per size rather than one layout that stretches. The host
+    // owns which size; the widget owns what that size looks like. Empty when the
+    // manifest declares no grid. It tracks the resize grip's live preview, so a
+    // drag reshapes the content as it goes instead of on release.
+    property string gridSize: ""
 
     readonly property string effectiveBasePath: manifestNode?._basePath || basePath
     readonly property string componentPath: manifestNode?.component && effectiveBasePath
@@ -153,6 +159,8 @@ Item {
                     item.wallpaperSafetyTriggered = Qt.binding(() => rootNode.hostWallpaperSafetyTriggered);
                 if (item.hostInteractionLocked !== undefined)
                     item.hostInteractionLocked = Qt.binding(() => rootNode.hostInteractionLocked);
+                if (item.hostGridSize !== undefined)
+                    item.hostGridSize = Qt.binding(() => rootNode.gridSize);
                 return;
             }
             if (manifestNode.props) {

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginOptions.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginOptions.qml
@@ -60,6 +60,15 @@ ColumnLayout {
         label: "Stay translucent",
         icon: "opacity",
         default: manifest.desktopWidget?.keepTranslucent === true
+    }, {
+        // The odd one out among the seeds: travelling with the desktop's
+        // parallax pan is the default, so the manifest field can only turn it
+        // OFF and the seed reads `!== false` rather than `=== true`.
+        key: "followParallax",
+        type: "boolean",
+        label: "Follow parallax",
+        icon: "panorama_horizontal",
+        default: manifest.desktopWidget?.followParallax !== false
     }] : []
 
     Repeater {

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginOptions.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginOptions.qml
@@ -12,6 +12,13 @@ ColumnLayout {
     required property var manifest
     spacing: Appearance.spacing.space25
 
+    // The widget's own options come first, because they are what the user
+    // opened this page for. The host's rows used to be concatenated in FRONT of
+    // them - four identical switches before a widget's two or three real
+    // settings, pushing them below the fold and reading as if the plugin had
+    // declared them. They live in their own section below instead.
+    readonly property var widgetOptions: manifest.options || []
+
     // Host blur is a desktop-widget mechanism (PluginWidget frost); bar/
     // overlay-only plugins were getting a dead "Blur background" toggle.
     readonly property bool hasBlurSurface: manifest.desktopWidget !== undefined
@@ -20,7 +27,12 @@ ColumnLayout {
     // blur row instead of being declared in a manifest `options` array. Their
     // manifest fields - `desktopWidget.locked` / `desktopWidget.clickThrough` -
     // only seed the default, which is what keeps a shipped default reversible.
-    readonly property var optionRows: (hasBlurSurface ? [{
+    //
+    // A row that cannot apply is omitted, not disabled: a control that can
+    // never be enabled is noise. The greying-out this file does elsewhere is
+    // for a row that is *temporarily* inert (`enabledWhen`), which is a
+    // different thing.
+    readonly property var behaviourRows: hasBlurSurface ? [{
         key: "blurEnabled",
         type: "boolean",
         label: "Blur background",
@@ -48,25 +60,45 @@ ColumnLayout {
         label: "Stay translucent",
         icon: "opacity",
         default: manifest.desktopWidget?.keepTranslucent === true
-    }] : []).concat(manifest.options || [])
+    }] : []
 
-    // Not a pluginOption on purpose: preset application replaces those, and
-    // this flag decides whether they get replaced (see presets.sh --apply).
-    ConfigSwitch {
-        Layout.fillWidth: true
-        leftPadding: 0
-        rightPadding: 0
-        buttonIcon: "push_pin"
-        text: Translation.tr("Keep settings across presets")
-        checked: PluginState.presetPersisted(root.manifest.id)
-        onCheckedChanged: {
-            if (checked !== PluginState.presetPersisted(root.manifest.id))
-                PluginState.setPresetPersist(root.manifest.id, checked);
+    Repeater {
+        model: root.widgetOptions
+        delegate: optionRow
+    }
+
+    // Every host row reads as one group rather than as more of the widget's own
+    // settings. The same rows appear for every widget - that is the point, and
+    // it is exactly why they should not sit among the plugin's.
+    ContentSubsection {
+        title: Translation.tr("Widget behaviour")
+
+        // Not a pluginOption on purpose: preset application replaces those, and
+        // this flag decides whether they get replaced (see presets.sh --apply).
+        ConfigSwitch {
+            id: presetPersistSwitch
+            Layout.fillWidth: true
+            leftPadding: 0
+            rightPadding: 0
+            buttonIcon: "push_pin"
+            text: Translation.tr("Keep settings across presets")
+            checked: PluginState.presetPersisted(root.manifest.id)
+            onCheckedChanged: {
+                if (checked !== PluginState.presetPersisted(root.manifest.id))
+                    PluginState.setPresetPersist(root.manifest.id, checked);
+            }
+        }
+
+        Repeater {
+            model: root.behaviourRows
+            delegate: optionRow
         }
     }
 
-    Repeater {
-        model: root.optionRows
+    // One delegate for both groups: they differ in where they come from and
+    // where they are drawn, never in how a row of a given type behaves.
+    Component {
+        id: optionRow
 
         Loader {
             id: optionLoader

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginOptions.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginOptions.qml
@@ -5,6 +5,7 @@ import qs.services
 import QtQuick.Layouts
 import qs.modules.common
 import qs.modules.common.widgets
+import "gridSizes.js" as GridSizes
 
 ColumnLayout {
     id: root
@@ -71,6 +72,26 @@ ColumnLayout {
         default: manifest.desktopWidget?.followParallax !== false
     }] : []
 
+    // The size row and the drag grip are two faces of one value: both read and
+    // write the host's `__gridSize`. The grip is what makes a resize quick; the
+    // row is what makes it discoverable and reachable from the keyboard.
+    //
+    // Not every widget is resizable, and offering a size where the widget has
+    // no layout for it is worse than offering nothing - so this is omitted
+    // rather than disabled unless the manifest names more than one span.
+    readonly property var offeredSizes: GridSizes.offeredSizes(manifest.grid)
+    readonly property var sizeRows: root.offeredSizes.length > 1 ? [{
+        key: "__gridSize",
+        type: "choice",
+        label: "Size",
+        icon: "aspect_ratio",
+        default: GridSizes.formatSize(GridSizes.defaultSize(manifest.grid)),
+        choices: root.offeredSizes.map(size => ({
+            displayName: `${size.cols} × ${size.rows}`,
+            value: GridSizes.formatSize(size)
+        }))
+    }] : []
+
     Repeater {
         model: root.widgetOptions
         delegate: optionRow
@@ -96,6 +117,11 @@ ColumnLayout {
                 if (checked !== PluginState.presetPersisted(root.manifest.id))
                     PluginState.setPresetPersist(root.manifest.id, checked);
             }
+        }
+
+        Repeater {
+            model: root.sizeRows
+            delegate: optionRow
         }
 
         Repeater {

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginState.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginState.qml
@@ -5,6 +5,7 @@ import QtQuick
 import Quickshell
 import Quickshell.Io
 import qs.modules.common
+import "gridSizes.js" as GridSizes
 
 Singleton {
     id: root
@@ -21,7 +22,11 @@ Singleton {
             pluginOptions: {},
             // Plugin ids whose options/positions/enabled state survive preset
             // application (never captured INTO presets - see presets.sh).
-            presetPersist: {}
+            presetPersist: {},
+            // One-shot store migrations that have already run, by name. Same
+            // shape as Config's `migrated*` flags, kept here because this is
+            // the file being migrated.
+            migrations: {}
         };
     }
 
@@ -103,6 +108,63 @@ Singleton {
             baseOpacity === undefined ? Config.options.plugins.blurOpacity : baseOpacity,
             Config.options.appearance.transparency.enable,
             root.option(pluginId, "keepTranslucent", keepTranslucentDefault === true));
+    }
+
+    readonly property string sizeModeMarker: "migratedSizeMode"
+
+    function migrationRan(name) {
+        return root.state?.migrations?.[name] === true;
+    }
+
+    // Retires the plugin-declared `sizeMode` option in favour of the host's
+    // `__gridSize`: same concept, same "<cols>x<rows>" format, two mechanisms.
+    // Without this, upgrading resets the two widgets that declared it to their
+    // default size - a visible change to a setting the user chose, with
+    // nothing reporting why.
+    //
+    // Driven by PluginManager rather than run from here, because the manifests
+    // are what say which spans are on offer, and they load asynchronously. The
+    // marker is the trap AGENT.md names: it records that the pass *ran*, not
+    // that it saw the user's data, so burning it against a half-loaded
+    // manifest list would lose exactly the size this exists to keep. Hence
+    // both guards - the empty list returns without marking, and the caller
+    // waits for the manifest loads to settle before calling at all.
+    //
+    // The per-plugin work itself deletes the old key (gridSizes.migrateSizeMode),
+    // so the pass is idempotent on its own and the marker only saves the walk.
+    //
+    // Split in two so the substance can be driven from a TestCase: the whole
+    // point of the pass is which options come out the other side, and a
+    // function that reads and writes the live singleton can only be tested by
+    // mutating it.
+    function stateWithSizeModesMigrated(state, manifests) {
+        const nextOptions = Object.assign({}, state?.pluginOptions || {});
+        for (const manifest of manifests) {
+            if (!manifest || !manifest.id) continue;
+            const migrated = GridSizes.migrateSizeMode(nextOptions[manifest.id], manifest.grid);
+            if (!migrated) continue;
+            nextOptions[manifest.id] = migrated;
+        }
+
+        const nextMigrations = Object.assign({}, state?.migrations || {});
+        nextMigrations[root.sizeModeMarker] = true;
+
+        const nextState = Object.assign({}, state);
+        nextState.version = root.schemaVersion;
+        nextState.pluginOptions = nextOptions;
+        nextState.migrations = nextMigrations;
+        return nextState;
+    }
+
+    function migrateSizeModes(manifests) {
+        if (!root.ready) return;
+        if (root.migrationRan(root.sizeModeMarker)) return;
+        // Returning without marking is the whole guard: a pass over an empty
+        // manifest list would burn the marker having read nothing.
+        if (!Array.isArray(manifests) || manifests.length === 0) return;
+
+        root.state = root.stateWithSizeModesMigrated(root.state, manifests);
+        writeTimer.restart();
     }
 
     function presetPersisted(pluginId) {
@@ -264,6 +326,11 @@ Singleton {
                     && typeof parsed.presetPersist === "object"
                     && !Array.isArray(parsed.presetPersist)
                     ? parsed.presetPersist
+                    : {},
+                migrations: parsed.migrations
+                    && typeof parsed.migrations === "object"
+                    && !Array.isArray(parsed.migrations)
+                    ? parsed.migrations
                     : {}
             };
         } catch (error) {

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginValidator.js
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginValidator.js
@@ -56,7 +56,8 @@ function validateManifest(manifest) {
     // the matching PluginState option, so a non-boolean would slip through as
     // a truthy default nobody can account for later - reject it here instead.
     if (manifest.desktopWidget) {
-        const desktopFlags = ["blur", "locked", "clickThrough", "keepTranslucent"];
+        const desktopFlags = ["blur", "locked", "clickThrough", "keepTranslucent",
+            "followParallax"];
         for (const flag of desktopFlags) {
             if (manifest.desktopWidget[flag] !== undefined
                     && typeof manifest.desktopWidget[flag] !== "boolean") {

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
@@ -9,6 +9,7 @@ import qs.modules.common.widgets
 import qs.modules.imi.background.widgets
 import "../functions/parallax.js" as ParallaxMath
 import "gridSizes.js" as GridSizes
+import "../functions/parallax.js" as ParallaxMath
 
 AbstractBackgroundWidget {
     id: rootWidget
@@ -91,6 +92,13 @@ AbstractBackgroundWidget {
     readonly property bool keepTranslucent: manifest
         ? PluginState.option(manifest.id, "keepTranslucent", manifest.desktopWidget?.keepTranslucent === true)
         : false
+    // Whether this widget travels with the desktop's parallax pan. Same
+    // manifest-seeds-the-default shape as the four above, but the seed reads
+    // `!== false` rather than `=== true`: following is the default, and a
+    // manifest can only opt out of it.
+    readonly property bool followParallax: manifest
+        ? PluginState.option(manifest.id, "followParallax", manifest.desktopWidget?.followParallax !== false)
+        : true
     // Frost mode is user-selectable: "blur" samples + blurs the wallpaper region
     // behind the widget; "tint" (any non-"blur" value) leaves the widget's own
     // translucent panel to show the sharp wallpaper through it.
@@ -216,20 +224,34 @@ AbstractBackgroundWidget {
 
     // `forceCenter` overrides the persisted position for as long as it is set,
     // without disturbing it - the widget returns to where the user left it the
-    // moment the condition clears. Dragging assigns x/y directly and so breaks
-    // these bindings; AbstractBackgroundWidget calls restoreXYBinding() on
-    // release for exactly this case, so the override has to be restored there
-    // too or a single drag disables centring for the rest of the session.
-    x: rootWidget.forceCenter ? ((scaledScreenWidth - width) / 2) : targetX
-    y: rootWidget.forceCenter ? ((scaledScreenHeight - height) / 2) : targetY
+    // moment the condition clears.
+    readonly property real placedX: rootWidget.forceCenter
+        ? ((scaledScreenWidth - width) / 2) : targetX
+    readonly property real placedY: rootWidget.forceCenter
+        ? ((scaledScreenHeight - height) / 2) : targetY
+
+    // The widget canvas is a sibling of the wallpaper viewport and its x/y ARE
+    // the widget parallax (Background.qml), so every widget on it travels
+    // whether or not it wants to. Opting out is therefore a cancellation, not
+    // a smaller offset - see ParallaxMath.parallaxCancel. Found by walking the
+    // parent chain rather than passed down, the same way AbstractWidget already
+    // reaches its canvas for drag bookkeeping.
+    readonly property Item parallaxCanvas: rootWidget.findCanvas(rootWidget.parent)
+    readonly property real parallaxCancelX: ParallaxMath.parallaxCancel(
+        rootWidget.parallaxCanvas ? rootWidget.parallaxCanvas.x : 0, rootWidget.followParallax)
+    readonly property real parallaxCancelY: ParallaxMath.parallaxCancel(
+        rootWidget.parallaxCanvas ? rootWidget.parallaxCanvas.y : 0, rootWidget.followParallax)
+
+    // Dragging assigns x/y directly and so breaks these bindings;
+    // AbstractBackgroundWidget calls restoreXYBinding() on release for exactly
+    // this case, so the override has to be restored there too or a single drag
+    // disables centring for the rest of the session.
+    x: rootWidget.placedX + rootWidget.parallaxCancelX
+    y: rootWidget.placedY + rootWidget.parallaxCancelY
 
     function restoreXYBinding() {
-        rootWidget.x = Qt.binding(() => rootWidget.forceCenter
-            ? ((rootWidget.scaledScreenWidth - rootWidget.width) / 2)
-            : rootWidget.targetX);
-        rootWidget.y = Qt.binding(() => rootWidget.forceCenter
-            ? ((rootWidget.scaledScreenHeight - rootWidget.height) / 2)
-            : rootWidget.targetY);
+        rootWidget.x = Qt.binding(() => rootWidget.placedX + rootWidget.parallaxCancelX);
+        rootWidget.y = Qt.binding(() => rootWidget.placedY + rootWidget.parallaxCancelY);
     }
 
     // Overrides AbstractBackgroundWidget's release path, which calls this on a
@@ -239,8 +261,13 @@ AbstractBackgroundWidget {
     // after the drag broke the x/y bindings, and setPosition is what makes the
     // move survive a restart.
     function commitPosition() {
-        rootWidget.targetX = rootWidget.x;
-        rootWidget.targetY = rootWidget.y;
+        // The cancellation is subtracted back out: `x` is where the widget is
+        // on the canvas, the persisted position is where it was PLACED. Storing
+        // the drawn coordinate would fold the current pan into the saved
+        // position, so an opted-out widget would walk by one pan's worth every
+        // time it was dragged.
+        rootWidget.targetX = rootWidget.x - rootWidget.parallaxCancelX;
+        rootWidget.targetY = rootWidget.y - rootWidget.parallaxCancelY;
         rootWidget.restoreXYBinding();
         if (!manifest) return;
         PluginState.setPosition(manifest.id, screenName, {

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
@@ -345,6 +345,9 @@ AbstractBackgroundWidget {
         // Widget.qml) to the span size instead of the content's implicit size.
         gridWidth: rootWidget.gridSpanWidth
         gridHeight: rootWidget.gridSpanHeight
+        // ...and hand the span down by name too, for a widget that has a
+        // different layout per size rather than one that stretches.
+        gridSize: GridSizes.formatSize(rootWidget.gridSize)
         anchors.centerIn: parent
     }
 

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-currency/Widget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-currency/Widget.qml
@@ -8,6 +8,12 @@ Item {
     objectName: "nandoroidCurrencyWrapper"
     readonly property var blurRegions: content.blurRegions
     readonly property bool managesBlurTint: content.managesBlurTint
+    // The span the host resolved, handed down by PluginNode: stored choice,
+    // then the manifest default. The host owns which size this widget is; the
+    // widget owns what that size looks like. It used to own both, through a
+    // `sizeMode` choice option of its own - a second mechanism for the concept
+    // `__gridSize` now owns, in the same format.
+    property string hostGridSize: ""
     implicitWidth: content.implicitWidth
     implicitHeight: content.implicitHeight
     width: implicitWidth
@@ -27,11 +33,10 @@ Item {
         objectName: "nandoroidCurrencyContent"
         width: implicitWidth
         height: implicitHeight
-        sizeMode: PluginState.option("nandoroid_currency", "sizeMode", "2x1")
+        sizeMode: root.hostGridSize || "2x1"
         useBlurBackground: PluginState.option("nandoroid_currency", "blurEnabled", false)
         backgroundOpacity: PluginState.effectiveBackgroundOpacity("nandoroid_currency")
         onBaseCurrencyRequested: value => PluginState.setOption("nandoroid_currency", "baseCurrency", value)
         onQuoteCurrencyRequested: (index, value) => PluginState.setOption("nandoroid_currency", `quote${index}`, value)
-        onSizeModeRequested: value => PluginState.setOption("nandoroid_currency", "sizeMode", value)
     }
 }

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-currency/manifest.json
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-currency/manifest.json
@@ -3,10 +3,11 @@
   "author": "na-ive / nandoroid-shell", "license": "AGPL-3.0", "sourceUrl": "https://github.com/na-ive/nandoroid-shell", "upstreamRevision": "4994e2d2a264a015d5a6dac4786c60cfe94e5d8a",
   "startupSafe": true,
   "capabilities": ["desktop-widget"], "permissions": ["network", "settings_read", "settings_write"],
+  "grid": {
+    "cols": 2, "rows": 1,
+    "sizes": [ { "cols": 1, "rows": 1 }, { "cols": 2, "rows": 1 } ]
+  },
   "options": [
-    { "key": "sizeMode", "type": "choice", "label": "Widget size", "icon": "aspect_ratio", "default": "2x1", "choices": [
-      { "displayName": "Compact (1×1)", "value": "1x1" }, { "displayName": "Wide (2×1)", "value": "2x1" }
-    ]},
     { "key": "baseCurrency", "type": "text", "label": "Base currency", "icon": "payments", "default": "USD", "placeholder": "USD", "uppercase": true, "maxLength": 8 },
     { "key": "quote1", "type": "text", "label": "Quote currency 1", "icon": "currency_exchange", "default": "EUR", "placeholder": "EUR", "uppercase": true, "maxLength": 8 },
     { "key": "quote2", "type": "text", "label": "Quote currency 2", "icon": "currency_exchange", "default": "GBP", "placeholder": "GBP", "uppercase": true, "maxLength": 8 },

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-weather/Widget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-weather/Widget.qml
@@ -3,8 +3,15 @@ import qs.modules.common.plugins
 import "../../designsystem/widgets" as Expressive
 
 Item {
+    id: root
     readonly property var blurRegions: content.blurRegions
     readonly property bool managesBlurTint: content.managesBlurTint
+    // The span the host resolved, handed down by PluginNode: stored choice,
+    // then the manifest default. The host owns which size this widget is; the
+    // widget owns what that size looks like. It used to own both, through a
+    // `sizeMode` choice option of its own - a second mechanism for the concept
+    // `__gridSize` now owns, in the same format.
+    property string hostGridSize: ""
     implicitWidth: content.implicitWidth
     implicitHeight: content.implicitHeight
     width: implicitWidth
@@ -13,9 +20,8 @@ Item {
         id: content
         width: implicitWidth
         height: implicitHeight
-        sizeMode: PluginState.option("nandoroid_weather", "sizeMode", "3x1")
+        sizeMode: root.hostGridSize || "3x1"
         useBlurBackground: PluginState.option("nandoroid_weather", "blurEnabled", false)
         backgroundOpacity: PluginState.effectiveBackgroundOpacity("nandoroid_weather")
-        onSizeModeRequested: value => PluginState.setOption("nandoroid_weather", "sizeMode", value)
     }
 }

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-weather/manifest.json
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-weather/manifest.json
@@ -2,10 +2,9 @@
   "id": "nandoroid_weather", "name": "Weather", "description": "Material 3 Expressive current conditions and forecast widget", "version": "1.0.0-port1", "apiVersion": 1,
   "author": "na-ive / nandoroid-shell", "license": "AGPL-3.0", "sourceUrl": "https://github.com/na-ive/nandoroid-shell", "upstreamRevision": "4994e2d2a264a015d5a6dac4786c60cfe94e5d8a",
   "capabilities": ["desktop-widget"], "permissions": ["network", "settings_read"],
-  "options": [
-    { "key": "sizeMode", "type": "choice", "label": "Widget size", "icon": "aspect_ratio", "default": "3x1", "choices": [
-      { "displayName": "Compact (1×1)", "value": "1x1" }, { "displayName": "Medium (2×1)", "value": "2x1" }, { "displayName": "Wide (3×1)", "value": "3x1" }
-    ]}
-  ],
+  "grid": {
+    "cols": 3, "rows": 1,
+    "sizes": [ { "cols": 1, "rows": 1 }, { "cols": 2, "rows": 1 }, { "cols": 3, "rows": 1 } ]
+  },
   "desktopWidget": { "component": "Widget.qml", "blur": false }
 }

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopCurrencyWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopCurrencyWidget.qml
@@ -14,7 +14,6 @@ Item {
     
     property var cfg: Config.ready ? Config.options.appearance.currencyWidget : null
     property string sizeMode: cfg ? cfg.sizeMode : "2x1"
-    property bool interactive: true
     property bool useBlurBackground: false
     // The host wrapper overrides this with its own plugin id; the fallback keeps
     // the toggle honoured for a component instantiated without one.
@@ -26,7 +25,6 @@ Item {
     }]
     signal baseCurrencyRequested(string value)
     signal quoteCurrencyRequested(int index, string value)
-    signal sizeModeRequested(string value)
 
     HoverHandler {
         id: widgetHoverHandler
@@ -52,11 +50,7 @@ Item {
         }
     }
 
-    function getModeForWidth(targetWidth) {
-        let mid = (width1x1 + width2x1) / 2;
-        if (targetWidth < mid) return "1x1";
-        return "2x1";
-    }
+
 
     property bool showingSettings: false
     
@@ -546,62 +540,6 @@ Item {
                             if (text.trim() !== "") root.quoteCurrencyRequested(4, text.toUpperCase().trim())
                         }
                     }
-                }
-            }
-        }
-    }
-
-    // Resize Handle (supports dragging between 1x1 and 2x1)
-    Rectangle {
-        id: resizeHandle
-        anchors.right: parent.right
-        anchors.bottom: parent.bottom
-        anchors.margins: 6 * Appearance.effectiveScale
-        width: 28 * Appearance.effectiveScale
-        height: 28 * Appearance.effectiveScale
-        radius: 10 * Appearance.effectiveScale
-        color: Appearance.m3colors.darkmode ? Appearance.colors.colOnTertiaryContainer : Appearance.colors.colSecondaryContainer
-        z: 100
-
-        opacity: root.interactive && (cfg && !cfg.locked) && (widgetHoverHandler.hovered || resizeArea.containsMouse || resizeArea.pressed) ? 0.9 : 0
-        visible: opacity > 0
-
-        Behavior on opacity {
-            NumberAnimation { duration: 150 }
-        }
-
-        MaterialSymbol {
-            anchors.centerIn: parent
-            text: "swap_horiz"
-            iconSize: 15 * Appearance.effectiveScale
-            color: Appearance.m3colors.darkmode ? Appearance.colors.colTertiaryContainer : Appearance.colors.colOnSecondaryContainer
-        }
-
-        MouseArea {
-            id: resizeArea
-            anchors.fill: parent
-            hoverEnabled: true
-            cursorShape: Qt.SizeHorCursor
-            preventStealing: true
-
-            property real startWidth: 0
-            property real startGlobalX: 0
-
-            onPressed: (mouse) => {
-                startWidth = root.width;
-                let p = mapToItem(null, mouse.x, mouse.y);
-                startGlobalX = p.x;
-            }
-
-            onPositionChanged: (mouse) => {
-                if (!pressed) return;
-                let p = mapToItem(null, mouse.x, mouse.y);
-                let deltaX = p.x - startGlobalX;
-                let targetWidth = startWidth + deltaX;
-                
-                let targetMode = root.getModeForWidth(targetWidth);
-                if (targetMode !== root.sizeMode) {
-                    root.sizeModeRequested(targetMode)
                 }
             }
         }

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopWeatherWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopWeatherWidget.qml
@@ -13,21 +13,15 @@ Item {
     // Config configuration linkage
     property var cfg: Config.ready ? Config.options.appearance.weatherWidget : null
     property string sizeMode: cfg ? cfg.sizeMode : "3x1"
-    property bool interactive: true
     property bool useBlurBackground: false
     // The host wrapper overrides this with its own plugin id; the fallback keeps
     // the toggle honoured for a component instantiated without one.
 
     property real backgroundOpacity: PluginState.effectiveBackgroundOpacity("", 0.1)
-    signal sizeModeRequested(string value)
     readonly property bool managesBlurTint: true
     readonly property var blurRegions: [{
         x: card.x, y: card.y, width: card.width, height: card.height, radius: card.radius
     }]
-    
-    HoverHandler {
-        id: widgetHoverHandler
-    }
     
     // Choice A Grid System Specs
     readonly property real baseWidth: 132 * Appearance.effectiveScale
@@ -80,14 +74,7 @@ Item {
         return "cloudy"
     }
 
-    // Helper logic to convert dragged width into matching size modes
-    function getModeForWidth(targetWidth) {
-        let mid1 = (width1x1 + width2x1) / 2;
-        let mid2 = (width2x1 + width3x1) / 2;
-        if (targetWidth < mid1) return "1x1";
-        if (targetWidth < mid2) return "2x1";
-        return "3x1";
-    }
+
 
     // Flat Material 3 container (No shadows for clean widget look)
     Rectangle {
@@ -392,68 +379,5 @@ Item {
             }
         }
 
-    }
-
-    // ──────────────────────────────
-    // Drag Handle to Resize (Horizontal) - Placed outside card to prevent OpacityMask clipping
-    // ──────────────────────────────
-    Rectangle {
-        id: resizeHandle
-        z: 10
-        width: 28 * Appearance.effectiveScale
-        height: 28 * Appearance.effectiveScale
-        radius: 10 * Appearance.effectiveScale
-        
-        // Restore dynamic colors matching AtAGlance/SystemMonitor
-        color: Appearance.m3colors.darkmode ? Appearance.colors.colOnTertiaryContainer : Appearance.colors.colSecondaryContainer
-        
-        anchors {
-            right: root.right
-            bottom: root.bottom
-            margins: 6 * Appearance.effectiveScale
-        }
-        
-        opacity: root.interactive && (cfg && !cfg.locked) && (widgetHoverHandler.hovered || resizeArea.containsMouse || resizeArea.pressed) ? 0.9 : 0
-        visible: opacity > 0
-
-        Behavior on opacity {
-            NumberAnimation { duration: 150 }
-        }
-
-        MaterialSymbol {
-            anchors.centerIn: parent
-            text: "swap_horiz"
-            iconSize: 15 * Appearance.effectiveScale
-            color: Appearance.m3colors.darkmode ? Appearance.colors.colTertiaryContainer : Appearance.colors.colOnSecondaryContainer
-        }
-
-        MouseArea {
-            id: resizeArea
-            anchors.fill: parent
-            hoverEnabled: true
-            cursorShape: Qt.SizeHorCursor
-            preventStealing: true
-
-            property real startWidth: 0
-            property real startGlobalX: 0
-
-            onPressed: (mouse) => {
-                startWidth = root.width;
-                let p = mapToItem(null, mouse.x, mouse.y);
-                startGlobalX = p.x;
-            }
-
-            onPositionChanged: (mouse) => {
-                if (!pressed) return;
-                let p = mapToItem(null, mouse.x, mouse.y);
-                let deltaX = p.x - startGlobalX;
-                let targetWidth = startWidth + deltaX;
-                
-                let targetMode = root.getModeForWidth(targetWidth);
-                if (targetMode !== root.sizeMode) {
-                    root.sizeModeRequested(targetMode)
-                }
-            }
-        }
     }
 }

--- a/dots/.config/quickshell/imi/modules/common/plugins/gridSizes.js
+++ b/dots/.config/quickshell/imi/modules/common/plugins/gridSizes.js
@@ -124,6 +124,48 @@ function resolveSize(grid, stored) {
     return fallback;
 }
 
+// Folding a legacy `sizeMode` option into the host's `__gridSize`.
+//
+// `sizeMode` was a plugin-*declared* choice option on two bundled widgets, in
+// this module's own "<cols>x<rows>" format: a second mechanism for the concept
+// `__gridSize` owns, which is why it is retired rather than kept in step.
+// Takes a plugin's stored options and its manifest grid; returns the options
+// with the old key gone, or null when there is nothing to change.
+//
+// Deleting the old key rather than merely shadowing it is what makes this
+// idempotent - a second pass finds no `sizeMode` and answers null. Four rules
+// beyond the obvious mapping, each one a refusal to invent or destroy a size:
+//   - **a manifest that does not offer several spans is left alone entirely.**
+//     `sizeMode` is not only a retired manifest option: `world-clock` and
+//     `calendar` declare no `grid` and manage a `sizeMode` of their own through
+//     their own toggles, so it is a live setting for them. Migrating on the key
+//     name alone deletes it and resets both widgets - the exact loss this
+//     function exists to prevent, aimed at the wrong widgets.
+//   - a stored mode the manifest does not offer is dropped without being
+//     written, exactly as resolveSize refuses to honour a stored span that is
+//     no longer offered. The widget falls back to its default rather than
+//     being laid out into a size its content does not fill.
+//   - an existing `__gridSize` wins. It can only have come from the resize
+//     grip, which is the more recent choice.
+//   - a plugin with no stored options at all is left alone, so the migration
+//     never creates state for a widget the user has never placed.
+function migrateSizeMode(options, grid) {
+    if (!options || typeof options !== "object" || Array.isArray(options)) return null;
+    if (options.sizeMode === undefined) return null;
+    if (offeredSizes(grid).length <= 1) return null;
+
+    const next = {};
+    for (const key in options) {
+        if (key !== "sizeMode") next[key] = options[key];
+    }
+    if (next.__gridSize === undefined) {
+        const wanted = parseSize(options.sizeMode);
+        if (wanted && containsSize(offeredSizes(grid), wanted))
+            next.__gridSize = formatSize(wanted);
+    }
+    return next;
+}
+
 // The drag snap. `candidates` carry their own pixel measurements because the
 // span-to-pixel conversion is Appearance's (widgetGridSpanX/Y, which also
 // applies effectiveScale) and copying that formula here would be a second one

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -179,6 +179,12 @@ if ! python3 "$SCRIPT_DIR/test_widgets_page_filters.py"; then
     exit 1
 fi
 
+echo "Running plugin options section tests..."
+if ! python3 "$SCRIPT_DIR/test_plugin_options_sections.py"; then
+    echo "Plugin options section tests failed."
+    exit 1
+fi
+
 echo "Running widget grid lattice tests..."
 if ! python3 "$SCRIPT_DIR/test_widget_grid_lattice.py"; then
     echo "Widget grid lattice tests failed."

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -224,6 +224,15 @@ if ! python3 "$SCRIPT_DIR/test_widget_resize_grip_runtime.py"; then
     exit 1
 fi
 
+# The source half is static. The runtime half pans a real WidgetCanvas under
+# real PluginWidgets and brings its own headless weston, so it needs no display
+# of its own - but it does need weston, and skips without it.
+echo "Running widget parallax opt-out tests..."
+if ! python3 "$SCRIPT_DIR/test_widget_parallax_optout.py"; then
+    echo "Widget parallax opt-out tests failed."
+    exit 1
+fi
+
 echo "Running widget group selection tests..."
 if ! python3 "$SCRIPT_DIR/test_widget_group_selection.py"; then
     echo "Widget group selection tests failed."

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -185,6 +185,12 @@ if ! python3 "$SCRIPT_DIR/test_plugin_options_sections.py"; then
     exit 1
 fi
 
+echo "Running widget size row tests..."
+if ! python3 "$SCRIPT_DIR/test_widget_size_row.py"; then
+    echo "Widget size row tests failed."
+    exit 1
+fi
+
 echo "Running widget grid lattice tests..."
 if ! python3 "$SCRIPT_DIR/test_widget_grid_lattice.py"; then
     echo "Widget grid lattice tests failed."

--- a/dots/.config/quickshell/imi/tests/test_expressive_design_system.py
+++ b/dots/.config/quickshell/imi/tests/test_expressive_design_system.py
@@ -19,8 +19,10 @@ PLUGIN_DIRS = (
 EXPECTED_OPTIONS = {
     "nandoroid-media": {"showLyrics", "useRomaji"},
     "nandoroid-system-monitor": {"vertical", "showBattery"},
-    "nandoroid-weather": {"sizeMode"},
-    "nandoroid-currency": {"sizeMode", "baseCurrency", "quote1", "quote2", "quote3", "quote4"},
+    # Both widgets declared a `sizeMode` choice option until the host's
+    # `__gridSize` took the concept over; their spans are `grid.sizes` now.
+    "nandoroid-weather": set(),
+    "nandoroid-currency": {"baseCurrency", "quote1", "quote2", "quote3", "quote4"},
 }
 EXPECTED_ENTRY_TYPES = {
     "nandoroid-media": "Expressive.DesktopMediaWidget",
@@ -133,7 +135,6 @@ class ExpressiveDesignSystemTest(unittest.TestCase):
         self.assertNotIn("Config.options.appearance.currencyWidget.quote", currency_widget)
         self.assertIn("signal baseCurrencyRequested", currency_widget)
         self.assertIn("signal quoteCurrencyRequested", currency_widget)
-        self.assertIn("signal sizeModeRequested", currency_widget)
 
     def test_imported_service_compatibility_is_explicit(self):
         date_time = (ROOT / "services" / "DateTime.qml").read_text(encoding="utf-8")
@@ -147,20 +148,44 @@ class ExpressiveDesignSystemTest(unittest.TestCase):
         self.assertNotIn("Weather.todayHigh", weather)
         self.assertNotIn("Weather.todayLow", weather)
 
-    def test_weather_resize_is_visible_and_persisted_by_the_plugin(self):
-        weather = (DESIGN_SYSTEM / "widgets" / "DesktopWeatherWidget.qml").read_text(
-            encoding="utf-8"
-        )
-        wrapper = (PLUGIN_ROOT / "nandoroid-weather" / "Widget.qml").read_text(
-            encoding="utf-8"
-        )
-        self.assertIn("signal sizeModeRequested(string value)", weather)
-        self.assertIn("root.sizeModeRequested(targetMode)", weather)
-        self.assertNotIn("margins: -8 * Appearance.effectiveScale", weather)
-        self.assertIn(
-            'onSizeModeRequested: value => PluginState.setOption("nandoroid_weather", "sizeMode", value)',
-            wrapper,
-        )
+    def test_weather_and_currency_resize_through_the_host_not_their_own_grip(self):
+        """Both widgets used to draw a `swap_horiz` grip in their bottom-right
+        corner, writing a plugin-declared `sizeMode` option. The host now draws
+        its own grip in that exact corner for any manifest offering several
+        spans, so keeping theirs would stack two controls on one spot - and
+        theirs gated on a legacy `cfg.locked` rather than the host's resolved
+        lock, so it stayed live on a pinned widget.
+        """
+        for directory, component, default in (
+                ("nandoroid-weather", "DesktopWeatherWidget", "3x1"),
+                ("nandoroid-currency", "DesktopCurrencyWidget", "2x1")):
+            widget = (DESIGN_SYSTEM / "widgets" / f"{component}.qml").read_text(
+                encoding="utf-8")
+            wrapper = (PLUGIN_ROOT / directory / "Widget.qml").read_text(
+                encoding="utf-8")
+            manifest = json.loads(
+                (PLUGIN_ROOT / directory / "manifest.json").read_text(encoding="utf-8"))
+
+            self.assertNotIn("sizeModeRequested", widget,
+                             f"{component} still asks to change its own size")
+            self.assertNotIn("id: resizeHandle", widget,
+                             f"{component} still draws a second resize grip")
+            self.assertNotIn('"sizeMode"', wrapper,
+                             f"{directory} still reads the retired option "
+                             "out of PluginState")
+
+            # The host owns which size; the widget owns what that size looks
+            # like, which is why the span still arrives as a name.
+            self.assertIn(f'sizeMode: root.hostGridSize || "{default}"', wrapper)
+            self.assertIn("property string hostGridSize", wrapper)
+
+            # ...and the manifest is where the spans on offer are declared now.
+            self.assertNotIn(
+                "sizeMode",
+                json.dumps(manifest.get("options", []) or []),
+                f"{directory} still declares a sizeMode option")
+            self.assertGreater(len(manifest["grid"]["sizes"]), 1,
+                               f"{directory} must offer the spans it has layouts for")
 
     def test_plugin_blur_supports_tint_and_widget_regions(self):
         options = (ROOT / "modules/common/plugins/PluginOptions.qml").read_text(encoding="utf-8")
@@ -196,7 +221,6 @@ class ExpressiveDesignSystemTest(unittest.TestCase):
             encoding="utf-8"
         )
         self.assertNotIn("anchors.margins: -8 * Appearance.effectiveScale", currency)
-        self.assertIn("anchors.margins: 6 * Appearance.effectiveScale", currency)
         self.assertIn("signal verticalRequested(bool value)", monitor)
         self.assertIn("root.verticalRequested(!root.isVertical)", monitor)
         self.assertNotIn("margins: -8 * Appearance.effectiveScale", monitor)

--- a/dots/.config/quickshell/imi/tests/test_plugin_options_sections.py
+++ b/dots/.config/quickshell/imi/tests/test_plugin_options_sections.py
@@ -83,10 +83,12 @@ class TheTwoGroupsStaySeparate(unittest.TestCase):
                         "the widget's own options must render above the shared "
                         "section - they are what the page was opened for")
 
-    def test_one_delegate_serves_both_repeaters(self):
+    def test_one_delegate_serves_every_repeater(self):
         """Two copies of the row delegate is how the groups drift apart."""
-        self.assertEqual(self.source.count("delegate: optionRow"), 2)
         self.assertEqual(self.source.count("id: optionRow"), 1)
+        self.assertEqual(self.source.count("delegate: optionRow"),
+                         self.source.count("Repeater {"),
+                         "every group of rows draws through the one delegate")
 
 
 if __name__ == "__main__":

--- a/dots/.config/quickshell/imi/tests/test_plugin_options_sections.py
+++ b/dots/.config/quickshell/imi/tests/test_plugin_options_sections.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Source contract: a widget's own options and the host's rows are two groups.
+
+`PluginOptions.qml` used to build one flat model - four synthesized host rows
+(`Blur background`, `Lock position`, `Click through`, `Stay translucent`)
+`.concat(manifest.options)` in front of whatever the plugin declared. Every
+widget's settings page therefore opened with four identical switches, and the
+two or three settings the user actually came for sat below them, reading as if
+the plugin had declared the switches too.
+
+The split is presentation only, so nothing at runtime notices if a later edit
+concatenates the two lists again - the page still renders, just wrong again.
+This is the greppable half: the plugin's own options render first and outside
+the section, and every host row renders inside a `ContentSubsection` titled
+"Widget behaviour".
+"""
+from pathlib import Path
+import re
+import sys
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+OPTIONS = ROOT / "modules/common/plugins/PluginOptions.qml"
+
+SUBSECTION_TITLE = "Widget behaviour"
+
+
+def block_extent(source, opener):
+    """[start, end) of the QML block introduced by `opener` ("Foo {")."""
+    start = source.index(opener)
+    depth = 0
+    for index in range(start + len(opener) - 1, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return start, index + 1
+    raise AssertionError(f"unbalanced braces after {opener!r}")
+
+
+class TheTwoGroupsStaySeparate(unittest.TestCase):
+    def setUp(self):
+        self.source = OPTIONS.read_text(encoding="utf-8")
+
+    def test_the_two_models_are_declared_separately(self):
+        self.assertRegex(
+            self.source,
+            r"readonly property var widgetOptions:\s*manifest\.options \|\| \[\]",
+            "the plugin's own options must be their own model")
+        self.assertRegex(
+            self.source,
+            r"readonly property var behaviourRows:\s*hasBlurSurface \?",
+            "the host's rows must be their own model")
+
+    def test_the_host_rows_are_never_concatenated_onto_the_plugin_s(self):
+        """The exact shape this split removed."""
+        self.assertIsNone(
+            re.search(r"\.concat\(\s*manifest\.options", self.source),
+            "host rows are concatenated in front of the plugin's options again")
+        self.assertIsNone(
+            re.search(r"\.concat\(\s*root\.widgetOptions", self.source),
+            "host rows are concatenated onto the plugin's options again")
+        self.assertIsNone(
+            re.search(r"widgetOptions[^\n]*behaviourRows", self.source),
+            "the two models must not be joined into one")
+
+    def test_a_subsection_holds_the_host_rows(self):
+        self.assertIn(f'title: Translation.tr("{SUBSECTION_TITLE}")', self.source,
+                      "the host rows need a titled ContentSubsection")
+        start, end = block_extent(self.source, "ContentSubsection {")
+        section = self.source[start:end]
+        self.assertIn("model: root.behaviourRows", section,
+                      "every host row belongs inside the shared section")
+        self.assertNotIn("model: root.widgetOptions", section,
+                         "the plugin's own options must not be drawn inside "
+                         "the host's section")
+
+    def test_the_plugin_s_own_options_render_first_and_outside_the_section(self):
+        start, end = block_extent(self.source, "ContentSubsection {")
+        own = self.source.index("model: root.widgetOptions")
+        self.assertLess(own, start,
+                        "the widget's own options must render above the shared "
+                        "section - they are what the page was opened for")
+
+    def test_one_delegate_serves_both_repeaters(self):
+        """Two copies of the row delegate is how the groups drift apart."""
+        self.assertEqual(self.source.count("delegate: optionRow"), 2)
+        self.assertEqual(self.source.count("id: optionRow"), 1)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/dots/.config/quickshell/imi/tests/test_widget_interaction_modes.py
+++ b/dots/.config/quickshell/imi/tests/test_widget_interaction_modes.py
@@ -244,9 +244,9 @@ class TheSettingsSideExists(unittest.TestCase):
         PluginOptions' switch. An unlisted type renders no row at all.
         """
         rows = self._rows()
-        self.assertEqual(rows.count('type: "boolean"'), 4,
-                         "blur, lock, click-through and stay-translucent are "
-                         "all boolean rows")
+        self.assertEqual(rows.count('type: "boolean"'), 5,
+                         "blur, lock, click-through, stay-translucent and "
+                         "follow-parallax are all boolean rows")
 
     def test_the_rows_are_desktop_widget_only(self):
         """A bar-only plugin has no draggable surface, so these are as dead

--- a/dots/.config/quickshell/imi/tests/test_widget_interaction_modes.py
+++ b/dots/.config/quickshell/imi/tests/test_widget_interaction_modes.py
@@ -218,14 +218,14 @@ class TheSettingsSideExists(unittest.TestCase):
         self.src = squashed(OPTIONS)
 
     def _rows(self):
-        """The `optionRows` list literal alone.
+        """The `behaviourRows` list literal alone.
 
         Reading to end-of-file instead would swallow the Repeater's own
         `PluginState.option(...)` calls, and every assertion about which rows
         are synthesized here would pass on the generic delegate code.
         """
-        start = self.src.index("readonly property var optionRows")
-        return self.src[start:self.src.index(".concat(manifest.options", start)]
+        start = self.src.index("readonly property var behaviourRows")
+        return self.src[start:self.src.index("Repeater {", start)]
 
     def test_both_rows_are_offered(self):
         for key in ("positionLocked", "clickThrough"):
@@ -243,8 +243,7 @@ class TheSettingsSideExists(unittest.TestCase):
         """`boolean` is already in PluginValidator's type whitelist and
         PluginOptions' switch. An unlisted type renders no row at all.
         """
-        rows = self.src[self.src.index("readonly property var optionRows"):]
-        rows = rows[:rows.index("Not a pluginOption on purpose")]
+        rows = self._rows()
         self.assertEqual(rows.count('type: "boolean"'), 4,
                          "blur, lock, click-through and stay-translucent are "
                          "all boolean rows")

--- a/dots/.config/quickshell/imi/tests/test_widget_parallax_optout.py
+++ b/dots/.config/quickshell/imi/tests/test_widget_parallax_optout.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""The `followParallax` opt-out, in two halves.
+
+A widget on the desktop travels because the *canvas* travels: the widget canvas
+is one item whose x/y are the parallax pan (`Background.qml`). Opting a single
+widget out is therefore a cancellation, not a smaller offset, and that has one
+consequence worth guarding beyond the sign: the drag runs in canvas coordinates
+while `PluginState` holds placement coordinates, and the gap between them is
+exactly the cancellation. A `commitPosition` that stored the drawn coordinate
+would move an opted-out widget by a whole pan every time it was dragged -
+silently, because it looks right until the pan next changes.
+
+The source half below is static and runs everywhere, CI included.
+
+The runtime half drives `WidgetParallaxOptOutRuntimeTest.qml`: two real
+`PluginWidget`s on a real `WidgetCanvas`, panned the way `Background.qml` pans
+it and dragged while panned. It brings its own headless weston, so it needs no
+display of its own - but it does need weston, and skips without it. `tst_parallax`
+covers the arithmetic; only a live host can show what it does to the store.
+"""
+
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HARNESS = ROOT / "WidgetParallaxOptOutRuntimeTest.qml"
+HOST = ROOT / "modules/common/plugins/PluginWidget.qml"
+OPTIONS = ROOT / "modules/common/plugins/PluginOptions.qml"
+VALIDATOR = ROOT / "modules/common/plugins/PluginValidator.js"
+MATHS = ROOT / "modules/common/functions/parallax.js"
+SOCKET = "wayland-imi-widget-parallax"
+
+
+def squashed(path: Path) -> str:
+    return re.sub(r"\s+", " ", path.read_text(encoding="utf-8"))
+
+
+class TheArithmeticIsExtracted(unittest.TestCase):
+    """Beside `widgetOffset`, where it can be driven without a compositor."""
+
+    def test_the_cancellation_lives_in_parallax_js(self):
+        self.assertIn("function parallaxCancel(canvasOffset, follows)",
+                      MATHS.read_text(encoding="utf-8"))
+
+    def test_the_host_does_not_reimplement_it(self):
+        """A `-canvas.x` written inline in the host is the same expression with
+        nowhere to test it, and it is one sign away from doubling the pan.
+        """
+        host = squashed(HOST)
+        self.assertIn("ParallaxMath.parallaxCancel(", host)
+        self.assertNotRegex(host, r"x:\s*-\s*\w*[Cc]anvas\.x")
+
+
+class TheHostCancelsRatherThanOffsets(unittest.TestCase):
+    def setUp(self):
+        self.host = squashed(HOST)
+
+    def test_the_flag_is_a_plugin_state_option_seeded_by_the_manifest(self):
+        self.assertIn(
+            'PluginState.option(manifest.id, "followParallax", '
+            "manifest.desktopWidget?.followParallax !== false)",
+            self.host,
+            "following is the default, so the manifest seed can only opt OUT")
+
+    def test_both_axes_are_cancelled(self):
+        for axis in ("parallaxCancelX", "parallaxCancelY"):
+            self.assertIn(f"readonly property real {axis}", self.host)
+
+    def test_the_drawn_position_is_placement_plus_cancellation(self):
+        self.assertIn("x: rootWidget.placedX + rootWidget.parallaxCancelX", self.host)
+        self.assertIn("y: rootWidget.placedY + rootWidget.parallaxCancelY", self.host)
+
+    def test_the_drag_release_rebinding_keeps_the_cancellation(self):
+        """`restoreXYBinding` is what runs after every drag. Rebinding to the
+        placement alone would drop an opted-out widget back onto the pan for
+        the rest of the session, with nothing reporting it.
+        """
+        body = self.host[self.host.index("function restoreXYBinding()"):]
+        body = body[:body.index("function commitPosition")]
+        self.assertIn("rootWidget.placedX + rootWidget.parallaxCancelX", body)
+        self.assertIn("rootWidget.placedY + rootWidget.parallaxCancelY", body)
+
+    def test_the_stored_position_has_the_cancellation_taken_back_out(self):
+        """The drift bug. `x` is where the widget is drawn on the canvas; the
+        store holds where it was placed.
+        """
+        body = self.host[self.host.index("function commitPosition()"):]
+        self.assertIn("rootWidget.targetX = rootWidget.x - rootWidget.parallaxCancelX", body)
+        self.assertIn("rootWidget.targetY = rootWidget.y - rootWidget.parallaxCancelY", body)
+
+
+class TheSettingsSideExists(unittest.TestCase):
+    """A persisted option with no UI silently does nothing (CONTRIBUTING:
+    "Settings additions are two-sided")."""
+
+    def test_the_row_is_offered_and_seeded_the_same_way(self):
+        options = squashed(OPTIONS)
+        self.assertIn('key: "followParallax"', options)
+        self.assertIn("default: manifest.desktopWidget?.followParallax !== false", options)
+
+    def test_the_manifest_field_is_type_checked(self):
+        """The other four seeds are validated; an unvalidated fifth would
+        accept a string and seed a truthy default nobody can account for.
+        """
+        self.assertIn('"followParallax"', VALIDATOR.read_text(encoding="utf-8"))
+
+
+def _stop(proc):
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+
+
+def _runtime_available():
+    return shutil.which("qs") is not None and shutil.which("weston") is not None
+
+
+@unittest.skipUnless(_runtime_available(), "needs qs and weston on PATH")
+class WidgetParallaxOptOutRuntimeTest(unittest.TestCase):
+    def setUp(self):
+        self.home = Path(tempfile.mkdtemp(prefix="imi-widget-parallax-"))
+        self.addCleanup(shutil.rmtree, self.home, ignore_errors=True)
+
+    def test_an_opted_out_widget_holds_its_place_and_stores_its_placement(self):
+        env = dict(os.environ)
+        env.setdefault("XDG_RUNTIME_DIR", f"/run/user/{os.getuid()}")
+        env["WAYLAND_DISPLAY"] = SOCKET
+        env.pop("DISPLAY", None)
+
+        weston = subprocess.Popen(
+            ["weston", "--backend=headless", "--renderer=pixman",
+             f"--socket={SOCKET}", "--width=1400", "--height=900"],
+            env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        self.addCleanup(_stop, weston)
+
+        socket_path = Path(env["XDG_RUNTIME_DIR"]) / SOCKET
+        deadline = time.monotonic() + 15
+        while not socket_path.exists() and time.monotonic() < deadline:
+            time.sleep(0.2)
+        self.assertTrue(socket_path.exists(), "headless weston never came up")
+
+        # This box's headless EGL has no driver, so force software rendering.
+        env["LIBGL_ALWAYS_SOFTWARE"] = "1"
+        env["QT_QUICK_BACKEND"] = "software"
+        env["XDG_CONFIG_HOME"] = str(self.home / "config")
+        env["XDG_STATE_HOME"] = str(self.home / "state")
+
+        proc = subprocess.run(["qs", "-p", str(HARNESS)], cwd=str(ROOT), env=env,
+                              capture_output=True, text=True, timeout=180)
+        output = proc.stdout + proc.stderr
+        failed = [line for line in output.splitlines() if "FAIL" in line]
+        self.assertEqual(failed, [], f"harness reported failures:\n{output}")
+        self.assertIn("[WidgetParallax] failures: 0", output,
+                      f"harness did not finish cleanly:\n{output}")
+
+        # A cancellation folded back into the placement it is derived from
+        # shows up here rather than as a failed check.
+        self.assertNotIn("Binding loop", output,
+                         f"the host tree grew a binding loop:\n{output}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dots/.config/quickshell/imi/tests/test_widget_size_row.py
+++ b/dots/.config/quickshell/imi/tests/test_widget_size_row.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Source contract: the Size row and the drag grip are one value.
+
+A widget whose manifest offers more than one span already resizes by dragging
+its corner. The grip is quick and it is also invisible until hovered, so the
+same span is offered as a row in Settings > Widgets - discoverable, and
+reachable from the keyboard.
+
+What makes them one thing rather than two is that both read and write the
+host's `__gridSize`, in `gridSizes.js`'s `"<cols>x<rows>"` form. A row writing
+any other key, or the same key in another format, would be a second size the
+widget does not have.
+
+The gate is the other half. Not every widget is resizable: a widget qualifies
+only when it has a design per size, so the row is *omitted* where the manifest
+names one span, not shown disabled. A control that can never be enabled is
+noise, and one that offers a span the widget has no layout for is worse than
+no row at all.
+"""
+from pathlib import Path
+import re
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+OPTIONS = ROOT / "modules/common/plugins/PluginOptions.qml"
+HOST = ROOT / "modules/common/plugins/PluginWidget.qml"
+GRID_SIZES = ROOT / "modules/common/plugins/gridSizes.js"
+
+
+def squashed(path: Path) -> str:
+    return re.sub(r"\s+", " ", path.read_text(encoding="utf-8"))
+
+
+class TheRowAndTheGripShareOneValue(unittest.TestCase):
+    def setUp(self):
+        self.options = squashed(OPTIONS)
+        self.host = squashed(HOST)
+
+    def test_the_row_writes_the_key_the_grip_writes(self):
+        self.assertIn('key: "__gridSize"', self.options)
+        self.assertIn('PluginState.setOption(manifest.id, "__gridSize"', self.host,
+                      "the grip's writer moved; the row now writes a key "
+                      "nothing reads")
+
+    def test_the_choices_are_formatted_by_the_module_that_parses_them(self):
+        """A row spelling the span itself is a second format to keep in step,
+        and `resolveSize` would silently reject anything it cannot parse -
+        leaving the widget at its default with the row showing a size it is
+        not.
+        """
+        self.assertIn("value: GridSizes.formatSize(size)", self.options)
+        self.assertIn("function formatSize(size)",
+                      GRID_SIZES.read_text(encoding="utf-8"))
+
+    def test_the_spans_offered_are_the_ones_the_host_resolves_against(self):
+        self.assertIn("GridSizes.offeredSizes(manifest.grid)", self.options)
+        self.assertIn("GridSizes.offeredSizes(rootWidget.gridSpec)", self.host)
+
+    def test_the_default_is_the_manifest_s_own_span(self):
+        self.assertIn("default: GridSizes.formatSize(GridSizes.defaultSize(manifest.grid))",
+                      self.options)
+
+
+class TheRowIsOmittedWhereItCannotApply(unittest.TestCase):
+    def setUp(self):
+        self.options = squashed(OPTIONS)
+
+    def test_it_needs_more_than_one_offered_span(self):
+        self.assertRegex(
+            self.options,
+            r"readonly property var sizeRows: root\.offeredSizes\.length > 1 \?",
+            "a widget with one span must get no size row at all")
+
+    def test_the_empty_case_is_an_empty_list_not_a_disabled_row(self):
+        rows = self.options[self.options.index("readonly property var sizeRows"):]
+        rows = rows[:rows.index("Repeater {")]
+        self.assertIn("] : []", rows)
+        self.assertNotIn("enabled:", rows,
+                         "the row is omitted where it cannot apply, never "
+                         "greyed out - greying is for rows that are only "
+                         "temporarily inert")
+
+    def test_it_is_a_choice_row_so_the_generic_delegate_draws_it(self):
+        """`choice` is already in PluginValidator's type whitelist and
+        PluginOptions' delegate switch. An unlisted type renders nothing.
+        """
+        rows = self.options[self.options.index("readonly property var sizeRows"):]
+        rows = rows[:rows.index("Repeater {")]
+        self.assertIn('type: "choice"', rows)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/dots/.config/quickshell/imi/tests/test_widget_transparency_opacity.py
+++ b/dots/.config/quickshell/imi/tests/test_widget_transparency_opacity.py
@@ -162,12 +162,13 @@ class TheOptOutIsReachable(unittest.TestCase):
         self.assertIn("default: manifest.desktopWidget?.keepTranslucent === true", src)
 
     def test_the_manifest_field_is_type_checked(self):
-        """The other three seeds are validated; an unvalidated fourth would
-        accept a string and seed a truthy default nobody can account for.
+        """The other seeds are validated; an unvalidated one would accept a
+        string and seed a truthy default nobody can account for. Matched inside
+        the flag list rather than against the whole line, which grows.
         """
-        self.assertIn(
-            'const desktopFlags = ["blur", "locked", "clickThrough", "keepTranslucent"]',
-            VALIDATOR.read_text(encoding="utf-8"))
+        validator = squashed(VALIDATOR)
+        flags = validator[validator.index("const desktopFlags"):]
+        self.assertIn('"keepTranslucent"', flags[:flags.index("]")])
 
 
 class TheInertControlsSaySo(unittest.TestCase):

--- a/dots/.config/quickshell/imi/tests/tst_grid_sizes.qml
+++ b/dots/.config/quickshell/imi/tests/tst_grid_sizes.qml
@@ -192,6 +192,75 @@ TestCase {
         compare(GridSizes.nearestSize(candidates(), NaN, NaN), null);
     }
 
+    // --- retiring the plugin-declared `sizeMode` -----------------------------
+
+    function weatherGrid() {
+        return { cols: 3, rows: 1,
+                 sizes: [{ cols: 1, rows: 1 }, { cols: 2, rows: 1 }, { cols: 3, rows: 1 }] };
+    }
+
+    function test_a_stored_sizeMode_becomes_the_same_span_under_the_host_key() {
+        const migrated = GridSizes.migrateSizeMode(
+            { sizeMode: "2x1", blurEnabled: true }, weatherGrid());
+        compare(migrated.__gridSize, "2x1");
+        compare(migrated.sizeMode, undefined);
+        // Every other option the user set survives untouched.
+        compare(migrated.blurEnabled, true);
+    }
+
+    function test_a_mode_the_manifest_does_not_offer_is_dropped_not_honoured() {
+        // Same refusal resolveSize makes for a stored span no longer on offer:
+        // the widget falls back to its manifest default rather than being laid
+        // out into a size its content does not fill.
+        const migrated = GridSizes.migrateSizeMode({ sizeMode: "1x3" }, weatherGrid());
+        compare(migrated.__gridSize, undefined);
+        compare(migrated.sizeMode, undefined);
+    }
+
+    function test_an_unparseable_mode_is_dropped_the_same_way() {
+        const migrated = GridSizes.migrateSizeMode({ sizeMode: "wide" }, weatherGrid());
+        compare(migrated.__gridSize, undefined);
+        compare(migrated.sizeMode, undefined);
+    }
+
+    function test_running_it_twice_changes_nothing_the_second_time() {
+        // The old key is deleted, not shadowed, so the second pass has nothing
+        // to act on - and answering null is how the caller knows not to write.
+        const once = GridSizes.migrateSizeMode({ sizeMode: "1x1" }, weatherGrid());
+        compare(once.__gridSize, "1x1");
+        compare(GridSizes.migrateSizeMode(once, weatherGrid()), null);
+    }
+
+    function test_a_span_already_chosen_with_the_grip_wins() {
+        const migrated = GridSizes.migrateSizeMode(
+            { sizeMode: "1x1", __gridSize: "3x1" }, weatherGrid());
+        compare(migrated.__gridSize, "3x1");
+        compare(migrated.sizeMode, undefined);
+    }
+
+    function test_a_plugin_with_no_sizeMode_is_left_alone() {
+        // Answering null rather than a copy is what keeps the store from being
+        // rewritten for every plugin on every launch.
+        compare(GridSizes.migrateSizeMode({ blurEnabled: true }, weatherGrid()), null);
+        compare(GridSizes.migrateSizeMode({}, weatherGrid()), null);
+        compare(GridSizes.migrateSizeMode(undefined, weatherGrid()), null);
+        compare(GridSizes.migrateSizeMode(null, weatherGrid()), null);
+    }
+
+    function test_a_widget_that_owns_its_own_sizeMode_is_left_alone() {
+        // `sizeMode` is not only a retired manifest option. world-clock and
+        // calendar declare no `grid` and drive a `sizeMode` of their own from
+        // their own toggles, so for them it is a live setting - migrating on
+        // the key name alone would delete it and reset both widgets, which is
+        // this migration's own failure mode aimed at the wrong widgets.
+        compare(GridSizes.migrateSizeMode({ sizeMode: "2x1" }, undefined), null);
+        compare(GridSizes.migrateSizeMode({ sizeMode: "2x1" }, {}), null);
+        // A single-span grid is the same case: the host does not offer a
+        // choice, so it has no size of its own to take over.
+        compare(GridSizes.migrateSizeMode({ sizeMode: "2x1" }, { cols: 2, rows: 1 }), null);
+    }
+
+
     // --- a `sizes` list that has crossed a QML model boundary ---------------
 
     // What a JS array looks like after a round trip through a Repeater's

--- a/dots/.config/quickshell/imi/tests/tst_parallax.qml
+++ b/dots/.config/quickshell/imi/tests/tst_parallax.qml
@@ -163,6 +163,45 @@ TestCase {
         compare(Parallax.widgetOffset(0, 1.2), 0);
     }
 
+    // --- Opting a single widget out of the pan -----------------------------
+
+    function test_a_following_widget_adds_nothing() {
+        // The canvas already carries it. Adding anything here would move it
+        // twice.
+        compare(Parallax.parallaxCancel(-600, true), 0);
+        compare(Parallax.parallaxCancel(0, true), 0);
+    }
+
+    function test_an_opted_out_widget_cancels_the_canvas_offset_exactly() {
+        // The two must sum to zero: the widget's position on screen is
+        // canvas.x + widget.x, so anything short of the exact negative leaves
+        // it drifting a fraction of the pan rather than holding still.
+        compare(Parallax.parallaxCancel(-600, false), 600);
+        compare(Parallax.parallaxCancel(600, false), -600);
+        compare(Parallax.parallaxCancel(-600, false) + -600, 0);
+    }
+
+    function test_an_opted_out_widget_on_a_still_canvas_adds_nothing() {
+        compare(Parallax.parallaxCancel(0, false), 0);
+    }
+
+    function test_following_is_the_default_for_anything_but_an_explicit_false() {
+        // PluginState.option answers undefined until the state file has loaded.
+        // Reading that as "opted out" would pin every widget against a canvas
+        // offset it has not seen, which shows up as the widgets refusing to
+        // parallax at all for the first moment of a session.
+        compare(Parallax.parallaxCancel(-600, undefined), 0);
+        compare(Parallax.parallaxCancel(-600, null), 0);
+        compare(Parallax.parallaxCancel(-600, 0), 0);
+    }
+
+    function test_a_missing_canvas_offset_does_not_produce_nan() {
+        // Bound straight to x/y: a NaN there does not misplace the widget, it
+        // stops it rendering.
+        compare(Parallax.parallaxCancel(undefined, false), 0);
+        verify(!isNaN(Parallax.parallaxCancel("nonsense", false)));
+    }
+
     // --- Guards ------------------------------------------------------------
 
     function test_missing_state_does_not_produce_nan() {

--- a/dots/.config/quickshell/imi/tests/tst_plugin_state.qml
+++ b/dots/.config/quickshell/imi/tests/tst_plugin_state.qml
@@ -196,4 +196,72 @@ TestCase {
         PluginState.loadText("[1, 2, 3]");
         compare(Object.keys(PluginState.state.desktopPositions).length, 0);
     }
+
+    // --- retiring the plugin-declared `sizeMode` ----------------------------
+    //
+    // Driven through the pure half rather than the live singleton: the pass is
+    // one-shot by design, so a test that ran it against `PluginState.state`
+    // could only ever exercise the first case and would burn the marker for
+    // every test after it.
+
+    function weatherManifest() {
+        return {
+            id: "nandoroid_weather",
+            grid: { cols: 3, rows: 1,
+                    sizes: [{ cols: 1, rows: 1 }, { cols: 2, rows: 1 }, { cols: 3, rows: 1 }] }
+        };
+    }
+
+    function migratedState(pluginOptions) {
+        return PluginState.stateWithSizeModesMigrated(
+            { pluginOptions: pluginOptions, desktopPositions: {}, presetPersist: {}, migrations: {} },
+            [weatherManifest()]);
+    }
+
+    function test_sizeModeMigrationKeepsTheChosenSize() {
+        // The whole reason this exists: without it, upgrading resets the widget
+        // to its manifest default and the user's chosen size is gone.
+        const next = migratedState({ nandoroid_weather: { sizeMode: "1x1", blurEnabled: true } });
+        compare(next.pluginOptions.nandoroid_weather.__gridSize, "1x1");
+        compare(next.pluginOptions.nandoroid_weather.sizeMode, undefined);
+        compare(next.pluginOptions.nandoroid_weather.blurEnabled, true);
+    }
+
+    function test_sizeModeMigrationMarksItselfDone() {
+        const next = migratedState({});
+        compare(next.migrations[PluginState.sizeModeMarker], true);
+    }
+
+    function test_sizeModeMigrationLeavesAWidgetOwnedSizeModeAlone() {
+        // world-clock declares no `grid` and drives its own sizeMode from its
+        // own toggle, so for it the key is a live setting. Measured against a
+        // real shell before it was guarded: a pass keyed on the name alone
+        // emptied its options and reset the widget.
+        const next = PluginState.stateWithSizeModesMigrated(
+            { pluginOptions: { nandoroid_weather: { sizeMode: "2x1" },
+                               "world-clock": { sizeMode: "3x1" } },
+              desktopPositions: {}, presetPersist: {}, migrations: {} },
+            [weatherManifest(), { id: "world-clock" }]);
+        compare(next.pluginOptions["world-clock"].sizeMode, "3x1");
+        compare(next.pluginOptions.nandoroid_weather.__gridSize, "2x1");
+    }
+
+    function test_sizeModeMigrationRunTwiceIsANoOp() {
+        const once = migratedState({ nandoroid_weather: { sizeMode: "2x1" } });
+        const twice = PluginState.stateWithSizeModesMigrated(once, [weatherManifest()]);
+        compare(twice.pluginOptions.nandoroid_weather.__gridSize, "2x1");
+        compare(twice.pluginOptions.nandoroid_weather.sizeMode, undefined);
+    }
+
+    function test_sizeModeMigrationDoesNotDisturbPositions() {
+        const state = {
+            pluginOptions: { nandoroid_weather: { sizeMode: "1x1" } },
+            desktopPositions: { "DP-1": { nandoroid_weather: { x: 12, y: 34, placementStrategy: "free" } } },
+            presetPersist: { nandoroid_weather: true },
+            migrations: {}
+        };
+        const next = PluginState.stateWithSizeModesMigrated(state, [weatherManifest()]);
+        compare(next.desktopPositions["DP-1"].nandoroid_weather.x, 12);
+        compare(next.presetPersist.nandoroid_weather, true);
+    }
 }


### PR DESCRIPTION
Steps 1-4 of `docs/superpowers/specs/2026-08-10-widget-common-settings-design.md`. **Stacked on #160** — merge that first.

Every widget's settings page opened with the same four host rows in front of its own two or three
real options, and two more were arriving. They now sit in a **"Widget behaviour"** subsection
*beneath* the widget's own options.

- **`followParallax`** — a widget can hold its screen position while the canvas pans.
- **A Size row**, shown only when the manifest offers more than one span, reading the same
  `__gridSize` the resize grip writes. The row and the grip are two faces of one value.
- **`sizeMode` retired.** Weather and currency declared a `sizeMode` *choice option* — a second
  mechanism for the concept `__gridSize` now owns, in the same string format. Both move to
  `grid.sizes`, with a one-shot migration so nobody's chosen size resets.

## It found a bug that made #160 inert

`offeredSizes` gated `grid.sizes` on `Array.isArray`, which is **not the test**: an array reaching a
delegate through a `Repeater`'s `model` has crossed into QVariant and back, so indices and `length`
survive but `Array.isArray` does not — and `Background.qml` builds every desktop widget from exactly
such a model. Manifests declaring three spans arrived offering one, with no error anywhere. Fixed on
#160 itself (`677d6ff05`) so that PR is correct standalone.

## Two more things the spec did not anticipate

- **The widgets already had their own grips.** Weather and currency each drew a `swap_horiz` chip in
  the same corner the host grip occupies, gated on a legacy `cfg.locked` rather than the host's
  resolved lock — so it stayed live on a pinned widget. Removed.
- **"Read a stored `sizeMode`" was too broad.** `world-clock` and `calendar` drive a `sizeMode` of
  their own from their own toggles and declare no grid. A first pass emptied their options and reset
  both widgets — the migration's own failure mode, aimed at the wrong widgets. Now scoped to
  manifests offering more than one span, and verified against a real shell that both keep theirs.

## Position, not offset

Opting out means *cancelling* the canvas pan, so `commitPosition` subtracts the cancellation back
out: the drag runs in canvas coordinates, the store holds placement coordinates. Without that an
opted-out widget walks by a whole pan on every drag — silently, since it looks right until you
switch workspaces.

## Testing

`./tests/run_tests.sh` — **410 passed, 0 failed** (390 on the base branch). Three new Python modules
plus static and weston-runtime checks, all wired into `run_tests.sh`.

The migration was verified against a real `qs` over a seeded throwaway state file: a chosen `1x1`
survives as `__gridSize`, a never-offered `1x3` is dropped and falls back to the manifest default, an
already-marked state is untouched, and `world-clock`/`calendar` keep their own `sizeMode`. Every new
check proven non-vacuous by planting the broken behaviour back and reverting.

Docs: updated AGENT.md §Dynamic/data-driven QML gotchas, docs/widget-grid.md