### PR TITLE
fix(mpris): stop a proxy and duplicate suppression hiding what is playing

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -366,8 +366,16 @@ services/                  Singletons wrapping external state/processes - one pe
                               builds every Material variant from it. Cached against the wallpaper
                               and the dark/light mode, so refresh() is free while those hold and
                               nothing recomputes while no picker is on screen
+  MprisController.qml         The one answer to "which player is the media UI showing". It filters
+                              the bus list (proxies always, duplicates by setting) through
+                              MprisSelection.js - a .pragma library kept pure so the rules are
+                              reachable from tests - resolves bar.media.preferredPlayer, and
+                              publishes activePlayer / meaningfulPlayers / playerOptions. The bar,
+                              the media popup, the right sidebar and the lock screen read those
+                              rather than each resolving the setting again
+                              (25329ade9 ("feat(mpris): resolve the preferred player once, against a stable bus id"))
   Brightness.qml, Battery.qml, Hyprsunset.qml, Network.qml, BluetoothStatus.qml, TrayService.qml,
-  MprisController.qml, Weather.qml, Docker.qml, ... (one per integration)
+  Weather.qml, Docker.qml, ... (one per integration)
 
 panelFamilies/              PanelLoader.qml (thin LazyLoader) + ImmaterialImpulseFamily.qml (the
                             actual list of panels for the "imi" family)
