### PR TITLE
fix(widgets): make the parallax opt-out actually hold still

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1113,6 +1113,54 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   on every drag, silently, because it looks right until the pan next changes. Anything else
   that reads a widget's `x` and means "where the user put it" has the same subtraction to do.
   95f851c28 ("feat(plugins): let a widget opt out of the desktop's parallax pan").
+- **`PluginState` stores a widget's placement in the canvas's *rest* frame, and that is one
+  meaning for every widget — do not let it become two.** A follower's canvas coordinate is
+  already pan-invariant; an opted-out widget's screen coordinate is the same number, because
+  `widgetOffsets` subtracts CENTRE and the canvas therefore covers the screen exactly at rest.
+  So there is one clamp range (`[0, screenSize - widgetSize]`) for both, toggling the flag never
+  rewrites a stored position, and `followParallax` is a *rendering* fact rather than a storage
+  one. What differs is where the widget is **drawn**, which is the placement plus the
+  cancellation — `ParallaxMath.drawnFromPlacement` / `placementFromDrawn`, a pair rather than the
+  same arithmetic spelled out at each call site, which is how the render and the save came to
+  disagree in the first place. 6acb5b0e8 ("feat(parallax): name both directions of a widget's
+  placement conversion").
+- **A `Behavior` whose target moves every frame restarts every frame and never ticks — the
+  property freezes.** This is what made the parallax opt-out inert on a real desktop for its
+  whole life: `x: placedX + parallaxCancelX` re-evaluates on every frame of `Background.qml`'s
+  600ms pan, so `x` sat at exactly its pre-pan value for the entire transition and the widget
+  travelled the *full* pan on screen before sliding back — the opposite of what the setting
+  promises, and indistinguishable from "the toggle does nothing". Two consequences worth
+  separating. On screen it is a wobble; **in the store it is corruption**, because `onReleased`
+  runs `commitPosition` for *any* release (a click that never dragged included) and that
+  conversion read a frozen `x` against a live cancellation, writing `placement + canvasOffset`.
+  Every click or drag during a pan walked the saved position by one pan. The rule: a property
+  carrying both a value that should animate and one that must not cannot animate at all — set
+  `AbstractWidget.animatePosition: false` and say why. The corollary for tests is sharper than
+  the fix: the runtime harness for this feature set `animateXPos: false` on both probes and
+  panned by assignment, i.e. it switched off both halves of the interaction it existed to score,
+  and stayed green for the entire life of the bug. b710ef731 ("fix(plugins): stop the position
+  Behavior swallowing the parallax cancellation").
+- **A subclass cannot read `AbstractWidget.gridSize`: `PluginWidget` shadows it.** The base's
+  `gridSize` is the 12px drag lattice; `PluginWidget` declares its own `gridSize`, the
+  component-grid span (`{"cols": 2, "rows": 1}`). Code *inside* the base still resolves to the
+  base property — measured, `snap(100)` is 96 there — while anything reading `rootWidget.gridSize`
+  from the subclass gets the object, and a snap written against it silently applies no lattice at
+  all. Nothing warns. That is why the drag lattice never leaves the file that owns it and a
+  subclass declares `snapOffsetX`/`snapOffsetY` instead: the seam hands in the frame, not the
+  lattice. 8a534a7da ("fix(plugins): snap a widget's drag to the lattice it is stored on").
+- **Clamp a position where it is written, not only where it is read.** The widget drag is
+  deliberately unclamped (the release decides), but only `applyPersistedPosition` clamped, so a
+  drag that ended past a screen edge stored the overshoot and the widget was drawn somewhere
+  else — permanently, silently, and read by the user as the widget moving on its own. A real
+  store held `visualizer` at `x: -852` on a 5120px screen. When two sides of a store apply
+  different rules to the same number, the disagreement is invisible by construction. For entries
+  already on disk: an unreachable value **cannot be repaired** (the offset it absorbed depends on
+  which workspace was showing and whether a sidebar was open, and it accrued over an unknown
+  number of releases) and **must not be reset to a default** (that moves the widget somewhere the
+  user never chose) — it is pinned to what is already on screen, once, on a settle timer, only
+  where the clamp actually bites, and only after `width` has arrived. A clamp written back on
+  every load is the `ConfigSpinBox` trap in [The Config system](#the-config-system-settings-page--persisted-json).
+  705e9006d ("fix(plugins): stop a widget's stored position disagreeing with where it is drawn").
 - **A per-plugin key can be a retired manifest option for one widget and a live setting for
   another, so migrate on what the manifest says, not on the key name.** `sizeMode` was a
   manifest *option* on weather and currency, which `__gridSize` took over; `world-clock` and

--- a/dots/.config/quickshell/imi/WidgetParallaxOptOutRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/WidgetParallaxOptOutRuntimeTest.qml
@@ -143,6 +143,9 @@ ShellRoot {
 
     function storedX(id) { return Math.round(PluginState.position(id, harness.testScreen).x); }
     function storedY(id) { return Math.round(PluginState.position(id, harness.testScreen).y); }
+    // Unrounded, for the one check that is about the fraction itself.
+    function rawStoredX(id) { return PluginState.position(id, harness.testScreen).x; }
+    function rawStoredY(id) { return PluginState.position(id, harness.testScreen).y; }
 
     // Snapped to the shared 12px lattice by AbstractWidget, so every gesture
     // here is a whole number of steps and the expected result is exact.
@@ -309,6 +312,27 @@ ShellRoot {
             harness.check("pan settled: the follower arrived",
                           harness.screenX(followWidget) === -72
                           && harness.screenY(followWidget) === 24);
+        },
+
+        // --- The lattice belongs to the frame the position is stored in -----
+        //
+        // A real canvas offset is not a round number: 5120px wide at 107% zoom
+        // with a 1.2 widget factor is 215.04000000000033. Snapping the drawn
+        // coordinate puts the widget on the lattice where it is drawn and off
+        // it where it is saved - which is a stored x of 95.04000000000033, and
+        // a widget that no longer lines up with its neighbours at rest.
+        () => { canvas.animatePan = false; harness.pan(-215.04000000000033, -60.5); },
+        // The gesture is deliberately NOT a whole number of lattice steps: a
+        // drag of 48 from a placement of 696 lands on the lattice whether or
+        // not anything snapped, which is a check that cannot fail.
+        () => harness.dragWidget(holdWidget, 50, 26),
+        () => {
+            harness.check("dragged at a fractional pan: the placement is on the lattice",
+                          harness.rawStoredX("hold-probe") % 12 === 0
+                          && harness.rawStoredY("hold-probe") % 12 === 0);
+            harness.check("dragged at a fractional pan: lands on the nearest lattice cell",
+                          harness.screenX(holdWidget) === 744
+                          && harness.screenY(holdWidget) === 432);
         }
     ]
 

--- a/dots/.config/quickshell/imi/WidgetParallaxOptOutRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/WidgetParallaxOptOutRuntimeTest.qml
@@ -333,6 +333,40 @@ ShellRoot {
             harness.check("dragged at a fractional pan: lands on the nearest lattice cell",
                           harness.screenX(holdWidget) === 744
                           && harness.screenY(holdWidget) === 432);
+        },
+
+        // --- A stored position the screen will not honour -------------------
+        //
+        // The author's `visualizer` sat at `x: -852` on a 5120px screen: the
+        // drag is unclamped, only the load clamped, so the store kept a number
+        // the widget was drawn nowhere near - permanently, and silently.
+        () => { canvas.animatePan = false; harness.pan(0, 0);
+                PluginState.setPosition("hold-probe", harness.testScreen,
+                                        { x: -852, y: 1200, placementStrategy: "free" }); },
+        () => {
+            harness.check("an unreachable stored position is clamped on screen",
+                          harness.screenX(holdWidget) === 0
+                          && harness.screenY(holdWidget) === 700 - Math.round(holdWidget.height));
+            harness.check("...and the store is left holding what the screen refused",
+                          harness.storedX("hold-probe") === -852);
+            holdWidget.repairUnreachableStoredPosition();
+        },
+        () => {
+            harness.check("repaired: the store agrees with where the widget is drawn",
+                          harness.storedX("hold-probe") === 0
+                          && harness.storedY("hold-probe") === 700 - Math.round(holdWidget.height));
+            harness.check("repaired: nothing moved - it is not a reset to the default",
+                          harness.screenX(holdWidget) === 0
+                          && harness.screenY(holdWidget) === 700 - Math.round(holdWidget.height));
+        },
+
+        // A drag that ends outside the screen is stored clamped, so the two
+        // cannot come apart again.
+        () => harness.dragWidget(holdWidget, -600, 0),
+        () => {
+            harness.check("dragged off the left edge: the store holds the edge, not the overshoot",
+                          harness.storedX("hold-probe") === 0
+                          && harness.screenX(holdWidget) === 0);
         }
     ]
 

--- a/dots/.config/quickshell/imi/WidgetParallaxOptOutRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/WidgetParallaxOptOutRuntimeTest.qml
@@ -25,10 +25,13 @@ import qs.modules.common.widgets.widgetCanvas
  * The following widget is the control throughout: three "it did not move"
  * checks prove nothing if the harness stopped delivering events.
  *
- * Position Behaviors are switched off (`animateXPos`/`animateYPos`) so a score
- * reads a settled coordinate rather than a frame of an animation. The
- * cancellation is a binding, not a transition - the animation is the same one
- * every widget already has.
+ * The follower's position Behaviors are switched off (`animateXPos`/
+ * `animateYPos`) so a score reads a settled coordinate rather than a frame of
+ * an animation. The opted-out widget's are deliberately left alone: the host
+ * turns them off itself (`animatePosition: followParallax`), and that IS the
+ * fix the last block scores. Setting them here would hide it - which is what
+ * the first version of this harness did, on both widgets, and it is why the
+ * opt-out shipped doing nothing at all on a real desktop.
  *
  * Run it against a throwaway config:
  *   XDG_CONFIG_HOME=$(mktemp -d) XDG_STATE_HOME=$(mktemp -d) qs -p WidgetParallaxOptOutRuntimeTest.qml
@@ -79,6 +82,21 @@ ShellRoot {
             width: 1200
             height: 700
 
+            // Background.qml animates the pan, and that turns out to be the
+            // whole difference between an opt-out that works and one that does
+            // not - so the harness can offer both. Off for the settled checks,
+            // which want an instant pan; on for the last block, which is about
+            // what happens *during* one.
+            property bool animatePan: false
+            Behavior on x {
+                enabled: canvas.animatePan
+                NumberAnimation { duration: 600; easing.type: Easing.OutCubic }
+            }
+            Behavior on y {
+                enabled: canvas.animatePan
+                NumberAnimation { duration: 600; easing.type: Easing.OutCubic }
+            }
+
             PluginWidget {
                 id: followWidget
                 manifest: harness.followManifest
@@ -101,8 +119,6 @@ ShellRoot {
                 scaledScreenWidth: 1200
                 scaledScreenHeight: 700
                 wallpaperScale: 1
-                animateXPos: false
-                animateYPos: false
             }
         }
     }
@@ -138,6 +154,17 @@ ShellRoot {
         driver.mouseMove(canvas, x + dx / 2, y + dy / 2, 20, Qt.LeftButton);
         driver.mouseMove(canvas, x + dx, y + dy, 20, Qt.LeftButton);
         driver.mouseRelease(canvas, x + dx, y + dy, Qt.LeftButton);
+    }
+
+    // A press and release that never moves. It runs the same commitPosition
+    // path a drag does - `onReleased` does not ask whether anything was
+    // dragged - so it must be a no-op on the store.
+    function clickWidget(widget) {
+        const x = widget.x + widget.width / 2;
+        const y = widget.y + widget.height / 2;
+        driver.mouseMove(canvas, x, y);
+        driver.mousePress(canvas, x, y, Qt.LeftButton);
+        driver.mouseRelease(canvas, x, y, Qt.LeftButton);
     }
 
     readonly property var steps: [
@@ -184,10 +211,42 @@ ShellRoot {
                           && harness.storedY("hold-probe") === 408);
         },
 
+        // The same round trip for the widget that does follow, because the
+        // store has to mean one thing for both. A follower's drag needs no
+        // conversion at all, so the two land on the same number from opposite
+        // directions - which is the property, not a coincidence.
+        () => harness.dragWidget(followWidget, 48, 24),
+        () => {
+            harness.check("follower dragged while panned: stores its placement too",
+                          harness.storedX("follow-probe") === 168
+                          && harness.storedY("follow-probe") === 144);
+            harness.check("follower dragged while panned: lands where the pointer left it",
+                          harness.screenX(followWidget) === -12
+                          && harness.screenY(followWidget) === 84);
+        },
+
+        // Reload, with the pan still on. `applyPersistedPosition` is what runs
+        // when the shell comes back up (and on every external state change), so
+        // driving it directly is the closest a live harness gets to a restart -
+        // and it is where the clamp lives, which is the half that decides
+        // whether a stored coordinate is honoured or quietly replaced.
+        () => {
+            followWidget.applyPersistedPosition();
+            holdWidget.applyPersistedPosition();
+        },
+        () => {
+            harness.check("reloaded while panned: the follower is where it was dropped",
+                          harness.screenX(followWidget) === -12
+                          && harness.screenY(followWidget) === 84);
+            harness.check("reloaded while panned: the opted-out widget is where it was dropped",
+                          harness.screenX(holdWidget) === 696
+                          && harness.screenY(holdWidget) === 408);
+        },
+
         () => harness.pan(0, 0),
         () => {
             harness.check("pan released: the follower comes back",
-                          harness.screenX(followWidget) === 120 && harness.screenY(followWidget) === 120);
+                          harness.screenX(followWidget) === 168 && harness.screenY(followWidget) === 144);
             harness.check("pan released: the opted-out widget has not moved at all",
                           harness.screenX(holdWidget) === 696 && harness.screenY(holdWidget) === 408);
         },
