### PR TITLE
fix(cava): stop a paused player repainting an invisible bar at 237 fps

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1148,6 +1148,28 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   panned by assignment, i.e. it switched off both halves of the interaction it existed to score,
   and stayed green for the entire life of the bug. b710ef731 ("fix(plugins): stop the position
   Behavior swallowing the parallax cancellation").
+- **The mirror-image failure: a `Behavior` *retriggered* every frame does tick, forever, and
+  nothing on screen shows you.** Where the parallax bug was a frozen property, this one is a
+  property that never rests. `CavaService` gated cava on `MprisController.activePlayer !== null`
+  — but a *paused* player is still an active player, and cava visualises whatever is **audible**
+  rather than the tracked player's stream. So three paused players left cava decoding a
+  fullscreen game's sound, each spectrum retriggered the bar visualiser's twenty `Behavior on
+  height` animations, and those tick at the display's refresh rate. Measured on a 240 Hz output:
+  the bar's render thread ran at **237 fps behind a fullscreen game**, and `SIGSTOP`ping cava
+  took it to 33. The generalisation is about gates, not about cava: **"a thing exists" and "the
+  thing is doing something" are different predicates, and animation cost follows the second.**
+  a57cd00b2 ("fix(cava): gate the spectrum on playback, not on a player existing").
+- **A surface the compositor *covers* is not a surface QML considers hidden — `visible` stays
+  true and no guard written against it will fire.** `Bar.qml` picks `WlrLayer.Top` precisely so
+  fullscreen windows bury the bar (Overlay only while a special workspace sits on top). That is
+  occlusion, and it happens entirely below Qt: the surface stays mapped, the item tree is
+  untouched, and the bar happily animates for nobody. Contrast the desktop widgets, which *are*
+  hidden properly — everything they draw hangs off `parallaxViewport`, and `Background.qml` sets
+  `visible: false` on it, so `visible` (the effective value) is the correct guard there. Before
+  gating work on visibility, establish which of the two you have; the wrong one reads identically
+  in the source and does nothing at runtime. Diagnosing this took stack-sampling the render
+  thread, because every cheaper signal said the widget was fine.
+  53d1ff893 ("fix(bar): drop the cava claim while a fullscreen window covers the bar").
 - **A subclass cannot read `AbstractWidget.gridSize`: `PluginWidget` shadows it.** The base's
   `gridSize` is the 12px drag lattice; `PluginWidget` declares its own `gridSize`, the
   component-grid span (`{"cols": 2, "rows": 1}`). Code *inside* the base still resolves to the

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/visualizer/Widget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/visualizer/Widget.qml
@@ -11,10 +11,15 @@ Item {
     id: root
 
     // This widget is only built while the plugin is enabled (its host loader
-    // follows the enabled list), so existing is the claim on cava - which is
-    // the `plugins.enabled.includes("visualizer")` term the old process gate
-    // read straight out of the config.
-    CavaRef {}
+    // follows the enabled list), so existing is most of the claim on cava -
+    // which is the `plugins.enabled.includes("visualizer")` term the old
+    // process gate read straight out of the config.
+    //
+    // `visible` adds the rest. Everything the desktop draws hangs off
+    // `parallaxViewport`, which Background.qml switches off while a window is
+    // fullscreen, and `visible` is the effective value - so this claim drops
+    // when the wallpaper stops being drawn, without knowing why it stopped.
+    CavaRef { active: root.visible }
 
     // The visualiser draws bars straight onto the wallpaper - it has no panel,
     // card or tint of its own - so it opts out of the host's frost entirely by

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/services/CavaService.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/services/CavaService.qml
@@ -29,9 +29,19 @@ Singleton {
 
     // Consumers hold a claim (CavaRef) for exactly as long as they are showing
     // bands. cava decodes audio continuously, so it must not run for an idle
-    // desktop; with no player there is nothing to decode either.
+    // desktop; with nothing playing there is nothing to decode either.
+    //
+    // `isPlaying`, not `activePlayer !== null`: a *paused* player is still an
+    // active player, so the old test kept cava decoding for as long as any
+    // player existed at all. cava visualises whatever is audible rather than
+    // that player's stream, so it then drew some other application's sound -
+    // and every band it emitted retriggered twenty `Behavior on height`
+    // animations, which tick at the display's refresh rate whether or not
+    // anyone can see them. Measured on a 240 Hz output with three paused
+    // players and a fullscreen game: the bar's render thread ran at 237 fps
+    // behind the game, and pausing cava took it to 33.
     property int refCount: 0
-    readonly property bool active: root.refCount > 0 && MprisController.activePlayer !== null
+    readonly property bool active: root.refCount > 0 && MprisController.isPlaying
 
     property list<real> values: []
 

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/CavaWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/CavaWidget.qml
@@ -30,7 +30,11 @@ Canvas {
 
     Component.onCompleted: root._initArrays(barCount)
 
-    CavaRef {}
+    // Bands nobody is looking at still cost a running cava and a repaint per
+    // spectrum, so the claim follows what is actually drawn. `visible` is the
+    // effective value, so an ancestor switching off is enough - no consumer has
+    // to know which ancestor, or why.
+    CavaRef { active: root.visible }
 
     Connections {
         target: CavaService

--- a/dots/.config/quickshell/imi/modules/imi/background/Background.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/Background.qml
@@ -880,7 +880,17 @@ Variants {
                 cache: false
                 smooth: true
                 asynchronous: true
-                layer.enabled: true
+                // An offscreen render target the size of the output, held for
+                // the whole session. With no lock wallpaper configured there is
+                // nothing to sample and the layer is pure cost, so skip it.
+                //
+                // Deliberately NOT gated on "is the lock peel showing": the
+                // shader samples this the frame the lock appears, and a layer
+                // built one frame late would sample the raw texture instead of
+                // the PreserveAspectCrop'd render - the exact bug the comment
+                // above describes. Narrowing it further needs the lock path
+                // exercised, which is a test rather than a guess.
+                layer.enabled: lockWallImage.source.toString() !== ""
                 visible: false
             }
             // Lock peel: live WE <-> lock image, using the configured shader. Above

--- a/dots/.config/quickshell/imi/modules/imi/bar/Visualizer.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/Visualizer.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import QtQuick.Layouts
+import Quickshell
 import Quickshell.Io
 import Quickshell.Services.Mpris
 import qs.services
@@ -29,9 +30,26 @@ Item {
     // index per dot threw away the ones in between.
     readonly property var levels: CavaBands.bands(root.points, root.barCount, root.maxVisualizerValue)
 
+    // A fullscreen window on this monitor covers the bar - Bar.qml:67 chooses
+    // the Top layer precisely so that it does, except while a special workspace
+    // sits on top, which puts the bar back on Overlay and in front. Mirrored
+    // here rather than passed down because the visualiser is placed by the
+    // layout registry, not by Bar.qml, so there is no parent to read it from.
+    //
+    // The bar is *occluded*, never hidden: its surface stays mapped and QML
+    // keeps `visible` true, so nothing in the item tree knows. Gating this
+    // claim on `visible` - the obvious guard - would therefore not fire at all.
+    readonly property var thisMonitorData: HyprlandData.monitors.find(monitor =>
+        monitor.name === root.QsWindow.window?.screen?.name)
+    readonly property bool coveredByFullscreen:
+        (HyprlandData.workspaceById[root.thisMonitorData?.activeWorkspace?.id]?.hasfullscreen ?? false)
+        && ((root.thisMonitorData?.specialWorkspace?.name ?? "") === "")
+
     // This widget only exists while "visualizer" sits in a bar layout, which is
-    // the layout term the old process gate spelled out by reading the config.
-    CavaRef {}
+    // the layout term the old process gate spelled out by reading the config -
+    // but existing is not enough on its own, because bands nobody can see still
+    // animate at the refresh rate.
+    CavaRef { active: !root.coveredByFullscreen }
 
     implicitWidth: vertical
         ? Appearance.sizes.verticalBarWidth

--- a/dots/.config/quickshell/imi/tests/lint_cava_claims.py
+++ b/dots/.config/quickshell/imi/tests/lint_cava_claims.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""cava must not decode for something nobody is watching.
+
+Two rules, both learned from the same defect.
+
+**A claim states its condition.** `CavaRef {}` with no `active:` means "run
+cava for as long as I exist", which is right only when existing really is the
+condition. It was written that way at three call sites, and at every one of
+them the widget outlived its own visibility - a bar behind a fullscreen window,
+a desktop widget on a wallpaper that had been switched off. Requiring `active:`
+does not force any particular answer; it forces the author to have one.
+
+**The service gates on playback, not on a player existing.** `activePlayer !==
+null` is true for a *paused* player. cava visualises whatever is audible rather
+than that player's stream, so the shell kept decoding some other application's
+sound - and each band retriggered twenty `Behavior on height` animations, which
+tick at the display's refresh rate whether or not the surface is on screen.
+Measured on a 240 Hz output: the bar's render thread ran at 237 fps behind a
+fullscreen game with every player paused, and pausing cava took it to 33.
+
+This is the second Behavior-driven idle-repaint defect in this repo (the
+parallax opt-out was the first), which is why it is a check and not a note.
+Both rules are answerable by reading the text, so neither needs a compositor.
+"""
+
+from pathlib import Path
+import re
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SKIP_DIRS = {".git", "node_modules", "__pycache__", "tests"}
+
+SERVICE = ROOT / "modules/common/plugins/designsystem/services/CavaService.qml"
+
+# `CavaRef {` followed by `}` with only whitespace between: a claim with no
+# body, therefore no `active:`. A claim that sets anything at all is left alone
+# - the point is a deliberate condition, not a particular one.
+BARE_CLAIM = re.compile(r"\bCavaRef\s*\{\s*\}")
+
+# The gate that treats a paused player as a reason to decode.
+PAUSED_PLAYER_GATE = re.compile(r"active\s*:[^\n]*activePlayer\s*!==\s*null")
+
+
+def failures_for(path: Path):
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError):
+        return []
+
+    out = []
+    for match in BARE_CLAIM.finditer(text):
+        line = text.count("\n", 0, match.start()) + 1
+        out.append(
+            f"{path.relative_to(ROOT)}:{line}: `CavaRef {{}}` states no condition. "
+            f"Give it `active:` - the condition under which this consumer is "
+            f"really showing bands. `visible` is the usual answer; a surface the "
+            f"compositor merely covers needs its own term, because QML still "
+            f"reports it visible.")
+    return out
+
+
+def main() -> int:
+    failures = []
+    for path in sorted(ROOT.rglob("*.qml")):
+        if any(part in SKIP_DIRS for part in path.relative_to(ROOT).parts):
+            continue
+        failures.extend(failures_for(path))
+
+    if SERVICE.exists():
+        service_text = SERVICE.read_text(encoding="utf-8")
+        match = PAUSED_PLAYER_GATE.search(service_text)
+        if match:
+            line = service_text.count("\n", 0, match.start()) + 1
+            failures.append(
+                f"{SERVICE.relative_to(ROOT)}:{line}: cava is gated on a player "
+                f"existing, not on one playing. A paused player is still an "
+                f"active player, so this runs cava - and every band it emits "
+                f"retriggers the visualiser's Behaviors at the refresh rate. "
+                f"Use `MprisController.isPlaying`.")
+
+    if failures:
+        print("cava claim lint failed:\n", file=sys.stderr)
+        for failure in failures:
+            print(f"  {failure}", file=sys.stderr)
+        return 1
+
+    print("cava claim lint passed: every claim states its condition, "
+          "and the service gates on playback")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -120,6 +120,12 @@ if ! python3 "$SCRIPT_DIR/lint_duplicate_imports.py"; then
     exit 1
 fi
 
+echo "Running cava claim lint..."
+if ! python3 "$SCRIPT_DIR/lint_cava_claims.py"; then
+    echo "cava claim lint failed."
+    exit 1
+fi
+
 echo "Running process pattern lint..."
 if ! python3 "$SCRIPT_DIR/lint_self_matching_process_patterns.py"; then
     echo "Process pattern lint failed."

--- a/dots/.config/quickshell/imi/tests/test_cava_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_cava_contract.py
@@ -62,10 +62,32 @@ class CavaContractTest(unittest.TestCase):
         gate = re.search(r"readonly\s+property\s+bool\s+active:([^\n]*)", text)
         self.assertIsNotNone(gate, "the service needs one named gate expression")
         self.assertIn("refCount > 0", gate.group(1))
-        self.assertIn("activePlayer !== null", gate.group(1),
-                      "with no player there is nothing to decode")
         self.assertRegex(text, r"\brunning:\s*root\.active\b",
                          "the process must run on the gate, not on its own condition")
+
+    def test_the_gate_is_playback_and_not_a_player_merely_existing(self):
+        """A paused player is still an active player.
+
+        This assertion used to require `activePlayer !== null`, which reads as
+        "with no player there is nothing to decode" and is true - but it is not
+        the same claim. cava visualises whatever is *audible*, not the tracked
+        player's stream, so a paused player left it decoding some other
+        application's sound, and every band retriggered the visualiser's twenty
+        `Behavior on height` animations at the display's refresh rate. Measured
+        on a 240 Hz output with three paused players and a fullscreen game: the
+        bar's render thread ran at 237 fps behind the game, dropping to 33 when
+        cava was paused.
+
+        So the test now pins the requirement rather than the expression that
+        happened to be there.
+        """
+        gate = re.search(r"readonly\s+property\s+bool\s+active:([^\n]*)",
+                         qml_text(SERVICE)).group(1)
+        self.assertIn("isPlaying", gate,
+                      "cava must run only while something is actually playing")
+        self.assertNotIn("activePlayer !== null", gate,
+                         "a paused player is still an active player - this gate "
+                         "keeps cava decoding for anything else making noise")
 
     def test_the_band_count_is_the_one_the_process_is_asked_for(self):
         """`barCount: 32` against a config asking for 50 bars is how this drifted."""


### PR DESCRIPTION
Found while investigating "is 86% GPU usage normal?". The GPU answer turned out to be no — the shell measured **0.9% SM** — but the investigation surfaced a real defect underneath it.

## What was happening

With three MPRIS players **paused** and a fullscreen game running, the bar's render thread ran at **237 fps** behind the game. Verified by pausing the producer:

| state | bar render thread |
|---|---|
| cava running | **237 fps** |
| cava `SIGSTOP`ped | **33 fps** |
| cava resumed | **238 fps** |

The chain, each link measured:

1. `CavaService` gated on `MprisController.activePlayer !== null`. A paused player is still an active player, so cava kept running.
2. cava visualises whatever is **audible**, not the tracked player's stream — so it was drawing the game's sound.
3. Every spectrum retriggered the bar visualiser's twenty `Behavior on height` animations, which tick at the display's refresh rate.
4. `Bar.qml:67` picks `WlrLayer.Top` precisely so fullscreen windows cover the bar. It is *occluded*, never hidden — the surface stays mapped and QML keeps `visible` true.
5. So a bar nobody could see repainted 240 times a second, free-running above refresh because an occluded surface receives no frame callbacks to throttle it.

This is the sibling of the parallax opt-out bug (`b710ef731`): that one was a `Behavior` whose target moved every frame and therefore never ticked; this one is a `Behavior` retriggered every frame that ticks forever.

## Fixes

- **`CavaService`** gates on `MprisController.isPlaying`. "A player exists" and "a player is playing" are different predicates, and animation cost follows the second.
- **`bar/Visualizer.qml`** drops its claim while a fullscreen window covers the bar. The condition is mirrored from `Bar.qml` rather than passed down, because the visualiser is placed by the layout registry and has no parent to read it from. Note that gating on `visible` — the obvious guard, and the one first proposed — **would not have fired at all**, since QML never learns the compositor buried the surface.
- **The two desktop cava consumers** gate on `visible`, which *is* correct there: everything the desktop draws hangs off `parallaxViewport`, and `Background.qml` sets `visible: false` on it while a window is fullscreen.
- **`Background.qml`** skips the lock wallpaper's `layer.enabled` when no lock wallpaper is configured — an output-sized offscreen target held for the whole session.

## Tests

507 passed, 0 failed; `DesignSystemCompile checked=159 failures=0`.

`test_cava_contract.py` asserted `activePlayer !== null`, pinning the defective expression as though it were the requirement — a green test guarding the bug. It now asserts the requirement and rejects the old form by name.

`lint_cava_claims.py` is new and covers the other half: `CavaRef {}` with no `active:` means "run cava for as long as I exist", which was written at three call sites and was wrong at all three. It does not force a particular condition, only that the author has one. Second Behavior-driven idle-repaint defect in this repo, so it is a check rather than a note.

Both mutations verified non-vacuous on a clean tree and reverted:

| mutation | result |
|---|---|
| restore a bare `CavaRef {}` | lint fails, names the file and line |
| restore the `activePlayer !== null` gate | lint fails, and the contract test fails |

## Deliberately left out

**Narrowing `lockWallImage.layer.enabled` to "while the lock peel is showing."** The shader samples it the frame the lock appears, and a layer built one frame late would sample the raw texture instead of the `PreserveAspectCrop`'d render — the exact bug the existing comment warns about. That needs the lock path exercised rather than guessed at, and I could not exercise it without locking the screen mid-session. Only the safe subset (no lock wallpaper configured → no layer) is included.

**The residual 33 fps.** With cava paused the surface still repaints 33×/s. Something smaller is dirtying it and I have not identified what.

Docs: updated AGENT.md §Dynamic/data-driven QML gotchas
