### PR TITLE
Desktop widget cards cast a shadow, and lift when handled

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1293,6 +1293,19 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   which passed every hover assertion while the cursor never changed. Input areas own their
   cursors; z order guarantees the interactive thing is topmost.
   05bf3013f ("feat(media): the play button's body IS the visualizer").
+- **A layer clips at its item's bounds, so anything drawn outside needs the item grown first.** The
+  widget card's shadow (`Appearance.elevation`, one `MultiEffect` over a frame wrapping all three
+  body renderers) is taken from the BODY, never the card: over the card it would put a shadow under
+  every label and glyph inside it. That frame is inset NEGATIVELY by the bow's reach, because the
+  elastic-resize canvas deliberately draws up to `2*BOW_PX` outside the card and a layer would cut
+  it. The shadow is dropped while the card is moving and restored on settle, for the same reason the
+  frost is: re-rendering a blurred copy of the body every frame of a morph is the expensive path.
+  Verification is pixels, not source text (`test_card_shadow.py`), and two traps live there:
+  `ItemGrabResult.image` is not scriptable from QML, so analysis belongs outside; and `grabToImage`
+  captures the ITEM, so a field relying on its WINDOW's colour grabs a transparent PNG whose "white"
+  reads as black to any analyser - a measurement that looks like a catastrophic failure when nothing
+  is wrong, and would equally hide a real one.
+  4046f1854 ("feat(widgets): the card casts a shadow, and lifts when handled").
 - **A Behavior whose animation reads its tier from a binding carries the PREVIOUS transition.** The
   shared interaction model (`Appearance.interaction`, decided in `modules/common/interaction_motion.js`)
   gives every control the same five states, and each pair of states has its own duration and curve -

