### PR TITLE
feat(media): three sizes for the desktop media widget

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1343,17 +1343,37 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   fallback: 0.77ms per cookie per frame at 240px, and four animating at once still held 62fps
   offscreen. f6a7e251e ("feat(designsystem): VisualizerCookie, a cookie driven by one level per
   lobe").
-- **Nothing writes `CavaService.values`, so a widget wired to it is silent.**
-  `modules/common/plugins/designsystem/services/CavaService.qml` looks like a service - `barCount`,
-  `values`, and a `refCount` that `CavaWidget`, `MediaCard` and `VisualizerCookie` all take and
-  release - but no code in this tree ever assigns `values` or starts a cava process when the
-  refcount rises. The live band source is `GlobalStates.visualizerPoints`, filled by the `cavaProc`
-  `Process` in `modules/imi/mediaControls/MediaControls.qml` (50 bars, 0..1000, running only while
-  a sidebar, the media controls or a visualizer widget wants it), and that is what the bar
-  visualizer and the bundled `visualizer` plugin read. Don't read the refcount as evidence of a
-  producer behind it; either give `CavaService` one or point the consumer's band input at
-  `GlobalStates.visualizerPoints`. 66da530c4 ("feat(designsystem): drive the visualizer cookie from
-  cava").
+- **`CavaService` has had a producer since ce41c4f9c, and `GlobalStates.visualizerPoints` is
+  gone.** This entry used to say the opposite and to send a new consumer to `visualizerPoints`,
+  which by then had been removed - so the advice named a property that does not exist. Claim the
+  bands with a `CavaRef` and read `CavaService.values`; the reasoning behind the one-source rule,
+  and the failure that produced it, are under
+  [State propagation is reactive](#state-propagation-is-reactive-or-it-is-a-bug-waiting).
+  ce41c4f9c ("feat(cava): give CavaService the producer it always implied").
+- **A `Canvas`'s `setLineDash` is measured in line widths, not in path length.** HTML's is in
+  path-length units; QML's hands the array to `QPen::setDashPattern`, which is specified in
+  multiples of the pen width - so a pattern computed honestly from a path's arc length comes out
+  wrong by a factor of the line width. Watch the shape of the failure, because it does not look
+  like one: both the "on" and the "off" run shrink by the same factor, so the *period* shrinks
+  with them and the pattern repeats. A 25% progress ring stroked around a cookie drew as thirteen
+  evenly spaced dashes all the way round, growing together as progress rose - which reads as a
+  deliberate dashed border. `shapes/path-length.js` measures the outline (sampled per cubic, paid
+  once per geometry change) and `dashInPenWidths` does the conversion, named rather than left as a
+  division at the call site. Found by rendering the ring offscreen with `qml6` and looking at the
+  PNG: nothing about a `Canvas` is reachable from `qmltestrunner`, and the software scene graph
+  the runtime harnesses use draws none of it either.
+  08341739f ("fix(shapes): Qt measures a dash pattern in line widths, not in path length").
+- **A shape that must carry two moving things on one edge should carry one.** The media widget's
+  2x1 strokes playback progress around its play button's own cookie outline, and its cookie is
+  deliberately the *static* `MaterialCookie` shape rather than the audio-reactive
+  `VisualizerCookie` the 2x2 uses: an outline that ripples while also filling up is two motions on
+  one edge and neither is readable. Draw the body and the ring as two concentric passes over the
+  same outline (the body inside the ring) rather than as one stroked shape, or the stroke reads as
+  a line laid over the button's edge instead of as its border. And rotate the path so its first
+  vertex sits at twelve o'clock: the dash starts where the path starts, which is wherever that
+  vertex happens to be, and a twelve-lobed cookie is symmetric every 30 degrees so nothing about
+  the shape reads as rotated. 8c211b3d8 ("feat(media): draw the 2x1 as three controls whose centre
+  carries the seek bar").
 
 **Wallpaper parallax is one oversized viewport, not a per-layer effect.**
 `Background.qml` draws every wallpaper layer inside `parallaxViewport`, an item sized to

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -254,6 +254,12 @@ bug in anything that qualifies:
   (`PluginWidget.qml`, which only compiles once a plugin is enabled on some monitor) - it compiles
   them, so a bad property on a page nobody opened is caught. Everything else still needs the live
   load. 494580b65 ("feat(plugins): resolve a placed widget's span from its stored choice").
+  **It sweeps a bundled package through its `Widget.qml` only**, on the reasoning that a sibling
+  file is a type resolved through the package's `qmldir` and so is reached from the entry point
+  anyway. A file the entry point loads *by URL* is not that - it is a standalone component that
+  compiles, or does not, on its own - so it has to be named in the explicit list or it compiles for
+  the first time on the user's desktop. The media widget's three per-span layouts are the current
+  case. 61e2f723c ("refactor(media): move the media widget's content into LayoutLarge").
 - **A new Python check must actually run.** `run_tests.sh` invokes each one as `python3 <file>`, so
   a module of bare `test_*` functions exits zero without executing anything. Either subclass
   `unittest.TestCase` with `unittest.main()`, or end the file with the `contract_runner` block

--- a/docs/superpowers/specs/2026-08-10-media-widget-sizes-design.md
+++ b/docs/superpowers/specs/2026-08-10-media-widget-sizes-design.md
@@ -26,8 +26,9 @@ one-size limitation.
   one span gets it.
 - **2x2 is cookie-as-artwork**: album art inside the cookie, visualizer lobes around it, title and
   artist below.
-- **2x1 is exactly the reference**: prev, cookie-shaped play/pause, next. No text, no art, no
-  progress.
+- **2x1 is exactly the reference**: prev, cookie-shaped play/pause, next. No text and no artwork —
+  but progress *is* shown, stroked around the centre button's own outline rather than as a separate
+  track. See §5.
 
 ---
 
@@ -141,8 +142,20 @@ The existing content moves to `LayoutLarge.qml` unchanged, so the current widget
 - **2x2 `LayoutCookie.qml`** — 276x228. `VisualizerCookie` with album art clipped inside it, title
   and artist beneath. Tap the cookie to play/pause.
 - **2x1 `LayoutCompact.qml`** — 276x108. Prev pill, cookie-shaped play/pause, next pill, centred.
-  The cookie here is a static `MaterialCookie`, not the visualizer — at this size a rippling
-  outline behind an icon is noise.
+
+  **The centre button's border is the seek bar.** Playback progress is stroked around the cookie's
+  own outline rather than drawn as a separate track, which is what makes this layout read as one
+  object instead of three controls with a line under them. There is still no text and no artwork.
+
+  That changes what the shape has to support. A cookie outline is a run of cubic Beziers, so a
+  partial stroke needs the path's arc length: sample the cubics once per geometry change to get the
+  cumulative length, then stroke with `setLineDash([progress * total, total])`. Length only has to
+  be recomputed when the shape changes, which for a static cookie is once.
+
+  The cookie here is a static `MaterialCookie`-shaped path, not the visualizer — at this size a
+  rippling outline would fight the progress it is also carrying, and the two would be
+  indistinguishable. Both nonetheless stroke a rounded polygon, so the arc-length helper belongs
+  beside `rounded-polygon.js` where `VisualizerCookie` can reach it if a future layout wants both.
 
 All three read the same media state, so no new service work.
 

--- a/docs/superpowers/specs/2026-08-10-media-widget-sizes-design.md
+++ b/docs/superpowers/specs/2026-08-10-media-widget-sizes-design.md
@@ -1,8 +1,19 @@
 # Media widget sizes, and a resize handle for every grid widget — design
 
-**Status:** design, not implemented
+**Status:** implemented. Steps 1-5 (the grid machinery, the grip, `VisualizerCookie` and its
+cava input) landed on `main`; steps 6-9 (the three media layouts and the docs) landed on
+`feat/media-layouts`.
 **Scope:** `modules/common/plugins/` (grid machinery, shapes), the bundled
 `nandoroid-media` widget, `docs/widget-grid.md`
+
+**Where §5 met reality.** The 3x2's migration risk did not exist: measured through a `qs -p`
+probe, the widget was already exactly `spanX(3) x spanY(2)` = 420x228 before and after adopting
+the grid, because the design-system component declares those pixels itself. The 2x2's artwork is
+clipped to a circle inside the cookie rather than to the cookie's own outline - masking it with
+the rippling outline swallows the motion the outline exists to show. And the 2x1's arc-length
+maths was right while its units were not: Qt measures `setLineDash` in pen widths, not path
+length, which draws a repeating dashed border instead of one arc (AGENT.md, "Dynamic/data-driven
+QML gotchas").
 
 Paths are relative to the theme root `dots/.config/quickshell/imi/` unless written repo-relative.
 

--- a/docs/widget-grid.md
+++ b/docs/widget-grid.md
@@ -115,8 +115,8 @@ shown disabled — for a manifest naming a single span.
 **Only declare `sizes` for a widget that has a design per size.** Most widgets have one
 layout, and the host swaps the pixel size and nothing else: offering a span a widget has
 no layout for is worse than offering no choice at all. `nandoroid-weather` (1x1 / 2x1 /
-3x1) and `nandoroid-currency` (1x1 / 2x1) qualify because each span is a different
-layout inside the widget; nothing else bundled does.
+3x1), `nandoroid-currency` (1x1 / 2x1) and `nandoroid-media` (3x2 / 2x2 / 2x1) qualify
+because each span is a different layout inside the widget; nothing else bundled does.
 
 Such a widget reads the resolved span back from the host as `hostGridSize`
 (`"<cols>x<rows>"`, declared as a `property string` on its `Widget.qml` root and bound
@@ -162,6 +162,50 @@ covered by `tests/tst_grid_sizes.qml`):
   crosses a model, so it now also builds one widget through a `Repeater`.
   109e6d897 ("fix(plugins): a manifest's grid.sizes survives the model boundary").
 
+### A layout per span
+
+`nandoroid-weather` and `nandoroid-currency` switch on `hostGridSize` inside one file.
+`nandoroid-media` has three genuinely different designs - a 3x2 with lyrics and a wavy
+seek bar, a 2x2 whose album art sits inside an audio-reactive cookie, a 2x1 of three
+controls whose centre button's border *is* the seek bar - so its `Widget.qml` is a shell
+that loads one of `LayoutLarge.qml` / `LayoutCookie.qml` / `LayoutCompact.qml`. Four
+things that costs, all of them one-time:
+
+- **The span-to-file mapping is one table, read twice** (`media_layouts.js`): once for
+  the file and once for the cell counts behind the widget's own implicit size. Two
+  lookups over one table is what stops a layout being drawn at another span's pixels.
+- **Anything unrecognised resolves to the default entry, never to nothing.**
+  `hostGridSize` is empty until the host answers, and stays empty for a bare `qs -p`
+  probe of `Widget.qml`; a span a later manifest stops offering is still sitting in
+  `plugin-state.json`. A lookup returning nothing for either leaves the widget drawing
+  nothing at all, which on screen is indistinguishable from a layout that failed to
+  compile. That fallback must be the *manifest's* default, since that is the span the
+  host will resolve in the same situation.
+- **The manifest's `sizes` and the table are two lists in two files**, which is the
+  drift AGENT.md's validator/renderer note describes: a span offered with no layout of
+  its own does not fail, it silently draws the default layout squeezed into a box it was
+  never designed for, and the grip goes on offering that size forever.
+  `tests/test_media_layouts_contract.py` pins them together and
+  `tests/tst_media_layouts.qml` drives the lookup itself.
+- **A layout loaded by URL escapes `DesignSystemCompile`'s sweep**, which takes a bundled
+  package through its `Widget.qml` only - so each layout is named in that file's explicit
+  list, or it compiles for the first time on the user's desktop.
+
+The wrapper must also answer the blur contract for whichever layout is loaded
+(`blurRegions`, `managesBlurTint`), and every layout must therefore declare both: an
+empty region list means "blur the whole widget", so a layout that declared neither would
+frost its own shadow rather than error - at one span only.
+61e2f723c ("refactor(media): move the media widget's content into LayoutLarge"),
+b4113ecd6 ("feat(media): offer the media widget three spans, and pick a layout from it").
+
+**Measure a content-sized widget before pinning it to a span.** Adopting the grid replaces
+whatever the content happened to measure with exactly `spanX(cols) x spanY(rows)`, and if
+those differ every placed copy resizes on upgrade with nothing reporting why. Media
+measured 420x228 through a `qs -p` probe both before and after, which is exactly
+`spanX(3) x spanY(2)` - the design-system widget already declared the span's pixels. Where
+they do differ, adjust the layout to the span rather than picking the span that flatters
+the current content.
+
 Growing past the screen edge needs no new rule: committing a span writes plugin state,
 which re-evaluates the widget's persisted position, so the existing clamp
 (`PluginWidget.applyPersistedPosition`) pulls it back inside against its *new* width -
@@ -201,9 +245,9 @@ The only test is `size === widgetGridSpanX(cols)` / `widgetGridSpanY(rows)`.
   broken at the smallest. Switch on the resolved span if the content needs to differ,
   rather than scaling one layout down.
 - **The `nandoroid-*` widgets already conform.** They define this grid (media = 3x2,
-  system monitor = 3x1 / 1x3). Media and the system monitor are content-sized rather than
-  declaring `grid`, but their pixel sizes are exactly on it, so new `grid` widgets tile
-  flush beside them; weather (1x1 / 2x1 / 3x1) and currency (1x1 / 2x1) declare
+  system monitor = 3x1 / 1x3). The system monitor is content-sized rather than declaring
+  `grid`, but its pixel sizes are exactly on it, so new `grid` widgets tile flush beside
+  it; weather (1x1 / 2x1 / 3x1), currency (1x1 / 2x1) and media (3x2 / 2x2 / 2x1) declare
   `grid.sizes` and take their size from the host. `clock` is exempt by decision: its shape
   places neatly without a span, so it stays content-sized behind
   `defaultWidth`/`defaultHeight`.

--- a/dots/.config/quickshell/imi/DesignSystemCompile.qml
+++ b/dots/.config/quickshell/imi/DesignSystemCompile.qml
@@ -50,6 +50,7 @@ ShellRoot {
                 // a standalone component and compiles - or does not - on its own.
                 Quickshell.shellPath("modules/common/plugins/bundled/nandoroid-media/LayoutLarge.qml"),
                 Quickshell.shellPath("modules/common/plugins/bundled/nandoroid-media/LayoutCookie.qml"),
+                Quickshell.shellPath("modules/common/plugins/bundled/nandoroid-media/LayoutCompact.qml"),
                 Quickshell.shellPath("modules/common/plugins/PluginOptions.qml"),
                 // The desktop-widget host. It only compiles once a plugin is
                 // enabled on some monitor, so a bad property on it is invisible

--- a/dots/.config/quickshell/imi/DesignSystemCompile.qml
+++ b/dots/.config/quickshell/imi/DesignSystemCompile.qml
@@ -43,6 +43,12 @@ ShellRoot {
             }
 
             const paths = designSystem.concat(packages).concat(settingsPages).concat([
+                // The media widget's per-span layouts. A package is otherwise
+                // swept through its entry point only, on the reasoning that a
+                // sibling file is a type resolved through the package's qmldir.
+                // These are not: Widget.qml loads one of them by URL, so each is
+                // a standalone component and compiles - or does not - on its own.
+                Quickshell.shellPath("modules/common/plugins/bundled/nandoroid-media/LayoutLarge.qml"),
                 Quickshell.shellPath("modules/common/plugins/PluginOptions.qml"),
                 // The desktop-widget host. It only compiles once a plugin is
                 // enabled on some monitor, so a bad property on it is invisible

--- a/dots/.config/quickshell/imi/DesignSystemCompile.qml
+++ b/dots/.config/quickshell/imi/DesignSystemCompile.qml
@@ -49,6 +49,7 @@ ShellRoot {
                 // These are not: Widget.qml loads one of them by URL, so each is
                 // a standalone component and compiles - or does not - on its own.
                 Quickshell.shellPath("modules/common/plugins/bundled/nandoroid-media/LayoutLarge.qml"),
+                Quickshell.shellPath("modules/common/plugins/bundled/nandoroid-media/LayoutCookie.qml"),
                 Quickshell.shellPath("modules/common/plugins/PluginOptions.qml"),
                 // The desktop-widget host. It only compiles once a plugin is
                 // enabled on some monitor, so a bad property on it is invisible

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/LayoutCompact.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/LayoutCompact.qml
@@ -1,0 +1,244 @@
+import QtQuick
+import QtQuick.Layouts
+import qs.modules.common
+import qs.modules.common.functions as Functions
+import qs.modules.common.widgets
+import qs.modules.common.plugins
+import qs.services
+import "../../designsystem/widgets/shapes/material-shapes.js" as MaterialShapes
+import "../../designsystem/widgets/shapes/path-length.js" as PathLength
+
+// The 2x1 media widget: prev, play/pause, next, centred. No text and no
+// artwork - but playback progress is there, stroked around the centre button's
+// own cookie outline rather than drawn as a separate track underneath, which is
+// what makes the three controls read as one object.
+//
+// The cookie here is static, unlike the 2x2's. A rippling outline carrying a
+// progress ring would fight it: two things moving on one edge, neither
+// readable.
+Item {
+    id: root
+
+    implicitWidth: Appearance.sizes.widgetGridSpanX(2)
+    implicitHeight: Appearance.sizes.widgetGridSpanY(1)
+
+    readonly property bool useBlurBackground: PluginState.option("nandoroid_media", "blurEnabled", false)
+    readonly property real backgroundOpacity: PluginState.effectiveBackgroundOpacity("nandoroid_media")
+
+    readonly property bool managesBlurTint: true
+    readonly property var blurRegions: [{
+        x: bgCard.x, y: bgCard.y, width: bgCard.width, height: bgCard.height, radius: bgCard.radius
+    }]
+
+    readonly property real controlSize: 56 * Appearance.effectiveScale
+    readonly property real playSize: 72 * Appearance.effectiveScale
+    readonly property real progress: MprisController.length > 0
+        ? MprisController.position / MprisController.length : 0
+
+    readonly property color controlColor: Appearance.m3colors.darkmode
+        ? Appearance.colors.colOnTertiaryContainer : Appearance.colors.colSecondaryContainer
+    readonly property color controlIconColor: Appearance.m3colors.darkmode
+        ? Appearance.colors.colTertiaryContainer : Appearance.colors.colOnSecondaryContainer
+
+    // MprisPlayer caches its position and refetches when something asks, so a
+    // widget that only reads it draws a ring frozen where the track started.
+    // The bar's media widget pokes it on exactly this interval; a desktop widget
+    // cannot assume the bar is on screen.
+    Timer {
+        running: MprisController.isPlaying
+        interval: Config.options.resources.updateInterval
+        repeat: true
+        onTriggered: MprisController.activePlayer?.positionChanged()
+    }
+
+    Rectangle {
+        id: bgCard
+        anchors.fill: parent
+        radius: 30 * Appearance.effectiveScale
+        color: root.useBlurBackground
+            ? Functions.ColorUtils.applyAlpha(Appearance.colors.colOnPrimary, root.backgroundOpacity)
+            : Appearance.colors.colOnPrimary
+    }
+
+    RowLayout {
+        anchors.centerIn: parent
+        spacing: Appearance.spacing.space150
+
+        Rectangle {
+            id: prevPill
+            implicitWidth: root.controlSize
+            implicitHeight: root.controlSize
+            radius: height / 2
+            color: root.controlColor
+
+            MaterialSymbol {
+                anchors.centerIn: parent
+                text: "skip_previous"
+                iconSize: 26 * Appearance.effectiveScale
+                fill: 0
+                color: prevArea.containsMouse ? Appearance.colors.colPrimary : root.controlIconColor
+                Behavior on color { ColorAnimation { duration: Appearance.animation.elementMoveFast.duration } }
+            }
+
+            MouseArea {
+                id: prevArea
+                anchors.fill: parent
+                hoverEnabled: true
+                cursorShape: Qt.PointingHandCursor
+                onClicked: MprisController.previous()
+            }
+        }
+
+        Item {
+            id: playButton
+            implicitWidth: root.playSize
+            implicitHeight: root.playSize
+
+            // The button body and the seek ring are two concentric draws of one
+            // cookie outline: the body sits inside the ring rather than under
+            // it, so the stroke reads as the button's border and not as a line
+            // laid over its edge.
+            Canvas {
+                id: cookieCanvas
+                anchors.fill: parent
+
+                readonly property real strokeWidth: Appearance.borderWidth.heavy * Appearance.effectiveScale
+                readonly property var polygon: MaterialShapes.getCookie12Sided()
+                // Measured once: the shape never changes, so a moving progress
+                // costs a dash pattern rather than a re-measure.
+                readonly property real outlineLength: PathLength.measureCubics(cookieCanvas.polygon.cubics).total
+                // The dash starts where the path does, which is wherever the
+                // first vertex happens to sit. Turning that point to the top
+                // makes progress start at twelve o'clock and travel clockwise;
+                // a twelve-lobed cookie is symmetric every 30 degrees, so
+                // nothing about the shape reads as rotated.
+                readonly property real startRotation: {
+                    const cubics = cookieCanvas.polygon.cubics;
+                    if (cubics.length === 0)
+                        return 0;
+                    return -Math.PI / 2 - Math.atan2(cubics[0].anchor0Y - 0.5, cubics[0].anchor0X - 0.5);
+                }
+
+                // A Canvas repaints on resize and on nothing else, so every
+                // input it reads is mirrored here to be observed. A colour
+                // reached only from inside onPaint is the silent half: the
+                // ring would keep the old theme's colours until something
+                // resized the widget.
+                readonly property real progress: root.progress
+                readonly property color bodyColor: Appearance.colors.colPrimary
+                readonly property color trackColor: Functions.ColorUtils.applyAlpha(Appearance.colors.colPrimary, 0.25)
+
+                onWidthChanged: requestPaint()
+                onHeightChanged: requestPaint()
+                onProgressChanged: requestPaint()
+                onBodyColorChanged: requestPaint()
+                onTrackColorChanged: requestPaint()
+
+                // Opens a path under the transform that puts the normalized
+                // polygon on screen at `diameter`, and leaves the transform in
+                // place: the caller fills or strokes, then restores.
+                function trace(ctx, diameter) {
+                    const cubics = cookieCanvas.polygon.cubics;
+                    ctx.save();
+                    ctx.translate(width / 2, height / 2);
+                    ctx.rotate(cookieCanvas.startRotation);
+                    ctx.scale(diameter, diameter);
+                    ctx.translate(-0.5, -0.5);
+                    ctx.beginPath();
+                    ctx.moveTo(cubics[0].anchor0X, cubics[0].anchor0Y);
+                    for (const cubic of cubics)
+                        ctx.bezierCurveTo(cubic.control0X, cubic.control0Y,
+                            cubic.control1X, cubic.control1Y, cubic.anchor1X, cubic.anchor1Y);
+                    ctx.closePath();
+                }
+
+                onPaint: {
+                    const ctx = getContext("2d");
+                    ctx.clearRect(0, 0, width, height);
+                    if (cookieCanvas.polygon.cubics.length === 0)
+                        return;
+
+                    const size = Math.min(width, height);
+                    const stroke = cookieCanvas.strokeWidth;
+                    // The ring's outer edge lands on the button's bounds, and
+                    // the body clears its inner edge by half a stroke.
+                    const ringDiameter = size - stroke;
+                    const bodyDiameter = ringDiameter - stroke * 3;
+
+                    trace(ctx, bodyDiameter);
+                    ctx.fillStyle = cookieCanvas.bodyColor;
+                    ctx.fill();
+                    ctx.restore();
+
+                    // The line width is divided by the diameter because the
+                    // scale drawing the path scales the pen with it. The dash
+                    // pattern is then in multiples of *that* width, which is
+                    // Qt's unit for it rather than HTML's path length.
+                    trace(ctx, ringDiameter);
+                    ctx.lineWidth = stroke / ringDiameter;
+                    ctx.setLineDash([]);
+                    ctx.strokeStyle = cookieCanvas.trackColor;
+                    ctx.stroke();
+                    ctx.restore();
+
+                    // Skipped rather than dashed at zero: `[0, total]` is an
+                    // honest pattern and a degenerate thing to hand a painter.
+                    if (cookieCanvas.progress > 0) {
+                        trace(ctx, ringDiameter);
+                        ctx.lineWidth = stroke / ringDiameter;
+                        ctx.setLineDash(PathLength.dashInPenWidths(
+                            cookieCanvas.outlineLength, cookieCanvas.progress, ctx.lineWidth));
+                        ctx.strokeStyle = cookieCanvas.bodyColor;
+                        ctx.stroke();
+                        ctx.setLineDash([]);
+                        ctx.restore();
+                    }
+                }
+            }
+
+            MaterialSymbol {
+                anchors.centerIn: parent
+                text: MprisController.isPlaying ? "pause" : "play_arrow"
+                iconSize: 30 * Appearance.effectiveScale
+                fill: 0
+                color: playArea.pressed
+                    ? Functions.ColorUtils.applyAlpha(Appearance.colors.colOnPrimary, 0.7)
+                    : Appearance.colors.colOnPrimary
+                Behavior on color { ColorAnimation { duration: Appearance.animation.elementMoveFast.duration } }
+            }
+
+            MouseArea {
+                id: playArea
+                anchors.fill: parent
+                hoverEnabled: true
+                cursorShape: Qt.PointingHandCursor
+                onClicked: MprisController.togglePlaying()
+            }
+        }
+
+        Rectangle {
+            id: nextPill
+            implicitWidth: root.controlSize
+            implicitHeight: root.controlSize
+            radius: height / 2
+            color: root.controlColor
+
+            MaterialSymbol {
+                anchors.centerIn: parent
+                text: "skip_next"
+                iconSize: 26 * Appearance.effectiveScale
+                fill: 0
+                color: nextArea.containsMouse ? Appearance.colors.colPrimary : root.controlIconColor
+                Behavior on color { ColorAnimation { duration: Appearance.animation.elementMoveFast.duration } }
+            }
+
+            MouseArea {
+                id: nextArea
+                anchors.fill: parent
+                hoverEnabled: true
+                cursorShape: Qt.PointingHandCursor
+                onClicked: MprisController.next()
+            }
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/LayoutCookie.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/LayoutCookie.qml
@@ -1,0 +1,162 @@
+import QtQuick
+import QtQuick.Layouts
+import Qt5Compat.GraphicalEffects
+import qs.modules.common
+import qs.modules.common.functions as Functions
+import qs.modules.common.widgets
+import qs.modules.common.plugins
+import qs.services
+import "../../designsystem/widgets" as Expressive
+
+// The 2x2 media widget: the cookie is the artwork, its lobes are the spectrum,
+// and the track sits underneath. There are no transport buttons - the cookie is
+// the only control, and it plays and pauses.
+Item {
+    id: root
+
+    implicitWidth: Appearance.sizes.widgetGridSpanX(2)
+    implicitHeight: Appearance.sizes.widgetGridSpanY(2)
+
+    readonly property real cardInset: Appearance.spacing.space200
+    readonly property bool useBlurBackground: PluginState.option("nandoroid_media", "blurEnabled", false)
+    readonly property real backgroundOpacity: PluginState.effectiveBackgroundOpacity("nandoroid_media")
+
+    readonly property bool managesBlurTint: true
+    readonly property var blurRegions: [{
+        x: bgCard.x, y: bgCard.y, width: bgCard.width, height: bgCard.height, radius: bgCard.radius
+    }]
+
+    readonly property string artUrl: MprisController.activePlayer?.trackArtUrl ?? ""
+    readonly property bool hasArt: root.artUrl !== "" && albumArt.status === Image.Ready
+
+    Rectangle {
+        id: bgCard
+        anchors.fill: parent
+        radius: 30 * Appearance.effectiveScale
+        color: root.useBlurBackground
+            ? Functions.ColorUtils.applyAlpha(Appearance.colors.colOnPrimary, root.backgroundOpacity)
+            : Appearance.colors.colOnPrimary
+    }
+
+    // The cookie takes whatever the track block leaves. Measured against the
+    // column's *implicit* height rather than its height: the column is anchored
+    // to three edges, so its actual height is the card's, and reading that back
+    // would size the cookie to nothing.
+    Expressive.VisualizerCookie {
+        id: cookie
+        anchors.top: parent.top
+        anchors.topMargin: root.cardInset
+        anchors.horizontalCenter: parent.horizontalCenter
+        width: Math.max(0, Math.min(root.width - root.cardInset * 2,
+            root.height - root.cardInset * 2 - trackColumn.implicitHeight - Appearance.spacing.space100))
+        height: width
+
+        lobes: 12
+        // Claimed only while something is playing: the claim starts cava, and a
+        // paused desktop has no spectrum to draw. The lobes decay back to the
+        // resting cookie on their own when the claim drops.
+        audioReactive: MprisController.isPlaying
+        color: Appearance.colors.colPrimary
+    }
+
+    // Clipped to a circle rather than to the cookie: the lobes are what ripples,
+    // so masking the artwork with the same moving outline would swallow the
+    // motion instead of showing it. The circle sits inside the lobes' valleys,
+    // which is what leaves the scalloped edge visible all the way round.
+    Item {
+        id: artClip
+        anchors.centerIn: cookie
+        width: cookie.width * 0.72
+        height: width
+        layer.enabled: true
+        layer.effect: OpacityMask {
+            maskSource: Rectangle {
+                width: artClip.width
+                height: artClip.height
+                radius: width / 2
+            }
+        }
+
+        Rectangle {
+            anchors.fill: parent
+            color: Appearance.colors.colOnPrimary
+        }
+
+        Image {
+            id: albumArt
+            anchors.fill: parent
+            source: root.artUrl
+            fillMode: Image.PreserveAspectCrop
+            asynchronous: true
+            visible: root.hasArt
+        }
+
+        Rectangle {
+            anchors.fill: parent
+            color: Appearance.colors.colOnPrimary
+            opacity: !root.hasArt ? 0 : (cookieTap.containsMouse ? 0.55 : 0)
+            Behavior on opacity { NumberAnimation { duration: Appearance.animation.elementMoveFast.duration } }
+        }
+    }
+
+    MaterialSymbol {
+        anchors.centerIn: artClip
+        text: MprisController.isPlaying ? "pause" : "play_arrow"
+        iconSize: artClip.width * 0.42
+        fill: 1
+        color: Appearance.colors.colPrimary
+        opacity: (!root.hasArt || cookieTap.containsMouse) ? 1 : 0
+        Behavior on opacity { NumberAnimation { duration: Appearance.animation.elementMoveFast.duration } }
+    }
+
+    // Only the artwork takes the press, not the cookie's whole bounding box: a
+    // nested MouseArea claims it from the host's drag-to-move, and a target the
+    // size of the cookie would leave the card with almost nothing to drag by.
+    MouseArea {
+        id: cookieTap
+        anchors.centerIn: artClip
+        width: artClip.width
+        height: artClip.height
+        hoverEnabled: true
+        cursorShape: Qt.PointingHandCursor
+        onClicked: MprisController.togglePlaying()
+    }
+
+    ColumnLayout {
+        id: trackColumn
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
+        anchors.margins: root.cardInset
+        spacing: Appearance.spacing.space25
+
+        StyledText {
+            Layout.fillWidth: true
+            horizontalAlignment: Text.AlignHCenter
+            text: Functions.StringUtils.cleanMusicTitle(MprisController.trackTitle) || "No Music Playing"
+            font.pixelSize: Appearance.font.pixelSize.normal
+            font.weight: Font.DemiBold
+            color: Appearance.colors.colPrimary
+            elide: Text.ElideRight
+            maximumLineCount: 1
+        }
+
+        StyledText {
+            Layout.fillWidth: true
+            horizontalAlignment: Text.AlignHCenter
+            text: {
+                const rawTitle = (MprisController.trackTitle || "").trim().toLowerCase();
+                const hasTitle = rawTitle !== "" && rawTitle !== "no media" && rawTitle !== "no music playing";
+                const hasArtist = MprisController.trackArtist && MprisController.trackArtist.trim() !== "";
+                if (hasTitle)
+                    return hasArtist ? MprisController.trackArtist : "Unknown Artist";
+                return "Play some media";
+            }
+            font.pixelSize: Appearance.font.pixelSize.smaller
+            font.weight: Font.DemiBold
+            color: Functions.ColorUtils.applyAlpha(Appearance.colors.colPrimary, 0.75)
+            elide: Text.ElideRight
+            maximumLineCount: 1
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/LayoutLarge.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/LayoutLarge.qml
@@ -12,8 +12,7 @@ Item {
 
     Expressive.DesktopMediaWidget {
         id: content
-        width: implicitWidth
-        height: implicitHeight
+        anchors.fill: parent
         showLyrics: PluginState.option("nandoroid_media", "showLyrics", false)
         useRomaji: PluginState.option("nandoroid_media", "useRomaji", false)
         useBlurBackground: PluginState.option("nandoroid_media", "blurEnabled", false)

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/LayoutLarge.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/LayoutLarge.qml
@@ -1,0 +1,22 @@
+import QtQuick
+import qs.modules.common.plugins
+import "../../designsystem/widgets" as Expressive
+
+// The 3x2 media widget: artwork-free controls, lyrics page, wavy seek bar.
+// This is the layout the widget has always had, unchanged.
+Item {
+    readonly property var blurRegions: content.blurRegions
+    readonly property bool managesBlurTint: content.managesBlurTint
+    implicitWidth: content.implicitWidth
+    implicitHeight: content.implicitHeight
+
+    Expressive.DesktopMediaWidget {
+        id: content
+        width: implicitWidth
+        height: implicitHeight
+        showLyrics: PluginState.option("nandoroid_media", "showLyrics", false)
+        useRomaji: PluginState.option("nandoroid_media", "useRomaji", false)
+        useBlurBackground: PluginState.option("nandoroid_media", "blurEnabled", false)
+        backgroundOpacity: PluginState.effectiveBackgroundOpacity("nandoroid_media")
+    }
+}

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/Widget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/Widget.qml
@@ -1,23 +1,30 @@
 import QtQuick
+import qs.modules.common
+import "media_layouts.js" as MediaLayouts
 
-// A shell around one layout file. The widget is content-sized, so the Loader is
-// deliberately unanchored and takes its size from this item instead: anchoring
-// it to a parent whose own implicit size is derived from the loaded item is the
-// binding loop AGENT.md warns about.
+// A shell around one layout file per span.
 Item {
     id: root
 
+    // The span the host resolved, handed down by PluginNode: the stored choice,
+    // then the manifest default. Empty until the host answers, and for a bare
+    // `qs -p` probe of this file.
+    property string hostGridSize: ""
+
+    readonly property var span: MediaLayouts.spanFor(root.hostGridSize)
+
+    // Not derived from the loaded layout: the manifest declares a grid, so the
+    // host sizes this item to the span and fills it, and reading the item's
+    // implicit size back through a filled Loader is a binding loop.
+    implicitWidth: Appearance.sizes.widgetGridSpanX(root.span.cols)
+    implicitHeight: Appearance.sizes.widgetGridSpanY(root.span.rows)
+
     readonly property var blurRegions: layout.item ? layout.item.blurRegions : []
     readonly property bool managesBlurTint: layout.item ? layout.item.managesBlurTint === true : false
-    implicitWidth: layout.item ? layout.item.implicitWidth : 0
-    implicitHeight: layout.item ? layout.item.implicitHeight : 0
-    width: implicitWidth
-    height: implicitHeight
 
     Loader {
         id: layout
-        width: root.width
-        height: root.height
-        source: "LayoutLarge.qml"
+        anchors.fill: parent
+        source: MediaLayouts.layoutFor(root.hostGridSize)
     }
 }

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/Widget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/Widget.qml
@@ -1,21 +1,23 @@
 import QtQuick
-import qs.modules.common.plugins
-import "../../designsystem/widgets" as Expressive
 
+// A shell around one layout file. The widget is content-sized, so the Loader is
+// deliberately unanchored and takes its size from this item instead: anchoring
+// it to a parent whose own implicit size is derived from the loaded item is the
+// binding loop AGENT.md warns about.
 Item {
-    readonly property var blurRegions: content.blurRegions
-    readonly property bool managesBlurTint: content.managesBlurTint
-    implicitWidth: content.implicitWidth
-    implicitHeight: content.implicitHeight
+    id: root
+
+    readonly property var blurRegions: layout.item ? layout.item.blurRegions : []
+    readonly property bool managesBlurTint: layout.item ? layout.item.managesBlurTint === true : false
+    implicitWidth: layout.item ? layout.item.implicitWidth : 0
+    implicitHeight: layout.item ? layout.item.implicitHeight : 0
     width: implicitWidth
     height: implicitHeight
-    Expressive.DesktopMediaWidget {
-        id: content
-        width: implicitWidth
-        height: implicitHeight
-        showLyrics: PluginState.option("nandoroid_media", "showLyrics", false)
-        useRomaji: PluginState.option("nandoroid_media", "useRomaji", false)
-        useBlurBackground: PluginState.option("nandoroid_media", "blurEnabled", false)
-        backgroundOpacity: PluginState.effectiveBackgroundOpacity("nandoroid_media")
+
+    Loader {
+        id: layout
+        width: root.width
+        height: root.height
+        source: "LayoutLarge.qml"
     }
 }

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/manifest.json
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/manifest.json
@@ -6,5 +6,9 @@
     { "key": "showLyrics", "type": "boolean", "label": "Enable lyrics view", "icon": "lyrics", "default": false },
     { "key": "useRomaji", "type": "boolean", "label": "Prefer romaji lyrics", "icon": "translate", "default": false }
   ],
+  "grid": {
+    "cols": 3, "rows": 2,
+    "sizes": [ { "cols": 3, "rows": 2 }, { "cols": 2, "rows": 2 }, { "cols": 2, "rows": 1 } ]
+  },
   "desktopWidget": { "component": "Widget.qml", "blur": false }
 }

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/media_layouts.js
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/media_layouts.js
@@ -13,7 +13,8 @@
 // default one, squeezed into a box it was never designed for.
 var SIZES = [
     { size: "3x2", cols: 3, rows: 2, layout: "LayoutLarge.qml" },
-    { size: "2x2", cols: 2, rows: 2, layout: "LayoutCookie.qml" }
+    { size: "2x2", cols: 2, rows: 2, layout: "LayoutCookie.qml" },
+    { size: "2x1", cols: 2, rows: 1, layout: "LayoutCompact.qml" }
 ];
 
 // Anything unrecognised resolves to the first entry rather than to nothing:

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/media_layouts.js
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/media_layouts.js
@@ -12,7 +12,8 @@
 // span the manifest offers with no layout of its own would silently draw the
 // default one, squeezed into a box it was never designed for.
 var SIZES = [
-    { size: "3x2", cols: 3, rows: 2, layout: "LayoutLarge.qml" }
+    { size: "3x2", cols: 3, rows: 2, layout: "LayoutLarge.qml" },
+    { size: "2x2", cols: 2, rows: 2, layout: "LayoutCookie.qml" }
 ];
 
 // Anything unrecognised resolves to the first entry rather than to nothing:

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/media_layouts.js
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/media_layouts.js
@@ -1,0 +1,42 @@
+.pragma library
+
+// Which file draws which span, in one table.
+//
+// The host owns *which* size a widget is - it resolves the stored `__gridSize`
+// against the manifest and hands the answer down as `hostGridSize`
+// (docs/widget-grid.md) - and the widget owns what that size looks like. This
+// is the whole of the widget's half: span in, layout file out.
+//
+// The entries are in the manifest's `sizes` order, which is the resize order,
+// and `tests/test_media_layouts_contract.py` fails if the two lists drift: a
+// span the manifest offers with no layout of its own would silently draw the
+// default one, squeezed into a box it was never designed for.
+var SIZES = [
+    { size: "3x2", cols: 3, rows: 2, layout: "LayoutLarge.qml" }
+];
+
+// Anything unrecognised resolves to the first entry rather than to nothing:
+// `hostGridSize` is empty until the host answers (and stays empty for a bare
+// `qs -p` probe of Widget.qml), and a span a future manifest stops offering
+// would otherwise load no layout at all - which on screen is indistinguishable
+// from a widget that failed to compile.
+function entryFor(gridSize) {
+    for (let i = 0; i < SIZES.length; i++) {
+        if (SIZES[i].size === gridSize)
+            return SIZES[i];
+    }
+    return SIZES[0];
+}
+
+function layoutFor(gridSize) {
+    return entryFor(gridSize).layout;
+}
+
+// The span as cell counts, for the widget's own implicit size. It is a fallback
+// only - the host sizes a grid widget to the span it resolved - but it has to
+// be the same span the layout is drawn for, or a probe renders one size into
+// another's box.
+function spanFor(gridSize) {
+    const entry = entryFor(gridSize);
+    return { cols: entry.cols, rows: entry.rows };
+}

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/shapes/path-length.js
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/shapes/path-length.js
@@ -77,3 +77,18 @@ function dashForProgress(total, progress) {
     const fraction = isFinite(progress) ? Math.max(0, Math.min(1, progress)) : 0;
     return [length * fraction, length];
 }
+
+// The same pattern in the units a QML `Canvas` actually reads.
+//
+// HTML's `setLineDash` takes path-length units. Qt's implementation of it does
+// not: it hands the array to `QPen::setDashPattern`, which is specified in
+// multiples of the pen width. Handing it path units therefore produces a
+// pattern the wrong size by a factor of the line width - and because the "off"
+// run shrinks by the same factor, the pattern *repeats*, so a progress ring
+// comes out as a ring of evenly spaced dashes that all grow together as
+// progress rises. It looks like a deliberate dashed border rather than like a
+// bug, which is why it needs naming rather than a comment at the call site.
+function dashInPenWidths(total, progress, lineWidth) {
+    const width = isFinite(lineWidth) && lineWidth > 0 ? lineWidth : 1;
+    return dashForProgress(total, progress).map(value => value / width);
+}

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/shapes/path-length.js
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/shapes/path-length.js
@@ -1,0 +1,79 @@
+.pragma library
+
+// Arc length along a run of cubic Beziers, so a partial stroke can be dashed
+// onto a shape's *own* outline instead of drawn as a separate track beside it.
+//
+// A rounded polygon is a closed run of cubics (rounded-polygon.js), and a cubic
+// has no closed-form length - so each one is sampled into a polyline. The
+// estimate converges on the true length from below as `samples` rises, and 16
+// segments is exact to far under a pixel here because a rounded polygon's
+// cubics are short arcs rather than long S-curves.
+//
+// The cost is per geometry change, not per frame: a static shape pays it once,
+// which is what makes a progress ring stroked around a cookie's outline cost
+// nothing to animate. It lives beside rounded-polygon.js rather than inside the
+// one component that strokes today, because VisualizerCookie walks the same
+// kind of path and a layout wanting both is a change of caller, not of maths.
+
+var DEFAULT_SAMPLES = 16;
+
+// Deliberately not cubic.js's `pointOnCurve`: a caller measuring cubics it
+// built by hand should not have to construct that type, and the eight
+// coordinates are the whole of what a length needs.
+function pointOnCubic(cubic, t) {
+    const u = 1 - t;
+    return {
+        x: cubic.anchor0X * u * u * u
+            + cubic.control0X * 3 * t * u * u
+            + cubic.control1X * 3 * t * t * u
+            + cubic.anchor1X * t * t * t,
+        y: cubic.anchor0Y * u * u * u
+            + cubic.control0Y * 3 * t * u * u
+            + cubic.control1Y * 3 * t * t * u
+            + cubic.anchor1Y * t * t * t
+    };
+}
+
+function cubicLength(cubic, samples) {
+    if (!cubic)
+        return 0;
+    const steps = Math.max(1, Math.round(samples > 0 ? samples : DEFAULT_SAMPLES));
+    let length = 0;
+    let previous = { x: cubic.anchor0X, y: cubic.anchor0Y };
+    for (let step = 1; step <= steps; step++) {
+        const point = pointOnCubic(cubic, step / steps);
+        length += Math.hypot(point.x - previous.x, point.y - previous.y);
+        previous = point;
+    }
+    return isFinite(length) ? length : 0;
+}
+
+// `lengths[i]` is the distance from the path's start to the start of cubic `i`,
+// so `lengths` is one longer than `cubics` and its last entry is `total`. The
+// cumulative form is what a caller needs to find a point at a given progress;
+// dashing only needs the total, and gets it from the same pass.
+function measureCubics(cubics, samples) {
+    const count = cubics && typeof cubics.length === "number" ? cubics.length : 0;
+    const lengths = [0];
+    let total = 0;
+    for (let i = 0; i < count; i++) {
+        total += cubicLength(cubics[i], samples);
+        lengths.push(total);
+    }
+    return { total: total, lengths: lengths };
+}
+
+// The dash pattern that strokes the first `progress` of a closed path and
+// nothing after it: one "on" run of that length, then an "off" run long enough
+// to reach the end at any progress.
+//
+// Progress outside 0..1 is clamped rather than trusted - a player reporting a
+// position past its own length is ordinary, and a negative dash length is not a
+// pattern. A caller must skip the stroke entirely at zero: the pattern is
+// honestly `[0, total]` there, and a zero-length dash is a degenerate thing to
+// hand a painter.
+function dashForProgress(total, progress) {
+    const length = isFinite(total) && total > 0 ? total : 0;
+    const fraction = isFinite(progress) ? Math.max(0, Math.min(1, progress)) : 0;
+    return [length * fraction, length];
+}

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -769,6 +769,12 @@ if ! python3 "$SCRIPT_DIR/test_plugin_store_contract.py"; then
     exit 1
 fi
 
+echo "Running media layout contract tests..."
+if ! python3 "$SCRIPT_DIR/test_media_layouts_contract.py"; then
+    echo "Media layout contract tests failed."
+    exit 1
+fi
+
 if [[ "${RUN_DOCKER_RUNTIME_MEMORY_TEST:-0}" == "1" ]]; then
     echo "Running capped Docker runtime memory test..."
     bash "$SCRIPT_DIR/run_docker_memory_test.sh"

--- a/dots/.config/quickshell/imi/tests/test_expressive_design_system.py
+++ b/dots/.config/quickshell/imi/tests/test_expressive_design_system.py
@@ -30,6 +30,23 @@ EXPECTED_ENTRY_TYPES = {
     "nandoroid-weather": "Expressive.DesktopWeatherWidget",
     "nandoroid-currency": "Expressive.DesktopCurrencyWidget",
 }
+# Which file in a package instantiates the design-system component. It is the
+# package's entry point for three of the four, and for media it is the layout
+# the entry point loads: media has a layout file per offered span
+# (docs/widget-grid.md), so everything this module pins about a wrapper - which
+# type it builds, which options it reads, how it forwards the blur contract -
+# moved one file down when Widget.qml became a switch on the resolved span.
+ENTRY_FILES = {
+    "nandoroid-media": "LayoutLarge.qml",
+}
+# ...and the size assertion below moved with it, to the other side: a widget
+# whose manifest declares a grid is sized by the host to the span it resolved,
+# so its wrapper names spans rather than forwarding a content size.
+SIZED_BY_THE_HOST_GRID = {"nandoroid-media"}
+
+
+def entry_file(directory):
+    return PLUGIN_ROOT / directory / ENTRY_FILES.get(directory, "Widget.qml")
 
 
 class ExpressiveDesignSystemTest(unittest.TestCase):
@@ -69,12 +86,41 @@ class ExpressiveDesignSystemTest(unittest.TestCase):
             self.assertEqual(option_keys, EXPECTED_OPTIONS[directory])
 
             wrapper = (package / "Widget.qml").read_text(encoding="utf-8")
+            entry = entry_file(directory).read_text(encoding="utf-8")
             self.assertNotIn("target: Config.options", wrapper)
-            self.assertIn(EXPECTED_ENTRY_TYPES[directory], wrapper)
-            self.assertIn("width: implicitWidth", wrapper)
-            self.assertIn("height: implicitHeight", wrapper)
+            self.assertNotIn("target: Config.options", entry)
+            self.assertIn(EXPECTED_ENTRY_TYPES[directory], entry)
+            if directory in SIZED_BY_THE_HOST_GRID:
+                self.assertIn("Appearance.sizes.widgetGridSpanX(", wrapper)
+                self.assertIn("Appearance.sizes.widgetGridSpanY(", wrapper)
+            else:
+                self.assertIn("width: implicitWidth", wrapper)
+                self.assertIn("height: implicitHeight", wrapper)
             for option_key in option_keys:
-                self.assertIn(f'PluginState.option("{manifest["id"]}", "{option_key}"', wrapper)
+                self.assertIn(f'PluginState.option("{manifest["id"]}", "{option_key}"', entry)
+
+    def test_every_media_layout_answers_the_blur_contract(self):
+        """The wrapper forwards whichever layout is loaded, so each must answer.
+
+        `PluginNode` reads `blurRegions`/`managesBlurTint` off the loaded item
+        and treats an empty region list as "blur the whole widget". A layout
+        that declared neither would therefore frost its own shadow rather than
+        error, and only at the span that loads it - which is the one span nobody
+        looks at while writing the other two.
+        """
+        package = PLUGIN_ROOT / "nandoroid-media"
+        wrapper = (package / "Widget.qml").read_text(encoding="utf-8")
+        self.assertIn("blurRegions: layout.item ? layout.item.blurRegions : []", wrapper)
+        self.assertIn(
+            "managesBlurTint: layout.item ? layout.item.managesBlurTint === true : false",
+            wrapper)
+
+        layouts = sorted(package.glob("Layout*.qml"))
+        self.assertEqual(len(layouts), 3, "one layout per offered span")
+        for layout in layouts:
+            text = layout.read_text(encoding="utf-8")
+            self.assertIn("readonly property var blurRegions", text, layout.name)
+            self.assertIn("readonly property bool managesBlurTint", text, layout.name)
 
     def test_system_monitor_third_card_can_show_the_battery(self):
         """The built-in this widget replaced showed Battery on a laptop.
@@ -211,11 +257,11 @@ class ExpressiveDesignSystemTest(unittest.TestCase):
         self.assertIn("readonly property var blurRegions: content.blurRegions", wrapper)
 
         for directory in ("nandoroid-currency", "nandoroid-media", "nandoroid-weather"):
-            wrapper_text = (PLUGIN_ROOT / directory / "Widget.qml").read_text(encoding="utf-8")
-            self.assertIn("readonly property var blurRegions: content.blurRegions", wrapper_text)
-            self.assertIn("readonly property bool managesBlurTint: content.managesBlurTint", wrapper_text)
-            self.assertIn("useBlurBackground: PluginState.option", wrapper_text)
-            self.assertIn("backgroundOpacity: PluginState.effectiveBackgroundOpacity(", wrapper_text)
+            entry_text = entry_file(directory).read_text(encoding="utf-8")
+            self.assertIn("readonly property var blurRegions: content.blurRegions", entry_text)
+            self.assertIn("readonly property bool managesBlurTint: content.managesBlurTint", entry_text)
+            self.assertIn("useBlurBackground: PluginState.option", entry_text)
+            self.assertIn("backgroundOpacity: PluginState.effectiveBackgroundOpacity(", entry_text)
 
         currency = (DESIGN_SYSTEM / "widgets" / "DesktopCurrencyWidget.qml").read_text(
             encoding="utf-8"

--- a/dots/.config/quickshell/imi/tests/test_media_layouts_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_media_layouts_contract.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Source contract: the media widget's spans and its layouts are one list.
+
+The host resolves which span a placed widget is (`__gridSize`, docs/widget-grid.md)
+and the widget picks the file that draws it, so the manifest's `grid.sizes` and
+`media_layouts.js`'s table are two lists that have to name the same set. They
+are edited in different files, which is exactly the drift AGENT.md's
+validator/renderer note describes: a span offered with no layout of its own does
+not fail, it silently draws the default layout squeezed into a box it was never
+designed for - and the grip offers that size for the rest of the widget's life.
+
+`tests/tst_media_layouts.qml` drives the lookup itself; this is the half that
+can see the manifest.
+"""
+from pathlib import Path
+import json
+import re
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGE = ROOT / "modules/common/plugins/bundled/nandoroid-media"
+MANIFEST = PACKAGE / "manifest.json"
+LAYOUTS = PACKAGE / "media_layouts.js"
+
+ENTRY = re.compile(
+    r'\{\s*size:\s*"(?P<size>\d+x\d+)"\s*,\s*'
+    r'cols:\s*(?P<cols>\d+)\s*,\s*'
+    r'rows:\s*(?P<rows>\d+)\s*,\s*'
+    r'layout:\s*"(?P<layout>[^"]+)"\s*\}')
+
+
+def table():
+    body = LAYOUTS.read_text(encoding="utf-8")
+    start = body.index("var SIZES = [")
+    end = body.index("];", start)
+    return [match.groupdict() for match in ENTRY.finditer(body[start:end])]
+
+
+def grid():
+    return json.loads(MANIFEST.read_text(encoding="utf-8"))["grid"]
+
+
+class TheManifestAndTheTableNameTheSameSpans(unittest.TestCase):
+    def test_the_table_is_not_empty(self):
+        # The regex is the only thing standing between this whole module and a
+        # vacuous pass, so say so out loud.
+        self.assertEqual(len(table()), 3, "media_layouts.js parsed to nothing")
+
+    def test_every_offered_span_has_a_layout_of_its_own(self):
+        offered = [f"{size['cols']}x{size['rows']}" for size in grid()["sizes"]]
+        drawn = [entry["size"] for entry in table()]
+        self.assertEqual(offered, drawn,
+                         "the manifest's sizes and media_layouts.js's table "
+                         "must name the same spans, in the same order - the "
+                         "order is the resize order the grip walks")
+
+    def test_every_entry_agrees_with_its_own_cell_counts(self):
+        for entry in table():
+            self.assertEqual(entry["size"], f"{entry['cols']}x{entry['rows']}",
+                             f"entry {entry['size']} disagrees with its cells")
+
+    def test_every_layout_file_exists(self):
+        for entry in table():
+            self.assertTrue((PACKAGE / entry["layout"]).is_file(),
+                            f"{entry['layout']} is named but not shipped")
+
+    def test_the_fallback_entry_is_the_manifest_default(self):
+        """An unrecognised span resolves to the table's first entry, and the
+        host resolves an unrecognised stored span to the manifest default. Those
+        two answers have to be the same span, or the one case where both fire -
+        a stored span dropped from the manifest - draws one size's layout at
+        another size's pixels.
+        """
+        default = grid()
+        self.assertEqual(table()[0]["size"],
+                         f"{default['cols']}x{default['rows']}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dots/.config/quickshell/imi/tests/tst_media_layouts.qml
+++ b/dots/.config/quickshell/imi/tests/tst_media_layouts.qml
@@ -19,6 +19,12 @@ TestCase {
         compare(MediaLayouts.spanFor("3x2").rows, 2);
     }
 
+    function test_the_two_by_two_span_draws_the_cookie_layout() {
+        compare(MediaLayouts.layoutFor("2x2"), "LayoutCookie.qml");
+        compare(MediaLayouts.spanFor("2x2").cols, 2);
+        compare(MediaLayouts.spanFor("2x2").rows, 2);
+    }
+
     function test_an_unanswered_host_draws_the_default_layout() {
         compare(MediaLayouts.layoutFor(""), "LayoutLarge.qml");
         compare(MediaLayouts.layoutFor(undefined), "LayoutLarge.qml");

--- a/dots/.config/quickshell/imi/tests/tst_media_layouts.qml
+++ b/dots/.config/quickshell/imi/tests/tst_media_layouts.qml
@@ -25,6 +25,12 @@ TestCase {
         compare(MediaLayouts.spanFor("2x2").rows, 2);
     }
 
+    function test_the_two_by_one_span_draws_the_compact_layout() {
+        compare(MediaLayouts.layoutFor("2x1"), "LayoutCompact.qml");
+        compare(MediaLayouts.spanFor("2x1").cols, 2);
+        compare(MediaLayouts.spanFor("2x1").rows, 1);
+    }
+
     function test_an_unanswered_host_draws_the_default_layout() {
         compare(MediaLayouts.layoutFor(""), "LayoutLarge.qml");
         compare(MediaLayouts.layoutFor(undefined), "LayoutLarge.qml");

--- a/dots/.config/quickshell/imi/tests/tst_media_layouts.qml
+++ b/dots/.config/quickshell/imi/tests/tst_media_layouts.qml
@@ -1,0 +1,51 @@
+import QtTest
+import "../modules/common/plugins/bundled/nandoroid-media/media_layouts.js" as MediaLayouts
+
+// The media widget's half of the grid contract: the host resolves a span and
+// hands it down as a "<cols>x<rows>" string, and this maps that string onto the
+// file that draws it.
+//
+// The rule worth pinning is the fallback. `hostGridSize` is empty until the
+// host answers - and stays empty for a bare `qs -p` probe of Widget.qml - so a
+// lookup that returned nothing for an unrecognised string would leave the
+// widget drawing nothing at all, which on screen is indistinguishable from a
+// layout that failed to compile.
+TestCase {
+    name: "MediaLayoutsTest"
+
+    function test_the_default_span_draws_the_large_layout() {
+        compare(MediaLayouts.layoutFor("3x2"), "LayoutLarge.qml");
+        compare(MediaLayouts.spanFor("3x2").cols, 3);
+        compare(MediaLayouts.spanFor("3x2").rows, 2);
+    }
+
+    function test_an_unanswered_host_draws_the_default_layout() {
+        compare(MediaLayouts.layoutFor(""), "LayoutLarge.qml");
+        compare(MediaLayouts.layoutFor(undefined), "LayoutLarge.qml");
+        compare(MediaLayouts.layoutFor(null), "LayoutLarge.qml");
+    }
+
+    function test_a_span_the_manifest_no_longer_offers_draws_the_default() {
+        // The mirror of gridSizes.resolveSize refusing a stored span that is no
+        // longer offered: one upgrade later, plugin-state.json still names it.
+        compare(MediaLayouts.layoutFor("9x9"), "LayoutLarge.qml");
+        compare(MediaLayouts.spanFor("9x9").cols, 3);
+        compare(MediaLayouts.spanFor("9x9").rows, 2);
+    }
+
+    function test_the_fallback_span_and_the_fallback_layout_agree() {
+        // Two lookups over one table, so a layout can never be drawn for a span
+        // other than the one it was designed for.
+        const unknown = MediaLayouts.spanFor("nonsense");
+        compare(MediaLayouts.layoutFor(unknown.cols + "x" + unknown.rows),
+            MediaLayouts.layoutFor("nonsense"));
+    }
+
+    function test_every_entry_names_a_span_that_maps_back_to_itself() {
+        for (const entry of MediaLayouts.SIZES) {
+            compare(entry.size, entry.cols + "x" + entry.rows,
+                "entry " + entry.size + " disagrees with its own cell counts");
+            compare(MediaLayouts.layoutFor(entry.size), entry.layout);
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/tests/tst_path_length.qml
+++ b/dots/.config/quickshell/imi/tests/tst_path_length.qml
@@ -1,0 +1,111 @@
+import QtTest
+import "../modules/common/plugins/designsystem/widgets/shapes/path-length.js" as PathLength
+
+// Arc length along a run of cubic Beziers. This is what lets a progress ring be
+// stroked around a shape's own outline: `setLineDash` measures in path length,
+// and a cubic does not carry one.
+//
+// Every case here is a path whose length is known independently - a straight
+// line, a square, a quarter circle - so the sampling is scored against
+// arithmetic rather than against its own output.
+TestCase {
+    name: "PathLengthTest"
+
+    // A cubic whose controls sit on the line between its anchors is exactly
+    // that line, so its length is the distance between them at any sampling.
+    function line(x0, y0, x1, y1) {
+        return {
+            anchor0X: x0, anchor0Y: y0,
+            control0X: x0 + (x1 - x0) / 3, control0Y: y0 + (y1 - y0) / 3,
+            control1X: x0 + 2 * (x1 - x0) / 3, control1Y: y0 + 2 * (y1 - y0) / 3,
+            anchor1X: x1, anchor1Y: y1
+        };
+    }
+
+    // The standard cubic approximation of a quarter circle of radius 1: control
+    // points at k = 4/3 * (sqrt(2) - 1) along the tangents. Its length is within
+    // 0.02% of pi/2, which is far tighter than anything the sampling can fake.
+    function quarterCircle() {
+        const k = 0.5522847498307933;
+        return {
+            anchor0X: 1, anchor0Y: 0,
+            control0X: 1, control0Y: k,
+            control1X: k, control1Y: 1,
+            anchor1X: 0, anchor1Y: 1
+        };
+    }
+
+    function square() {
+        return [line(0, 0, 10, 0), line(10, 0, 10, 10),
+            line(10, 10, 0, 10), line(0, 10, 0, 0)];
+    }
+
+    // --- lengths -----------------------------------------------------------
+
+    function test_a_straight_cubic_measures_its_own_span() {
+        fuzzyCompare(PathLength.cubicLength(line(0, 0, 30, 0)), 30, 1e-9);
+        fuzzyCompare(PathLength.cubicLength(line(0, 0, 3, 4)), 5, 1e-9);
+    }
+
+    function test_a_quarter_circle_measures_a_quarter_of_a_circle() {
+        fuzzyCompare(PathLength.cubicLength(quarterCircle()), Math.PI / 2, 1e-3);
+    }
+
+    function test_a_square_measures_its_perimeter_side_by_side() {
+        const measured = PathLength.measureCubics(square());
+        fuzzyCompare(measured.total, 40, 1e-9);
+        compare(measured.lengths.length, 5,
+            "one more entry than cubics: the start of each, then the total");
+        for (let i = 0; i <= 4; i++)
+            fuzzyCompare(measured.lengths[i], i * 10, 1e-9);
+    }
+
+    function test_sampling_converges_from_below() {
+        // The polyline through the curve is a chord walk, so it can only
+        // under-estimate - which is why a coarse sample is safe and a wrong
+        // accumulation (measuring anchor to anchor, say) shows up as a length
+        // that does not move with the sample count.
+        const coarse = PathLength.cubicLength(quarterCircle(), 2);
+        const fine = PathLength.cubicLength(quarterCircle(), 64);
+        const settled = PathLength.cubicLength(quarterCircle(), 4096);
+        verify(coarse < fine, "a coarser sample must be shorter, not equal");
+        verify(fine <= settled + 1e-9, "sampling must not overshoot the curve");
+        // And the default sampling is already within a thousandth of settled on
+        // a quarter circle - a far longer arc than any cubic in a rounded
+        // polygon - which is why the measurement is worth paying once per
+        // geometry change instead of refining it per frame.
+        fuzzyCompare(PathLength.cubicLength(quarterCircle()), settled, 1e-3);
+    }
+
+    function test_an_empty_path_has_no_length_and_still_has_a_start() {
+        const measured = PathLength.measureCubics([]);
+        compare(measured.total, 0);
+        compare(measured.lengths.length, 1);
+        compare(measured.lengths[0], 0);
+        compare(PathLength.measureCubics(undefined).total, 0);
+        compare(PathLength.cubicLength(null), 0);
+    }
+
+    // --- dashes ------------------------------------------------------------
+
+    function test_progress_becomes_an_on_run_of_that_fraction() {
+        const total = PathLength.measureCubics(square()).total;
+        compare(PathLength.dashForProgress(total, 0), [0, 40]);
+        compare(PathLength.dashForProgress(total, 0.5), [20, 40]);
+        compare(PathLength.dashForProgress(total, 1), [40, 40]);
+    }
+
+    function test_a_position_past_the_end_is_clamped_not_trusted() {
+        // Players report a position past their own reported length routinely,
+        // and a dash longer than the path draws a second lap over the first.
+        compare(PathLength.dashForProgress(40, 2), [40, 40]);
+        compare(PathLength.dashForProgress(40, -1), [0, 40]);
+        compare(PathLength.dashForProgress(40, NaN), [0, 40]);
+        compare(PathLength.dashForProgress(40, undefined), [0, 40]);
+    }
+
+    function test_a_path_with_no_length_dashes_to_nothing() {
+        compare(PathLength.dashForProgress(0, 0.5), [0, 0]);
+        compare(PathLength.dashForProgress(NaN, 0.5), [0, 0]);
+    }
+}

--- a/dots/.config/quickshell/imi/tests/tst_path_length.qml
+++ b/dots/.config/quickshell/imi/tests/tst_path_length.qml
@@ -108,4 +108,22 @@ TestCase {
         compare(PathLength.dashForProgress(0, 0.5), [0, 0]);
         compare(PathLength.dashForProgress(NaN, 0.5), [0, 0]);
     }
+
+    function test_the_painter_wants_the_pattern_in_line_widths() {
+        // Qt's setLineDash is QPen::setDashPattern, which is specified in
+        // multiples of the pen width - not in path length the way HTML's is.
+        // Both runs scale, so getting this wrong shrinks the *period* too and
+        // the ring comes out as a repeating dashed border instead of one arc.
+        compare(PathLength.dashInPenWidths(40, 0.5, 2), [10, 20]);
+        compare(PathLength.dashInPenWidths(40, 1, 4), [10, 10]);
+        compare(PathLength.dashInPenWidths(40, 0, 4), [0, 10]);
+    }
+
+    function test_a_pen_with_no_width_leaves_the_pattern_in_path_units() {
+        // A cosmetic pen is one device pixel wide whatever the transform says,
+        // so there is no factor to divide by - and dividing by zero would hand
+        // the painter an infinite dash.
+        compare(PathLength.dashInPenWidths(40, 0.5, 0), [20, 40]);
+        compare(PathLength.dashInPenWidths(40, 0.5, NaN), [20, 40]);
+    }
 }


### PR DESCRIPTION
Steps 5-8 of `docs/superpowers/specs/2026-08-10-media-widget-sizes-design.md`. The original request:
a 2x2 and a 2x1 beside the existing 3x2, switchable by the resize grip.

- **3x2 `LayoutLarge.qml`** — today's widget, moved verbatim.
- **2x2 `LayoutCookie.qml`** — `VisualizerCookie` with album art inside it, lobes rippling per
  frequency band, title and artist beneath, tap to play/pause.
- **2x1 `LayoutCompact.qml`** — prev / cookie play-pause / next, with **progress stroked around the
  cookie's own outline** rather than as a separate track.

## The migration risk did not exist

The design flagged that adopting the grid would pin a content-sized widget to exactly 420x228 and
might move it. Measured with a `qs -p` probe before committing: **420x228 both before and after** —
`DesktopMediaWidget` already declared exactly that. No placed widget moves on upgrade.

## The spec's seek-bar recipe was wrong

`setLineDash([progress * total, total])` is **HTML canvas** semantics. QML hands that array to
`QPen::setDashPattern`, which is in **multiples of the pen width** — so both runs shrink together,
the period shrinks with them, and the pattern repeats. 25% progress drew as thirteen evenly spaced
dashes right around the ring, which reads as a deliberate dashed border rather than a bug.

Found by rendering the ring offscreen and looking at the PNG, not by reasoning. Fixed with
`dashInPenWidths` in the new `shapes/path-length.js`, and the on-screen checklist below names the
symptom so a regression is recognisable.

## Two more things worth knowing

- **"Album art clipped inside the cookie" taken literally destroys the effect.** Masking the art with
  the rippling outline swallows the motion the outline exists to show; the art is clipped to a circle
  *inside* the valleys instead.
- **`DesignSystemCompile` sweeps a bundled package through `Widget.qml` only**, so a layout loaded by
  URL escaped it entirely. All three are now named explicitly — 156 → 159 files.

## A documentation contradiction on main, fixed here

`AGENT.md` currently carries **two** `CavaService` entries that disagree. The one at ~908 is correct
(the producer landed in #159); the one at ~1298 came from #161, was written before the producer
existed, and tells the reader to point consumers at `GlobalStates.visualizerPoints` — which #159
removed. Merging that stacked pair left both. Corrected here, since this PR is exactly the consumer
that bullet would have misdirected.

## Testing

`./tests/run_tests.sh` — **491 passed, 0 failed** (470 on main), `DesignSystemCompile` 159/0.

New: `tst_path_length.qml` (10), `tst_media_layouts.qml` (7), `test_media_layouts_contract.py` (5),
plus a case pinning that every media layout answers the blur contract. **10 mutations** proved
non-vacuous on committed trees, each reddening its specific test.

Two existing pins in `test_expressive_design_system.py` were re-anchored, not loosened: they asserted
the design-system type, options and blur contract on `Widget.qml`, and all three moved one file down.

Rendered output is not testable here — `qmltestrunner` cannot construct Quickshell types and the
software scene graph draws no `Canvas`. What was reachable headlessly was done: all three layouts
loaded in a headless-weston `qs` with zero binding loops, and the ring geometry checked as a PNG at
progress 0 / 0.25 / 0.5 / 0.99.

`test_widget_resize_grip_runtime.py` flakes with "The Wayland connection broke" roughly one run in
several **on pristine main** — reproduced there, passes in isolation and on rerun. Pre-existing, not
from this branch.

Docs: updated AGENT.md §Dynamic/data-driven QML gotchas, docs/widget-grid.md