### PR TITLE
feat(widgets): animate a widget's resize, for every resizable widget

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1148,8 +1148,37 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   panned by assignment, i.e. it switched off both halves of the interaction it existed to score,
   and stayed green for the entire life of the bug. b710ef731 ("fix(plugins): stop the position
   Behavior swallowing the parallax cancellation").
-- **The mirror-image failure: a `Behavior` *retriggered* every frame does tick, forever, and
-  nothing on screen shows you.** Where the parallax bug was a frozen property, this one is a
+- **The mirror image of that rule: a binding that re-evaluates every frame is not a target
+  that moves every frame, and a `Behavior` is fine on the second.** A desktop widget's span
+  resize animates its `width`/`height` even though the grip re-previews on every mouse move
+  and hands `previewGridSize` a fresh object each time — because the *value* the binding
+  produces changes only at a span boundary, and Qt does not restart a running Behavior for a
+  write of the value it is already animating to (`QQuickBehavior::write` returns early when
+  the target value is unchanged). So the test is what the property is written *with*, not how
+  often the binding runs, and the way to find out is to sample the property mid-change rather
+  than to reason about it. Two things follow for anything animating a size here. Nothing may
+  clamp, measure or persist against the *animating* value: the position clamp runs when the
+  span commits, while the widget is still the size it is leaving, and nothing runs again once
+  the animation lands — so `AbstractBackgroundWidget.clampWidth`/`clampHeight` exist for a
+  subclass to point at the size it is heading for (a property rather than an argument on
+  `clampX`, because a call site that forgets to pass one is silent). And a settled-size test
+  passes identically on an animation and on the snap it replaced, which is why
+  `WidgetResizeMotionRuntimeTest.qml` samples the width 80ms in and fails if it is already at
+  the destination — the sibling grip harness scores only settled sizes and stayed green under
+  every mutation of the motion. fa1e2a8b5 ("feat(plugins): animate a resizable widget's size
+  between its offered spans"), 4e33a332a ("test(widgets): score a span change as in flight, not
+  as a snap").
+- **A change handler that writes the state its own binding reads is a binding loop, and Qt
+  drops the re-evaluation rather than erroring where you are looking.** `PluginWidget` repairs a
+  resized widget's stored position from `onStoredGridSpanChanged`, and that repair calls
+  `PluginState.setPosition` — which is the state `storedGridSize` is derived from, so the write
+  lands inside that binding's own evaluation and the log says `Binding loop detected for
+  property "storedGridSize"` at the *call site's* file. A zero-interval `Timer` moves the write
+  one turn of the event loop out of the evaluation and costs nothing, since what the widget is
+  drawn at was already clamped by a different path. fa1e2a8b5 ("feat(plugins): animate a
+  resizable widget's size between its offered spans").
+- **A third failure in the same family: a `Behavior` *retriggered* every frame does tick,
+  forever, and nothing on screen shows you.** Where the parallax bug was a frozen property, this one is a
   property that never rests. `CavaService` gated cava on `MprisController.activePlayer !== null`
   — but a *paused* player is still an active player, and cava visualises whatever is **audible**
   rather than the tracked player's stream. So three paused players left cava decoding a

--- a/docs/tests-README.md
+++ b/docs/tests-README.md
@@ -182,6 +182,32 @@ XDG_CONFIG_HOME=$(mktemp -d) XDG_STATE_HOME=$(mktemp -d) \
   qs -p WidgetInteractionRuntimeTest.qml
 ```
 
+`WidgetResizeGripRuntimeTest.qml` and `WidgetResizeMotionRuntimeTest.qml` split one
+feature between them, and the split is the point. The grip harness
+(`tests/test_widget_resize_grip_runtime.py`) drags the corner of two real
+`PluginWidget`s — one offering three spans, one offering a single one as the
+control — and scores only **settled** sizes plus the widget's position, because
+its question is whether the corner resizes the widget or *walks* it. That leaves
+it blind to whether the resize is animated at all: a `Behavior` handed a target
+that moves every frame compiles, never ticks, and snaps the property to its final
+value, which is how the parallax opt-out shipped inert. So the motion harness
+(`tests/test_widget_resize_motion_runtime.py`) samples the size 80ms and 240ms
+**into** a span change and fails if it was already at the destination, if it had
+not left the old span, or if the two samples agree — driving both the Size row's
+single write and a live grip drag, since only the second re-writes the target on
+every mouse move. It also scores the three things a settled size cannot show: that
+the content's span name is still the old one early and the new one past the
+midpoint (read off `PluginNode`, not off the host property feeding it — reading the
+latter passed while the pop was back), that a widget grown flush with the right
+screen edge ends up inside the screen with its stored position agreeing, and that
+Escape returns the size on a move rather than a snap. Both write plugin state, so
+run them by hand against a throwaway config:
+
+```bash
+XDG_CONFIG_HOME=$(mktemp -d) XDG_STATE_HOME=$(mktemp -d) \
+  qs -p WidgetResizeMotionRuntimeTest.qml
+```
+
 `ConfigControlWriteBackRuntimeTest.qml` is self-checking and driven by
 `tests/test_config_control_write_back.py`. It seeds a throwaway
 `XDG_CONFIG_HOME` with `osd.timeout: 4321` — a value the config format accepts

--- a/docs/widget-grid.md
+++ b/docs/widget-grid.md
@@ -260,7 +260,11 @@ animating size**: the frost surface's default region is the widget's own `width`
 (and a custom `blurRegions` list belongs to content that is being stretched with the box),
 and the grip is anchored to the corner. The frost costs no extra decode while it moves —
 the slice is a `ShaderEffectSource` `sourceRect` over a shared cached wallpaper `Image`,
-which is free to move (AGENT.md's shared-decode note). The grip's *gesture* is measured in
+which is free to move (AGENT.md's shared-decode note) — and the surface itself is not
+rebuilt, even though the region list handed to its `Repeater`'s `model` is a new array on
+every frame of the resize: a replacement list of the same length reaches the delegate as a
+change rather than a reset. That is Qt behaviour rather than a decision here, so the motion
+harness scores the surface's identity across a resize instead of trusting it. The grip's *gesture* is measured in
 scene coordinates from the press for the same reason it always was, plus one: it captures
 the span being animated **to**, so pressing the grip again mid-animation does not measure
 from a size the widget is leaving.

--- a/docs/widget-grid.md
+++ b/docs/widget-grid.md
@@ -122,8 +122,10 @@ Such a widget reads the resolved span back from the host as `hostGridSize`
 (`"<cols>x<rows>"`, declared as a `property string` on its `Widget.qml` root and bound
 by `PluginNode`), and switches its layout on it. **The host owns which size a widget is;
 the widget owns what that size looks like.** It tracks the grip's live preview, so a
-drag reshapes the content as it goes rather than on release. A widget must not persist a
-size of its own alongside this — that is what `sizeMode` was, and it is retired
+drag reshapes the content as it goes rather than on release — half a resize behind the
+box, which is where the swap is invisible; see [Resizing is animated](#resizing-is-animated).
+A widget must not persist a size of its own alongside this — that is what `sizeMode` was,
+and it is retired
 (db3a7d009 ("refactor(plugins): retire sizeMode in favour of the host's __gridSize")).
 
 The rules, all of them refusals to guess (`modules/common/plugins/gridSizes.js`,
@@ -206,10 +208,83 @@ measured 420x228 through a `qs -p` probe both before and after, which is exactly
 they do differ, adjust the layout to the span rather than picking the span that flatters
 the current content.
 
-Growing past the screen edge needs no new rule: committing a span writes plugin state,
-which re-evaluates the widget's persisted position, so the existing clamp
-(`PluginWidget.applyPersistedPosition`) pulls it back inside against its *new* width -
-the same clamp that catches a widget dragged past the edge.
+## Resizing is animated
+
+A span change is a **spatial move**, and the host draws it as one — there is no snap
+between spans and no plugin opts into this. The tokens are `Appearance`'s expressive
+spatial curves, and which one is running is decided by whether the grip is still
+previewing (`modules/common/plugins/gridResize.js`, covered by
+`tests/tst_grid_resize.qml`):
+
+| what changed the span | duration | curve |
+| --- | --- | --- |
+| a grip drag, previewing | `elementMoveSmall` (350ms) | `expressiveFastSpatial` |
+| a release, the Size row, an Escape | `elementMove` (500ms) | `expressiveDefaultSpatial` |
+
+The split is the whole answer to "responsive or smooth": the grip previews live, so
+during a drag the widget is chasing the pointer and the full curve reads as lag when a
+fast drag crosses two thresholds. Everything else is a destination rather than tracking.
+Escape falls out of it for free — clearing the preview is what changes the size, and by
+then nothing is previewing, so the return to the span the drag started from is a move and
+not a snap back.
+
+**A `Behavior` is right here and wrong on the same widget's `x`/`y`, and the difference is
+the whole trap.** A Behavior handed a target that moves every frame restarts every frame,
+never ticks, and leaves the property frozen — that is how the parallax opt-out shipped
+inert (AGENT.md, b710ef731 ("fix(plugins): stop the position Behavior swallowing the
+parallax cancellation")). A span is discrete: it moves when the *resolved span* moves and
+at no other time. The grip does re-evaluate the width binding on every mouse move — it
+hands `previewGridSize` a fresh object each time — but the value that binding produces
+changes only at a span boundary, and Qt does not restart a running Behavior for a write of
+the value it is already animating to. Both gates on `enabled` matter from the other side:
+a content-sized widget's width follows its content, which may well move every frame, and
+the first span the store answers with is not a resize anybody just made.
+
+**The content swaps at the midpoint, under a fade.** A widget offering several spans has a
+design per span by construction (see above), so the content has to change identity
+somewhere in the move, and both ends of it are a pop: hand the new span name down at the
+start and the incoming layout is drawn inside the outgoing box for the whole animation;
+hand it down at the end and the outgoing one is. So the host keeps two spans — the one the
+widget *is* and the one the content is *showing* — and moves the second at the midpoint
+with `PluginNode`'s opacity faded out and back in around it. `hostGridSize` is that second
+one. Meanwhile the node is sized to the host's *animating* width rather than to the target
+span, so the layout on either side of the swap fills the box on every frame instead of
+overflowing it while the box grows.
+
+None of that is per plugin: the host cannot know whether the widget it is holding swaps a
+whole file (media) or a branch inside one (weather, currency), and a fade it did not need
+is indistinguishable from the resize it sits inside.
+
+**Everything that tracks the widget's rect keeps up on its own, because it is bound to the
+animating size**: the frost surface's default region is the widget's own `width`/`height`
+(and a custom `blurRegions` list belongs to content that is being stretched with the box),
+and the grip is anchored to the corner. The frost costs no extra decode while it moves —
+the slice is a `ShaderEffectSource` `sourceRect` over a shared cached wallpaper `Image`,
+which is free to move (AGENT.md's shared-decode note). The grip's *gesture* is measured in
+scene coordinates from the press for the same reason it always was, plus one: it captures
+the span being animated **to**, so pressing the grip again mid-animation does not measure
+from a size the widget is leaving.
+
+**Growing past the screen edge is the one thing the animation does not handle by itself.**
+Committing a span writes plugin state, which re-evaluates the widget's persisted position,
+so the existing clamp (`PluginWidget.applyPersistedPosition`) pulls it back inside — but it
+runs while the widget is still the size it is *leaving*, and nothing runs again once the
+animation lands. So the clamp measures the widget by
+`AbstractBackgroundWidget.clampWidth`/`clampHeight`, which `PluginWidget` binds to the span
+it is resizing to; the widget then slides in while it grows, in one motion, and cannot
+settle outside the screen. The stored position is repaired on the same clamp, one turn of
+the event loop later (the repair writes the state the handler is reading), so the store
+does not keep a number the widget is no longer drawn at — 705e9006d ("fix(plugins): stop a
+widget's stored position disagreeing with where it is drawn") reached from the other side.
+
+The motion is scored by `WidgetResizeMotionRuntimeTest.qml`
+(`tests/test_widget_resize_motion_runtime.py`), which samples the size 80ms and 240ms into
+a change and fails if it was already at its destination. Its sibling
+`WidgetResizeGripRuntimeTest.qml` deliberately reads only settled sizes, and so passes
+whether the resize is animated or instant — which is why the in-flight harness exists at
+all.
+fa1e2a8b5 ("feat(plugins): animate a resizable widget's size between its offered spans"),
+9f6cc1de7 ("feat(plugins): swap a resized widget's content at the middle of the move").
 
 ## Position snapping
 

--- a/dots/.config/quickshell/imi/WidgetResizeGripRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/WidgetResizeGripRuntimeTest.qml
@@ -331,9 +331,16 @@ ShellRoot {
     // One step per tick: the grip only becomes visible once the hover has
     // animated its opacity off zero, so the hover and the press it enables
     // cannot share a frame.
+    //
+    // The tick outlasts the resize itself (Appearance's 500ms elementMove,
+    // which a commit and an Escape both take) because these checks read the
+    // widget's *settled* width. A shorter tick scores a frame the size
+    // Behavior is still travelling through, which is a working animation
+    // reading as a failed resize. Whether that motion happens at all is
+    // `WidgetResizeMotionRuntimeTest.qml`'s question, not this one's.
     Timer {
         id: runner
-        interval: 400
+        interval: 700
         repeat: true
         running: false
         onTriggered: {

--- a/dots/.config/quickshell/imi/WidgetResizeMotionRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/WidgetResizeMotionRuntimeTest.qml
@@ -1,0 +1,365 @@
+import QtQuick
+import QtTest
+import Quickshell
+import qs.modules.common
+import qs.modules.common.plugins
+import qs.modules.common.widgets.widgetCanvas
+
+/**
+ * Scores a span change as motion rather than as a result.
+ *
+ * `WidgetResizeGripRuntimeTest.qml` deliberately reads only settled sizes -
+ * whether the corner resizes the widget or walks it is a question about where
+ * things end up. This harness asks the opposite question, and it is the only
+ * one that can tell a working animation from the snap it replaced: it samples
+ * the widget's width *while* a span change is in flight and fails if the width
+ * was already at its destination.
+ *
+ * That is precisely the failure a `Behavior` produces when it is handed a
+ * target that moves every frame (AGENT.md: the parallax opt-out froze that
+ * way). It never ticks, the property jumps to the final value, and every
+ * settled-size check in the sibling harness stays green. So both gestures are
+ * driven here: a Size row change, which is one discrete write, and a grip drag,
+ * which re-previews on every mouse move and hands the host a fresh span object
+ * each time.
+ *
+ * Three further things are scored because none of them are visible from a
+ * settled size either:
+ *   - the content's span name swaps at the *midpoint* of the move, not at
+ *     either end - a widget with a layout per span (media loads a different
+ *     file per span) would otherwise pop at the moment the motion exists to
+ *     cover;
+ *   - a widget grown at the right-hand screen edge ends up inside the screen,
+ *     and its stored position agrees. The clamp runs when the span commits,
+ *     when the widget is still the size it is leaving, so an animation that is
+ *     measured wrong strands it outside with nothing left running to notice;
+ *   - Escape returns the size on a move, not on a snap.
+ *
+ * Run it against a throwaway config:
+ *   XDG_CONFIG_HOME=$(mktemp -d) XDG_STATE_HOME=$(mktemp -d) qs -p WidgetResizeMotionRuntimeTest.qml
+ */
+ShellRoot {
+    id: harness
+
+    property int failures: 0
+    readonly property string testScreen: "MOTION-TEST"
+    readonly property int screenW: 1200
+    readonly property int screenH: 700
+
+    function check(label, ok) {
+        console.log(`[WidgetResizeMotion] ${label}: ${ok ? "ok" : "FAIL"}`);
+        if (!ok)
+            harness.failures++;
+    }
+
+    function spanW(cols) { return Math.round(Appearance.sizes.widgetGridSpanX(cols)); }
+    function spanH(rows) { return Math.round(Appearance.sizes.widgetGridSpanY(rows)); }
+
+    function manifestFor(id) {
+        return {
+            id: id,
+            name: id,
+            grid: {
+                cols: 3, rows: 2,
+                sizes: [{ cols: 3, rows: 2 }, { cols: 2, rows: 2 }, { cols: 2, rows: 1 }]
+            },
+            desktopWidget: { type: "Item" }
+        };
+    }
+
+    readonly property var motionManifest: harness.manifestFor("motion-probe")
+    readonly property var edgeManifest: harness.manifestFor("edge-probe")
+
+    FloatingWindow {
+        visible: true
+        implicitWidth: harness.screenW
+        implicitHeight: harness.screenH
+        color: "black"
+
+        TestCase {
+            id: driver
+            when: false
+            name: "WidgetResizeMotionDriver"
+        }
+
+        WidgetCanvas {
+            id: canvas
+            anchors.fill: parent
+
+            PluginWidget {
+                id: motionWidget
+                manifest: harness.motionManifest
+                screenName: harness.testScreen
+                screenWidth: harness.screenW
+                screenHeight: harness.screenH
+                scaledScreenWidth: harness.screenW
+                scaledScreenHeight: harness.screenH
+                wallpaperScale: 1
+            }
+
+            // Placed so that its 2x2 self ends exactly at the right edge: one
+            // step up to 3x2 is 144px it does not have.
+            PluginWidget {
+                id: edgeWidget
+                manifest: harness.edgeManifest
+                screenName: harness.testScreen
+                screenWidth: harness.screenW
+                screenHeight: harness.screenH
+                scaledScreenWidth: harness.screenW
+                scaledScreenHeight: harness.screenH
+                wallpaperScale: 1
+            }
+        }
+    }
+
+    readonly property real edgeStartX: harness.screenW - harness.spanW(2)
+
+    function placeWidgets() {
+        PluginState.setPosition("motion-probe", harness.testScreen,
+                                { x: 40, y: 40, placementStrategy: "free" });
+        PluginState.setPosition("edge-probe", harness.testScreen,
+                                { x: harness.edgeStartX, y: 400, placementStrategy: "free" });
+    }
+
+    // ---- sampling -------------------------------------------------------
+    //
+    // Three samples per gesture, taken against wall-clock offsets from the
+    // moment the span changes. 80ms and 240ms are both well inside the 500ms
+    // commit move (and the 350ms drag move), and 400ms is past the midpoint the
+    // content swap lands on and still short of the end.
+
+    property var samples: ({})
+
+    function sampleOf(widget) {
+        return {
+            width: Math.round(widget.width),
+            height: Math.round(widget.height),
+            shown: widget.shownGridSpan,
+            x: Math.round(widget.x)
+        };
+    }
+
+    property Item sampledWidget: null
+
+    function startSampling(widget) {
+        harness.samples = ({});
+        harness.sampledWidget = widget;
+        earlySample.restart();
+        midSample.restart();
+        lateSample.restart();
+    }
+
+    Timer {
+        id: earlySample
+        interval: 80
+        onTriggered: harness.samples.early = harness.sampleOf(harness.sampledWidget)
+    }
+    Timer {
+        id: midSample
+        interval: 240
+        onTriggered: harness.samples.mid = harness.sampleOf(harness.sampledWidget)
+    }
+    Timer {
+        id: lateSample
+        interval: 400
+        onTriggered: harness.samples.late = harness.sampleOf(harness.sampledWidget)
+    }
+
+    // The check that separates an animation from a snap. A size that is already
+    // at the target 80ms in is exactly what a Behavior that never ticks
+    // produces, and it is indistinguishable from the instant resize this
+    // replaced.
+    //
+    // The axis is named by the caller rather than assumed: a 2x2 -> 2x1 drag
+    // moves only the height, and scoring its width instead passes every check
+    // here vacuously - the width is neither of the two *heights* it is being
+    // compared against.
+    function scoreInFlight(label, axis, fromSize, toSize) {
+        const early = harness.samples.early;
+        const mid = harness.samples.mid;
+        harness.check(`${label}: sampled at all`, !!early && !!mid);
+        if (!early || !mid) return;
+        harness.check(`${label}: the axis under test actually moves`, fromSize !== toSize);
+        harness.check(`${label}: was not already at the new span`,
+                      early[axis] !== toSize);
+        harness.check(`${label}: had left the old span`, early[axis] !== fromSize);
+        harness.check(`${label}: was still travelling`, early[axis] !== mid[axis]);
+    }
+
+    function scoreSettled(label, widget, cols, rows) {
+        harness.check(`${label}: settles on the span`,
+                      Math.round(widget.width) === harness.spanW(cols)
+                      && Math.round(widget.height) === harness.spanH(rows));
+        harness.check(`${label}: the content is the span it settled on`,
+                      widget.shownGridSpan === `${cols}x${rows}`);
+    }
+
+    // The content changes identity once, in the middle. Either end is a pop:
+    // at the start the new layout is drawn into the old box for the whole
+    // move, at the end the old one is.
+    function scoreSwapsAtTheMidpoint(label, fromSpan, toSpan) {
+        const early = harness.samples.early;
+        const late = harness.samples.late;
+        harness.check(`${label}: sampled at all`, !!early && !!late);
+        if (!early || !late) return;
+        harness.check(`${label}: the content is still the old span early on`,
+                      early.shown === fromSpan);
+        harness.check(`${label}: and the new one by the second half`,
+                      late.shown === toSpan);
+    }
+
+    // ---- gestures -------------------------------------------------------
+
+    function gripCenter(widget) {
+        const inset = Appearance.spacing.space100 + 8;
+        return { x: widget.x + widget.width - inset, y: widget.y + widget.height - inset };
+    }
+
+    property var pendingGrip: null
+
+    function hoverGrip(widget) {
+        harness.pendingGrip = harness.gripCenter(widget);
+        driver.mouseMove(canvas, harness.pendingGrip.x, harness.pendingGrip.y);
+    }
+
+    // Press and drag, leaving the button down: the samples are taken while the
+    // gesture is still live, which is the whole point of driving the grip as
+    // well as the Size row.
+    function pressAndDrag(dx, dy) {
+        const point = harness.pendingGrip;
+        driver.mousePress(canvas, point.x, point.y, Qt.LeftButton);
+        driver.mouseMove(canvas, point.x + dx, point.y + dy, 20, Qt.LeftButton);
+    }
+
+    function releaseDrag(dx, dy) {
+        const point = harness.pendingGrip;
+        driver.mouseRelease(canvas, point.x + dx, point.y + dy, Qt.LeftButton);
+    }
+
+    function escapeDrag() { driver.keyClick(Qt.Key_Escape); }
+
+    function setSpan(id, span) { PluginState.setOption(id, "__gridSize", span); }
+
+    // ---- the steps ------------------------------------------------------
+
+    readonly property var steps: [
+        // The Size row's path: one discrete write, from the manifest default.
+        () => {
+            harness.setSpan("motion-probe", "2x2");
+            harness.startSampling(motionWidget);
+        },
+        () => {
+            harness.scoreInFlight("a Size row change", "width", harness.spanW(3), harness.spanW(2));
+            harness.scoreSwapsAtTheMidpoint("a Size row change", "3x2", "2x2");
+            harness.scoreSettled("a Size row change", motionWidget, 2, 2);
+        },
+
+        // The grip's path. Its target is re-written on every mouse move with a
+        // fresh span object, which is the shape that froze the parallax
+        // opt-out's position Behavior solid.
+        () => harness.hoverGrip(motionWidget),
+        () => {
+            harness.pressAndDrag(0, -120);
+            harness.startSampling(motionWidget);
+        },
+        () => {
+            harness.scoreInFlight("a grip drag", "height", harness.spanH(2), harness.spanH(1));
+            harness.releaseDrag(0, -120);
+        },
+        () => harness.scoreSettled("a grip drag", motionWidget, 2, 1),
+
+        // Escape mid-drag returns the size, and that return is a move too.
+        () => harness.hoverGrip(motionWidget),
+        () => {
+            harness.pressAndDrag(144, 0);
+            harness.startSampling(motionWidget);
+        },
+        () => {
+            harness.escapeDrag();
+            harness.startSampling(motionWidget);
+        },
+        () => {
+            harness.scoreInFlight("escape", "width", harness.spanW(3), harness.spanW(2));
+            harness.releaseDrag(144, 0);
+        },
+        () => harness.scoreSettled("escape", motionWidget, 2, 1),
+
+        // Growing at the screen edge. The clamp runs when the span commits,
+        // while the widget is still the size it is leaving, so it has to
+        // measure the widget by the span it is growing *into*.
+        () => {
+            harness.check("the edge widget starts flush with the right edge",
+                          Math.round(edgeWidget.x) === Math.round(harness.edgeStartX));
+            harness.setSpan("edge-probe", "3x2");
+            harness.startSampling(edgeWidget);
+        },
+        () => {
+            harness.scoreSettled("growing at the edge", edgeWidget, 3, 2);
+            harness.check("growing at the edge: the widget stays on screen",
+                          Math.round(edgeWidget.x + edgeWidget.width) <= harness.screenW);
+            harness.check("growing at the edge: the store agrees with the screen",
+                          Math.round(PluginState.position("edge-probe", harness.testScreen).x)
+                              === harness.screenW - harness.spanW(3));
+        }
+    ]
+
+    property int stepIndex: 0
+
+    Timer {
+        id: setup
+        interval: 250
+        repeat: true
+        running: true
+        onTriggered: {
+            if (!PluginState.ready || !Config.ready)
+                return;
+            Config.options.background.widgetsLocked = false;
+            // Both manifests default to 3x2, which is 420 wide: the edge widget
+            // cannot be placed flush with the right edge until it is the 2x2 it
+            // is meant to grow *from*, because the host clamps it back in.
+            if (PluginState.option("edge-probe", "__gridSize", "") !== "2x2") {
+                PluginState.setOption("edge-probe", "__gridSize", "2x2");
+                return;
+            }
+            if (Math.round(motionWidget.x) === 40
+                    && Math.round(edgeWidget.x) === Math.round(harness.edgeStartX)) {
+                setup.running = false;
+                runner.running = true;
+                return;
+            }
+            harness.placeWidgets();
+        }
+    }
+
+    // A harness that never reaches its steps is a 180s timeout in the driver
+    // and no output at all - qs buffers stdout into a pipe, so a killed run
+    // says nothing about why.
+    Timer {
+        interval: 60000
+        running: true
+        onTriggered: {
+            console.log(`[WidgetResizeMotion] FAIL: gave up at step ${harness.stepIndex}`
+                        + ` of ${harness.steps.length}`);
+            console.log(`[WidgetResizeMotion] failures: ${harness.failures + 1}`);
+            Qt.exit(1);
+        }
+    }
+
+    // Long enough for the whole move plus the position Behavior that follows a
+    // clamp, so every step starts from a settled widget.
+    Timer {
+        id: runner
+        interval: 900
+        repeat: true
+        running: false
+        onTriggered: {
+            if (harness.stepIndex >= harness.steps.length) {
+                runner.running = false;
+                console.log(`[WidgetResizeMotion] failures: ${harness.failures}`);
+                Qt.exit(harness.failures === 0 ? 0 : 1);
+                return;
+            }
+            harness.steps[harness.stepIndex++]();
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/WidgetResizeMotionRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/WidgetResizeMotionRuntimeTest.qml
@@ -130,11 +130,34 @@ ShellRoot {
 
     property var samples: ({})
 
+    // The span the CONTENT is being told it is, read off the host's PluginNode
+    // rather than off the host property that feeds it.
+    //
+    // Scoring `shownGridSpan` instead looks equivalent and is not: rewiring the
+    // node back to the widget's own span makes every layout pop at the start of
+    // the move again while the property this would have read goes on behaving
+    // perfectly. Measured - that mutation passed a version of this file that
+    // read the host property.
+    //
+    // Found by walking for PluginNode's own `hasGrid`, because the node is a
+    // grandchild of the widget (AbstractBackgroundWidget parents everything a
+    // subclass declares into a content Item) and neither has an objectName the
+    // host has any other reason to carry.
+    function contentNode(item) {
+        for (const child of item.children) {
+            if (child.hasGrid !== undefined && child.gridSize !== undefined) return child;
+            const found = harness.contentNode(child);
+            if (found) return found;
+        }
+        return null;
+    }
+
     function sampleOf(widget) {
+        const node = harness.contentNode(widget);
         return {
             width: Math.round(widget.width),
             height: Math.round(widget.height),
-            shown: widget.shownGridSpan,
+            shown: node ? node.gridSize : "<no content node>",
             x: Math.round(widget.x)
         };
     }
@@ -191,7 +214,7 @@ ShellRoot {
                       Math.round(widget.width) === harness.spanW(cols)
                       && Math.round(widget.height) === harness.spanH(rows));
         harness.check(`${label}: the content is the span it settled on`,
-                      widget.shownGridSpan === `${cols}x${rows}`);
+                      harness.sampleOf(widget).shown === `${cols}x${rows}`);
     }
 
     // The content changes identity once, in the middle. Either end is a pop:

--- a/dots/.config/quickshell/imi/WidgetResizeMotionRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/WidgetResizeMotionRuntimeTest.qml
@@ -23,12 +23,15 @@ import qs.modules.common.widgets.widgetCanvas
  * which re-previews on every mouse move and hands the host a fresh span object
  * each time.
  *
- * Three further things are scored because none of them are visible from a
+ * Four further things are scored because none of them are visible from a
  * settled size either:
  *   - the content's span name swaps at the *midpoint* of the move, not at
  *     either end - a widget with a layout per span (media loads a different
  *     file per span) would otherwise pop at the moment the motion exists to
  *     cover;
+ *   - the frost surface is the widget's rect on every frame and is the *same*
+ *     surface throughout, rather than being destroyed and rebuilt at the
+ *     refresh rate by a region list handed to a `Repeater`'s `model`;
  *   - a widget grown at the right-hand screen edge ends up inside the screen,
  *     and its stored position agrees. The clamp runs when the span commits,
  *     when the widget is still the size it is leaving, so an animation that is
@@ -55,6 +58,8 @@ ShellRoot {
     function spanW(cols) { return Math.round(Appearance.sizes.widgetGridSpanX(cols)); }
     function spanH(rows) { return Math.round(Appearance.sizes.widgetGridSpanY(rows)); }
 
+    // `blur: true` seeds the host's own frost surface on, which is the thing
+    // that has to keep up with an animating rect without being rebuilt.
     function manifestFor(id) {
         return {
             id: id,
@@ -63,7 +68,7 @@ ShellRoot {
                 cols: 3, rows: 2,
                 sizes: [{ cols: 3, rows: 2 }, { cols: 2, rows: 2 }, { cols: 2, rows: 1 }]
             },
-            desktopWidget: { type: "Item" }
+            desktopWidget: { type: "Item", blur: true }
         };
     }
 
@@ -152,12 +157,28 @@ ShellRoot {
         return null;
     }
 
+    // The widget's frost surface, found the same way and for the same reason:
+    // it is what the wallpaper is sampled through, and it has to track a rect
+    // that is now moving under it.
+    function frostSurface(item) {
+        for (const child of item.children) {
+            if (child.surfaceX !== undefined && child.wallpaperSource !== undefined) return child;
+            const found = harness.frostSurface(child);
+            if (found) return found;
+        }
+        return null;
+    }
+
     function sampleOf(widget) {
         const node = harness.contentNode(widget);
+        const frost = harness.frostSurface(widget);
         return {
             width: Math.round(widget.width),
             height: Math.round(widget.height),
             shown: node ? node.gridSize : "<no content node>",
+            frost: frost,
+            frostWidth: frost ? Math.round(frost.width) : -1,
+            frostHeight: frost ? Math.round(frost.height) : -1,
             x: Math.round(widget.x)
         };
     }
@@ -217,6 +238,36 @@ ShellRoot {
                       harness.sampleOf(widget).shown === `${cols}x${rows}`);
     }
 
+    // The frost samples the wallpaper by the widget's rect, so it has to be that
+    // rect on every frame - and it has to be the *same surface* throughout.
+    //
+    // The second half is the one that is not obvious. The host's region list is
+    // a JS array handed to a `Repeater`'s `model`, and it is now rebuilt on
+    // every frame of a resize: the default region is the widget's own animating
+    // rect, and a custom `blurRegions` list belongs to content being stretched
+    // with the box. Rebuilding the surface per frame would mean a fresh
+    // ShaderEffectSource, FastBlur and image request per frame - the serialized
+    // decode cascade #147 removed, re-created at the refresh rate. Measured, it
+    // does not: a replacement list of the same length reaches the delegate as a
+    // change rather than a reset, so the surface survives and its own bindings
+    // move it. That is worth a check rather than a comment, because it is a Qt
+    // behaviour nothing in this repo controls. A destroyed QObject reads as null
+    // from JS, so an identity comparison catches the day it stops holding.
+    function scoreFrostKeepsUp(label) {
+        const early = harness.samples.early;
+        const mid = harness.samples.mid;
+        harness.check(`${label}: the frost surface exists`,
+                      !!early && !!early.frost && !!mid && !!mid.frost);
+        if (!early || !mid || !early.frost || !mid.frost) return;
+        harness.check(`${label}: the frost is not rebuilt mid-resize`,
+                      early.frost === mid.frost);
+        // Both axes, because a gesture that moves only the height would
+        // otherwise be scored on a width neither of them touched.
+        harness.check(`${label}: the frost is the widget's own rect`,
+                      early.frostWidth === early.width && mid.frostWidth === mid.width
+                      && early.frostHeight === early.height && mid.frostHeight === mid.height);
+    }
+
     // The content changes identity once, in the middle. Either end is a pop:
     // at the start the new layout is drawn into the old box for the whole
     // move, at the end the old one is.
@@ -274,6 +325,7 @@ ShellRoot {
         () => {
             harness.scoreInFlight("a Size row change", "width", harness.spanW(3), harness.spanW(2));
             harness.scoreSwapsAtTheMidpoint("a Size row change", "3x2", "2x2");
+            harness.scoreFrostKeepsUp("a Size row change");
             harness.scoreSettled("a Size row change", motionWidget, 2, 2);
         },
 
@@ -287,6 +339,7 @@ ShellRoot {
         },
         () => {
             harness.scoreInFlight("a grip drag", "height", harness.spanH(2), harness.spanH(1));
+            harness.scoreFrostKeepsUp("a grip drag");
             harness.releaseDrag(0, -120);
         },
         () => harness.scoreSettled("a grip drag", motionWidget, 2, 1),
@@ -337,6 +390,9 @@ ShellRoot {
             if (!PluginState.ready || !Config.ready)
                 return;
             Config.options.background.widgetsLocked = false;
+            // The host builds no frost surface with the transparency switch
+            // off, and it ships off.
+            Config.options.appearance.transparency.enable = true;
             // Both manifests default to 3x2, which is 420 wide: the edge widget
             // cannot be placed flush with the right edge until it is the 2x2 it
             // is meant to grow *from*, because the host clamps it back in.

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
@@ -9,6 +9,7 @@ import qs.modules.common.widgets
 import qs.modules.imi.background.widgets
 import "../functions/parallax.js" as ParallaxMath
 import "gridSizes.js" as GridSizes
+import "gridResize.js" as GridResize
 
 AbstractBackgroundWidget {
     id: rootWidget
@@ -144,10 +145,64 @@ AbstractBackgroundWidget {
     property var previewGridSize: null
     readonly property bool resizingGrid: previewGridSize !== null
     readonly property var gridSize: previewGridSize ?? storedGridSize
+    readonly property bool gridSized: rootWidget.gridSize !== null && rootWidget.gridSize !== undefined
     readonly property int gridCols: gridSize ? gridSize.cols : 0
     readonly property int gridRows: gridSize ? gridSize.rows : 0
     readonly property real gridSpanWidth: gridSize ? Appearance.sizes.widgetGridSpanX(gridCols) : 0
     readonly property real gridSpanHeight: gridSize ? Appearance.sizes.widgetGridSpanY(gridRows) : 0
+
+    // The span change is a spatial move, so it is drawn as one rather than
+    // snapped. Two things make a Behavior the right mechanism here and the
+    // wrong one on this widget's x/y (see `animatePosition` below): the target
+    // is discrete - it moves when the resolved span moves and at no other time
+    // - and Qt does not restart a running Behavior for a write of the value it
+    // is already animating to. That matters because the grip re-previews on
+    // every mouse move and hands `previewGridSize` a fresh object each time, so
+    // the width binding re-evaluates per frame while the *value* it produces
+    // changes only at a span boundary.
+    //
+    // Only while the size is a span: a content-sized widget's width follows its
+    // content, which may well move every frame, and that is the shape a
+    // Behavior freezes solid.
+    //
+    // ...and only once the store has answered. A widget whose stored span is
+    // not its manifest default resolves it the moment plugin-state.json lands,
+    // and animating that would have every resized widget on the desktop grow or
+    // shrink on login for a size nobody just chose.
+    readonly property bool gridResizeAnimated: rootWidget.gridSized && PluginState.ready
+    readonly property int gridResizeDuration: GridResize.resizeDurationMs(
+        rootWidget.resizingGrid,
+        Appearance.animation.elementMoveSmall.duration,
+        Appearance.animation.elementMove.duration)
+    readonly property var gridResizeCurve: rootWidget.resizingGrid
+        ? Appearance.animationCurves.expressiveFastSpatial
+        : Appearance.animationCurves.expressiveDefaultSpatial
+
+    Behavior on width {
+        enabled: rootWidget.gridResizeAnimated
+        NumberAnimation {
+            duration: rootWidget.gridResizeDuration
+            easing.type: Easing.BezierSpline
+            easing.bezierCurve: rootWidget.gridResizeCurve
+        }
+    }
+    Behavior on height {
+        enabled: rootWidget.gridResizeAnimated
+        NumberAnimation {
+            duration: rootWidget.gridResizeDuration
+            easing.type: Easing.BezierSpline
+            easing.bezierCurve: rootWidget.gridResizeCurve
+        }
+    }
+
+    // The size the widget is resizing *to*. Everything that has to agree with
+    // where the widget ends up - the position clamp, and the grip's own press
+    // measurement - reads this rather than `width`, which is a frame of an
+    // animation for half a second after every span change.
+    readonly property real settledWidth: rootWidget.gridSized ? rootWidget.gridSpanWidth : rootWidget.width
+    readonly property real settledHeight: rootWidget.gridSized ? rootWidget.gridSpanHeight : rootWidget.height
+    clampWidth: rootWidget.settledWidth
+    clampHeight: rootWidget.settledHeight
 
     function commitGridSize(size) {
         if (!manifest || !size) return;
@@ -226,6 +281,35 @@ AbstractBackgroundWidget {
     onCurrentConfigChanged: applyPersistedPosition()
     Component.onCompleted: applyPersistedPosition()
 
+    // A widget resized near a screen edge no longer fits where it is stored,
+    // and the two halves of that go wrong in different directions. Where the
+    // widget is *drawn* is already handled: committing a span writes plugin
+    // state, which re-evaluates `currentConfig` and re-runs the clamp above -
+    // now against the span being animated to rather than the frame's width, so
+    // the widget slides in while it grows instead of settling outside the
+    // screen. The *store* keeps the old number, which is 705e9006d's
+    // disagreement reached from the other side, so the same repair the settle
+    // timer runs is run again here.
+    //
+    // Keyed on the span as a string, not on `storedGridSize`: that binding
+    // hands out a fresh object on every plugin-state write, so a widget being
+    // dragged somewhere else on the desktop would re-run every other widget's
+    // repair. Both the grip and the Size row land here, because both write the
+    // same stored span.
+    // Deferred by one turn of the event loop, because the repair *writes*
+    // plugin state and this handler runs inside the evaluation of a binding
+    // that reads it - Qt reports that as a binding loop on `storedGridSize`
+    // and drops the re-evaluation. Nothing is lost by the delay: what the
+    // widget is drawn at is already clamped by the line above.
+    readonly property string storedGridSpan: GridSizes.formatSize(rootWidget.storedGridSize)
+    onStoredGridSpanChanged: storedSpanRepair.restart()
+
+    Timer {
+        id: storedSpanRepair
+        interval: 0
+        onTriggered: rootWidget.repairUnreachableStoredPosition()
+    }
+
     // A stored position the screen will never honour, written back so it stops
     // being a lie.
     //
@@ -250,6 +334,10 @@ AbstractBackgroundWidget {
     // the guard against it here is that `width` has to have arrived first.
     function repairUnreachableStoredPosition() {
         if (!manifest || !PluginState.ready) return;
+        // The settle timer below waits for a real size before calling; the
+        // resize path calls straight from a span change, where a screen that
+        // has not arrived yet would clamp every widget to 0,0 and store it.
+        if (rootWidget.settledWidth <= 0 || rootWidget.scaledScreenWidth <= 0) return;
         const stored = rootWidget.currentConfig;
         const nextX = rootWidget.clampX(stored.x);
         const nextY = rootWidget.clampY(stored.y);
@@ -421,8 +509,16 @@ AbstractBackgroundWidget {
         hostInteractionLocked: rootWidget.interactionLocked
         // When the manifest declares a grid span, drive the node (and its loaded
         // Widget.qml) to the span size instead of the content's implicit size.
-        gridWidth: rootWidget.gridSpanWidth
-        gridHeight: rootWidget.gridSpanHeight
+        //
+        // The host's animating size rather than the span it is heading for, so
+        // the content is the box on every frame of a resize: handed the target
+        // instead, it would paint outside the widget while the box grows into
+        // it and leave a gap inside it while the box shrinks. This is not the
+        // circular sizing PluginNode's Loader comment warns about - the branch
+        // that reads this widget's `width` is the one where `width` comes from
+        // the span and not from the node.
+        gridWidth: rootWidget.gridSized ? rootWidget.width : 0
+        gridHeight: rootWidget.gridSized ? rootWidget.height : 0
         // ...and hand the span down by name too, for a widget that has a
         // different layout per size rather than one that stretches.
         gridSize: GridSizes.formatSize(rootWidget.gridSize)
@@ -494,8 +590,13 @@ AbstractBackgroundWidget {
                 const scenePoint = resizeArea.mapToItem(null, mouse.x, mouse.y);
                 resizeArea.pressSceneX = scenePoint.x;
                 resizeArea.pressSceneY = scenePoint.y;
-                resizeArea.pressWidth = rootWidget.width;
-                resizeArea.pressHeight = rootWidget.height;
+                // The span being animated to, not the frame's width: pressing
+                // the grip again while the last resize is still travelling
+                // would otherwise measure the gesture from a size the widget
+                // is in the middle of leaving, and every span the drag
+                // previewed would be off by whatever the animation had left.
+                resizeArea.pressWidth = rootWidget.settledWidth;
+                resizeArea.pressHeight = rootWidget.settledHeight;
                 rootWidget.beginGridResize();
                 resizeHandle.forceActiveFocus();
             }

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
@@ -195,6 +195,56 @@ AbstractBackgroundWidget {
         }
     }
 
+    // The span the CONTENT is currently drawn as, which is not always the span
+    // the widget IS.
+    //
+    // A manifest only offers several spans when it has a design per span
+    // (docs/widget-grid.md): media loads a different layout file per span,
+    // weather and currency switch branches inside one file. So the content has
+    // to change identity somewhere during the move, and both ends are a pop -
+    // hand the new name down at the start and the incoming layout is drawn
+    // inside the outgoing box for the whole animation; hand it down at the end
+    // and the outgoing one is. It changes at the midpoint instead, under a fade
+    // out and back in, which is the one moment the swap is not visible.
+    //
+    // The host cannot know which of those two kinds of widget it is holding,
+    // and it does not need to: a swap it did not have to make costs a fade
+    // nobody can distinguish from the resize it sits inside.
+    readonly property string targetGridSpan: GridSizes.formatSize(rootWidget.gridSize)
+    property string shownGridSpan: ""
+
+    onTargetGridSpanChanged: {
+        if (!rootWidget.gridResizeAnimated
+                || !GridResize.animatesSpanSwap(rootWidget.shownGridSpan, rootWidget.targetGridSpan)) {
+            spanSwap.stop();
+            pluginNode.opacity = 1;
+            rootWidget.shownGridSpan = rootWidget.targetGridSpan;
+            return;
+        }
+        spanSwap.restart();
+    }
+
+    SequentialAnimation {
+        id: spanSwap
+        NumberAnimation {
+            target: pluginNode
+            property: "opacity"
+            to: 0
+            duration: GridResize.contentSwapHalfMs(rootWidget.gridResizeDuration)
+            easing.type: Easing.BezierSpline
+            easing.bezierCurve: Appearance.animationCurves.expressiveEffects
+        }
+        ScriptAction { script: rootWidget.shownGridSpan = rootWidget.targetGridSpan }
+        NumberAnimation {
+            target: pluginNode
+            property: "opacity"
+            to: 1
+            duration: GridResize.contentSwapHalfMs(rootWidget.gridResizeDuration)
+            easing.type: Easing.BezierSpline
+            easing.bezierCurve: Appearance.animationCurves.expressiveEffects
+        }
+    }
+
     // The size the widget is resizing *to*. Everything that has to agree with
     // where the widget ends up - the position clamp, and the grip's own press
     // measurement - reads this rather than `width`, which is a frame of an
@@ -279,7 +329,12 @@ AbstractBackgroundWidget {
     }
 
     onCurrentConfigChanged: applyPersistedPosition()
-    Component.onCompleted: applyPersistedPosition()
+    Component.onCompleted: {
+        rootWidget.applyPersistedPosition();
+        // The first span the host resolves is adopted rather than animated
+        // into, and `onTargetGridSpanChanged` only sees changes.
+        rootWidget.shownGridSpan = rootWidget.targetGridSpan;
+    }
 
     // A widget resized near a screen edge no longer fits where it is stored,
     // and the two halves of that go wrong in different directions. Where the
@@ -520,8 +575,10 @@ AbstractBackgroundWidget {
         gridWidth: rootWidget.gridSized ? rootWidget.width : 0
         gridHeight: rootWidget.gridSized ? rootWidget.height : 0
         // ...and hand the span down by name too, for a widget that has a
-        // different layout per size rather than one that stretches.
-        gridSize: GridSizes.formatSize(rootWidget.gridSize)
+        // different layout per size rather than one that stretches. The span
+        // the content is *showing*, which lags the widget's own by half a
+        // resize - see shownGridSpan.
+        gridSize: rootWidget.shownGridSpan
         anchors.centerIn: parent
     }
 

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
@@ -226,6 +226,12 @@ AbstractBackgroundWidget {
 
     SequentialAnimation {
         id: spanSwap
+        // The span the widget loads with is adopted rather than animated into,
+        // and `onTargetGridSpanChanged` only ever sees changes. Declared on the
+        // animation that owns every later value of `shownGridSpan` rather than
+        // in the host's own `Component.onCompleted`, which stays the single
+        // call `tests/test_presets.py` pins.
+        Component.onCompleted: rootWidget.shownGridSpan = rootWidget.targetGridSpan
         NumberAnimation {
             target: pluginNode
             property: "opacity"
@@ -329,12 +335,7 @@ AbstractBackgroundWidget {
     }
 
     onCurrentConfigChanged: applyPersistedPosition()
-    Component.onCompleted: {
-        rootWidget.applyPersistedPosition();
-        // The first span the host resolves is adopted rather than animated
-        // into, and `onTargetGridSpanChanged` only sees changes.
-        rootWidget.shownGridSpan = rootWidget.targetGridSpan;
-    }
+    Component.onCompleted: applyPersistedPosition()
 
     // A widget resized near a screen edge no longer fits where it is stored,
     // and the two halves of that go wrong in different directions. Where the

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
@@ -352,6 +352,7 @@ AbstractBackgroundWidget {
     // dragged somewhere else on the desktop would re-run every other widget's
     // repair. Both the grip and the Size row land here, because both write the
     // same stored span.
+    //
     // Deferred by one turn of the event loop, because the repair *writes*
     // plugin state and this handler runs inside the evaluation of a binding
     // that reads it - Qt reports that as a binding loop on `storedGridSize`

--- a/dots/.config/quickshell/imi/modules/common/plugins/gridResize.js
+++ b/dots/.config/quickshell/imi/modules/common/plugins/gridResize.js
@@ -1,0 +1,48 @@
+.pragma library
+
+// The motion a placed widget's span change is drawn with (docs/widget-grid.md).
+//
+// Resolving *which* span a widget is lives in gridSizes.js; this is the sibling
+// question of how it gets there. Both are here rather than inline in
+// PluginWidget for the same reason: everything else about the resize needs a
+// real host, which `qmltestrunner` cannot construct, so the arithmetic is the
+// part a test can reach at all.
+
+// A span previewed mid-drag is answered on a shorter curve than one that has
+// been committed.
+//
+// The grip previews live - the size on screen during the drag is the size a
+// release commits - so the widget is chasing the pointer, and 500ms of
+// expressive spatial motion between two spans reads as lag rather than as
+// smoothness when a fast drag crosses two thresholds. A commit, a Size row
+// change and an Escape are all destinations rather than tracking, and take the
+// full curve. Nothing here picks the curve *shape*: the caller pairs each
+// duration with the Appearance curve it belongs to (expressiveFastSpatial with
+// the drag, expressiveDefaultSpatial with the commit).
+function resizeDurationMs(previewing, dragMs, commitMs) {
+    return previewing ? dragMs : commitMs;
+}
+
+// The content changes at the move's midpoint, under a fade out and back in.
+//
+// A widget offering several spans has a design per span (docs/widget-grid.md) -
+// media loads a different layout FILE per span - so animating the box while the
+// content swaps instantly pops at exactly the moment the motion is supposed to
+// hide. Half the move each way makes the swap land where the content is least
+// visible and puts the fade inside the resize rather than beside it, whichever
+// duration the resize is running at.
+function contentSwapHalfMs(durationMs) {
+    if (typeof durationMs !== "number" || !isFinite(durationMs)) return 0;
+    return Math.max(0, Math.round(durationMs / 2));
+}
+
+// Whether a span change is a swap to animate or a value to adopt in place.
+//
+// The empty string is "no span resolved yet", which every widget passes through
+// once: the host answers with the manifest default and the stored choice
+// arrives with plugin-state.json a moment later. Fading that would have every
+// resized widget on the desktop dissolve on login for a size nobody just chose.
+function animatesSpanSwap(shown, next) {
+    return typeof shown === "string" && typeof next === "string"
+        && shown !== "" && next !== "" && shown !== next;
+}

--- a/dots/.config/quickshell/imi/modules/imi/background/widgets/AbstractBackgroundWidget.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/widgets/AbstractBackgroundWidget.qml
@@ -95,8 +95,20 @@ AbstractWidget {
         root.y = Qt.binding(() => root.targetY);
     }
 
-    function clampX(v) { return Math.max(0, Math.min(v, scaledScreenWidth - width)); }
-    function clampY(v) { return Math.max(0, Math.min(v, scaledScreenHeight - height)); }
+    // The size the clamp measures this widget by. `width`/`height` for
+    // everything that changes size in one frame - but a subclass whose size
+    // *animates* overrides them with the size the animation is heading for,
+    // because a clamp taken mid-flight is taken against a size the widget is
+    // about to leave, and nothing runs again once the animation lands: the
+    // widget settles past the screen edge and stays there (PluginWidget's span
+    // resize). Two properties rather than an extra argument on the clamp - a
+    // call site that forgets to pass one clamps against the wrong size in
+    // silence, and this function exists so there is one clamp and not several.
+    property real clampWidth: root.width
+    property real clampHeight: root.height
+
+    function clampX(v) { return Math.max(0, Math.min(v, scaledScreenWidth - clampWidth)); }
+    function clampY(v) { return Math.max(0, Math.min(v, scaledScreenHeight - clampHeight)); }
 
     onReleased: root.commitPosition()
 

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -251,6 +251,15 @@ if ! python3 "$SCRIPT_DIR/test_widget_resize_grip_runtime.py"; then
     exit 1
 fi
 
+# The grip harness above reads settled sizes on purpose, so it passes whether a
+# span change is animated or instant. This one samples the size mid-change,
+# which is the only way to tell a Behavior that ticks from one that never does.
+echo "Running widget resize motion runtime tests..."
+if ! python3 "$SCRIPT_DIR/test_widget_resize_motion_runtime.py"; then
+    echo "Widget resize motion runtime tests failed."
+    exit 1
+fi
+
 # The source half is static. The runtime half pans a real WidgetCanvas under
 # real PluginWidgets and brings its own headless weston, so it needs no display
 # of its own - but it does need weston, and skips without it.

--- a/dots/.config/quickshell/imi/tests/test_widget_resize_motion_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_widget_resize_motion_runtime.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Scores a widget's span change as motion rather than as a result.
+
+`WidgetResizeMotionRuntimeTest.qml` builds real `PluginWidget`s on a real
+`WidgetCanvas`, changes their span both ways a user can - the Size row's single
+write and a live grip drag - and samples the widget's width *while* the change
+is in flight. This module is the driver: it stands up a headless weston, points
+throwaway XDG dirs at it, and fails the suite on any check the harness reports.
+
+This is the half `test_widget_resize_grip_runtime.py` cannot answer. That
+harness reads settled sizes on purpose, so it passes identically whether the
+resize is animated or instant - and so would every static check, because a
+`Behavior` handed a target that moves every frame compiles fine, never ticks,
+and leaves the property snapping to its final value (AGENT.md: that is exactly
+how the parallax opt-out shipped inert). A width that is already at its
+destination 80ms into a 500ms move is the signature of that bug, and it is what
+these checks fail on.
+
+The grip is driven as well as the Size row for the same reason: it re-previews
+on every mouse move and hands the host a fresh span object each time, which is
+the shape that froze the position Behavior.
+
+Skips when weston or qs is missing, as in CI.
+"""
+
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HARNESS = ROOT / "WidgetResizeMotionRuntimeTest.qml"
+SOCKET = "wayland-imi-widget-resize-motion"
+
+
+def _stop(proc):
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+
+
+def _runtime_available():
+    return shutil.which("qs") is not None and shutil.which("weston") is not None
+
+
+@unittest.skipUnless(_runtime_available(), "needs qs and weston on PATH")
+class WidgetResizeMotionRuntimeTest(unittest.TestCase):
+    def setUp(self):
+        self.home = Path(tempfile.mkdtemp(prefix="imi-widget-resize-motion-"))
+        self.addCleanup(shutil.rmtree, self.home, ignore_errors=True)
+
+    def test_a_span_change_is_animated_not_snapped(self):
+        env = dict(os.environ)
+        env.setdefault("XDG_RUNTIME_DIR", f"/run/user/{os.getuid()}")
+        env["WAYLAND_DISPLAY"] = SOCKET
+        env.pop("DISPLAY", None)
+
+        weston = subprocess.Popen(
+            ["weston", "--backend=headless", "--renderer=pixman",
+             f"--socket={SOCKET}", "--width=1400", "--height=900"],
+            env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        self.addCleanup(_stop, weston)
+
+        socket_path = Path(env["XDG_RUNTIME_DIR"]) / SOCKET
+        deadline = time.monotonic() + 15
+        while not socket_path.exists() and time.monotonic() < deadline:
+            time.sleep(0.2)
+        self.assertTrue(socket_path.exists(), "headless weston never came up")
+
+        # This box's headless EGL has no driver, so force software rendering.
+        env["LIBGL_ALWAYS_SOFTWARE"] = "1"
+        env["QT_QUICK_BACKEND"] = "software"
+        env["XDG_CONFIG_HOME"] = str(self.home / "config")
+        env["XDG_STATE_HOME"] = str(self.home / "state")
+
+        proc = subprocess.run(["qs", "-p", str(HARNESS)], cwd=str(ROOT), env=env,
+                              capture_output=True, text=True, timeout=180)
+        output = proc.stdout + proc.stderr
+        failed = [line for line in output.splitlines() if "FAIL" in line]
+        self.assertEqual(failed, [], f"harness reported failures:\n{output}")
+        self.assertIn("[WidgetResizeMotion] failures: 0", output,
+                      f"harness did not finish cleanly:\n{output}")
+
+        # The content's size follows the host's animating width, so a span
+        # bound back through the item it sizes shows up here rather than as a
+        # failed check - the widget would resize and never settle.
+        self.assertNotIn("Binding loop", output,
+                         f"the host tree grew a binding loop:\n{output}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dots/.config/quickshell/imi/tests/tst_grid_resize.qml
+++ b/dots/.config/quickshell/imi/tests/tst_grid_resize.qml
@@ -1,0 +1,83 @@
+import QtTest
+import "../modules/common/plugins/gridResize.js" as GridResize
+
+// The arithmetic behind a resizable widget's span change: how long the move
+// takes, when its content swaps, and which changes are moves at all.
+//
+// The motion itself is unreachable from here - `qmltestrunner` cannot construct
+// a `PluginWidget` - so `WidgetResizeMotionRuntimeTest.qml` scores whether the
+// width is genuinely in flight. What this pins is the three decisions that can
+// be got wrong without any of that being visible: a drag answered on the same
+// long curve as a commit, a content swap that lands outside the move it is
+// meant to hide inside, and a widget dissolving on login because the store
+// answering for the first time looks like a resize.
+TestCase {
+    name: "GridResizeTest"
+
+    // --- how long ---------------------------------------------------------
+
+    function test_a_previewed_span_gets_the_shorter_curve() {
+        compare(GridResize.resizeDurationMs(true, 350, 500), 350);
+    }
+
+    function test_a_committed_span_gets_the_full_curve() {
+        compare(GridResize.resizeDurationMs(false, 350, 500), 500);
+    }
+
+    // Escape clears the preview before the size changes, so the return to the
+    // span the drag started from is not a preview and reads as a deliberate
+    // move rather than as a snap back.
+    function test_the_cancel_is_a_commit_length_move() {
+        compare(GridResize.resizeDurationMs(false, 350, 500), 500);
+    }
+
+    // --- when the content swaps -------------------------------------------
+
+    function test_the_swap_lands_at_the_midpoint_of_whichever_move_is_running() {
+        compare(GridResize.contentSwapHalfMs(500), 250);
+        compare(GridResize.contentSwapHalfMs(350), 175);
+    }
+
+    function test_two_halves_never_outlast_the_move_they_sit_inside() {
+        for (const duration of [0, 1, 150, 200, 350, 351, 500, 650]) {
+            verify(2 * GridResize.contentSwapHalfMs(duration) <= duration + 1,
+                   "swap outlasts a " + duration + "ms move");
+        }
+    }
+
+    function test_a_nonsense_duration_is_no_fade_rather_than_a_stuck_one() {
+        // A NaN duration on a NumberAnimation runs forever, which would leave
+        // the content parked at zero opacity with nothing reporting why.
+        compare(GridResize.contentSwapHalfMs(NaN), 0);
+        compare(GridResize.contentSwapHalfMs(undefined), 0);
+        compare(GridResize.contentSwapHalfMs(-100), 0);
+    }
+
+    // --- which changes are moves ------------------------------------------
+
+    function test_a_real_span_change_animates() {
+        compare(GridResize.animatesSpanSwap("3x2", "2x2"), true);
+        compare(GridResize.animatesSpanSwap("2x1", "3x2"), true);
+    }
+
+    function test_the_first_span_the_host_resolves_is_adopted_in_place() {
+        // Every widget passes through this once, and a widget whose stored span
+        // is not its manifest default passes through it again when
+        // plugin-state.json lands.
+        compare(GridResize.animatesSpanSwap("", "3x2"), false);
+    }
+
+    function test_a_span_that_did_not_change_is_not_a_move() {
+        // The grip re-previews on every mouse move, and the nearest span is
+        // usually the one already showing.
+        compare(GridResize.animatesSpanSwap("2x2", "2x2"), false);
+    }
+
+    function test_losing_the_span_is_not_a_move_either() {
+        // A content-sized widget formats as "", and so does a manifest whose
+        // grid stopped resolving.
+        compare(GridResize.animatesSpanSwap("2x2", ""), false);
+        compare(GridResize.animatesSpanSwap("2x2", undefined), false);
+        compare(GridResize.animatesSpanSwap(null, "2x2"), false);
+    }
+}


### PR DESCRIPTION
Resizing a widget snapped instantly. It now travels, on the shell's own expressive spatial curves, and
it is generic — anything declaring `grid.sizes` inherits it, not just media.

## The trap this could have fallen into

**A `Behavior` handed a target that moves every frame never ticks** — that is exactly what broke the
parallax opt-out last night, and it fails *silently*, looking identical to today's snap.

Confirmed safe here, with the reason rather than a hope: the grip does re-evaluate the width binding
on every mouse move, but the *value* only changes at a span boundary, and `QQuickBehavior::write`
returns early for a write of the value it is already animating to. Both `enabled` gates carry the
rest — content-sized widgets are excluded (their width can move per frame), and so is the first span
the store resolves, so nothing grows in on login.

None of that was assumed: the harness drives a real grip drag and samples mid-gesture.

## The four other problems

- **Responsive vs smooth** — split by state. Previewing mid-drag is 350ms `expressiveFastSpatial`; a
  release, the Size row and Escape are 500ms `expressiveDefaultSpatial`. Escape falls out for free:
  clearing the preview *is* the size change, so the return is a move rather than a snap back.
- **Content changing with the span** — the node is sized to the host's animating width so the layout
  fills the box while it grows, and the span *name* moves at the midpoint under a fade. Media (a file
  swap) and weather/currency (a branch swap within one file) are handled identically, because the
  host cannot tell them apart and does not need to.
- **Geometry followers** — frost, grip anchor and blur sample already tracked the animating rect. The
  clamp did not: it ran while the widget was still the size it was leaving, and nothing ran again
  afterwards. It now measures by the target span, so a widget near the edge slides in *while* it
  grows, and the stored position is repaired on the same clamp.
- **Escape** animates back on the commit curve, scored in flight.

## Proof the motion runs

Every check planted-and-reverted on a committed tree:

| mutation | result |
| --- | --- |
| `Behavior { enabled: false }` | 6 FAILs across Size row, grip drag, Escape |
| instant content swap | "content is still the old span early on" FAIL |
| clamp against the animating width | widget stranded off screen, 2 FAILs |
| drop the stored-position repair | "the store agrees with the screen" FAIL |
| duration/midpoint arithmetic broken | 4 FAILs in the unit test |

**Two of its own checks were found vacuous this way and fixed** — scoring a 2x2→2x1 drag's *width*
passes on nothing, and reading `shownGridSpan` instead of the node's own span passed while the pop
was still there. Both are documented in the harness.

One measurement changed a decision: the frost surface is **not** rebuilt by the per-frame region
array (a same-length replacement reaches the delegate as a change, not a reset), so a "fix" for that
was reverted and the measurement kept as a check.

## Testing

`./tests/run_tests.sh` — **507 passed, 0 failed** (495 on main), `DesignSystemCompile` 159/0.

No plugin package was touched: media's `Widget.qml` is byte-identical to main.

Docs: updated AGENT.md §Dynamic/data-driven QML gotchas, docs/widget-grid.md, docs/tests-README.md