### PR TITLE
The interaction motion model, with RippleButton as first adopter

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1229,6 +1229,21 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   which passed every hover assertion while the cursor never changed. Input areas own their
   cursors; z order guarantees the interactive thing is topmost.
   05bf3013f ("feat(media): the play button's body IS the visualizer").
+- **A Behavior whose animation reads its tier from a binding carries the PREVIOUS transition.** The
+  shared interaction model (`Appearance.interaction`, decided in `modules/common/interaction_motion.js`)
+  gives every control the same five states, and each pair of states has its own duration and curve -
+  a press is acknowledged faster than it is released, and a release animates even when the pointer
+  has already left, because press → drag off → let go is `pressed -> rest` with no hover in between
+  and treating that as a hover-out leaves the control visibly stuck. Selecting the tier through a
+  binding on the animation's `duration` hands the Behavior whichever tier was current *before* the
+  state changed; `InteractionMotion.qml` therefore writes the tier onto the animation and only then
+  writes the target, in the same handler. Interruptibility comes free from the Behavior itself - a
+  press landing mid-hover retargets from where the value actually is, which a `SequentialAnimation`
+  fired on a signal cannot do. Related: `lint_disabled_opacity.py` recognises a self-dimming control
+  by its dim EXPRESSION, so adopting the model made `RippleButton` invisible to it and would have
+  vacated the nested-dim rule for every component rooted on one - a detector that knows only one
+  idiom stops detecting the moment the idiom changes.
+  af09ed3b9 ("feat(widgets): one driver wires a control to the model").
 - **A one-tree widget's geometry reads the SETTLED span's box, never the animating one.** Three
   trees were written with `spanW: root.implicitWidth`, and `implicitWidth` carries a Behavior: every
   rect became a per-frame target, so the Behaviors that carry the travel never converged, and any

--- a/dots/.config/quickshell/imi/modules/common/Appearance.qml
+++ b/dots/.config/quickshell/imi/modules/common/Appearance.qml
@@ -2,6 +2,7 @@ import QtQuick
 import Quickshell
 import qs
 import qs.modules.common.functions
+import "interaction_motion.js" as InteractionMotion
 pragma Singleton
 pragma ComponentBehavior: Bound
 
