### PR TITLE
fix(media): the 2x2 is the cookie clock's shape, with transport where the date was

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1382,6 +1382,22 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   vertex happens to be, and a twelve-lobed cookie is symmetric every 30 degrees so nothing about
   the shape reads as rotated. 8c211b3d8 ("feat(media): draw the 2x1 as three controls whose centre
   carries the seek bar").
+- **A square design copied into a non-square tile keeps its own square frame; anchoring its parts
+  to the tile's corners quietly breaks the relationship being copied.** The media widget's 2x2 is
+  the cookie clock's shape - `clock/CookieClock.qml` is a square `implicitSize: 230` and
+  `dateIndicator/DateIndicator.qml` anchors two `dateSquareSize: 64` badges to opposite corners of
+  it - with next and previous where the day and month are. What makes a badge read as *fastened*
+  to the cookie is that it bites into the edge: its centre sits on the diagonal at 1.02 outer
+  radii, so ~13% of the frame overlaps. The 2x2 span is 276x228, and anchoring the badges to the
+  tile's corners instead moves them along a shallower bearing and cuts that bite from 26px to 8px
+  - the badge grazes the cookie and the tile reads as three unrelated objects. Centre a square
+  frame in the tile and hang everything off *that*; the leftover width becomes symmetric margin.
+  The same arithmetic is why the title and artist left: a text block under the cookie is paid for
+  out of the cookie's diameter, so keeping it shrinks the frame and pushes the badges off the edge
+  anyway. `cookie_layout.js` is the whole of it, extracted because nothing else about that layout
+  is reachable from a test - and `badgeOverlap` returns the bite in pixels rather than a boolean,
+  so a changed ratio reads as a number instead of as "still positive".
+  562cdf815 ("feat(media): rebuild the 2x2 as the cookie clock with next and previous").
 
 **Wallpaper parallax is one oversized viewport, not a per-layer effect.**
 `Background.qml` draws every wallpaper layer inside `parallaxViewport`, an item sized to

--- a/docs/superpowers/specs/2026-08-10-media-widget-sizes-design.md
+++ b/docs/superpowers/specs/2026-08-10-media-widget-sizes-design.md
@@ -15,6 +15,12 @@ maths was right while its units were not: Qt measures `setLineDash` in pen width
 length, which draws a repeating dashed border instead of one arc (AGENT.md, "Dynamic/data-driven
 QML gotchas").
 
+**And the 2x2 was designed wrong here, not implemented wrong.** §5 described it as a cookie with
+the title and artist beneath, which is what shipped; the design is the cookie clock's shape with
+next and previous where its date badges are. Both §"Settled input" and §5 are corrected below
+rather than rewritten, because the two designs are not compatible and the reason is the useful
+part. 562cdf815 ("feat(media): rebuild the 2x2 as the cookie clock with next and previous").
+
 Paths are relative to the theme root `dots/.config/quickshell/imi/` unless written repo-relative.
 
 ## Problem
@@ -35,8 +41,9 @@ one-size limitation.
   ripples asymmetrically. Not a uniform pulse.
 - **The handle is generic** — it lives in `PluginWidget`, so any grid widget that declares more than
   one span gets it.
-- **2x2 is cookie-as-artwork**: album art inside the cookie, visualizer lobes around it, title and
-  artist below.
+- **2x2 is the cookie clock's shape**: album art inside the cookie, visualizer lobes around it, and
+  the clock's two date badges replaced by previous and next. No title and no artist — see §5, which
+  records why the first version of this line ("title and artist below") was the wrong design.
 - **2x1 is exactly the reference**: prev, cookie-shaped play/pause, next. No text and no artwork —
   but progress *is* shown, stroked around the centre button's own outline rather than as a separate
   track. See §5.
@@ -150,8 +157,25 @@ The existing content moves to `LayoutLarge.qml` unchanged, so the current widget
   already that, this is a visible change on upgrade** and is the one migration risk here; measure
   before committing to it, and if it differs, the honest fix is to adjust the layout to the span
   rather than to pick a span that flatters the current content.
-- **2x2 `LayoutCookie.qml`** — 276x228. `VisualizerCookie` with album art clipped inside it, title
-  and artist beneath. Tap the cookie to play/pause.
+- **2x2 `LayoutCookie.qml`** — 276x228. **The cookie clock's shape, with next and previous where
+  its date badges are.** `VisualizerCookie` filling a square frame centred in the tile, album art
+  clipped to a circle inside the lobe valleys, and two circular transport badges at opposite
+  corners of that frame: previous in the top-left (the clock's day bubble) and next in the
+  bottom-right (its month bubble), each overlapping the cookie's edge. Tap the artwork to
+  play/pause.
+
+  **This corrects what this section said first** — "with album art clipped inside it, title and
+  artist beneath" — which is what shipped and was the wrong design. The two do not coexist: a text
+  block under the cookie is paid for out of the cookie's diameter, and a smaller cookie moves the
+  badges off its edge, which is the one relationship being copied. The 3x2 is the size that names
+  the track; dropping the text here grew the cookie from ~150px to 204.
+
+  The placement is `cookie_layout.js`, and it is the layout's only testable part: the clock's own
+  `implicitSize: 230` and `dateSquareSize: 64` give the badge ratio, the square frame is centred in
+  a tile that is 48px wider than it is tall, and `badgeOverlap` names the bite into the cookie's
+  edge in pixels so a changed ratio reads as a number rather than as "still positive". Anchoring
+  the badges to the *tile's* corners instead drops that bite from 26px to 8px — see AGENT.md,
+  "Dynamic/data-driven QML gotchas".
 - **2x1 `LayoutCompact.qml`** — 276x108. Prev pill, cookie-shaped play/pause, next pill, centred.
 
   **The centre button's border is the seek bar.** Playback progress is stroked around the cookie's
@@ -183,6 +207,9 @@ pointer grabs, shapes or layout is testable here.
 - The nearest-size snap: given a pointer delta and a list of spans, which span wins. Pure.
 - Band aggregation: 32 values to 12 lobes, including the short-array and empty cases that happen
   before cava has produced anything.
+- The 2x2's placement (`cookie_layout.js`, `tests/tst_media_cookie_layout.qml`): the square frame
+  centred in a non-square tile, the badge's proportion to it, and how far a corner badge overlaps
+  the cookie's edge. Pure arithmetic over numbers, and the only part of that layout a test reaches.
 - A lint that no manifest declares an option key beginning with `__`.
 
 **Not testable, needs the screen:** the handle claiming the press before drag-to-move, the cookie's

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/LayoutCookie.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/LayoutCookie.qml
@@ -1,5 +1,4 @@
 import QtQuick
-import QtQuick.Layouts
 import Qt5Compat.GraphicalEffects
 import qs.modules.common
 import qs.modules.common.functions as Functions
@@ -7,17 +6,26 @@ import qs.modules.common.widgets
 import qs.modules.common.plugins
 import qs.services
 import "../../designsystem/widgets" as Expressive
+import "cookie_layout.js" as CookieLayout
 
-// The 2x2 media widget: the cookie is the artwork, its lobes are the spectrum,
-// and the track sits underneath. There are no transport buttons - the cookie is
-// the only control, and it plays and pauses.
+// The 2x2 media widget: the cookie clock's shape, with transport controls where
+// its date badges are. One cookie fills a square frame centred in the tile,
+// previous sits in the frame's top-left corner (the clock's day bubble) and
+// next in its bottom-right (the clock's month bubble), each overlapping the
+// cookie's edge.
+//
+// There is deliberately no title and no artist here. The clock carries no text
+// either, and the two cannot both fit: a text block under the cookie is paid
+// for out of the cookie's diameter, and shrinking the cookie moves the badges
+// off its edge, which is the whole relationship this size exists to draw. The
+// 3x2 is the size that names the track.
 Item {
     id: root
 
     implicitWidth: Appearance.sizes.widgetGridSpanX(2)
     implicitHeight: Appearance.sizes.widgetGridSpanY(2)
 
-    readonly property real cardInset: Appearance.spacing.space200
+    readonly property real cardInset: Appearance.spacing.space150
     readonly property bool useBlurBackground: PluginState.option("nandoroid_media", "blurEnabled", false)
     readonly property real backgroundOpacity: PluginState.effectiveBackgroundOpacity("nandoroid_media")
 
@@ -29,6 +37,54 @@ Item {
     readonly property string artUrl: MprisController.activePlayer?.trackArtUrl ?? ""
     readonly property bool hasArt: root.artUrl !== "" && albumArt.status === Image.Ready
 
+    // The tile is 276x228 and the clock's structure is square, so the square is
+    // centred in it rather than stretched to it. See cookie_layout.js.
+    readonly property var frame: CookieLayout.frame(root.width, root.height, root.cardInset)
+
+    // The same pair the 2x1's pills use, so the three sizes draw one widget's
+    // controls rather than three widgets'.
+    readonly property color controlColor: Appearance.m3colors.darkmode
+        ? Appearance.colors.colOnTertiaryContainer : Appearance.colors.colSecondaryContainer
+    readonly property color controlIconColor: Appearance.m3colors.darkmode
+        ? Appearance.colors.colTertiaryContainer : Appearance.colors.colOnSecondaryContainer
+
+    // Two badges differing only by glyph, corner and action. Written as an
+    // inline component rather than reusing the clock's `BubbleDate`: that one
+    // reads its own text off `DateTime` and branches on `isMonth` for both its
+    // shape and its colours, so it has no slot to put a glyph in - "reusing" it
+    // means rewriting it generic and re-parameterising the clock's two call
+    // sites, for a shape this widget already draws in LayoutCompact.
+    component TransportBadge: Rectangle {
+        id: badge
+
+        property string glyph: ""
+        signal triggered
+
+        implicitWidth: CookieLayout.badgeSize(root.frame.size)
+        implicitHeight: badge.implicitWidth
+        width: badge.implicitWidth
+        height: badge.implicitHeight
+        radius: badge.height / 2
+        color: root.controlColor
+
+        MaterialSymbol {
+            anchors.centerIn: parent
+            text: badge.glyph
+            iconSize: badge.height * 0.46
+            fill: 0
+            color: badgeArea.containsMouse ? Appearance.colors.colPrimary : root.controlIconColor
+            Behavior on color { ColorAnimation { duration: Appearance.animation.elementMoveFast.duration } }
+        }
+
+        MouseArea {
+            id: badgeArea
+            anchors.fill: parent
+            hoverEnabled: true
+            cursorShape: Qt.PointingHandCursor
+            onClicked: badge.triggered()
+        }
+    }
+
     Rectangle {
         id: bgCard
         anchors.fill: parent
@@ -38,125 +94,103 @@ Item {
             : Appearance.colors.colOnPrimary
     }
 
-    // The cookie takes whatever the track block leaves. Measured against the
-    // column's *implicit* height rather than its height: the column is anchored
-    // to three edges, so its actual height is the card's, and reading that back
-    // would size the cookie to nothing.
-    Expressive.VisualizerCookie {
-        id: cookie
-        anchors.top: parent.top
-        anchors.topMargin: root.cardInset
-        anchors.horizontalCenter: parent.horizontalCenter
-        width: Math.max(0, Math.min(root.width - root.cardInset * 2,
-            root.height - root.cardInset * 2 - trackColumn.implicitHeight - Appearance.spacing.space100))
-        height: width
-
-        lobes: 12
-        // Claimed only while something is playing: the claim starts cava, and a
-        // paused desktop has no spectrum to draw. The lobes decay back to the
-        // resting cookie on their own when the claim drops.
-        audioReactive: MprisController.isPlaying
-        color: Appearance.colors.colPrimary
-    }
-
-    // Clipped to a circle rather than to the cookie: the lobes are what ripples,
-    // so masking the artwork with the same moving outline would swallow the
-    // motion instead of showing it. The circle sits inside the lobes' valleys,
-    // which is what leaves the scalloped edge visible all the way round.
     Item {
-        id: artClip
-        anchors.centerIn: cookie
-        width: cookie.width * 0.72
-        height: width
-        layer.enabled: true
-        layer.effect: OpacityMask {
-            maskSource: Rectangle {
-                width: artClip.width
-                height: artClip.height
-                radius: width / 2
+        id: cookieFrame
+        x: root.frame.x
+        y: root.frame.y
+        width: root.frame.size
+        height: root.frame.size
+
+        Expressive.VisualizerCookie {
+            id: cookie
+            anchors.fill: parent
+
+            lobes: 12
+            // Claimed only while something is playing: the claim starts cava, and a
+            // paused desktop has no spectrum to draw. The lobes decay back to the
+            // resting cookie on their own when the claim drops.
+            audioReactive: MprisController.isPlaying
+            color: Appearance.colors.colPrimary
+        }
+
+        // Clipped to a circle rather than to the cookie: the lobes are what ripples,
+        // so masking the artwork with the same moving outline would swallow the
+        // motion instead of showing it. The circle sits inside the lobes' valleys,
+        // which is what leaves the scalloped edge visible all the way round.
+        Item {
+            id: artClip
+            anchors.centerIn: parent
+            width: cookieFrame.width * 0.72
+            height: width
+            layer.enabled: true
+            layer.effect: OpacityMask {
+                maskSource: Rectangle {
+                    width: artClip.width
+                    height: artClip.height
+                    radius: width / 2
+                }
+            }
+
+            Rectangle {
+                anchors.fill: parent
+                color: Appearance.colors.colOnPrimary
+            }
+
+            Image {
+                id: albumArt
+                anchors.fill: parent
+                source: root.artUrl
+                fillMode: Image.PreserveAspectCrop
+                asynchronous: true
+                visible: root.hasArt
+            }
+
+            Rectangle {
+                anchors.fill: parent
+                color: Appearance.colors.colOnPrimary
+                opacity: !root.hasArt ? 0 : (cookieTap.containsMouse ? 0.55 : 0)
+                Behavior on opacity { NumberAnimation { duration: Appearance.animation.elementMoveFast.duration } }
             }
         }
 
-        Rectangle {
-            anchors.fill: parent
-            color: Appearance.colors.colOnPrimary
-        }
-
-        Image {
-            id: albumArt
-            anchors.fill: parent
-            source: root.artUrl
-            fillMode: Image.PreserveAspectCrop
-            asynchronous: true
-            visible: root.hasArt
-        }
-
-        Rectangle {
-            anchors.fill: parent
-            color: Appearance.colors.colOnPrimary
-            opacity: !root.hasArt ? 0 : (cookieTap.containsMouse ? 0.55 : 0)
+        MaterialSymbol {
+            anchors.centerIn: artClip
+            text: MprisController.isPlaying ? "pause" : "play_arrow"
+            iconSize: artClip.width * 0.42
+            fill: 1
+            color: Appearance.colors.colPrimary
+            opacity: (!root.hasArt || cookieTap.containsMouse) ? 1 : 0
             Behavior on opacity { NumberAnimation { duration: Appearance.animation.elementMoveFast.duration } }
         }
-    }
 
-    MaterialSymbol {
-        anchors.centerIn: artClip
-        text: MprisController.isPlaying ? "pause" : "play_arrow"
-        iconSize: artClip.width * 0.42
-        fill: 1
-        color: Appearance.colors.colPrimary
-        opacity: (!root.hasArt || cookieTap.containsMouse) ? 1 : 0
-        Behavior on opacity { NumberAnimation { duration: Appearance.animation.elementMoveFast.duration } }
-    }
-
-    // Only the artwork takes the press, not the cookie's whole bounding box: a
-    // nested MouseArea claims it from the host's drag-to-move, and a target the
-    // size of the cookie would leave the card with almost nothing to drag by.
-    MouseArea {
-        id: cookieTap
-        anchors.centerIn: artClip
-        width: artClip.width
-        height: artClip.height
-        hoverEnabled: true
-        cursorShape: Qt.PointingHandCursor
-        onClicked: MprisController.togglePlaying()
-    }
-
-    ColumnLayout {
-        id: trackColumn
-        anchors.left: parent.left
-        anchors.right: parent.right
-        anchors.bottom: parent.bottom
-        anchors.margins: root.cardInset
-        spacing: Appearance.spacing.space25
-
-        StyledText {
-            Layout.fillWidth: true
-            horizontalAlignment: Text.AlignHCenter
-            text: Functions.StringUtils.cleanMusicTitle(MprisController.trackTitle) || "No Music Playing"
-            font.pixelSize: Appearance.font.pixelSize.normal
-            font.weight: Font.DemiBold
-            color: Appearance.colors.colPrimary
-            elide: Text.ElideRight
-            maximumLineCount: 1
+        // Only the artwork takes the press, not the cookie's whole bounding box: a
+        // nested MouseArea claims it from the host's drag-to-move, and a target the
+        // size of the cookie would leave the card with almost nothing to drag by.
+        MouseArea {
+            id: cookieTap
+            anchors.centerIn: artClip
+            width: artClip.width
+            height: artClip.height
+            hoverEnabled: true
+            cursorShape: Qt.PointingHandCursor
+            onClicked: MprisController.togglePlaying()
         }
 
-        StyledText {
-            Layout.fillWidth: true
-            horizontalAlignment: Text.AlignHCenter
-            text: {
-                const rawTitle = (MprisController.trackTitle || "").trim().toLowerCase();
-                const hasTitle = rawTitle !== "" && rawTitle !== "no media" && rawTitle !== "no music playing";
-                const hasArtist = MprisController.trackArtist && MprisController.trackArtist.trim() !== "";
-                if (hasTitle)
-                    return hasArtist ? MprisController.trackArtist : "Unknown Artist";
-                return "Play some media";
-            }
-            font.pixelSize: Appearance.font.pixelSize.smaller
-            font.weight: Font.DemiBold
-            color: Functions.ColorUtils.applyAlpha(Appearance.colors.colPrimary, 0.75)
-            elide: Text.ElideRight
-            maximumLineCount: 1
+        // Declared after the cookie so they draw over its edge, which is the
+        // DateIndicator stacking too - a badge under the lobes would be eaten
+        // by whichever one happens to be pushed out at the time.
+        TransportBadge {
+            anchors.left: parent.left
+            anchors.top: parent.top
+            glyph: "skip_previous"
+            onTriggered: MprisController.previous()
+        }
+
+        TransportBadge {
+            anchors.right: parent.right
+            anchors.bottom: parent.bottom
+            glyph: "skip_next"
+            onTriggered: MprisController.next()
         }
     }
 }

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/cookie_layout.js
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/cookie_layout.js
@@ -1,0 +1,51 @@
+.pragma library
+
+// The cookie clock's geometry, extracted because the 2x2 media tile *is* that
+// geometry with transport controls where the date badges are.
+//
+// Both numbers come off the clock's own files rather than being re-invented:
+// `clock/CookieClock.qml` is a square `implicitSize: 230` with the cookie
+// filling it, and `clock/dateIndicator/DateIndicator.qml` anchors two
+// `dateSquareSize: 64` badges to opposite corners of that same square. The
+// ratio between them is the entire relationship being copied - it is what puts
+// a badge *on* the cookie's edge instead of beside it.
+var CLOCK_FRAME = 230;
+var CLOCK_BADGE = 64;
+var BADGE_RATIO = CLOCK_BADGE / CLOCK_FRAME;
+
+// The clock is square and the 2x2 tile is not (276x228), so the structure gets
+// a square frame centred in the tile rather than being stretched to fill it.
+// The badges anchor to the *frame's* corners, never the tile's: spread to the
+// tile's corners they slide off the cookie's edge along a shallower diagonal
+// and stop reading as attached to it, which is the one relationship this whole
+// module exists to preserve.
+//
+// `inset` is clamped rather than trusted: a tile narrower than twice the inset
+// would otherwise produce a negative size, and a negatively-sized Item is drawn
+// as if it were zero while every offset computed from it is wrong.
+function frame(tileWidth, tileHeight, inset) {
+    var size = Math.max(0, Math.min(tileWidth, tileHeight) - inset * 2);
+    return {
+        size: size,
+        x: (tileWidth - size) / 2,
+        y: (tileHeight - size) / 2
+    };
+}
+
+function badgeSize(frameSize) {
+    return Math.max(0, frameSize) * BADGE_RATIO;
+}
+
+// How far a corner badge bites into the cookie's outer radius, in pixels.
+//
+// The badge's box sits in the frame's corner, so its centre lands on the
+// frame's diagonal at `sqrt(2)/2 * (frameSize - badgeSize)` from the centre,
+// while the cookie's lobes reach `frameSize / 2`. Positive means the two
+// overlap - what the clock does, and what makes the badge read as fastened to
+// the cookie. Zero or less means it floats clear and the tile reads as three
+// unrelated objects, which is the failure this number names.
+function badgeOverlap(frameSize) {
+    var badge = badgeSize(frameSize);
+    var centreDistance = Math.SQRT2 * (frameSize - badge) / 2;
+    return frameSize / 2 + badge / 2 - centreDistance;
+}

--- a/dots/.config/quickshell/imi/tests/tst_media_cookie_layout.qml
+++ b/dots/.config/quickshell/imi/tests/tst_media_cookie_layout.qml
@@ -1,0 +1,76 @@
+import QtTest
+import "../modules/common/plugins/bundled/nandoroid-media/cookie_layout.js" as CookieLayout
+
+// The 2x2 media tile is the cookie clock's shape with next/previous where the
+// day and month badges are, so the arithmetic that places them is the clock's
+// arithmetic and is pinned here.
+//
+// Nothing about the rendered tile is reachable from qmltestrunner - it cannot
+// construct Quickshell types and the software scene graph draws no Canvas - so
+// the placement is extracted precisely so this much *is* checkable. What the
+// numbers have to hold up: the square frame never leaves the tile (a clipped
+// cookie), and a badge overlaps the cookie's edge rather than floating beside
+// it (three unrelated objects instead of one).
+TestCase {
+    name: "MediaCookieLayoutTest"
+
+    readonly property real tileWidth: 276
+    readonly property real tileHeight: 228
+
+    function test_the_frame_is_square_and_centred_in_a_tile_that_is_not() {
+        const frame = CookieLayout.frame(tileWidth, tileHeight, 12);
+        compare(frame.size, 204);
+        // The tile is 48px wider than it is tall, so the leftover width is
+        // split rather than handed to one side.
+        compare(frame.x, 36);
+        compare(frame.y, 12);
+    }
+
+    function test_the_frame_never_exceeds_the_tile_s_smaller_dimension() {
+        // A frame wider than the tile is short, so the cookie would be clipped
+        // top and bottom with nothing reporting it.
+        for (const inset of [0, 6, 12, 16, 24]) {
+            const frame = CookieLayout.frame(tileWidth, tileHeight, inset);
+            verify(frame.size <= Math.min(tileWidth, tileHeight));
+            verify(frame.x >= 0);
+            verify(frame.y >= 0);
+            compare(frame.size, Math.min(tileWidth, tileHeight) - inset * 2);
+        }
+    }
+
+    function test_an_inset_larger_than_the_tile_yields_no_frame_rather_than_a_negative_one() {
+        const frame = CookieLayout.frame(tileWidth, tileHeight, 200);
+        compare(frame.size, 0);
+        verify(frame.x >= 0);
+        verify(frame.y >= 0);
+    }
+
+    function test_the_badge_keeps_the_clock_s_own_proportion() {
+        // The clock's two numbers, reproduced: 230px square, 64px badge. If
+        // this stops holding, the badge has stopped being the clock's badge.
+        fuzzyCompare(CookieLayout.badgeSize(CookieLayout.CLOCK_FRAME),
+            CookieLayout.CLOCK_BADGE, 0.0001);
+    }
+
+    function test_the_badge_scales_with_the_frame() {
+        fuzzyCompare(CookieLayout.badgeSize(204), 204 * 64 / 230, 0.0001);
+        compare(CookieLayout.badgeSize(0), 0);
+    }
+
+    function test_a_corner_badge_overlaps_the_cookie_s_edge() {
+        // The relationship being copied from the clock. A badge whose centre
+        // sat further out than the lobes reach would read as a separate pill
+        // parked near the cookie.
+        verify(CookieLayout.badgeOverlap(204) > 0);
+        // The clock's own overlap, so a changed ratio shows up as a number
+        // rather than as "still positive".
+        fuzzyCompare(CookieLayout.badgeOverlap(CookieLayout.CLOCK_FRAME), 29.62, 0.01);
+    }
+
+    function test_the_overlap_scales_with_the_frame() {
+        // Every term is linear in the frame size, so a smaller tile shrinks the
+        // bite rather than losing it.
+        fuzzyCompare(CookieLayout.badgeOverlap(204) * 2,
+            CookieLayout.badgeOverlap(408), 0.0001);
+    }
+}


### PR DESCRIPTION
The 2x2 was built to the wrong design — **my spec's fault**, not the implementation's. It said
"cookie with title and artist beneath", which is not the cookie clock's shape at all. The correction,
from the user:

> "It should be like the cookie clock with similar dimensions but instead of the day and the month,
> we get next and previous."

So: a square frame centred in the 276x228 tile, `VisualizerCookie` filling it, album art still clipped
to a circle inside the lobe valleys and still the play/pause target, **previous** anchored to the
frame's top-left (the clock's day bubble) and **next** to its bottom-right (the month bubble).

Geometry is taken *off the clock* rather than re-invented — `CookieClock.qml`'s `implicitSize: 230`
and `DateIndicator.qml`'s `dateSquareSize: 64` — and lives in `cookie_layout.js` so it is testable.

## The three judgement calls

**Title and artist dropped.** Not only because the clock has no text: the two cannot coexist. A text
block under the cookie is paid for out of the cookie's diameter, and a smaller cookie moves the
badges off its edge — which is the one relationship this size exists to draw. The cookie grew from
~150px to 204 as a result. The 3x2 remains the size that names the track.

**A local `component TransportBadge` rather than reusing `BubbleDate`.** That component reads its own
text off `DateTime` and branches on `isMonth` for both shape and colours — there is no content slot,
so "reuse" means rewriting it generic and re-parameterising the clock's two call sites, for a circle
and a symbol this widget already draws in `LayoutCompact`. The reuse that mattered was the colours:
the badges take `LayoutCompact`'s `controlColor`/`controlIconColor`, so all three spans draw one
widget's controls.

**Badges on the frame's corners, not the tile's.** Measured both: at the tile's corners the badge
centre swings off the 45° diagonal and its bite into the cookie drops from **26px to 8px** — it
grazes the cookie instead of being fastened to it, and the tile reads as three unrelated objects.
The spare 48px of width becomes symmetric side margin. That trade-off is generic, so it is the
AGENT.md point.

The `bgCard` background is kept even though the clock has no card: `blurRegions`/`managesBlurTint`
flow through it, so removing it would silently kill the widget's "Blur background" option.

## Testing

`./tests/run_tests.sh` — **504 passed, 0 failed** (495 on main), `DesignSystemCompile` 159/0.

Three planted mutations, each reverted: badge ratio off the clock's → 2 failures; `frame` ignoring the
inset → 3; `frame` taking the tile's larger dimension → 2.

Rendered output is not testable here, so two offscreen probes did what they could: the real 12-lobe
polygon rendered at the computed frame with both badge circles, inspected as a PNG (badges land on
the scalloped edge, art circle clears them by ~2px), and the **real** `LayoutCookie.qml` instantiated
under `qs -p` to evaluate its bindings rather than merely compile it — no `WARN scene`, frame
`{size:204, x:36, y:12}`.

Docs: updated AGENT.md §Design language, docs/superpowers/specs/2026-08-10-media-widget-sizes-design.md