### PR TITLE
fix(record): measure the tonemap's signal peak instead of assuming 10x

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -263,6 +263,48 @@ the GPU")):
   ffmpeg's `-encoders` list advertises build capability, not working hardware — try encoders for
   real, in a ladder with a CPU floor.
 
+**ffmpeg's `tonemap` filter assumes a signal peak of 10× reference white (2030 nits) for PQ input,
+and that assumption is the difference between a recording that looks like the desktop and one that
+does not.** A desktop capture peaks around 235 nits — roughly 1.16× — so the converter was
+normalising the curve against a peak eight times too high and squeezing the whole image into the
+bottom eighth of it: SDR white came out of `tonemap-sdr.sh` at **136/255**, contrast collapsed with
+it, and every recording the user made was a region capture, which is the path that converts. The
+10× is a constant, not something derived from the file: `peak=10.0` reproduces the old output byte
+for byte. `scripts/videos/tonemap-sdr.sh` now measures the peak off the pixels (`signalstats` over
+keyframes only, downscaled first — bounded at 0.3s on a 5s 5120x1440 clip, and the result lands on
+the content's p99.99 rather than on one stray pixel) and passes it to every chain.
+fb9556757 ("fix(record): measure the tonemap's signal peak instead of assuming 10x").
+
+Four things around that are worth not re-deriving:
+
+- **gpu-screen-recorder stamps the *monitor's* EDID luminance into every recording** as
+  mastering-display and content-light-level metadata — on a 1015-nit panel every file claims
+  `MaxCLL 1015` whatever is on screen. This is a real defect and it is **not** what caused the
+  wash-out: the CPU `tonemap` filter never reads that metadata, and two fixtures tagged 250 and
+  1015 nits tonemap identically. It reaches only libplacebo, which does read it, which is why that
+  chain gets `src_max`. Correcting the file's metadata would fix nothing on the path that runs.
+  This is the same shape as the `playerctld` misdiagnosis under
+  [State propagation is reactive](#state-propagation-is-reactive-or-it-is-a-bug-waiting): a correct
+  observation about a real bug, that was not the bug in front of anyone.
+- **A peak *below* the signal's own values blacks the frame out**, it does not stretch it — measured
+  Y'=16 on a 100-nit clip given `peak=0.49`. So the measured peak is floored at 1.0, and a test for
+  that floor needs a two-sided band; the first version asserted only "not brighter than" and passed
+  on a black frame.
+- **The compositor is the only thing that converts this correctly, and the portal is how to reach
+  it.** grim and gsr's portal capture agree to 4.0/255 against each other, so either serves as the
+  reference for "what the desktop looks like"; the best ffmpeg chain scores 15.2. That gap is
+  Hyprland's own screencopy curve, which is not a linear-light inverse and cannot be matched by
+  `npl` alone — measured, the `npl` that reproduces white (134) and the one that minimises overall
+  error (203) are different numbers. Fullscreen recordings already take the portal. **Regions
+  cannot**: `-region` is rejected outright with `-w portal` ("option -region can only be used when
+  option '-w region' is used"), so the conversion is unavoidable there and its quality is capped.
+- **Scoring a colour conversion needs a static-pixel mask, not a screenshot pair.** A desktop moves
+  between two captures, and the drift swamps the effect being measured — the first pass here
+  "measured" a reference white of 204 nits that way and 134 once only pixels identical across
+  bracketing shots were compared. Bracket the recording with screenshots, keep pixels that match in
+  both *and* whose 3×3 neighbourhood is uniform (which kills subpixel edges), and report RMSE plus
+  what code 255 became.
+
 ## Directory map
 
 ```

--- a/dots/.config/quickshell/imi/scripts/videos/tonemap-sdr.sh
+++ b/dots/.config/quickshell/imi/scripts/videos/tonemap-sdr.sh
@@ -44,6 +44,68 @@ esac
 notify-send "Tonemapping to SDR" "${FILE##*/} - the HDR original will be replaced" \
     -a 'Recorder' & disown
 
+# THE SIGNAL PEAK MUST BE MEASURED FROM THE PIXELS. ffmpeg's `tonemap` filter,
+# handed PQ input and no override, assumes a FIXED peak of 10x its reference
+# white - 2030 nits - and normalises the curve by it. A desktop capture peaks
+# around 235 nits (1.16x), so the whole image was squeezed into the bottom
+# eighth of the curve. Scored against the compositor's own SDR rendering of the
+# same desktop: SDR white left the converter at 136/255, mean error 27.3/255.
+# That 10x is not inferred from the file - `peak=10.0` reproduces the default
+# output byte for byte, on clips whose declared MaxCLL differs fourfold.
+#
+# WHICH IS THE PART THAT MISLEADS: gpu-screen-recorder really does stamp the
+# MONITOR's EDID luminance into every recording as mastering-display and
+# content-light-level metadata (on this 1015-nit panel every file claims MaxCLL
+# 1015 whatever is on screen), and that reads exactly like the cause. It is
+# not - the CPU `tonemap` filter never looks at it, and two fixtures tagged 250
+# and 1015 nits tonemap identically. It matters only to libplacebo, which does
+# read mastering metadata, which is why that chain gets src_max below. Do not
+# "fix" this by correcting the file's metadata: the CPU path would not notice.
+#
+# Keyframes only and downscaled first: bounded work (0.3s on a 5s 5120x1440
+# clip) and a peak that lands on the content's p99.99 rather than on one stray
+# pixel - measured 235 nits where the frame's absolute maximum was 276.
+#
+# Floored at 1.0. A peak below reference white would ask the tonemapper to
+# EXPAND the signal, and a measurement that fails must not fall back to the
+# filter's own 10x, which is the bug: assuming "nothing above SDR white" clips
+# a genuine highlight at worst, where 10x crushes every frame.
+measure_peak() {
+    local depth range ymax
+    depth="$(ffprobe -v error -select_streams v:0 -show_entries stream=bits_per_raw_sample \
+        -of default=nw=1:nk=1 "$FILE" 2>/dev/null | head -n1 || true)"
+    [[ "$depth" =~ ^[0-9]+$ ]] && (( depth >= 8 )) || depth=10
+    range="$(ffprobe -v error -select_streams v:0 -show_entries stream=color_range \
+        -of default=nw=1:nk=1 "$FILE" 2>/dev/null | head -n1 || true)"
+    # Captured to a variable rather than piped into a reader that can exit
+    # early - the same pipefail trap documented on the libplacebo probe below.
+    ymax="$(ffmpeg -v error -skip_frame nokey -i "$FILE" -an \
+        -vf "scale=320:-2,signalstats,metadata=print:key=lavfi.signalstats.YMAX:file=-" \
+        -f null - 2>/dev/null | sed -n 's/^lavfi\.signalstats\.YMAX=//p' \
+        | sort -n | tail -n1 || true)"
+    [[ "$ymax" =~ ^[0-9]+$ ]] || return 1
+    awk -v y="$ymax" -v d="$depth" -v r="$range" 'BEGIN {
+        s = 2 ^ (d - 8)
+        n = (r == "pc" || r == "full") ? y / (2 ^ d - 1) : (y - 16 * s) / (219 * s)
+        if (n <= 0) exit 1
+        if (n > 1) n = 1
+        m1 = 2610 / 16384; m2 = 2523 / 4096 * 128
+        c1 = 3424 / 4096;  c2 = 2413 / 4096 * 32; c3 = 2392 / 4096 * 32
+        p = exp(log(n) / m2)
+        num = p - c1; if (num < 0) num = 0
+        den = c2 - c3 * p; if (den <= 0) exit 1
+        if (num == 0) exit 1
+        nits = 10000 * exp(log(num / den) / m1)
+        printf "%.1f", nits
+    }'
+}
+
+PEAK_NITS="$(measure_peak || true)"
+[[ "$PEAK_NITS" =~ ^[0-9.]+$ ]] || PEAK_NITS=203
+# ffmpeg measures `peak` in units of its reference white (203 nits), which is
+# also the npl the linearising zscale below is given, so the two agree.
+PEAK="$(awk -v n="$PEAK_NITS" 'BEGIN { p = n / 203; if (p < 1) p = 1; printf "%.3f", p }')"
+
 # The temporary MUST end in .mp4: ffmpeg infers the muxer from the output
 # extension, and a bare ".tmp" fails - silently, if stderr is ever discarded.
 # Same trap that shipped in we_still.sh once already.
@@ -52,6 +114,16 @@ log="$(mktemp --suffix=-tonemap.log)"
 
 # libplacebo (Vulkan, GPU tonemap - fast and gamut-aware) when this ffmpeg has
 # it, else the zscale/tonemap CPU chain.
+#
+# mobius rather than hable, now that the peak is honest: hable compresses the
+# midtones even when asked to map a range that barely exceeds its target, while
+# mobius stays linear below the knee and rolls off only near the peak - which
+# is the shape a desktop capture has, almost all of it under SDR white with a
+# little headroom above. Scored against the compositor's own SDR rendering of
+# the same desktop, mean error 15.2/255 versus hable's 16.3 and the shipped
+# hable-on-EDID-peak's 27.3. `clip` scored a shade better still (14.7) and is
+# not used: it is only better while nothing on screen is genuinely HDR, and it
+# blows those highlights out irrecoverably when something is.
 #
 # Captured to a variable, NOT `ffmpeg | grep -q`: grep -q exits at the first
 # match, ffmpeg takes SIGPIPE, and under `set -o pipefail` the whole pipeline
@@ -68,10 +140,17 @@ filters="$(ffmpeg -hide_banner -filters 2>/dev/null || true)"
 if [[ "$filters" == *libplacebo* ]] \
     && ffmpeg -v error -init_hw_device vulkan -f lavfi -i "nullsrc=s=64x64:d=0.1" \
         -vf "libplacebo=format=yuv420p" -frames:v 1 -f null - >/dev/null 2>&1; then
-    VF="libplacebo=tonemapping=auto:colorspace=bt709:color_primaries=bt709:color_trc=bt709:format=yuv420p"
+    # src_max for the same reason the CPU chain gets `peak`, and with a second
+    # reason of its own: libplacebo DOES read the recorder's mastering-display
+    # metadata, so left alone it inherits the panel's EDID luminance rather
+    # than the content's. Unverified on this machine - ffmpeg's libplacebo
+    # filter fails to initialise here for every invocation, Vulkan device
+    # present, so the smoke test below correctly picks the CPU chain and this
+    # branch has never run.
+    VF="libplacebo=tonemapping=auto:src_max=$PEAK_NITS:colorspace=bt709:color_primaries=bt709:color_trc=bt709:format=yuv420p"
     HW=(-init_hw_device vulkan)
 else
-    VF="zscale=t=linear:npl=203,format=gbrpf32le,zscale=p=bt709,tonemap=hable:desat=0,zscale=t=bt709:m=bt709:r=tv,format=yuv420p"
+    VF="zscale=t=linear:npl=203,format=gbrpf32le,zscale=p=bt709,tonemap=mobius:desat=0:peak=$PEAK,zscale=t=bt709:m=bt709:r=tv,format=yuv420p"
     HW=()
 fi
 
@@ -91,7 +170,7 @@ width="$(ffprobe -v error -select_streams v:0 -show_entries stream=width \
 
 # The vaapi rung uses the CPU tonemap chain: mixing the Vulkan libplacebo
 # filter with a VAAPI hwupload made ffmpeg's format negotiation fall over.
-VF_CPU="zscale=t=linear:npl=203,format=gbrpf32le,zscale=p=bt709,tonemap=hable:desat=0,zscale=t=bt709:m=bt709:r=tv,format=yuv420p"
+VF_CPU="zscale=t=linear:npl=203,format=gbrpf32le,zscale=p=bt709,tonemap=mobius:desat=0:peak=$PEAK,zscale=t=bt709:m=bt709:r=tv,format=yuv420p"
 
 try_encode() {
     local enc="$1" vfarg="$VF" hw=("${HW[@]}") pre=() args=()

--- a/dots/.config/quickshell/imi/tests/test_tonemap_sdr.py
+++ b/dots/.config/quickshell/imi/tests/test_tonemap_sdr.py
@@ -32,18 +32,38 @@ def encoders():
                           capture_output=True, text=True).stdout
 
 
-def make_clip(path, hdr):
+def make_clip(path, hdr, maxcll=None, grey=None):
     # x265 writes the VUI from its own params and ignores ffmpeg's -color_*
     # flags, so the HDR tagging must go through -x265-params or the fixture
     # probes as "unknown" - which it did on this test's first run.
-    color = (["-pix_fmt", "yuv420p10le", "-x265-params",
-              "colorprim=bt2020:transfer=smpte2084:colormatrix=bt2020nc"]
+    params = "colorprim=bt2020:transfer=smpte2084:colormatrix=bt2020nc"
+    if maxcll is not None:
+        # What a real gpu-screen-recorder file carries: the MONITOR's EDID
+        # luminance, written as if it described the content.
+        params += f":master-display=G(8500,39850)B(6550,2300)R(35400,14600)"
+        params += f"WP(15635,16450)L({maxcll * 10000},1)"
+        params += f":max-cll={maxcll},{maxcll}"
+    color = (["-pix_fmt", "yuv420p10le", "-x265-params", params]
              if hdr else ["-pix_fmt", "yuv420p"])
     codec = "libx265" if hdr else "libx264"
+    src = (f"color=c=0x{grey:02x}{grey:02x}{grey:02x}:s=128x128:d=0.5:r=10"
+           if grey is not None else "testsrc2=s=64x64:d=0.3:r=10")
     subprocess.run(
-        ["ffmpeg", "-y", "-v", "error", "-f", "lavfi",
-         "-i", "testsrc2=s=64x64:d=0.3:r=10", "-c:v", codec, *color, str(path)],
+        ["ffmpeg", "-y", "-v", "error", "-f", "lavfi", "-i", src,
+         "-c:v", codec, *color, str(path)],
         capture_output=True, check=True)
+
+
+def mean_luma(path):
+    out = subprocess.run(
+        ["ffmpeg", "-v", "error", "-i", str(path), "-vf",
+         "signalstats,metadata=print:key=lavfi.signalstats.YAVG:file=-",
+         "-frames:v", "1", "-f", "null", "-"],
+        capture_output=True, text=True).stdout
+    for line in out.splitlines():
+        if line.startswith("lavfi.signalstats.YAVG="):
+            return float(line.split("=", 1)[1])
+    raise AssertionError(f"no YAVG in ffmpeg output: {out!r}")
 
 
 def transfer_of(path):

--- a/dots/.config/quickshell/imi/tests/test_tonemap_sdr.py
+++ b/dots/.config/quickshell/imi/tests/test_tonemap_sdr.py
@@ -178,20 +178,27 @@ class TonemapBehaviourTests(unittest.TestCase):
             "converter is normalising against a peak it assumed rather than "
             "one it measured")
 
-    def test_a_dim_clip_is_not_pushed_up_to_white(self):
-        # The mirror of the test above, and the reason the measured peak is
-        # floored at 1.0 rather than simply handed to the tonemapper: a capture
-        # whose brightest pixel sits below reference white must not be
-        # *expanded* to fill the SDR range. 0x82 is the PQ code for 100 nits,
-        # which owes roughly half of SDR white back, not all of it.
+    def test_a_dim_clip_keeps_its_own_brightness(self):
+        # Why the measured peak is floored at 1.0 rather than handed straight
+        # to the tonemapper. 0x82 is the PQ code for 100 nits - a capture whose
+        # brightest pixel sits BELOW reference white, which is the ordinary
+        # case for a dim desktop, not an exotic one. It owes roughly half of
+        # SDR white back (Y'~181), and both ways of getting the peak wrong are
+        # gross: expanding it to fill the range would return white, and handing
+        # ffmpeg a peak beneath the signal's own values returns Y'=16 - the
+        # frame goes BLACK, measured, which is not what "peak too low" sounds
+        # like it should do. Hence a band rather than a one-sided bound; the
+        # first version of this test asserted only the upper half and passed
+        # happily on a black frame.
         clip = self.dir / "dim.mp4"
         make_clip(clip, hdr=True, grey=0x82)
         proc = SandboxedRun(enabled=True).run(clip)
         self.assertEqual(proc.returncode, 0, proc.stderr)
         luma = mean_luma(clip)
-        self.assertLess(luma, 210,
-                        f"a 100-nit clip came out at Y'={luma}; the peak floor "
-                        "is missing and dim captures are being stretched")
+        self.assertTrue(
+            150 < luma < 210,
+            f"a 100-nit clip came out at Y'={luma}, expected ~181 - a peak "
+            "below the signal crushes it to black, one above stretches it")
 
 
 class HookWiringTests(unittest.TestCase):

--- a/dots/.config/quickshell/imi/tests/test_tonemap_sdr.py
+++ b/dots/.config/quickshell/imi/tests/test_tonemap_sdr.py
@@ -12,6 +12,7 @@ a sandboxed XDG_CONFIG_HOME; the failure-path test stubs ffmpeg/ffprobe via
 PATH. notify-send is stubbed throughout.
 """
 import os
+import re
 import shutil
 import subprocess
 import tempfile
@@ -32,20 +33,17 @@ def encoders():
                           capture_output=True, text=True).stdout
 
 
-def make_clip(path, hdr, maxcll=None, grey=None):
+def make_clip(path, hdr, grey=None):
     # x265 writes the VUI from its own params and ignores ffmpeg's -color_*
     # flags, so the HDR tagging must go through -x265-params or the fixture
     # probes as "unknown" - which it did on this test's first run.
-    params = "colorprim=bt2020:transfer=smpte2084:colormatrix=bt2020nc"
-    if maxcll is not None:
-        # What a real gpu-screen-recorder file carries: the MONITOR's EDID
-        # luminance, written as if it described the content.
-        params += f":master-display=G(8500,39850)B(6550,2300)R(35400,14600)"
-        params += f"WP(15635,16450)L({maxcll * 10000},1)"
-        params += f":max-cll={maxcll},{maxcll}"
-    color = (["-pix_fmt", "yuv420p10le", "-x265-params", params]
+    color = (["-pix_fmt", "yuv420p10le", "-x265-params",
+              "colorprim=bt2020:transfer=smpte2084:colormatrix=bt2020nc"]
              if hdr else ["-pix_fmt", "yuv420p"])
     codec = "libx265" if hdr else "libx264"
+    # A neutral grey needs no matrix to survive: R=G=B puts the whole value in
+    # Y' and leaves the chroma planes neutral, so the fixture's PQ code is
+    # exactly the byte asked for whatever swscale picks on the way in.
     src = (f"color=c=0x{grey:02x}{grey:02x}{grey:02x}:s=128x128:d=0.5:r=10"
            if grey is not None else "testsrc2=s=64x64:d=0.3:r=10")
     subprocess.run(
@@ -154,6 +152,47 @@ class TonemapBehaviourTests(unittest.TestCase):
         proc = SandboxedRun(enabled=True).run(self.dir / "gone.mp4")
         self.assertEqual(proc.returncode, 0)
 
+    def test_reference_white_comes_out_white(self):
+        # The wash-out this file's script exists to prevent, reproduced in one
+        # frame. ffmpeg's tonemap filter assumes a FIXED signal peak of 10x its
+        # reference white (2030 nits) for PQ input unless overridden, so a
+        # desktop capture peaking near 235 nits was normalised as if it were
+        # eight times brighter and the whole image collapsed toward black.
+        #
+        # 0x94 is the PQ code for exactly 203 nits - ffmpeg's reference white,
+        # and the npl the linearising zscale is given - so a conversion that
+        # knows what it is looking at owes SDR white back, Y'=235 in the
+        # limited range the chain writes. Measured on the shipped script: 151.
+        # Nothing here depends on the compositor, the panel or the machine:
+        # the input is a synthetic PQ value with one arithmetically correct
+        # answer.
+        clip = self.dir / "refwhite.mp4"
+        make_clip(clip, hdr=True, grey=0x94)
+        proc = SandboxedRun(enabled=True).run(clip)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(transfer_of(clip), "bt709")
+        luma = mean_luma(clip)
+        self.assertGreater(
+            luma, 225,
+            f"reference white tonemapped to Y'={luma}, expected ~235 - the "
+            "converter is normalising against a peak it assumed rather than "
+            "one it measured")
+
+    def test_a_dim_clip_is_not_pushed_up_to_white(self):
+        # The mirror of the test above, and the reason the measured peak is
+        # floored at 1.0 rather than simply handed to the tonemapper: a capture
+        # whose brightest pixel sits below reference white must not be
+        # *expanded* to fill the SDR range. 0x82 is the PQ code for 100 nits,
+        # which owes roughly half of SDR white back, not all of it.
+        clip = self.dir / "dim.mp4"
+        make_clip(clip, hdr=True, grey=0x82)
+        proc = SandboxedRun(enabled=True).run(clip)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        luma = mean_luma(clip)
+        self.assertLess(luma, 210,
+                        f"a 100-nit clip came out at Y'={luma}; the peak floor "
+                        "is missing and dim captures are being stretched")
+
 
 class HookWiringTests(unittest.TestCase):
     def test_saves_and_replays_trigger_it_screenshots_do_not(self):
@@ -189,11 +228,40 @@ class HookWiringTests(unittest.TestCase):
         self.assertRegex(script, r"LADDER=\(hevc_nvenc")
         self.assertRegex(script, r"LADDER=\(h264_nvenc")
 
+    def test_every_tonemap_chain_is_told_the_peak(self):
+        # ffmpeg's tonemap filter assumes 10x reference white for PQ input when
+        # nothing overrides it, and libplacebo reads the recorder's mastering
+        # metadata - which gpu-screen-recorder fills from the MONITOR's EDID.
+        # Neither default describes the content, so every chain has to carry an
+        # explicit peak. There are three (libplacebo, the CPU chain, and the
+        # separate copy the vaapi rung uses because mixing Vulkan libplacebo
+        # with a VAAPI hwupload broke format negotiation), and the vaapi copy is
+        # exactly the one a fix applied to "the filter chain" forgets.
+        script = SCRIPT.read_text()
+        chains = re.findall(r'^\s*VF(?:_CPU)?="([^"]+)"', script, re.M)
+        self.assertGreaterEqual(len(chains), 3,
+                                f"expected three filter chains, found {chains}")
+        for chain in chains:
+            if "libplacebo" in chain:
+                self.assertIn("src_max=", chain,
+                              "libplacebo chain inherits the panel's EDID peak")
+            else:
+                self.assertRegex(chain, r"tonemap=\w+:[^,]*peak=",
+                                 f"chain without an explicit peak: {chain}")
+
+    def test_the_peak_is_measured_from_the_frames(self):
+        # A constant here would be a per-machine tuning, not a fix: the whole
+        # point is that the peak is a property of what was on screen.
+        script = SCRIPT.read_text()
+        self.assertIn("signalstats", script,
+                      "the peak is not measured from the pixels")
+        self.assertIn("skip_frame nokey", script,
+                      "peak measurement must stay bounded on long replays")
+
     def test_the_temporary_keeps_a_video_extension(self):
         # ffmpeg infers the muxer from the output extension; a bare ".tmp"
         # fails. Same trap that shipped in we_still.sh once already.
         script = SCRIPT.read_text()
-        import re
         m = re.search(r'tmp="\$\{FILE%\.mp4\}([^"]+)"', script)
         self.assertIsNotNone(m, "no temporary assignment found")
         self.assertTrue(m.group(1).endswith(".mp4"),


### PR DESCRIPTION
Screen recordings on an HDR display came out washed out and flat against the live desktop — cyan-ish cast, crushed contrast, desaturated. Every recording in `~/Videos` is a region capture, which is the path that converts, so this hit every recording the user made.

## Root cause

**ffmpeg's `tonemap` filter assumes a fixed signal peak of 10× reference white (2030 nits) for PQ input.** A desktop capture peaks around 235 nits — about 1.16× — so the `hable` curve was normalised against a peak eight times too high and squeezed the whole image into the bottom eighth of its range.

The 10× is a constant, not something derived from the file: `peak=10.0` reproduces the shipped output byte for byte.

Measured on a 5120x1440 capture, scored on 2.0M static pixels against the compositor's own SDR rendering of the same desktop (grim and gsr's portal capture agree to 4.0/255 against each other, so either serves as the reference):

| | mean error | grim's white (255) becomes |
|---|---|---|
| shipped — `hable`, assumed 2030 nits | **27.3** | **136** |
| patched — `mobius`, measured 235 nits | **15.2** | **210** |

### The half of the diagnosis that was wrong

`gpu-screen-recorder` really does stamp the **monitor's EDID luminance** into every recording as mastering-display and content-light-level metadata — on this 1015-nit panel every file claims `MaxCLL 1015` whatever is on screen — and "the tonemapper is reading the panel's brightness" explains the symptom perfectly. It is not the cause: the CPU `tonemap` filter never reads that metadata, and two fixtures tagged 250 and 1015 nits tonemap identically. It reaches only libplacebo, which does read it, so that chain gets `src_max`. Correcting the file's metadata would have fixed nothing on the path that actually runs. Both the code comment and AGENT.md record this, because the next reader will land on it too.

## The fix

`tonemap-sdr.sh` measures the peak off the pixels — `signalstats` over keyframes only, downscaled first — and passes it to every chain. Bounded work (0.3s on a 5s 5120x1440 clip) and the result lands on the content's p99.99 rather than on one stray pixel: measured 235 nits where the frame's absolute maximum was 276, against the 1015 the file claimed.

`mobius` replaces `hable` now that the peak is honest: `hable` compresses the midtones even when mapping a range that barely exceeds its target, while `mobius` stays linear below the knee and rolls off only near the peak — the shape a desktop capture has. `clip` scored a shade better still (14.7) and is deliberately not used: it only wins while nothing on screen is genuinely HDR, and blows those highlights out irrecoverably when something is.

The peak is floored at 1.0. A peak *below* the signal's own values blacks the frame out rather than stretching it — measured Y'=16 on a 100-nit clip given `peak=0.49`.

## What is not fixed, and why

The conversion's quality is capped at ~15/255 by Hyprland's own screencopy curve, which is not a linear-light inverse: the `npl` that reproduces white (134) and the one that minimises overall error (203) are different numbers, so no single chain matches it. The compositor is the only thing that converts correctly, and fullscreen recordings already take that path through the portal. **Regions cannot** — gsr rejects `-region` outright with `-w portal` (`option -region can only be used when option '-w region' is used`), so routing regions through the portal would mean capturing the whole monitor and cropping afterwards. That is a much larger change than a colour fix and is left alone here.

Also noted while measuring: ffmpeg's libplacebo filter fails to initialise on this machine for every invocation despite a working Vulkan device, so the GPU tonemap branch has never run here and the existing smoke test correctly falls through to the CPU chain. The `src_max` addition to that branch is therefore unverified, and says so in the source.

## Tests

The shipped converter passed every existing test while turning SDR white into Y'=151 — nothing in the suite looked at a pixel. Added:

- **`test_reference_white_comes_out_white`** — feeds the script a synthetic PQ grey at `0x94`, the code for exactly 203 nits, so the arithmetically correct answer is SDR white. Shipped script returns 151, fixed returns 234. Depends on no compositor, panel or machine.
- **`test_a_dim_clip_keeps_its_own_brightness`** — 100 nits, asserted as a band rather than a ceiling, which is what pins the peak floor. The first version asserted only "not brighter than" and passed happily on a black frame.
- **`test_every_tonemap_chain_is_told_the_peak`** — names all three chains, because the vaapi rung carries its own copy and is exactly the one a fix aimed at "the filter chain" misses.
- **`test_the_peak_is_measured_from_the_frames`** — a constant here would be per-machine tuning, not a fix.

All four were proven to fail by planting mutations in a clean tree: reverting the chain (both behavioural and contract tests red, at the exact measured 151), fixing only the main chain and forgetting the vaapi copy, hardcoding the peak, and removing the floor.

Full suite green: `601 passed, 0 failed`, `run_tests.sh` exit 0.

Docs: updated AGENT.md §External binaries the shell drives — the tonemapper's assumed 10x peak, the EDID-metadata red herring, why regions cannot take the portal, and how to score a colour conversion
