### PR TITLE
feat(widgets): elastic resize - tension, breakaway, and a card that bows

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1207,6 +1207,17 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   `shapeName` parameter that turns the card into a stretched `MaterialShape` (which morphs on any
   shape change, because `ShapeCanvas` does). calendar is the one exempted copy until its scheduled
   rebuild. b362d8c80 ("feat(widgets): one card component for the surface every widget redrew").
+- **The resize grip accumulates tension; it does not pick the nearest span.** A widget holds its
+  span while pull builds, gives one offered span per 60px breakaway with the remainder carried, and
+  rubber-bands at a wall. `resize-tension.js` owns every constant and all of the arithmetic; the
+  host exposes the live bow as `resizeBow`, injected into wrappers as `hostResizeBow` by the same
+  duck-typed pattern as `hostGridSize`, and a `WidgetCard` renders it via `tensionX`/`tensionY`.
+  Two things to know before touching it: spent pull must move the gesture's origin (the grip
+  re-bases its press point by exactly what a give consumed, or the next mouse event re-delivers the
+  pull and the resize sprints to the largest span), and a sub-breakaway regression probe is only
+  meaningful at a span with somewhere to step - probed at a wall, both semantics hold the span and
+  the check is vacuous. ccde619bf ("feat(plugins): the grip accumulates tension instead of picking
+  the nearest span").
 - **A subclass cannot read `AbstractWidget.gridSize`: `PluginWidget` shadows it.** The base's
   `gridSize` is the 12px drag lattice; `PluginWidget` declares its own `gridSize`, the
   component-grid span (`{"cols": 2, "rows": 1}`). Code *inside* the base still resolves to the

--- a/dots/.config/quickshell/imi/WidgetResizeGripRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/WidgetResizeGripRuntimeTest.qml
@@ -210,9 +210,16 @@ ShellRoot {
         harness.check(`${label}: the widget stays put`,
                       after.resizableX === harness.before.resizableX
                       && after.resizableY === harness.before.resizableY);
+        // Against the span REMEMBERED at the gesture's start, not a literal:
+        // the original hardcoded span 2 and was only ever called at 2x2, so
+        // the first caller at another span failed on a correct tree.
+        const spanCols = parseInt(harness.before.resizableSize[0]);
+        const spanRows = parseInt(harness.before.resizableSize[2]);
         harness.check(`${label}: the widget is back at its stored span`,
                       Math.round(resizableWidget.width)
-                          === Math.round(Appearance.sizes.widgetGridSpanX(2)));
+                          === Math.round(Appearance.sizes.widgetGridSpanX(spanCols))
+                      && Math.round(resizableWidget.height)
+                          === Math.round(Appearance.sizes.widgetGridSpanY(spanRows)));
     }
 
     // The control. A widget offering one span has no grip, so the same gesture
