### PR TITLE
feat(weather): one tree, one glyph container - Ghostish to panel to leaf

### DIFF
--- a/dots/.config/quickshell/imi/WeatherTreeMotionProbe.qml
+++ b/dots/.config/quickshell/imi/WeatherTreeMotionProbe.qml
@@ -1,0 +1,149 @@
+import QtQuick
+import QtTest
+import Quickshell
+import qs
+import qs.services
+import qs.modules.common
+import qs.modules.common.plugins
+import qs.modules.common.widgets.widgetCanvas
+
+/*
+ * The weather tree's motion sweep: every span pair, both directions, with
+ * signal trails on the shared three - and a PNG at each settle and
+ * mid-flight (MEDIA_PROBE_SHOTS-style, WEATHER_PROBE_SHOTS here).
+ */
+ShellRoot {
+    id: harness
+
+    readonly property int screenW: 1200
+    readonly property int screenH: 700
+    readonly property string testScreen: "probe-screen"
+
+    property int failures: 0
+    function check(label, ok) {
+        console.log(`[WeatherTreeMotion] ${label}: ${ok ? "ok" : "FAIL"}`);
+        if (!ok) harness.failures++;
+    }
+
+    readonly property var manifest: {
+        const base = Quickshell.shellPath("modules/common/plugins/bundled/nandoroid-weather");
+        return {
+            id: "nandoroid_weather",
+            name: "weather probe",
+            _basePath: base,
+            grid: { cols: 3, rows: 1,
+                sizes: [{ cols: 3, rows: 1 }, { cols: 2, rows: 1 }, { cols: 1, rows: 1 }] },
+            desktopWidget: { component: "Widget.qml" }
+        };
+    }
+
+    function findByName(item, name) {
+        if (!item) return null;
+        if (item.objectName === name) return item;
+        for (const child of item.children) {
+            const hit = harness.findByName(child, name);
+            if (hit) return hit;
+        }
+        return null;
+    }
+
+    FloatingWindow {
+        visible: true
+        implicitWidth: harness.screenW
+        implicitHeight: harness.screenH
+        color: "black"
+
+        TestCase { id: driver; when: false; name: "WeatherTreePointerDriver" }
+
+        WidgetCanvas {
+            id: canvas
+            anchors.fill: parent
+
+            PluginWidget {
+                id: widget
+                manifest: harness.manifest
+                screenName: harness.testScreen
+                screenWidth: harness.screenW
+                screenHeight: harness.screenH
+                scaledScreenWidth: harness.screenW
+                scaledScreenHeight: harness.screenH
+                wallpaperScale: 1
+            }
+        }
+    }
+
+    property string shotDir: Quickshell.env("WEATHER_PROBE_SHOTS") || ""
+    function shoot(tag) {
+        if (harness.shotDir === "") return;
+        widget.grabToImage(result => result.saveToFile(`${harness.shotDir}/${tag}.png`));
+    }
+
+    readonly property var transitions: [
+        ["3x1", "2x1"], ["2x1", "1x1"], ["1x1", "3x1"],
+        ["3x1", "1x1"], ["1x1", "2x1"], ["2x1", "3x1"]
+    ]
+    property int transitionIndex: 0
+    property var trails: ({})
+    property var connections: []
+
+    function spanOf(name) { return { cols: parseInt(name[0]), rows: 1 }; }
+
+    function watch(label, object, signalName, getter) {
+        if (!object) { console.log(`[WeatherTreeMotion] missing: ${label}`); return; }
+        harness.trails[label] = [getter()];
+        const handler = () => harness.trails[label].push(getter());
+        object[signalName].connect(handler);
+        harness.connections.push({ object: object, signalName: signalName, handler: handler });
+    }
+    function unwatchAll() {
+        for (const c of harness.connections)
+            c.object[c.signalName].disconnect(c.handler);
+        harness.connections = [];
+    }
+
+    Timer { id: midShot; interval: 160; onTriggered: harness.shoot(`${harness.transitions[harness.transitionIndex][0]}-to-${harness.transitions[harness.transitionIndex][1]}_mid`) }
+
+    function beginTransition() {
+        const pair = harness.transitions[harness.transitionIndex];
+        harness.shoot(`${pair[0]}_settled`);
+        midShot.start();
+        harness.trails = ({});
+        const temp = harness.findByName(widget, "weatherTemp");
+        const glyph = harness.findByName(widget, "weatherGlyph");
+        const condition = harness.findByName(widget, "weatherCondition");
+        harness.watch("temp.x", temp, "xChanged", () => temp.x);
+        harness.watch("glyph.x", glyph, "xChanged", () => glyph.x);
+        harness.watch("glyph.w", glyph, "widthChanged", () => glyph.width);
+        harness.watch("glyph.rot", glyph, "rotationChanged", () => glyph.rotation);
+        harness.watch("cond.x", condition, "xChanged", () => condition.x);
+        widget.commitGridSize(harness.spanOf(pair[1]));
+        settleTimer.start();
+    }
+
+    Timer { id: settleTimer; interval: 1100; onTriggered: {
+        const pair = harness.transitions[harness.transitionIndex];
+        const tag = `${pair[0]}->${pair[1]}`;
+        harness.unwatchAll();
+        for (const label in harness.trails) {
+            const trail = harness.trails[label];
+            const first = trail[0], last = trail[trail.length - 1];
+            const moved = Math.abs(last - first) > 0.5;
+            if (!moved) { console.log(`[WeatherTreeMotion] ${tag} ${label}: static`); continue; }
+            harness.check(`${tag} ${label} animates (${trail.length} steps)`, trail.length >= 4);
+        }
+        harness.transitionIndex++;
+        if (harness.transitionIndex < harness.transitions.length) {
+            nextTimer.start();
+        } else {
+            console.log(`[WeatherTreeMotion] failures: ${harness.failures}`);
+            Qt.quit();
+        }
+    } }
+    Timer { id: nextTimer; interval: 250; onTriggered: harness.beginTransition() }
+
+    Timer { id: t0; interval: 1200; running: true; onTriggered: {
+        PluginState.setPosition("nandoroid_weather", harness.testScreen, { x: 40, y: 40, placementStrategy: "free" });
+        settle0.start();
+    } }
+    Timer { id: settle0; interval: 800; onTriggered: harness.beginTransition() }
+}

