### PR TITLE
Currency: one tree, a container that morphs, and a fetch that retries

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1229,6 +1229,23 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   which passed every hover assertion while the cursor never changed. Input areas own their
   cursors; z order guarantees the interactive thing is topmost.
   05bf3013f ("feat(media): the play button's body IS the visualizer").
+- **A one-tree widget's geometry reads the SETTLED span's box, never the animating one.** Three
+  trees were written with `spanW: root.implicitWidth`, and `implicitWidth` carries a Behavior: every
+  rect became a per-frame target, so the Behaviors that carry the travel never converged, and any
+  rect measured from the right edge (the media play button, the weather glyph, the currency panel
+  and its cells) crawled behind the card instead of travelling with it. The settled width is a
+  function of the span name alone. A widget's SHAPE also morphs off a t that must be reset through a
+  closed gate - writing `morphT = 0` through a live Behavior retargets it, which is a snap wearing
+  the morph's clothes. Both are checked:
+  `test_geometry_rects_come_from_the_settled_span_not_the_animating_box`.
+  189caa6ff ("fix(weather): geometry reads the settled span, not the animating box").
+- **An element that changes its TEXT across spans is two elements, not one.** The currency base
+  code read "to USD" at 1x1 and "USD" at 2x1 from a single `StyledText`, so the content swapped in
+  one frame in the middle of an otherwise continuous morph. "to" is its own element that fades,
+  and the code slides left into the space it vacates as it goes. The same rule retires the
+  screenshot that hid it: `grabToImage` renders a LATER frame, so a probe that shoots and then
+  commits the span in one call files the transition's first frame as "settled".
+  38ad4d94b ("fix(currency): the word \"to\" becomes its own element, and rates stop colliding").
 - **A bundled package component loaded by URL has no implicit siblings - the package needs a
   qmldir naming every component, and the qmldir then governs DIRECTORY imports of the package
   too.** MediaTransportButton shipped bare and every media widget vanished with "is not a type";

--- a/dots/.config/quickshell/imi/CurrencyTreeMotionProbe.qml
+++ b/dots/.config/quickshell/imi/CurrencyTreeMotionProbe.qml
@@ -1,0 +1,158 @@
+import QtQuick
+import QtTest
+import Quickshell
+import qs
+import qs.services
+import qs.modules.common
+import qs.modules.common.plugins
+import qs.modules.common.widgets.widgetCanvas
+
+/*
+ * The weather tree's motion sweep: every span pair, both directions, with
+ * signal trails on the shared three - and a PNG at each settle and
+ * mid-flight (MEDIA_PROBE_SHOTS-style, CURRENCY_PROBE_SHOTS here).
+ */
+ShellRoot {
+    id: harness
+
+    readonly property int screenW: 1200
+    readonly property int screenH: 700
+    readonly property string testScreen: "probe-screen"
+
+    property int failures: 0
+    function check(label, ok) {
+        console.log(`[CurrencyTreeMotion] ${label}: ${ok ? "ok" : "FAIL"}`);
+        if (!ok) harness.failures++;
+    }
+
+    readonly property var manifest: {
+        const base = Quickshell.shellPath("modules/common/plugins/bundled/nandoroid-currency");
+        return {
+            id: "nandoroid_currency",
+            name: "weather probe",
+            _basePath: base,
+            grid: { cols: 2, rows: 1,
+                sizes: [{ cols: 1, rows: 1 }, { cols: 2, rows: 1 }] },
+            desktopWidget: { component: "Widget.qml" }
+        };
+    }
+
+    function findByName(item, name) {
+        if (!item) return null;
+        if (item.objectName === name) return item;
+        for (const child of item.children) {
+            const hit = harness.findByName(child, name);
+            if (hit) return hit;
+        }
+        return null;
+    }
+
+    FloatingWindow {
+        visible: true
+        implicitWidth: harness.screenW
+        implicitHeight: harness.screenH
+        color: "black"
+
+        TestCase { id: driver; when: false; name: "WeatherTreePointerDriver" }
+
+        WidgetCanvas {
+            id: canvas
+            anchors.fill: parent
+
+            PluginWidget {
+                id: widget
+                manifest: harness.manifest
+                screenName: harness.testScreen
+                screenWidth: harness.screenW
+                screenHeight: harness.screenH
+                scaledScreenWidth: harness.screenW
+                scaledScreenHeight: harness.screenH
+                wallpaperScale: 1
+            }
+        }
+    }
+
+    property string shotDir: Quickshell.env("CURRENCY_PROBE_SHOTS") || ""
+    function shoot(tag) {
+        if (harness.shotDir === "") return;
+        widget.grabToImage(result => result.saveToFile(`${harness.shotDir}/${tag}.png`));
+    }
+
+    readonly property var transitions: [
+        ["2x1", "1x1"], ["1x1", "2x1"]
+    ]
+    property int transitionIndex: 0
+    property var trails: ({})
+    property var connections: []
+
+    function spanOf(name) { return { cols: parseInt(name[0]), rows: 1 }; }
+
+    function watch(label, object, signalName, getter) {
+        if (!object) { console.log(`[CurrencyTreeMotion] missing: ${label}`); return; }
+        harness.trails[label] = [getter()];
+        const handler = () => harness.trails[label].push(getter());
+        object[signalName].connect(handler);
+        harness.connections.push({ object: object, signalName: signalName, handler: handler });
+    }
+    function unwatchAll() {
+        for (const c of harness.connections)
+            c.object[c.signalName].disconnect(c.handler);
+        harness.connections = [];
+    }
+
+    Timer { id: midShot; interval: 160; onTriggered: harness.shoot(`${harness.transitions[harness.transitionIndex][0]}-to-${harness.transitions[harness.transitionIndex][1]}_mid`) }
+
+    function beginTransition() {
+        const pair = harness.transitions[harness.transitionIndex];
+        harness.shoot(`${pair[0]}_settled`);
+        midShot.start();
+        harness.trails = ({});
+        const container = harness.findByName(widget, "currencyContainer");
+        const base = harness.findByName(widget, "currencyBase");
+        const label = harness.findByName(widget, "currencyRatesLabel");
+        harness.watch("container.x", container, "xChanged", () => container.x);
+        harness.watch("container.w", container, "widthChanged", () => container.width);
+        harness.watch("base.y", base, "yChanged", () => base.y);
+        harness.watch("base.size", base, "fontChanged", () => base.font.pixelSize);
+        harness.watch("label.x", label, "xChanged", () => label.x);
+        if (container && container.children.length > 0 && container.children[0].morphT !== undefined) {
+            const canvas = container.children[0];
+            harness.watch("container.morphT", canvas, "morphTChanged", () => canvas.morphT);
+        }
+        widget.commitGridSize(harness.spanOf(pair[1]));
+        settleTimer.start();
+    }
+
+    Timer { id: settleTimer; interval: 1100; onTriggered: {
+        const pair = harness.transitions[harness.transitionIndex];
+        const tag = `${pair[0]}->${pair[1]}`;
+        harness.unwatchAll();
+        for (const label in harness.trails) {
+            const trail = harness.trails[label];
+            const first = trail[0], last = trail[trail.length - 1];
+            const moved = label === "container.morphT"
+                ? trail.some(v => v > 0.05 && v < 0.95)
+                : Math.abs(last - first) > 0.5;
+            if (label === "container.morphT" && trail.length > 1 && !moved) {
+                harness.check(`${tag} container.morphT sweeps instead of flipping`, false);
+                continue;
+            }
+            if (!moved) { console.log(`[CurrencyTreeMotion] ${tag} ${label}: static`); continue; }
+            harness.check(`${tag} ${label} animates (${trail.length} steps)`, trail.length >= 4);
+        }
+        harness.transitionIndex++;
+        if (harness.transitionIndex < harness.transitions.length) {
+            nextTimer.start();
+        } else {
+            console.log(`[CurrencyTreeMotion] failures: ${harness.failures}`);
+            Qt.quit();
+        }
+    } }
+    Timer { id: nextTimer; interval: 250; onTriggered: harness.beginTransition() }
+
+    Timer { id: t0; interval: 1200; running: true; onTriggered: {
+        PluginState.setPosition("nandoroid_currency", harness.testScreen, { x: 40, y: 40, placementStrategy: "free" });
+        settle0.start();
+    } }
+    Timer { id: settle0; interval: 800; onTriggered: harness.beginTransition() }
+}

