### PR TITLE
Media transport controls adopt the interaction model

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1306,6 +1306,18 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   reads as black to any analyser - a measurement that looks like a catastrophic failure when nothing
   is wrong, and would equally hide a real one.
   4046f1854 ("feat(widgets): the card casts a shadow, and lifts when handled").
+- **A state property that says "hovered" is not evidence a pixel moved.** The media badge's hover
+  lift shipped through `transform: Scale { origin.x: width / 2 }`, whose `width` resolved against a
+  scope that has none - the model reported `hovered`, `scale` read 1.02, and the badge measured
+  60px before and 60px after on the desktop. `Item.scale` is centred by default and cannot miss it.
+  A probe that asserts only the model's value passes this happily, so the sweep now also reads the
+  scale of the item that is DRAWN (`appliedBadgeScale`), which is the check that fails. Related: at
+  2x2 and 2x1 the seek ring sits ABOVE the play button, so after a press grab ends the pointer's
+  leave goes to the ring and a `MouseArea.containsMouse` under it never clears - the button sat
+  permanently hovered, and at 2x2 that means the play glyph never leaves the artwork again. Hover
+  STATE belongs to a `HoverHandler` there; the cursor and the clicks stay with the MouseArea, which
+  is the same channels rule as 05bf3013f, applied the other way round.
+  0b9a5df1e ("feat(media): the transport controls adopt the interaction model").
 - **A Behavior whose animation reads its tier from a binding carries the PREVIOUS transition.** The
   shared interaction model (`Appearance.interaction`, decided in `modules/common/interaction_motion.js`)
   gives every control the same five states, and each pair of states has its own duration and curve -

--- a/dots/.config/quickshell/imi/MediaTreeMotionProbe.qml
+++ b/dots/.config/quickshell/imi/MediaTreeMotionProbe.qml
@@ -189,11 +189,61 @@ ShellRoot {
             const scene = item.mapToItem(null, item.width / 2, item.height / 2);
             driver.mouseMove(canvas, scene.x, scene.y);
             harness.check(`${span} ${pair[0]} hovers under the pointer`, item.hoveredNow === true);
-            driver.mouseClick(canvas, scene.x, scene.y, Qt.LeftButton);
+            // The shared interaction model resolves the state immediately;
+            // only the progress toward it is animated.
+            harness.check(`${span} ${pair[0]} reads as hovered to the model`,
+                item.motion.interactionState === "hovered");
+            driver.mousePress(canvas, scene.x, scene.y, Qt.LeftButton);
+            harness.check(`${span} ${pair[0]} acknowledges the press`,
+                item.motion.interactionState === "pressed");
+            driver.mouseRelease(canvas, scene.x, scene.y, Qt.LeftButton);
             item.activated.disconnect(bump);
             harness.check(`${span} ${pair[0]} click reaches the button`, hits === 1);
+            harness.check(`${span} ${pair[0]} returns to hovered after release`,
+                item.motion.interactionState === "hovered");
         }
+        // The wash the body paints is driven by hoverProgress, and a state
+        // flag that flips while the progress stays at 0 would paint nothing.
+        // Canvas pixels are not readable from QML, so the value the painter
+        // consumes is what gets checked.
+        {
+            const scene = play.mapToItem(null, play.width / 2, play.height / 2);
+            driver.mouseMove(canvas, scene.x, scene.y);
+            driver.wait(320);
+            harness.check(`${span} play's wash progress rises on hover`,
+                play.motion.hoverProgress > 0.5, `(${play.motion.hoverProgress.toFixed(2)})`);
+
+            // The badge lifts instead - the play button deliberately does not
+            // scale, or it would pull away from the ring drawn around it.
+            const prevScene = prev.mapToItem(null, prev.width / 2, prev.height / 2);
+            driver.mouseMove(canvas, prevScene.x, prevScene.y);
+            driver.wait(320);
+            harness.check(`${span} prev's badge lifts on hover`,
+                prev.motion.scale > 1.005, `(scale ${prev.motion.scale.toFixed(3)})`);
+            // ...and the lift reaches the item that is drawn, not just the
+            // model: a transform that silently does nothing passes the check
+            // above and moves no pixel.
+            harness.check(`${span} the lift reaches the drawn badge`,
+                prev.appliedBadgeScale > 1.005,
+                `(applied ${prev.appliedBadgeScale.toFixed(3)})`);
+            harness.check(`${span} the play button does not scale`,
+                Math.abs(play.motion.scale - 1) < 0.001
+                || play.motion.interactionState === "rest",
+                `(scale ${play.motion.scale.toFixed(3)})`);
+        }
+
         driver.mouseMove(canvas, 5, 5);
