### PR TITLE
feat(media): media_geometry.js - the shared elements' rects, per span

### DIFF
--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/media_geometry.js
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/media_geometry.js
@@ -1,0 +1,154 @@
+.pragma library
+
+.import "cookie_layout.js" as CookieLayout
+
+// Where every shared element of the media widget sits, per span.
+//
+// This is step 3 of the expressive-morphing plan (spec 2026-08-11, §1): the
+// one place a size's layout is decided. Today three layout files each place
+// their own controls and a span change destroys one set to construct another;
+// step 4 collapses them into one tree whose elements *bind* these rects, so
+// the play button at 3x2 and the play button at 2x1 become the same object in
+// two places. Nothing calls this module yet - it exists to be tested first.
+//
+// The numbers are measured off the current layouts, not designed fresh:
+// DesktopMediaWidget.qml (3x2), LayoutCookie.qml + cookie_layout.js (2x2),
+// LayoutCompact.qml (2x1). One deliberate change of anchor: the 3x2 places
+// its controls in a ColumnLayout under two text lines, so their positions
+// drift with font metrics. Shared elements must not move because a title got
+// taller, so here they anchor to the CARD's bottom edge and the time label
+// gets a fixed slot (TIME_LABEL_H) instead of flow. The step-4 review is
+// where "close enough to today" is judged, on screen.
+//
+// Every function takes the span's box in *scaled* pixels (what the widget is
+// actually given) plus the scale, and returns rects in the same space. A rect
+// is { x, y, width, height }; elements a span does not have return null,
+// which is the "enters and exits" half of the design - a null rect is a fade,
+// never a morph.
+
+// ---- 3x2 constants (unscaled, as authored) -------------------------------
+var LARGE_MARGIN = 17;         // mainStack margins
+var LARGE_BOTTOM = 22;         // its deeper bottom margin
+var LARGE_SPACING = 2;         // the column's spacing
+var LARGE_PREV_NEXT = 62;      // prev/next buttons, square
+var LARGE_PLAY_W = 192;        // the wide play pill
+var LARGE_PLAY_H = 66;
+var LARGE_ROW_SPACING = 12;
+var LARGE_SLIDER_W = 170;      // the wavy StyledSlider
+var LARGE_SLIDER_H = 12;
+// The time label's slot. In the current 3x2 this is a flowed StyledText whose
+// height rides the font; the one tree gives it this fixed slot instead, which
+// is the single deliberate deviation this module makes from today's layout.
+var TIME_LABEL_H = 16;
+
+// ---- 2x1 constants (unscaled, as authored) -------------------------------
+var COMPACT_CONTROL = 56;      // prev/next pills
+var COMPACT_PLAY = 72;         // the cookie play button
+var COMPACT_SPACING = 12;      // Appearance.spacing.space150
+
+// ---- 2x2 constants -------------------------------------------------------
+var COOKIE_INSET = 12;         // cardInset = Appearance.spacing.space150
+var COOKIE_ART_RATIO = 0.72;   // artClip diameter / frame size
+
+function _rect(x, y, w, h) {
+    return { x: x, y: y, width: w, height: h };
+}
+
+// The square cookie frame the 2x2 centres everything in.
+function cookieFrame(width, height, scale) {
+    return CookieLayout.frame(width, height, COOKIE_INSET * scale);
+}
+
+// ---- the shared elements -------------------------------------------------
+
+// prev / play / next.
+//
+// 3x2: a centred row of prev(62) play(192x66) next(62), anchored above the
+//      time slot and slider rather than flowed below the text.
+// 2x2: prev and next are the clock's corner badges on the cookie frame's
+//      diagonal; "play" is the artwork circle, because tapping the cookie is
+//      what toggles playback there.
+// 2x1: the centred pill row.
+function transportRects(span, width, height, scale) {
+    if (span === "3x2") {
+        var rowH = LARGE_PLAY_H * scale;
+        var rowW = (2 * LARGE_PREV_NEXT + LARGE_PLAY_W + 2 * LARGE_ROW_SPACING) * scale;
+        var rowY = sliderRect3x2(width, height, scale).y
+            - (LARGE_SPACING + TIME_LABEL_H + LARGE_SPACING) * scale - rowH;
+        var rowX = (width - rowW) / 2;
+        var sideY = rowY + (rowH - LARGE_PREV_NEXT * scale) / 2;
+        return {
+            prev: _rect(rowX, sideY, LARGE_PREV_NEXT * scale, LARGE_PREV_NEXT * scale),
+            play: _rect(rowX + (LARGE_PREV_NEXT + LARGE_ROW_SPACING) * scale, rowY,
+                        LARGE_PLAY_W * scale, rowH),
+            next: _rect(rowX + (LARGE_PREV_NEXT + LARGE_ROW_SPACING + LARGE_PLAY_W
+                        + LARGE_ROW_SPACING) * scale, sideY,
+                        LARGE_PREV_NEXT * scale, LARGE_PREV_NEXT * scale)
+        };
+    }
+    if (span === "2x2") {
+        var frame = cookieFrame(width, height, scale);
+        var badge = CookieLayout.badgeSize(frame.size);
+        var art = frame.size * COOKIE_ART_RATIO;
+        return {
+            prev: _rect(frame.x, frame.y, badge, badge),
+            play: _rect(frame.x + (frame.size - art) / 2,
+                        frame.y + (frame.size - art) / 2, art, art),
+            next: _rect(frame.x + frame.size - badge,
+                        frame.y + frame.size - badge, badge, badge)
+        };
+    }
+    if (span === "2x1") {
+        var control = COMPACT_CONTROL * scale;
+        var play = COMPACT_PLAY * scale;
+        var gap = COMPACT_SPACING * scale;
+        var totalW = 2 * control + play + 2 * gap;
+        var x = (width - totalW) / 2;
+        return {
+            prev: _rect(x, (height - control) / 2, control, control),
+            play: _rect(x + control + gap, (height - play) / 2, play, play),
+            next: _rect(x + control + gap + play + gap, (height - control) / 2,
+                        control, control)
+        };
+    }
+    return null;
+}
+
+function sliderRect3x2(width, height, scale) {
+    return _rect((width - LARGE_SLIDER_W * scale) / 2,
+                 height - (LARGE_BOTTOM + LARGE_SLIDER_H) * scale,
+                 LARGE_SLIDER_W * scale, LARGE_SLIDER_H * scale);
+}
+
+// Progress / seek.
+//
+// 3x2: the wavy slider. 2x1: the ring stroked around the play button - the
+// SAME rect as play, which is the "two concentric draws of one outline"
+// arrangement, and the reason the seeker morphs with the button rather than
+// toward a bar somewhere else. 2x2: the cookie frame; today it draws no
+// progress there, and the decided design (spec §3) gives it an inner ring on
+// this rect in step 7 - the geometry reserves the slot now so the element has
+// a rect at every span from the day the tree exists.
+function progressRect(span, width, height, scale) {
+    if (span === "3x2") return sliderRect3x2(width, height, scale);
+    if (span === "2x1") return transportRects(span, width, height, scale).play;
+    if (span === "2x2") {
+        var frame = cookieFrame(width, height, scale);
+        return _rect(frame.x, frame.y, frame.size, frame.size);
+    }
+    return null;
+}
+
+// The time label's slot (3x2 only - it fades elsewhere).
+function timeLabelRect(span, width, height, scale) {
+    if (span !== "3x2") return null;
+    var slider = sliderRect3x2(width, height, scale);
+    return _rect(LARGE_MARGIN * scale, slider.y - (LARGE_SPACING + TIME_LABEL_H) * scale,
+                 width - 2 * LARGE_MARGIN * scale, TIME_LABEL_H * scale);
+}
+
+// Artwork (2x2 only - the circle clipped inside the cookie's lobes).
+function artworkRect(span, width, height, scale) {
+    if (span !== "2x2") return null;
+    return transportRects(span, width, height, scale).play;
+}