--- a/dots/.config/quickshell/imi/ShadowTuningPlayground.qml
+++ b/dots/.config/quickshell/imi/ShadowTuningPlayground.qml
@@ -1,0 +1,253 @@
+import QtQuick
+import QtQuick.Effects
+import QtQuick.Layouts
+import Quickshell
+
+/*
+ * Pick the widget card's shadow numbers on the real wallpaper, the same way
+ * the elastic-resize constants were picked: sliders, a live readout, and the
+ * states side by side rather than one at a time.
+ *
+ *   qs -p ShadowTuningPlayground.qml
+ *
+ * Standalone on purpose - no Appearance, no Config, no shell singletons - so
+ * it starts in a second and cannot be broken by the shell it is tuning. The
+ * card here is a stand-in with the same three body renderers WidgetCard has
+ * (plain rounded rect, a named shape, and a canvas), because a shadow that
+ * only works under a Rectangle is not the one we need.
+ */
+FloatingWindow {
+    id: harness
+    implicitWidth: 1500
+    implicitHeight: 900
+    color: "#101014"
+
+    // Tunables, all live.
+    property real restBlur: 0.42
+    property real restOpacity: 0.30
+    property real restOffsetY: 4
+    property real restScale: 1.0
+    property real hoverLift: 1.6      // multiplier on blur and offset while hovered
+    property real dragLift: 2.4       // ...and while dragged
+    property color shadowColor: "#000000"
+
+    readonly property string readout:
+        `blur ${restBlur.toFixed(2)} opacity ${restOpacity.toFixed(2)} ` +
+        `offset ${restOffsetY.toFixed(1)} scale ${restScale.toFixed(2)} ` +
+        `hover ${hoverLift.toFixed(2)} drag ${dragLift.toFixed(2)}`
+
+    // The wallpaper, so the shadow is judged over the image it will live on
+    // and not over a flat grey that flatters everything.
+    property string wallpaper: Quickshell.env("SHADOW_PLAYGROUND_WALL")
+        || "/home/xephy/Pictures/Wallpapers/aishot-1206.jpg"
+
+    Item {
+        id: pageFrame
+        anchors.fill: parent
+
+    Image {
+        anchors.fill: parent
+        source: harness.wallpaper === "" ? "" : `file://${harness.wallpaper}`
+        fillMode: Image.PreserveAspectCrop
+        asynchronous: true
+    }
+
+    // A light patch and a dark patch: a shadow that reads well over one and
+    // vanishes or smears over the other is the usual failure.
+    Row {
+        anchors { left: parent.left; right: parent.right; top: parent.top }
+        height: 120
+        Rectangle { width: parent.width / 2; height: parent.height; color: "#f2f0ee" }
+        Rectangle { width: parent.width / 2; height: parent.height; color: "#141218" }
+    }
+
+    component TunedCard: Item {
+        id: card
+        property string label: ""
+        property string shapeMode: "rect"   // rect | cookie | canvas
+        property bool dragging: false
+        width: 260
+        height: 150
+
+        property real lift: card.dragging ? harness.dragLift
+            : (hoverArea.containsMouse ? harness.hoverLift : 1.0)
+        Behavior on lift { NumberAnimation { duration: 220; easing.type: Easing.OutCubic } }
+
+        Item {
+            id: body
+            anchors.fill: parent
+
+            Rectangle {
+                anchors.fill: parent
+                visible: card.shapeMode === "rect"
+                radius: 30
+                color: "#2a2733"
+            }
+
+            // A stand-in for the shape body: a squircle-ish blob, to prove the
+            // shadow follows painted alpha rather than a rounded rect.
+            Canvas {
+                anchors.fill: parent
+                visible: card.shapeMode !== "rect"
+                onPaint: {
+                    const ctx = getContext("2d");
+                    ctx.reset();
+                    ctx.fillStyle = "#2a2733";
+                    ctx.beginPath();
+                    const lobes = card.shapeMode === "cookie" ? 8 : 4;
+                    const cx = width / 2, cy = height / 2;
+                    const rx = width / 2 - 6, ry = height / 2 - 6;
+                    for (let i = 0; i <= 240; i++) {
+                        const t = i / 240 * Math.PI * 2;
+                        const wobble = 1 + 0.10 * Math.cos(lobes * t);
+                        const x = cx + Math.cos(t) * rx * wobble;
+                        const y = cy + Math.sin(t) * ry * wobble;
+                        i === 0 ? ctx.moveTo(x, y) : ctx.lineTo(x, y);
+                    }
+                    ctx.closePath();
+                    ctx.fill();
+                }
+                Component.onCompleted: requestPaint()
+            }
+
+            Text {
+                anchors.centerIn: parent
+                text: card.label
+                color: "#e8e4ef"
+                font.pixelSize: 15
+                font.bold: true
+            }
+        }
+
+        // The shadow: one effect over whatever painted the body, so all three
+        // renderers are covered by the same path.
+        layer.enabled: true
+        layer.effect: MultiEffect {
+            shadowEnabled: true
+            shadowBlur: harness.restBlur * card.lift
+            shadowOpacity: harness.restOpacity
+            shadowVerticalOffset: harness.restOffsetY * card.lift
+            shadowHorizontalOffset: 0
+            shadowScale: harness.restScale
+            shadowColor: harness.shadowColor
+        }
+
+        MouseArea {
+            id: hoverArea
+            anchors.fill: parent
+            hoverEnabled: true
+            drag.target: card
+            onPressed: card.dragging = true
+            onReleased: card.dragging = false
+        }
+    }
+
+    Item {
+        anchors.fill: parent
+        anchors.topMargin: 170
+
+        TunedCard { x: 90; y: 40; label: "rest / hover me"; shapeMode: "rect" }
+        TunedCard { x: 400; y: 40; label: "drag me"; shapeMode: "rect" }
+        TunedCard { x: 710; y: 40; label: "shape body"; shapeMode: "cookie" }
+        TunedCard { x: 1020; y: 40; label: "shape body"; shapeMode: "blob"; width: 200 }
+
+        // The same four again over the light strip's colour, since a shadow's
+        // opacity reads completely differently there.
+        Rectangle {
+            x: 60; y: 260; width: 1200; height: 240; radius: 20; color: "#f2f0ee"
+            TunedCard { x: 30; y: 45; label: "on light"; shapeMode: "rect" }
+            TunedCard { x: 340; y: 45; label: "on light"; shapeMode: "cookie" }
+        }
+    }
+
+    component Slider: RowLayout {
+        property string label
+        property real value
+        property real from
+        property real to
+        property real step: 0.01
+        spacing: 8
+        Text { text: parent.label; color: "#cfc9d8"; font.pixelSize: 12; Layout.preferredWidth: 74 }
+        Rectangle {
+            Layout.preferredWidth: 190
+            Layout.preferredHeight: 6
+            radius: 3
+            color: "#3a3543"
+            Rectangle {
+                width: parent.width * (parent.parent.value - parent.parent.from)
+                    / Math.max(parent.parent.to - parent.parent.from, 0.0001)
+                height: parent.height
+                radius: 3
+                color: "#b9a8e6"
+            }
+            MouseArea {
+                anchors.fill: parent
+                anchors.margins: -10
+                function set(mx) {
+                    const t = Math.max(0, Math.min(1, (mx - 10) / parent.width));
+                    const raw = parent.parent.from + t * (parent.parent.to - parent.parent.from);
+                    parent.parent.value = Math.round(raw / parent.parent.step) * parent.parent.step;
+                }
+                onPressed: mouse => set(mouse.x)
+                onPositionChanged: mouse => { if (pressed) set(mouse.x); }
+            }
+        }
+        Text { text: parent.value.toFixed(2); color: "#e8e4ef"; font.pixelSize: 12; Layout.preferredWidth: 40 }
+    }
+
+    // Headless review path: set SHADOW_PLAYGROUND_SHOT to grab the page and exit.
+    readonly property string shotPath: Quickshell.env("SHADOW_PLAYGROUND_SHOT") || ""
+    Timer {
+        running: pageFrame.shotPath !== ""
+        interval: 1800
+        onTriggered: pageFrame.grabToImage(result => {
+            result.saveToFile(pageFrame.shotPath);
+            Qt.quit();
+        })
+    }
+
+    Rectangle {
+        anchors { right: parent.right; bottom: parent.bottom; margins: 16 }
+        width: 360
+        height: controls.implicitHeight + 28
+        radius: 16
+        color: "#181620"
+        opacity: 0.94
+
+        ColumnLayout {
+            id: controls
+            anchors { fill: parent; margins: 14 }
+            spacing: 6
+
+            Text { text: "Widget card shadow"; color: "#e8e4ef"; font.pixelSize: 14; font.bold: true }
+            Slider { label: "blur"; from: 0; to: 1; value: harness.restBlur
+                     onValueChanged: harness.restBlur = value }
+            Slider { label: "opacity"; from: 0; to: 1; value: harness.restOpacity
+                     onValueChanged: harness.restOpacity = value }
+            Slider { label: "offset Y"; from: 0; to: 24; step: 0.5; value: harness.restOffsetY
+                     onValueChanged: harness.restOffsetY = value }
+            Slider { label: "scale"; from: 0.8; to: 1.2; value: harness.restScale
+                     onValueChanged: harness.restScale = value }
+            Slider { label: "hover x"; from: 1; to: 3; value: harness.hoverLift
+                     onValueChanged: harness.hoverLift = value }
+            Slider { label: "drag x"; from: 1; to: 4; value: harness.dragLift
+                     onValueChanged: harness.dragLift = value }
+
+            Text {
+                Layout.fillWidth: true
+                text: harness.readout
+                color: "#b9a8e6"
+                font.pixelSize: 11
+                wrapMode: Text.Wrap
+            }
+            Text {
+                Layout.fillWidth: true
+                text: "Hover a card to see the hover lift; press and drag for the drag lift. Paste the line above back when the numbers feel right."
+                color: "#8d8699"
+                font.pixelSize: 10
+                wrapMode: Text.Wrap
+            }
+        }
+    }
+    }
+}