--- a/dots/.config/quickshell/imi/CurrencyTreeMotionProbe.qml
+++ b/dots/.config/quickshell/imi/CurrencyTreeMotionProbe.qml
@@ -73,9 +73,16 @@ ShellRoot {
     }
 
     property string shotDir: Quickshell.env("CURRENCY_PROBE_SHOTS") || ""
-    function shoot(tag) {
-        if (harness.shotDir === "") return;
-        widget.grabToImage(result => result.saveToFile(`${harness.shotDir}/${tag}.png`));
+    // The grab renders a LATER frame, so anything that changes the widget has
+    // to wait for `andThen` - shooting and then committing the span in the
+    // same call captured the first frame of the transition and labelled it
+    // "settled".
+    function shoot(tag, andThen) {
+        if (harness.shotDir === "") { if (andThen) andThen(); return; }
+        widget.grabToImage(result => {
+            result.saveToFile(`${harness.shotDir}/${tag}.png`);
+            if (andThen) andThen();
+        });
     }
 
     readonly property var transitions: [
@@ -104,7 +111,11 @@ ShellRoot {
 
     function beginTransition() {
         const pair = harness.transitions[harness.transitionIndex];
-        harness.shoot(`${pair[0]}_settled`);
+        harness.shoot(`${pair[0]}_settled`, () => harness.driveTransition());
+    }
+
+    function driveTransition() {
+        const pair = harness.transitions[harness.transitionIndex];
         midShot.start();
         harness.trails = ({});
         const container = harness.findByName(widget, "currencyContainer");

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-currency/Widget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-currency/Widget.qml
@@ -1,4 +1,5 @@
 import QtQuick
+import qs.modules.common
 import qs.modules.common.plugins
 import "../../designsystem/widgets" as Expressive
 import "../../designsystem/services" as ExpressiveServices
@@ -14,11 +15,16 @@ Item {
     // `sizeMode` choice option of its own - a second mechanism for the concept
     // `__gridSize` now owns, in the same format.
     property string hostGridSize: ""
+    // One tree below: shared elements travel and the container morphs, so
+    // the host's midpoint dissolve yields.
+    readonly property bool handlesSpanTransition: true
     property point hostResizeBow: Qt.point(0, 0)
-    implicitWidth: content.implicitWidth
-    implicitHeight: content.implicitHeight
-    width: implicitWidth
-    height: implicitHeight
+    // Implicit from the SPAN; the content fills whatever the host gives -
+    // the host's animating box is the resize (weather's wrapper shipped the
+    // self-sized version of this and its card teleported).
+    readonly property int spanCols: parseInt((root.hostGridSize || "2x1")[0]) || 2
+    implicitWidth: Appearance.sizes.widgetGridSpanX(root.spanCols)
+    implicitHeight: Appearance.sizes.widgetGridSpanY(1)
     readonly property string baseCode: PluginState.option("nandoroid_currency", "baseCurrency", "USD")
     readonly property string quoteOne: PluginState.option("nandoroid_currency", "quote1", "EUR")
     readonly property string quoteTwo: PluginState.option("nandoroid_currency", "quote2", "GBP")
@@ -32,8 +38,7 @@ Item {
     Expressive.DesktopCurrencyWidget {
         id: content
         objectName: "nandoroidCurrencyContent"
-        width: implicitWidth
-        height: implicitHeight
+        anchors.fill: parent
         sizeMode: root.hostGridSize || "2x1"
         resizeBow: root.hostResizeBow
         useBlurBackground: PluginState.option("nandoroid_currency", "blurEnabled", false)

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/services/CurrencyService.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/services/CurrencyService.qml
@@ -2,6 +2,7 @@ pragma Singleton
 import QtQuick
 import Quickshell
 import "CurrencyMath.js" as CurrencyMath
+import "currency_schedule.js" as Schedule
 
 Singleton {
     id: root
@@ -14,6 +15,9 @@ Singleton {
     property string quote3: "JPY"
     property string quote4: "CAD"
     property int requestGeneration: 0
+    // Consecutive failures, for the backoff. Reset by success and by any
+    // settings change (a new base deserves a fresh quick attempt).
+    property int failureCount: 0
 
     // PluginState bindings are applied just after this singleton is created.  A
     // short debounce prevents the default USD request from winning that race
@@ -33,12 +37,23 @@ Singleton {
             // Invalidate the callback without aborting from inside a timer.
             // Qt's XHR abort path can synchronously re-enter QML handlers.
             root.requestGeneration++;
-            root.loading = false;
-            root.errorMessage = "Network timeout";
+            root.attemptFailed("Network timeout");
         }
     }
 
+    // The schedule (currency_schedule.js): failure backs off from quick
+    // retries to patient ones; success settles into an hourly refresh. The
+    // service used to make ONE attempt per session, so a shell that started
+    // before the network stayed on "Network timeout" forever.
+    Timer {
+        id: nextAttempt
+        repeat: false
+        onTriggered: root.refresh()
+    }
+
     function scheduleRefresh() {
+        root.failureCount = 0;
+        nextAttempt.stop();
         refreshDebounce.restart();
     }
 
@@ -53,12 +68,26 @@ Singleton {
         return String(value || "").trim().toLowerCase();
     }
 
+    function attemptFailed(message) {
+        root.loading = false;
+        // Stale rates stay on screen; the message only fills empty slots.
+        root.errorMessage = message;
+        root.failureCount++;
+        nextAttempt.interval = Schedule.nextRetryMs(root.failureCount);
+        nextAttempt.restart();
+    }
+
+    function attemptSucceeded() {
+        root.loading = false;
+        root.failureCount = 0;
+        nextAttempt.interval = Schedule.REFRESH_MS;
+        nextAttempt.restart();
+    }
+
     function refresh() {
         if (!root.baseCurrency) return;
         requestTimeout.stop();
         root.loading = true;
-        root.errorMessage = "";
-        const generation = ++root.requestGeneration;
         const target = normalizedCode(root.baseCurrency);
         const quotes = [root.quote1, root.quote2, root.quote3, root.quote4]
             .map(normalizedCode).filter(code => code.length > 0);
@@ -69,24 +98,41 @@ Singleton {
             root.rates = ({});
             return;
         }
+        root.tryHost(Schedule.urlsFor(target), 0, target, uniqueQuotes);
+    }
 
+    // One attempt walks the host list (primary, then the mirror) before it
+    // counts as a failure and backs off.
+    function tryHost(urls, hostIndex, target, uniqueQuotes) {
+        if (hostIndex >= urls.length) {
+            root.attemptFailed(root.errorMessage || "No network");
+            return;
+        }
+        const generation = ++root.requestGeneration;
         const xhr = new XMLHttpRequest();
-        xhr.open("GET", `https://latest.currency-api.pages.dev/v1/currencies/${encodeURIComponent(target)}.json`);
+        xhr.open("GET", urls[hostIndex]);
         xhr.onreadystatechange = function() {
             if (xhr.readyState !== XMLHttpRequest.DONE || generation !== root.requestGeneration) return;
             requestTimeout.stop();
-            root.loading = false;
             if (xhr.status !== 200) {
                 root.errorMessage = xhr.status === 0 ? "No network" : `HTTP ${xhr.status}`;
+                root.tryHost(urls, hostIndex + 1, target, uniqueQuotes);
                 return;
             }
             try {
                 const table = JSON.parse(xhr.responseText)[target] || {};
                 const fetchedRates = CurrencyMath.ratesIntoTarget(table, uniqueQuotes);
-                root.rates = fetchedRates;
-                root.errorMessage = Object.keys(fetchedRates).length > 0 ? "" : "No rates returned";
+                if (Object.keys(fetchedRates).length > 0) {
+                    root.rates = fetchedRates;
+                    root.errorMessage = "";
+                    root.attemptSucceeded();
+                } else {
+                    root.errorMessage = "No rates returned";
+                    root.tryHost(urls, hostIndex + 1, target, uniqueQuotes);
+                }
             } catch (error) {
                 root.errorMessage = "Parse error";
+                root.tryHost(urls, hostIndex + 1, target, uniqueQuotes);
             }
         };
         requestTimeout.restart();

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/services/currency_schedule.js
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/services/currency_schedule.js
@@ -1,0 +1,34 @@
+.pragma library
+
+// When the currency service tries again, as arithmetic.
+//
+// The service used to make exactly ONE attempt, 50ms after startup, and any
+// failure - most commonly the shell starting before the network is up -
+// left "Network timeout" on screen until a settings edit happened to trigger
+// a new request. Rates also never refreshed within a session.
+//
+// Failure backs off: quick retries first (the boot race resolves in
+// seconds), then patient ones, capped at five minutes so a laptop that was
+// offline for an hour still recovers within five minutes of the network
+// returning. Success settles into an hourly refresh - the upstream dataset
+// updates daily, so anything faster is discourtesy to a free API.
+
+var RETRY_DELAYS_MS = [5000, 15000, 60000, 300000];
+var REFRESH_MS = 3600000;
+
+function nextRetryMs(failureCount) {
+    if (failureCount <= 0) return RETRY_DELAYS_MS[0];
+    var index = Math.min(failureCount - 1, RETRY_DELAYS_MS.length - 1);
+    return RETRY_DELAYS_MS[index];
+}
+
+// The hosts, in the order they are tried within one attempt. Both serve the
+// same dataset (fawazahmed0/exchange-api); the pages.dev host is primary and
+// the jsdelivr mirror is the documented fallback.
+function urlsFor(baseCode) {
+    var code = encodeURIComponent(baseCode);
+    return [
+        "https://latest.currency-api.pages.dev/v1/currencies/" + code + ".json",
+        "https://cdn.jsdelivr.net/npm/@fawazahmed0/currency-api@latest/v1/currencies/" + code + ".json"
+    ];
+}

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopCurrencyWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopCurrencyWidget.qml
@@ -45,8 +45,11 @@ Item {
     }
 
     // Geometry evaluates at the span's SETTLED box; Behaviors carry the
-    // travel (the media tree's frozen-Behavior lesson).
-    readonly property real spanW: root.implicitWidth
+    // travel (the media tree's frozen-Behavior lesson). Reading implicitWidth
+    // here instead would retarget every element every frame, and elements
+    // whose x depends on the right edge - the panel, its cells - would crawl
+    // behind the card instead of travelling with it.
+    readonly property real spanW: root.sizeMode === "1x1" ? root.width1x1 : root.width2x1
     readonly property real spanH: root.baseHeight
 
     component TravelBehavior: NumberAnimation {
@@ -284,15 +287,52 @@ Item {
                 Behavior on opacity { FadeBehavior {} }
             }
 
+            // ---- 1x1 only: the word "to" ----------------------------------
+            // Its own element, because swapping the text of the code below
+            // ("to USD" to "USD") would be a content snap in the middle of
+            // the morph - exactly what this architecture exists to kill.
+            StyledText {
+                id: basePrefix
+                objectName: "currencyBasePrefix"
+                readonly property var slot: Geometry.basePrefixRect(root.sizeMode, root.spanW, root.spanH, Appearance.effectiveScale)
+                readonly property var lastSlot: slot ?? ({ x: x, y: y, size: font.pixelSize })
+                x: lastSlot.x
+                y: lastSlot.y
+                Behavior on x { TravelBehavior {} }
+                Behavior on y { TravelBehavior {} }
+                text: "to"
+                // It keeps its small size while it fades, so the growing code
+                // beside it does not drag it up in scale on the way out.
+                font.pixelSize: Math.round(lastSlot.size)
+                font.weight: Font.Bold
+                color: Appearance.colors.colPrimary
+                opacity: slot !== null ? 1 : 0
+                // Quicker than the shared fade: "Rates" travels down onto this
+                // line on the way to 2x1, and the two must not be legible on
+                // top of each other while it passes.
+                Behavior on opacity {
+                    NumberAnimation {
+                        duration: Math.round(Appearance.animation.elementMove.duration * 0.45)
+                        easing.type: Easing.BezierSpline
+                        easing.bezierCurve: Appearance.animationCurves.expressiveEffects
+                    }
+                }
+                visible: opacity > 0
+            }
+
             // ---- shared: the base currency --------------------------------
             StyledText {
                 objectName: "currencyBase"
                 readonly property var slot: Geometry.baseLabelRect(root.sizeMode, root.spanW, root.spanH, Appearance.effectiveScale)
-                x: slot.x
+                // The group's left edge travels; the code then sits after
+                // whatever width the fading prefix still occupies, so it
+                // slides into that space instead of jumping when it vanishes.
+                property real groupX: slot.x
+                Behavior on groupX { TravelBehavior {} }
+                x: groupX + (basePrefix.paintedWidth + 3 * Appearance.effectiveScale) * basePrefix.opacity
                 y: slot.y
-                Behavior on x { TravelBehavior {} }
                 Behavior on y { TravelBehavior {} }
-                text: root.sizeMode === "1x1" ? "to " + CurrencyService.baseCurrency : CurrencyService.baseCurrency
+                text: CurrencyService.baseCurrency
                 font.pixelSize: Math.round(slot.size)
                 Behavior on font.pixelSize { TravelBehavior {} }
                 font.weight: Font.Bold
@@ -349,16 +389,23 @@ Item {
                     StyledText {
                         // the value: under the code when stacked, right-aligned
                         // in a row
-                        x: quoteCell.lastSlot.stacked ? 0 : quoteCell.width - width
+                        width: quoteCell.width
+                        horizontalAlignment: quoteCell.lastSlot.stacked
+                            ? Text.AlignLeft : Text.AlignRight
+                        x: 0
                         y: quoteCell.lastSlot.stacked ? 14 * Appearance.effectiveScale
                             : (quoteCell.height - height) / 2
-                        Behavior on x { TravelBehavior {} }
                         Behavior on y { TravelBehavior {} }
                         text: {
                             if (quoteCell.rateVal > 0.0) return root.formatRate(quoteCell.rateVal);
                             if (CurrencyService.loading) return "...";
                             return CurrencyService.errorMessage || "...";
                         }
+                        // A JPY-sized rate is six decimals wide and used to run
+                        // straight into the next column; shrinking to fit keeps
+                        // the precision without the collision.
+                        fontSizeMode: Text.HorizontalFit
+                        minimumPixelSize: Math.round(8 * Appearance.effectiveScale)
                         font.pixelSize: Appearance.font.pixelSize.small
                         font.weight: Font.Bold
                         color: quoteCell.inkColor

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopCurrencyWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopCurrencyWidget.qml
@@ -8,6 +8,8 @@ import QtQuick
 import QtQuick.Layouts
 import QtQuick.Controls
 import "."
+import "currency_geometry.js" as Geometry
+import "currency_shapes.js" as CurrencyShapes
 
 Item {
     id: root
@@ -40,6 +42,22 @@ Item {
     implicitWidth: {
         if (sizeMode === "1x1") return width1x1;
         return width2x1;
+    }
+
+    // Geometry evaluates at the span's SETTLED box; Behaviors carry the
+    // travel (the media tree's frozen-Behavior lesson).
+    readonly property real spanW: root.implicitWidth
+    readonly property real spanH: root.baseHeight
+
+    component TravelBehavior: NumberAnimation {
+        duration: Appearance.animation.elementMove.duration
+        easing.type: Easing.BezierSpline
+        easing.bezierCurve: Appearance.animationCurves.expressiveDefaultSpatial
+    }
+    component FadeBehavior: NumberAnimation {
+        duration: Appearance.animation.elementMove.duration
+        easing.type: Easing.BezierSpline
+        easing.bezierCurve: Appearance.animationCurves.expressiveEffects
     }
 
     Behavior on implicitWidth {
@@ -135,244 +153,216 @@ Item {
                 }
             }
 
-            // ── [RADICAL M3 DESAIN 1x1: Original Immaterial Impulse Layout (Top-Right Icon, Left Bottom-Aligned Texts)] ──
-            Item {
-                visible: sizeMode === "1x1"
+            // ---- one tree (spec 2026-08-11): the container, the labels and
+            // the first two quote cells are single elements that travel;
+            // quotes 3-4 and the sparkline belong to 2x1 alone and fade.
+            // The container is the weather glyph's pattern, third adopter:
+            // one canvas whose shape is a parameter, Bun at 1x1 morphing
+            // into the full-height panel at 2x1.
+
+            // 2x1 only: the sparkline backdrop
+            Canvas {
+                id: sparklineCanvas
                 anchors.fill: parent
-
-                // Sisi Atas Kiri: Info teks mata uang dasar (e.g. "to IDR")
-                ColumnLayout {
-                    spacing: 0
-                    anchors {
-                        top: parent.top
-                        left: parent.left
-                        topMargin: 14 * Appearance.effectiveScale
-                        leftMargin: 14 * Appearance.effectiveScale
+                opacity: root.sizeMode === "2x1" ? 0.35 : 0
+                Behavior on opacity { FadeBehavior {} }
+                visible: opacity > 0
+                onPaint: {
+                    var ctx = getContext("2d");
+                    ctx.reset();
+                    ctx.clearRect(0, 0, width, height);
+                    ctx.strokeStyle = Appearance.colors.colOnPrimaryContainer;
+                    ctx.lineWidth = 2 * Appearance.effectiveScale;
+                    ctx.lineCap = "round";
+                    ctx.beginPath();
+                    let points = [0.8, 0.6, 0.75, 0.4, 0.55, 0.3, 0.45, 0.2];
+                    let step = width / (points.length - 1);
+                    ctx.moveTo(0, height * points[0]);
+                    for (let i = 1; i < points.length; i++) {
+                        let x = i * step;
+                        let y = height * points[i];
+                        let prevX = (i - 1) * step;
+                        let prevY = height * points[i - 1];
+                        ctx.bezierCurveTo(prevX + step/2, prevY, x - step/2, y, x, y);
                     }
-                    StyledText {
-                        text: "Rates"
-                        font.pixelSize: Appearance.font.pixelSize.smallest
-                        font.weight: Font.DemiBold
-                        color: Appearance.colors.colOnPrimaryContainer
-                        opacity: 0.6
-                    }
-                    StyledText {
-                        text: "to " + CurrencyService.baseCurrency
-                        font.pixelSize: Math.round(10 * Appearance.effectiveScale)
-                        font.weight: Font.Bold
-                        color: Appearance.colors.colPrimary
-                    }
-                }
-
-                // Sisi Atas Kanan: Material Shape Wrapped Symbol (Top Right)
-                MaterialShape {
-                    id: currencyIconShape
-                    width: 34 * Appearance.effectiveScale
-                    height: 34 * Appearance.effectiveScale
-                    shape: MaterialShape.Shape.Bun
-                    color: Appearance.colors.colPrimary
-                    anchors {
-                        top: parent.top
-                        right: parent.right
-                        topMargin: 14 * Appearance.effectiveScale
-                        rightMargin: 14 * Appearance.effectiveScale
-                    }
-
-                    MaterialSymbol {
-                        anchors.centerIn: parent
-                        text: "payments"
-                        iconSize: 18 * Appearance.effectiveScale
-                        color: Appearance.colors.colOnPrimary
-                    }
-                }
-
-                // Sisi Bawah Kiri: 2 Stacked Rates (Bottom-Aligned Left)
-                ColumnLayout {
-                    spacing: -2 * Appearance.effectiveScale
-                    anchors {
-                        bottom: parent.bottom
-                        left: parent.left
-                        right: parent.right
-                        bottomMargin: 14 * Appearance.effectiveScale
-                        leftMargin: 14 * Appearance.effectiveScale
-                        rightMargin: 14 * Appearance.effectiveScale
-                    }
-                    
-                    // Quote 1 Row (USD)
-                    RowLayout {
-                        Layout.fillWidth: true
-                        spacing: 4 * Appearance.effectiveScale
-
-                        StyledText {
-                            text: CurrencyService.quote1
-                            font.pixelSize: Appearance.font.pixelSize.small
-                            font.weight: Font.DemiBold
-                            color: Appearance.colors.colOnPrimaryContainer
-                            opacity: 0.6
-                        }
-                        
-                        Item { Layout.fillWidth: true } // Spacer
-
-                        StyledText {
-                            text: {
-                                let v = CurrencyService.rates[CurrencyService.quote1] || 0.0;
-                                if (v > 0.0) return root.formatRate(v);
-                                return CurrencyService.errorMessage || "...";
-                            }
-                            font.pixelSize: Appearance.font.pixelSize.small
-                            font.weight: Font.Bold
-                            color: Appearance.colors.colOnPrimaryContainer
-                        }
-                    }
-
-                    // Quote 2 Row (EUR)
-                    RowLayout {
-                        Layout.fillWidth: true
-                        spacing: 4 * Appearance.effectiveScale
-
-                        StyledText {
-                            text: CurrencyService.quote2
-                            font.pixelSize: Appearance.font.pixelSize.small
-                            font.weight: Font.DemiBold
-                            color: Appearance.colors.colOnPrimaryContainer
-                            opacity: 0.6
-                        }
-                        
-                        Item { Layout.fillWidth: true } // Spacer
-
-                        StyledText {
-                            text: {
-                                let v = CurrencyService.rates[CurrencyService.quote2] || 0.0;
-                                if (v > 0.0) return root.formatRate(v);
-                                return CurrencyService.errorMessage || "...";
-                            }
-                            font.pixelSize: Appearance.font.pixelSize.small
-                            font.weight: Font.Bold
-                            color: Appearance.colors.colOnPrimaryContainer
-                        }
-                    }
+                    ctx.stroke();
                 }
             }
 
-            // ── [RADICAL M3 DESAIN 2x1: Wavy Sparkline / Trading Card] ──
+            // ---- shared: the container (Bun <-> panel) --------------------
             Item {
-                visible: sizeMode === "2x1"
-                anchors.fill: parent
+                id: container
+                objectName: "currencyContainer"
+                readonly property var slot: Geometry.containerRect(root.sizeMode, root.spanW, root.spanH, Appearance.effectiveScale)
+                x: slot.x
+                y: slot.y
+                width: slot.width
+                height: slot.height
+                Behavior on x { TravelBehavior {} }
+                Behavior on y { TravelBehavior {} }
+                Behavior on width { TravelBehavior {} }
+                Behavior on height { TravelBehavior {} }
 
-                // Wavy line di background untuk kesan trading chart live yang sangat premium
                 Canvas {
-                    id: sparklineCanvas
+                    id: containerCanvas
                     anchors.fill: parent
-                    opacity: 0.35
+                    property string shownShape: container.slot.shape
+                    property string fromShape: container.slot.shape
+                    property real morphT: 1
+                    Behavior on morphT { id: morphGate; TravelBehavior {} }
+                    readonly property string targetShape: container.slot.shape
+                    onTargetShapeChanged: {
+                        containerCanvas.fromShape = containerCanvas.shownShape;
+                        containerCanvas.shownShape = containerCanvas.targetShape;
+                        // Through a CLOSED gate - written through the live
+                        // Behavior, a reset retargets instead (the weather
+                        // glyph shipped that snap).
+                        morphGate.enabled = false;
+                        morphT = 0;
+                        morphGate.enabled = true;
+                        morphT = 1;
+                    }
+                    readonly property color fillColor: Appearance.colors.colPrimary
+                    onMorphTChanged: requestPaint()
+                    onFillColorChanged: requestPaint()
+                    onWidthChanged: requestPaint()
+                    onHeightChanged: requestPaint()
+                    onAvailableChanged: if (available) requestPaint()
                     onPaint: {
-                        var ctx = getContext("2d");
-                        ctx.reset();
+                        const ctx = getContext("2d");
                         ctx.clearRect(0, 0, width, height);
-
-                        // Draw a smooth sparkline trend
-                        ctx.strokeStyle = Appearance.colors.colOnPrimaryContainer;
-                        ctx.lineWidth = 2 * Appearance.effectiveScale;
-                        ctx.lineCap = "round";
+                        const shape = CurrencyShapes.containerAt(
+                            containerCanvas.fromShape, containerCanvas.shownShape, containerCanvas.morphT);
+                        if (shape.cubics.length === 0) return;
+                        const spanX = Math.max(0.001, shape.maxX - shape.minX);
+                        const spanY = Math.max(0.001, shape.maxY - shape.minY);
+                        const scale = Math.min(width / spanX, height / spanY);
+                        ctx.save();
+                        ctx.translate(width / 2 - (shape.minX + spanX / 2) * scale,
+                                      height / 2 - (shape.minY + spanY / 2) * scale);
+                        ctx.scale(scale, scale);
                         ctx.beginPath();
-                        
-                        let points = [0.8, 0.6, 0.75, 0.4, 0.55, 0.3, 0.45, 0.2];
-                        let step = width / (points.length - 1);
-                        
-                        ctx.moveTo(0, height * points[0]);
-                        for (let i = 1; i < points.length; i++) {
-                            let x = i * step;
-                            let y = height * points[i];
-                            // Curving coordinates
-                            let prevX = (i - 1) * step;
-                            let prevY = height * points[i - 1];
-                            ctx.bezierCurveTo(prevX + step/2, prevY, x - step/2, y, x, y);
-                        }
-                        ctx.stroke();
+                        ctx.moveTo(shape.cubics[0].anchor0X, shape.cubics[0].anchor0Y);
+                        for (const cubic of shape.cubics)
+                            ctx.bezierCurveTo(cubic.control0X, cubic.control0Y,
+                                cubic.control1X, cubic.control1Y, cubic.anchor1X, cubic.anchor1Y);
+                        ctx.closePath();
+                        ctx.fillStyle = containerCanvas.fillColor;
+                        ctx.fill();
+                        ctx.restore();
                     }
                 }
 
-                // Sisi Kiri: Base currency label besar
-                ColumnLayout {
-                    anchors {
-                        left: parent.left
-                        verticalCenter: parent.verticalCenter
-                        leftMargin: 20 * Appearance.effectiveScale
-                    }
-                    spacing: -4 * Appearance.effectiveScale
+                // 1x1 only: the payments badge glyph, fading as the container
+                // becomes a data panel.
+                MaterialSymbol {
+                    anchors.centerIn: parent
+                    text: "payments"
+                    iconSize: 18 * Appearance.effectiveScale
+                    color: Appearance.colors.colOnPrimary
+                    opacity: root.sizeMode === "1x1" ? 1 : 0
+                    Behavior on opacity { FadeBehavior {} }
+                    visible: opacity > 0
+                }
+            }
+
+            // ---- shared: "Rates" ------------------------------------------
+            StyledText {
+                objectName: "currencyRatesLabel"
+                readonly property var slot: Geometry.ratesLabelRect(root.sizeMode, root.spanW, root.spanH, Appearance.effectiveScale)
+                x: slot.x
+                y: slot.y
+                Behavior on x { TravelBehavior {} }
+                Behavior on y { TravelBehavior {} }
+                text: "Rates"
+                font.pixelSize: root.sizeMode === "1x1" ? Appearance.font.pixelSize.smallest : Appearance.font.pixelSize.small
+                Behavior on font.pixelSize { TravelBehavior {} }
+                font.weight: root.sizeMode === "1x1" ? Font.DemiBold : Font.Bold
+                Behavior on font.weight { TravelBehavior {} }
+                color: Appearance.colors.colOnPrimaryContainer
+                opacity: root.sizeMode === "1x1" ? 0.6 : 0.8
+                Behavior on opacity { FadeBehavior {} }
+            }
+
+            // ---- shared: the base currency --------------------------------
+            StyledText {
+                objectName: "currencyBase"
+                readonly property var slot: Geometry.baseLabelRect(root.sizeMode, root.spanW, root.spanH, Appearance.effectiveScale)
+                x: slot.x
+                y: slot.y
+                Behavior on x { TravelBehavior {} }
+                Behavior on y { TravelBehavior {} }
+                text: root.sizeMode === "1x1" ? "to " + CurrencyService.baseCurrency : CurrencyService.baseCurrency
+                font.pixelSize: Math.round(slot.size)
+                Behavior on font.pixelSize { TravelBehavior {} }
+                font.weight: Font.Bold
+                color: root.sizeMode === "1x1" ? Appearance.colors.colPrimary : Appearance.colors.colOnPrimaryContainer
+                Behavior on color { ColorAnimation { duration: Appearance.animation.elementMove.duration } }
+            }
+
+            // ---- the quote cells: 1-2 shared, 3-4 enter and exit ----------
+            Repeater {
+                model: 4
+                Item {
+                    id: quoteCell
+                    required property int index
+                    readonly property var slot: Geometry.quoteCellRect(index, root.sizeMode, root.spanW, root.spanH, Appearance.effectiveScale)
+                    readonly property var lastSlot: slot ?? ({ x: x, y: y, width: width, height: height, stacked: true })
+                    readonly property string quoteCurrency:
+                        index === 0 ? CurrencyService.quote1
+                        : index === 1 ? CurrencyService.quote2
+                        : index === 2 ? CurrencyService.quote3
+                        : CurrencyService.quote4
+                    readonly property real rateVal: CurrencyService.rates[quoteCurrency] !== undefined
+                        ? CurrencyService.rates[quoteCurrency] : 0.0
+                    x: lastSlot.x
+                    y: lastSlot.y
+                    width: lastSlot.width
+                    height: lastSlot.height
+                    Behavior on x { TravelBehavior {} }
+                    Behavior on y { TravelBehavior {} }
+                    Behavior on width { TravelBehavior {} }
+                    opacity: slot !== null ? 1 : 0
+                    Behavior on opacity { FadeBehavior {} }
+                    visible: opacity > 0
+                    z: 2
+
+                    readonly property color inkColor: quoteCell.lastSlot.stacked
+                        ? Appearance.colors.colOnPrimary
+                        : Appearance.colors.colOnPrimaryContainer
 
                     StyledText {
-                        text: "Rates"
+                        // the code: top-left when stacked, left-middle in a row
+                        x: 0
+                        y: quoteCell.lastSlot.stacked ? 0 : (quoteCell.height - height) / 2
+                        Behavior on y { TravelBehavior {} }
+                        text: quoteCell.quoteCurrency
+                        font.pixelSize: quoteCell.lastSlot.stacked
+                            ? Appearance.font.pixelSize.smallest : Appearance.font.pixelSize.small
+                        Behavior on font.pixelSize { TravelBehavior {} }
+                        font.weight: quoteCell.lastSlot.stacked ? Font.Bold : Font.DemiBold
+                        color: quoteCell.inkColor
+                        Behavior on color { ColorAnimation { duration: Appearance.animation.elementMove.duration } }
+                        opacity: quoteCell.lastSlot.stacked ? 1 : 0.6
+                        Behavior on opacity { FadeBehavior {} }
+                    }
+                    StyledText {
+                        // the value: under the code when stacked, right-aligned
+                        // in a row
+                        x: quoteCell.lastSlot.stacked ? 0 : quoteCell.width - width
+                        y: quoteCell.lastSlot.stacked ? 14 * Appearance.effectiveScale
+                            : (quoteCell.height - height) / 2
+                        Behavior on x { TravelBehavior {} }
+                        Behavior on y { TravelBehavior {} }
+                        text: {
+                            if (quoteCell.rateVal > 0.0) return root.formatRate(quoteCell.rateVal);
+                            if (CurrencyService.loading) return "...";
+                            return CurrencyService.errorMessage || "...";
+                        }
                         font.pixelSize: Appearance.font.pixelSize.small
                         font.weight: Font.Bold
-                        color: Appearance.colors.colOnPrimaryContainer
-                        opacity: 0.8
-                    }
-
-                    StyledText {
-                        text: CurrencyService.baseCurrency
-                        font.pixelSize: Math.round(42 * Appearance.effectiveScale)
-                        font.weight: Font.Bold
-                        color: Appearance.colors.colOnPrimaryContainer
-                    }
-                }
-
-                // Area Kanan: Split Solid Panel dengan sudut KIRI membulat (Rounded Left Edge)
-                Rectangle {
-                    id: rightSplitPanel
-                    width: 140 * Appearance.effectiveScale
-                    radius: 30 * Appearance.effectiveScale
-                    color: Appearance.colors.colPrimary
-                    
-                    anchors {
-                        right: parent.right
-                        top: parent.top
-                        bottom: parent.bottom
-                    }
-
-                    // Grid data mata uang di dalam panel kanan (tanpa pemotongan k)
-                    GridLayout {
-                        anchors.fill: parent
-                        anchors.margins: 14 * Appearance.effectiveScale
-                        columns: 2
-                        rowSpacing: 4 * Appearance.effectiveScale
-                        columnSpacing: 10 * Appearance.effectiveScale
-
-                        Repeater {
-                            model: 4
-                            delegate: ColumnLayout {
-                                spacing: -4 * Appearance.effectiveScale
-
-                                property string quoteCurrency: {
-                                    if (index === 0) return CurrencyService.quote1;
-                                    if (index === 1) return CurrencyService.quote2;
-                                    if (index === 2) return CurrencyService.quote3;
-                                    return CurrencyService.quote4;
-                                }
-
-                                property real rateVal: {
-                                    let r = CurrencyService.rates[quoteCurrency];
-                                    return r !== undefined ? r : 0.0;
-                                }
-
-                                StyledText {
-                                    text: quoteCurrency
-                                    font.pixelSize: Appearance.font.pixelSize.smallest
-                                    font.weight: Font.Bold
-                                    color: Appearance.colors.colOnPrimary
-                                }
-
-                                StyledText {
-                                    text: {
-                                        if (CurrencyService.loading) return "...";
-                                        if (rateVal === 0.0) return CurrencyService.errorMessage || "...";
-                                        return root.formatRate(rateVal);
-                                    }
-                                    font.pixelSize: Appearance.font.pixelSize.small
-                                    font.weight: Font.Bold
-                                    color: Appearance.colors.colOnPrimary
-                                }
-                            }
-                        }
+                        color: quoteCell.inkColor
+                        Behavior on color { ColorAnimation { duration: Appearance.animation.elementMove.duration } }
                     }
                 }
             }

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopWeatherWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopWeatherWidget.qml
@@ -54,7 +54,14 @@ Item {
     // Geometry evaluates at the span's SETTLED box (the media tree's lesson:
     // live-box rects made size snap and are per-frame Behavior targets, the
     // frozen-Behavior shape). Rects change once per span; Behaviors carry.
-    readonly property real spanW: root.implicitWidth
+    // implicitWidth is NOT that box - it animates, so reading it here
+    // retargets every rect every frame and a right-edge rect like the glyph's
+    // crawls behind the card instead of travelling with it.
+    readonly property real spanW: {
+        if (sizeMode === "1x1") return width1x1;
+        if (sizeMode === "2x1") return width2x1;
+        return width3x1;
+    }
     readonly property real spanH: root.baseHeight
     readonly property var tempSlot: Geometry.temperatureRect(root.sizeMode, root.spanW, root.spanH, Appearance.effectiveScale)
     readonly property var conditionSlot: Geometry.conditionRect(root.sizeMode, root.spanW, root.spanH, Appearance.effectiveScale)

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/currency_geometry.js
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/currency_geometry.js
@@ -1,0 +1,58 @@
+.pragma library
+
+// Where every shared element of the currency widget sits, per span.
+// Spans at scale 1: 1x1 = 132x108, 2x1 = 276x108. Numbers measured off the
+// two visible-branch layouts this replaces. null = the span does not have
+// the element (a fade, never a morph).
+
+function _rect(x, y, w, h) { return { x: x, y: y, width: w, height: h }; }
+
+// The container: the Bun badge at 1x1, the right panel at 2x1.
+function containerRect(span, width, height, scale) {
+    if (span === "1x1") return {
+        x: width - (14 + 34) * scale, y: 14 * scale,
+        width: 34 * scale, height: 34 * scale, shape: "bun"
+    };
+    return {
+        x: width - 140 * scale, y: 0,
+        width: 140 * scale, height: height, shape: "panel"
+    };
+}
+
+// "Rates", the small label.
+function ratesLabelRect(span, width, height, scale) {
+    if (span === "1x1") return { x: 14 * scale, y: 14 * scale };
+    return { x: 20 * scale, y: 24 * scale };
+}
+
+// The base currency: tiny "to USD" under the label at 1x1, the giant code at
+// 2x1. One element; the size is most of the identity change.
+function baseLabelRect(span, width, height, scale) {
+    if (span === "1x1") return { x: 14 * scale, y: 30 * scale, size: 10 * scale };
+    return { x: 20 * scale, y: 38 * scale, size: 42 * scale };
+}
+
+// A quote cell. All four exist at 2x1 (the panel's 2x2 grid); the first two
+// survive at 1x1 as the stacked rows bottom-left, the rest return null.
+// `stacked` is the cell's inner arrangement: label above value in the panel,
+// label-left value-right in the 1x1 rows.
+function quoteCellRect(index, span, width, height, scale) {
+    if (span === "1x1") {
+        if (index >= 2) return null;
+        var rowH = 18 * scale;
+        return {
+            x: 14 * scale, y: height - (14 + (2 - index) * rowH) * scale >= 0
+                ? height - 14 * scale - (2 - index) * rowH : 0,
+            width: width - 28 * scale, height: rowH, stacked: false
+        };
+    }
+    var panelX = width - 140 * scale;
+    var cellW = (140 - 28 - 10) / 2 * scale;
+    var cellH = (108 - 28 - 4) / 2 * scale;
+    var col = index % 2, row = Math.floor(index / 2);
+    return {
+        x: panelX + 14 * scale + col * (cellW + 10 * scale),
+        y: 14 * scale + row * (cellH + 4 * scale),
+        width: cellW, height: cellH, stacked: true
+    };
+}

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/currency_geometry.js
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/currency_geometry.js
@@ -25,11 +25,21 @@ function ratesLabelRect(span, width, height, scale) {
     return { x: 20 * scale, y: 24 * scale };
 }
 
-// The base currency: tiny "to USD" under the label at 1x1, the giant code at
-// 2x1. One element; the size is most of the identity change.
+// The base currency code. It reads "to USD" small at 1x1 and "USD" giant at
+// 2x1, but the word "to" is its own element (see basePrefixRect) - swapping
+// the text of one element would be a snap in the middle of the morph. `x` is
+// the left edge of the whole group; the code itself is offset by whatever
+// the fading prefix still occupies.
 function baseLabelRect(span, width, height, scale) {
     if (span === "1x1") return { x: 14 * scale, y: 30 * scale, size: 10 * scale };
     return { x: 20 * scale, y: 38 * scale, size: 42 * scale };
+}
+
+// The word "to", which only exists at 1x1. It keeps its small size while it
+// fades so the growing code does not drag it along.
+function basePrefixRect(span, width, height, scale) {
+    if (span === "1x1") return { x: 14 * scale, y: 30 * scale, size: 10 * scale };
+    return null;
 }
 
 // A quote cell. All four exist at 2x1 (the panel's 2x2 grid); the first two

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/currency_shapes.js
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/currency_shapes.js
@@ -1,0 +1,58 @@
+.pragma library
+
+.import "./shapes/material-shapes.js" as MaterialShapes
+.import "./shapes/rounded-polygon.js" as RoundedPolygon
+.import "./shapes/corner-rounding.js" as CornerRounding
+.import "./shapes/morph.js" as MorphLib
+
+// The currency container's two shapes in one centred height-1 space: the Bun
+// badge at 1x1 and the full-height right panel at 2x1 - the weather glyph's
+// pattern (weather_shapes.js), third adopter of "one component whose shape is
+// a parameter". The panel is built AT its aspect so the corners stay
+// circular. (Two hand-rolled copies of this pattern now exist; extraction is
+// step 10's call, made with both in hand.)
+
+var PANEL_ASPECT = 140 / 108;
+var PANEL_ROUNDING = 30 / 108;
+
+var _shapes = {};
+function shapeOf(name) {
+    if (_shapes[name] !== undefined) return _shapes[name];
+    var polygon;
+    if (name === "bun") {
+        polygon = MaterialShapes.getBun()
+            .transformed(function (x, y) { return { x: x - 0.5, y: y - 0.5 }; });
+    } else {
+        polygon = RoundedPolygon.RoundedPolygon.rectangle(
+            PANEL_ASPECT, 1, new CornerRounding.CornerRounding(PANEL_ROUNDING));
+    }
+    _shapes[name] = polygon;
+    return polygon;
+}
+
+var _morphs = {};
+function containerAt(fromName, toName, t) {
+    var clamped = Math.max(0, Math.min(1, t));
+    if (fromName === toName || clamped >= 0.999)
+        return _bounded(shapeOf(toName).cubics);
+    var key = fromName + ">" + toName;
+    if (_morphs[key] === undefined)
+        _morphs[key] = new MorphLib.Morph(shapeOf(fromName), shapeOf(toName));
+    return _bounded(_morphs[key].asCubics(clamped));
+}
+
+function _bounded(cubics) {
+    var minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+    for (var i = 0; i < cubics.length; i++) {
+        var c = cubics[i];
+        var xs = [c.anchor0X, c.control0X, c.control1X, c.anchor1X];
+        var ys = [c.anchor0Y, c.control0Y, c.control1Y, c.anchor1Y];
+        for (var j = 0; j < 4; j++) {
+            if (xs[j] < minX) minX = xs[j];
+            if (xs[j] > maxX) maxX = xs[j];
+            if (ys[j] < minY) minY = ys[j];
+            if (ys[j] > maxY) maxY = ys[j];
+        }
+    }
+    return { cubics: cubics, minX: minX, minY: minY, maxX: maxX, maxY: maxY };
+}

--- a/dots/.config/quickshell/imi/tests/run_currency_probe.sh
+++ b/dots/.config/quickshell/imi/tests/run_currency_probe.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Headless weston + qs, the runtime-harness pattern, trimmed to one probe.
+set -u
+SOCKET="wl-imi-currency-tree"
+TMP=$(mktemp -d)
+export XDG_RUNTIME_DIR="$TMP/runtime"; mkdir -p "$XDG_RUNTIME_DIR"; chmod 700 "$XDG_RUNTIME_DIR"
+export XDG_CONFIG_HOME="$TMP/config" XDG_CACHE_HOME="$TMP/cache" XDG_STATE_HOME="$TMP/state" XDG_DATA_HOME="$TMP/data"
+mkdir -p "$XDG_CONFIG_HOME" "$XDG_CACHE_HOME" "$XDG_STATE_HOME" "$XDG_DATA_HOME"
+weston --backend=headless-backend.so --socket="$SOCKET" --width=1280 --height=800 &>"$TMP/weston.log" &
+WPID=$!
+sleep 2
+DBUS_SESSION_BUS_ADDRESS="unix:path=/nonexistent" WAYLAND_DISPLAY="$SOCKET" CURRENCY_PROBE_SHOTS="${CURRENCY_PROBE_SHOTS:-}" timeout 60 qs -p "$(dirname "$0")/../CurrencyTreeMotionProbe.qml" 2>&1 | grep "CurrencyTreeMotion"
+kill $WPID 2>/dev/null
+rm -rf "$TMP"

--- a/dots/.config/quickshell/imi/tests/test_currency_service_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_currency_service_contract.py
@@ -7,9 +7,25 @@ WRAPPER = Path("modules/common/plugins/bundled/nandoroid-currency/Widget.qml")
 
 def test_currency_service_fetches_one_target_table_from_api():
     source = SERVICE.read_text()
-    assert "currencies/${encodeURIComponent(target)}.json" in source
+    schedule = (SERVICE.parent / "currency_schedule.js").read_text()
+    # URL building moved into the schedule module when the service gained a
+    # mirror host - one attempt walks both before counting as a failure.
+    assert "currencies/" in schedule and "encodeURIComponent(baseCode)" in schedule
+    assert "cdn.jsdelivr.net" in schedule, "the documented mirror"
     assert "CurrencyMath.ratesIntoTarget(table, uniqueQuotes)" in source
     assert source.count("new XMLHttpRequest()") == 1
+
+
+def test_currency_service_retries_instead_of_giving_up():
+    """The service used to make ONE attempt per session, so a shell that
+    started before the network stayed on 'Network timeout' forever."""
+    source = SERVICE.read_text()
+    schedule = (SERVICE.parent / "currency_schedule.js").read_text()
+    assert "attemptFailed" in source and "nextAttempt" in source
+    assert "Schedule.nextRetryMs" in source
+    assert "Schedule.REFRESH_MS" in source, "success settles into periodic refresh"
+    assert "failureCount" in source
+    assert "RETRY_DELAYS_MS" in schedule
 
 
 def test_currency_service_ignores_stale_responses():
@@ -36,7 +52,8 @@ def test_currency_service_has_bounded_non_reentrant_request():
     source = SERVICE.read_text()
     assert "id: requestTimeout" in source
     assert ".abort()" not in source
-    assert 'root.errorMessage = "Network timeout"' in source
+    assert 'root.attemptFailed("Network timeout")' in source, \
+        "the timeout feeds the retry schedule now, not a terminal message"
 
 
 if __name__ == "__main__":

--- a/dots/.config/quickshell/imi/tests/test_expressive_design_system.py
+++ b/dots/.config/quickshell/imi/tests/test_expressive_design_system.py
@@ -96,6 +96,34 @@ class ExpressiveDesignSystemTest(unittest.TestCase):
             for option_key in option_keys:
                 self.assertIn(f'PluginState.option("{manifest["id"]}", "{option_key}"', entry)
 
+    def test_geometry_rects_come_from_the_settled_span_not_the_animating_box(self):
+        """`spanW` may not read the box that is currently animating.
+
+        Three trees have now been written with `spanW: root.implicitWidth`,
+        and implicitWidth carries a Behavior: every element's rect became a
+        per-frame target, so Behaviors never converged and any rect measured
+        from the right edge (the media play button, the weather glyph, the
+        currency panel and its cells) crawled behind the card instead of
+        travelling with it. The settled span's width is a function of the
+        span name alone.
+        """
+        trees = [
+            PLUGIN_ROOT / "nandoroid-media/Widget.qml",
+            DESIGN_SYSTEM / "widgets/DesktopWeatherWidget.qml",
+            DESIGN_SYSTEM / "widgets/DesktopCurrencyWidget.qml",
+        ]
+        for tree in trees:
+            source = tree.read_text(encoding="utf-8")
+            self.assertIn("spanW", source, f"{tree.name} declares a span width")
+            for line in source.splitlines():
+                if "property real spanW" in line or "property real spanH" in line:
+                    # `root.width1x1` and friends are settled constants; the
+                    # live box is `root.width` / `root.implicitWidth` exactly.
+                    for live in (r"\bimplicitWidth\b", r"\bimplicitHeight\b",
+                                 r"\broot\.width\b", r"\broot\.height\b"):
+                        self.assertIsNone(re.search(live, line),
+                                          f"{tree.name}: {line.strip()}")
+
     def test_the_media_tree_answers_the_blur_contract_itself(self):
         """One tree, one card, one region list.
 

--- a/dots/.config/quickshell/imi/tests/test_expressive_design_system.py
+++ b/dots/.config/quickshell/imi/tests/test_expressive_design_system.py
@@ -39,7 +39,7 @@ ENTRY_FILES = {}
 # ...and the size assertion below moved with it, to the other side: a widget
 # whose manifest declares a grid is sized by the host to the span it resolved,
 # so its wrapper names spans rather than forwarding a content size.
-SIZED_BY_THE_HOST_GRID = {"nandoroid-media", "nandoroid-weather"}
+SIZED_BY_THE_HOST_GRID = {"nandoroid-media", "nandoroid-weather", "nandoroid-currency"}
 
 
 def entry_file(directory):

--- a/dots/.config/quickshell/imi/tests/tst_currency_geometry.qml
+++ b/dots/.config/quickshell/imi/tests/tst_currency_geometry.qml
@@ -41,6 +41,18 @@ TestCase {
         }
     }
 
+    function test_the_word_to_is_its_own_element() {
+        // The code used to read "to USD" at 1x1 and "USD" at 2x1 as one
+        // element, so its text swapped mid-morph - a content snap.
+        verify(Geometry.basePrefixRect("1x1", 132, 108, 1) !== null);
+        compare(Geometry.basePrefixRect("2x1", 276, 108, 1), null,
+                "no home at 2x1, so it fades");
+        const prefix = Geometry.basePrefixRect("1x1", 132, 108, 1);
+        const base = Geometry.baseLabelRect("1x1", 132, 108, 1);
+        compare(prefix.y, base.y, "one line at 1x1");
+        compare(prefix.size, base.size);
+    }
+
     function test_the_base_label_grows_between_spans() {
         const at1 = Geometry.baseLabelRect("1x1", 132, 108, 1);
         const at2 = Geometry.baseLabelRect("2x1", 276, 108, 1);

--- a/dots/.config/quickshell/imi/tests/tst_currency_geometry.qml
+++ b/dots/.config/quickshell/imi/tests/tst_currency_geometry.qml
@@ -1,0 +1,64 @@
+import QtTest
+import "../modules/common/plugins/designsystem/widgets/currency_geometry.js" as Geometry
+import "../modules/common/plugins/designsystem/widgets/currency_shapes.js" as CurrencyShapes
+
+// The currency widget's shared-element geometry and container shape space.
+// Spans at scale 1: 1x1 = 132x108, 2x1 = 276x108.
+TestCase {
+    name: "CurrencyGeometryTest"
+
+    function test_the_container_exists_at_both_spans_with_its_own_shape() {
+        const c1 = Geometry.containerRect("1x1", 132, 108, 1);
+        const c2 = Geometry.containerRect("2x1", 276, 108, 1);
+        compare(c1.shape, "bun");
+        compare(c2.shape, "panel");
+        compare(c1.width, 34, "the badge");
+        compare(c2.height, 108, "the flush full-height panel");
+        compare(c2.x + c2.width, 276, "flush with the card edge");
+    }
+
+    function test_the_first_two_quotes_survive_and_the_rest_exit() {
+        for (let i = 0; i < 4; i++) {
+            const at2 = Geometry.quoteCellRect(i, "2x1", 276, 108, 1);
+            verify(at2 !== null, "all four live in the panel");
+            verify(at2.stacked, "stacked cells in the panel");
+        }
+        verify(Geometry.quoteCellRect(0, "1x1", 132, 108, 1) !== null);
+        verify(Geometry.quoteCellRect(1, "1x1", 132, 108, 1) !== null);
+        compare(Geometry.quoteCellRect(2, "1x1", 132, 108, 1), null,
+                "null is a fade, never a morph");
+        compare(Geometry.quoteCellRect(3, "1x1", 132, 108, 1), null);
+        verify(!Geometry.quoteCellRect(0, "1x1", 132, 108, 1).stacked,
+               "rows, not stacks, at 1x1");
+    }
+
+    function test_the_panel_cells_sit_inside_the_panel() {
+        const panel = Geometry.containerRect("2x1", 276, 108, 1);
+        for (let i = 0; i < 4; i++) {
+            const cell = Geometry.quoteCellRect(i, "2x1", 276, 108, 1);
+            verify(cell.x >= panel.x, "cell " + i + " inside the panel");
+            verify(cell.x + cell.width <= panel.x + panel.width + 0.1);
+        }
+    }
+
+    function test_the_base_label_grows_between_spans() {
+        const at1 = Geometry.baseLabelRect("1x1", 132, 108, 1);
+        const at2 = Geometry.baseLabelRect("2x1", 276, 108, 1);
+        verify(at2.size > at1.size * 3, "tiny caption to giant code");
+    }
+
+    function test_every_shape_pair_morphs_with_mid_between_endpoints() {
+        const from = CurrencyShapes.containerAt("bun", "bun", 1);
+        const to = CurrencyShapes.containerAt("panel", "panel", 1);
+        const mid = CurrencyShapes.containerAt("bun", "panel", 0.5);
+        const w = s => s.maxX - s.minX;
+        verify((w(mid) - w(from)) * (w(mid) - w(to)) < 0,
+               "the morph travels, it does not snap");
+    }
+
+    function test_the_panel_shape_carries_its_aspect() {
+        const panel = CurrencyShapes.containerAt("panel", "panel", 1);
+        const aspect = (panel.maxX - panel.minX) / (panel.maxY - panel.minY);
+        fuzzyCompare(aspect, 140 / 108, 0.02);
+    }
+}

--- a/dots/.config/quickshell/imi/tests/tst_currency_schedule.qml
+++ b/dots/.config/quickshell/imi/tests/tst_currency_schedule.qml
@@ -1,0 +1,40 @@
+import QtTest
+import "../modules/common/plugins/designsystem/services/currency_schedule.js" as Schedule
+
+// The currency service's retry arithmetic. The service used to make ONE
+// attempt per session; these pin the schedule that replaced that.
+TestCase {
+    name: "CurrencyScheduleTest"
+
+    function test_the_first_retry_is_quick() {
+        // The common failure is the shell starting before the network; the
+        // boot race resolves in seconds and the retry should too.
+        compare(Schedule.nextRetryMs(1), 5000);
+    }
+
+    function test_failure_backs_off_and_caps() {
+        compare(Schedule.nextRetryMs(2), 15000);
+        compare(Schedule.nextRetryMs(3), 60000);
+        compare(Schedule.nextRetryMs(4), 300000);
+        compare(Schedule.nextRetryMs(50), 300000,
+                "an hour offline still recovers within five minutes");
+    }
+
+    function test_success_refreshes_hourly() {
+        verify(Schedule.REFRESH_MS === 3600000,
+               "the dataset updates daily; hourly is already generous");
+    }
+
+    function test_one_attempt_tries_the_mirror_too() {
+        const urls = Schedule.urlsFor("usd");
+        compare(urls.length, 2);
+        verify(urls[0].indexOf("currency-api.pages.dev") !== -1);
+        verify(urls[1].indexOf("cdn.jsdelivr.net") !== -1);
+        verify(urls[0].indexOf("/usd.json") !== -1);
+    }
+
+    function test_the_base_code_is_url_encoded() {
+        const urls = Schedule.urlsFor("a/b");
+        verify(urls[0].indexOf("a%2Fb") !== -1);
+    }
+}


### PR DESCRIPTION
Step 8 of the expressive morphing landing plan, plus the "Network timeout" the widget was stuck on.

## The service

It made exactly ONE attempt per session, 50ms after startup. A shell that started before the network was up showed "Network timeout" until a settings edit happened to trigger a new request, and rates never refreshed within a session either.

An attempt now walks both hosts (the pages.dev primary, then the jsdelivr mirror) before it counts as a failure. Failures back off 5s → 15s → 1m → 5m; success settles into an hourly refresh. Stale rates stay on screen throughout — the message only ever fills empty slots. The schedule is arithmetic in `currency_schedule.js` with its own tests.

## The tree

Every shared element — the container, "Rates", the base code, the four quote cells — is declared once and travels. The container is a Bun badge at 1x1 and the full-height panel at 2x1, morphing between two polygons in one shape space. The wrapper is sized by the host grid so the card rides the animating box, and `handlesSpanTransition` waives the host's midpoint dissolve. Only the two quote cells with no home at 1x1 fade.

Three things the probe's screenshots caught after the trails were already green:

- `spanW` was bound to `implicitWidth`, which animates — so every rect was a per-frame Behavior target and the panel crawled behind the card. **Weather had the same bug** (its glyph is right-edge anchored); fixed here too, and mechanized rather than noted, since this is the third tree to be written that way.
- The base code swapped its text ("to USD" → "USD") in one frame mid-morph. "to" is its own fading element now, and the code slides left into the space it vacates.
- The `_settled` screenshots were the transition's FIRST frame: `grabToImage` renders a later frame, and the probe committed the span in the same call. That is how both of the above passed a visual check.

## Verification

- `tests/run_tests.sh`: 601 passed, 0 failed
- `tests/run_currency_probe.sh`: 12/12 trails animate, 0 failures; stills judged at 3x
- Deployed and running on the live shell

Docs: updated AGENT.md §Dynamic/data-driven QML gotchas — the settled-span rule and the two-elements-for-two-texts rule, both citing the commits that fixed them; the settled-span half is enforced by `test_geometry_rects_come_from_the_settled_span_not_the_animating_box`.
