### PR TITLE
feat(widgets): the shared card, and the stretch that lets a shape be one

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1199,6 +1199,14 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   in the source and does nothing at runtime. Diagnosing this took stack-sampling the render
   thread, because every cheaper signal said the widget was fine.
   53d1ff893 ("fix(bar): drop the cava claim while a fullscreen window covers the bar").
+- **A widget's card surface comes from `WidgetCard`, not a hand-rolled tint pair.** The
+  `useBlurBackground ? applyAlpha(tint, opacity) : tint` conditional was written seven times across
+  the desktop widgets — the spec's own survey counted four, and the lint that now reserves the
+  pattern to the component (`lint_widget_card_tint.py`) found the other three on its first run.
+  `WidgetCard` owns the tint, the rounding, an optional content clip, a `blurRegion` record, and a
+  `shapeName` parameter that turns the card into a stretched `MaterialShape` (which morphs on any
+  shape change, because `ShapeCanvas` does). calendar is the one exempted copy until its scheduled
+  rebuild. b362d8c80 ("feat(widgets): one card component for the surface every widget redrew").
 - **A subclass cannot read `AbstractWidget.gridSize`: `PluginWidget` shadows it.** The base's
   `gridSize` is the 12px drag lattice; `PluginWidget` declares its own `gridSize`, the
   component-grid span (`{"cols": 2, "rows": 1}`). Code *inside* the base still resolves to the

--- a/docs/superpowers/specs/2026-08-11-expressive-morphing-design.md
+++ b/docs/superpowers/specs/2026-08-11-expressive-morphing-design.md
@@ -304,6 +304,21 @@ mask *is*, only that it has alpha. So
 That keeps every existing caller working — including the three system-monitor cards, which have no
 reason to stop being rounded rectangles — while making a morphing frosted card expressible at all.
 