+        // Pointer gone: a release that happened off the control still has to
+        // leave it resting, never stuck at its pressed size.
+        for (const pair of [["play", play], ["prev", prev], ["next", next]]) {
+            if (pair[1].motion.interactionState !== "rest")
+                console.log(`[MediaTreeMotion] DIAG ${span} ${pair[0]} state=${pair[1].motion.interactionState}`
+                    + ` hoveredNow=${pair[1].hoveredNow} covered=${pair[1].coveredHover}`
+                    + ` seekerHoverPlay=${seeker ? seeker.hoveringPlay : "n/a"}`
+                    + ` seekerContains=${seeker ? seeker.seekAreaContainsMouse : "n/a"}`);
+            harness.check(`${span} ${pair[0]} rests once the pointer leaves`,
+                pair[1].motion.interactionState === "rest");
+        }
         // a click on the seeker's own stroke seeks and does not activate play
         if (seeker && seeker.visible) {
             let sought = 0, played = 0;

--- a/dots/.config/quickshell/imi/modules/common/interaction_motion.js
+++ b/dots/.config/quickshell/imi/modules/common/interaction_motion.js
@@ -30,20 +30,24 @@ function stateOf(flags) {
 // Hover LIFTS (scale up, tint), press SETTLES (scale down, corners tighten).
 // `press` is that same settle as a plain 0..1, for adopters whose geometry is
 // not a multiple of anything - a control lerps its own pressed values with it
-// rather than working backwards from `radiusScale`.
+// rather than working backwards from `radiusScale`. `hover` is the same for
+// the lift, and a pressed control is still hovered by it: a wash that fades
+// out as the press lands would read as the control letting go.
 // Disabled is opacity only - it must not move, because motion reads as
 // affordance and there is none.
 function targetsFor(state, tokens) {
     switch (state) {
     case PRESSED:
         return { scale: tokens.pressScale, radiusScale: tokens.pressRadiusScale,
-                 press: 1, opacity: 1 };
+                 hover: 1, press: 1, opacity: 1 };
     case HOVERED:
-        return { scale: tokens.hoverScale, radiusScale: 1, press: 0, opacity: 1 };
+        return { scale: tokens.hoverScale, radiusScale: 1,
+                 hover: 1, press: 0, opacity: 1 };
     case DISABLED:
-        return { scale: 1, radiusScale: 1, press: 0, opacity: tokens.disabledOpacity };
+        return { scale: 1, radiusScale: 1, hover: 0, press: 0,
+                 opacity: tokens.disabledOpacity };
     default:
-        return { scale: 1, radiusScale: 1, press: 0, opacity: 1 };
+        return { scale: 1, radiusScale: 1, hover: 0, press: 0, opacity: 1 };
     }
 }
 

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/MediaSeeker.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/MediaSeeker.qml
@@ -201,6 +201,10 @@ Item {
     // button too: pointer cursor over the button's face, and hover reported
     // back through hoveringPlay.
     property var playItem: null
+    // Exposed for the probe's failure diagnostics: when a button reports
+    // itself hovered with the pointer elsewhere, the next question is always
+    // whether this area is the one holding it.
+    readonly property bool seekAreaContainsMouse: seekArea.containsMouse
     readonly property bool hoveringPlay: seekArea.containsMouse && root.playItem
         && root.playItem.visible && (function () {
             const point = seekArea.mapToItem(root.playItem, seekArea.mouseX, seekArea.mouseY);

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/MediaTransportButton.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/MediaTransportButton.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import Qt5Compat.GraphicalEffects
 import qs.modules.common
+import qs.modules.common.widgets
 import qs.modules.common.functions as Functions
 import qs.services
 import "../../designsystem/widgets" as Expressive
@@ -61,6 +62,18 @@ Item {
 
     readonly property bool isPlay: root.role === "play"
 
+    // The shared interaction states (step 9). The control keeps its own
+    // painting; the model decides only how far into hover and press it is,
+    // and on which tier it travels - so these buttons and every RippleButton
+    // in the shell acknowledge a press on the same clock.
+    // Hover has to be forwarded from the seeker (hover does not propagate);
+    // the press does not, because the seeker rejects anything off its stroke
+    // and an unaccepted press falls through to this button's own area.
+    readonly property InteractionMotion motion: InteractionMotion {
+        hovered: root.hoveredNow
+        down: hitArea.pressed
+    }
+
     // The colour pair the 2x1 pills and 2x2 badges share (LayoutCompact and
     // LayoutCookie declared them identically, which is why they read as one
     // widget's controls).
@@ -91,10 +104,29 @@ Item {
     // different object. The spin eases back to rest through the same
     // Behavior that always owned it, so the reel stops turning as it stops
     // being a reel.
+    // What the badge is ACTUALLY drawn at. The model saying "hovered" is not
+    // evidence the lift reached a pixel: the first version applied it through
+    // a `Scale` whose `origin.x: width / 2` resolved against a scope with no
+    // width, and every state property read correctly while the badge never
+    // moved. A probe can watch this one.
+    readonly property real appliedBadgeScale: badgeLoader.item ? badgeLoader.item.scale : 1
     Loader {
+        id: badgeLoader
         active: !root.isPlay
         anchors.fill: parent
         sourceComponent: Item {
+            // The badge lifts on hover and settles on press. The PLAY button
+            // deliberately does not: the seek ring is a perfect circle inside
+            // it at 2x2 and its own outline at 2x1, and scaling one and not
+            // the other pulls apart an alignment the review asked for
+            // explicitly. Its feedback is the wash on its own outline, which
+            // is what the ring is drawn around anyway.
+            // Item.scale, not a Scale transform: `origin.x: width / 2` inside
+            // the transform resolved against a scope with no width and the
+            // lift never reached a pixel, while every state property said it
+            // had. `scale` is centred by default and cannot miss.
+            scale: root.motion.scale
+
             Expressive.MaterialShape {
                 id: reelShape
                 anchors.fill: parent
@@ -171,6 +203,15 @@ Item {
                 // the rule is structural: this canvas never yields. At 2x1 it
                 // waves in the seeker's phase instead.
 
+                // Hover and press ride the BODY's own outline instead of a
+                // rectangle laid over it: the flat wash was square-cornered
+                // against a capsule at 3x2 and could not follow the cookie at
+                // all. One painter owns this face, so it paints the state too.
+                readonly property real washAlpha: 0.08 * root.motion.hoverProgress
+                    + 0.07 * root.motion.pressProgress
+                onWashAlphaChanged: requestPaint()
+                readonly property color washColor: Appearance.colors.colOnPrimary
+
                 property real morphT: root.span === "3x2" ? 0 : 1
                 Behavior on morphT { NumberAnimation { duration: Appearance.animation.elementMove.duration; easing.type: Easing.BezierSpline; easing.bezierCurve: Appearance.animationCurves.expressiveDefaultSpatial } }
                 readonly property color bodyColor: Appearance.colors.colPrimary
@@ -202,6 +243,15 @@ Item {
                     repeat: true
                     running: body.visible && (body.visualizing || body.settlingLevels)
                     onTriggered: body.stepLevels()
+                }
+
+                // Fills the path that is already current - the wash is the
+                // body's shape by construction, never an approximation of it.
+                function washOver(ctx) {
+                    if (body.washAlpha <= 0.001) return;
+                    ctx.fillStyle = Functions.ColorUtils.applyAlpha(
+                        body.washColor, body.washAlpha);
+                    ctx.fill();
                 }
 
                 onMorphTChanged: requestPaint()
@@ -259,6 +309,7 @@ Item {
                         ctx.closePath();
                         ctx.fillStyle = body.bodyColor;
                         ctx.fill();
+                        body.washOver(ctx);
                         return;
                     }
                     // Breathing takes over only once a lobe actually moves:
@@ -297,6 +348,7 @@ Item {
                     ctx.closePath();
                     ctx.fillStyle = body.bodyColor;
                     ctx.fill();
+                    body.washOver(ctx);
                     ctx.restore();
                 }
             }
@@ -377,16 +429,6 @@ Item {
                 Behavior on color { ColorAnimation { duration: 100 } }
             }
 
-            // The 3x2 pill's hover/press wash, riding the body's own shape is
-            // step 8's interaction-model work; the flat wash keeps parity.
-            Rectangle {
-                anchors.fill: parent
-                radius: playRoot.side / 2
-                color: Appearance.colors.colOnPrimary
-                visible: root.span === "3x2"
-                opacity: hitArea.pressed ? 0.15 : (root.hoveredNow ? 0.08 : 0)
-                Behavior on opacity { NumberAnimation { duration: 150 } }
-            }
         }
     }
 
@@ -397,7 +439,17 @@ Item {
     // interactive thing is topmost, so the bar's battle-tested pattern -
     // hoverEnabled + cursorShape on the input area itself - is sufficient
     // and unambiguous.
-    readonly property bool hoveredNow: hitArea.containsMouse || root.coveredHover
+    // Hover STATE comes from a HoverHandler; the cursor and the clicks stay
+    // with the MouseArea below. Those are different channels (the two-handlers
+    // lesson was about both of them answering for the CURSOR), and this one
+    // has to be the handler: at 2x2 and 2x1 the seek ring sits ABOVE this
+    // button, so once a press grab ends, the pointer's leave is delivered to
+    // the ring and a MouseArea's containsMouse here stays true forever - the
+    // button sat permanently hovered, which at 2x2 means the play glyph never
+    // leaves the artwork again. A HoverHandler tracks the scene position and
+    // clears.
+    readonly property bool hoveredNow: hoverTracker.hovered || root.coveredHover
+    HoverHandler { id: hoverTracker }
     MouseArea {
         id: hitArea
         anchors.fill: parent

--- a/dots/.config/quickshell/imi/modules/common/widgets/InteractionMotion.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/InteractionMotion.qml
@@ -39,7 +39,9 @@ QtObject {
     // stays its own business.
     property real scale: 1
     property real radiusScale: 1
-    // The settle as a plain 0..1, for geometry that is not a multiple.
+    // The lift and the settle as plain 0..1, for feedback that is not a
+    // multiple of anything - a tint wash, a stroke weight, a glyph's alpha.
+    property real hoverProgress: 0
     property real pressProgress: 0
     property real dimOpacity: 1
 
@@ -50,6 +52,8 @@ QtObject {
         scaleAnim.easing.bezierCurve = transition.curve;
         radiusAnim.duration = transition.duration;
         radiusAnim.easing.bezierCurve = transition.curve;
+        hoverAnim.duration = transition.duration;
+        hoverAnim.easing.bezierCurve = transition.curve;
         pressAnim.duration = transition.duration;
         pressAnim.easing.bezierCurve = transition.curve;
         opacityAnim.duration = transition.duration;
@@ -61,6 +65,7 @@ QtObject {
         const targets = Appearance.interaction.targets(root.interactionState);
         root.scale = targets.scale;
         root.radiusScale = targets.radiusScale;
+        root.hoverProgress = targets.hover;
         root.pressProgress = targets.press;
         root.dimOpacity = targets.opacity;
     }
@@ -70,6 +75,9 @@ QtObject {
     }
     Behavior on radiusScale {
         NumberAnimation { id: radiusAnim; easing.type: Easing.BezierSpline }
+    }
+    Behavior on hoverProgress {
+        NumberAnimation { id: hoverAnim; easing.type: Easing.BezierSpline }
     }
     Behavior on pressProgress {
         NumberAnimation { id: pressAnim; easing.type: Easing.BezierSpline }

--- a/dots/.config/quickshell/imi/tests/tst_interaction_motion.qml
+++ b/dots/.config/quickshell/imi/tests/tst_interaction_motion.qml
@@ -37,6 +37,15 @@ TestCase {
         compare(hover.radiusScale, 1, "hover does not reshape");
     }
 
+    function test_a_pressed_control_is_still_hovered_by_the_model() {
+        // A wash driven by `hover` must not fade out the instant the press
+        // lands - that reads as the control letting go under the finger.
+        compare(Motion.targetsFor("pressed", tokens).hover, 1);
+        compare(Motion.targetsFor("hovered", tokens).hover, 1);
+        compare(Motion.targetsFor("rest", tokens).hover, 0);
+        compare(Motion.targetsFor("disabled", tokens).hover, 0);
+    }
+
     function test_disabled_is_opacity_only() {
         const disabled = Motion.targetsFor("disabled", tokens);
         compare(disabled.scale, 1);


### PR DESCRIPTION
Step 9 of the expressive morphing landing plan — the last step before the extraction pass.

## What changed

The media controls are custom canvas, not `Button`s, so this is where the model has to work on something that is not a widget from the toolkit. It adopts the **model**, not a component: the buttons keep their own painting, and the model decides only how far into hover and press they are, and on which tier they travel — so these and every `RippleButton` in the shell acknowledge a press on the same clock.

- **The wash rides the body's own outline**, painted by the same canvas that draws the shape. The flat `Rectangle` it replaces was square-cornered against a capsule at 3x2 and could not follow the cookie at all. One painter owns that face, so it paints the state too — the file had a comment marking this exact spot as the interaction model's job.
- **The badge lifts on hover, settles on press.** The **play button deliberately does not scale**: the seek ring is a perfect circle inside it at 2x2 and its own outline at 2x1, and scaling one and not the other pulls apart an alignment the review asked for explicitly. Its feedback is the wash on the outline the ring is drawn around anyway.
- The model gained a `hoverProgress` for feedback that is not a multiple of anything. A pressed control still reports hovered — a wash fading out as the press lands reads as the control letting go under the finger.

## Two bugs found while building it, both invisible to the checks that existed

**The hover never cleared.** At 2x2 and 2x1 the seek ring sits *above* the play button. Once a press grab ends, the pointer's leave is delivered to the ring, so the button's `MouseArea.containsMouse` stayed true forever — the button sat permanently hovered, which at 2x2 means the play glyph never leaves the artwork again. Hover state now comes from a `HoverHandler`; the cursor and the clicks stay with the MouseArea. Different channels, same rule as the earlier cursor lesson applied the other way round. The probe found this: only 2x2 and 2x1 failed, which is exactly where something covers the button.

**The lift moved no pixels.** It first shipped as `transform: Scale { origin.x: width / 2 }`, whose `width` resolved against a scope that has none. Every state property read correctly — the model said `hovered`, `scale` said 1.02 — and the badge measured 60px before and 60px after on the real desktop. `Item.scale` is centred by default and cannot miss. The probe was passing throughout, because it asserted the model's value; it now also reads the scale of the item that is actually drawn, which is the assertion that fails.

## Verification

- `tests/run_media_probe.sh`: 0 failures, including new per-span cells for state, hover progress, the drawn badge's scale, and that the play button does *not* scale
- `tests/run_tests.sh`: 612 passed, 0 failed
- On the live desktop, with the pointer driven onto the controls: the wash measures 0.769 → 0.722 mean at the capsule's left end (sampled away from the cursor graphic, which contaminated the first measurement), and the badge measures 60px → 62px

Docs: updated AGENT.md §Dynamic/data-driven QML gotchas — the state-property-is-not-a-pixel rule and the hover-under-an-overlapping-item trap, citing the commit that fixed them.