--- a/dots/.config/quickshell/imi/WidgetCardShadowProbe.qml
+++ b/dots/.config/quickshell/imi/WidgetCardShadowProbe.qml
@@ -1,0 +1,92 @@
+import QtQuick
+import Quickshell
+import qs.modules.common
+import qs.modules.common.plugins.designsystem.widgets as Expressive
+
+/*
+ * Does the card actually cast a shadow, does it lift when handled, and does
+ * it stop casting one while it is moving?
+ *
+ * Structure tests can only see that the wiring is spelled correctly. This
+ * renders real WidgetCards on a white field and measures the pixels just
+ * below each one: a shadow darkens that strip, a bigger shadow darkens it
+ * more, and a card in motion should not darken it at all.
+ *
+ *   ./tests/run_card_shadow_probe.sh
+ */
+ShellRoot {
+    id: harness
+
+    property int failures: 0
+    function check(label, ok, detail) {
+        console.log(`[CardShadow] ${label}: ${ok ? "ok" : "FAIL"}${detail ? " " + detail : ""}`);
+        if (!ok) harness.failures++;
+    }
+
+    readonly property int cardW: 200
+    readonly property int cardH: 120
+
+    FloatingWindow {
+        id: window
+        implicitWidth: 900
+        implicitHeight: 400
+        color: "white"
+
+        Item {
+            id: field
+            anchors.fill: parent
+
+            // The grab takes THIS item, not the window, so the field carries
+            // its own ground - grabbing over the window's colour produces a
+            // transparent PNG whose "white" reads as black to any analyser.
+            Rectangle { anchors.fill: parent; color: "white" }
+
+            // Rest, handled, and mid-motion - same card, three states.
+            Expressive.WidgetCard {
+                id: restCard
+                x: 60; y: 60
+                width: harness.cardW; height: harness.cardH
+                tint: "#2a2733"
+            }
+            Expressive.WidgetCard {
+                id: draggedCard
+                x: 340; y: 60
+                width: harness.cardW; height: harness.cardH
+                tint: "#2a2733"
+                dragging: true
+            }
+            Expressive.WidgetCard {
+                id: movingCard
+                x: 620; y: 60
+                width: harness.cardW; height: harness.cardH
+                tint: "#2a2733"
+                // A card mid-morph: the shadow is dropped for the duration.
+                motionActive: true
+            }
+        }
+    }
+
+    // The measuring happens outside: ItemGrabResult.image is not scriptable
+    // from QML, so the probe renders and saves, and test_card_shadow.py reads
+    // the pixels. Card boxes are printed so the analyser needs no duplicate
+    // copy of this layout.
+    Timer {
+        running: true
+        interval: 1500
+        onTriggered: {
+            const shot = Quickshell.env("CARD_SHADOW_SHOT") || "";
+            if (shot === "") {
+                console.log("[CardShadow] FAIL: CARD_SHADOW_SHOT unset");
+                Qt.quit();
+                return;
+            }
+            console.log(`[CardShadow] layout cardW=${harness.cardW} cardH=${harness.cardH} `
+                + `rest=60 dragged=340 moving=620 top=60`);
+            field.grabToImage(result => {
+                result.saveToFile(shot);
+                console.log("[CardShadow] saved");
+                Qt.quit();
+            });
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/modules/common/Appearance.qml
+++ b/dots/.config/quickshell/imi/modules/common/Appearance.qml
@@ -378,6 +378,24 @@ Singleton {
         }
     }
 
+    // The desktop card's elevation. Numbers picked on the real wallpaper with
+    // ShadowTuningPlayground rather than argued about, the same way the
+    // resize-tension constants were:
+    //   blur 0.51 opacity 0.50 offset 4.0 scale 1.00 hover 1.94 drag 2.65
+    //
+    // hover/drag are multipliers on blur and offset, not separate shadows: a
+    // card lifts further off the wallpaper the more directly it is being
+    // handled, and one animated lift factor drives both.
+    property QtObject elevation: QtObject {
+        readonly property real blur: 0.51
+        readonly property real shadowOpacity: 0.50
+        readonly property real offsetY: 4.0
+        readonly property real shadowScale: 1.00
+        readonly property real hoverLift: 1.94
+        readonly property real dragLift: 2.65
+        readonly property color shadowColor: root.m3colors.m3shadow
+    }
+
     animation: QtObject {
         property QtObject elementMove: QtObject {
             property int duration: animationCurves.expressiveDefaultSpatialDuration

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginNode.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginNode.qml
@@ -66,6 +66,9 @@ Item {
     // The resize grip's live edge distortion, forwarded to widgets whose cards
     // bow under tension. A point of pixels; (0,0) at rest.
     property point resizeBow: Qt.point(0, 0)
+    // Whether the host is currently being dragged, for a widget that lifts
+    // its cards while handled.
+    property bool hostDragging: false
 
     readonly property string effectiveBasePath: manifestNode?._basePath || basePath
     readonly property string componentPath: manifestNode?.component && effectiveBasePath
@@ -171,6 +174,8 @@ Item {
                     item.hostGridSize = Qt.binding(() => rootNode.gridSize);
                 if (item.hostResizeBow !== undefined)
                     item.hostResizeBow = Qt.binding(() => rootNode.resizeBow);
+                if (item.hostDragging !== undefined)
+                    item.hostDragging = Qt.binding(() => rootNode.hostDragging);
                 return;
             }
             if (manifestNode.props) {

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
@@ -682,6 +682,7 @@ AbstractBackgroundWidget {
         // resize - see shownGridSpan.
         gridSize: rootWidget.shownGridSpan
         resizeBow: rootWidget.resizeBow
+        hostDragging: rootWidget.dragging
         anchors.centerIn: parent
     }
     }

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-currency/Widget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-currency/Widget.qml
@@ -19,6 +19,8 @@ Item {
     // the host's midpoint dissolve yields.
     readonly property bool handlesSpanTransition: true
     property point hostResizeBow: Qt.point(0, 0)
+    // Set by the host while this widget is being dragged; the cards lift.
+    property bool hostDragging: false
     // Implicit from the SPAN; the content fills whatever the host gives -
     // the host's animating box is the resize (weather's wrapper shipped the
     // self-sized version of this and its card teleported).
@@ -41,6 +43,7 @@ Item {
         anchors.fill: parent
         sizeMode: root.hostGridSize || "2x1"
         resizeBow: root.hostResizeBow
+        dragging: root.hostDragging
         useBlurBackground: PluginState.option("nandoroid_currency", "blurEnabled", false)
         backgroundOpacity: PluginState.effectiveBackgroundOpacity("nandoroid_currency")
         onBaseCurrencyRequested: value => PluginState.setOption("nandoroid_currency", "baseCurrency", value)

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/Widget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/Widget.qml
@@ -35,6 +35,8 @@ Item {
     // `qs -p` probe of this file.
     property string hostGridSize: ""
     property point hostResizeBow: Qt.point(0, 0)
+    // Set by the host while this widget is being dragged; the cards lift.
+    property bool hostDragging: false
 
     // The host's span-change cross-fade exists to hide a destroy. This tree
     // has no destroy: the shared elements re-derive their rects from the
@@ -92,6 +94,7 @@ Item {
         backgroundOpacity: root.backgroundOpacity
         tensionX: root.hostResizeBow.x
         tensionY: root.hostResizeBow.y
+        dragging: root.hostDragging
     }
 
     // ---- unshared content, entering and exiting per span -----------------

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-system-monitor/Widget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-system-monitor/Widget.qml
@@ -6,6 +6,8 @@ import "ThirdCard.js" as ThirdCard
 
 Item {
     property point hostResizeBow: Qt.point(0, 0)
+    // Set by the host while this widget is being dragged; the cards lift.
+    property bool hostDragging: false
     readonly property var blurRegions: content.blurRegions
     readonly property bool managesBlurTint: content.managesBlurTint
     implicitWidth: content.implicitWidth
@@ -15,6 +17,7 @@ Item {
     Expressive.DesktopSystemMonitorWidget {
         id: content
         resizeBow: root.hostResizeBow
+        dragging: root.hostDragging
         width: implicitWidth
         height: implicitHeight
         isVertical: PluginState.option("nandoroid_system_monitor", "vertical", false)

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-weather/Widget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-weather/Widget.qml
@@ -16,6 +16,8 @@ Item {
     // that deliberately never disappear.
     readonly property bool handlesSpanTransition: true
     property point hostResizeBow: Qt.point(0, 0)
+    // Set by the host while this widget is being dragged; the cards lift.
+    property bool hostDragging: false
 
     // Implicit size from the SPAN, and the content fills whatever the host
     // gives - the host's box is what animates a resize. The old wrapper set
@@ -31,6 +33,7 @@ Item {
         anchors.fill: parent
         sizeMode: root.hostGridSize || "3x1"
         resizeBow: root.hostResizeBow
+        dragging: root.hostDragging
         useBlurBackground: PluginState.option("nandoroid_weather", "blurEnabled", false)
         backgroundOpacity: PluginState.effectiveBackgroundOpacity("nandoroid_weather")
     }

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopCurrencyWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopCurrencyWidget.qml
@@ -18,6 +18,8 @@ Item {
     property string sizeMode: cfg ? cfg.sizeMode : "2x1"
     property bool useBlurBackground: false
     property point resizeBow: Qt.point(0, 0)
+    // Handled state, for the cards' elevation.
+    property bool dragging: false
     // The host wrapper overrides this with its own plugin id; the fallback keeps
     // the toggle honoured for a component instantiated without one.
 
@@ -114,6 +116,7 @@ Item {
         backgroundOpacity: root.backgroundOpacity
         tensionX: root.resizeBow.x
         tensionY: root.resizeBow.y
+        dragging: root.dragging
 
         // --- PAGE 1: View Mode ---
         Item {

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopMediaWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopMediaWidget.qml
@@ -24,6 +24,8 @@ Item {
     property bool useRomaji: Config.options.appearance.lyrics.lyricsUseRomaji
     property bool viewLyrics: false
     property bool useBlurBackground: false
+    // Handled state, for the card's elevation.
+    property bool dragging: false
     // The host wrapper overrides this with its own plugin id; the fallback keeps
     // the toggle honoured for a component instantiated without one.
 
@@ -42,6 +44,7 @@ Item {
         id: bgCard
         visible: !root.chromeless
         anchors.fill: parent
+        dragging: root.dragging
         useBlurBackground: root.useBlurBackground
         backgroundOpacity: root.backgroundOpacity
     }

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopSystemMonitorWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopSystemMonitorWidget.qml
@@ -48,6 +48,8 @@ Item {
     // card under it - thirdCard. All three bowing identically would read as
     // jelly, not as a pull.
     property point resizeBow: Qt.point(0, 0)
+    // Handled state, for the cards' elevation.
+    property bool dragging: false
     readonly property var blurRegions: [
         cpuCard.blurRegion,
         ramCard.blurRegion,
@@ -65,6 +67,7 @@ Item {
             id: cpuCard
             implicitWidth: root.cardWidth
             implicitHeight: root.cardHeight
+            dragging: root.dragging
             radius: Appearance.rounding.large
             tint: Appearance.colors.colPrimaryContainer
             useBlurBackground: root.useBlurBackground
@@ -156,6 +159,7 @@ Item {
             id: ramCard
             implicitWidth: root.cardWidth
             implicitHeight: root.cardHeight
+            dragging: root.dragging
             radius: Appearance.rounding.large
             tint: Appearance.colors.colSecondaryContainer
             useBlurBackground: root.useBlurBackground
@@ -253,6 +257,7 @@ Item {
             backgroundOpacity: root.backgroundOpacity
             tensionX: root.resizeBow.x
             tensionY: root.resizeBow.y
+            dragging: root.dragging
 
             // Sisi Atas: Liquid Cookie12Sided (Centered Top)
             Item {

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopWeatherWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopWeatherWidget.qml
@@ -32,6 +32,8 @@ Item {
     property string sizeMode: cfg ? cfg.sizeMode : "3x1"
     property bool useBlurBackground: false
     property point resizeBow: Qt.point(0, 0)
+    // Handled state, for the cards' elevation.
+    property bool dragging: false
 
     property real backgroundOpacity: PluginState.effectiveBackgroundOpacity("", 0.1)
     readonly property bool managesBlurTint: true
@@ -107,6 +109,7 @@ Item {
         clipContent: true
         tensionX: root.resizeBow.x
         tensionY: root.resizeBow.y
+        dragging: root.dragging
 
         // ---- shared: the glyph container, one shape-parameterised canvas --
         Item {

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/WidgetCard.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/WidgetCard.qml
@@ -1,4 +1,5 @@
 import QtQuick
+import QtQuick.Effects
 import Qt5Compat.GraphicalEffects
 import qs.modules.common
 import qs.modules.common.functions as Functions
@@ -75,60 +76,114 @@ Item {
     readonly property bool underTension: !root.usesShapeCanvas
         && (root.tensionX !== 0 || root.tensionY !== 0)
 
-    Rectangle {
-        id: rectSurface
-        visible: !root.usesShapeCanvas && !root.underTension
-        anchors.fill: parent
-        radius: root.radius
-        color: root.effectiveColor
-    }
+    // ---- elevation -------------------------------------------------------
+    // The card casts a shadow, and lifts further the more directly it is
+    // being handled: rest, hover, drag. The numbers are Appearance.elevation
+    // (picked on the real wallpaper in ShadowTuningPlayground); what varies
+    // here is only how far off the surface this card currently is.
+    //
+    // The shadow is taken from the BODY, not from the card as a whole - a
+    // layer over the content would have every label and glyph casting one too.
+    // It therefore follows painted alpha, which is the point: the plain
+    // rectangle, the bowed canvas and a MaterialShape polygon all cast the
+    // shape they actually draw.
+    property bool shadowEnabled: true
+    property bool dragging: false
+    // Motion drops the shadow and it returns on settle, exactly as the frost
+    // does: re-rendering a blurred copy of the body every frame of a morph is
+    // the expensive path, and the card is moving too fast to read a shadow.
+    property bool motionActive: root.underTension
+    readonly property bool shadowVisible: root.shadowEnabled && !root.motionActive
 
-    // The bulged surface, alive only while pulled. Margins give the bow room
-    // to draw outside the card's own box without being cut by the item.
-    Loader {
-        active: root.underTension
-        anchors.fill: parent
-        anchors.margins: -Tension.BOW_PX * 2
-        sourceComponent: Canvas {
-            id: tensionCanvas
-            onPaint: {
-                const ctx = getContext("2d");
-                ctx.clearRect(0, 0, width, height);
-                const pad = Tension.BOW_PX * 2;
-                const radii = Tension.cornerRadii(root.radius, root.tensionX, root.tensionY);
-                const path = Tension.outline(root.width, root.height,
-                    root.tensionX, root.tensionY, radii);
-                ctx.save();
-                ctx.translate(pad, pad);
-                ctx.fillStyle = root.effectiveColor;
-                ctx.beginPath();
-                for (const seg of path.segments) {
-                    if (seg.op === "move") ctx.moveTo(seg.x, seg.y);
-                    else if (seg.op === "line") ctx.lineTo(seg.x, seg.y);
-                    else ctx.quadraticCurveTo(seg.cx, seg.cy, seg.x, seg.y);
-                }
-                ctx.closePath();
-                ctx.fill();
-                ctx.restore();
-            }
-            // A Canvas repaints on resize and nothing else - mirror every
-            // input onPaint reads, or the shape keeps stale values.
-            Connections {
-                target: root
-                function onTensionXChanged() { tensionCanvas.requestPaint(); }
-                function onTensionYChanged() { tensionCanvas.requestPaint(); }
-                function onEffectiveColorChanged() { tensionCanvas.requestPaint(); }
-            }
+    property real elevationLift: root.dragging ? Appearance.elevation.dragLift
+        : (cardHover.hovered ? Appearance.elevation.hoverLift : 1.0)
+    Behavior on elevationLift {
+        NumberAnimation {
+            duration: Appearance.animation.elementMoveFast.duration
+            easing.type: Easing.BezierSpline
+            easing.bezierCurve: Appearance.animationCurves.expressiveEffects
         }
     }
 
-    Loader {
-        active: root.usesShapeCanvas
+    // State only, no cursor: the cursor is a different channel and two
+    // handlers arguing over it is a bug this repo has already paid for.
+    HoverHandler { id: cardHover }
+
+    // One frame around every body renderer, so one effect shadows all three.
+    // It is inset NEGATIVELY by the bow's reach: a layer clips at its item's
+    // bounds, and the bowed canvas deliberately draws outside the card.
+    Item {
+        id: bodySurface
         anchors.fill: parent
-        sourceComponent: MaterialShape {
-            shapeString: root.shapeName
+        anchors.margins: -Tension.BOW_PX * 2
+
+        layer.enabled: root.shadowVisible
+        layer.effect: MultiEffect {
+            shadowEnabled: true
+            shadowBlur: Appearance.elevation.blur * root.elevationLift
+            shadowOpacity: Appearance.elevation.shadowOpacity
+            shadowVerticalOffset: Appearance.elevation.offsetY * root.elevationLift
+            shadowHorizontalOffset: 0
+            shadowScale: Appearance.elevation.shadowScale
+            shadowColor: Appearance.elevation.shadowColor
+        }
+
+        Rectangle {
+            id: rectSurface
+            visible: !root.usesShapeCanvas && !root.underTension
+            anchors.fill: parent
+            anchors.margins: Tension.BOW_PX * 2
+            radius: root.radius
             color: root.effectiveColor
-            stretch: true
+        }
+
+        // The bulged surface, alive only while pulled. Margins give the bow room
+        // to draw outside the card's own box without being cut by the item.
+        Loader {
+            active: root.underTension
+            anchors.fill: parent
+            sourceComponent: Canvas {
+                id: tensionCanvas
+                onPaint: {
+                    const ctx = getContext("2d");
+                    ctx.clearRect(0, 0, width, height);
+                    const pad = Tension.BOW_PX * 2;
+                    const radii = Tension.cornerRadii(root.radius, root.tensionX, root.tensionY);
+                    const path = Tension.outline(root.width, root.height,
+                        root.tensionX, root.tensionY, radii);
+                    ctx.save();
+                    ctx.translate(pad, pad);
+                    ctx.fillStyle = root.effectiveColor;
+                    ctx.beginPath();
+                    for (const seg of path.segments) {
+                        if (seg.op === "move") ctx.moveTo(seg.x, seg.y);
+                        else if (seg.op === "line") ctx.lineTo(seg.x, seg.y);
+                        else ctx.quadraticCurveTo(seg.cx, seg.cy, seg.x, seg.y);
+                    }
+                    ctx.closePath();
+                    ctx.fill();
+                    ctx.restore();
+                }
+                // A Canvas repaints on resize and nothing else - mirror every
+                // input onPaint reads, or the shape keeps stale values.
+                Connections {
+                    target: root
+                    function onTensionXChanged() { tensionCanvas.requestPaint(); }
+                    function onTensionYChanged() { tensionCanvas.requestPaint(); }
+                    function onEffectiveColorChanged() { tensionCanvas.requestPaint(); }
+                }
+            }
+        }
+
+        Loader {
+            active: root.usesShapeCanvas
+            anchors.fill: parent
+            anchors.margins: Tension.BOW_PX * 2
+            sourceComponent: MaterialShape {
+                shapeString: root.shapeName
+                color: root.effectiveColor
+                stretch: true
+            }
         }
     }
 

--- a/dots/.config/quickshell/imi/tests/run_card_shadow_probe.sh
+++ b/dots/.config/quickshell/imi/tests/run_card_shadow_probe.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Headless weston + qs, the runtime-harness pattern, trimmed to one probe.
+set -u
+SOCKET="wl-imi-card-shadow"
+TMP=$(mktemp -d)
+export XDG_RUNTIME_DIR="$TMP/runtime"; mkdir -p "$XDG_RUNTIME_DIR"; chmod 700 "$XDG_RUNTIME_DIR"
+export XDG_CONFIG_HOME="$TMP/config" XDG_CACHE_HOME="$TMP/cache" XDG_STATE_HOME="$TMP/state" XDG_DATA_HOME="$TMP/data"
+mkdir -p "$XDG_CONFIG_HOME" "$XDG_CACHE_HOME" "$XDG_STATE_HOME" "$XDG_DATA_HOME"
+weston --backend=headless-backend.so --socket="$SOCKET" --width=1280 --height=800 &>"$TMP/weston.log" &
+WPID=$!
+sleep 2
+DBUS_SESSION_BUS_ADDRESS="unix:path=/nonexistent" WAYLAND_DISPLAY="$SOCKET" CARD_SHADOW_SHOT="${CARD_SHADOW_SHOT:-}" timeout 60 qs -p "$(dirname "$0")/../WidgetCardShadowProbe.qml" 2>&1 | grep "CardShadow"
+kill $WPID 2>/dev/null
+rm -rf "$TMP"

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -263,6 +263,14 @@ if ! python3 "$SCRIPT_DIR/test_widget_resize_grip_runtime.py"; then
     exit 1
 fi
 
+# Renders real cards and reads the pixels under them: the shadow is not
+# reachable from a source-text check. Brings its own headless weston.
+echo "Running widget card shadow tests..."
+if ! python3 "$SCRIPT_DIR/test_card_shadow.py"; then
+    echo "Widget card shadow tests failed."
+    exit 1
+fi
+
 # The grip harness above reads settled sizes on purpose, so it passes whether a
 # span change is animated or instant. This one samples the size mid-change,
 # which is the only way to tell a Behavior that ticks from one that never does.

--- a/dots/.config/quickshell/imi/tests/test_card_shadow.py
+++ b/dots/.config/quickshell/imi/tests/test_card_shadow.py
@@ -9,6 +9,7 @@ shadow is dropped for the duration of the movement, as the frost is.
 """
 
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -37,6 +38,15 @@ def darkness_below(shot, card_x):
     return (1.0 - float(mean)) * 255.0
 
 
+def _runtime_available():
+    # Same gate the other runtime probes use, plus the analyser: CI has no
+    # compositor, and a test that hard-fails there is reporting the runner's
+    # shape as a defect in the shadow.
+    return all(shutil.which(tool) is not None
+               for tool in ("qs", "weston", "magick"))
+
+
+@unittest.skipUnless(_runtime_available(), "needs qs, weston and magick on PATH")
 class CardShadowTest(unittest.TestCase):
     def test_the_card_casts_lifts_and_drops_its_shadow(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/dots/.config/quickshell/imi/tests/test_card_shadow.py
+++ b/dots/.config/quickshell/imi/tests/test_card_shadow.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""The card's shadow, measured in pixels rather than in source text.
+
+A structure test can only see that the wiring is spelled correctly. This
+renders real WidgetCards on a white field under headless weston and reads the
+strip just below each one: a shadow darkens it, a handled card's shadow
+darkens it more, and a card in motion should not darken it at all - the
+shadow is dropped for the duration of the movement, as the frost is.
+"""
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+PROBE = ROOT / "tests/run_card_shadow_probe.sh"
+
+CARD_W, CARD_H, TOP = 200, 120, 60
+COLUMNS = {"rest": 60, "dragged": 340, "moving": 620}
+
+
+def darkness_below(shot, card_x):
+    """Mean darkness (0 = untouched white) of the band under a card.
+
+    ImageMagick does the averaging: piping raw grey out of it and summing by
+    hand produced values that did not match the visible image at all.
+    """
+    top = TOP + CARD_H + 4
+    geometry = f"{CARD_W - 40}x14+{card_x + 20}+{top}"
+    mean = subprocess.run(
+        ["magick", str(shot), "-crop", geometry, "+repage",
+         "-colorspace", "Gray", "-format", "%[fx:mean]", "info:"],
+        capture_output=True, text=True, timeout=60).stdout.strip()
+    return (1.0 - float(mean)) * 255.0
+
+
+class CardShadowTest(unittest.TestCase):
+    def test_the_card_casts_lifts_and_drops_its_shadow(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            shot = Path(tmp) / "cards.png"
+            env = dict(os.environ, CARD_SHADOW_SHOT=str(shot))
+            result = subprocess.run([str(PROBE)], capture_output=True, text=True,
+                                    timeout=180, env=env)
+            self.assertIn("saved", result.stdout,
+                          f"probe did not render:\n{result.stdout}\n{result.stderr}")
+            self.assertTrue(shot.exists(), "no screenshot produced")
+
+            measured = {name: darkness_below(shot, x) for name, x in COLUMNS.items()}
+            detail = " ".join(f"{k}={v:.1f}" for k, v in measured.items())
+
+            self.assertGreater(measured["rest"], 3.0,
+                               f"a resting card casts no shadow ({detail})")
+            self.assertGreater(measured["dragged"], measured["rest"] * 1.2,
+                               f"a handled card does not lift ({detail})")
+            self.assertLess(measured["moving"], 1.0,
+                            f"a card in motion still casts one ({detail})")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/dots/.config/quickshell/imi/tests/test_expressive_design_system.py
+++ b/dots/.config/quickshell/imi/tests/test_expressive_design_system.py
@@ -124,6 +124,64 @@ class ExpressiveDesignSystemTest(unittest.TestCase):
                         self.assertIsNone(re.search(live, line),
                                           f"{tree.name}: {line.strip()}")
 
+    def test_every_card_is_told_when_its_widget_is_handled(self):
+        """A card that never receives `dragging` silently never lifts.
+
+        The elevation is a property chain - host -> node -> wrapper -> entry
+        component -> card - and any link that forgets to forward it produces
+        no error, no warning, and a card that simply sits flat while every
+        other one rises. The chain is short enough to pin end to end.
+        """
+        node = (PLUGIN_ROOT.parent / "PluginNode.qml").read_text(encoding="utf-8")
+        host = (PLUGIN_ROOT.parent / "PluginWidget.qml").read_text(encoding="utf-8")
+        self.assertIn("item.hostDragging = Qt.binding", node)
+        self.assertIn("hostDragging: rootWidget.dragging", host)
+
+        for directory in SIZED_BY_THE_HOST_GRID | {"nandoroid-system-monitor"}:
+            wrapper = (PLUGIN_ROOT / directory / "Widget.qml").read_text(encoding="utf-8")
+            self.assertIn("property bool hostDragging", wrapper, directory)
+            self.assertIn("dragging: root.hostDragging", wrapper, directory)
+
+        # ...and every card in the components those wrappers instantiate.
+        for name in ("DesktopCurrencyWidget", "DesktopWeatherWidget",
+                     "DesktopMediaWidget", "DesktopSystemMonitorWidget"):
+            source = (DESIGN_SYSTEM / "widgets" / name).with_suffix(".qml") \
+                .read_text(encoding="utf-8")
+            cards = source.count("WidgetCard {")
+            forwarded = source.count("dragging: root.dragging")
+            self.assertEqual(cards, forwarded,
+                             f"{name}: {cards} cards, {forwarded} told about the drag")
+
+    def test_the_card_shadows_its_body_and_drops_it_while_moving(self):
+        """The shadow comes off the BODY, and goes away during motion.
+
+        Taken from the card as a whole it would put a shadow under every label
+        and glyph inside it. And re-rendering a blurred copy of the body every
+        frame of a morph is the expensive path - the same reason the frost is
+        dropped for the duration of the motion.
+        """
+        card = (DESIGN_SYSTEM / "widgets/WidgetCard.qml").read_text(encoding="utf-8")
+        self.assertIn("id: bodySurface", card)
+        self.assertIn("shadowEnabled: true", card)
+        self.assertIn("layer.enabled: root.shadowVisible", card)
+        self.assertIn("root.shadowEnabled && !root.motionActive", card)
+        # The layer clips at its item's bounds and the bowed canvas draws
+        # outside the card, so the frame is inset negatively by the bow.
+        body = card[card.index("id: bodySurface"):]
+        self.assertIn("anchors.margins: -Tension.BOW_PX * 2", body[:400])
+        # The content layer is a different one and must not gain a shadow.
+        content = card[card.index("id: contentItem"):]
+        self.assertNotIn("shadow", content.lower())
+
+    def test_the_elevation_numbers_are_the_ones_that_were_picked(self):
+        """Tuned on the real wallpaper in ShadowTuningPlayground; a later edit
+        that drifts them should be a deliberate re-tune, not a stray diff."""
+        appearance = (ROOT / "modules/common/Appearance.qml").read_text(encoding="utf-8")
+        for token, value in (("blur", "0.51"), ("shadowOpacity", "0.50"),
+                             ("offsetY", "4.0"), ("shadowScale", "1.00"),
+                             ("hoverLift", "1.94"), ("dragLift", "2.65")):
+            self.assertIn(f"property real {token}: {value}", appearance)
+
     def test_the_media_tree_answers_the_blur_contract_itself(self):
         """One tree, one card, one region list.
 


### PR DESCRIPTION
The morphing widgets lost their shadows when they moved onto the shared `WidgetCard` — five older bundled widgets (clock, world-clock, custom-image, user-card, pixel-clock) still carry their own `StyledDropShadow`, and the newer cards had nothing.

## The numbers

Picked on the real wallpaper in a tuning playground rather than argued about, the same way the resize-tension constants were:

```
blur 0.51  opacity 0.50  offset 4.0  scale 1.00  hover 1.94  drag 2.65
```

`hover` and `drag` are multipliers on blur and offset, not separate shadows — one animated lift factor, so a card rises further the more directly it is being handled. A test pins the values so a later drift has to be a deliberate re-tune.

## How it is built

- **The shadow comes off the BODY, not the card.** One `MultiEffect` over a frame wrapping all three body renderers, so the plain rectangle, the bowed canvas and a `MaterialShape` polygon each cast the shape they actually draw. Over the card as a whole, every label and glyph inside would have cast one too.
- **The frame is inset negatively by the bow's reach.** A layer clips at its item's bounds and the elastic-resize canvas deliberately draws up to `2*BOW_PX` outside the card.
- **Motion drops it, settle restores it** — the same rule the frost already follows. Re-rendering a blurred copy of the body every frame of a morph is the expensive path, and a card moving that fast has no readable shadow anyway.
- **`dragging` travels the existing duck-typed path** (host → node → wrapper → entry component → card), exactly as `hostResizeBow` does. `AbstractWidget` has published the flag all along; nothing was listening.

## Verification

Pixels, not source text: real cards on a white field under headless weston, reading the strip below each one — a resting card darkens it, a handled card darkens it more, a card in motion not at all. Two traps that cost real time and are now recorded: `ItemGrabResult.image` is not scriptable from QML, so the analysis lives in Python; and `grabToImage` captures the ITEM, so a field relying on its window's colour grabs a transparent PNG whose "white" reads as black — a measurement that looks like catastrophic failure when nothing is wrong, and would equally hide a real one.

The structure half pins the property chain end to end, because a card that is never told about the drag lifts silently never — no error, no warning.

- `tests/run_tests.sh`: 611 passed, 0 failed
- Deployed to the live shell; loads clean

Calendar keeps its own hand-rolled card and gains nothing here; it picks this up when it adopts `WidgetCard`. Folding the older five off `StyledDropShadow` onto the shared elevation is the follow-up you deferred.

Docs: updated AGENT.md §Dynamic/data-driven QML gotchas — the layer-clips-at-its-bounds rule and the grab-takes-the-item measurement trap, citing the commit that established them.