@@ -271,6 +278,18 @@ ShellRoot {
         () => harness.hoverGrip(resizableWidget),
         () => harness.dragPending(144, 120),
         () => harness.scoreResize("grow back to 3x2", "3x2"),
+
+        // The elastic model's discriminating case, and the exact inverse of
+        // the old semantics: a pull SHORT of the breakaway (60px) must not
+        // resize. It runs at 3x2 with an inward pull because a smaller span
+        // exists in that direction - probed at a wall, both semantics hold
+        // the span and the check proves nothing (measured, not guessed).
+        // Under nearest-span mapping a 40px drag stepped; under tension it
+        // builds bow and commits nothing.
+        () => harness.remember(),
+        () => harness.hoverGrip(resizableWidget),
+        () => harness.dragPending(-40, 0),
+        () => harness.scoreCancelled("a pull short of the breakaway"),
 
         () => harness.remember(),
         () => harness.hoverGrip(resizableWidget),

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginNode.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginNode.qml
@@ -58,6 +58,9 @@ Item {
     // manifest declares no grid. It tracks the resize grip's live preview, so a
     // drag reshapes the content as it goes instead of on release.
     property string gridSize: ""
+    // The resize grip's live edge distortion, forwarded to widgets whose cards
+    // bow under tension. A point of pixels; (0,0) at rest.
+    property point resizeBow: Qt.point(0, 0)
 
     readonly property string effectiveBasePath: manifestNode?._basePath || basePath
     readonly property string componentPath: manifestNode?.component && effectiveBasePath
@@ -161,6 +164,8 @@ Item {
                     item.hostInteractionLocked = Qt.binding(() => rootNode.hostInteractionLocked);
                 if (item.hostGridSize !== undefined)
                     item.hostGridSize = Qt.binding(() => rootNode.gridSize);
+                if (item.hostResizeBow !== undefined)
+                    item.hostResizeBow = Qt.binding(() => rootNode.resizeBow);
                 return;
             }
             if (manifestNode.props) {

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
@@ -9,6 +9,7 @@ import qs.modules.common.widgets
 import qs.modules.imi.background.widgets
 import "../functions/parallax.js" as ParallaxMath
 import "gridSizes.js" as GridSizes
+import "resize-tension.js" as Tension
 import "gridResize.js" as GridResize
 
 AbstractBackgroundWidget {
@@ -269,28 +270,69 @@ AbstractBackgroundWidget {
         rootWidget.previewGridSize = rootWidget.storedGridSize;
     }
 
-    // The offered spans measured in pixels, which is where Appearance's
-    // effectiveScale enters: the snap compares the dragged rectangle against
-    // what each span would actually be on this screen, not against cell counts.
-    function previewGridResize(targetWidth, targetHeight) {
+    // ---- elastic resize (spec 3d) ---------------------------------------
+    //
+    // The grip no longer picks the nearest span - it accumulates PULL. The
+    // widget holds its span while tension builds; each whole breakaway steps
+    // one span in the pulled direction and the remainder carries, so a long
+    // drag walks several spans in one gesture. At a wall (no offered span
+    // further out) the leftover pull is held, clamped to one breakaway, so
+    // the bow rubber-bands against the limit instead of winding up unbounded.
+    //
+    // `resizeBow` is what the widget's cards render: the edge distortion in
+    // pixels, derived from the *unconsumed* pull. Zero the instant the drag
+    // ends - the settle back to the committed span is the box animation's job.
+    property real resizePullX: 0
+    property real resizePullY: 0
+    readonly property point resizeBow: Qt.point(
+        rootWidget.resizingGrid ? Tension.bow(rootWidget.resizePullX) : 0,
+        rootWidget.resizingGrid ? Tension.bow(rootWidget.resizePullY) : 0)
+
+    function previewGridResize(pullX, pullY) {
         if (!rootWidget.resizingGrid) return;
-        const nearest = GridSizes.nearestSize(rootWidget.offeredGridSizes.map(size => ({
-            cols: size.cols,
-            rows: size.rows,
-            width: Appearance.sizes.widgetGridSpanX(size.cols),
-            height: Appearance.sizes.widgetGridSpanY(size.rows)
-        })), targetWidth, targetHeight);
-        if (nearest) rootWidget.previewGridSize = nearest;
+        let current = rootWidget.previewGridSize;
+        const giveX = Tension.giveAxis(pullX);
+        const giveY = Tension.giveAxis(pullY);
+        let remainderX = giveX.remainder;
+        let remainderY = giveY.remainder;
+        for (let i = 0; i < Math.abs(giveX.steps); i++) {
+            const next = Tension.stepSize(rootWidget.offeredGridSizes, current,
+                Math.sign(giveX.steps), 0);
+            // The wall: the un-stepped pull stays live (capped), so the bow
+            // holds and the gesture does not eat pull that moved nothing.
+            if (next === current) { remainderX = Math.sign(pullX) * Tension.BREAK_PX; break; }
+            current = next;
+        }
+        for (let i = 0; i < Math.abs(giveY.steps); i++) {
+            const next = Tension.stepSize(rootWidget.offeredGridSizes, current,
+                0, Math.sign(giveY.steps));
+            if (next === current) { remainderY = Math.sign(pullY) * Tension.BREAK_PX; break; }
+            current = next;
+        }
+        rootWidget.previewGridSize = current;
+        rootWidget.resizePullX = remainderX;
+        rootWidget.resizePullY = remainderY;
+    }
+
+    // A give consumes pull, and the *gesture's* origin has to move with it or
+    // the next mouse event re-delivers the spent pull and the resize sprints
+    // to the largest span. The grip owns the press point, so it asks.
+    function consumedPull(pullX, pullY) {
+        return Qt.point(pullX - rootWidget.resizePullX, pullY - rootWidget.resizePullY);
     }
 
     function endGridResize() {
         const chosen = rootWidget.previewGridSize;
         rootWidget.previewGridSize = null;
+        rootWidget.resizePullX = 0;
+        rootWidget.resizePullY = 0;
         rootWidget.commitGridSize(chosen);
     }
 
     function cancelGridResize() {
         rootWidget.previewGridSize = null;
+        rootWidget.resizePullX = 0;
+        rootWidget.resizePullY = 0;
     }
 
     configEntryName: manifest ? "plugin_" + manifest.id : "plugin_unknown"
@@ -584,6 +626,7 @@ AbstractBackgroundWidget {
         // the content is *showing*, which lags the widget's own by half a
         // resize - see shownGridSpan.
         gridSize: rootWidget.shownGridSpan
+        resizeBow: rootWidget.resizeBow
         anchors.centerIn: parent
     }
 
@@ -665,9 +708,14 @@ AbstractBackgroundWidget {
             onPositionChanged: mouse => {
                 if (!rootWidget.resizingGrid) return;
                 const scenePoint = resizeArea.mapToItem(null, mouse.x, mouse.y);
-                rootWidget.previewGridResize(
-                    resizeArea.pressWidth + scenePoint.x - resizeArea.pressSceneX,
-                    resizeArea.pressHeight + scenePoint.y - resizeArea.pressSceneY);
+                const pullX = scenePoint.x - resizeArea.pressSceneX;
+                const pullY = scenePoint.y - resizeArea.pressSceneY;
+                rootWidget.previewGridResize(pullX, pullY);
+                // Move the gesture's origin by whatever the give consumed, so
+                // spent pull is not re-delivered on the next event.
+                const consumed = rootWidget.consumedPull(pullX, pullY);
+                resizeArea.pressSceneX += consumed.x;
+                resizeArea.pressSceneY += consumed.y;
             }
             // A release after Escape commits nothing: the cancel already
             // cleared the preview, and endGridResize has nothing to store.

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
@@ -591,14 +591,27 @@ AbstractBackgroundWidget {
         }
     }
 
-    PluginNode {
-        id: pluginNode
+    // The layer lives on this wrapper rather than on the node so its texture
+    // is a ring larger than the widget: a layer clips at its item's bounds,
+    // and the resize bow deliberately draws up to 2*BOW_PX outside the card -
+    // on the node's own layer the bulge came back with its edge sliced flat.
+    // The node keeps its exact geometry (centred both ways cancels out), so
+    // every coordinate that references it - blur regions included - is
+    // untouched.
+    Item {
+        id: nodeLayerFrame
         z: 1
+        anchors.centerIn: parent
+        width: pluginNode.width + Tension.BOW_PX * 4
+        height: pluginNode.height + Tension.BOW_PX * 4
         // Render package widgets on a bounded texture above the blur backdrop.
         // This avoids the background layer swallowing package content on some
         // Wayland scene-graph paths while keeping the texture widget-sized.
-        layer.enabled: width > 0 && height > 0
+        layer.enabled: pluginNode.width > 0 && pluginNode.height > 0
         layer.smooth: true
+
+    PluginNode {
+        id: pluginNode
         manifestNode: rootWidget.manifest ? rootWidget.manifest.desktopWidget : null
         pluginId: rootWidget.manifest?.id ?? ""
         optionDefinitions: rootWidget.manifest?.options ?? []
@@ -628,6 +641,7 @@ AbstractBackgroundWidget {
         gridSize: rootWidget.shownGridSpan
         resizeBow: rootWidget.resizeBow
         anchors.centerIn: parent
+    }
     }
 
     // Resize grip, for a widget whose manifest offers more than one span. It

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-currency/Widget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-currency/Widget.qml
@@ -14,6 +14,7 @@ Item {
     // `sizeMode` choice option of its own - a second mechanism for the concept
     // `__gridSize` now owns, in the same format.
     property string hostGridSize: ""
+    property point hostResizeBow: Qt.point(0, 0)
     implicitWidth: content.implicitWidth
     implicitHeight: content.implicitHeight
     width: implicitWidth
@@ -34,6 +35,7 @@ Item {
         width: implicitWidth
         height: implicitHeight
         sizeMode: root.hostGridSize || "2x1"
+        resizeBow: root.hostResizeBow
         useBlurBackground: PluginState.option("nandoroid_currency", "blurEnabled", false)
         backgroundOpacity: PluginState.effectiveBackgroundOpacity("nandoroid_currency")
         onBaseCurrencyRequested: value => PluginState.setOption("nandoroid_currency", "baseCurrency", value)

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/LayoutCompact.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/LayoutCompact.qml
@@ -26,6 +26,7 @@ Item {
     readonly property bool useBlurBackground: PluginState.option("nandoroid_media", "blurEnabled", false)
     readonly property real backgroundOpacity: PluginState.effectiveBackgroundOpacity("nandoroid_media")
 
+    property point resizeBow: Qt.point(0, 0)
     readonly property bool managesBlurTint: true
     readonly property var blurRegions: [{
         x: bgCard.x, y: bgCard.y, width: bgCard.width, height: bgCard.height, radius: bgCard.radius
@@ -57,6 +58,8 @@ Item {
         anchors.fill: parent
         useBlurBackground: root.useBlurBackground
         backgroundOpacity: root.backgroundOpacity
+        tensionX: root.resizeBow.x
+        tensionY: root.resizeBow.y
     }
 
     RowLayout {

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/LayoutCookie.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/LayoutCookie.qml
@@ -29,6 +29,7 @@ Item {
     readonly property bool useBlurBackground: PluginState.option("nandoroid_media", "blurEnabled", false)
     readonly property real backgroundOpacity: PluginState.effectiveBackgroundOpacity("nandoroid_media")
 
+    property point resizeBow: Qt.point(0, 0)
     readonly property bool managesBlurTint: true
     readonly property var blurRegions: [bgCard.blurRegion]
 
@@ -88,6 +89,8 @@ Item {
         anchors.fill: parent
         useBlurBackground: root.useBlurBackground
         backgroundOpacity: root.backgroundOpacity
+        tensionX: root.resizeBow.x
+        tensionY: root.resizeBow.y
     }
 
     Item {

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/Widget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/Widget.qml
@@ -10,6 +10,7 @@ Item {
     // then the manifest default. Empty until the host answers, and for a bare
     // `qs -p` probe of this file.
     property string hostGridSize: ""
+    property point hostResizeBow: Qt.point(0, 0)
 
     readonly property var span: MediaLayouts.spanFor(root.hostGridSize)
 
@@ -26,5 +27,12 @@ Item {
         id: layout
         anchors.fill: parent
         source: MediaLayouts.layoutFor(root.hostGridSize)
+        // Duck-typed like PluginNode's own injection: a layout that declares
+        // `resizeBow` receives the grip's tension, one that does not is left
+        // alone (LayoutLarge has no card to bow yet).
+        onLoaded: {
+            if (item.resizeBow !== undefined)
+                item.resizeBow = Qt.binding(() => root.hostResizeBow);
+        }
     }
 }

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-system-monitor/Widget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-system-monitor/Widget.qml
@@ -5,6 +5,7 @@ import "../../designsystem/widgets" as Expressive
 import "ThirdCard.js" as ThirdCard
 
 Item {
+    property point hostResizeBow: Qt.point(0, 0)
     readonly property var blurRegions: content.blurRegions
     readonly property bool managesBlurTint: content.managesBlurTint
     implicitWidth: content.implicitWidth
@@ -13,6 +14,7 @@ Item {
     height: implicitHeight
     Expressive.DesktopSystemMonitorWidget {
         id: content
+        resizeBow: root.hostResizeBow
         width: implicitWidth
         height: implicitHeight
         isVertical: PluginState.option("nandoroid_system_monitor", "vertical", false)

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-weather/Widget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-weather/Widget.qml
@@ -12,6 +12,7 @@ Item {
     // `sizeMode` choice option of its own - a second mechanism for the concept
     // `__gridSize` now owns, in the same format.
     property string hostGridSize: ""
+    property point hostResizeBow: Qt.point(0, 0)
     implicitWidth: content.implicitWidth
     implicitHeight: content.implicitHeight
     width: implicitWidth
@@ -21,6 +22,7 @@ Item {
         width: implicitWidth
         height: implicitHeight
         sizeMode: root.hostGridSize || "3x1"
+        resizeBow: root.hostResizeBow
         useBlurBackground: PluginState.option("nandoroid_weather", "blurEnabled", false)
         backgroundOpacity: PluginState.effectiveBackgroundOpacity("nandoroid_weather")
     }

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopCurrencyWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopCurrencyWidget.qml
@@ -15,6 +15,7 @@ Item {
     property var cfg: Config.ready ? Config.options.appearance.currencyWidget : null
     property string sizeMode: cfg ? cfg.sizeMode : "2x1"
     property bool useBlurBackground: false
+    property point resizeBow: Qt.point(0, 0)
     // The host wrapper overrides this with its own plugin id; the fallback keeps
     // the toggle honoured for a component instantiated without one.
 
@@ -90,6 +91,8 @@ Item {
         tint: Appearance.colors.colPrimaryContainer
         useBlurBackground: root.useBlurBackground
         backgroundOpacity: root.backgroundOpacity
+        tensionX: root.resizeBow.x
+        tensionY: root.resizeBow.y
 
         // --- PAGE 1: View Mode ---
         Item {

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopSystemMonitorWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopSystemMonitorWidget.qml
@@ -44,6 +44,10 @@ Item {
     property real cardSpacing: 12 * Appearance.effectiveScale
     property real cardHeight: isVertical ? (108 * Appearance.effectiveScale) : (108 * Appearance.effectiveScale)
     property real cardWidth: isVertical ? (132 * Appearance.effectiveScale) : ((420 * Appearance.effectiveScale - cardSpacing * 2) / 3)
+    // The grip sits at the widget's bottom-right, so the tension lands on the
+    // card under it - thirdCard. All three bowing identically would read as
+    // jelly, not as a pull.
+    property point resizeBow: Qt.point(0, 0)
     readonly property var blurRegions: [
         cpuCard.blurRegion,
         ramCard.blurRegion,
@@ -247,6 +251,8 @@ Item {
             tint: Appearance.colors.colTertiaryContainer
             useBlurBackground: root.useBlurBackground
             backgroundOpacity: root.backgroundOpacity
+            tensionX: root.resizeBow.x
+            tensionY: root.resizeBow.y
 
             // Sisi Atas: Liquid Cookie12Sided (Centered Top)
             Item {

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopWeatherWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopWeatherWidget.qml
@@ -14,6 +14,9 @@ Item {
     property var cfg: Config.ready ? Config.options.appearance.weatherWidget : null
     property string sizeMode: cfg ? cfg.sizeMode : "3x1"
     property bool useBlurBackground: false
+    // The grip's live tension, from the host through the wrapper. The card
+    // renders it; this widget only passes it along.
+    property point resizeBow: Qt.point(0, 0)
     // The host wrapper overrides this with its own plugin id; the fallback keeps
     // the toggle honoured for a component instantiated without one.
 
@@ -76,6 +79,8 @@ Item {
         useBlurBackground: root.useBlurBackground
         backgroundOpacity: root.backgroundOpacity
         clipContent: true
+        tensionX: root.resizeBow.x
+        tensionY: root.resizeBow.y
 
         // Layout Loader based on sizeMode
         Loader {

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/WidgetCard.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/WidgetCard.qml
@@ -3,6 +3,7 @@ import Qt5Compat.GraphicalEffects
 import qs.modules.common
 import qs.modules.common.functions as Functions
 import "./shapes"
+import "../../resize-tension.js" as Tension
 
 // The surface a desktop widget draws itself on.
 //
@@ -62,12 +63,63 @@ Item {
     default property alias data: contentItem.data
     property bool clipContent: false
 
+    // ---- tension ---------------------------------------------------------
+    // The bow the host's resize grip is applying, in pixels (resize-tension.js
+    // owns the arithmetic). Zero at rest - and at rest the surface below is
+    // the plain Rectangle, so a card that is never pulled never pays for a
+    // Canvas. The clip mask deliberately stays the rounded rectangle: the bow
+    // reaches at most BOW_PX outside the rect, and clipped content already
+    // sits inside it.
+    property real tensionX: 0
+    property real tensionY: 0
+    readonly property bool underTension: !root.usesShapeCanvas
+        && (root.tensionX !== 0 || root.tensionY !== 0)
+
     Rectangle {
         id: rectSurface
-        visible: !root.usesShapeCanvas
+        visible: !root.usesShapeCanvas && !root.underTension
         anchors.fill: parent
         radius: root.radius
         color: root.effectiveColor
+    }
+
+    // The bulged surface, alive only while pulled. Margins give the bow room
+    // to draw outside the card's own box without being cut by the item.
+    Loader {
+        active: root.underTension
+        anchors.fill: parent
+        anchors.margins: -Tension.BOW_PX * 2
+        sourceComponent: Canvas {
+            id: tensionCanvas
+            onPaint: {
+                const ctx = getContext("2d");
+                ctx.clearRect(0, 0, width, height);
+                const pad = Tension.BOW_PX * 2;
+                const radii = Tension.cornerRadii(root.radius, root.tensionX, root.tensionY);
+                const path = Tension.outline(root.width, root.height,
+                    root.tensionX, root.tensionY, radii);
+                ctx.save();
+                ctx.translate(pad, pad);
+                ctx.fillStyle = root.effectiveColor;
+                ctx.beginPath();
+                for (const seg of path.segments) {
+                    if (seg.op === "move") ctx.moveTo(seg.x, seg.y);
+                    else if (seg.op === "line") ctx.lineTo(seg.x, seg.y);
+                    else ctx.quadraticCurveTo(seg.cx, seg.cy, seg.x, seg.y);
+                }
+                ctx.closePath();
+                ctx.fill();
+                ctx.restore();
+            }
+            // A Canvas repaints on resize and nothing else - mirror every
+            // input onPaint reads, or the shape keeps stale values.
+            Connections {
+                target: root
+                function onTensionXChanged() { tensionCanvas.requestPaint(); }
+                function onTensionYChanged() { tensionCanvas.requestPaint(); }
+                function onEffectiveColorChanged() { tensionCanvas.requestPaint(); }
+            }
+        }
     }
 
     Loader {

--- a/dots/.config/quickshell/imi/modules/common/plugins/resize-tension.js
+++ b/dots/.config/quickshell/imi/modules/common/plugins/resize-tension.js
@@ -1,0 +1,139 @@
+.pragma library
+
+// The arithmetic of an elastic resize.
+//
+// The model (docs/superpowers/specs/2026-08-11-expressive-morphing-design.md
+// §3d): the card holds its size while pull builds, the edges being pulled
+// distort first, and only past a breakaway threshold does the material give
+// and the widget spring to the next offered span. Leftover pull carries, so
+// one long drag walks through several spans without a re-grab.
+//
+// Pure by design: the grip handler feeds pointer deltas in and binds the
+// results out, and everything below is scored by tests rather than by eye.
+// The constants were tuned on screen against the design brief's live demo and
+// are data, not preferences - change them here and nowhere else.
+
+var BREAK_PX = 60;        // pull before the card gives
+var BOW_PX = 14;          // how far an edge distorts at full tension
+var BOW_EASE = 1.15;      // >1: resists, then gives - force must be built
+var BULGE_PEAK = 0.85;    // the bulge sits near the corner being pulled
+var CORNER_FOLLOW = 1.0;  // the dragged corner leads; the edges follow it
+var SHARPEN = 0.5;        // pulled corner tightens, its neighbours open up
+
+// ---- breakaway -----------------------------------------------------------
+
+// How many spans a pull is worth, and what is left of it afterwards.
+//
+// Whole breakaways convert to steps; the remainder stays as live tension so
+// the bow does not snap to zero the instant a span commits. Sign carries
+// direction.
+function giveAxis(pull, breakPx) {
+    var limit = breakPx > 0 ? breakPx : BREAK_PX;
+    var steps = Math.trunc(pull / limit);
+    return { steps: steps, remainder: pull - steps * limit };
+}
+
+// The offered size one step along an axis, or the current one at a wall.
+//
+// `offered` is the manifest's list of {cols, rows}. A cols-step keeps the row
+// count when it can (2x1 -> 3x1, not 2x1 -> 3x2) and otherwise takes the
+// nearest row count among candidates; a rows-step mirrors that. Returns the
+// CURRENT size when no offered size lies in the pulled direction - the wall
+// the remaining tension rubber-bands against.
+function stepSize(offered, current, dCols, dRows) {
+    if (!offered || offered.length === 0 || !current) return current;
+    var best = null;
+    var bestPreferred = false;
+    var bestDistance = Infinity;
+    for (var i = 0; i < offered.length; i++) {
+        var candidate = offered[i];
+        if (dCols > 0 && candidate.cols <= current.cols) continue;
+        if (dCols < 0 && candidate.cols >= current.cols) continue;
+        if (dRows > 0 && candidate.rows <= current.rows) continue;
+        if (dRows < 0 && candidate.rows >= current.rows) continue;
+        // Preferred: the off-axis count survives the step (2x1 -> 3x1 on a
+        // cols pull, not 2x1 -> 3x2). A preferred candidate always beats a
+        // non-preferred one; ties resolve to the smallest step.
+        var preferred = dCols !== 0
+            ? candidate.rows === current.rows
+            : candidate.cols === current.cols;
+        var distance = dCols !== 0
+            ? Math.abs(candidate.cols - current.cols)
+            : Math.abs(candidate.rows - current.rows);
+        if (best === null
+                || (preferred && !bestPreferred)
+                || (preferred === bestPreferred && distance < bestDistance)) {
+            best = candidate;
+            bestPreferred = preferred;
+            bestDistance = distance;
+        }
+    }
+    return best ?? current;
+}
+
+// ---- the bow -------------------------------------------------------------
+
+// Edge distortion for a given pull. Sign-preserving power curve: at
+// BOW_EASE > 1 the edge barely moves under a light pull and gives increasingly
+// as the pull approaches the breakaway - force has to be built.
+function bow(pull, breakPx, bowPx, ease) {
+    var limit = breakPx > 0 ? breakPx : BREAK_PX;
+    var reach = bowPx !== undefined ? bowPx : BOW_PX;
+    var exponent = ease !== undefined ? ease : BOW_EASE;
+    var t = Math.max(-1, Math.min(1, pull / limit));
+    return Math.sign(t) * Math.pow(Math.abs(t), exponent) * reach;
+}
+
+// ---- corners under load --------------------------------------------------
+
+// The corner radii of a card whose bottom-right corner is being pulled.
+// Fixed radii are what read as "a rectangle with bent sides": under load the
+// pulled corner tightens (material drawn toward a point), the two corners it
+// pulls away from open up, and the anchored corner keeps its rest radius.
+function cornerRadii(cap, bowX, bowY, bowPx, sharpen) {
+    var reach = bowPx !== undefined ? bowPx : BOW_PX;
+    var grip = sharpen !== undefined ? sharpen : SHARPEN;
+    var tx = reach > 0 ? Math.max(-1, Math.min(1, bowX / reach)) : 0;
+    var ty = reach > 0 ? Math.max(-1, Math.min(1, bowY / reach)) : 0;
+    var load = Math.min(1, Math.hypot(tx, ty));
+    return {
+        tl: cap,
+        tr: cap * (1 + grip * 0.5 * Math.abs(ty)),
+        br: Math.max(2, cap * (1 - grip * load)),
+        bl: cap * (1 + grip * 0.5 * Math.abs(tx))
+    };
+}
+
+// ---- the outline ---------------------------------------------------------
+
+// The bulged rounded rectangle, as segments a Canvas can draw and a test can
+// chain-check. Every corner is rounded - the first version of this shape (in
+// the design brief's demo) ended two edges on a bare point and the corner
+// became a spike. The dragged corner travels CORNER_FOLLOW of the bulge; the
+// bulge peak sits BULGE_PEAK of the way toward it.
+//
+// Returns { segments: [...] } where each segment is
+//   { op: "move"|"line", x, y }  or  { op: "quad", cx, cy, x, y }.
+function outline(w, h, bowX, bowY, radii, peak, follow) {
+    var p = peak !== undefined ? peak : BULGE_PEAK;
+    var f = follow !== undefined ? follow : CORNER_FOLLOW;
+    var rTL = Math.min(radii.tl, w / 2, h / 2);
+    var rTR = Math.min(radii.tr, w / 2, h / 2);
+    var rBR = Math.min(radii.br, w / 2, h / 2);
+    var rBL = Math.min(radii.bl, w / 2, h / 2);
+    var cx = w + bowX * f;
+    var cy = h + bowY * f;
+    var midY = rTR + ((cy - rBR) - rTR) * p;
+    var midX = rBL + ((cx - rBR) - rBL) * p;
+    return { segments: [
+        { op: "move", x: rTL, y: 0 },
+        { op: "line", x: w - rTR, y: 0 },
+        { op: "quad", cx: w, cy: 0, x: w, y: rTR },
+        { op: "quad", cx: w + bowX, cy: midY, x: cx, y: cy - rBR },
+        { op: "quad", cx: cx, cy: cy, x: cx - rBR, y: cy },
+        { op: "quad", cx: midX, cy: h + bowY, x: rBL, y: h },
+        { op: "quad", cx: 0, cy: h, x: 0, y: h - rBL },
+        { op: "line", x: 0, y: rTL },
+        { op: "quad", cx: 0, cy: 0, x: rTL, y: 0 }
+    ] };
+}

--- a/dots/.config/quickshell/imi/tests/test_expressive_design_system.py
+++ b/dots/.config/quickshell/imi/tests/test_expressive_design_system.py
@@ -173,7 +173,15 @@ class ExpressiveDesignSystemTest(unittest.TestCase):
         background = (ROOT / "modules/imi/background/Background.qml").read_text(encoding="utf-8")
         self.assertIn("modelData.startupSafe !== false", background)
         host = (ROOT / "modules/common/plugins/PluginWidget.qml").read_text(encoding="utf-8")
-        self.assertRegex(host, r"id:\s*pluginNode\s*z:\s*1\b")
+        # The node renders above the frost (z 1). The z moved from the node
+        # itself to nodeLayerFrame - the padded wrapper carrying the bounded
+        # layer, sized with room for the resize bow - so the contract is that
+        # the frame is z 1 and the node lives inside it.
+        self.assertRegex(host, r"id:\s*nodeLayerFrame\s*z:\s*1\b")
+        frame_index = host.index("id: nodeLayerFrame")
+        node_index = host.index("id: pluginNode")
+        self.assertLess(frame_index, node_index,
+                        "the node must sit inside the layered frame")
         currency_widget = (
             DESIGN_SYSTEM / "widgets" / "DesktopCurrencyWidget.qml"
         ).read_text(encoding="utf-8")

--- a/dots/.config/quickshell/imi/tests/tst_resize_tension.qml
+++ b/dots/.config/quickshell/imi/tests/tst_resize_tension.qml
@@ -1,0 +1,166 @@
+import QtTest
+import "../modules/common/plugins/resize-tension.js" as Tension
+
+// The elastic resize's arithmetic: breakaway with carry, the bow's force
+// curve, corner radii under load, and the bulged outline. Everything here is
+// what the grip binds at runtime, scored against arithmetic rather than eyes -
+// the on-screen half (does it *feel* heavy) is the design brief's demo, which
+// these constants were tuned in.
+TestCase {
+    name: "ResizeTensionTest"
+
+    // ---- breakaway ----
+
+    function test_a_pull_short_of_the_threshold_gives_nothing() {
+        const give = Tension.giveAxis(59, 60);
+        compare(give.steps, 0);
+        compare(give.remainder, 59, "the tension stays live, it is not eaten");
+    }
+
+    function test_crossing_the_threshold_gives_one_span_and_carries_the_rest() {
+        const give = Tension.giveAxis(75, 60);
+        compare(give.steps, 1);
+        compare(give.remainder, 15, "leftover pull carries into the next span");
+    }
+
+    function test_a_long_drag_walks_several_spans_in_one_gesture() {
+        const give = Tension.giveAxis(190, 60);
+        compare(give.steps, 3);
+        compare(give.remainder, 10);
+    }
+
+    function test_pulling_inward_gives_negative_steps() {
+        const give = Tension.giveAxis(-130, 60);
+        compare(give.steps, -2);
+        compare(give.remainder, -10, "the remainder keeps the pull's sign");
+    }
+
+    // ---- stepping through the offered spans ----
+
+    readonly property var offered: [
+        { cols: 1, rows: 1 }, { cols: 2, rows: 1 },
+        { cols: 2, rows: 2 }, { cols: 3, rows: 2 }
+    ]
+
+    function test_a_cols_step_prefers_the_same_row_count() {
+        const next = Tension.stepSize(offered, { cols: 1, rows: 1 }, 1, 0);
+        compare(next.cols, 2);
+        compare(next.rows, 1, "1x1 grows to 2x1, not to 2x2");
+    }
+
+    function test_a_rows_step_prefers_the_same_column_count() {
+        const next = Tension.stepSize(offered, { cols: 2, rows: 1 }, 0, 1);
+        compare(next.cols, 2);
+        compare(next.rows, 2);
+    }
+
+    function test_at_the_wall_the_current_span_is_returned() {
+        const next = Tension.stepSize(offered, { cols: 3, rows: 2 }, 1, 0);
+        compare(next.cols, 3, "no larger span exists - the tension rubber-bands");
+        compare(next.rows, 2);
+    }
+
+    function test_shrinking_steps_downward() {
+        const next = Tension.stepSize(offered, { cols: 2, rows: 2 }, 0, -1);
+        compare(next.cols, 2);
+        compare(next.rows, 1);
+    }
+
+    function test_an_empty_offer_list_changes_nothing() {
+        const current = { cols: 2, rows: 1 };
+        compare(Tension.stepSize([], current, 1, 0), current);
+    }
+
+    // ---- the bow ----
+
+    function test_no_pull_no_bow() {
+        compare(Tension.bow(0, 60, 14, 1.15), 0);
+    }
+
+    function test_full_tension_reaches_the_full_bow() {
+        fuzzyCompare(Tension.bow(60, 60, 14, 1.15), 14, 0.001);
+    }
+
+    function test_the_ease_resists_first_and_gives_later() {
+        // ease > 1: at half pull the bow is LESS than half the reach - the
+        // material resists until force has been built.
+        const half = Tension.bow(30, 60, 14, 1.15);
+        verify(half < 7, "at half pull the bow is under half the reach, got " + half);
+        verify(half > 0);
+    }
+
+    function test_the_bow_keeps_the_pulls_sign() {
+        fuzzyCompare(Tension.bow(-60, 60, 14, 1.15), -14, 0.001);
+    }
+
+    function test_pull_past_the_threshold_does_not_bow_past_the_reach() {
+        fuzzyCompare(Tension.bow(200, 60, 14, 1.15), 14, 0.001);
+    }
+
+    // ---- corners under load ----
+
+    function test_at_rest_every_corner_keeps_the_cap() {
+        const radii = Tension.cornerRadii(26, 0, 0, 14, 0.5);
+        compare(radii.tl, 26);
+        compare(radii.tr, 26);
+        compare(radii.br, 26);
+        compare(radii.bl, 26);
+    }
+
+    function test_under_load_the_pulled_corner_tightens_and_neighbours_open() {
+        const radii = Tension.cornerRadii(26, 14, 14, 14, 0.5);
+        verify(radii.br < 26, "the pulled corner tightens, got " + radii.br);
+        verify(radii.tr > 26, "the corner pulled away from opens, got " + radii.tr);
+        verify(radii.bl > 26);
+        compare(radii.tl, 26, "the anchored corner keeps its rest radius");
+    }
+
+    function test_the_pulled_corner_never_collapses_to_a_point() {
+        const radii = Tension.cornerRadii(26, 14, 14, 14, 5.0);
+        verify(radii.br >= 2, "a floor keeps the corner a corner, got " + radii.br);
+    }
+
+    // ---- the outline ----
+
+    function chainOk(outline) {
+        const segs = outline.segments;
+        let x = null, y = null, sx = null, sy = null;
+        for (const seg of segs) {
+            if (seg.op === "move") { x = seg.x; y = seg.y; sx = seg.x; sy = seg.y; continue; }
+            x = seg.x; y = seg.y;
+        }
+        return Math.abs(x - sx) < 0.001 && Math.abs(y - sy) < 0.001;
+    }
+
+    function test_the_outline_closes_at_rest() {
+        const radii = Tension.cornerRadii(26, 0, 0, 14, 0.5);
+        verify(chainOk(Tension.outline(320, 112, 0, 0, radii, 0.85, 1.0)));
+    }
+
+    function test_the_outline_closes_under_full_load() {
+        const radii = Tension.cornerRadii(26, 14, 14, 14, 0.5);
+        verify(chainOk(Tension.outline(320, 112, 14, 14, radii, 0.85, 1.0)));
+    }
+
+    function test_the_outline_closes_when_shrinking() {
+        const radii = Tension.cornerRadii(26, -14, -14, 14, 0.5);
+        verify(chainOk(Tension.outline(96, 96, -14, -14, radii, 0.85, 1.0)));
+    }
+
+    function test_at_rest_the_outline_is_the_plain_rounded_rectangle() {
+        const radii = Tension.cornerRadii(26, 0, 0, 14, 0.5);
+        const segs = Tension.outline(320, 112, 0, 0, radii, 0.85, 1.0).segments;
+        // The right edge's bulge control point sits ON the edge when bow is 0.
+        compare(segs[3].cx, 320, "no bulge without tension");
+        compare(segs[5].cy, 112);
+    }
+
+    function test_the_dragged_corner_leads_by_the_follow_factor() {
+        const radii = Tension.cornerRadii(26, 0, 0, 14, 0.5);
+        const segs = Tension.outline(320, 112, 10, 0, radii, 0.85, 1.0).segments;
+        // corner x = w + bowX * follow; at follow 1.0 the corner carries the
+        // whole bow, and the edge's control point carries it too.
+        fuzzyCompare(segs[4].cx, 330, 0.001);
+        compare(segs[3].cx, 330, "the edge control point rides the full bow");
+    }
+}


### PR DESCRIPTION
Step 2 of the expressive-morphing plan (#174): resizing becomes elastic. Already deployed and approved on screen.

## The model

The grip no longer picks the nearest span. The widget **holds its span while pull builds**, the card's edges bow toward the hand (ease 1.15 — resists first, gives late), the pulled corner tightens while its neighbours open, and at **60 px** the material gives: one offered span steps in the pulled direction, the off-axis count preserved (2×1 → 3×1 on a cols pull, not 3×2). Leftover pull carries, so one drag walks several spans. At a wall the bow holds against the limit, clamped to one breakaway, instead of winding up.

Release drops the bow instantly; settling into the committed span stays on the box animation's clock (#171) — one clock per movement, per the spec.

## Where the pieces live

- **`resize-tension.js`** — all of the arithmetic and every constant (break 60, bow 14, ease 1.15, peak 0.85, follow 1.0, sharpen 0.5 — the values tuned in the design brief's demo). Pure; 24 tests. The first run caught a real bug: a same-axis-preserving candidate couldn't displace an already-found fallback, so shrinking 2×2 by rows stepped to 1×1 instead of 2×1.
- **`PluginWidget`** — tension accumulation, the give walk, and the one subtlety that matters: **spent pull moves the gesture's origin**. A give consumes pull; without re-basing the press point, the next mouse event re-delivers it and the resize sprints to the largest span.
- **`WidgetCard.tensionX/Y`** — the bow, drawn by a Canvas that exists only under load; at rest the card is the same plain Rectangle as before. Injection is the `hostGridSize` duck-typed pattern (`resizeBow` → `hostResizeBow`). Wired: weather, currency, media cookie + compact, and the monitor — where only the card under the grip bows, because three cards bowing identically read as jelly, not a pull. Media 3×2 steps spans but has no card to bow until the one-tree step.

## The clip that shipped mid-review

First deploy came back with the bulge sliced flat at the widget's rectangle: `PluginNode`'s bounded layer (the keep-content-above-the-frost workaround) clips at its item's bounds. The layer moved onto a wrapper frame a `BOW_PX*4` ring larger; the node keeps its exact geometry (centred in a centred frame cancels out), so every coordinate against it — blur regions included — is untouched, and the workaround stays permanently on rather than toggling mid-drag. One contract test pinned `id: pluginNode` + `z: 1` adjacency and was re-anchored on the intent: the frame is z 1, the node sits inside it.

## Tests

563 passed, 0 failed; `checked=160`. New: `tst_resize_tension.qml` (24) and the runtime harness gains the discriminating case — **a pull short of the breakaway must not resize**, the exact inverse of the old semantics.

That probe earned its place the hard way, and both lessons are in the commit: first placed at 2×2 pulling left it was **vacuous** — at a wall both semantics hold the span, measured by planting the regression and watching it pass. It now runs at 3×2, where the mutation goes red. And `scoreCancelled` hardcoded span 2 (only ever called at 2×2), so its first caller at another span failed on a *correct* tree; it now scores against the span remembered at the gesture's start.

| mutation | result |
|---|---|
| any pull = one instant step (nearest-ish) | runtime probe fails |
| same-axis preference dropped in `stepSize` | 1 qml test |
| bow ease linearised | 2 qml tests |
| corner floor removed | 1 qml test |

## Known deviation from the spec

§3d specifies the settle as a literal ω/ζ spring (56.79 rad/s, 1.268). QML's `SpringAnimation` cannot express that ω in its units; the settle keeps #171's Material expressive curve, which is visually equivalent for an overdamped spring. If a true spring is ever wanted, the conversion note in the spec is the starting point.

Docs: updated AGENT.md §Dynamic/data-driven QML gotchas