@@ -1441,6 +1449,43 @@ therefore needs a one-shot migration with a marker (`migrateDeadParallaxSwitches
 test that seeds a real config directory. Reset only the switches - a tuned number is a plausible
 preference and usually cannot disable the feature by itself.
 (fix(config): revive the parallax switches every stored config turned off.)
+
+**A player on the MPRIS bus may be a proxy for another player, and every field you would match on
+is the borrowed one.** `playerctld` is `playerctl`'s daemon, not a player: it re-publishes whichever
+player it considers *current* — and current means last **interacted with**, not playing — so it sits
+at `PlaybackStatus: "Playing"` over a paused player's metadata indefinitely.
+[#170](https://github.com/XephyLon/immaterial-impulse/issues/170) measured its `Identity` as
+`"Mozilla zen"`: the name of the player it was mirroring. So `identity`, `desktopEntry`, the track
+title and the playback state are all second-hand, and a rule as reasonable as "prefer a player that
+is playing and has metadata" matches it *truthfully*. The only honest thing about it is its bus
+name, which is what `services/MprisSelection.js` excludes it by — and unconditionally:
+`media.filterDuplicatePlayers` is a preference about duplicates, while a proxy is not a player at
+all. Two neighbours that look like the same case and are not: `plasma-browser-integration` may be
+the only MPRIS source for a browser whose own is switched off, and `kdeconnect.mpris_*` is a phone,
+which is a genuine remote rather than a local mirror. Both stay.
+bb789e017 ("fix(mpris): stop a proxy and duplicate suppression hiding what is playing").
+
+**Duplicate suppression must never drop a bus that is playing, and note which half of that issue's
+diagnosis was wrong.** #170 blamed `playerctld` — but on the reporting machine it was already
+excluded, and what actually decided the selection was the *other* filter: while
+`plasma-browser-integration` is on the bus, every native Firefox and Chromium bus was dropped as its
+duplicate. That integration republishes one browser tab at a time, so with a paused video mirrored
+through it and music playing in the other browser, the only bus carrying the music was suppressed
+and the paused mirror was the sole surviving candidate. A correct-looking diagnosis of a real
+lurking bug can still not be the bug in front of you; read what the filter chain actually returns
+before fixing the part that was named. bb789e017 ("fix(mpris): stop a proxy and duplicate
+suppression hiding what is playing").
+
+**An MPRIS bus name is not stable, so nothing may be stored against it.** The spec lets a program
+publishing more than one bus append `.instance<pid>` — Chromium writes
+`org.mpris.MediaPlayer2.chromium.instance700643`, Firefox `.instance_1_52` — and that suffix is new
+on every launch. `bar.media.preferredPlayer` stores the bus name minus the
+`org.mpris.MediaPlayer2.` prefix and minus that suffix, which is what survives a restart and what
+the settings picker writes; a `kdeconnect` bus carries no suffix and keeps its whole name, one id
+per device and player. Resolution lives in `MprisController` alone (`activePlayer`,
+`meaningfulPlayers`, `playerOptions`) because four widgets used to carry their own copy of it and
+had already drifted apart; `tests/test_mpris_controller_contract.py` fails the suite on a fifth.
+25329ade9 ("feat(mpris): resolve the preferred player once, against a stable bus id").
 
 **Treat repeated binding exceptions as potential resource runaways, not harmless log noise.** A
 sidebar media-player binding called `filterDuplicatePlayers()` without defining the helper in that

--- a/dots/.config/quickshell/imi/modules/common/Config.qml
+++ b/dots/.config/quickshell/imi/modules/common/Config.qml
@@ -5,6 +5,11 @@ import Quickshell
 import Quickshell.Io
 import qs.modules.common
 import qs.modules.common.functions
+// A `.pragma library` module of pure functions that happens to live beside its
+// other consumer, not the MprisController service - there is no cycle to have,
+// and the normalization below must apply the same rule the selection code
+// does, or the two disagree about what the setting means.
+import "../../services/MprisSelection.js" as MprisSelection
 
 Singleton {
     id: root
@@ -79,6 +84,27 @@ Singleton {
     // keycap. Nobody chose that value - there is no setting for it in the UI,
     // so the only way to have set it deliberately is by hand, and this runs
     // once either way.
+    // bar.media.preferredPlayer was free text matched as a substring of a
+    // player's identity; it is now the stable half of an MPRIS bus name, which
+    // is what the settings picker writes. Converting the stored value keeps the
+    // config and the picker talking about the same thing.
+    //
+    // Unconditional and unmarked, on the reasoning AGENT.md gives for
+    // clearStaleKbOptions: a marker records that the pass ran, not that it saw
+    // the user's config, and the two come apart exactly when the config
+    // directory migration declines and the installer default loads first.
+    // There is nothing to protect with one either way - normalization is
+    // idempotent, so a value the picker wrote is already its own normal form
+    // and running this every load cannot change it. A value it cannot parse
+    // into an id still resolves through MprisSelection.matchesPreference's
+    // legacy substring branch, so nothing is lost by converting it either.
+    function migratePreferredPlayerToBusId() {
+        const stored = root.options.bar.media.preferredPlayer;
+        const normalized = MprisSelection.normalizePreferredPlayer(stored);
+        if (normalized !== stored)
+            root.options.bar.media.preferredPlayer = normalized;
+    }
+
     function migrateSplitCheatsheetButtons() {
         if (root.options.cheatsheet.migratedSplitButtons)
             return;
@@ -437,6 +463,7 @@ Singleton {
             root.migrateUpstreamKeys(text());
             root.ready = true;
             root.clearStaleKbOptions();
+            root.migratePreferredPlayerToBusId();
             root.migrateDeadParallaxSwitches();
             root.migrateSplitCheatsheetButtons();
             root.migrateDesktopWidgetsToPlugins();

--- a/dots/.config/quickshell/imi/modules/imi/bar/Media.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/Media.qml
@@ -19,17 +19,7 @@ Item {
     property bool vertical: false
     property bool borderless: Config.options.bar.borderless
     property bool isMaterial: Config.options.bar.cornerStyle === 3
-    readonly property MprisPlayer activePlayer: {
-        const preferred = Config.options.bar.media.preferredPlayer.trim().toLowerCase()
-        if (preferred.length === 0) return MprisController.activePlayer
-        const _ = MprisController.players.count
-        for (const p of MprisController.players) {
-            if ((p.identity ?? "").toLowerCase().includes(preferred) ||
-                (p.desktopEntry ?? "").toLowerCase().includes(preferred))
-                return p
-        }
-        return MprisController.activePlayer
-    }
+    readonly property MprisPlayer activePlayer: MprisController.activePlayer
 
     readonly property string cleanedTitle: StringUtils.cleanMusicTitle(activePlayer?.trackTitle) || Translation.tr("No media")
 

--- a/dots/.config/quickshell/imi/modules/imi/lock/LockSurface.qml
+++ b/dots/.config/quickshell/imi/modules/imi/lock/LockSurface.qml
@@ -19,17 +19,7 @@ MouseArea {
     property bool active: false
     property bool showInputField: active || context.currentText.length > 0
     readonly property bool requirePasswordToPower: Config.options.lock.security.requirePasswordToPower
-    readonly property MprisPlayer activePlayer: {
-        const preferred = Config.options.bar.media.preferredPlayer.trim().toLowerCase()
-        if (preferred.length === 0) return MprisController.activePlayer
-        const _ = MprisController.players.count
-        for (const p of MprisController.players) {
-            if ((p.identity ?? "").toLowerCase().includes(preferred) ||
-                (p.desktopEntry ?? "").toLowerCase().includes(preferred))
-                return p
-        }
-        return MprisController.activePlayer
-    }
+    readonly property MprisPlayer activePlayer: MprisController.activePlayer
 
     property var    artUrl:      activePlayer?.trackArtUrl ?? ""
 

--- a/dots/.config/quickshell/imi/modules/imi/mediaControls/MediaControls.qml
+++ b/dots/.config/quickshell/imi/modules/imi/mediaControls/MediaControls.qml
@@ -18,16 +18,7 @@ Scope {
     property bool visible: false
     readonly property MprisPlayer activePlayer: MprisController.activePlayer
     readonly property var realPlayers: MprisController.players
-    readonly property var meaningfulPlayers: {
-        const preferred = Config.options.bar.media.preferredPlayer.trim().toLowerCase()
-        if (preferred.length === 0) return filterDuplicatePlayers(realPlayers)
-        const filtered = realPlayers.filter(p =>
-            (p.identity ?? "").toLowerCase().includes(preferred) ||
-            (p.desktopEntry ?? "").toLowerCase().includes(preferred)
-        )
-        if (filtered.length === 0) return filterDuplicatePlayers(realPlayers)
-        return filterDuplicatePlayers(filtered)
-    }
+    readonly property var meaningfulPlayers: MprisController.meaningfulPlayers
     readonly property real osdWidth: Appearance.sizes.osdWidth
     readonly property real widgetWidth: Appearance.sizes.mediaControlsWidth
     readonly property real widgetHeight: Appearance.sizes.mediaControlsHeight
@@ -48,35 +39,6 @@ Scope {
     readonly property real gap: Config.options.bar.cornerStyle === 3 ? Appearance.sizes.hyprlandGapsOut : 0
     readonly property bool cornerStyleReducesGap: Config.options.bar.cornerStyle === 1 || Config.options.bar.cornerStyle === 2
     readonly property real barThickness: barVertical ? Appearance.sizes.verticalBarWidth : Appearance.sizes.barHeight
-
-    function filterDuplicatePlayers(players) {
-        let filtered = [];
-        let used = new Set();
-
-        for (let i = 0; i < players.length; ++i) {
-            if (used.has(i))
-                continue;
-            let p1 = players[i];
-            let group = [i];
-
-            // Find duplicates by trackTitle prefix
-            for (let j = i + 1; j < players.length; ++j) {
-                let p2 = players[j];
-                if (p1.trackTitle && p2.trackTitle && (p1.trackTitle.includes(p2.trackTitle) || p2.trackTitle.includes(p1.trackTitle)) || (p1.position - p2.position <= 2 && p1.length - p2.length <= 2)) {
-                    group.push(j);
-                }
-            }
-
-            // Pick the one with non-empty trackArtUrl, or fallback to the first
-            let chosenIdx = group.find(idx => players[idx].trackArtUrl && players[idx].trackArtUrl.length > 0);
-            if (chosenIdx === undefined)
-                chosenIdx = group[0];
-
-            filtered.push(players[chosenIdx]);
-            group.forEach(idx => used.add(idx));
-        }
-        return filtered;
-    }
 
     // The cava process used to live here, gated on an expression naming every
     // surface that might want bands - this popup, the right sidebar, a bar

--- a/dots/.config/quickshell/imi/modules/imi/settings/pages/BarConfig.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/pages/BarConfig.qml
@@ -581,24 +581,42 @@ ContentPage {
             title: Translation.tr("Media")
 
             GroupedList {
-                ConfigTextArea {
-                    id: preferredPlayerField
+                ConfigComboBox {
+                    id: preferredPlayerPicker
                     Layout.fillWidth: true
                     buttonIcon: "play_circle"
+                    fieldWidth: 260
                     text: Translation.tr("Preferred Player")
-                    placeholderText: Translation.tr("e.g. spotify, firefox")
-                    value: Config.options.bar.media.preferredPlayer
-                    onValueChanged: {
-                        mediaDebounceTimer.restart();
-                    }
-
-                    Timer {
-                        id: mediaDebounceTimer
-                        interval: 600
-                        repeat: false
-                        onTriggered: {
-                            Config.options.bar.media.preferredPlayer = preferredPlayerField.value;
+                    description: Translation.tr("Automatic follows whatever is playing. A chosen player is remembered while it is closed.")
+                    // The stable half of the bus name, which is what
+                    // MprisController resolves the setting against - never the
+                    // running instance's bus name, which changes on relaunch.
+                    currentValue: MprisController.preferredPlayerId
+                    model: {
+                        const rows = [{
+                            value: "",
+                            icon: "auto_mode",
+                            displayName: Translation.tr("Automatic")
+                        }];
+                        for (const option of MprisController.playerOptions) {
+                            let label = option.name;
+                            if (!option.available)
+                                label = Translation.tr("%1 (not running)").arg(option.name);
+                            else if (option.trackTitle.length > 0)
+                                label = `${option.name} — ${option.trackTitle}`;
+                            rows.push({
+                                value: option.value,
+                                icon: !option.available ? "help" : (option.isPlaying ? "play_arrow" : "pause"),
+                                displayName: label
+                            });
                         }
+                        return rows;
+                    }
+                    // Only a real selection writes. Nothing here reacts to a
+                    // player appearing or disappearing, so closing the chosen
+                    // player cannot quietly reset the preference to Automatic.
+                    onSelected: newValue => {
+                        Config.options.bar.media.preferredPlayer = newValue;
                     }
                 }
                 ConfigSwitch {

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/SidebarRightContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/SidebarRightContent.qml
@@ -47,49 +47,7 @@ Item {
 
     readonly property MprisPlayer activePlayer: MprisController.activePlayer
     readonly property var realPlayers: MprisController.players
-    readonly property var meaningfulPlayers: {
-        const preferred = Config.options.bar.media.preferredPlayer.trim().toLowerCase()
-        if (preferred.length === 0) return filterDuplicatePlayers(realPlayers)
-        const filtered = realPlayers.filter(p =>
-            (p.identity ?? "").toLowerCase().includes(preferred) ||
-            (p.desktopEntry ?? "").toLowerCase().includes(preferred)
-        )
-        if (filtered.length === 0) return filterDuplicatePlayers(realPlayers)
-        return filterDuplicatePlayers(filtered)
-    }
-
-    function filterDuplicatePlayers(players) {
-        let filtered = []
-        let used = new Set()
-
-        for (let i = 0; i < players.length; ++i) {
-            if (used.has(i))
-                continue
-
-            const p1 = players[i]
-            const group = [i]
-
-            for (let j = i + 1; j < players.length; ++j) {
-                const p2 = players[j]
-                const titlesOverlap = p1.trackTitle && p2.trackTitle
-                    && (p1.trackTitle.includes(p2.trackTitle) || p2.trackTitle.includes(p1.trackTitle))
-                const timingMatches = Math.abs(p1.position - p2.position) <= 2
-                    && Math.abs(p1.length - p2.length) <= 2
-
-                if (titlesOverlap || timingMatches)
-                    group.push(j)
-            }
-
-            let chosenIdx = group.find(idx => players[idx].trackArtUrl?.length > 0)
-            if (chosenIdx === undefined)
-                chosenIdx = group[0]
-
-            filtered.push(players[chosenIdx])
-            group.forEach(idx => used.add(idx))
-        }
-
-        return filtered
-    }
+    readonly property var meaningfulPlayers: MprisController.meaningfulPlayers
 
     Connections {
         target: GlobalStates

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/SidebarRightContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/SidebarRightContent.qml
@@ -46,7 +46,6 @@ Item {
     readonly property Item backgroundItem: sidebarRightBackground
 
     readonly property MprisPlayer activePlayer: MprisController.activePlayer
-    readonly property var realPlayers: MprisController.players
     readonly property var meaningfulPlayers: MprisController.meaningfulPlayers
 
     Connections {

--- a/dots/.config/quickshell/imi/services/MprisController.qml
+++ b/dots/.config/quickshell/imi/services/MprisController.qml
@@ -17,7 +17,8 @@ import "MprisSelection.js" as MprisSelection
  */
 Singleton {
 	id: root;
-	property list<MprisPlayer> players: Mpris.players.values.filter(player => isRealPlayer(player));
+	property list<MprisPlayer> players: MprisSelection.candidatePlayers(
+		Mpris.players.values, Config.options.media.filterDuplicatePlayers);
 	property MprisPlayer trackedPlayer: null;
 	property MprisPlayer activePlayer: null;
 	readonly property string trackTitle: activePlayer?.trackTitle ?? "";
@@ -29,22 +30,6 @@ Singleton {
 	property bool __reverse: false;
 
 	property var activeTrack;
-
-	readonly property bool hasActivePlasmaIntegration: Mpris.players.values.some(
-		p => p.dbusName?.startsWith('org.mpris.MediaPlayer2.plasma-browser-integration')
-	)
-	function isRealPlayer(player) {
-        if (!Config.options.media.filterDuplicatePlayers) {
-            return true;
-        }
-        return (
-            // Remove native browser buses only if plasma-browser-integration is actually active on D-Bus
-            !(hasActivePlasmaIntegration && player.dbusName.startsWith('org.mpris.MediaPlayer2.firefox')) && !(hasActivePlasmaIntegration && player.dbusName.startsWith('org.mpris.MediaPlayer2.chromium')) &&
-            // playerctld just copies other buses and we don't need duplicates
-            !player.dbusName?.startsWith('org.mpris.MediaPlayer2.playerctld') &&
-            // Non-instance mpd bus
-            !(player.dbusName?.endsWith('.mpd') && !player.dbusName.endsWith('MediaPlayer2.mpd')));
-    }
 
 	function hasUsableMetadata(player) {
 		return MprisSelection.hasUsableMetadata(player);

--- a/dots/.config/quickshell/imi/services/MprisController.qml
+++ b/dots/.config/quickshell/imi/services/MprisController.qml
@@ -37,6 +37,7 @@ Singleton {
 		Config.options.bar.media.preferredPlayer);
 	readonly property bool preferenceApplies: MprisSelection.preferenceMatches(players, preferredPlayerId).length > 0;
 	readonly property var meaningfulPlayers: MprisSelection.meaningfulPlayers(players, preferredPlayerId);
+	readonly property var playerOptions: MprisSelection.playerOptions(players, preferredPlayerId);
 
 	function hasUsableMetadata(player) {
 		return MprisSelection.hasUsableMetadata(player);

--- a/dots/.config/quickshell/imi/services/MprisController.qml
+++ b/dots/.config/quickshell/imi/services/MprisController.qml
@@ -31,6 +31,12 @@ Singleton {
 
 	property var activeTrack;
 
+	// The one place the preferred-player setting is resolved. Four widgets used
+	// to carry their own copy of this block and had already drifted apart.
+	readonly property string preferredPlayerId: MprisSelection.normalizePreferredPlayer(
+		Config.options.bar.media.preferredPlayer);
+	readonly property bool preferenceApplies: MprisSelection.preferenceMatches(players, preferredPlayerId).length > 0;
+
 	function hasUsableMetadata(player) {
 		return MprisSelection.hasUsableMetadata(player);
 	}
@@ -39,25 +45,36 @@ Singleton {
 		return MprisSelection.preferredPlayer(candidates);
 	}
 
+	function honoursPreference(player) {
+		return !preferenceApplies || MprisSelection.matchesPreference(player, preferredPlayerId);
+	}
+
 	function reconcileTrackedPlayer(preferred) {
-		if (preferred && players.includes(preferred) && preferred.isPlaying) {
+		if (!honoursPreference(trackedPlayer)) {
+			trackedPlayer = MprisSelection.selectPlayer(players, preferredPlayerId);
+			syncActivePlayer();
+			return;
+		}
+		if (preferred && players.includes(preferred) && preferred.isPlaying && honoursPreference(preferred)) {
 			trackedPlayer = preferred;
 			syncActivePlayer();
 			return;
 		}
 		if (!trackedPlayer || !players.includes(trackedPlayer)
 				|| (!trackedPlayer.isPlaying && players.some(player => player.isPlaying))) {
-			trackedPlayer = MprisSelection.preferredPlayer(players);
+			trackedPlayer = MprisSelection.selectPlayer(players, preferredPlayerId);
 		}
 		syncActivePlayer();
 	}
 
 	function syncActivePlayer() {
-		const nextPlayer = trackedPlayer && players.includes(trackedPlayer)
-			? trackedPlayer : MprisSelection.preferredPlayer(players);
+		const nextPlayer = trackedPlayer && players.includes(trackedPlayer) && honoursPreference(trackedPlayer)
+			? trackedPlayer : MprisSelection.selectPlayer(players, preferredPlayerId);
 		if (activePlayer !== nextPlayer)
 			activePlayer = nextPlayer;
 	}
+
+	onPreferredPlayerIdChanged: reconcileTrackedPlayer(null)
 
 	onPlayersChanged: reconcileTrackedPlayer(null)
 	onTrackedPlayerChanged: syncActivePlayer()

--- a/dots/.config/quickshell/imi/services/MprisController.qml
+++ b/dots/.config/quickshell/imi/services/MprisController.qml
@@ -36,6 +36,7 @@ Singleton {
 	readonly property string preferredPlayerId: MprisSelection.normalizePreferredPlayer(
 		Config.options.bar.media.preferredPlayer);
 	readonly property bool preferenceApplies: MprisSelection.preferenceMatches(players, preferredPlayerId).length > 0;
+	readonly property var meaningfulPlayers: MprisSelection.meaningfulPlayers(players, preferredPlayerId);
 
 	function hasUsableMetadata(player) {
 		return MprisSelection.hasUsableMetadata(player);

--- a/dots/.config/quickshell/imi/services/MprisSelection.js
+++ b/dots/.config/quickshell/imi/services/MprisSelection.js
@@ -112,3 +112,41 @@ function selectPlayer(candidates, preference) {
         return preferredPlayer(matches);
     return preferredPlayer(candidates);
 }
+
+function collapseDuplicates(players) {
+    const all = Array.from(players ?? []);
+    const filtered = [];
+    const used = new Set();
+
+    for (let i = 0; i < all.length; ++i) {
+        if (used.has(i))
+            continue;
+
+        const p1 = all[i];
+        const group = [i];
+
+        for (let j = i + 1; j < all.length; ++j) {
+            const p2 = all[j];
+            const titlesOverlap = p1.trackTitle && p2.trackTitle
+                && (p1.trackTitle.includes(p2.trackTitle) || p2.trackTitle.includes(p1.trackTitle));
+            const timingMatches = Math.abs(p1.position - p2.position) <= 2
+                && Math.abs(p1.length - p2.length) <= 2;
+
+            if (titlesOverlap || timingMatches)
+                group.push(j);
+        }
+
+        let chosenIdx = group.find(idx => all[idx].trackArtUrl?.length > 0);
+        if (chosenIdx === undefined)
+            chosenIdx = group[0];
+
+        filtered.push(all[chosenIdx]);
+        group.forEach(idx => used.add(idx));
+    }
+    return filtered;
+}
+
+function meaningfulPlayers(candidates, preference) {
+    const matches = preferenceMatches(candidates, preference);
+    return collapseDuplicates(matches.length > 0 ? matches : Array.from(candidates ?? []));
+}

--- a/dots/.config/quickshell/imi/services/MprisSelection.js
+++ b/dots/.config/quickshell/imi/services/MprisSelection.js
@@ -1,5 +1,60 @@
 .pragma library
 
+const BUS_PREFIX = "org.mpris.MediaPlayer2.";
+
+// playerctld is playerctl's daemon, not a player. It re-publishes whichever
+// player it considers *current* - meaning last interacted with, not playing -
+// while answering `Identity` with that player's name, so it can report
+// `Playing` over a paused player's metadata under a borrowed identity. The bus
+// name is the only thing about it that is its own.
+const PROXY_PLAYER_IDS = ["playerctld"];
+
+// The stable half of an MPRIS bus name. The spec lets a program that may run
+// more than once append `.instance<pid>` (Firefox spells it `.instance_1_52`),
+// so the full bus name changes on every launch and cannot be stored as a
+// preference.
+function playerIdFromBusName(busName) {
+    let name = String(busName ?? "").trim().toLowerCase();
+    // Case-insensitively, because normalizePreferredPlayer feeds this an
+    // already-lowercased legacy value that may itself be a whole bus name.
+    if (name.startsWith(BUS_PREFIX.toLowerCase()))
+        name = name.slice(BUS_PREFIX.length);
+    return name.replace(/\.instance[^.]*$/i, "");
+}
+
+function playerId(player) {
+    return playerIdFromBusName(player?.dbusName);
+}
+
+function isProxyPlayer(player) {
+    return PROXY_PLAYER_IDS.indexOf(playerId(player)) !== -1;
+}
+
+// Duplicate suppression, which is a preference (media.filterDuplicatePlayers)
+// rather than a fact, unlike the proxy check above.
+function isSuppressedDuplicate(player, hasPlasmaIntegration) {
+    const busName = String(player?.dbusName ?? "");
+    if (busName.endsWith(".mpd") && !busName.endsWith(BUS_PREFIX + "mpd"))
+        return true;
+    if (!hasPlasmaIntegration)
+        return false;
+    // plasma-browser-integration republishes one browser tab at a time, so
+    // dropping every native browser bus while it is up hides whatever else is
+    // playing. A bus that is playing is never the duplicate worth losing.
+    if (player?.isPlaying)
+        return false;
+    const id = playerId(player);
+    return id.startsWith("firefox") || id.startsWith("chromium");
+}
+
+function candidatePlayers(players, filterDuplicates) {
+    const real = Array.from(players ?? []).filter(player => !isProxyPlayer(player));
+    if (!filterDuplicates)
+        return real;
+    const hasPlasmaIntegration = real.some(player => playerId(player) === "plasma-browser-integration");
+    return real.filter(player => !isSuppressedDuplicate(player, hasPlasmaIntegration));
+}
+
 function hasUsableMetadata(player) {
     return String(player?.trackTitle ?? "").trim().length > 0
         || String(player?.trackArtist ?? "").trim().length > 0;

--- a/dots/.config/quickshell/imi/services/MprisSelection.js
+++ b/dots/.config/quickshell/imi/services/MprisSelection.js
@@ -150,3 +150,56 @@ function meaningfulPlayers(candidates, preference) {
     const matches = preferenceMatches(candidates, preference);
     return collapseDuplicates(matches.length > 0 ? matches : Array.from(candidates ?? []));
 }
+
+// Rows for the settings picker, one per distinct player id. Labels are built
+// at the call site because a translated string is not reachable from a
+// `.pragma library`.
+function playerOptions(candidates, preference) {
+    const rows = [];
+    const seen = {};
+
+    for (const player of Array.from(candidates ?? [])) {
+        const id = playerId(player);
+        if (id.length === 0)
+            continue;
+        const existing = seen[id];
+        if (existing !== undefined) {
+            // Two instances of one program share an id, so let the one with
+            // something to say describe the row.
+            if (!existing.isPlaying && player?.isPlaying) {
+                existing.isPlaying = true;
+                existing.trackTitle = String(player?.trackTitle ?? "");
+            } else if (existing.trackTitle.length === 0) {
+                existing.trackTitle = String(player?.trackTitle ?? "");
+            }
+            continue;
+        }
+        const row = {
+            value: id,
+            name: String(player?.identity ?? "").trim() || id,
+            trackTitle: String(player?.trackTitle ?? ""),
+            isPlaying: !!player?.isPlaying,
+            available: true
+        };
+        seen[id] = row;
+        rows.push(row);
+    }
+
+    // A stored preference always gets a row, whether or not the player is
+    // running and whether or not it matches by id. Without it the combo box
+    // has nothing to show as current and falls back to displaying Automatic,
+    // which reads as "closing the player reset my choice".
+    const wanted = String(preference ?? "").trim().toLowerCase();
+    if (wanted.length > 0 && !rows.some(row => row.value === wanted)) {
+        const matches = preferenceMatches(candidates, wanted);
+        rows.push({
+            value: wanted,
+            name: String(matches[0]?.identity ?? "").trim() || wanted,
+            trackTitle: String(matches[0]?.trackTitle ?? ""),
+            isPlaying: matches.some(player => !!player?.isPlaying),
+            available: matches.length > 0
+        });
+    }
+
+    return rows;
+}

--- a/dots/.config/quickshell/imi/services/MprisSelection.js
+++ b/dots/.config/quickshell/imi/services/MprisSelection.js
@@ -68,3 +68,47 @@ function preferredPlayer(candidates) {
         ?? available[0]
         ?? null;
 }
+
+// The setting used to be free text matched as a substring of `identity` or
+// `desktopEntry`. It now stores a player id, but a config written before the
+// picker existed still holds whatever the user typed, so the substring match
+// stays as the fallback branch rather than as the rule.
+function matchesPreference(player, preference) {
+    const wanted = String(preference ?? "").trim().toLowerCase();
+    if (wanted.length === 0)
+        return false;
+    const id = playerId(player);
+    if (id === wanted)
+        return true;
+    return id.includes(wanted)
+        || String(player?.identity ?? "").toLowerCase().includes(wanted)
+        || String(player?.desktopEntry ?? "").toLowerCase().includes(wanted);
+}
+
+function preferenceMatches(candidates, preference) {
+    return Array.from(candidates ?? []).filter(player => matchesPreference(player, preference));
+}
+
+// Idempotent, so it is safe to run on every load without a "already migrated"
+// marker - a value the picker wrote is already its own normal form. A legacy
+// value may be a list ("spotify, firefox"), which the old substring match
+// could never have matched as a whole anyway; keep the first entry.
+function normalizePreferredPlayer(value) {
+    const raw = String(value ?? "").trim().toLowerCase();
+    if (raw.length === 0)
+        return "";
+    const first = raw.split(/[,;]/)[0].trim().split(/\s+/)[0];
+    return playerIdFromBusName(first);
+}
+
+// The preference is absolute while the player it names is present: a setting
+// that stops applying the moment anything else starts playing is not a
+// preference. When that player is absent the preference is simply not
+// applicable this session and normal selection resumes - nothing is written
+// back, so closing the player never forgets the choice.
+function selectPlayer(candidates, preference) {
+    const matches = preferenceMatches(candidates, preference);
+    if (matches.length > 0)
+        return preferredPlayer(matches);
+    return preferredPlayer(candidates);
+}

--- a/dots/.config/quickshell/imi/tests/imports/qs/services/MprisSelection.js
+++ b/dots/.config/quickshell/imi/tests/imports/qs/services/MprisSelection.js
@@ -1,0 +1,1 @@
+../../../../services/MprisSelection.js

--- a/dots/.config/quickshell/imi/tests/test_mpris_controller_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_mpris_controller_contract.py
@@ -36,6 +36,29 @@ class MprisControllerContractTests(unittest.TestCase):
             used = set(re.findall(r"MprisController\.(\w+)", widget))
             self.assertFalse(used - allowed, f"{relative}: undeclared fields {sorted(used - allowed)}")
 
+    def test_only_one_place_resolves_the_preferred_player(self):
+        """The bar, the media popup, the right sidebar and the lock screen each
+        carried their own copy of the preferred-player block, and the four had
+        already drifted apart (issue #170). MprisController resolves it now, and
+        everything else reads `activePlayer` / `meaningfulPlayers` from there.
+
+        `Config.qml` migrates the stored value and `BarConfig.qml` is the picker
+        that writes it, so those two name the key legitimately.
+        """
+        owners = {
+            "services/MprisController.qml",
+            "modules/common/Config.qml",
+            "modules/imi/settings/pages/BarConfig.qml",
+        }
+        offenders = []
+        for path in ROOT.rglob("*.qml"):
+            relative = path.relative_to(ROOT).as_posix()
+            if relative.startswith("tests/") or relative in owners:
+                continue
+            if "media.preferredPlayer" in path.read_text(encoding="utf-8"):
+                offenders.append(relative)
+        self.assertFalse(offenders, f"preferred-player resolution copied into {sorted(offenders)}")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/dots/.config/quickshell/imi/tests/tst_mpris_selection.qml
+++ b/dots/.config/quickshell/imi/tests/tst_mpris_selection.qml
@@ -5,6 +5,33 @@ import "../services/MprisSelection.js" as MprisSelection
 TestCase {
     name: "MprisSelectionTest"
 
+    function player(busName, isPlaying, trackTitle, identity) {
+        return {
+            dbusName: `org.mpris.MediaPlayer2.${busName}`,
+            identity: identity ?? busName,
+            desktopEntry: "",
+            isPlaying: isPlaying,
+            trackTitle: trackTitle ?? "",
+            trackArtist: "",
+            trackArtUrl: "",
+            position: 0,
+            length: 0
+        };
+    }
+
+    // The bus list measured on the reporting machine in issue #170: music
+    // genuinely playing in Chromium, a paused video in Firefox that
+    // plasma-browser-integration mirrors, and playerctld republishing that
+    // paused video's metadata while reporting Playing under Firefox's identity.
+    function liveBusList() {
+        return {
+            chromium: player("chromium.instance700643", true, "Provider", "Chromium"),
+            firefox: player("firefox.instance_1_52", false, "Hasan Piker on Backing Insurgent", "Firefox"),
+            plasma: player("plasma-browser-integration", false, "When Hasan Piker Met Mehdi Hasan", "Plasma Browser Integration"),
+            proxy: player("playerctld", true, "When Hasan Piker Met Mehdi Hasan", "Mozilla zen")
+        };
+    }
+
     function test_prefersPlayingPlayerWithMetadata() {
         const stale = { isPlaying: false, trackTitle: "", trackArtist: "" };
         const emptyPlaying = { isPlaying: true, trackTitle: "", trackArtist: "" };
@@ -24,5 +51,126 @@ TestCase {
         compare(MprisSelection.preferredPlayer([empty, titled]), titled);
         compare(MprisSelection.preferredPlayer([empty]), empty);
         compare(MprisSelection.preferredPlayer([]), null);
+    }
+
+    function test_busNameKeepsOnlyTheHalfThatSurvivesARestart() {
+        compare(MprisSelection.playerIdFromBusName("org.mpris.MediaPlayer2.chromium.instance700643"), "chromium");
+        compare(MprisSelection.playerIdFromBusName("org.mpris.MediaPlayer2.firefox.instance_1_52"), "firefox");
+        compare(MprisSelection.playerIdFromBusName("org.mpris.MediaPlayer2.spotify"), "spotify");
+        // A remote phone player is one id per device+player and carries no
+        // instance suffix, so nothing may be trimmed off it.
+        compare(MprisSelection.playerIdFromBusName("org.mpris.MediaPlayer2.kdeconnect.mpris_device1_vlc"),
+            "kdeconnect.mpris_device1_vlc");
+    }
+
+    // The bug: playerctld claims Playing over a paused player's metadata under
+    // that player's identity, so the "playing with metadata" rule matches it
+    // truthfully and Array.find takes whichever came first in the bus list.
+    function test_aProxyClaimingPlayingNeverWinsWhateverTheListOrder() {
+        const buses = liveBusList();
+        const orders = [
+            [buses.proxy, buses.chromium, buses.firefox, buses.plasma],
+            [buses.chromium, buses.firefox, buses.plasma, buses.proxy],
+            [buses.plasma, buses.proxy, buses.chromium, buses.firefox]
+        ];
+        for (const order of orders) {
+            const candidates = MprisSelection.candidatePlayers(order, true);
+            verify(!candidates.includes(buses.proxy), "playerctld is not a candidate");
+            compare(MprisSelection.selectPlayer(candidates, ""), buses.chromium);
+        }
+    }
+
+    function test_theProxyIsExcludedEvenWithDuplicateFilteringOff() {
+        const buses = liveBusList();
+        const candidates = MprisSelection.candidatePlayers(
+            [buses.proxy, buses.chromium, buses.firefox, buses.plasma], false);
+        verify(!candidates.includes(buses.proxy), "playerctld is never a real player");
+        compare(candidates.length, 3);
+    }
+
+    // plasma-browser-integration may be the only source for a browser whose own
+    // MPRIS is off, and a kdeconnect bus is somebody's phone rather than a
+    // local duplicate. Neither is a proxy.
+    function test_plasmaIntegrationAndKdeconnectStayCandidates() {
+        const plasma = player("plasma-browser-integration", false, "A tab");
+        const phone = player("kdeconnect.mpris_device1_vlc", true, "Phone track");
+        const candidates = MprisSelection.candidatePlayers([plasma, phone], true);
+        verify(candidates.includes(plasma));
+        verify(candidates.includes(phone));
+    }
+
+    // Suppressing every native browser bus while plasma-browser-integration is
+    // up removed the only bus carrying what was actually playing, leaving the
+    // paused mirror as the sole candidate.
+    function test_duplicateSuppressionNeverDropsThePlayingBus() {
+        const buses = liveBusList();
+        const candidates = MprisSelection.candidatePlayers(
+            [buses.chromium, buses.firefox, buses.plasma], true);
+        verify(candidates.includes(buses.chromium), "the playing browser bus survives");
+        verify(!candidates.includes(buses.firefox), "the paused browser bus is still a duplicate");
+        verify(candidates.includes(buses.plasma));
+    }
+
+    function test_normalizingThePreferenceIsIdempotent() {
+        const once = MprisSelection.normalizePreferredPlayer("Spotify");
+        compare(once, "spotify");
+        compare(MprisSelection.normalizePreferredPlayer(once), "spotify");
+        compare(MprisSelection.normalizePreferredPlayer(MprisSelection.normalizePreferredPlayer(once)), "spotify");
+    }
+
+    function test_normalizingConvertsLegacyAndBusNameValues() {
+        compare(MprisSelection.normalizePreferredPlayer(""), "");
+        compare(MprisSelection.normalizePreferredPlayer("  "), "");
+        compare(MprisSelection.normalizePreferredPlayer(undefined), "");
+        compare(MprisSelection.normalizePreferredPlayer("spotify, firefox"), "spotify");
+        compare(MprisSelection.normalizePreferredPlayer("org.mpris.MediaPlayer2.chromium.instance700643"), "chromium");
+    }
+
+    function test_aPreferenceThatCannotBeParsedStillMatchesThePlayerItNamed() {
+        const firefox = player("firefox.instance_1_52", true, "A video", "Mozilla Firefox");
+        const stored = MprisSelection.normalizePreferredPlayer("Mozilla Firefox");
+        compare(stored, "mozilla");
+        compare(MprisSelection.selectPlayer([firefox], stored), firefox);
+    }
+
+    function test_thePreferenceWinsOverWhateverElseIsPlaying() {
+        const spotify = player("spotify", false, "A paused album");
+        const chromium = player("chromium.instance700643", true, "Provider");
+        compare(MprisSelection.selectPlayer([chromium, spotify], "spotify"), spotify);
+        const shown = MprisSelection.meaningfulPlayers([chromium, spotify], "spotify");
+        compare(shown.length, 1);
+        compare(shown[0], spotify);
+    }
+
+    function test_aPreferredPlayerThatIsNotRunningFallsBackRatherThanShowingNothing() {
+        const chromium = player("chromium.instance700643", true, "Provider");
+        compare(MprisSelection.selectPlayer([chromium], "spotify"), chromium);
+        const shown = MprisSelection.meaningfulPlayers([chromium], "spotify");
+        compare(shown.length, 1);
+        compare(shown[0], chromium);
+        // ...and with nothing running at all it is still a null, not a throw.
+        compare(MprisSelection.selectPlayer([], "spotify"), null);
+    }
+
+    function test_thePickerKeepsARowForAPreferenceWhosePlayerIsGone() {
+        const chromium = player("chromium.instance700643", true, "Provider", "Chromium");
+        const options = MprisSelection.playerOptions([chromium], "spotify");
+        compare(options.length, 2);
+        compare(options[0].value, "chromium");
+        compare(options[0].name, "Chromium");
+        compare(options[0].trackTitle, "Provider");
+        verify(options[0].available);
+        compare(options[1].value, "spotify");
+        verify(!options[1].available, "the stored choice is still offered, marked absent");
+    }
+
+    function test_thePickerOffersOneRowPerPlayerNotPerInstance() {
+        const idle = player("chromium.instance1", false, "", "Chromium");
+        const playing = player("chromium.instance2", true, "Provider", "Chromium");
+        const options = MprisSelection.playerOptions([idle, playing], "");
+        compare(options.length, 1);
+        compare(options[0].value, "chromium");
+        verify(options[0].isPlaying, "the instance with something to say describes the row");
+        compare(options[0].trackTitle, "Provider");
     }
 }


### PR DESCRIPTION
Closes #170.

## The diagnosis in the issue named the wrong filter

`playerctld` was already excluded — `isRealPlayer` dropped it before this branch. The filter that actually pinned the shell to the paused video is the other one: while `plasma-browser-integration` is on the bus, *every* native Firefox and Chromium bus was suppressed as its duplicate. plasma republishes one browser tab at a time, so with a paused video mirrored there and music playing in Chromium, the only bus carrying the music was dropped and the paused mirror was the sole surviving candidate.

Both filters are fixed:

- The proxy exclusion is now **unconditional** and keyed on the bus name. `media.filterDuplicatePlayers` is a preference about duplicates; a proxy is not a player, so it should not be reachable by a preference.
- **Duplicate suppression never drops a bus that is playing.**

`plasma-browser-integration` and `kdeconnect.mpris_*` are kept, as requested.

## The setting no longer needs typing

"Preferred Player" was a free-text field matched by substring against `Identity`. It is now a `ConfigComboBox`: "Automatic", then one row per running player labelled `<Identity> — <what it's playing>` with a play/pause icon.

What is stored is the *stable* bus id — `chromium`, `firefox`, `spotify` — with the `org.mpris.MediaPlayer2.` prefix and the spec's `.instance<pid>` suffix stripped, because a full bus name changes on every launch and cannot survive as a preference. `playerOptions` always emits a row for the stored preference, drawn "(not running)" when absent, so closing the preferred player does not make the picker read as though it reset.

The preference is **absolute** while that player is present, which is the existing semantics — a preference that stops applying the moment anything else plays is not a preference. When it is absent, ordinary selection resumes.

Migration is unconditional, unmarked and idempotent (`migratePreferredPlayerToBusId`), modelled on `clearStaleKbOptions`. Old free-text values that do not parse still resolve through the legacy substring branch, so `Mozilla Firefox` keeps working.

## Unification

`MprisController` now publishes `activePlayer`, `meaningfulPlayers`, `playerOptions` and `preferredPlayerId`; the bar widget, media-controls popup, right sidebar and lock screen all read those. The two hand-rolled copies of the title-based duplicate collapse are gone — the popup's had a real bug, missing `Math.abs` and mixing `&&`/`||` so its timing clause differed from the sidebar's.

## Tests

507 passed, 0 failed (`main` baseline: 495). New: `tst_mpris_selection.qml` (+12) and `test_mpris_controller_contract.py`, which fails the suite if any QML file outside `Config`/`BarConfig`/`MprisController` names `media.preferredPlayer` again.

Every check was verified non-vacuous by planting the mutation on a clean tree and reverting:

| mutation | reddens |
|---|---|
| `PROXY_PLAYER_IDS = []` | 2 |
| remove the `isPlaying` exemption (the pre-fix rule) | 2 |
| stop stripping `.instance…` | 4 |
| make normalization non-idempotent | 3 |
| preference becomes a tiebreak | 1 |
| absent preference returns nothing | 2 |
| picker drops the absent-preference row | 1 |
| reintroduce `media.preferredPlayer` in `Media.qml` | the contract check |

The three-order sweep in the proxy test is load-bearing rather than decorative: with only the proxy filter removed, `selectPlayer` returns `playerctld` when the proxy is first in the list and `chromium` when it is second.

Docs: updated AGENT.md §Dynamic/data-driven QML gotchas, §Directory map