@@ -202,6 +261,54 @@ ShellRoot {
             harness.check("opt-in again: its stored position is untouched",
                           harness.storedX("hold-probe") === 696
                           && harness.storedY("hold-probe") === 408);
+        },
+
+        // --- The pan takes 600ms, and that is where the opt-out died --------
+        //
+        // Everything above pans by assignment, which settles the canvas within
+        // one frame. Background.qml animates it, so an opted-out widget's x/y
+        // binding re-evaluates on every frame of a 600ms transition - and a
+        // Behavior handed a target that moves every frame restarts every frame
+        // and never ticks. The widget then holds its OLD canvas coordinate for
+        // the whole pan, which is to say it travels the full pan on screen,
+        // and any release taken during it saves that stale coordinate.
+        () => { PluginState.setOption("hold-probe", "followParallax", false); },
+        () => harness.pan(0, 0),
+        () => {
+            harness.check("re-opted-out at rest: still where it was left",
+                          harness.screenX(holdWidget) === 696 && harness.screenY(holdWidget) === 408);
+            canvas.animatePan = true;
+            harness.pan(-240, -120);
+        },
+        () => {
+            // The instrument first: every check under it would also pass
+            // against a canvas that had already finished panning.
+            harness.check("mid-pan: the pan is genuinely in flight",
+                          canvas.x < -1 && canvas.x > -239
+                          && canvas.y < -1 && canvas.y > -119);
+            harness.check("mid-pan: the follower is travelling",
+                          harness.screenX(followWidget) === Math.round(canvas.x) + 168
+                          && harness.screenX(followWidget) !== 168);
+            harness.check("mid-pan: the opted-out widget has not moved on screen",
+                          harness.screenX(holdWidget) === 696
+                          && harness.screenY(holdWidget) === 408);
+            // Not a drag. `onReleased` commits regardless, so a click landing
+            // in this window used to walk the stored position by one pan -
+            // repeatedly, which is how a real store reached x: -852.
+            harness.clickWidget(holdWidget);
+            harness.check("mid-pan: a click does not rewrite the placement",
+                          harness.storedX("hold-probe") === 696
+                          && harness.storedY("hold-probe") === 408);
+        },
+        () => {},
+        () => {},
+        () => {
+            harness.check("pan settled: the opted-out widget never moved at all",
+                          harness.screenX(holdWidget) === 696
+                          && harness.screenY(holdWidget) === 408);
+            harness.check("pan settled: the follower arrived",
+                          harness.screenX(followWidget) === -72
+                          && harness.screenY(followWidget) === 24);
         }
     ]
 

