### PR TITLE
fix(notifications): blur every popup, not just the first of the session

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -743,6 +743,28 @@ Two non-obvious behaviors have bitten this codebase before and are worth knowing
   publish that takes effect is the settle timer's - which is a guaranteed ~96ms of surface-up-and-
   unblurred on every open. Publish immediately *and* keep the timer. Motivated by 4a1b4f850
   ("fix(blur): stop the compositor frosting drop shadows").
+- **A blur region built from a *list* of items must observe those items, and a model count is not
+  observing them.** `WindowBlurRegion.regionItems` takes the rects a panel paints when the set is
+  not known in advance, and the notification stack is its only caller. A `Region` whose item has
+  been destroyed reports itself `empty()`, so a stale list is not a slightly-wrong blur - it is *no*
+  blur, with the region still published, nothing in any log, and QML that reads correctly.
+  `NotificationListView` refreshed its card set from `onCountChanged`, and the popup's ordinary life
+  defeats that twice over: a notification times out, the window hides, another arrives from the same
+  app, and the app-name list ends the cycle exactly where it started - so `count` reads 1 throughout
+  while the delegate is torn down and rebuilt. `count`'s signal is raised from the view's layout
+  pass as well, which does not run while the surface is down (`visible: false` destroys a layer
+  surface), so even the 1 -> 0 -> 1 in between is never announced. Measured against a real popup:
+  `countChanged` fired exactly *once* per shell session, so every notification after the first had
+  been unblurred for the whole life of the feature. Observe `contentItem`'s children, which is the
+  thing that actually changes; see
+  [State propagation is reactive](#state-propagation-is-reactive-or-it-is-a-bug-waiting) for the
+  general rule. Both halves of seeing it are worth reusing: `tests/run_notification_blur_probe.sh`
+  photographs the frost under a *nested Hyprland on its own bus* - `qmltestrunner` cannot construct
+  a `Region` and weston implements no ext-background-effect, so nothing else can - and it shoots
+  three popups because the first one is the one that works.
+  `tests/test_notification_cards_runtime.py` pins the card set itself, which headless weston can
+  reach.
+  bd69d191f ("fix(notifications): publish the cards that are on screen, not the first popup's").
 - **A window's `color` is not just a colour: an alpha of 255 permanently costs that surface its
   blur.** `QQuickWindow::setColor()` rewrites the window's *requested surface format* whenever the
   new colour's alpha crosses the 255 boundary - `fmt.setAlphaBufferSize(alpha < 255 ? 8 : -1)` then

--- a/dots/.config/quickshell/imi/NotificationBlurProbe.qml
+++ b/dots/.config/quickshell/imi/NotificationBlurProbe.qml
@@ -1,0 +1,101 @@
+import qs.modules.common
+import qs.modules.common.widgets
+import qs.modules.imi.notificationPopup
+import qs.services
+import QtQuick
+import Quickshell
+import Quickshell.Wayland
+
+/**
+ * The real notification popup over a high-contrast backdrop, so one screenshot
+ * says whether the compositor is frosting the cards.
+ *
+ * Nothing about this is reachable from qmltestrunner - Quickshell's plugin does
+ * not load there, so Region cannot even be constructed - and weston implements
+ * no ext-background-effect, so it runs under a nested Hyprland on an isolated
+ * bus. See tests/run_notification_blur_probe.sh.
+ *
+ * The two control surfaces flank it: `probeStatic` publishes a region the way
+ * the bar and the sidebars do (one declared Region over a fixed item), and
+ * `probeUnblurred` publishes none at all. They bracket the answer - the
+ * notification cards should read like the first and not like the second.
+ */
+Scope {
+    id: probe
+
+    PanelWindow {
+        WlrLayershell.namespace: "quickshell:probeBackdrop"
+        WlrLayershell.layer: WlrLayer.Background
+        anchors { top: true; bottom: true; left: true; right: true }
+        color: "black"
+
+        Grid {
+            anchors.fill: parent
+            columns: 40
+            Repeater {
+                model: 40 * 40
+                Rectangle {
+                    required property int index
+                    width: 40
+                    height: 40
+                    color: ((index + Math.floor(index / 40)) % 2 === 0) ? "white" : "black"
+                }
+            }
+        }
+    }
+
+    PanelWindow {
+        id: staticSurface
+        WlrLayershell.namespace: "quickshell:probeStatic"
+        WlrLayershell.layer: WlrLayer.Overlay
+        exclusiveZone: 0
+        anchors { top: true; bottom: true; left: true; right: true }
+        color: "transparent"
+        mask: Region { item: staticCard }
+
+        WindowBlurRegion {
+            targetWindow: staticSurface
+            regionItem: staticCard
+            regionRadius: 20
+        }
+
+        Rectangle {
+            id: staticCard
+            x: 60
+            y: 60
+            width: 260
+            height: 120
+            radius: 20
+            color: Appearance.colors.colBackgroundSurfaceContainer
+        }
+    }
+
+    PanelWindow {
+        id: unblurredSurface
+        WlrLayershell.namespace: "quickshell:probeUnblurred"
+        WlrLayershell.layer: WlrLayer.Overlay
+        exclusiveZone: 0
+        anchors { top: true; bottom: true; left: true; right: true }
+        color: "transparent"
+        mask: Region { item: unblurredCard }
+
+        Rectangle {
+            id: unblurredCard
+            x: 60
+            y: 220
+            width: 260
+            height: 120
+            radius: 20
+            color: Appearance.colors.colBackgroundSurfaceContainer
+        }
+    }
+
+    NotificationPopup {}
+
+    Timer {
+        interval: 2500
+        running: true
+        repeat: false
+        onTriggered: console.log("[NotifBlurProbe] popups:", Notifications.popupList.length, "ready")
+    }
+}

--- a/dots/.config/quickshell/imi/NotificationCardsRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/NotificationCardsRuntimeTest.qml
@@ -1,0 +1,135 @@
+import QtQuick
+import Quickshell
+import qs.modules.common.widgets
+import qs.services
+
+/**
+ * Pins the contract the notification popup's compositor blur rests on: the
+ * cards `NotificationListView` publishes are the ones currently on screen.
+ *
+ * `NotificationPopup` hands that list to a `WindowBlurRegion`, which builds one
+ * `Region` per card. A `Region` whose item has been destroyed reports itself
+ * empty, so a stale list is not a slightly wrong blur - it is no blur at all,
+ * silently, with the region still published and nothing in any log.
+ *
+ * The case that broke it is the ordinary one: a popup times out, the window
+ * hides, another notification arrives from the same app. The app-name list ends
+ * that cycle exactly where it started, so the model count reads 1 throughout
+ * while the delegate is torn down and rebuilt - and `count`'s signal is raised
+ * from the view's layout pass, which does not run while the window is
+ * unmapped, so even the 1 -> 0 -> 1 in between is never announced. Every
+ * notification after the first was unblurred for the whole life of the feature.
+ *
+ * The window here is a `FloatingWindow` rather than the real layer surface, so
+ * this runs under headless weston: what has to be reproduced is the window
+ * going down and coming back, not wlr-layer-shell. Nothing about the published
+ * region itself is reachable from a test - Quickshell's plugin does not load in
+ * qmltestrunner and weston implements no ext-background-effect - which is what
+ * `tests/run_notification_blur_probe.sh` is for.
+ *
+ * Driven by tests/test_notification_cards_runtime.py; run it against throwaway
+ * XDG dirs and an isolated bus, never a real session.
+ */
+ShellRoot {
+    id: harness
+
+    property int failures: 0
+    property int elapsed: 0
+    property var firstCard: null
+    property int seenPopups: 0
+    property bool wentDown: false
+
+    function check(label, ok) {
+        console.log(`[NotifCards] ${label}: ${ok ? "ok" : "FAIL"}`);
+        if (!ok)
+            harness.failures++;
+    }
+
+    function finish() {
+        console.log(`[NotifCards] failures: ${harness.failures}`);
+        Qt.exit(harness.failures === 0 ? 0 : 1);
+    }
+
+    // Walks up from the card instead of re-reading the list's own children, so
+    // the assertion is not the function under test spelled a second time.
+    function isOnScreen(card) {
+        if (!card)
+            return false;
+        let node = card;
+        while (node) {
+            if (node === listview.contentItem)
+                return true;
+            node = node.parent;
+        }
+        return false;
+    }
+
+    FloatingWindow {
+        id: window
+        // The real popup window is bound exactly this way, and the binding is
+        // what takes the surface down between notifications.
+        visible: Notifications.popupList.length > 0
+        implicitWidth: 460
+        implicitHeight: 420
+        color: "black"
+
+        NotificationListView {
+            id: listview
+            anchors.fill: parent
+            popup: true
+        }
+    }
+
+    Timer {
+        interval: 200
+        repeat: true
+        running: true
+        onTriggered: {
+            harness.elapsed += 200;
+
+            if (harness.seenPopups === 0 && Notifications.popupList.length > 0) {
+                harness.seenPopups = 1;
+                settle.restart();
+                return;
+            }
+
+            if (harness.seenPopups === 1 && Notifications.popupList.length === 0)
+                harness.wentDown = true;
+
+            if (harness.wentDown && Notifications.popupList.length > 0) {
+                harness.seenPopups = 2;
+                settle.restart();
+                running = false;
+                return;
+            }
+
+            if (harness.elapsed >= 60000) {
+                harness.check("two notifications arrive with the popup down in between", false);
+                harness.finish();
+            }
+        }
+    }
+
+    Timer {
+        id: settle
+        interval: 600
+        onTriggered: {
+            const cards = listview.cardItems;
+            if (harness.seenPopups === 1) {
+                harness.check("the first popup publishes one card", cards.length === 1);
+                harness.check("the first card is on screen", harness.isOnScreen(cards[0] ?? null));
+                harness.firstCard = cards[0] ?? null;
+                return;
+            }
+
+            // Without this the rest is vacuous: if the delegate had survived
+            // the cycle, a list that never refreshed would still be right.
+            harness.check("the first popup's card left the screen",
+                !harness.isOnScreen(harness.firstCard));
+            harness.check("the second popup publishes one card", cards.length === 1);
+            harness.check("the second popup's card is on screen",
+                harness.isOnScreen(cards[0] ?? null));
+            harness.finish();
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/modules/common/widgets/NotificationListView.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/NotificationListView.qml
@@ -35,9 +35,22 @@ StyledListView { // Scrollable window
         root.cardItems = items;
     }
 
-    // Delegates are built a beat after the count changes, so read the children
-    // once the current pass of the event loop has created them.
-    onCountChanged: Qt.callLater(root.refreshCardItems)
+    // Observe the delegates, not the model count. The set of realized delegates
+    // changes for reasons `count` cannot report, and the popup's ordinary life
+    // is one of them: a notification times out, the popup window hides, another
+    // arrives from the same app, and the app-name list ends the cycle exactly
+    // where it started - so the delegate is torn down and rebuilt while `count`
+    // reads 1 throughout. `count`'s signal is raised from the view's layout
+    // pass as well, which does not run while the popup window's surface is
+    // down, so even the 1 -> 0 -> 1 in between is never announced.
+    // Qt.callLater coalesces a burst and defers the read until the pass that
+    // built the delegates has finished.
+    Connections {
+        target: root.contentItem
+        function onChildrenChanged() {
+            Qt.callLater(root.refreshCardItems);
+        }
+    }
     Component.onCompleted: Qt.callLater(root.refreshCardItems)
 
     model: ScriptModel {

--- a/dots/.config/quickshell/imi/tests/run_notification_blur_probe.sh
+++ b/dots/.config/quickshell/imi/tests/run_notification_blur_probe.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+# Looks at the notification popup's compositor blur, which nothing else can.
+#
+# The blur is produced by Hyprland from an ext-background-effect region the
+# shell publishes, so neither qmltestrunner (Quickshell's plugin does not load
+# there - Region cannot even be constructed) nor headless weston (it implements
+# no ext-background-effect) can see it. This runs a NESTED Hyprland on its own
+# D-Bus session instead, and photographs the result with grim.
+#
+# NotificationBlurProbe.qml draws a hard checkerboard backdrop and, over it, the
+# real NotificationPopup between two controls: a card publishing a region the
+# way the bar does, and a card publishing none. The notification cards should
+# read like the first and not like the second.
+#
+# It shoots three times, and the third is the point: the popup times out between
+# them, so the layer surface goes down and comes back exactly as it does all day
+# on a real desktop. The bug this probe was written for only showed from the
+# second popup onward - see NotificationCardsRuntimeTest.qml.
+#
+# It measures rather than leaving you to squint, because the difference is real
+# but small: over the checkerboard, at the default 0.11 background transparency,
+# a blurred card's interior varies by ~2/255 along a row and an unblurred one by
+# ~25. The two control cards are printed beside each shot as the calibration -
+# read the notification number against them, not against an absolute threshold.
+# Look at the PNGs too, upscaled with `magick -filter point -resize 300%`.
+#
+# Usage: tests/run_notification_blur_probe.sh [/tmp/notifblur.png]
+set -u
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+OUT="${1:-/tmp/notifblur.png}"
+
+for binary in Hyprland qs grim notify-send dbus-launch; do
+    command -v "$binary" >/dev/null 2>&1 || { echo "SKIPPED: $binary not on PATH"; exit 0; }
+done
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+export XDG_CONFIG_HOME="$TMP/config" XDG_CACHE_HOME="$TMP/cache"
+export XDG_STATE_HOME="$TMP/state" XDG_DATA_HOME="$TMP/data"
+mkdir -p "$XDG_CONFIG_HOME/immaterial-impulse" "$XDG_CACHE_HOME" "$XDG_STATE_HOME" "$XDG_DATA_HOME"
+# Bottom left, away from Hyprland's own startup banners, and transparency on -
+# an opaque card has nothing to show through it either way.
+printf '%s' '{"appearance":{"transparency":{"enable":true,"automatic":false,"backgroundTransparency":0.11,"contentTransparency":0.57}},"notifications":{"position":"bottom_left"}}' \
+    > "$XDG_CONFIG_HOME/immaterial-impulse/config.json"
+
+# Mirrors dots/.config/hypr/hyprland/rules.lua for the namespaces under test:
+# the catch-all whole-surface blur on, turned off again for the surfaces that
+# publish a region of their own.
+cat > "$TMP/hypr.lua" <<'LUA'
+-- Scale 1, so the control cards sit at the pixel coordinates the probe declares
+-- and the measurement below can read them without hunting for them.
+hl.monitor({ output = "", mode = "preferred", position = "auto", scale = 1 })
+hl.config({
+    misc = { disable_hyprland_logo = true, disable_splash_rendering = true,
+             force_default_wallpaper = 0, disable_autoreload = true },
+    animations = { enabled = false },
+    decoration = {
+        blur = { enabled = true, xray = false, special = false, new_optimizations = true,
+                 size = 10, passes = 3, brightness = 1, noise = 0.05, contrast = 0.89,
+                 vibrancy = 0.5, vibrancy_darkness = 0.5, popups = false,
+                 popups_ignorealpha = 0.6 },
+    },
+})
+hl.layer_rule({ match = { namespace = ".*" }, xray = false})
+hl.layer_rule({ match = { namespace = "quickshell:.*" }, blur_popups = true})
+hl.layer_rule({ match = { namespace = "quickshell:.*" }, blur = true})
+hl.layer_rule({ match = { namespace = "quickshell:.*" }, ignore_alpha = 0.05})
+hl.layer_rule({ match = { namespace = "quickshell:notificationPopup" }, blur = false})
+hl.layer_rule({ match = { namespace = "quickshell:probeStatic" }, blur = false})
+hl.layer_rule({ match = { namespace = "quickshell:probeUnblurred" }, blur = false})
+LUA
+
+eval "$(dbus-launch --sh-syntax)"
+before=$(ls "$XDG_RUNTIME_DIR" | grep -E '^wayland-[0-9]+$' | tr '\n' ' ')
+Hyprland -c "$TMP/hypr.lua" > "$TMP/hypr.log" 2>&1 &
+HPID=$!
+
+NEW=""
+for _ in $(seq 1 60); do
+    sleep 0.5
+    for s in $(ls "$XDG_RUNTIME_DIR" | grep -E '^wayland-[0-9]+$'); do
+        case " $before " in *" $s "*) ;; *) NEW="$s";; esac
+    done
+    [ -n "$NEW" ] && break
+done
+if [ -z "$NEW" ]; then
+    echo "FAILED: the nested compositor never came up"
+    tail -20 "$TMP/hypr.log"
+    kill $HPID 2>/dev/null
+    exit 1
+fi
+export WAYLAND_DISPLAY="$NEW"
+echo "nested compositor on $NEW"
+
+cd "$ROOT"
+qs -p "$ROOT/NotificationBlurProbe.qml" > "$TMP/probe.log" 2>&1 &
+QPID=$!
+sleep 8
+
+notify-send "Probe" "First card - the surface is fresh"
+sleep 4
+grim "${OUT%.png}_first.png"
+# 7s default timeout, so this outlives the popup: the surface goes down.
+sleep 12
+notify-send "Probe" "Second card - the surface was rebuilt"
+sleep 4
+grim "${OUT%.png}_second.png"
+sleep 12
+notify-send "Probe" "Third card - and rebuilt again"
+sleep 4
+grim "${OUT%.png}_third.png"
+
+kill $QPID 2>/dev/null
+hyprctl dispatch exit >/dev/null 2>&1
+sleep 1
+kill $HPID 2>/dev/null
+kill "$DBUS_SESSION_BUS_PID" 2>/dev/null
+
+grep -E "ERROR|WARN scene" "$TMP/probe.log" | head -10
+echo "wrote ${OUT%.png}_first.png ${OUT%.png}_second.png ${OUT%.png}_third.png"
+
+python3 - "${OUT%.png}" <<'PY'
+import sys
+
+try:
+    from PIL import Image
+except ImportError:
+    print("(install python-pillow for the numbers; the PNGs are still there)")
+    raise SystemExit(0)
+
+
+def spread(im, x0, x1, y):
+    row = [im.getpixel((x, y))[0] for x in range(x0, x1)]
+    return max(row) - min(row), sum(row) / len(row)
+
+
+def card_rows(im):
+    """The notification card's flat interior rows, found from the bottom left.
+
+    Only rows dark enough to be inside the card and free of its text and icon,
+    so the number reported is backdrop bleed rather than glyph contrast.
+    """
+    width, height = im.size
+    rows = []
+    for y in range(height - 5, height - 200, -1):
+        s, mean = spread(im, 45, min(350, width), y)
+        if mean < 70 and s < 60:
+            rows.append(s)
+    return rows
+
+
+for shot in ("first", "second", "third"):
+    im = Image.open(f"{sys.argv[1]}_{shot}.png").convert("RGB")
+    blurred, _ = spread(im, 70, 310, 120)
+    plain, _ = spread(im, 70, 310, 280)
+    rows = card_rows(im)
+    card = min(rows) if rows else None
+    print(f"  {shot:<6} control blurred={blurred:<4} control unblurred={plain:<4} "
+          f"notification card={card if card is not None else 'not found'}")
+PY

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -322,6 +322,14 @@ if ! python3 "$SCRIPT_DIR/test_notes_surfaces_runtime.py"; then
     exit 1
 fi
 
+# Also brings its own weston, plus its own D-Bus session so the harness's
+# notification server is the one notify-send reaches rather than the caller's.
+echo "Running notification card list runtime tests..."
+if ! python3 "$SCRIPT_DIR/test_notification_cards_runtime.py"; then
+    echo "Notification card list runtime tests failed."
+    exit 1
+fi
+
 echo "Running plugin installer tests..."
 if ! python3 "$SCRIPT_DIR/test_plugin_installer.py"; then
     echo "Plugin installer tests failed."

--- a/dots/.config/quickshell/imi/tests/test_notification_cards_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_notification_cards_runtime.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Drives two real notifications past the popup's card list, with the window
+going down in between.
+
+`NotificationCardsRuntimeTest.qml` builds the real `NotificationListView` in a
+window bound to `Notifications.popupList` exactly as `NotificationPopup` binds
+its layer surface. This module is the driver: headless weston, an isolated
+D-Bus session so the harness's own notification server is the one `notify-send`
+reaches, throwaway XDG dirs, and a short notification timeout so the first
+popup goes away on its own.
+
+Why a driver rather than a unit test: the list's card set is what the popup
+hands to `WindowBlurRegion`, a stale entry publishes an empty region, and an
+empty region is indistinguishable from a correct one everywhere except on
+screen. The failure it guards ran for the whole life of the feature - every
+notification after the first was unblurred - because the refresh observed the
+model count, which does not move across a hide/show cycle from the same app.
+
+Skips when weston, qs, notify-send or dbus-run-session are missing, as in CI.
+"""
+
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HARNESS = ROOT / "NotificationCardsRuntimeTest.qml"
+SOCKET = "wayland-imi-notif-cards"
+CONFIG = ('{"notifications":{"timeout":1500},'
+          '"appearance":{"transparency":{"enable":true}}}')
+
+
+def _stop(proc):
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+
+
+def _runtime_available():
+    return all(shutil.which(binary) is not None
+               for binary in ("qs", "weston", "notify-send", "dbus-run-session"))
+
+
+@unittest.skipUnless(_runtime_available(),
+                     "needs qs, weston, notify-send and dbus-run-session on PATH")
+class NotificationCardsRuntimeTest(unittest.TestCase):
+    def setUp(self):
+        self.home = Path(tempfile.mkdtemp(prefix="imi-notif-cards-"))
+        self.addCleanup(shutil.rmtree, self.home, ignore_errors=True)
+
+    def test_every_popup_publishes_the_card_that_is_on_screen(self):
+        env = dict(os.environ)
+        env.setdefault("XDG_RUNTIME_DIR", f"/run/user/{os.getuid()}")
+        env["WAYLAND_DISPLAY"] = SOCKET
+        env.pop("DISPLAY", None)
+
+        weston = subprocess.Popen(
+            ["weston", "--backend=headless", "--renderer=pixman",
+             f"--socket={SOCKET}", "--width=900", "--height=700"],
+            env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        self.addCleanup(_stop, weston)
+
+        socket_path = Path(env["XDG_RUNTIME_DIR"]) / SOCKET
+        deadline = time.monotonic() + 15
+        while not socket_path.exists() and time.monotonic() < deadline:
+            time.sleep(0.2)
+        self.assertTrue(socket_path.exists(), "headless weston never came up")
+
+        # This box's headless EGL has no driver, so force software rendering.
+        env["LIBGL_ALWAYS_SOFTWARE"] = "1"
+        env["QT_QUICK_BACKEND"] = "software"
+        env["XDG_CONFIG_HOME"] = str(self.home / "config")
+        env["XDG_CACHE_HOME"] = str(self.home / "cache")
+        env["XDG_STATE_HOME"] = str(self.home / "state")
+        env["XDG_DATA_HOME"] = str(self.home / "data")
+        shell_config = Path(env["XDG_CONFIG_HOME"]) / "immaterial-impulse"
+        shell_config.mkdir(parents=True)
+        (shell_config / "config.json").write_text(CONFIG)
+
+        # The harness owns org.freedesktop.Notifications on this bus, so the
+        # notify-send calls below have to run on the same one - and must not
+        # reach the caller's real notification daemon.
+        script = self.home / "drive.sh"
+        script.write_text(
+            "#!/bin/bash\n"
+            f'cd "{ROOT}"\n'
+            "qs -p '%s' > '%s' 2>&1 &\n"
+            "QS=$!\n"
+            "sleep 6\n"
+            "notify-send 'Cards probe' 'first popup'\n"
+            "sleep 6\n"
+            "notify-send 'Cards probe' 'second popup'\n"
+            "sleep 8\n"
+            "kill $QS 2>/dev/null\n"
+            "wait $QS 2>/dev/null\n" % (HARNESS, self.home / "harness.log"))
+        script.chmod(0o755)
+
+        subprocess.run(["dbus-run-session", "--", str(script)],
+                       cwd=str(ROOT), env=env, capture_output=True,
+                       text=True, timeout=180)
+
+        output = (self.home / "harness.log").read_text(errors="ignore")
+        failed = [line for line in output.splitlines() if "FAIL" in line]
+        self.assertEqual(failed, [], f"harness reported failures:\n{output}")
+        self.assertIn("[NotifCards] failures: 0", output,
+                      f"harness never reached a verdict:\n{output}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Notification popups were not blurred — every one of them except the very first of each shell session.

## Root cause

Not a missing region, and not a deliberate exclusion. Everything the shell's body-scoped blur needs was in place and read correctly: `rules.lua` turns the whole-surface blur off for `quickshell:notificationPopup`, `NotificationPopup` publishes a `WindowBlurRegion` over `listview.cardItems`, and `lint_blur_region_pairing.py` was satisfied. That is exactly why it survived — a `Region` whose `item` has been destroyed reports itself `empty()`, so the region stays published, the compositor is handed an empty area, and nothing in any log says a word.

`NotificationListView` refreshed its card set from `onCountChanged`, and the popup's ordinary life defeats that twice over:

- the model is a list of **app names**, so a notification timing out and another arriving from the same app leaves `count` at 1 across the whole cycle while the delegate is torn down and a new one built;
- `count`'s signal is raised from the view's layout pass, which does not run while the window's surface is down (`visible: false` destroys a layer surface), so even the 1 → 0 → 1 in between is never announced.

Instrumented against a real popup, `countChanged` fired **exactly once** — for the first notification — and never again. So the region kept describing the first popup's card, which had long since been destroyed.

The fix observes `contentItem`'s children instead: the thing that actually changes when a card appears or is replaced. One `Connections` block; `Qt.callLater` still coalesces.

## Evidence

**Live session, before the fix.** A test-pattern layer surface placed under the popup shows through the card with perfectly sharp edges — the card is translucent and unblurred. Measured spread along a row of the card's interior: ~20/255, where a blurred surface reads ~2.

**Nested Hyprland probe** (`tests/run_notification_blur_probe.sh`), card-interior spread over a checkerboard across three consecutive popups, with the two control cards as calibration:

| | control blurred | control unblurred | popup 1 | popup 2 | popup 3 |
|---|---|---|---|---|---|
| before | 2 | 28 | 1 | 20 | 20 |
| after | 2 | 28 | 1 | 1 | 1 |

At 3x zoom the third popup goes from a card with the checkerboard visible straight through it to a uniform frosted panel.

## Tests

- `tests/test_notification_cards_runtime.py` + `NotificationCardsRuntimeTest.qml` — headless weston plus its own D-Bus session, two real notifications with the window down in between, asserting the published card is the one on screen. Confirmed it reddens with the old `onCountChanged` trigger restored, and that it reproduces the real mechanism (`countChanged` fires once there too) rather than a lookalike. Wired into `run_tests.sh`.
- `tests/run_notification_blur_probe.sh` + `NotificationBlurProbe.qml` — the visual probe above. Manual, like the other `run_*_probe.sh`, since it needs a nested compositor.
- Full suite green.

## What the sandbox could not prove

The frost itself is out of reach of everything the suite normally uses: `qmltestrunner` does not load Quickshell's plugin, so a `Region` cannot be constructed there, and headless weston implements no `ext-background-effect`. That is why the visual evidence comes from a nested Hyprland rather than the usual weston harness — llvmpipe composites the blur correctly there, and the numbers above are real `grim` captures of that compositor, not `grabToImage`.

Nothing was deployed: the running `qs -c imi` is still on the old code. To confirm on screen, restart the shell, then send two notifications a good 10 seconds apart (`notify-send a b`, wait for the first to disappear, `notify-send c d`) over a *sharp* area of wallpaper or a window — the second card must be as frosted as the first. Over the current soft wallpaper the difference is nearly invisible, which is part of why this went unnoticed for so long.

Docs: updated AGENT.md §Layer-shell (wlr-layer-shell) gotchas — a blur region built from a list of items must observe the items, not a model count