@@ -13,6 +14,7 @@ Singleton {
     property QtObject m3colors
     property QtObject animation
     property QtObject animationCurves
+    property QtObject interaction
     property QtObject colors
     property QtObject rounding
     property QtObject spacing
@@ -326,6 +328,54 @@ Singleton {
         readonly property real expressiveDefaultSpatialDuration: 500
         readonly property real expressiveSlowSpatialDuration: 650
         readonly property real expressiveEffectsDuration: 200
+    }
+
+    // The motion vocabulary every interactive element passes through, in one
+    // place, so five controls do not each invent their own hover. The states
+    // and the transition between any two of them are decided by
+    // interaction_motion.js (pure, and therefore tested); this object holds
+    // the numbers and maps the tiers onto the shell's existing curves.
+    //
+    // Adopters read `state`, `targets` and `transition` - they do not hardcode
+    // a duration. `InteractionMotion.qml` wires all three to a control.
+    interaction: QtObject {
+        id: interactionModel
+
+        // Multipliers on whatever geometry the control already has.
+        readonly property real hoverScale: 1.02
+        readonly property real pressScale: 0.97
+        readonly property real pressRadiusScale: 0.85
+        readonly property real disabledOpacity: 0.4
+
+        readonly property var tokens: ({
+            hoverScale: interactionModel.hoverScale,
+            pressScale: interactionModel.pressScale,
+            pressRadiusScale: interactionModel.pressRadiusScale,
+            disabledOpacity: interactionModel.disabledOpacity
+        })
+
+        // The tiers, on the shell's existing curves. The press tier is the
+        // fastest one there is because a press must be acknowledged before
+        // anything else; the release is longer AND lands on the spatial curve
+        // whose control points leave the unit box, so it springs back rather
+        // than deflating.
+        readonly property var tiers: ({
+            hoverIn: { duration: root.animationCurves.expressiveEffectsDuration,
+                       curve: root.animationCurves.expressiveEffects },
+            hoverOut: { duration: Math.round(root.animationCurves.expressiveEffectsDuration * 1.25),
+                        curve: root.animationCurves.expressiveEffects },
+            press: { duration: 150, curve: root.animationCurves.expressiveEffects },
+            release: { duration: root.animationCurves.expressiveFastSpatialDuration,
+                       curve: root.animationCurves.expressiveFastSpatial },
+            instant: { duration: 0, curve: root.animationCurves.standard },
+            hold: { duration: 0, curve: root.animationCurves.standard }
+        })
+
+        function state(flags) { return InteractionMotion.stateOf(flags); }
+        function targets(state) { return InteractionMotion.targetsFor(state, interactionModel.tokens); }
+        function transition(fromState, toState) {
+            return InteractionMotion.transitionFor(fromState, toState, interactionModel.tiers);
+        }
     }
 
     animation: QtObject {

--- a/dots/.config/quickshell/imi/modules/common/interaction_motion.js
+++ b/dots/.config/quickshell/imi/modules/common/interaction_motion.js
@@ -1,0 +1,74 @@
+.pragma library
+
+// The motion vocabulary every interactive element shares, as data.
+//
+// The point of expressing it here rather than as inline animations in each
+// control is that the SELECTION is then testable: which state a set of input
+// flags resolves to, what that state targets, and which transition carries the
+// element there. How it looks is not reachable from a test; which curve and
+// duration were chosen is.
+//
+// The states are ordered by precedence, not by how they are usually entered: a
+// disabled control that still reports `hovered` is disabled.
+
+var REST = "rest";
+var HOVERED = "hovered";
+var PRESSED = "pressed";
+var DISABLED = "disabled";
+
+function stateOf(flags) {
+    if (flags && flags.enabled === false) return DISABLED;
+    if (flags && flags.down) return PRESSED;
+    if (flags && flags.hovered) return HOVERED;
+    return REST;
+}
+
+// What the state asks the element to look like, as multipliers on whatever
+// the element's own rest geometry is. `tokens` comes from Appearance so the
+// numbers stay tunable in one place.
+//
+// Hover LIFTS (scale up, tint), press SETTLES (scale down, corners tighten).
+// `press` is that same settle as a plain 0..1, for adopters whose geometry is
+// not a multiple of anything - a control lerps its own pressed values with it
+// rather than working backwards from `radiusScale`.
+// Disabled is opacity only - it must not move, because motion reads as
+// affordance and there is none.
+function targetsFor(state, tokens) {
+    switch (state) {
+    case PRESSED:
+        return { scale: tokens.pressScale, radiusScale: tokens.pressRadiusScale,
+                 press: 1, opacity: 1 };
+    case HOVERED:
+        return { scale: tokens.hoverScale, radiusScale: 1, press: 0, opacity: 1 };
+    case DISABLED:
+        return { scale: 1, radiusScale: 1, press: 0, opacity: tokens.disabledOpacity };
+    default:
+        return { scale: 1, radiusScale: 1, press: 0, opacity: 1 };
+    }
+}
+
+// Which transition carries the element from one state to the next.
+//
+// Three rules make five animations read as one system:
+//   - a press is acknowledged IMMEDIATELY, so it takes the fastest tier;
+//   - the return is allowed to be slower than the arrival, and overshoots;
+//   - a release animates even when the pointer has already left, so
+//     pressed -> rest is a RELEASE, never a hover-out. Getting that wrong
+//     leaves a control visibly stuck after a drag off its own edge.
+//
+// Anything to or from disabled has no motion at all: a control that animates
+// as it greys out is claiming an interaction it will not honour.
+function transitionFor(fromState, toState, tiers) {
+    if (fromState === toState) return tiers.hold;
+    if (fromState === DISABLED || toState === DISABLED) return tiers.instant;
+    if (toState === PRESSED) return tiers.press;
+    if (fromState === PRESSED) return tiers.release;
+    if (toState === HOVERED) return tiers.hoverIn;
+    return tiers.hoverOut;
+}
+
+// A transition is a curve, a duration, and nothing else - the element decides
+// what it applies them to.
+function isMotionless(transition) {
+    return transition.duration === 0;
+}

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/RippleButton.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/RippleButton.qml
@@ -2,6 +2,7 @@ import QtQuick
 import QtQuick.Controls
 import Qt5Compat.GraphicalEffects
 import qs.modules.common
+import qs.modules.common.widgets
 import qs.modules.common.functions as Functions
 import "."
 
@@ -17,10 +18,26 @@ Button {
     hoverEnabled: true
     readonly property bool realHovered: mouseArea.containsMouse
     
+    // The shared interaction states, same model the mainline button adopted:
+    // hover lifts, press settles, disabled is opacity only. This copy has
+    // diverged far enough that it cannot simply BE that button (its hover is
+    // its own MouseArea, and SegmentedWrapper drives its per-corner radii), so
+    // it adopts the model rather than the component. Unifying the two is
+    // step 10's job, not this change's.
+    property bool interactionMotionEnabled: true
+    property InteractionMotion interactionMotion: InteractionMotion {
+        hovered: root.hovered && root.interactionMotionEnabled
+        down: root.down && root.interactionMotionEnabled
+        controlEnabled: root.enabled
+    }
+
     // Base radii
     property real buttonRadius: Appearance.rounding.button
-    property real buttonRadiusPressed: buttonRadius
-    property real buttonEffectiveRadius: root.down ? root.buttonRadiusPressed : root.buttonRadius
+    property real buttonRadiusPressed: buttonRadius * (Appearance?.interaction?.pressRadiusScale ?? 1)
+    // The corners ARRIVE at the pressed radius instead of snapping: the
+    // per-corner Behaviors below carried a target that changed in one frame.
+    property real buttonEffectiveRadius: root.buttonRadius
+        + (root.buttonRadiusPressed - root.buttonRadius) * root.interactionMotion.pressProgress
     
     // Properties for SegmentedWrapper support
     property real topLeftRadius: buttonEffectiveRadius
@@ -46,7 +63,7 @@ Button {
     
     property color colRipple: Functions.ColorUtils.applyAlpha(root.textColor, 0.12)
 
-    opacity: root.enabled ? 1 : 0.4
+    opacity: root.interactionMotion.dimOpacity
     
     // Simplified color logic: Use the specific color based on state
     property color baseColor: root.toggled ? 
@@ -55,8 +72,16 @@ Button {
     
     property color textColor: root.toggled ? colTextToggled : colText
 
+    // The lift. A Scale rather than a width/height change, so a button inside
+    // a Layout does not shove its neighbours as the pointer crosses it.
+    transform: Scale {
+        origin.x: root.width / 2
+        origin.y: root.height / 2
+        xScale: root.interactionMotion.scale
+        yScale: root.interactionMotion.scale
+    }
+
     // ── Animations ──
-    Behavior on opacity { animation: Appearance.animation.elementResize.numberAnimation.createObject(root) }
     Behavior on topLeftRadius { animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(root) }
     Behavior on topRightRadius { animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(root) }
     Behavior on bottomLeftRadius { animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(root) }

--- a/dots/.config/quickshell/imi/modules/common/widgets/InteractionMotion.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/InteractionMotion.qml
@@ -1,0 +1,82 @@
+import qs.modules.common
+import QtQuick
+
+/**
+ * Drives one control through the shared interaction states.
+ *
+ * A control hands it `hovered`, `down` and `controlEnabled`, and reads back
+ * `scale`, `radiusScale` and `dimOpacity` - all three already animated on
+ * whichever transition the model chose. Nothing here decides timing; the
+ * vocabulary lives in `Appearance.interaction`.
+ *
+ * Two things this arrangement buys, both easy to lose:
+ *
+ * - Interruptibility. The targets are written through Behaviors, so a press
+ *   landing halfway through the hover-in RETARGETS from where the value
+ *   actually is. A SequentialAnimation fired on a signal would restart from
+ *   its own idea of the start value and visibly jump.
+ * - The right transition. Each animation's duration and curve are set BEFORE
+ *   the target is written, in the same handler, so the Behavior carries the
+ *   change with the tier belonging to THAT change - not the previous one,
+ *   which is what a plain binding on duration would hand it.
+ *
+ * A QtObject rather than an Item on purpose: `Item.state` is taken, and a
+ * driver that owns a rect would tempt callers into parenting things to it.
+ */
+QtObject {
+    id: root
+
+    property bool hovered: false
+    property bool down: false
+    property bool controlEnabled: true
+
+    readonly property string interactionState: Appearance.interaction.state({
+        hovered: root.hovered, down: root.down, enabled: root.controlEnabled
+    })
+    property string previousState: root.interactionState
+
+    // What the control applies. Multipliers, so a control's own geometry
+    // stays its own business.
+    property real scale: 1
+    property real radiusScale: 1
+    // The settle as a plain 0..1, for geometry that is not a multiple.
+    property real pressProgress: 0
+    property real dimOpacity: 1
+
+    onInteractionStateChanged: {
+        const transition = Appearance.interaction.transition(root.previousState, root.interactionState);
+        root.previousState = root.interactionState;
+        scaleAnim.duration = transition.duration;
+        scaleAnim.easing.bezierCurve = transition.curve;
+        radiusAnim.duration = transition.duration;
+        radiusAnim.easing.bezierCurve = transition.curve;
+        pressAnim.duration = transition.duration;
+        pressAnim.easing.bezierCurve = transition.curve;
+        opacityAnim.duration = transition.duration;
+        opacityAnim.easing.bezierCurve = transition.curve;
+        root.applyTargets();
+    }
+
+    function applyTargets() {
+        const targets = Appearance.interaction.targets(root.interactionState);
+        root.scale = targets.scale;
+        root.radiusScale = targets.radiusScale;
+        root.pressProgress = targets.press;
+        root.dimOpacity = targets.opacity;
+    }
+
+    Behavior on scale {
+        NumberAnimation { id: scaleAnim; easing.type: Easing.BezierSpline }
+    }
+    Behavior on radiusScale {
+        NumberAnimation { id: radiusAnim; easing.type: Easing.BezierSpline }
+    }
+    Behavior on pressProgress {
+        NumberAnimation { id: pressAnim; easing.type: Easing.BezierSpline }
+    }
+    Behavior on dimOpacity {
+        NumberAnimation { id: opacityAnim; easing.type: Easing.BezierSpline }
+    }
+
+    Component.onCompleted: root.applyTargets()
+}

--- a/dots/.config/quickshell/imi/modules/common/widgets/RippleButton.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/RippleButton.qml
@@ -14,8 +14,13 @@ Button {
     property string buttonText
     property bool pointingHandCursor: true
     property real buttonRadius: Appearance?.rounding?.small ?? 4
-    property real buttonRadiusPressed: buttonRadius
-    property real buttonEffectiveRadius: root.down ? root.buttonRadiusPressed : root.buttonRadius
+    // The pressed radius is the shared model's tightening, unless a caller
+    // names its own - a header button that squares off while open still wins.
+    property real buttonRadiusPressed: buttonRadius * (Appearance?.interaction?.pressRadiusScale ?? 1)
+    // ...and it ARRIVES there: the model's press progress is animated, so a
+    // press no longer snaps the corners in one frame.
+    property real buttonEffectiveRadius: root.buttonRadius
+        + (root.buttonRadiusPressed - root.buttonRadius) * interactionMotion.pressProgress
     // Per-corner overrides, defaulting to the uniform radius. A button used as
     // the header of an expanding surface needs square bottom corners while
     // open so its hover and ripple blend into the content below instead of
@@ -45,13 +50,33 @@ Button {
     // this instead of `opacity` directly keeps the disabled-state binding
     // below alive - an imperative write to `opacity` destroys it, and every
     // disabled button then renders as if it were enabled.
+    // The shared interaction states: hover lifts, press settles, disabled is
+    // opacity only. The button keeps owning its colours and its ripple - this
+    // drives the motion, and only the motion.
+    property bool interactionMotionEnabled: true
+    property InteractionMotion interactionMotion: InteractionMotion {
+        hovered: root.hovered && root.interactionMotionEnabled
+        down: root.down && root.interactionMotionEnabled
+        controlEnabled: root.enabled
+    }
+
     property real appear: 1
-    opacity: (root.enabled ? 1 : 0.4) * root.appear
+    opacity: root.interactionMotion.dimOpacity * root.appear
     // Staggered entrances read as motion, not just a fade: the button rises
     // into place as it appears. A Translate leaves `y` alone, which a layout
     // owns, so this is safe inside a Row/Flow/Layout.
     property real appearRise: 6
-    transform: Translate { y: (1 - root.appear) * root.appearRise }
+    // Two transforms, not one: the rise belongs to the entrance and the scale
+    // to the interaction, and a control can be doing both at once.
+    transform: [
+        Translate { y: (1 - root.appear) * root.appearRise },
+        Scale {
+            origin.x: root.width / 2
+            origin.y: root.height / 2
+            xScale: root.interactionMotion.scale
+            yScale: root.interactionMotion.scale
+        }
+    ]
     property color buttonColor: ColorUtils.transparentize(root.toggled ? 
         (root.hovered ? colBackgroundToggledHover : 
             colBackgroundToggled) :

--- a/dots/.config/quickshell/imi/tests/imports/qs/modules/common/interaction_motion.js
+++ b/dots/.config/quickshell/imi/tests/imports/qs/modules/common/interaction_motion.js
@@ -1,0 +1,1 @@
+../../../../../modules/common/interaction_motion.js

--- a/dots/.config/quickshell/imi/tests/lint_disabled_opacity.py
+++ b/dots/.config/quickshell/imi/tests/lint_disabled_opacity.py
@@ -28,8 +28,18 @@ MODULES = ROOT / "modules"
 
 # A property of the root object: the repo indents QML with four spaces, so a
 # root-level binding sits at one level and anything nested sits deeper.
-ROOT_DIM = re.compile(r"^ {1,4}opacity:.*\benabled\b.*\?")
-NESTED_DIM = re.compile(r"^ {5,}opacity:.*\benabled\b.*\?")
+#
+# There are two ways a component says "disabled" now. The literal
+# `opacity: enabled ? 1 : 0.4` is the original; a control that adopted the
+# shared interaction model instead reads the dim off its driver
+# (`interactionMotion.dimOpacity`), and the model resolves the disabled state
+# from `enabled` itself. Both are a root-level dim and both must be recognised
+# - a detector that only knows the literal quietly stops seeing the adopters,
+# and the nested-dim rule below then passes vacuously for every component
+# rooted on one.
+DIM_SOURCE = r"(?:\benabled\b.*\?|\bdimOpacity\b)"
+ROOT_DIM = re.compile(r"^ {1,4}opacity:.*" + DIM_SOURCE)
+NESTED_DIM = re.compile(r"^ {5,}opacity:.*" + DIM_SOURCE)
 ROOT_TYPE = re.compile(r"^([A-Z]\w*)\s*\{")
 NESTED_TYPE = re.compile(r"^ {5,}([A-Z]\w*)\s*\{")
 

--- a/dots/.config/quickshell/imi/tests/tst_interaction_motion.qml
+++ b/dots/.config/quickshell/imi/tests/tst_interaction_motion.qml
@@ -1,0 +1,79 @@
+import QtTest
+import "../modules/common/interaction_motion.js" as Motion
+
+// The interaction motion model: which state the flags resolve to, what that
+// state targets, and which transition carries the element there.
+TestCase {
+    name: "InteractionMotionTest"
+
+    readonly property var tokens: ({
+        hoverScale: 1.02, pressScale: 0.97,
+        pressRadiusScale: 0.85, disabledOpacity: 0.4
+    })
+    readonly property var tiers: ({
+        hoverIn: { duration: 200, curve: [0, 0, 1, 1] },
+        hoverOut: { duration: 250, curve: [0, 0, 1, 1] },
+        press: { duration: 150, curve: [0, 0, 1, 1] },
+        release: { duration: 350, curve: [0.42, 1.67, 0.21, 0.9, 1, 1] },
+        instant: { duration: 0, curve: [0, 0, 1, 1] },
+        hold: { duration: 0, curve: [0, 0, 1, 1] }
+    })
+
+    function test_disabled_outranks_every_other_flag() {
+        compare(Motion.stateOf({ enabled: false, hovered: true, down: true }), "disabled");
+        compare(Motion.stateOf({ enabled: true, hovered: true, down: true }), "pressed");
+        compare(Motion.stateOf({ enabled: true, hovered: true }), "hovered");
+        compare(Motion.stateOf({ enabled: true }), "rest");
+        compare(Motion.stateOf({}), "rest", "absent flags are a resting control");
+    }
+
+    function test_hover_lifts_and_press_settles() {
+        const hover = Motion.targetsFor("hovered", tokens);
+        const press = Motion.targetsFor("pressed", tokens);
+        const rest = Motion.targetsFor("rest", tokens);
+        verify(hover.scale > rest.scale, "hover lifts");
+        verify(press.scale < rest.scale, "press settles into the surface");
+        verify(press.radiusScale < 1, "and its corners tighten");
+        compare(hover.radiusScale, 1, "hover does not reshape");
+    }
+
+    function test_disabled_is_opacity_only() {
+        const disabled = Motion.targetsFor("disabled", tokens);
+        compare(disabled.scale, 1);
+        compare(disabled.radiusScale, 1);
+        verify(disabled.opacity < 1);
+        verify(Motion.isMotionless(Motion.transitionFor("rest", "disabled", tiers)));
+        verify(Motion.isMotionless(Motion.transitionFor("disabled", "hovered", tiers)));
+    }
+
+    function test_a_press_is_acknowledged_faster_than_it_is_released() {
+        const press = Motion.transitionFor("hovered", "pressed", tiers);
+        const release = Motion.transitionFor("pressed", "hovered", tiers);
+        verify(press.duration < release.duration);
+        compare(press, tiers.press);
+    }
+
+    function test_a_release_animates_even_when_the_pointer_has_left() {
+        // Press, drag off the control, let go: the state goes pressed -> rest
+        // with no hover in between. Treating that as a hover-out is how a
+        // control ends up visibly stuck at its pressed size.
+        compare(Motion.transitionFor("pressed", "rest", tiers), tiers.release);
+        compare(Motion.transitionFor("hovered", "rest", tiers), tiers.hoverOut);
+    }
+
+    function test_the_return_is_slower_than_the_arrival() {
+        verify(Motion.transitionFor("rest", "hovered", tiers).duration
+             < Motion.transitionFor("hovered", "rest", tiers).duration);
+    }
+
+    function test_the_release_curve_overshoots() {
+        // The spring is the point: a release that eases flat reads as the
+        // control deflating rather than springing back.
+        const release = Motion.transitionFor("pressed", "rest", tiers);
+        verify(release.curve.some(v => v > 1.0), "some control point leaves the unit box");
+    }
+
+    function test_a_state_that_did_not_change_does_not_animate() {
+        verify(Motion.isMotionless(Motion.transitionFor("hovered", "hovered", tiers)));
+    }
+}


### PR DESCRIPTION
Step 8 of the expressive morphing landing plan (§4 of the spec).

## What it is

One vocabulary for the states every interactive element passes through, in three pieces:

- `modules/common/interaction_motion.js` — pure: which state a set of flags resolves to, what that state targets, and which transition carries an element between any two states. Pure because the *selection* is the testable part; how it looks is not reachable from a test.
- `Appearance.interaction` — the numbers and the tier→curve mapping, next to the shell's other motion tokens.
- `modules/common/widgets/InteractionMotion.qml` — the driver a control instantiates.

Three rules are pinned by tests, all three from the spec:

- **A press is acknowledged faster than it is released.** Press takes the fastest tier; the release is longer and lands on the spatial curve whose control points leave the unit box, so it springs back rather than deflating.
- **A release animates even when the pointer has left.** Press, drag off the control, let go is `pressed -> rest` with no hover in between. Treating that as a hover-out is how a control ends up visibly stuck at its pressed size.
- **Disabled is opacity only.** Motion reads as affordance and there is none.

## Two things worth reviewing

**Tier before target.** Selecting the transition through a binding on the animation's `duration` hands the Behavior whichever tier was current *before* the state changed. The driver writes the tier onto the animation and only then writes the target, in the same handler. Interruptibility then comes free: a press landing mid-hover retargets from where the value actually is.

**The lint caught a regression in this change.** `lint_disabled_opacity.py` identifies a self-dimming control by the literal `enabled ? 1 : 0.4`. Moving the dim onto the model made `RippleButton` invisible to it, which would have silently vacated the nested-dim rule for every component rooted on one — the rule whose absence once rendered disabled rows at 0.16 opacity. It knows both idioms now, and the expected-set pin is what surfaced it.

**Both** RippleButtons adopt. The mainline one (99 call sites) covers the sidebars, settings pages, bar popups and dock menus; the design system ships a second, diverged copy that is the one behind the buttons on the desktop — per-widget chrome in `PluginNode`, notes, docker, discordVoice, notification actions, `DatePicker`, `MediaCard`, the context menus. Adopting only the mainline one would have left the half of the shell you actually look at moving differently from the rest. The copy adopts the *model*, not the component — it has diverged too far (its hover is its own MouseArea, `SegmentedWrapper` drives its per-corner radii), and unifying them is step 10's job.

What each gains: hover lifts, press settles and *animates* the corners tighter instead of snapping them in one frame, disabled dim comes off the model. Colours and the ripple stay the button's own — this drives motion only — and `interactionMotionEnabled` opts a caller out. Media controls are step 9.

## Verification

- `tests/run_tests.sh`: 611 passed, 0 failed
- Deployed to the live shell; loads clean, no errors in the session log

Docs: updated AGENT.md §Dynamic/data-driven QML gotchas — the tier-before-target rule and the detector-knows-one-idiom lesson, citing the commits that established them.