--- a/dots/.config/quickshell/imi/tests/tst_media_geometry.qml
+++ b/dots/.config/quickshell/imi/tests/tst_media_geometry.qml
@@ -1,0 +1,135 @@
+import QtTest
+import "../modules/common/plugins/bundled/nandoroid-media/media_geometry.js" as Geometry
+
+// The media widget's shared-element geometry, scored against the numbers
+// measured off the three current layouts. Spans in scaled pixels at scale 1:
+// 3x2 = 420x228, 2x2 = 276x228, 2x1 = 276x108 (Appearance.widgetGridSpan*).
+//
+// These are the rects step 4's one tree will bind, so every value asserted
+// here is a value the play button will actually travel to. Cross-span
+// relationships matter as much as the absolutes - the whole point is that
+// prev at 3x2 and prev at 2x1 are the same element in two places.
+TestCase {
+    name: "MediaGeometryTest"
+
+    // ---- 3x2 -------------------------------------------------------------
+
+    function test_3x2_slider_is_bottom_anchored_and_centred() {
+        const slider = Geometry.progressRect("3x2", 420, 228, 1);
+        compare(slider.width, 170);
+        compare(slider.height, 12);
+        compare(slider.x, 125, "(420 - 170) / 2");
+        compare(slider.y, 228 - 22 - 12, "bottom margin 22, then its own height");
+    }
+
+    function test_3x2_transport_row_is_centred_and_sized_as_authored() {
+        const t = Geometry.transportRects("3x2", 420, 228, 1);
+        compare(t.prev.width, 62);
+        compare(t.play.width, 192);
+        compare(t.play.height, 66);
+        compare(t.next.width, 62);
+        // row: 62 + 12 + 192 + 12 + 62 = 340, centred in 420.
+        compare(t.prev.x, 40);
+        compare(t.play.x, 114);
+        compare(t.next.x, 318);
+    }
+
+    function test_3x2_transport_sits_above_the_time_slot_and_slider() {
+        const t = Geometry.transportRects("3x2", 420, 228, 1);
+        const time = Geometry.timeLabelRect("3x2", 420, 228, 1);
+        const slider = Geometry.progressRect("3x2", 420, 228, 1);
+        compare(time.y + time.height + 2, slider.y, "time slot, spacing 2, slider");
+        compare(t.play.y + t.play.height + 2, time.y, "play, spacing 2, time slot");
+        verify(t.play.y > 0, "the row stays inside the card");
+    }
+
+    function test_3x2_prev_and_next_are_vertically_centred_on_the_play_pill() {
+        const t = Geometry.transportRects("3x2", 420, 228, 1);
+        compare(t.prev.y - t.play.y, (66 - 62) / 2);
+        compare(t.prev.y, t.next.y);
+    }
+
+    function test_3x2_has_no_artwork() {
+        compare(Geometry.artworkRect("3x2", 420, 228, 1), null,
+                "null is a fade, never a morph");
+    }
+
+    // ---- 2x2 -------------------------------------------------------------
+
+    function test_2x2_frame_is_the_cookie_layouts_frame() {
+        const frame = Geometry.cookieFrame(276, 228, 1);
+        compare(frame.size, 204, "min(276, 228) - 2 * 12");
+        compare(frame.x, 36);
+        compare(frame.y, 12);
+    }
+
+    function test_2x2_badges_sit_on_the_frames_corners() {
+        const t = Geometry.transportRects("2x2", 276, 228, 1);
+        const frame = Geometry.cookieFrame(276, 228, 1);
+        compare(t.prev.x, frame.x);
+        compare(t.prev.y, frame.y);
+        fuzzyCompare(t.next.x, frame.x + frame.size - t.next.width, 0.001);
+        fuzzyCompare(t.prev.width, 204 * 64 / 230, 0.001, "the clock's badge ratio");
+    }
+
+    function test_2x2_play_is_the_artwork_circle() {
+        const t = Geometry.transportRects("2x2", 276, 228, 1);
+        const art = Geometry.artworkRect("2x2", 276, 228, 1);
+        compare(t.play.x, art.x);
+        compare(t.play.width, art.width);
+        fuzzyCompare(art.width, 204 * 0.72, 0.001);
+    }
+
+    function test_2x2_progress_reserves_the_cookie_frame() {
+        const progress = Geometry.progressRect("2x2", 276, 228, 1);
+        const frame = Geometry.cookieFrame(276, 228, 1);
+        compare(progress.x, frame.x);
+        compare(progress.width, frame.size,
+                "the slot step 7's inner ring lands in");
+    }
+
+    // ---- 2x1 -------------------------------------------------------------
+
+    function test_2x1_row_is_centred_with_the_authored_sizes() {
+        const t = Geometry.transportRects("2x1", 276, 108, 1);
+        compare(t.prev.width, 56);
+        compare(t.play.width, 72);
+        // row: 56 + 12 + 72 + 12 + 56 = 208, centred in 276.
+        compare(t.prev.x, 34);
+        compare(t.play.x, 102);
+        compare(t.next.x, 186);
+        compare(t.play.y, 18, "(108 - 72) / 2");
+        compare(t.prev.y, 26, "(108 - 56) / 2");
+    }
+
+    function test_2x1_progress_is_the_play_buttons_own_rect() {
+        const t = Geometry.transportRects("2x1", 276, 108, 1);
+        const progress = Geometry.progressRect("2x1", 276, 108, 1);
+        compare(progress.x, t.play.x, "two concentric draws of one outline");
+        compare(progress.width, t.play.width);
+    }
+
+    // ---- cross-span, and scale -------------------------------------------
+
+    function test_every_span_has_the_full_transport_set() {
+        for (const span of ["3x2", "2x2", "2x1"]) {
+            const t = Geometry.transportRects(span, 276, 108, 1);
+            verify(t.prev && t.play && t.next,
+                   span + ": a shared element exists at every span");
+        }
+    }
+
+    function test_an_unknown_span_returns_null_rather_than_a_guess() {
+        compare(Geometry.transportRects("4x4", 400, 400, 1), null);
+        compare(Geometry.progressRect("4x4", 400, 400, 1), null);
+    }
+
+    function test_scale_multiplies_sizes_and_preserves_centring() {
+        const at1 = Geometry.transportRects("2x1", 276, 108, 1);
+        const at2 = Geometry.transportRects("2x1", 552, 216, 2);
+        compare(at2.play.width, at1.play.width * 2);
+        compare(at2.play.x, at1.play.x * 2, "a doubled box doubles the centring");
+        const slider2 = Geometry.progressRect("3x2", 840, 456, 2);
+        compare(slider2.y, (228 - 34) * 2);
+    }
+}