+**From implementation (12 Aug):** the blocker was not where this section expected. `ShapeCanvas`
+already strokes an outline (`borderWidth`/`borderColor`), so a shape loses nothing there. What a
+shape could not do was *be a card at all*: every normalised polygon was scaled by
+`min(width, height)` and centred, so a 320x112 card would have drawn a 112x112 shape floating in its
+middle. The foundation was an opt-in `stretch` placement — identical to the square one on square
+items, which is what makes it safe under every existing caller — with the path built in pixel space,
+because scaling the context scales the pen and only a uniform scale cancels that out; stretched axes
+differ, so a border would thicken on the short axis by the aspect ratio.
+
+**And the count was wrong: seven copies, not four.** The lint that reserves the tint pair to the
+card found three more on its first run — the media 3x2, the media 2x1, and the system monitor's
+helper feeding three cards. calendar's drift also went further than recorded: it does not use the
+conditional at all. A survey done by reading finds the copies already known about; the mechanized
+rule found the rest immediately.
+
 ### Why this lands before the media work
 
 It is the cheapest step in the whole plan and the least likely to break anything: mechanical,

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
@@ -539,6 +539,9 @@ AbstractBackgroundWidget {
             liveWallpaperActive: rootWidget.liveWallpaperActive
             weSurfaceItem: rootWidget.weSurfaceItem
             cornerRadius: Number(modelData.radius ?? rootWidget.widgetRounding)
+            // A region may carry its own mask item (a non-rounded-rect card's
+            // outline); absent, the surface builds its radius Rectangle.
+            maskItem: modelData.mask ?? null
             wallpaperWidth: rootWidget.wallpaperRect.width
             wallpaperHeight: rootWidget.wallpaperRect.height
             surfaceX: rootWidget.frostSampleOrigin.x + x

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/LayoutCompact.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/LayoutCompact.qml
@@ -5,6 +5,7 @@ import qs.modules.common.functions as Functions
 import qs.modules.common.widgets
 import qs.modules.common.plugins
 import qs.services
+import "../../designsystem/widgets" as Expressive
 import "../../designsystem/widgets/shapes/material-shapes.js" as MaterialShapes
 import "../../designsystem/widgets/shapes/path-length.js" as PathLength
 
@@ -51,13 +52,11 @@ Item {
         onTriggered: MprisController.activePlayer?.positionChanged()
     }
 
-    Rectangle {
+    Expressive.WidgetCard {
         id: bgCard
         anchors.fill: parent
-        radius: 30 * Appearance.effectiveScale
-        color: root.useBlurBackground
-            ? Functions.ColorUtils.applyAlpha(Appearance.colors.colOnPrimary, root.backgroundOpacity)
-            : Appearance.colors.colOnPrimary
+        useBlurBackground: root.useBlurBackground
+        backgroundOpacity: root.backgroundOpacity
     }
 
     RowLayout {

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/LayoutCookie.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/LayoutCookie.qml
@@ -30,9 +30,7 @@ Item {
     readonly property real backgroundOpacity: PluginState.effectiveBackgroundOpacity("nandoroid_media")
 
     readonly property bool managesBlurTint: true
-    readonly property var blurRegions: [{
-        x: bgCard.x, y: bgCard.y, width: bgCard.width, height: bgCard.height, radius: bgCard.radius
-    }]
+    readonly property var blurRegions: [bgCard.blurRegion]
 
     readonly property string artUrl: MprisController.activePlayer?.trackArtUrl ?? ""
     readonly property bool hasArt: root.artUrl !== "" && albumArt.status === Image.Ready
@@ -85,13 +83,11 @@ Item {
         }
     }
 
-    Rectangle {
+    Expressive.WidgetCard {
         id: bgCard
         anchors.fill: parent
-        radius: 30 * Appearance.effectiveScale
-        color: root.useBlurBackground
-            ? Functions.ColorUtils.applyAlpha(Appearance.colors.colOnPrimary, root.backgroundOpacity)
-            : Appearance.colors.colOnPrimary
+        useBlurBackground: root.useBlurBackground
+        backgroundOpacity: root.backgroundOpacity
     }
 
     Item {

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopCurrencyWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopCurrencyWidget.qml
@@ -20,9 +20,7 @@ Item {
 
     property real backgroundOpacity: PluginState.effectiveBackgroundOpacity("", 0.1)
     readonly property bool managesBlurTint: true
-    readonly property var blurRegions: [{
-        x: card.x, y: card.y, width: card.width, height: card.height, radius: card.radius
-    }]
+    readonly property var blurRegions: [card.blurRegion]
     signal baseCurrencyRequested(string value)
     signal quoteCurrencyRequested(int index, string value)
 
@@ -84,15 +82,14 @@ Item {
             Qt.locale(), "f", CurrencyMath.fractionDigits(value));
     }
 
-    // Main Card Rectangle (Colored using colPrimaryContainer)
-    Rectangle {
+    // The shared card, on the currency tint.
+    WidgetCard {
         id: card
         objectName: "nandoroidCurrencyCard"
         anchors.fill: parent
-        radius: 30 * Appearance.effectiveScale
-        color: root.useBlurBackground
-            ? Functions.ColorUtils.applyAlpha(Appearance.colors.colPrimaryContainer, root.backgroundOpacity)
-            : Appearance.colors.colPrimaryContainer
+        tint: Appearance.colors.colPrimaryContainer
+        useBlurBackground: root.useBlurBackground
+        backgroundOpacity: root.backgroundOpacity
 
         // --- PAGE 1: View Mode ---
         Item {

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopMediaWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopMediaWidget.qml
@@ -30,14 +30,12 @@ Item {
         LyricsService.desktopWidgetLyricsActive = viewLyrics;
     }
 
-    // Main Card Background
-    Rectangle {
+    // Main Card Background. Card bg = play/pause icon color (user request).
+    WidgetCard {
         id: bgCard
         anchors.fill: parent
-        radius: 30 * Appearance.effectiveScale
-        color: root.useBlurBackground
-            ? Functions.ColorUtils.applyAlpha(Appearance.colors.colOnPrimary, root.backgroundOpacity)
-            : Appearance.colors.colOnPrimary // Card bg = play/pause icon color (user request)
+        useBlurBackground: root.useBlurBackground
+        backgroundOpacity: root.backgroundOpacity
     }
 
     // Toggle button in top right corner (M3 Styled Shape)

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopSystemMonitorWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopSystemMonitorWidget.qml
@@ -45,14 +45,11 @@ Item {
     property real cardHeight: isVertical ? (108 * Appearance.effectiveScale) : (108 * Appearance.effectiveScale)
     property real cardWidth: isVertical ? (132 * Appearance.effectiveScale) : ((420 * Appearance.effectiveScale - cardSpacing * 2) / 3)
     readonly property var blurRegions: [
-        { x: cpuCard.x, y: cpuCard.y, width: cpuCard.width, height: cpuCard.height, radius: cpuCard.radius },
-        { x: ramCard.x, y: ramCard.y, width: ramCard.width, height: ramCard.height, radius: ramCard.radius },
-        { x: thirdCard.x, y: thirdCard.y, width: thirdCard.width, height: thirdCard.height, radius: thirdCard.radius }
+        cpuCard.blurRegion,
+        ramCard.blurRegion,
+        thirdCard.blurRegion
     ]
 
-    function cardColor(color) {
-        return useBlurBackground ? Functions.ColorUtils.applyAlpha(color, backgroundOpacity) : color;
-    }
 
     Grid {
         id: gridLayout
@@ -60,12 +57,14 @@ Item {
         spacing: root.cardSpacing
 
         // CARD 1: CPU (Split-Level Centered Layout)
-        Rectangle {
+        WidgetCard {
             id: cpuCard
             implicitWidth: root.cardWidth
             implicitHeight: root.cardHeight
             radius: Appearance.rounding.large
-            color: root.cardColor(Appearance.colors.colPrimaryContainer)
+            tint: Appearance.colors.colPrimaryContainer
+            useBlurBackground: root.useBlurBackground
+            backgroundOpacity: root.backgroundOpacity
 
             // Sisi Atas: Liquid Gem (Centered Top)
             Item {
@@ -149,12 +148,14 @@ Item {
         }
 
         // CARD 2: RAM (Split-Level Centered Layout)
-        Rectangle {
+        WidgetCard {
             id: ramCard
             implicitWidth: root.cardWidth
             implicitHeight: root.cardHeight
             radius: Appearance.rounding.large
-            color: root.cardColor(Appearance.colors.colSecondaryContainer)
+            tint: Appearance.colors.colSecondaryContainer
+            useBlurBackground: root.useBlurBackground
+            backgroundOpacity: root.backgroundOpacity
 
             // Sisi Atas: Liquid Cookie4Sided (Centered Top)
             Item {
@@ -238,12 +239,14 @@ Item {
         }
 
         // CARD 3: DISK or BATTERY (Split-Level Centered Layout)
-        Rectangle {
+        WidgetCard {
             id: thirdCard
             implicitWidth: root.cardWidth
             implicitHeight: root.cardHeight
             radius: Appearance.rounding.large
-            color: root.cardColor(Appearance.colors.colTertiaryContainer)
+            tint: Appearance.colors.colTertiaryContainer
+            useBlurBackground: root.useBlurBackground
+            backgroundOpacity: root.backgroundOpacity
 
             // Sisi Atas: Liquid Cookie12Sided (Centered Top)
             Item {

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopWeatherWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopWeatherWidget.qml
@@ -19,9 +19,7 @@ Item {
 
     property real backgroundOpacity: PluginState.effectiveBackgroundOpacity("", 0.1)
     readonly property bool managesBlurTint: true
-    readonly property var blurRegions: [{
-        x: card.x, y: card.y, width: card.width, height: card.height, radius: card.radius
-    }]
+    readonly property var blurRegions: [card.blurRegion]
     
     // Choice A Grid System Specs
     readonly property real baseWidth: 132 * Appearance.effectiveScale
@@ -38,13 +36,6 @@ Item {
         if (sizeMode === "1x1") return width1x1;
         if (sizeMode === "2x1") return width2x1;
         return width3x1;
-    }
-
-    Behavior on implicitWidth {
-        NumberAnimation {
-            duration: 250
-            easing.bezierCurve: Appearance.animation.elementResize.numberAnimation?.easing?.bezierCurve || [0.2, 0, 0, 1]
-        }
     }
 
     // CustomIcon lives one directory below this imported widget's former location.
@@ -76,24 +67,15 @@ Item {
 
 
 
-    // Flat Material 3 container (No shadows for clean widget look)
-    Rectangle {
+    // The shared card. Clipped so the split vertical panels and slanted leaves
+    // cut cleanly at the rounded corners; tint and blur-thinning are the
+    // card's own logic now rather than this widget's.
+    WidgetCard {
         id: card
         anchors.fill: parent
-        radius: 30 * Appearance.effectiveScale
-        color: root.useBlurBackground
-            ? Functions.ColorUtils.applyAlpha(Appearance.colors.colOnPrimary, root.backgroundOpacity)
-            : Appearance.colors.colOnPrimary
-
-        // Mask the entire card contents to ensure split vertical panels and slanted leaves clip perfectly at the rounded corners
-        layer.enabled: true
-        layer.effect: OpacityMask {
-            maskSource: Rectangle {
-                width: card.width
-                height: card.height
-                radius: card.radius
-            }
-        }
+        useBlurBackground: root.useBlurBackground
+        backgroundOpacity: root.backgroundOpacity
+        clipContent: true
 
         // Layout Loader based on sizeMode
         Loader {

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/MaterialShape.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/MaterialShape.qml
@@ -102,9 +102,13 @@ Item {
     
     property color borderColor: "transparent"
     property real borderWidth: 0
-    
+
+    // Fill the item's box rather than the largest square inside it - what lets
+    // this shape serve as a non-square card's outline. See ShapeCanvas.stretch.
+    property bool stretch: false
+
     // Explicitly expose properties expected by ShapeCanvas users if needed
-    property bool polygonIsNormalized: true 
+    property bool polygonIsNormalized: true
 
     implicitHeight: implicitSize
     implicitWidth: implicitSize
@@ -166,6 +170,7 @@ Item {
         borderColor: root.borderColor
         roundedPolygon: root.roundedPolygon
         polygonIsNormalized: root.polygonIsNormalized
+        stretch: root.stretch
     }
 
     // Image overlay with masking

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/WidgetCard.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/WidgetCard.qml
@@ -1,0 +1,95 @@
+import QtQuick
+import Qt5Compat.GraphicalEffects
+import qs.modules.common
+import qs.modules.common.functions as Functions
+import "./shapes"
+
+// The surface a desktop widget draws itself on.
+//
+// Before this existed, each widget declared its own: DesktopWeatherWidget,
+// DesktopCurrencyWidget and nandoroid-media's LayoutCookie carried three
+// byte-identical `Rectangle { radius: 30 * effectiveScale; color: blur ?
+// applyAlpha(tint, opacity) : tint }` blocks, and calendar's copy had already
+// drifted to a different rounding token and colour source - which is the
+// argument for the component: with four copies, container motion means tuning
+// it four times and getting four slightly different results.
+//
+// A widget composes zero, one or many of these (the system monitor has three
+// and no outer container), so this is a *card*, not a widget container, and it
+// deliberately does not own frost: `blurRegions` stays a widget-level
+// declaration, for which `blurRegion` below is the per-card record.
+//
+// The shape is a parameter. Unset, the card is a plain Rectangle - the cheap
+// path, and the only one the frost's OpacityMask can currently follow. Set to a
+// MaterialShape name ("Squircle", "Ghostish", ...), the card is that polygon
+// stretched to the card's box, drawn by the same ShapeCanvas the wallpaper
+// shape picker morphs - so a card whose `shapeName` changes morphs for free.
+Item {
+    id: root
+
+    // ---- the tint --------------------------------------------------------
+    // The colour pair every copy spelled out: opaque tint normally, the same
+    // tint thinned to `backgroundOpacity` when the widget frosts the wallpaper
+    // behind it (the frost supplies the body, the tint only warms it).
+    property color tint: Appearance.colors.colOnPrimary
+    property bool useBlurBackground: false
+    property real backgroundOpacity: 0.1
+    readonly property color effectiveColor: root.useBlurBackground
+        ? Functions.ColorUtils.applyAlpha(root.tint, root.backgroundOpacity)
+        : root.tint
+
+    // ---- the shape -------------------------------------------------------
+    property real radius: 30 * Appearance.effectiveScale
+    // Empty = rounded rectangle. A MaterialShape enum name = that polygon,
+    // stretched to fill this card rather than squared inside it.
+    property string shapeName: ""
+    readonly property bool usesShapeCanvas: root.shapeName !== ""
+
+    // ---- what the widget's blurRegions entry should say ------------------
+    // One place builds the record, so a widget cannot disagree with its card
+    // about where the frost goes. Radius is meaningless for a polygon card,
+    // but the frost mask cannot follow a polygon yet either - that widget
+    // should not frost this card until the mask learns shapes.
+    readonly property var blurRegion: ({
+        x: root.x, y: root.y, width: root.width, height: root.height,
+        radius: root.radius
+    })
+
+    // ---- content ---------------------------------------------------------
+    // Children land inside the card. With `clipContent` on they are cut at the
+    // card's own outline (weather clips its split panels and slanted leaves
+    // this way; it is also what cuts a 1x1 glyph hanging off the corner).
+    default property alias data: contentItem.data
+    property bool clipContent: false
+
+    Rectangle {
+        id: rectSurface
+        visible: !root.usesShapeCanvas
+        anchors.fill: parent
+        radius: root.radius
+        color: root.effectiveColor
+    }
+
+    Loader {
+        active: root.usesShapeCanvas
+        anchors.fill: parent
+        sourceComponent: MaterialShape {
+            shapeString: root.shapeName
+            color: root.effectiveColor
+            stretch: true
+        }
+    }
+
+    Item {
+        id: contentItem
+        anchors.fill: parent
+        layer.enabled: root.clipContent
+        layer.effect: OpacityMask {
+            maskSource: Rectangle {
+                width: root.width
+                height: root.height
+                radius: root.radius
+            }
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/qmldir
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/qmldir
@@ -4,6 +4,7 @@ CustomIcon CustomIcon.qml
 DragManager DragManager.qml
 DashedBorder DashedBorder.qml
 MaterialShape MaterialShape.qml
+WidgetCard WidgetCard.qml
 MaterialSymbol MaterialSymbol.qml
 NotificationActionButton NotificationActionButton.qml
 NotificationAppIcon NotificationAppIcon.qml

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/shapes/ShapeCanvas.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/shapes/ShapeCanvas.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import "./morph.js" as Morph
+import "./shape-fit.js" as ShapeFit
 
 Canvas {
     id: root
@@ -8,6 +9,16 @@ Canvas {
     property bool polygonIsNormalized: true
     property real borderWidth: 0
     property color borderColor: "transparent"
+
+    // Fill the whole item rather than the largest square inside it.
+    //
+    // The default is the square: a normalised polygon is scaled by
+    // `min(width, height)` and centred, which is right for a glyph, a button or
+    // anything else that is as tall as it is wide. A *card* is not - at 320x112
+    // the default draws a 112x112 shape floating in the middle of it - so a
+    // shape can only be a card's outline if it may stretch to the box it is
+    // given. Off by default because every existing caller wants the square.
+    property bool stretch: false
 
     // Internals: size
     property var bounds: roundedPolygon.calculateBounds()
@@ -39,10 +50,16 @@ Canvas {
         animation: root.animation
     }
 
+    // A Canvas repaints on resize and on nothing else, so every input onPaint
+    // reads has to be mirrored here or it is the silent half - the shape keeps
+    // the last values it happened to be drawn with.
     onProgressChanged: requestPaint()
     onColorChanged: requestPaint()
     onWidthChanged: requestPaint()
     onHeightChanged: requestPaint()
+    onStretchChanged: requestPaint()
+    onBorderWidthChanged: requestPaint()
+    onBorderColorChanged: requestPaint()
     onPaint: {
         var ctx = getContext("2d")
         ctx.fillStyle = root.color
@@ -51,30 +68,28 @@ Canvas {
         const cubics = root.morph.asCubics(root.progress)
         if (cubics.length === 0) return
 
-        const size = Math.min(root.width, root.height)
-        const offsetX = root.width / 2 - size / 2
-        const offsetY = root.height / 2 - size / 2
-
-        ctx.save()
-        ctx.translate(offsetX, offsetY)
-        if (root.polygonIsNormalized) ctx.scale(size, size)
+        // Placement and the pixel mapping live in shape-fit.js - see there for
+        // why the path is built in pixels rather than drawn through ctx.scale().
+        const placement = ShapeFit.fit(root.width, root.height,
+            root.polygonIsNormalized, root.stretch)
+        const mapX = value => ShapeFit.mapX(value, placement)
+        const mapY = value => ShapeFit.mapY(value, placement)
 
         ctx.beginPath()
-        ctx.moveTo(cubics[0].anchor0X, cubics[0].anchor0Y)
+        ctx.moveTo(mapX(cubics[0].anchor0X), mapY(cubics[0].anchor0Y))
         for (const cubic of cubics) {
             ctx.bezierCurveTo(
-                cubic.control0X, cubic.control0Y,
-                cubic.control1X, cubic.control1Y,
-                cubic.anchor1X, cubic.anchor1Y
+                mapX(cubic.control0X), mapY(cubic.control0Y),
+                mapX(cubic.control1X), mapY(cubic.control1Y),
+                mapX(cubic.anchor1X), mapY(cubic.anchor1Y)
             )
         }
         ctx.closePath()
         ctx.fill()
         if (root.borderWidth > 0) {
             ctx.strokeStyle = root.borderColor
-            ctx.lineWidth = root.borderWidth / (root.polygonIsNormalized ? size : 1)
+            ctx.lineWidth = root.borderWidth
             ctx.stroke()
         }
-        ctx.restore()
     }
 }

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/shapes/shape-fit.js
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/shapes/shape-fit.js
@@ -1,0 +1,48 @@
+.pragma library
+
+// How a normalised rounded polygon is placed inside the item that draws it.
+//
+// This lived inline in `ShapeCanvas.onPaint`, which made it unreachable: a
+// `Canvas` draws nothing under the software scene graph the tests run on, so
+// the only part anyone could check was that the file parsed. It is arithmetic,
+// so it belongs where arithmetic can be scored.
+//
+// Two placements:
+//
+// - **square** (the default, and what every existing caller wants): scale by
+//   `min(width, height)` and centre. Right for a glyph, a button, a clock face
+//   - anything as tall as it is wide.
+// - **stretch**: fill the item. A card is 320x112, and under the square rule it
+//   would draw a 112x112 shape floating in the middle of it, so a shape can
+//   only be a card's outline if it may take the box it is given.
+//
+// `normalized` false means the polygon already carries pixel coordinates, so it
+// is placed but never scaled - the centring still applies, which is what the
+// original did and what its callers expect.
+function fit(width, height, normalized, stretch) {
+    const w = Number.isFinite(width) && width > 0 ? width : 0;
+    const h = Number.isFinite(height) && height > 0 ? height : 0;
+    const size = Math.min(w, h);
+
+    if (!normalized)
+        return { scaleX: 1, scaleY: 1, offsetX: w / 2 - size / 2, offsetY: h / 2 - size / 2 };
+    if (stretch)
+        return { scaleX: w, scaleY: h, offsetX: 0, offsetY: 0 };
+    return { scaleX: size, scaleY: size, offsetX: w / 2 - size / 2, offsetY: h / 2 - size / 2 };
+}
+
+// Map a polygon point into pixels.
+//
+// The path is built in pixel space rather than drawn through `ctx.scale()`,
+// because scaling the context scales the pen with it. The square case hid that:
+// one `lineWidth / size` divide cancelled a uniform scale exactly. Stretching
+// scales x and y differently and no single divide cancels that - a stroke would
+// come out thicker on the short axis by the aspect ratio. Mapping the points
+// leaves the pen in pixel space, so a border width means pixels at any aspect.
+function mapX(value, placement) {
+    return placement.offsetX + value * placement.scaleX;
+}
+
+function mapY(value, placement) {
+    return placement.offsetY + value * placement.scaleY;
+}

--- a/dots/.config/quickshell/imi/modules/common/widgets/WallpaperBlurSurface.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/WallpaperBlurSurface.qml
@@ -52,6 +52,15 @@ Item {
     // tests/tst_wallpaper_blur_sharing.qml.
     readonly property int sampleStatus: wallpaperImage.status
 
+    // The frost's shape. By default a rounded rectangle built from
+    // `cornerRadius` - which is why, historically, a frosted card could *only*
+    // be a rounded rectangle: this was the one mask there was. A caller whose
+    // card is not a rounded rect (a MaterialShape card, morphing or settled)
+    // supplies its own mask item instead; OpacityMask only reads alpha, so any
+    // item drawing the card's outline serves. The fallback keeps every
+    // existing region record working untouched.
+    property Item maskItem: null
+
     readonly property Rectangle _mask: Rectangle {
         width: root.width
         height: root.height
@@ -103,7 +112,7 @@ Item {
         radius: root.blurRadius
         layer.enabled: true
         layer.effect: OpacityMask {
-            maskSource: root._mask
+            maskSource: root.maskItem ?? root._mask
         }
     }
 }

--- a/dots/.config/quickshell/imi/tests/lint_qmldir_registration.py
+++ b/dots/.config/quickshell/imi/tests/lint_qmldir_registration.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""A QML type used by identifier must be listed in its directory's qmldir.
+
+A directory with a `qmldir` is a module, and the qmldir is the whole of its
+type list: implicit same-directory resolution is OFF, and a directory import
+(`import "..." as Alias`) shows only the listed names too. So a new .qml file
+in such a directory is not a type until the qmldir says so - referencing it
+compiles nowhere and fails only at scene load, as `Type X unavailable` /
+`X is not a type`, taking every widget built on it down with it.
+
+That is not hypothetical. `WidgetCard.qml` shipped unregistered: the full test
+suite was green - `DesignSystemCompile` checked the file standalone and
+reported `failures=0` - and the deploy blanked every desktop widget at once.
+Second time this blind spot has bitten (the duplicate-import incident was the
+first), which per the house rule makes it a check rather than a note.
+
+Files reached only by URL (`Loader { source: "clock/PillClock.qml" }`) are
+deliberately exempt: a URL bypasses the qmldir, so listing is not required -
+the three NandoClock styles are the standing example. The lint therefore
+checks *references by identifier*, not directory contents:
+
+- a bare `TypeName {` in a file whose own directory holds `TypeName.qml`
+  under a qmldir that does not list it;
+- an `Alias.TypeName {` where `Alias` is a directory import of a qmldir
+  module that does not list `TypeName`.
+"""
+
+from pathlib import Path
+import re
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SKIP_DIRS = {".git", "node_modules", "__pycache__", "tests"}
+
+DIR_IMPORT = re.compile(r'^\s*import\s+"([^"]+)"\s+as\s+(\w+)\s*$', re.M)
+
+
+def listed_types(qmldir: Path) -> set:
+    names = set()
+    for line in qmldir.read_text(encoding="utf-8").splitlines():
+        parts = line.split()
+        # `Name File.qml` or `singleton Name File.qml` (with optional version
+        # numbers between) - the declared name is the first capitalised token.
+        if len(parts) >= 2 and parts[-1].endswith(".qml"):
+            for token in parts[:-1]:
+                if token[:1].isupper():
+                    names.add(token)
+                    break
+    return names
+
+
+def main() -> int:
+    qml_files = [p for p in sorted(ROOT.rglob("*.qml"))
+                 if not any(part in SKIP_DIRS for part in p.relative_to(ROOT).parts)]
+    modules = {}  # dir -> set of listed type names
+    for qmldir in ROOT.rglob("qmldir"):
+        if any(part in SKIP_DIRS for part in qmldir.relative_to(ROOT).parts):
+            continue
+        modules[qmldir.parent.resolve()] = listed_types(qmldir)
+
+    failures = []
+    for path in qml_files:
+        text = path.read_text(encoding="utf-8")
+        directory = path.parent.resolve()
+
+        # Bare same-directory siblings under a qmldir.
+        if directory in modules:
+            listed = modules[directory]
+            for sibling in directory.glob("*.qml"):
+                name = sibling.stem
+                if sibling == path or name in listed or not name[:1].isupper():
+                    continue
+                if re.search(rf"(?<![\w.\"/]){name}\s*\{{", text):
+                    failures.append(
+                        f"{path.relative_to(ROOT)}: uses `{name}` but "
+                        f"{directory.relative_to(ROOT.resolve())}/qmldir does not list it - "
+                        f"a qmldir directory has no implicit siblings, so this fails at "
+                        f"scene load as '{name} is not a type'.")
+
+        # Aliased directory imports of qmldir modules.
+        for match in DIR_IMPORT.finditer(text):
+            target = (directory / match.group(1)).resolve()
+            alias = match.group(2)
+            if target not in modules:
+                continue
+            listed = modules[target]
+            for use in re.finditer(rf"\b{alias}\.(\w+)\s*\{{", text):
+                name = use.group(1)
+                if name in listed or not (target / f"{name}.qml").exists():
+                    continue
+                failures.append(
+                    f"{path.relative_to(ROOT)}: uses `{alias}.{name}` but "
+                    f"{target.relative_to(ROOT.resolve())}/qmldir does not list it - "
+                    f"fails at scene load as 'Type {alias}.{name} unavailable'.")
+
+    if failures:
+        print("qmldir registration lint failed:\n", file=sys.stderr)
+        for failure in sorted(set(failures)):
+            print(f"  {failure}", file=sys.stderr)
+        return 1
+
+    print(f"qmldir registration lint passed: every identifier-referenced type is "
+          f"listed ({len(modules)} modules)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dots/.config/quickshell/imi/tests/lint_widget_card_tint.py
+++ b/dots/.config/quickshell/imi/tests/lint_widget_card_tint.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""A widget draws its surface with WidgetCard, not with a hand-rolled tint.
+
+The card exists because the same container was written four times - three
+byte-identical `useBlurBackground ? applyAlpha(tint, opacity) : tint`
+Rectangles in weather, currency and the media cookie, and a fourth in calendar
+that had already drifted to a different rounding token and colour source. Four
+copies is how container motion becomes four slightly different tunings.
+
+So the pattern that built those copies is now reserved to the component: the
+blur-thinned tint conditional may appear in WidgetCard.qml and nowhere else.
+This does not force a widget to use the card (the system monitor's three cards
+are its own composition); it forces a widget that wants the *standard* card
+look to get it from the standard card, where its motion can be tuned once.
+
+calendar/Widget.qml is the one temporary exemption: it is scheduled to be
+rebuilt on the card once the architecture settles on media and weather, and
+its drifted copy is left alone until then rather than half-migrated. Remove
+the exemption with the rebuild.
+"""
+
+from pathlib import Path
+import re
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SKIP_DIRS = {".git", "node_modules", "__pycache__", "tests"}
+
+ALLOWED = {
+    Path("modules/common/plugins/designsystem/widgets/WidgetCard.qml"),
+    # Rebuilt on the card after media and weather settle - see docstring.
+    Path("modules/common/plugins/bundled/calendar/Widget.qml"),
+}
+
+# The tint conditional, however the alpha helper is qualified and whatever the
+# tint colour is: `useBlurBackground ? <something>applyAlpha(...)`.
+TINT_PAIR = re.compile(r"useBlurBackground\s*\?\s*[\w.]*applyAlpha\s*\(", re.I)
+
+
+def main() -> int:
+    failures = []
+    for path in sorted(ROOT.rglob("*.qml")):
+        rel = path.relative_to(ROOT)
+        if any(part in SKIP_DIRS for part in rel.parts) or rel in ALLOWED:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+        for match in TINT_PAIR.finditer(text):
+            line = text.count("\n", 0, match.start()) + 1
+            failures.append(
+                f"{rel}:{line}: hand-rolled card tint. Use WidgetCard "
+                f"(tint/useBlurBackground/backgroundOpacity) so the surface and "
+                f"its motion are tuned in one place.")
+
+    if failures:
+        print("Widget card tint lint failed:\n", file=sys.stderr)
+        for failure in failures:
+            print(f"  {failure}", file=sys.stderr)
+        return 1
+
+    print("Widget card tint lint passed: the tint conditional lives in WidgetCard only")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -120,6 +120,12 @@ if ! python3 "$SCRIPT_DIR/lint_duplicate_imports.py"; then
     exit 1
 fi
 
+echo "Running qmldir registration lint..."
+if ! python3 "$SCRIPT_DIR/lint_qmldir_registration.py"; then
+    echo "qmldir registration lint failed."
+    exit 1
+fi
+
 echo "Running widget card tint lint..."
 if ! python3 "$SCRIPT_DIR/lint_widget_card_tint.py"; then
     echo "Widget card tint lint failed."

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -120,6 +120,12 @@ if ! python3 "$SCRIPT_DIR/lint_duplicate_imports.py"; then
     exit 1
 fi
 
+echo "Running widget card tint lint..."
+if ! python3 "$SCRIPT_DIR/lint_widget_card_tint.py"; then
+    echo "Widget card tint lint failed."
+    exit 1
+fi
+
 echo "Running cava claim lint..."
 if ! python3 "$SCRIPT_DIR/lint_cava_claims.py"; then
     echo "cava claim lint failed."

--- a/dots/.config/quickshell/imi/tests/tst_shape_fit.qml
+++ b/dots/.config/quickshell/imi/tests/tst_shape_fit.qml
@@ -1,0 +1,88 @@
+import QtTest
+import "../modules/common/plugins/designsystem/widgets/shapes/shape-fit.js" as ShapeFit
+
+// Where a normalised rounded polygon lands inside the item drawing it.
+//
+// This is the arithmetic that decides whether a shape can be a *card*. Under
+// the square rule a 320x112 card draws a 112x112 shape floating in the middle
+// of itself, which is why the stretch placement exists at all.
+//
+// It is scored here rather than on screen because a `Canvas` draws nothing
+// under the software scene graph the suite runs on: rendering proves the file
+// parses and nothing else. The placement is pure arithmetic, so it is checked
+// against arithmetic.
+TestCase {
+    name: "ShapeFitTest"
+
+    function test_the_square_placement_scales_by_the_short_side() {
+        const placement = ShapeFit.fit(320, 112, true, false);
+        compare(placement.scaleX, 112, "a square placement uses the short side");
+        compare(placement.scaleY, 112, "and uses it on both axes");
+    }
+
+    function test_the_square_placement_centres_what_it_shrinks() {
+        const placement = ShapeFit.fit(320, 112, true, false);
+        compare(placement.offsetX, 104, "(320 - 112) / 2");
+        compare(placement.offsetY, 0, "the short axis has nothing to centre");
+    }
+
+    function test_stretch_fills_the_box_on_both_axes() {
+        const placement = ShapeFit.fit(320, 112, true, true);
+        compare(placement.scaleX, 320);
+        compare(placement.scaleY, 112);
+        compare(placement.offsetX, 0, "filling leaves nothing to centre");
+        compare(placement.offsetY, 0);
+    }
+
+    function test_a_square_item_is_the_same_either_way() {
+        // The reason stretch is safe to add: on the shapes that already exist -
+        // glyphs, buttons, clock faces - it changes nothing.
+        const square = ShapeFit.fit(120, 120, true, false);
+        const stretched = ShapeFit.fit(120, 120, true, true);
+        compare(square.scaleX, stretched.scaleX);
+        compare(square.scaleY, stretched.scaleY);
+        compare(square.offsetX, stretched.offsetX);
+        compare(square.offsetY, stretched.offsetY);
+    }
+
+    function test_a_pixel_polygon_is_placed_but_never_scaled() {
+        const placement = ShapeFit.fit(320, 112, false, false);
+        compare(placement.scaleX, 1, "already in pixels");
+        compare(placement.scaleY, 1);
+        compare(placement.offsetX, 104, "but still centred, as it always was");
+    }
+
+    function test_a_degenerate_size_does_not_produce_nonsense() {
+        // A Canvas is laid out before it is sized, so this runs with 0 and with
+        // undefined on the first frames.
+        const zero = ShapeFit.fit(0, 0, true, true);
+        compare(zero.scaleX, 0);
+        compare(zero.scaleY, 0);
+        const undef = ShapeFit.fit(undefined, undefined, true, false);
+        compare(undef.scaleX, 0);
+        compare(undef.offsetX, 0);
+    }
+
+    function test_mapping_puts_a_normalised_point_where_the_placement_says() {
+        const placement = ShapeFit.fit(320, 112, true, true);
+        compare(ShapeFit.mapX(0, placement), 0, "left edge");
+        compare(ShapeFit.mapX(1, placement), 320, "right edge");
+        compare(ShapeFit.mapY(0.5, placement), 56, "vertical centre");
+    }
+
+    function test_mapping_respects_the_square_placement_offset() {
+        const placement = ShapeFit.fit(320, 112, true, false);
+        compare(ShapeFit.mapX(0, placement), 104, "the shape starts after the gap");
+        compare(ShapeFit.mapX(1, placement), 216, "and ends before the other one");
+        compare(ShapeFit.mapY(1, placement), 112);
+    }
+
+    function test_the_stretched_aspect_is_the_items_aspect() {
+        // The property that makes a stretched shape usable as a card outline:
+        // the drawn shape has the box's aspect, not the polygon's.
+        const placement = ShapeFit.fit(300, 100, true, true);
+        const width = ShapeFit.mapX(1, placement) - ShapeFit.mapX(0, placement);
+        const height = ShapeFit.mapY(1, placement) - ShapeFit.mapY(0, placement);
+        compare(width / height, 3, "300 x 100 is 3:1");
+    }
+}


### PR DESCRIPTION
Step 1 of the expressive-morphing landing plan (spec merged in #174; visual brief: https://claude.ai/code/artifact/bb2ce6ec-18f9-421f-9abe-35783403d3e5). Deduplication and foundations only — nothing morphs yet, and nothing should look different on screen.

## What the spec got wrong, found by building

**Borders were not the loss.** The spec claimed a shape loses `border.width` and needs a stroked path added. `ShapeCanvas` already strokes (`borderWidth`/`borderColor`). What a shape actually could not do was **be a card at all**: every normalised polygon was scaled by `min(width, height)` and centred, so a 320×112 card would draw a 112×112 shape floating in its middle.

So the foundation commit is an opt-in `stretch` placement on `ShapeCanvas` — provably identical to the square placement on square items, which is what makes it safe under every existing caller. The path is now built in pixel space rather than through `ctx.scale()`: scaling the context scales the pen, and only a *uniform* scale cancels that with one divide — stretched axes differ, so a border would have come out thicker on the short axis by the aspect ratio. The placement arithmetic moved to `shape-fit.js` because inside `onPaint` it was untestable (a Canvas draws nothing under the software scene graph); it now carries 11 tests, mutation-verified.

**The copy count was wrong: seven, not four.** The lint written to hold the rule found three more hand-rolled tint pairs on its first run — the media 3×2, the media 2×1, and the system monitor's helper feeding three cards. calendar's drift also went further than the spec recorded: it doesn't use the conditional at all.

## The card

`WidgetCard` owns what every copy spelled out: the tint pair (opaque normally, alpha-thinned when frosting), the 30-unit rounding, an optional content clip (weather's split panels), and a `blurRegion` record so a widget cannot disagree with its card about where the frost goes. Shape is a parameter: unset → the plain `Rectangle` it always was; a `MaterialShape` name → that polygon stretched to the card's box, drawn by the same `ShapeCanvas` the wallpaper shape picker morphs — so a card whose `shapeName` changes morphs for free.

Six adoptions: weather, currency, media cookie, media 3×2, media 2×1, and the system monitor as **three cards with three tints** — the zero-one-many composition the component was shaped around. Frost stays widget-level, per the settled design.

Weather also loses its `Behavior on implicitWidth` — a hardcoded 250 ms second clock on the movement `PluginWidget` already animates, running even with the resize setting off.

## Frost's half

`WallpaperBlurSurface` prefers a caller-supplied mask item and falls back to its radius `Rectangle`; a `PluginWidget` region record may carry `mask`. `OpacityMask` only reads alpha, so a `MaterialShape` serves as a mask unchanged. Every existing record is untouched — this is the wiring a morphing frosted card needs later, landed while the file is open.

## Tests

527 passed, 0 failed; `DesignSystemCompile checked=160 failures=0` (the card is compiled). New: `tst_shape_fit.qml` (11 tests) and `lint_widget_card_tint.py`.

| mutation | reddens |
|---|---|
| stretch ignores the box | 3 |
| pixel polygon loses centring | 1 |
| mapX drops the offset | 1 |
| tint pair planted in a widget | the lint, naming file and line |

The lint's calendar exemption is named and expires with calendar's scheduled rebuild.

## Not in this PR

Two diverged copies of `ShapeCanvas` exist (`common/widgets/shapes/` vs `designsystem/widgets/shapes/` — different properties, different animation sources). Only the designsystem one, which all six adopters resolve to, gained `stretch`. Unifying the copies is the same duplication problem one layer down and deserves its own change.

On-screen check: all six widgets should look exactly as before — same tints, same rounding, weather's corner clip intact, frost unchanged. The one visible difference is intended: weather's width no longer runs its own 250 ms animation against the widget's resize animation.

Docs: updated AGENT.md §Dynamic/data-driven QML gotchas