--- a/dots/.config/quickshell/imi/WeatherTreeMotionProbe.qml
+++ b/dots/.config/quickshell/imi/WeatherTreeMotionProbe.qml
@@ -116,6 +116,13 @@ ShellRoot {
         harness.watch("glyph.w", glyph, "widthChanged", () => glyph.width);
         harness.watch("glyph.rot", glyph, "rotationChanged", () => glyph.rotation);
         harness.watch("cond.x", condition, "xChanged", () => condition.x);
+        // The shape morph itself: morphT must sweep 0 -> 1 on a shape change,
+        // not flip at the top - the retarget-through-a-live-Behavior bug made
+        // exactly that snap while every position trail stayed green.
+        if (glyph && glyph.children.length > 0 && glyph.children[0].morphT !== undefined) {
+            const canvas = glyph.children[0];
+            harness.watch("glyph.morphT", canvas, "morphTChanged", () => canvas.morphT);
+        }
         widget.commitGridSize(harness.spanOf(pair[1]));
         settleTimer.start();
     }
@@ -127,7 +134,13 @@ ShellRoot {
         for (const label in harness.trails) {
             const trail = harness.trails[label];
             const first = trail[0], last = trail[trail.length - 1];
-            const moved = Math.abs(last - first) > 0.5;
+            const moved = label === "glyph.morphT"
+                ? trail.some(v => v > 0.05 && v < 0.95)
+                : Math.abs(last - first) > 0.5;
+            if (label === "glyph.morphT" && trail.length > 1 && !moved) {
+                harness.check(`${tag} glyph.morphT sweeps instead of flipping`, false);
+                continue;
+            }
             if (!moved) { console.log(`[WeatherTreeMotion] ${tag} ${label}: static`); continue; }
             harness.check(`${tag} ${label} animates (${trail.length} steps)`, trail.length >= 4);
         }

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-weather/Widget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-weather/Widget.qml
@@ -12,6 +12,10 @@ Item {
     // `sizeMode` choice option of its own - a second mechanism for the concept
     // `__gridSize` now owns, in the same format.
     property string hostGridSize: ""
+    // One tree below: the shared elements travel and the glyph container
+    // morphs, so the host's midpoint dissolve would put a fade over elements
+    // that deliberately never disappear.
+    readonly property bool handlesSpanTransition: true
     property point hostResizeBow: Qt.point(0, 0)
     implicitWidth: content.implicitWidth
     implicitHeight: content.implicitHeight

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-weather/Widget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-weather/Widget.qml
@@ -1,4 +1,5 @@
 import QtQuick
+import qs.modules.common
 import qs.modules.common.plugins
 import "../../designsystem/widgets" as Expressive
 
@@ -8,23 +9,26 @@ Item {
     readonly property bool managesBlurTint: content.managesBlurTint
     // The span the host resolved, handed down by PluginNode: stored choice,
     // then the manifest default. The host owns which size this widget is; the
-    // widget owns what that size looks like. It used to own both, through a
-    // `sizeMode` choice option of its own - a second mechanism for the concept
-    // `__gridSize` now owns, in the same format.
+    // widget owns what that size looks like.
     property string hostGridSize: ""
     // One tree below: the shared elements travel and the glyph container
     // morphs, so the host's midpoint dissolve would put a fade over elements
     // that deliberately never disappear.
     readonly property bool handlesSpanTransition: true
     property point hostResizeBow: Qt.point(0, 0)
-    implicitWidth: content.implicitWidth
-    implicitHeight: content.implicitHeight
-    width: implicitWidth
-    height: implicitHeight
+
+    // Implicit size from the SPAN, and the content fills whatever the host
+    // gives - the host's box is what animates a resize. The old wrapper set
+    // `width: implicitWidth` on itself AND its content, so the card snapped
+    // to each span's size in one frame while the host's animated box was
+    // ignored: elements travelled, the card teleported (the review).
+    readonly property int spanCols: parseInt((root.hostGridSize || "3x1")[0]) || 3
+    implicitWidth: Appearance.sizes.widgetGridSpanX(root.spanCols)
+    implicitHeight: Appearance.sizes.widgetGridSpanY(1)
+
     Expressive.DesktopWeatherWidget {
         id: content
-        width: implicitWidth
-        height: implicitHeight
+        anchors.fill: parent
         sizeMode: root.hostGridSize || "3x1"
         resizeBow: root.hostResizeBow
         useBlurBackground: PluginState.option("nandoroid_weather", "blurEnabled", false)

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopWeatherWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopWeatherWidget.qml
@@ -205,10 +205,14 @@ Item {
             Behavior on y { TravelBehavior {} }
             Behavior on width { TravelBehavior {} }
             text: root.condition
+            // The size and weight are part of the element's travel - snapped,
+            // the same text visibly becomes a different text at the boundary.
             font.pixelSize: root.sizeMode === "1x1" ? Appearance.font.pixelSize.smallest
                 : root.sizeMode === "2x1" ? Appearance.font.pixelSize.normal
                 : Appearance.font.pixelSize.large
+            Behavior on font.pixelSize { TravelBehavior {} }
             font.weight: root.sizeMode === "1x1" ? Font.Medium : Font.DemiBold
+            Behavior on font.weight { TravelBehavior {} }
             color: root.contentColor
             opacity: root.sizeMode === "1x1" ? 0.8 : 1
             Behavior on opacity { FadeBehavior {} }

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopWeatherWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopWeatherWidget.qml
@@ -6,30 +6,40 @@ import "."
 import QtQuick
 import QtQuick.Layouts
 import Qt5Compat.GraphicalEffects
+import "weather_geometry.js" as Geometry
+import "weather_shapes.js" as WeatherShapes
 
+// The weather widget as ONE tree (spec 2026-08-11, §3b - this widget is the
+// element the morphing design was specified around).
+//
+// It used to be a Loader over three inline Components, so a span change
+// destroyed one layout and constructed another: the temperature at 3x1 and
+// the temperature at 1x1 were different objects, and the glyph's container
+// was three different TYPES - a Ghostish MaterialShape, a radius-30 panel and
+// a radius-16 leaf. Now the shared three - temperature, condition, the glyph
+// container - are declared once and travel; the container is one canvas whose
+// shape is a parameter, morphing Ghostish -> panel -> leaf through
+// weather_shapes.js. The card's content clip is what cuts the leaf at the
+// corner, which is the half the spec called unsolved before the card owned
+// clipping.
+//
+// Unshared content (feels-like at 2x1; high/low, the divider and the badge
+// pills at 3x1) fades and scales - it has nothing to morph into.
 Item {
     id: root
-    
-    // Config configuration linkage
+
     property var cfg: Config.ready ? Config.options.appearance.weatherWidget : null
     property string sizeMode: cfg ? cfg.sizeMode : "3x1"
     property bool useBlurBackground: false
-    // The grip's live tension, from the host through the wrapper. The card
-    // renders it; this widget only passes it along.
     property point resizeBow: Qt.point(0, 0)
-    // The host wrapper overrides this with its own plugin id; the fallback keeps
-    // the toggle honoured for a component instantiated without one.
 
     property real backgroundOpacity: PluginState.effectiveBackgroundOpacity("", 0.1)
     readonly property bool managesBlurTint: true
     readonly property var blurRegions: [card.blurRegion]
-    
-    // Choice A Grid System Specs
+
     readonly property real baseWidth: 132 * Appearance.effectiveScale
     readonly property real baseHeight: 108 * Appearance.effectiveScale
     readonly property real gap: 12 * Appearance.effectiveScale
-    
-    // Snap mode dimensions
     readonly property real width1x1: baseWidth
     readonly property real width2x1: (baseWidth * 2) + gap
     readonly property real width3x1: (baseWidth * 3) + (gap * 2)
@@ -41,14 +51,17 @@ Item {
         return width3x1;
     }
 
-    // CustomIcon lives one directory below this imported widget's former location.
-    // Walk back to the shared, preserved upstream icon set at repository /assets.
+    // Geometry evaluates at the span's SETTLED box (the media tree's lesson:
+    // live-box rects made size snap and are per-frame Behavior targets, the
+    // frozen-Behavior shape). Rects change once per span; Behaviors carry.
+    readonly property real spanW: root.implicitWidth
+    readonly property real spanH: root.baseHeight
+    readonly property var tempSlot: Geometry.temperatureRect(root.sizeMode, root.spanW, root.spanH, Appearance.effectiveScale)
+    readonly property var conditionSlot: Geometry.conditionRect(root.sizeMode, root.spanW, root.spanH, Appearance.effectiveScale)
+    readonly property var glyphSlot: Geometry.glyphRect(root.sizeMode, root.spanW, root.spanH, Appearance.effectiveScale)
+
     readonly property string weatherIconsDir: "../../../../assets/icons/google-weather"
     readonly property color contentColor: Appearance.m3colors.m3onSurface
-    readonly property real midOpacity: 0.8
-    readonly property real lowOpacity: 0.6
-    // Adapt end4's OpenWeather service schema to the original nandoroid visual.
-    // The widget remains visually unchanged; only its data source is translated.
     readonly property var weatherData: Weather.data || ({})
     readonly property string temperature: (weatherData.temp || "--").replace(/[^0-9+\-.]/g, "")
     readonly property string feelsLike: (weatherData.tempFeelsLike || "--").replace(/[^0-9+\-.]/g, "")
@@ -68,11 +81,17 @@ Item {
         return "cloudy"
     }
 
+    component TravelBehavior: NumberAnimation {
+        duration: Appearance.animation.elementMove.duration
+        easing.type: Easing.BezierSpline
+        easing.bezierCurve: Appearance.animationCurves.expressiveDefaultSpatial
+    }
+    component FadeBehavior: NumberAnimation {
+        duration: Appearance.animation.elementMove.duration
+        easing.type: Easing.BezierSpline
+        easing.bezierCurve: Appearance.animationCurves.expressiveEffects
+    }
 
-
-    // The shared card. Clipped so the split vertical panels and slanted leaves
-    // cut cleanly at the rounded corners; tint and blur-thinning are the
-    // card's own logic now rather than this widget's.
     WidgetCard {
         id: card
         anchors.fill: parent
@@ -82,289 +101,197 @@ Item {
         tensionX: root.resizeBow.x
         tensionY: root.resizeBow.y
 
-        // Layout Loader based on sizeMode
-        Loader {
-            anchors.fill: parent
-            sourceComponent: {
-                if (root.sizeMode === "1x1") return mode1x1Layout;
-                if (root.sizeMode === "2x1") return mode2x1Layout;
-                return mode3x1Layout;
+        // ---- shared: the glyph container, one shape-parameterised canvas --
+        Item {
+            id: glyph
+            objectName: "weatherGlyph"
+            x: root.glyphSlot.x
+            y: root.glyphSlot.y
+            width: root.glyphSlot.width
+            height: root.glyphSlot.height
+            rotation: root.glyphSlot.rotation
+            Behavior on x { TravelBehavior {} }
+            Behavior on y { TravelBehavior {} }
+            Behavior on width { TravelBehavior {} }
+            Behavior on height { TravelBehavior {} }
+            Behavior on rotation { TravelBehavior {} }
+
+            Canvas {
+                id: glyphCanvas
+                anchors.fill: parent
+
+                // The morph: on every span change the previous shape becomes
+                // the start and morphT runs 0 -> 1 (the ShapeCanvas idiom).
+                property string shownShape: root.glyphSlot.shape
+                property string fromShape: root.glyphSlot.shape
+                property real morphT: 1
+                Behavior on morphT { TravelBehavior {} }
+                readonly property string targetShape: root.glyphSlot.shape
+                onTargetShapeChanged: {
+                    glyphCanvas.fromShape = glyphCanvas.shownShape;
+                    glyphCanvas.shownShape = glyphCanvas.targetShape;
+                    morphT = 0;
+                    morphT = 1;
+                }
+                readonly property color fillColor: Appearance.colors.colPrimary
+
+                onMorphTChanged: requestPaint()
+                onFillColorChanged: requestPaint()
+                onWidthChanged: requestPaint()
+                onHeightChanged: requestPaint()
+                onAvailableChanged: if (available) requestPaint()
+
+                onPaint: {
+                    const ctx = getContext("2d");
+                    ctx.clearRect(0, 0, width, height);
+                    const shape = WeatherShapes.containerAt(
+                        glyphCanvas.fromShape, glyphCanvas.shownShape, glyphCanvas.morphT);
+                    if (shape.cubics.length === 0) return;
+                    const spanX = Math.max(0.001, shape.maxX - shape.minX);
+                    const spanY = Math.max(0.001, shape.maxY - shape.minY);
+                    const scale = Math.min(width / spanX, height / spanY);
+                    ctx.save();
+                    ctx.translate(width / 2 - (shape.minX + spanX / 2) * scale,
+                                  height / 2 - (shape.minY + spanY / 2) * scale);
+                    ctx.scale(scale, scale);
+                    ctx.beginPath();
+                    ctx.moveTo(shape.cubics[0].anchor0X, shape.cubics[0].anchor0Y);
+                    for (const cubic of shape.cubics)
+                        ctx.bezierCurveTo(cubic.control0X, cubic.control0Y,
+                            cubic.control1X, cubic.control1Y, cubic.anchor1X, cubic.anchor1Y);
+                    ctx.closePath();
+                    ctx.fillStyle = glyphCanvas.fillColor;
+                    ctx.fill();
+                    ctx.restore();
+                }
+            }
+
+            CustomIcon {
+                anchors.centerIn: parent
+                source: root.weatherIcon
+                iconFolder: root.weatherIconsDir
+                width: root.glyphSlot.icon
+                height: root.glyphSlot.icon
+                Behavior on width { TravelBehavior {} }
+                Behavior on height { TravelBehavior {} }
+                colorize: true
+                color: Appearance.colors.colOnPrimary
+                // The leaf slants; the glyph inside stays upright.
+                rotation: -glyph.rotation
             }
         }
 
-        // ──────────────────────────────
-        // TATA LETAK 1x1
-        // ──────────────────────────────
-        Component {
-            id: mode1x1Layout
-            Item {
-                anchors.fill: parent
-
-                // Kiri Atas: Suhu Utama Sangat Besar
-                ColumnLayout {
-                    anchors {
-                        left: parent.left
-                        top: parent.top
-                        leftMargin: 16 * Appearance.effectiveScale
-                        topMargin: 14 * Appearance.effectiveScale
-                    }
-                    spacing: 2 * Appearance.effectiveScale
-
-                    StyledText {
-                        text: root.temperature + "°"
-                        font.pixelSize: Math.round(44 * Appearance.effectiveScale)
-                        font.weight: Font.Bold
-                        color: Appearance.colors.colPrimary
-                    }
-
-                    StyledText {
-                        text: root.condition
-                        font.pixelSize: Appearance.font.pixelSize.smallest
-                        font.weight: Font.Medium
-                        color: root.contentColor
-                        opacity: 0.8
-                        wrapMode: Text.WordWrap
-                        maximumLineCount: 2
-                        Layout.maximumWidth: 58 * Appearance.effectiveScale // Clean wrap before reaching the leaf
-                    }
-                }
-
-                // Kanan Bawah: Giant Slanted Leaf Overlay (Rotated Pill overlapping the edge)
-                Item {
-                    width: 50 * Appearance.effectiveScale
-                    height: 50 * Appearance.effectiveScale
-                    
-                    anchors {
-                        right: parent.right
-                        bottom: parent.bottom
-                        rightMargin: -6 * Appearance.effectiveScale // Elegant overlap
-                        bottomMargin: -6 * Appearance.effectiveScale
-                    }
-
-                    Rectangle {
-                        anchors.fill: parent
-                        radius: 16 * Appearance.effectiveScale
-                        color: Appearance.colors.colPrimary
-                        rotation: -22 // Bold Android slanted shape
-                    }
-
-                    CustomIcon {
-                        anchors.centerIn: parent
-                        source: root.weatherIcon
-                        iconFolder: root.weatherIconsDir
-                        width: 28 * Appearance.effectiveScale
-                        height: 28 * Appearance.effectiveScale
-                        colorize: true
-                        color: Appearance.colors.colOnPrimary
-                        rotation: 22 // Rotate icon back straight
-                    }
-                }
-            }
+        // ---- shared: temperature ------------------------------------------
+        StyledText {
+            objectName: "weatherTemp"
+            x: root.tempSlot.x
+            y: root.tempSlot.y
+            Behavior on x { TravelBehavior {} }
+            Behavior on y { TravelBehavior {} }
+            text: root.temperature + "°"
+            font.pixelSize: Math.round(root.tempSlot.size)
+            Behavior on font.pixelSize { TravelBehavior {} }
+            font.weight: Font.Bold
+            color: Appearance.colors.colPrimary
         }
 
-        // ──────────────────────────────
-        // TATA LETAK 2x1
-        // ──────────────────────────────
-        Component {
-            id: mode2x1Layout
-            Item {
-                anchors.fill: parent
+        // ---- shared: condition --------------------------------------------
+        StyledText {
+            objectName: "weatherCondition"
+            x: root.conditionSlot.x
+            y: root.conditionSlot.y
+            width: root.conditionSlot.w
+            Behavior on x { TravelBehavior {} }
+            Behavior on y { TravelBehavior {} }
+            Behavior on width { TravelBehavior {} }
+            text: root.condition
+            font.pixelSize: root.sizeMode === "1x1" ? Appearance.font.pixelSize.smallest
+                : root.sizeMode === "2x1" ? Appearance.font.pixelSize.normal
+                : Appearance.font.pixelSize.large
+            font.weight: root.sizeMode === "1x1" ? Font.Medium : Font.DemiBold
+            color: root.contentColor
+            opacity: root.sizeMode === "1x1" ? 0.8 : 1
+            Behavior on opacity { FadeBehavior {} }
+            elide: root.sizeMode === "1x1" ? Text.ElideNone : Text.ElideRight
+            wrapMode: root.sizeMode === "1x1" ? Text.WordWrap : Text.NoWrap
+            maximumLineCount: root.sizeMode === "1x1" ? 2 : 1
+        }
 
-                // Area Kiri: Info Cuaca Vertikal - Terpusat Vertikal Secara Geometris
-                ColumnLayout {
-                    id: textCol
-                    spacing: 2 * Appearance.effectiveScale
-                    
-                    anchors {
-                        left: parent.left
-                        right: rightIconCard.left
-                        verticalCenter: parent.verticalCenter
-                        leftMargin: 20 * Appearance.effectiveScale
-                        rightMargin: 12 * Appearance.effectiveScale
-                    }
+        // ---- unshared: enters and exits -----------------------------------
+        StyledText {
+            // 2x1 only
+            x: 20 * Appearance.effectiveScale
+            y: 84 * Appearance.effectiveScale
+            text: `Feels like ${root.feelsLike}°`
+            font.pixelSize: Appearance.font.pixelSize.smallest
+            color: root.contentColor
+            opacity: root.sizeMode === "2x1" ? 0.6 : 0
+            Behavior on opacity { FadeBehavior {} }
+            visible: opacity > 0
+        }
 
-                    StyledText {
-                        text: root.temperature + "°"
-                        font.pixelSize: Math.round(44 * Appearance.effectiveScale)
-                        font.weight: Font.Bold
-                        color: Appearance.colors.colPrimary
-                    }
+        StyledText {
+            // 3x1 only
+            x: 20 * Appearance.effectiveScale
+            y: 74 * Appearance.effectiveScale
+            text: `High ${root.highTemperature}° · Low ${root.lowTemperature}°`
+            font.pixelSize: Appearance.font.pixelSize.smallest
+            color: root.contentColor
+            opacity: root.sizeMode === "3x1" ? 0.6 : 0
+            Behavior on opacity { FadeBehavior {} }
+            visible: opacity > 0
+        }
 
-                    StyledText {
-                        Layout.fillWidth: true
-                        text: root.condition
-                        font.pixelSize: Appearance.font.pixelSize.normal
-                        font.weight: Font.DemiBold
-                        color: root.contentColor
-                        elide: Text.ElideRight
-                    }
+        Rectangle {
+            // 3x1 only: the column divider
+            x: 132 * Appearance.effectiveScale
+            y: 16 * Appearance.effectiveScale
+            width: 1
+            height: root.spanH - 32 * Appearance.effectiveScale
+            color: root.contentColor
+            opacity: root.sizeMode === "3x1" ? 0.15 : 0
+            Behavior on opacity { FadeBehavior {} }
+            visible: opacity > 0
+        }
 
-                    StyledText {
-                        Layout.fillWidth: true
-                        text: `Feels like ${root.feelsLike}°`
-                        font.pixelSize: Appearance.font.pixelSize.smallest
-                        color: root.contentColor
-                        opacity: 0.6
-                        elide: Text.ElideRight
-                    }
-                }
+        RowLayout {
+            // 3x1 only: the humidity and wind pills
+            x: 148 * Appearance.effectiveScale
+            y: 60 * Appearance.effectiveScale
+            spacing: 8 * Appearance.effectiveScale
+            opacity: root.sizeMode === "3x1" ? 1 : 0
+            Behavior on opacity { FadeBehavior {} }
+            visible: opacity > 0
 
-                // Area Kanan: Split Solid Panel dengan sudut KIRI membulat (Rounded Left Edge)
+            Repeater {
+                model: [
+                    { icon: "humidity_mid", value: root.humidity },
+                    { icon: "air", value: root.wind }
+                ]
                 Rectangle {
-                    id: rightIconCard
-                    width: 76 * Appearance.effectiveScale
-                    radius: 30 * Appearance.effectiveScale // Rounds the left-top and left-bottom edges beautifully
-                    color: Appearance.colors.colPrimary
-                    
-                    anchors {
-                        right: parent.right
-                        top: parent.top
-                        bottom: parent.bottom
-                    }
-
-                    CustomIcon {
-                        anchors.centerIn: parent
-                        source: root.weatherIcon
-                        iconFolder: root.weatherIconsDir
-                        width: 36 * Appearance.effectiveScale
-                        height: 36 * Appearance.effectiveScale
-                        colorize: true
-                        color: Appearance.colors.colOnPrimary
-                    }
-                }
-            }
-        }
-
-        // ──────────────────────────────
-        // TATA LETAK 3x1
-        // ──────────────────────────────
-        Component {
-            id: mode3x1Layout
-            RowLayout {
-                anchors.fill: parent
-                anchors.margins: 16 * Appearance.effectiveScale
-                anchors.leftMargin: 20 * Appearance.effectiveScale
-                spacing: 16 * Appearance.effectiveScale
-
-                // 1. Suhu Utama Raksasa di Kiri
-                ColumnLayout {
-                    Layout.alignment: Qt.AlignVCenter
-                    spacing: 2 * Appearance.effectiveScale
-
-                    StyledText {
-                        text: root.temperature + "°"
-                        font.pixelSize: Math.round(48 * Appearance.effectiveScale)
-                        font.weight: Font.Bold
-                        color: Appearance.colors.colPrimary
-                    }
-                    
-                    StyledText {
-                        text: `High ${root.highTemperature}° · Low ${root.lowTemperature}°`
-                        font.pixelSize: Appearance.font.pixelSize.smallest
-                        color: root.contentColor
-                        opacity: 0.6
-                    }
-                }
-
-                // Divider line vertical
-                Rectangle {
-                    Layout.fillHeight: true
-                    Layout.preferredWidth: 1
-                    color: root.contentColor
-                    opacity: 0.15
-                }
-
-                // 2. Deskripsi & Mini Badge Pills
-                ColumnLayout {
-                    Layout.fillWidth: true
-                    Layout.alignment: Qt.AlignVCenter
-                    spacing: 8 * Appearance.effectiveScale
-
-                    StyledText {
-                        Layout.fillWidth: true
-                        text: root.condition
-                        font.pixelSize: Appearance.font.pixelSize.large
-                        font.weight: Font.DemiBold
-                        color: root.contentColor
-                        elide: Text.ElideRight
-                    }
-
+                    required property var modelData
+                    Layout.preferredHeight: 22 * Appearance.effectiveScale
+                    implicitWidth: pillRow.implicitWidth + (16 * Appearance.effectiveScale)
+                    radius: 11 * Appearance.effectiveScale
+                    color: Appearance.m3colors.darkmode ? Qt.rgba(1, 1, 1, 0.08) : Qt.rgba(0, 0, 0, 0.05)
                     RowLayout {
-                        Layout.fillWidth: true
-                        spacing: 8 * Appearance.effectiveScale
-
-                        // Humidity Badge (Clean Solid Text via RGBA Background Color)
-                        Rectangle {
-                            Layout.preferredHeight: 22 * Appearance.effectiveScale
-                            implicitWidth: humidityLayout.implicitWidth + (16 * Appearance.effectiveScale)
-                            radius: 11 * Appearance.effectiveScale
-                            color: Appearance.m3colors.darkmode ? Qt.rgba(1, 1, 1, 0.08) : Qt.rgba(0, 0, 0, 0.05)
-
-                            RowLayout {
-                                id: humidityLayout
-                                anchors.centerIn: parent
-                                spacing: 4 * Appearance.effectiveScale
-                                MaterialSymbol {
-                                    iconSize: 14 * Appearance.effectiveScale
-                                    text: "humidity_mid"
-                                    color: Appearance.colors.colPrimary
-                                }
-                                StyledText {
-                                    text: root.humidity
-                                    font.pixelSize: Appearance.font.pixelSize.smallest
-                                    font.weight: Font.DemiBold
-                                    color: root.contentColor
-                                }
-                            }
-                        }
-
-                        // Wind Speed Badge (Clean Solid Text via RGBA Background Color)
-                        Rectangle {
-                            Layout.preferredHeight: 22 * Appearance.effectiveScale
-                            implicitWidth: windLayout.implicitWidth + (16 * Appearance.effectiveScale)
-                            radius: 11 * Appearance.effectiveScale
-                            color: Appearance.m3colors.darkmode ? Qt.rgba(1, 1, 1, 0.08) : Qt.rgba(0, 0, 0, 0.05)
-
-                            RowLayout {
-                                id: windLayout
-                                anchors.centerIn: parent
-                                spacing: 4 * Appearance.effectiveScale
-                                MaterialSymbol {
-                                    iconSize: 14 * Appearance.effectiveScale
-                                    text: "air"
-                                    color: Appearance.colors.colPrimary
-                                }
-                                StyledText {
-                                    text: root.wind
-                                    font.pixelSize: Appearance.font.pixelSize.smallest
-                                    font.weight: Font.DemiBold
-                                    color: root.contentColor
-                                }
-                            }
-                        }
-                    }
-                }
-
-                // 3. Ikon Cuaca berbentuk Ghostish Raksasa (Estetika Premium & Anti-Luber) di Kanan
-                MaterialShape {
-                    Layout.alignment: Qt.AlignVCenter
-                    implicitWidth: 72 * Appearance.effectiveScale
-                    implicitHeight: 72 * Appearance.effectiveScale
-                    shape: MaterialShape.Shape.Ghostish // Sleek asymmetric wavy shape
-                    color: Appearance.colors.colPrimary
-
-                    CustomIcon {
+                        id: pillRow
                         anchors.centerIn: parent
-                        source: root.weatherIcon
-                        iconFolder: root.weatherIconsDir
-                        width: 42 * Appearance.effectiveScale
-                        height: 42 * Appearance.effectiveScale
-                        colorize: true
-                        color: Appearance.colors.colOnPrimary
+                        spacing: 4 * Appearance.effectiveScale
+                        MaterialSymbol {
+                            iconSize: 14 * Appearance.effectiveScale
+                            text: parent.parent.modelData.icon
+                            color: Appearance.colors.colPrimary
+                        }
+                        StyledText {
+                            text: parent.parent.modelData.value
+                            font.pixelSize: Appearance.font.pixelSize.smallest
+                            font.weight: Font.DemiBold
+                            color: root.contentColor
+                        }
                     }
                 }
             }
         }
-
     }
 }

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopWeatherWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopWeatherWidget.qml
@@ -125,12 +125,20 @@ Item {
                 property string shownShape: root.glyphSlot.shape
                 property string fromShape: root.glyphSlot.shape
                 property real morphT: 1
-                Behavior on morphT { TravelBehavior {} }
+                Behavior on morphT { id: morphGate; TravelBehavior {} }
                 readonly property string targetShape: root.glyphSlot.shape
                 onTargetShapeChanged: {
                     glyphCanvas.fromShape = glyphCanvas.shownShape;
                     glyphCanvas.shownShape = glyphCanvas.targetShape;
+                    // The gate is the whole trick (ShapeCanvas's own idiom,
+                    // cited and then not copied): written through a live
+                    // Behavior, `morphT = 0` RETARGETS the animation toward 0
+                    // instead of resetting, the immediate `= 1` retargets it
+                    // back from wherever it got, and the shape flips at
+                    // nearly full morphT - a snap wearing a morph's clothes.
+                    morphGate.enabled = false;
                     morphT = 0;
+                    morphGate.enabled = true;
                     morphT = 1;
                 }
                 readonly property color fillColor: Appearance.colors.colPrimary

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/weather_geometry.js
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/weather_geometry.js
@@ -1,0 +1,48 @@
+.pragma library
+
+// Where every shared element of the weather widget sits, per span.
+//
+// The shared three (spec 2026-08-11 §3b): temperature, condition, and the
+// weather-glyph container - the element whose persistence the design was
+// specified around. Numbers measured off the three inline layouts this
+// replaces. Rects are in scaled pixels; null means the span does not have the
+// element (a fade, never a morph).
+
+function _rect(x, y, w, h) { return { x: x, y: y, width: w, height: h }; }
+
+// Temperature: the big number. Size rides the span.
+function temperatureRect(span, width, height, scale) {
+    if (span === "1x1") return { x: 16 * scale, y: 10 * scale, size: 44 * scale };
+    if (span === "2x1") return { x: 20 * scale, y: 8 * scale, size: 44 * scale };
+    return { x: 20 * scale, y: 16 * scale, size: 48 * scale };
+}
+
+// Condition: under the temperature at the small spans, the second column's
+// headline at 3x1.
+function conditionRect(span, width, height, scale) {
+    if (span === "1x1") return { x: 16 * scale, y: 64 * scale, w: 58 * scale };
+    if (span === "2x1") return { x: 20 * scale, y: 62 * scale, w: 140 * scale };
+    return { x: 148 * scale, y: 28 * scale, w: 150 * scale };
+}
+
+// The glyph container - three shapes, one element.
+//  3x1: the Ghostish, floating right of the row.
+//  2x1: the full-height right panel (flush; the card's clip rounds it).
+//  1x1: the slanted leaf hanging off the corner (the card's clip cuts it).
+function glyphRect(span, width, height, scale) {
+    if (span === "1x1") return {
+        x: width - 44 * scale, y: height - 44 * scale,
+        width: 50 * scale, height: 50 * scale,
+        rotation: -22, icon: 28 * scale, shape: "leaf"
+    };
+    if (span === "2x1") return {
+        x: width - 76 * scale, y: 0,
+        width: 76 * scale, height: height,
+        rotation: 0, icon: 36 * scale, shape: "panel"
+    };
+    return {
+        x: width - (16 + 72) * scale, y: (height - 72 * scale) / 2,
+        width: 72 * scale, height: 72 * scale,
+        rotation: 0, icon: 42 * scale, shape: "ghostish"
+    };
+}

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/weather_shapes.js
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/weather_shapes.js
@@ -1,0 +1,69 @@
+.pragma library
+
+.import "./shapes/material-shapes.js" as MaterialShapes
+.import "./shapes/rounded-polygon.js" as RoundedPolygon
+.import "./shapes/corner-rounding.js" as CornerRounding
+.import "./shapes/morph.js" as MorphLib
+
+// The weather glyph container's three shapes, in ONE centred height-1 space,
+// and the Morphs between them - the media body's pattern (media_shapes.js),
+// applied to the element the morphing spec was written around (§3b: a
+// Rectangle cannot morph into a MaterialShape; one component whose shape is a
+// parameter can).
+//
+//  ghostish - the 3x1 floating shape, material-shapes' own, recentred.
+//  panel    - the 2x1 right panel: aspect 76:108, r30, built AT aspect so the
+//             corners stay circular (normalized-then-stretched corners are
+//             the ellipse-pill lesson).
+//  leaf     - the 1x1 slanted square, r16 at 50px. Rotation stays on the
+//             item, not the polygon, so the icon can counter-rotate.
+
+var PANEL_ASPECT = 76 / 108;
+var PANEL_ROUNDING = 30 / 108;
+var LEAF_ROUNDING = 16 / 50;
+
+var _shapes = {};
+function shapeOf(name) {
+    if (_shapes[name] !== undefined) return _shapes[name];
+    var polygon;
+    if (name === "ghostish") {
+        // normalized 0..1 -> centred -0.5..0.5
+        polygon = MaterialShapes.getGhostish()
+            .transformed(function (x, y) { return { x: x - 0.5, y: y - 0.5 }; });
+    } else if (name === "panel") {
+        polygon = RoundedPolygon.RoundedPolygon.rectangle(
+            PANEL_ASPECT, 1, new CornerRounding.CornerRounding(PANEL_ROUNDING));
+    } else {
+        polygon = RoundedPolygon.RoundedPolygon.rectangle(
+            1, 1, new CornerRounding.CornerRounding(LEAF_ROUNDING));
+    }
+    _shapes[name] = polygon;
+    return polygon;
+}
+
+var _morphs = {};
+function containerAt(fromName, toName, t) {
+    var clamped = Math.max(0, Math.min(1, t));
+    if (fromName === toName || clamped >= 0.999)
+        return _bounded(shapeOf(toName).cubics);
+    var key = fromName + ">" + toName;
+    if (_morphs[key] === undefined)
+        _morphs[key] = new MorphLib.Morph(shapeOf(fromName), shapeOf(toName));
+    return _bounded(_morphs[key].asCubics(clamped));
+}
+
+function _bounded(cubics) {
+    var minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+    for (var i = 0; i < cubics.length; i++) {
+        var c = cubics[i];
+        var xs = [c.anchor0X, c.control0X, c.control1X, c.anchor1X];
+        var ys = [c.anchor0Y, c.control0Y, c.control1Y, c.anchor1Y];
+        for (var j = 0; j < 4; j++) {
+            if (xs[j] < minX) minX = xs[j];
+            if (xs[j] > maxX) maxX = xs[j];
+            if (ys[j] < minY) minY = ys[j];
+            if (ys[j] > maxY) maxY = ys[j];
+        }
+    }
+    return { cubics: cubics, minX: minX, minY: minY, maxX: maxX, maxY: maxY };
+}

--- a/dots/.config/quickshell/imi/tests/run_weather_probe.sh
+++ b/dots/.config/quickshell/imi/tests/run_weather_probe.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Headless weston + qs, the runtime-harness pattern, trimmed to one probe.
+set -u
+SOCKET="wl-imi-weather-tree"
+TMP=$(mktemp -d)
+export XDG_RUNTIME_DIR="$TMP/runtime"; mkdir -p "$XDG_RUNTIME_DIR"; chmod 700 "$XDG_RUNTIME_DIR"
+export XDG_CONFIG_HOME="$TMP/config" XDG_CACHE_HOME="$TMP/cache" XDG_STATE_HOME="$TMP/state" XDG_DATA_HOME="$TMP/data"
+mkdir -p "$XDG_CONFIG_HOME" "$XDG_CACHE_HOME" "$XDG_STATE_HOME" "$XDG_DATA_HOME"
+weston --backend=headless-backend.so --socket="$SOCKET" --width=1280 --height=800 &>"$TMP/weston.log" &
+WPID=$!
+sleep 2
+DBUS_SESSION_BUS_ADDRESS="unix:path=/nonexistent" WAYLAND_DISPLAY="$SOCKET" WEATHER_PROBE_SHOTS="${WEATHER_PROBE_SHOTS:-}" timeout 60 qs -p "$(dirname "$0")/../WeatherTreeMotionProbe.qml" 2>&1 | grep "WeatherTreeMotion"
+kill $WPID 2>/dev/null
+rm -rf "$TMP"

--- a/dots/.config/quickshell/imi/tests/test_expressive_design_system.py
+++ b/dots/.config/quickshell/imi/tests/test_expressive_design_system.py
@@ -39,7 +39,7 @@ ENTRY_FILES = {}
 # ...and the size assertion below moved with it, to the other side: a widget
 # whose manifest declares a grid is sized by the host to the span it resolved,
 # so its wrapper names spans rather than forwarding a content size.
-SIZED_BY_THE_HOST_GRID = {"nandoroid-media"}
+SIZED_BY_THE_HOST_GRID = {"nandoroid-media", "nandoroid-weather"}
 
 
 def entry_file(directory):

--- a/dots/.config/quickshell/imi/tests/tst_weather_geometry.qml
+++ b/dots/.config/quickshell/imi/tests/tst_weather_geometry.qml
@@ -1,0 +1,78 @@
+import QtTest
+import "../modules/common/plugins/designsystem/widgets/weather_geometry.js" as Geometry
+import "../modules/common/plugins/designsystem/widgets/weather_shapes.js" as WeatherShapes
+
+// The weather widget's shared-element geometry and the glyph container's
+// shape space. Spans at scale 1: 1x1 = 132x108, 2x1 = 276x108, 3x1 = 420x108.
+TestCase {
+    name: "WeatherGeometryTest"
+
+    function test_the_glyph_exists_at_every_span_with_its_own_shape() {
+        const g3 = Geometry.glyphRect("3x1", 420, 108, 1);
+        const g2 = Geometry.glyphRect("2x1", 276, 108, 1);
+        const g1 = Geometry.glyphRect("1x1", 132, 108, 1);
+        compare(g3.shape, "ghostish");
+        compare(g2.shape, "panel");
+        compare(g1.shape, "leaf");
+        verify(g3.width === 72 && g3.height === 72, "floating square at 3x1");
+        verify(g2.height === 108, "flush full-height panel at 2x1");
+        compare(g1.rotation, -22, "the slanted leaf");
+    }
+
+    function test_the_leaf_hangs_off_the_card_corner() {
+        // x + width > span width: the overflow is what the card's clip cuts,
+        // the case the spec called out as the clip half of the design.
+        const g1 = Geometry.glyphRect("1x1", 132, 108, 1);
+        verify(g1.x + g1.width > 132, "overflows right");
+        verify(g1.y + g1.height > 108, "overflows bottom");
+    }
+
+    function test_the_panel_is_flush_with_the_card_edge() {
+        const g2 = Geometry.glyphRect("2x1", 276, 108, 1);
+        compare(g2.x + g2.width, 276, "right edge on the card edge");
+        compare(g2.y, 0);
+    }
+
+    function test_temperature_and_condition_exist_at_every_span() {
+        for (const span of ["3x1", "2x1", "1x1"]) {
+            verify(Geometry.temperatureRect(span, 420, 108, 1) !== null, span);
+            verify(Geometry.conditionRect(span, 420, 108, 1) !== null, span);
+        }
+    }
+
+    function test_scale_multiplies_the_glyph() {
+        const at1 = Geometry.glyphRect("3x1", 420, 108, 1);
+        const at2 = Geometry.glyphRect("3x1", 840, 216, 2);
+        compare(at2.width, at1.width * 2);
+        compare(at2.icon, at1.icon * 2);
+    }
+
+    // ---- the shape space ----
+
+    function test_every_shape_pair_morphs_and_stays_bounded() {
+        for (const pair of [["ghostish", "panel"], ["panel", "leaf"], ["ghostish", "leaf"]]) {
+            for (const t of [0, 0.5, 1]) {
+                const shape = WeatherShapes.containerAt(pair[0], pair[1], t);
+                verify(shape.cubics.length > 0, pair + " at " + t);
+                verify(shape.maxX - shape.minX > 0.3, "has width");
+                verify(shape.maxX - shape.minX < 2, "not exploded");
+            }
+        }
+    }
+
+    function test_the_panel_shape_carries_its_aspect() {
+        const panel = WeatherShapes.containerAt("panel", "panel", 1);
+        const aspect = (panel.maxX - panel.minX) / (panel.maxY - panel.minY);
+        fuzzyCompare(aspect, 76 / 108, 0.02,
+                     "built AT aspect so the corners stay circular");
+    }
+
+    function test_mid_morph_is_strictly_between_the_endpoints() {
+        const from = WeatherShapes.containerAt("ghostish", "ghostish", 1);
+        const to = WeatherShapes.containerAt("panel", "panel", 1);
+        const mid = WeatherShapes.containerAt("ghostish", "panel", 0.5);
+        const w = s => s.maxX - s.minX;
+        verify((w(mid) - w(from)) * (w(mid) - w(to)) < 0,
+               "the morph travels, it does not snap");
+    }
+}


### PR DESCRIPTION
The weather widget joins the morphing principle — spec #174 §3b, the element the design was specified around. Deployed and accepted on the desktop through four review rounds.

## The glyph container is one element

It was three different *types*: a Ghostish `MaterialShape` at 3×1, a radius-30 full-height panel at 2×1, a radius-16 slanted leaf at 1×1. A `Rectangle` cannot morph into a `MaterialShape`; one canvas whose shape is a parameter can. `weather_shapes.js` builds all three in one centred height-1 space — the panel **at** its 76:108 aspect so its corners stay circular (the ellipse-pill lesson, pre-applied) — with cached `Morph`s between every pair. The leaf's −22° tilt is item rotation, animated, with the icon counter-rotating upright. **The card's content clip cuts the leaf at the corner** — the half §3b called unsolved before the card owned clipping.

## One tree

The `Loader` over three inline `Component`s is gone. Temperature, condition and the glyph travel on Behaviors between `weather_geometry.js` rects (evaluated at the settled span — the media tree's frozen-Behavior lesson); the condition's font size and weight travel too. Unshared content fades in place. The wrapper declares `handlesSpanTransition` and is **host-grid-sized** — its old `width: implicitWidth` ignored the host's animating box entirely, so the card teleported while its contents travelled (review round 2; the design-system test now pins weather in the host-sized set).

## The bug the trails couldn't see

The glyph's morph reset wrote `morphT = 0` through its own **live Behavior**, which retargets rather than resets — the shape flipped at nearly full `morphT`, a snap wearing a morph's clothes, while every position trail stayed green. The `ShapeCanvas` gate idiom (disable, snap, re-enable, run) was cited in the comment above that code and not copied. Fixed, and the probe now trails `morphT` itself, failing any shape change whose sweep never passes through the middle.

## Sandbox

`WeatherTreeMotionProbe.qml` + driver: 24 motion cells (six transitions × five signal trails) + 6 morph-sweep cells, all green. Honest limit, known from the media branch: the card's clip is an `OpacityMask` the sandbox's software GL can't composite, and unlike media the clip *is* the design — so captures verify only the masked band, the trails carry the motion proof, and settled looks were judged on the desktop.

585 suite / 0 failed. 10 new geometry tests, including the two contracts the design turns on: the leaf overflows the card on both axes, and every shape pair's mid-morph is strictly between its endpoints.

Docs: not needed — the pattern this follows is already recorded in AGENT.md (the media one-tree entries: one-painter, settled-span geometry, handlesSpanTransition); this PR adds an adopter, not a rule.