### PR DESCRIPTION
Step 3 of the expressive-morphing plan (#174): `media_geometry.js`, pure and tested, **no caller**. Step 4 (media collapses to one tree) binds these rects; landing the numbers first means the structural PR is reviewed against an already-agreed geometry instead of both changing at once.

## What it decides

For each span, the rect of every shared element — the set the design says must never be destroyed:

| element | 3×2 | 2×2 | 2×1 |
|---|---|---|---|
| prev / next | 62² in the centred row | the clock's corner badges on the cookie frame | 56² pills |
| play | 192×66 pill | the artwork circle (tapping the cookie toggles playback) | 72² cookie |
| progress | the wavy slider, bottom-anchored | **the cookie frame — reserved** | the play button's own rect |
| artwork | null | the 0.72-frame circle | null |

`null` is the "enters and exits" half: a fade, never a morph.

Two relationships worth reviewing over any absolute number:

- **2×1 progress *is* the play rect** — the "two concentric draws of one outline" arrangement, and the reason the seeker morphs with the button.
- **2×2 progress reserves the cookie frame now**, though nothing draws there today, so the element has a rect at every span from the day the tree exists — step 7's inner wavy ring lands in it without a geometry change.

## The one deliberate deviation

The 3×2 currently flows its controls in a `ColumnLayout` under two text lines, so their positions ride the font metrics. Shared elements must not move because a title got taller. Here they anchor to the **card's bottom edge**, and the time label gets a fixed slot (`TIME_LABEL_H`) instead of flow. Named in the module; judged on screen at step 4's review.

Everything else is measured off the current layouts, not designed fresh — the 2×2 comes through `cookie_layout.js`, so the badge ratio stays the clock's.

## Tests

579 passed, 0 failed. `tst_media_geometry.qml` is 16 tests scoring absolutes and the cross-span relationships; mutation-verified — off-centring the row, detaching a badge from its corner, and detaching the 2×1 ring from the play button each redden.

Docs: not needed — no behaviour changes; the module documents itself and AGENT.md gains its entry when step 4 gives it a caller.