--- a/dots/.config/quickshell/imi/modules/common/functions/parallax.js
+++ b/dots/.config/quickshell/imi/modules/common/functions/parallax.js
@@ -174,18 +174,3 @@ function drawnFromPlacement(placement, cancel) {
 function placementFromDrawn(drawn, cancel) {
     return number(drawn, 0) - number(cancel, 0);
 }
-
-// The drag's snap lattice, applied in the frame the position is stored in.
-//
-// The lattice exists so widgets line up with each other, and they line up at
-// rest - so it belongs to the placement frame. Snapping the drawn coordinate
-// instead leaves an opted-out widget's *placement* off the lattice by whatever
-// fraction the pan happened to be holding, which is how an x of
-// 95.04000000000033 reached disk: 0.04 is the tail of a live canvas offset.
-// Returns a drawn coordinate, because that is what the drag writes.
-function snapPlacement(drawn, cancel, gridSize) {
-    const grid = number(gridSize, 0);
-    if (grid <= 0) return number(drawn, 0);
-    const placement = placementFromDrawn(drawn, cancel);
-    return drawnFromPlacement(Math.round(placement / grid) * grid, cancel);
-}

--- a/dots/.config/quickshell/imi/modules/common/functions/parallax.js
+++ b/dots/.config/quickshell/imi/modules/common/functions/parallax.js
@@ -152,3 +152,40 @@ function parallaxCancel(canvasOffset, follows) {
     if (follows === false) return -number(canvasOffset, 0);
     return 0;
 }
+
+// A desktop widget has two positions, and this is the only conversion between
+// them. Both directions live here so they cannot drift apart.
+//
+// PluginState stores a widget's PLACEMENT: where it sits when the pan is at
+// rest. That is one meaning for every widget, whatever its `followParallax`
+// says - a following widget's canvas coordinate is already pan-invariant, and
+// an opted-out widget's screen coordinate is the same number, because at rest
+// the canvas covers the screen exactly (widgetOffsets subtracts CENTRE). So
+// the clamp to [0, screenSize - widgetSize] is valid for both, and toggling
+// the flag never has to rewrite a stored position.
+//
+// What the flag changes is where the widget is DRAWN on the canvas, which is
+// the placement plus the cancellation. Anything that reads a widget's `x` is
+// reading the drawn coordinate; anything that writes the store converts back.
+function drawnFromPlacement(placement, cancel) {
+    return number(placement, 0) + number(cancel, 0);
+}
+
+function placementFromDrawn(drawn, cancel) {
+    return number(drawn, 0) - number(cancel, 0);
+}
+
+// The drag's snap lattice, applied in the frame the position is stored in.
+//
+// The lattice exists so widgets line up with each other, and they line up at
+// rest - so it belongs to the placement frame. Snapping the drawn coordinate
+// instead leaves an opted-out widget's *placement* off the lattice by whatever
+// fraction the pan happened to be holding, which is how an x of
+// 95.04000000000033 reached disk: 0.04 is the tail of a live canvas offset.
+// Returns a drawn coordinate, because that is what the drag writes.
+function snapPlacement(drawn, cancel, gridSize) {
+    const grid = number(gridSize, 0);
+    if (grid <= 0) return number(drawn, 0);
+    const placement = placementFromDrawn(drawn, cancel);
+    return drawnFromPlacement(Math.round(placement / grid) * grid, cancel);
+}

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
@@ -241,16 +241,29 @@ AbstractBackgroundWidget {
     readonly property real parallaxCancelY: ParallaxMath.parallaxCancel(
         rootWidget.parallaxCanvas ? rootWidget.parallaxCanvas.y : 0, rootWidget.followParallax)
 
+    // The cancellation is not a move, and it must not go through the position
+    // Behaviors: the canvas pans over 600ms, so an opted-out widget's x/y
+    // binding re-evaluates on every frame of it, and a Behavior whose target
+    // moves every frame restarts every frame and never ticks. Measured, not
+    // reasoned about - with the Behaviors on, x sat at its pre-pan value for
+    // the whole 600ms while the canvas travelled under it, so the widget moved
+    // the *full* pan on screen and only slid back afterwards. The animation is
+    // what an opted-out widget gives up for holding still; the drag is
+    // unaffected, since the Behaviors are already off while dragging.
+    animatePosition: rootWidget.followParallax
+
     // Dragging assigns x/y directly and so breaks these bindings;
     // AbstractBackgroundWidget calls restoreXYBinding() on release for exactly
     // this case, so the override has to be restored there too or a single drag
     // disables centring for the rest of the session.
-    x: rootWidget.placedX + rootWidget.parallaxCancelX
-    y: rootWidget.placedY + rootWidget.parallaxCancelY
+    x: ParallaxMath.drawnFromPlacement(rootWidget.placedX, rootWidget.parallaxCancelX)
+    y: ParallaxMath.drawnFromPlacement(rootWidget.placedY, rootWidget.parallaxCancelY)
 
     function restoreXYBinding() {
-        rootWidget.x = Qt.binding(() => rootWidget.placedX + rootWidget.parallaxCancelX);
-        rootWidget.y = Qt.binding(() => rootWidget.placedY + rootWidget.parallaxCancelY);
+        rootWidget.x = Qt.binding(() => ParallaxMath.drawnFromPlacement(
+            rootWidget.placedX, rootWidget.parallaxCancelX));
+        rootWidget.y = Qt.binding(() => ParallaxMath.drawnFromPlacement(
+            rootWidget.placedY, rootWidget.parallaxCancelY));
     }
 
     // Overrides AbstractBackgroundWidget's release path, which calls this on a
@@ -260,13 +273,15 @@ AbstractBackgroundWidget {
     // after the drag broke the x/y bindings, and setPosition is what makes the
     // move survive a restart.
     function commitPosition() {
-        // The cancellation is subtracted back out: `x` is where the widget is
-        // on the canvas, the persisted position is where it was PLACED. Storing
-        // the drawn coordinate would fold the current pan into the saved
-        // position, so an opted-out widget would walk by one pan's worth every
-        // time it was dragged.
-        rootWidget.targetX = rootWidget.x - rootWidget.parallaxCancelX;
-        rootWidget.targetY = rootWidget.y - rootWidget.parallaxCancelY;
+        // The cancellation is taken back out: `x` is where the widget is drawn
+        // on the canvas, the persisted position is where it was PLACED (see
+        // ParallaxMath). Storing the drawn coordinate would fold the current
+        // pan into the saved position, so an opted-out widget would walk by one
+        // pan's worth every time it was dragged.
+        rootWidget.targetX = ParallaxMath.placementFromDrawn(
+            rootWidget.x, rootWidget.parallaxCancelX);
+        rootWidget.targetY = ParallaxMath.placementFromDrawn(
+            rootWidget.y, rootWidget.parallaxCancelY);
         rootWidget.restoreXYBinding();
         if (!manifest) return;
         PluginState.setPosition(manifest.id, screenName, {

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
@@ -211,15 +211,68 @@ AbstractBackgroundWidget {
     // Dragging assigns targetX/targetY directly and therefore intentionally
     // breaks their initial bindings. Re-apply persisted geometry whenever the
     // external state file changes so preset switches also move live widgets.
+    //
+    // The clamp is AbstractBackgroundWidget's own, rather than the same
+    // expression written again: the placement frame is the one both ends of
+    // this agree on (ParallaxMath), so the range is the same range for every
+    // widget and there is no reason for two copies of it to exist.
     function applyPersistedPosition() {
         const nextX = currentConfig.x !== undefined ? currentConfig.x : 100;
         const nextY = currentConfig.y !== undefined ? currentConfig.y : 100;
-        rootWidget.targetX = Math.max(0, Math.min(nextX, scaledScreenWidth - width));
-        rootWidget.targetY = Math.max(0, Math.min(nextY, scaledScreenHeight - height));
+        rootWidget.targetX = rootWidget.clampX(nextX);
+        rootWidget.targetY = rootWidget.clampY(nextY);
     }
 
     onCurrentConfigChanged: applyPersistedPosition()
     Component.onCompleted: applyPersistedPosition()
+
+    // A stored position the screen will never honour, written back so it stops
+    // being a lie.
+    //
+    // The drag is unclamped - deliberately, it is the release that decides -
+    // but until now only the *load* clamped, so a drag that ended outside the
+    // screen stored a number the widget was then drawn nowhere near. It is
+    // silent, permanent, and it reads exactly as the widget moving on its own:
+    // the author's `visualizer` sat at `x: -852` on a 5120px screen and was
+    // drawn at 0 every session.
+    //
+    // Note what this is not. The corrupt values that motivated it cannot be
+    // *repaired* - the offset each one absorbed depends on which workspace was
+    // showing and whether a sidebar was open at that instant, and it accrued
+    // over an unknown number of releases, so there is no arithmetic that
+    // recovers the intended position. Nor are they reset to the default, which
+    // would move a widget to somewhere the user never put it. They are pinned
+    // to what is already on screen, which is the one answer that changes
+    // nothing visible.
+    //
+    // It runs once, on a settle timer, and only where the clamp actually bites
+    // - a write-back on every load is the ConfigSpinBox trap in AGENT.md, and
+    // the guard against it here is that `width` has to have arrived first.
+    function repairUnreachableStoredPosition() {
+        if (!manifest || !PluginState.ready) return;
+        const stored = rootWidget.currentConfig;
+        const nextX = rootWidget.clampX(stored.x);
+        const nextY = rootWidget.clampY(stored.y);
+        if (nextX === stored.x && nextY === stored.y) return;
+        PluginState.setPosition(manifest.id, screenName, {
+            x: nextX,
+            y: nextY,
+            placementStrategy: rootWidget.placementStrategy
+        });
+    }
+
+    Timer {
+        id: storedPositionRepair
+        interval: 1000
+        repeat: true
+        running: true
+        onTriggered: {
+            if (!PluginState.ready || rootWidget.width <= 0 || rootWidget.height <= 0)
+                return;
+            storedPositionRepair.running = false;
+            rootWidget.repairUnreachableStoredPosition();
+        }
+    }
 
     // `forceCenter` overrides the persisted position for as long as it is set,
     // without disturbing it - the widget returns to where the user left it the
@@ -286,11 +339,13 @@ AbstractBackgroundWidget {
         // on the canvas, the persisted position is where it was PLACED (see
         // ParallaxMath). Storing the drawn coordinate would fold the current
         // pan into the saved position, so an opted-out widget would walk by one
-        // pan's worth every time it was dragged.
-        rootWidget.targetX = ParallaxMath.placementFromDrawn(
-            rootWidget.x, rootWidget.parallaxCancelX);
-        rootWidget.targetY = ParallaxMath.placementFromDrawn(
-            rootWidget.y, rootWidget.parallaxCancelY);
+        // pan's worth every time it was dragged. It is clamped here as well as
+        // on the way back in, so the store can never hold a position the
+        // widget is not drawn at.
+        rootWidget.targetX = rootWidget.clampX(ParallaxMath.placementFromDrawn(
+            rootWidget.x, rootWidget.parallaxCancelX));
+        rootWidget.targetY = rootWidget.clampY(ParallaxMath.placementFromDrawn(
+            rootWidget.y, rootWidget.parallaxCancelY));
         rootWidget.restoreXYBinding();
         if (!manifest) return;
         PluginState.setPosition(manifest.id, screenName, {

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
@@ -252,6 +252,15 @@ AbstractBackgroundWidget {
     // unaffected, since the Behaviors are already off while dragging.
     animatePosition: rootWidget.followParallax
 
+    // The 12px lattice is what makes widgets line up with each other, and they
+    // line up at rest - so it belongs to the placement frame, not to the drawn
+    // one. Snapping the drawn coordinate leaves an opted-out widget's stored
+    // position off the lattice by whatever fraction the pan happened to be
+    // holding, which is what put `x: 95.04000000000033` in a real
+    // plugin-state.json.
+    snapOffsetX: rootWidget.parallaxCancelX
+    snapOffsetY: rootWidget.parallaxCancelY
+
     // Dragging assigns x/y directly and so breaks these bindings;
     // AbstractBackgroundWidget calls restoreXYBinding() on release for exactly
     // this case, so the override has to be restored there too or a single drag

--- a/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/AbstractWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/AbstractWidget.qml
@@ -143,6 +143,24 @@ MouseArea {
         return Math.round(value / root.gridSize) * root.gridSize
     }
 
+    // The drag snaps through these, so a subclass whose x/y are not the
+    // coordinate it stores can move the lattice into the frame it means
+    // something in. Per axis because that offset is per axis (PluginWidget:
+    // the desktop pans x and y by different amounts, and usually only one of
+    // them at all).
+    //
+    // The subclass hands in an offset rather than doing the snap itself,
+    // because the lattice is not reachable from a subclass: `gridSize` is
+    // shadowed - PluginWidget declares its own, the component-grid span a
+    // manifest offers - so a snap written there reads `{"cols":2,"rows":1}`
+    // where it wants 12 and silently produces no lattice at all. Measured:
+    // `snap(100)` is 96 from in here and the same widget's `gridSize` is that
+    // object from out there. Nothing warns.
+    property real snapOffsetX: 0
+    property real snapOffsetY: 0
+    function snapX(value) { return root.snap(value - root.snapOffsetX) + root.snapOffsetX }
+    function snapY(value) { return root.snap(value - root.snapOffsetY) + root.snapOffsetY }
+
     function findCanvas(item) {
         var p = item
         while (p) {
@@ -182,7 +200,7 @@ MouseArea {
         target: root
         property: "x"
         value: Math.max(root.groupDragMinX, Math.min(root.groupDragMaxX,
-            root.snapEnabled ? root.snap(dragProxy.x) : dragProxy.x))
+            root.snapEnabled ? root.snapX(dragProxy.x) : dragProxy.x))
         when: root.dragging
         restoreMode: Binding.RestoreNone
     }
@@ -190,7 +208,7 @@ MouseArea {
         target: root
         property: "y"
         value: Math.max(root.groupDragMinY, Math.min(root.groupDragMaxY,
-            root.snapEnabled ? root.snap(dragProxy.y) : dragProxy.y))
+            root.snapEnabled ? root.snapY(dragProxy.y) : dragProxy.y))
         when: root.dragging
         restoreMode: Binding.RestoreNone
     }

--- a/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/AbstractWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/AbstractWidget.qml
@@ -9,6 +9,16 @@ MouseArea {
     id: root
     property alias animateXPos: xBehavior.enabled
     property alias animateYPos: yBehavior.enabled
+    // Set false by a subclass whose x/y carry something that is not a move.
+    //
+    // A `Behavior` handed a target that changes every frame restarts every
+    // frame and never gets to tick, so the property sits frozen at its old
+    // value for as long as the target keeps moving. That is exactly what the
+    // desktop's parallax opt-out feeds it (PluginWidget), and a frozen
+    // position is worse than an unanimated one twice over: the widget travels
+    // with the pan it was supposed to decline, and every save taken during the
+    // pan reads a stale coordinate.
+    property bool animatePosition: true
     property bool draggable: true
     property int gridSize: 12
     property bool snapEnabled: true
@@ -214,12 +224,12 @@ MouseArea {
 
     Behavior on x {
         id: xBehavior
-        enabled: !root.dragging && !root.groupDragging
+        enabled: root.animatePosition && !root.dragging && !root.groupDragging
         animation: Appearance.animation.elementMove.numberAnimation.createObject(this)
     }
     Behavior on y {
         id: yBehavior
-        enabled: !root.dragging && !root.groupDragging
+        enabled: root.animatePosition && !root.dragging && !root.groupDragging
         animation: Appearance.animation.elementMove.numberAnimation.createObject(this)
     }
 

--- a/dots/.config/quickshell/imi/tests/test_widget_group_selection.py
+++ b/dots/.config/quickshell/imi/tests/test_widget_group_selection.py
@@ -125,7 +125,7 @@ class GroupDragIsRigid(unittest.TestCase):
                 text,
                 rf"Math\.max\(root\.groupDragMin{axis}, Math\.min\("
                 rf"root\.groupDragMax{axis}, root\.snapEnabled \? "
-                rf"root\.snap\({re.escape(proxy)}\) : {re.escape(proxy)}\)\)",
+                rf"root\.snap{axis}\({re.escape(proxy)}\) : {re.escape(proxy)}\)\)",
                 f"the {axis} drag binding must clamp the snapped value")
 
     def test_the_widget_reports_its_drag_to_the_canvas(self):
@@ -145,7 +145,7 @@ class GroupDragIsRigid(unittest.TestCase):
         text = squashed(WIDGET)
         self.assertIn("property bool groupDragging: false", text)
         self.assertEqual(
-            text.count("enabled: !root.dragging && !root.groupDragging"), 2,
+            text.count("&& !root.dragging && !root.groupDragging"), 2,
             "both position Behaviors must gate on groupDragging too")
 
     def test_followers_commit_like_a_released_drag(self):

--- a/dots/.config/quickshell/imi/tests/test_widget_parallax_optout.py
+++ b/dots/.config/quickshell/imi/tests/test_widget_parallax_optout.py
@@ -135,6 +135,35 @@ class TheHostCancelsRatherThanOffsets(unittest.TestCase):
             2, base.count("enabled: root.animatePosition && !root.dragging"),
             "both position Behaviors have to honour it, or one axis still freezes")
 
+    def test_the_drag_lattice_is_applied_in_the_frame_the_position_is_stored_in(self):
+        """Snapping the drawn coordinate leaves the *placement* off the
+        lattice by the pan's own fraction - a real store holds 95.04000000000033.
+        """
+        self.assertIn("snapOffsetX: rootWidget.parallaxCancelX", self.host)
+        self.assertIn("snapOffsetY: rootWidget.parallaxCancelY", self.host)
+        base = squashed(BASE_WIDGET)
+        self.assertIn("root.snapEnabled ? root.snapX(dragProxy.x)", base)
+        self.assertIn("root.snapEnabled ? root.snapY(dragProxy.y)", base)
+        self.assertIn(
+            "function snapX(value) { return root.snap(value - root.snapOffsetX) "
+            "+ root.snapOffsetX }", base)
+
+    def test_the_lattice_itself_stays_inside_the_base(self):
+        """The host hands in an offset and never does the snap itself.
+
+        `gridSize` is shadowed here - PluginWidget declares its own, the
+        component-grid span a manifest offers - so a snap written in this file
+        reads `{"cols": 2, "rows": 1}` where it wants 12, produces no lattice
+        at all, and nothing warns. That shipped for one commit.
+        """
+        self.assertNotRegex(self.host, r"function snap[XY]\s*\(")
+        self.assertNotRegex(self.host, r"Math\.round\([^)]*rootWidget\.gridSize")
+        base = squashed(BASE_WIDGET)
+        self.assertIn("property bool animatePosition: true", base)
+        self.assertEqual(
+            2, base.count("enabled: root.animatePosition && !root.dragging"),
+            "both position Behaviors have to honour it, or one axis still freezes")
+
 
 class TheSettingsSideExists(unittest.TestCase):
     """A persisted option with no UI silently does nothing (CONTRIBUTING:

--- a/dots/.config/quickshell/imi/tests/test_widget_parallax_optout.py
+++ b/dots/.config/quickshell/imi/tests/test_widget_parallax_optout.py
@@ -31,6 +31,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 HARNESS = ROOT / "WidgetParallaxOptOutRuntimeTest.qml"
 HOST = ROOT / "modules/common/plugins/PluginWidget.qml"
+BASE_WIDGET = ROOT / "modules/common/widgets/widgetCanvas/AbstractWidget.qml"
 OPTIONS = ROOT / "modules/common/plugins/PluginOptions.qml"
 VALIDATOR = ROOT / "modules/common/plugins/PluginValidator.js"
 MATHS = ROOT / "modules/common/functions/parallax.js"
@@ -48,6 +49,14 @@ class TheArithmeticIsExtracted(unittest.TestCase):
         self.assertIn("function parallaxCancel(canvasOffset, follows)",
                       MATHS.read_text(encoding="utf-8"))
 
+    def test_both_directions_of_the_conversion_live_beside_it(self):
+        """Applying the cancellation by hand at each call site is what let the
+        render and the save disagree about which frame they were in.
+        """
+        maths = MATHS.read_text(encoding="utf-8")
+        self.assertIn("function drawnFromPlacement(placement, cancel)", maths)
+        self.assertIn("function placementFromDrawn(drawn, cancel)", maths)
+
     def test_the_host_does_not_reimplement_it(self):
         """A `-canvas.x` written inline in the host is the same expression with
         nowhere to test it, and it is one sign away from doubling the pan.
@@ -55,6 +64,15 @@ class TheArithmeticIsExtracted(unittest.TestCase):
         host = squashed(HOST)
         self.assertIn("ParallaxMath.parallaxCancel(", host)
         self.assertNotRegex(host, r"x:\s*-\s*\w*[Cc]anvas\.x")
+
+    def test_the_host_applies_it_through_the_named_conversions(self):
+        host = squashed(HOST)
+        self.assertNotRegex(
+            host, r"placedX \+ rootWidget\.parallaxCancelX",
+            "the drawn position goes through ParallaxMath.drawnFromPlacement")
+        self.assertNotRegex(
+            host, r"rootWidget\.x - rootWidget\.parallaxCancelX",
+            "the stored position goes through ParallaxMath.placementFromDrawn")
 
 
 class TheHostCancelsRatherThanOffsets(unittest.TestCase):
@@ -73,8 +91,12 @@ class TheHostCancelsRatherThanOffsets(unittest.TestCase):
             self.assertIn(f"readonly property real {axis}", self.host)
 
     def test_the_drawn_position_is_placement_plus_cancellation(self):
-        self.assertIn("x: rootWidget.placedX + rootWidget.parallaxCancelX", self.host)
-        self.assertIn("y: rootWidget.placedY + rootWidget.parallaxCancelY", self.host)
+        self.assertIn(
+            "x: ParallaxMath.drawnFromPlacement(rootWidget.placedX, "
+            "rootWidget.parallaxCancelX)", self.host)
+        self.assertIn(
+            "y: ParallaxMath.drawnFromPlacement(rootWidget.placedY, "
+            "rootWidget.parallaxCancelY)", self.host)
 
     def test_the_drag_release_rebinding_keeps_the_cancellation(self):
         """`restoreXYBinding` is what runs after every drag. Rebinding to the
@@ -83,16 +105,35 @@ class TheHostCancelsRatherThanOffsets(unittest.TestCase):
         """
         body = self.host[self.host.index("function restoreXYBinding()"):]
         body = body[:body.index("function commitPosition")]
-        self.assertIn("rootWidget.placedX + rootWidget.parallaxCancelX", body)
-        self.assertIn("rootWidget.placedY + rootWidget.parallaxCancelY", body)
+        for axis in ("X", "Y"):
+            self.assertIn(f"ParallaxMath.drawnFromPlacement( rootWidget.placed{axis}, "
+                          f"rootWidget.parallaxCancel{axis})", body)
 
     def test_the_stored_position_has_the_cancellation_taken_back_out(self):
         """The drift bug. `x` is where the widget is drawn on the canvas; the
         store holds where it was placed.
         """
         body = self.host[self.host.index("function commitPosition()"):]
-        self.assertIn("rootWidget.targetX = rootWidget.x - rootWidget.parallaxCancelX", body)
-        self.assertIn("rootWidget.targetY = rootWidget.y - rootWidget.parallaxCancelY", body)
+        for axis in ("X", "Y"):
+            self.assertIn(f"rootWidget.target{axis} = ParallaxMath.placementFromDrawn( "
+                          f"rootWidget.{axis.lower()}, rootWidget.parallaxCancel{axis})", body)
+
+    def test_an_opted_out_widget_does_not_animate_its_position(self):
+        """The bug that made the opt-out inert on a real desktop.
+
+        `Background.qml` animates the pan over 600ms, so an opted-out widget's
+        x/y binding re-evaluates on every frame of it - and a `Behavior` whose
+        target moves every frame restarts every frame and never ticks. The
+        widget sat at its pre-pan canvas coordinate for the whole transition,
+        which is to say it travelled the full pan on screen, and any release
+        landing in that window saved the stale coordinate.
+        """
+        self.assertIn("animatePosition: rootWidget.followParallax", self.host)
+        base = squashed(BASE_WIDGET)
+        self.assertIn("property bool animatePosition: true", base)
+        self.assertEqual(
+            2, base.count("enabled: root.animatePosition && !root.dragging"),
+            "both position Behaviors have to honour it, or one axis still freezes")
 
 
 class TheSettingsSideExists(unittest.TestCase):

--- a/dots/.config/quickshell/imi/tests/test_widget_parallax_optout.py
+++ b/dots/.config/quickshell/imi/tests/test_widget_parallax_optout.py
@@ -115,8 +115,8 @@ class TheHostCancelsRatherThanOffsets(unittest.TestCase):
         """
         body = self.host[self.host.index("function commitPosition()"):]
         for axis in ("X", "Y"):
-            self.assertIn(f"rootWidget.target{axis} = ParallaxMath.placementFromDrawn( "
-                          f"rootWidget.{axis.lower()}, rootWidget.parallaxCancel{axis})", body)
+            self.assertIn(f"ParallaxMath.placementFromDrawn( rootWidget.{axis.lower()}, "
+                          f"rootWidget.parallaxCancel{axis})", body)
 
     def test_an_opted_out_widget_does_not_animate_its_position(self):
         """The bug that made the opt-out inert on a real desktop.
@@ -147,6 +147,36 @@ class TheHostCancelsRatherThanOffsets(unittest.TestCase):
         self.assertIn(
             "function snapX(value) { return root.snap(value - root.snapOffsetX) "
             "+ root.snapOffsetX }", base)
+
+    def test_the_stored_position_is_clamped_where_it_is_written(self):
+        """The store held positions the screen would never honour, because the
+        drag was unclamped and only the load clamped. `visualizer` sat at
+        `x: -852` on a 5120px screen and was drawn at 0 every session.
+        """
+        body = self.host[self.host.index("function commitPosition()"):]
+        self.assertIn("rootWidget.targetX = rootWidget.clampX(", body)
+        self.assertIn("rootWidget.targetY = rootWidget.clampY(", body)
+
+    def test_an_unreachable_stored_position_is_pinned_not_reset(self):
+        """Not repaired - the offset a corrupt value absorbed is unrecoverable
+        - and not reset to the default either, which would move the widget
+        somewhere the user never put it. Pinned to what is already on screen.
+        """
+        body = self.host[self.host.index("function repairUnreachableStoredPosition()"):]
+        body = body[:body.index("Timer {")]
+        self.assertIn("if (!manifest || !PluginState.ready) return", body)
+        self.assertIn("if (nextX === stored.x && nextY === stored.y) return", body,
+                      "a write on every load is the ConfigSpinBox trap in AGENT.md")
+        self.assertIn("rootWidget.clampX(stored.x)", body)
+        self.assertNotIn("defaultPosition", body)
+
+    def test_the_repair_waits_for_a_size_before_it_believes_the_clamp(self):
+        """The clamp is against `screenWidth - width`, so a repair taken before
+        the widget has a width writes a range that is not the real one.
+        """
+        self.assertIn(
+            "if (!PluginState.ready || rootWidget.width <= 0 "
+            "|| rootWidget.height <= 0) return;", self.host)
 
     def test_the_lattice_itself_stays_inside_the_base(self):
         """The host hands in an offset and never does the snap itself.

--- a/dots/.config/quickshell/imi/tests/tst_parallax.qml
+++ b/dots/.config/quickshell/imi/tests/tst_parallax.qml
@@ -202,6 +202,90 @@ TestCase {
         verify(!isNaN(Parallax.parallaxCancel("nonsense", false)));
     }
 
+    // --- Placement <-> drawn ------------------------------------------------
+    //
+    // The property these exist for is the round trip, not the formula: a widget
+    // is placed, the desktop pans, the user drags it, the position is saved,
+    // the shell reloads - and the widget must come back where it was dropped.
+    // The assertions below walk exactly that, once for a widget that follows
+    // the pan and once for one that does not, at a non-zero pan both times.
+
+    function roundTrip(placement, canvasOffset, follows, dragDelta) {
+        // Place, then pan.
+        const cancel = Parallax.parallaxCancel(canvasOffset, follows);
+        const drawn = Parallax.drawnFromPlacement(placement, cancel);
+        // Drag: the gesture is a delta in the canvas's own frame.
+        const dragged = drawn + dragDelta;
+        // Save, then reload.
+        const stored = Parallax.placementFromDrawn(dragged, cancel);
+        return {
+            drawnBeforeDrag: drawn,
+            screenBeforeDrag: canvasOffset + drawn,
+            stored: stored,
+            screenAfterReload: canvasOffset + Parallax.drawnFromPlacement(stored, cancel)
+        };
+    }
+
+    function test_a_following_widget_survives_place_pan_drag_save_reload() {
+        const trip = roundTrip(600, -180, true, 48);
+        // It travels, which is the whole point of following.
+        compare(trip.screenBeforeDrag, 420);
+        compare(trip.stored, 648, "a follower stores its canvas placement");
+        compare(trip.screenAfterReload, 468, "dropped at 468, comes back at 468");
+    }
+
+    function test_an_opted_out_widget_survives_place_pan_drag_save_reload() {
+        const trip = roundTrip(600, -180, false, 48);
+        // It does not travel, which is the whole point of opting out.
+        compare(trip.screenBeforeDrag, 600);
+        compare(trip.stored, 648, "an opted-out widget stores the same number");
+        compare(trip.screenAfterReload, 648, "dropped at 648, comes back at 648");
+    }
+
+    function test_the_two_directions_are_each_other_s_inverse_at_any_pan() {
+        // Storing the drawn coordinate, or drawing the stored one, is the bug
+        // class this pair exists to make impossible to write by accident.
+        for (const cancel of [0, 215.04000000000033, -600]) {
+            for (const placement of [0, 95.04, 1276]) {
+                compare(Parallax.placementFromDrawn(
+                            Parallax.drawnFromPlacement(placement, cancel), cancel),
+                        placement);
+            }
+        }
+    }
+
+    function test_a_widget_that_never_moves_keeps_its_stored_position() {
+        // A release that is a click rather than a drag runs the same save path.
+        // It must be a no-op, at rest and mid-pan alike.
+        const cancel = Parallax.parallaxCancel(-180, false);
+        compare(Parallax.placementFromDrawn(
+                    Parallax.drawnFromPlacement(600, cancel), cancel), 600);
+    }
+
+    // --- The snap lattice ---------------------------------------------------
+
+    function test_the_snap_lands_the_placement_on_the_lattice_not_the_drawing() {
+        // 215.04 is the author's real canvas offset (5120px wide, 107% zoom,
+        // 1.2 widget factor). Snapping the drawn coordinate stored
+        // 95.04000000000033 - on the lattice where it was drawn, off it where
+        // it was saved, which is "the widget can be placed outside the grid".
+        const cancel = Parallax.parallaxCancel(215.04000000000033, false);
+        const snapped = Parallax.snapPlacement(-118, cancel, 12);
+        const placement = Parallax.placementFromDrawn(snapped, cancel);
+        fuzzyCompare(placement % 12, 0, 0.0001);
+    }
+
+    function test_the_snap_is_the_plain_lattice_for_a_following_widget() {
+        compare(Parallax.snapPlacement(-118, 0, 12), -120);
+        compare(Parallax.snapPlacement(-114, 0, 12), -114 + 6);
+    }
+
+    function test_the_snap_declines_a_nonsense_lattice_rather_than_dividing_by_it() {
+        compare(Parallax.snapPlacement(37, 0, 0), 37);
+        compare(Parallax.snapPlacement(37, 0, undefined), 37);
+        verify(!isNaN(Parallax.snapPlacement(37, "nonsense", 12)));
+    }
+
     // --- Guards ------------------------------------------------------------
 
     function test_missing_state_does_not_produce_nan() {

--- a/dots/.config/quickshell/imi/tests/tst_parallax.qml
+++ b/dots/.config/quickshell/imi/tests/tst_parallax.qml
@@ -262,30 +262,6 @@ TestCase {
                     Parallax.drawnFromPlacement(600, cancel), cancel), 600);
     }
 
-    // --- The snap lattice ---------------------------------------------------
-
-    function test_the_snap_lands_the_placement_on_the_lattice_not_the_drawing() {
-        // 215.04 is the author's real canvas offset (5120px wide, 107% zoom,
-        // 1.2 widget factor). Snapping the drawn coordinate stored
-        // 95.04000000000033 - on the lattice where it was drawn, off it where
-        // it was saved, which is "the widget can be placed outside the grid".
-        const cancel = Parallax.parallaxCancel(215.04000000000033, false);
-        const snapped = Parallax.snapPlacement(-118, cancel, 12);
-        const placement = Parallax.placementFromDrawn(snapped, cancel);
-        fuzzyCompare(placement % 12, 0, 0.0001);
-    }
-
-    function test_the_snap_is_the_plain_lattice_for_a_following_widget() {
-        compare(Parallax.snapPlacement(-118, 0, 12), -120);
-        compare(Parallax.snapPlacement(-114, 0, 12), -114 + 6);
-    }
-
-    function test_the_snap_declines_a_nonsense_lattice_rather_than_dividing_by_it() {
-        compare(Parallax.snapPlacement(37, 0, 0), 37);
-        compare(Parallax.snapPlacement(37, 0, undefined), 37);
-        verify(!isNaN(Parallax.snapPlacement(37, "nonsense", 12)));
-    }
-
     // --- Guards ------------------------------------------------------------
 
     function test_missing_state_does_not_produce_nan() {


### PR DESCRIPTION
"Follow parallax" off still followed the pan, and the widget could end up outside the grid. Both come
from one mechanism, and it is not the one I put in the issue.

## My diagnosis was wrong

I claimed `commitPosition` mixed coordinate spaces. It does not — the round trip
`placement → drawn → drag → save → reload` is exact under the existing formula, for both flag values,
proved on paper and in a live harness.

**The real fault: `x` never received the cancellation while the canvas was panning.** `Behavior on x`
is enabled by default on every desktop widget, and during `Background.qml`'s 600 ms pan its target
moves every frame. A Behavior restarted every frame never ticks, so `x` sat frozen at its pre-pan
value for the whole transition:

```
canvas.x=-75.2   x=600.0  cancel=75.2   follows=false  placed=600.0  screenX=524.8
canvas.x=-180.0  x=600.0  cancel=180.0  follows=false  placed=600.0  screenX=420.0
```

`cancel` tracks perfectly; `x` is dead. So the opted-out widget travelled the **full** pan and only
slid back afterwards — inert on a real desktop for its entire life. Independently reproduced with an
offscreen probe: a `Behavior` handed a per-frame target lags its target by hundreds of pixels.

**And that is the corruption mechanism too.** `onReleased` runs `commitPosition` on *any* release,
including a click that never dragged. Frozen `x` minus live cancel writes `placement + canvasOffset`,
so every click during a pan walked the stored value by one pan. `visualizer: -852` and the `.04` tail
on `notes: 95.04…` both follow from that.

Why my probe missed it: `onXChanged` never fires when the value is frozen, so it reported the last
good value and read as "the cancellation is correct". A probe that only fires on change cannot detect
*stopped changing*.

## Storage model

**Placement in the canvas's rest frame, for every widget** — which is what both already stored. A
follower's canvas coordinate is pan-invariant, and an opted-out widget's screen coordinate is the
same number, because `widgetOffsets` subtracts CENTRE so the canvas covers the screen exactly at
rest. One meaning, one clamp range, and toggling the flag never rewrites a stored position.

Storing screen placement for everything is not available: a follower's screen position is not a
storable quantity without also storing which pan it was measured at.

The conversion is now the named pair `ParallaxMath.drawnFromPlacement` / `placementFromDrawn` rather
than the same arithmetic hand-written at each site.

## Three more faults found on the way

- **The 12 px lattice snap ran on the drawn coordinate**, so an opted-out widget's *placement* landed
  off-grid by the pan's fraction — that is the `.04000000000033`. Snapped in the stored frame now.
  Worth knowing: a first attempt overriding `snapX`/`snapY` in the host was **inert**, because
  `gridSize` is shadowed — `PluginWidget` declares its own (`{"cols":2,"rows":1}`) where the base
  means `12`. `snap(100)` is 96 inside the base and the same widget's `gridSize` is an object
  outside it, and nothing warns.
- **The clamp was asymmetric** — the drag was unclamped and only the load clamped, so the store kept
  overshoots that were never honoured. It clamps where it writes now.
- **Corrupt entries cannot be repaired**, and are not reset to a default either. The absorbed offset
  depends on which workspace was showing and whether a sidebar was open at that instant, and it
  accrued over an unknown number of releases; a default would move a widget somewhere the user never
  chose. They are **pinned to what is already on screen**, once, on a settle timer, only where the
  clamp bites. No manual editing of `plugin-state.json` is needed.

## Testing

`./tests/run_tests.sh` — **474 passed, 0 failed** (470 on main).
`test_widget_parallax_optout.py` 10 → 18.

The harness is why this shipped broken: it set `animateXPos: false` on both probes and panned by
assignment, switching off both halves of the interaction it existed to score. It now animates the pan
like `Background.qml` does, asserts the canvas is genuinely mid-flight before scoring, and clicks the
widget mid-pan.

Every new check planted-and-reverted, including controls that must stay green.

## One intentional behaviour change

An opted-out widget no longer animates its position, so a drag release snaps instantly instead of
easing. A Behavior cannot animate the placement without also animating the cancellation.

Docs: updated AGENT.md §Dynamic/data-driven QML gotchas