### PR TITLE
Dock position: one derivation, and the top edge works

### DIFF
--- a/dots/.config/hypr/hyprland/rules.lua
+++ b/dots/.config/hypr/hyprland/rules.lua
@@ -144,7 +144,11 @@ hl.layer_rule({ match = { namespace = "quickshell:.*" }, ignore_alpha = 0.05})
 hl.layer_rule({ match = { namespace = "quickshell:bar" }, animation = "slide"})
 hl.layer_rule({ match = { namespace = "quickshell:actionCenter" }, no_anim = true})
 hl.layer_rule({ match = { namespace = "quickshell:cheatsheet" }, animation = "slide bottom"})
-hl.layer_rule({ match = { namespace = "quickshell:dock" }, animation = "slide bottom"})
+-- Bare `slide`, like the bar above: the compositor slides toward whichever
+-- edge the surface is anchored to, so the dock's exit and entry follow its
+-- configured edge. Naming the edge here pinned it to the bottom, and a top
+-- dock then slid downward, into the screen, to leave.
+hl.layer_rule({ match = { namespace = "quickshell:dock" }, animation = "slide"})
 hl.layer_rule({ match = { namespace = "quickshell:screenCorners" }, animation = "popin 120%"})
 hl.layer_rule({ match = { namespace = "quickshell:lockWindowPusher" }, no_anim = true})
 hl.layer_rule({ match = { namespace = "quickshell:notificationPopup" }, animation = "fade"})

--- a/dots/.config/quickshell/imi/defaults/config.json
+++ b/dots/.config/quickshell/imi/defaults/config.json
@@ -486,6 +486,7 @@
   "dock": {
     "enable": true,
     "height": 60,
+        "edge": "bottom",
     "hoverRegionHeight": 2,
     "hoverToReveal": true,
     "ignoredAppRegexes": [],

--- a/dots/.config/quickshell/imi/modules/common/Config.qml
+++ b/dots/.config/quickshell/imi/modules/common/Config.qml
@@ -1128,6 +1128,16 @@ Singleton {
                 property bool showMedia: true
                 property bool monochromeIcons: true
                 property real height: 60
+                // Which screen edge the dock lives on. A string rather than
+                // the bar's `bottom` + `vertical` pair: presets are never
+                // rewritten, so a new key needs no migration where renaming
+                // an existing one would lose every stored value.
+                //
+                // `height` and `hoverRegionHeight` keep their names at every
+                // edge - they are the dock's THICKNESS, and renaming them
+                // would mean migrating the presets this key was designed to
+                // avoid touching.
+                property string edge: "bottom"
                 property real hoverRegionHeight: 2
                 property bool pinnedOnStartup: false
                 property bool hoverToReveal: true // When false, only reveals on empty workspace

--- a/dots/.config/quickshell/imi/modules/common/widgets/DockAppButton.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/DockAppButton.qml
@@ -140,9 +140,15 @@ DockButton {
 
                 RowLayout {
                     spacing: Appearance.spacing.space50
+                    // The running dots sit between the icon and the screen
+                    // edge, so they swap sides with the dock: below the icon
+                    // at the bottom edge, above it at the top.
+                    readonly property bool dockAtTop: (Config.options?.dock.edge ?? "bottom") === "top"
                     anchors {
-                        top: iconImageLoader.bottom
-                        topMargin: Appearance.spacing.space25
+                        top: dockAtTop ? undefined : iconImageLoader.bottom
+                        bottom: dockAtTop ? iconImageLoader.top : undefined
+                        topMargin: dockAtTop ? 0 : Appearance.spacing.space25
+                        bottomMargin: dockAtTop ? Appearance.spacing.space25 : 0
                         horizontalCenter: parent.horizontalCenter
                     }
                     Repeater {

--- a/dots/.config/quickshell/imi/modules/common/widgets/DockContextMenu.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/DockContextMenu.qml
@@ -65,10 +65,13 @@ Item {
             id: contextPopup
             visible: true
 
+            // Away from the edge the dock is on: a menu that opens upward
+            // from a top dock is drawn off the screen.
+            readonly property bool dockAtTop: (Config.options?.dock.edge ?? "bottom") === "top"
             anchor {
                 item: root.targetButton
-                gravity: Edges.Top
-                edges: Edges.Top
+                gravity: contextPopup.dockAtTop ? Edges.Bottom : Edges.Top
+                edges: contextPopup.dockAtTop ? Edges.Bottom : Edges.Top
                 adjustment: PopupAdjustment.SlideX
             }
 
@@ -91,9 +94,11 @@ Item {
                 property real contentPadding: Appearance.spacing.space50
 
                 anchors {
-                    bottom: parent.bottom
+                    top: contextPopup.dockAtTop ? parent.top : undefined
+                    bottom: contextPopup.dockAtTop ? undefined : parent.bottom
                     horizontalCenter: parent.horizontalCenter
-                    bottomMargin: Appearance.sizes.elevationMargin
+                    topMargin: contextPopup.dockAtTop ? Appearance.sizes.elevationMargin : 0
+                    bottomMargin: contextPopup.dockAtTop ? 0 : Appearance.sizes.elevationMargin
                 }
                 color: Appearance.m3colors.m3surfaceContainer
                 radius: Appearance.rounding.normal

--- a/dots/.config/quickshell/imi/modules/common/widgets/DragApps.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/DragApps.qml
@@ -233,9 +233,15 @@ Item {
 
                         RowLayout {
                             spacing: Appearance.spacing.space50
+                            // The running dots sit between the icon and the
+                            // screen edge, so they swap sides with the dock.
+                            readonly property bool dockAtTop:
+                                (Config.options?.dock.edge ?? "bottom") === "top"
                             anchors {
-                                top: appIcon.bottom
-                                topMargin: Appearance.spacing.space25
+                                top: dockAtTop ? undefined : appIcon.bottom
+                                bottom: dockAtTop ? appIcon.top : undefined
+                                topMargin: dockAtTop ? 0 : Appearance.spacing.space25
+                                bottomMargin: dockAtTop ? Appearance.spacing.space25 : 0
                                 horizontalCenter: parent.horizontalCenter
                             }
                             Repeater {

--- a/dots/.config/quickshell/imi/modules/imi/dock/Dock.qml
+++ b/dots/.config/quickshell/imi/modules/imi/dock/Dock.qml
@@ -11,10 +11,16 @@ import Quickshell.Io
 import Quickshell
 import Quickshell.Widgets
 import Quickshell.Wayland
+import "dock_geometry.js" as DockGeometry
 
 Scope {
     id: root
     property bool pinned: Config.options?.dock.pinnedOnStartup ?? false
+
+    // Which edge the dock lives on. Hardcoded for now: this step moves the
+    // geometry into one derivation without changing where anything sits, so
+    // that a later step can change this one value and have the rest follow.
+    readonly property string edge: "bottom"
 
     Variants {
         model: Quickshell.screens
@@ -40,19 +46,32 @@ Scope {
                     || (!ToplevelManager.activeToplevel?.activated)
             }
 
+            // Everything positional comes from one derivation
+            // (dock_geometry.js), so the four places that used to spell the
+            // margin pair out by hand cannot drift apart.
+            readonly property real dockThickness: DockGeometry.thickness(
+                Config.options?.dock.height ?? 60,
+                Appearance.sizes.elevationMargin, Appearance.sizes.hyprlandGapsOut)
+            readonly property var dockMargins: DockGeometry.margins(
+                root.edge, Appearance.sizes.elevationMargin, Appearance.sizes.hyprlandGapsOut)
+
             exclusiveZone: (root.pinned && !fullscreenOnThisMonitor)
-                ? implicitHeight - Appearance.sizes.hyprlandGapsOut
-                  - (Appearance.sizes.elevationMargin - Appearance.sizes.hyprlandGapsOut)
+                ? DockGeometry.exclusiveZone(
+                    Config.options?.dock.height ?? 60,
+                    Appearance.sizes.elevationMargin, Appearance.sizes.hyprlandGapsOut)
                 : 0
 
-            anchors { bottom: true; left: true; right: true }
+            anchors {
+                top: DockGeometry.anchors(root.edge).top
+                bottom: DockGeometry.anchors(root.edge).bottom
+                left: DockGeometry.anchors(root.edge).left
+                right: DockGeometry.anchors(root.edge).right
+            }
             implicitWidth: dockBackground.implicitWidth
             WlrLayershell.namespace: "quickshell:dock"
             color: "transparent"
 
-            implicitHeight: (Config.options?.dock.height ?? 70)
-                + Appearance.sizes.elevationMargin
-                + Appearance.sizes.hyprlandGapsOut
+            implicitHeight: dockRoot.dockThickness
 
             mask: Region { item: dockMouseArea }
 
@@ -76,13 +95,18 @@ Scope {
             MouseArea {
                 id: dockMouseArea
                 height: parent.height
+                // The reveal is one number: revealed, a sliver, or one past
+                // gone. Which margin it lands on is the edge's business.
+                readonly property var revealOffsets: DockGeometry.revealOffsets(
+                    dockRoot.implicitHeight, Config.options?.dock.hoverRegionHeight ?? 2)
+                readonly property real revealOffset: dockRoot.reveal
+                    ? revealOffsets.revealed
+                    : (Config.options?.dock.hoverToReveal
+                        ? revealOffsets.peeking : revealOffsets.hidden)
+
                 anchors {
                     top: parent.top
-                    topMargin: dockRoot.reveal
-                        ? 0
-                        : Config.options?.dock.hoverToReveal
-                            ? (dockRoot.implicitHeight - Config.options.dock.hoverRegionHeight)
-                            : (dockRoot.implicitHeight + 1)
+                    topMargin: dockMouseArea.revealOffset
                     horizontalCenter: parent.horizontalCenter
                 }
                 implicitWidth: dockHoverRegion.implicitWidth + Appearance.sizes.elevationMargin * 2
@@ -118,8 +142,8 @@ Scope {
                             id: dockVisualBackground
                             property real margin: Appearance.sizes.elevationMargin
                             anchors.fill: parent
-                            anchors.topMargin:    Appearance.sizes.elevationMargin
-                            anchors.bottomMargin: Appearance.sizes.hyprlandGapsOut
+                            anchors.topMargin:    dockRoot.dockMargins.top
+                            anchors.bottomMargin: dockRoot.dockMargins.bottom
                             color: Config.options.dock.showBackground
                                    ? Appearance.colors.colLayer0 : "transparent"
                             border.width: Config.options.dock.showBackground ? 1 : 0

--- a/dots/.config/quickshell/imi/modules/imi/dock/Dock.qml
+++ b/dots/.config/quickshell/imi/modules/imi/dock/Dock.qml
@@ -17,10 +17,10 @@ Scope {
     id: root
     property bool pinned: Config.options?.dock.pinnedOnStartup ?? false
 
-    // Which edge the dock lives on. Hardcoded for now: this step moves the
-    // geometry into one derivation without changing where anything sits, so
-    // that a later step can change this one value and have the rest follow.
-    readonly property string edge: "bottom"
+    // Which edge the dock lives on. Everything positional derives from this
+    // one value; nothing below names a side directly.
+    readonly property string edge: DockGeometry.normalizedEdge(
+        Config.options?.dock.edge ?? "bottom")
 
     Variants {
         model: Quickshell.screens
@@ -104,15 +104,23 @@ Scope {
                     : (Config.options?.dock.hoverToReveal
                         ? revealOffsets.peeking : revealOffsets.hidden)
 
+                // The offset lands on the side the dock lives on: a top dock
+                // that pushed its topMargin would slide further onto the
+                // screen to hide.
                 anchors {
-                    top: parent.top
-                    topMargin: dockMouseArea.revealOffset
+                    top: root.edge === "bottom" ? parent.top : undefined
+                    bottom: root.edge === "top" ? parent.bottom : undefined
+                    topMargin: root.edge === "bottom" ? dockMouseArea.revealOffset : 0
+                    bottomMargin: root.edge === "top" ? dockMouseArea.revealOffset : 0
                     horizontalCenter: parent.horizontalCenter
                 }
                 implicitWidth: dockHoverRegion.implicitWidth + Appearance.sizes.elevationMargin * 2
                 hoverEnabled: true
 
                 Behavior on anchors.topMargin {
+                    animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
+                }
+                Behavior on anchors.bottomMargin {
                     animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
                 }
 

--- a/dots/.config/quickshell/imi/modules/imi/dock/dock_geometry.js
+++ b/dots/.config/quickshell/imi/modules/imi/dock/dock_geometry.js
@@ -1,0 +1,106 @@
+.pragma library
+
+// Where the dock sits, for each edge it can be put on.
+//
+// The dock spelled all of this out four times - in Dock.qml's anchors and
+// exclusive zone, and again as hand-written topMargin/bottomMargin pairs in
+// DockSeparator, DockButton and DockAppButton. Four coordinated edits that
+// have to agree is how a mirror drifts; this is the one derivation they read.
+//
+// Two ideas carry the whole thing:
+//
+//   INWARD is toward the screen's middle, OUTWARD is toward the edge the dock
+//   is on. The dock's margins are asymmetric - an elevation margin inward for
+//   the drop shadow, the compositor's gap outward - and naming them by
+//   direction rather than by "top" and "bottom" is what makes the flip a
+//   state change instead of a rewrite.
+//
+//   THICKNESS is the dock's size across its own axis: a height at the top and
+//   bottom edges, a width at the left and right ones. The arithmetic does not
+//   change with the axis, only what it is applied to.
+
+var EDGES = ["top", "bottom", "left", "right"];
+
+function isVertical(edge) {
+    return edge === "left" || edge === "right";
+}
+
+function normalizedEdge(edge) {
+    return EDGES.indexOf(edge) === -1 ? "bottom" : edge;
+}
+
+// Which sides the layer surface anchors to: both ends of the long axis, plus
+// the edge it lives on.
+function anchors(edge) {
+    var e = normalizedEdge(edge);
+    if (isVertical(e))
+        return { top: true, bottom: true, left: e === "left", right: e === "right" };
+    return { left: true, right: true, top: e === "top", bottom: e === "bottom" };
+}
+
+// The dock's own size across its axis, including both margins. `dockHeight`
+// keeps its name at every edge: it is the thickness, and renaming it would
+// mean migrating every preset that has ever stored it.
+function thickness(dockHeight, elevationMargin, gapsOut) {
+    return dockHeight + elevationMargin + gapsOut;
+}
+
+// What the compositor reserves. Unchanged arithmetic, and deliberately
+// expressed against the measured baseline: at defaults (height 60, elevation
+// 10, gaps 5) the compositor reports reserved [0, 45, 0, 65] and a 5120x75
+// dock, so a regression here is a number rather than an impression that
+// something moved.
+function exclusiveZone(dockHeight, elevationMargin, gapsOut) {
+    return thickness(dockHeight, elevationMargin, gapsOut)
+        - gapsOut - (elevationMargin - gapsOut);
+}
+
+// The margin pair, by direction rather than by side name.
+function insets(elevationMargin, gapsOut) {
+    return { inward: elevationMargin, outward: gapsOut };
+}
+
+// The same pair mapped onto the anchor names an Item actually uses, so a
+// caller writes `anchors.topMargin: Geometry.margins(edge, ...).top` and the
+// flip costs nothing.
+function margins(edge, elevationMargin, gapsOut) {
+    var e = normalizedEdge(edge);
+    var pair = insets(elevationMargin, gapsOut);
+    if (e === "bottom") return { top: pair.inward, bottom: pair.outward, left: 0, right: 0 };
+    if (e === "top") return { top: pair.outward, bottom: pair.inward, left: 0, right: 0 };
+    if (e === "left") return { left: pair.outward, right: pair.inward, top: 0, bottom: 0 };
+    return { left: pair.inward, right: pair.outward, top: 0, bottom: 0 };
+}
+
+// How far the dock is pushed off-screen when hidden, and how far it peeks
+// when the pointer is near. Both are the INWARD margin's value, so the reveal
+// is one animated number at every edge.
+//
+// `revealed` is the resting position, `peeking` leaves a sliver the pointer
+// can hit, `hidden` is one pixel past gone - a dock that stops exactly at the
+// edge leaves a seam of itself lit.
+function revealOffsets(dockThickness, hoverRegion) {
+    return {
+        revealed: 0,
+        peeking: dockThickness - hoverRegion,
+        hidden: dockThickness + 1
+    };
+}
+
+// Which way a popup opens from a dock on this edge: away from the edge, or
+// the menu opens into it and is clipped.
+function popupGravity(edge) {
+    var e = normalizedEdge(edge);
+    if (e === "bottom") return "top";
+    if (e === "top") return "bottom";
+    if (e === "left") return "right";
+    return "left";
+}
+
+// The sign the reveal travels in: a bottom dock hides DOWNWARD (positive y),
+// a top dock upward. Callers animate one number and multiply.
+function hideDirection(edge) {
+    var e = normalizedEdge(edge);
+    if (e === "bottom" || e === "right") return 1;
+    return -1;
+}

--- a/dots/.config/quickshell/imi/modules/imi/settings/pages/BarConfig.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/pages/BarConfig.qml
@@ -667,6 +667,20 @@ ContentPage {
                     checked: Config.options.dock.enable
                     onToggleRequested: Config.options.dock.enable = !Config.options.dock.enable
                 }
+                ConfigSelectionArray {
+                    text: Translation.tr("Dock position")
+                    icon: "swap_vert"
+                    // The value IS the stored string - no bitfield to
+                    // open-code, which is the whole argument for the new key.
+                    currentValue: Config.options.dock.edge
+                    onSelected: newValue => { Config.options.dock.edge = newValue; }
+                    options: [
+                        { displayName: Translation.tr("Top"),    icon: "arrow_upward",   value: "top" },
+                        { displayName: Translation.tr("Left"),   icon: "arrow_back",     value: "left" },
+                        { displayName: Translation.tr("Bottom"), icon: "arrow_downward", value: "bottom" },
+                        { displayName: Translation.tr("Right"),  icon: "arrow_forward",  value: "right" }
+                    ]
+                }
                 ConfigSwitch {
                     buttonIcon: "background_dot_small"
                     text: Translation.tr("Background")

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -265,6 +265,12 @@ fi
 
 # Renders real cards and reads the pixels under them: the shadow is not
 # reachable from a source-text check. Brings its own headless weston.
+echo "Running dock position contract tests..."
+if ! python3 "$SCRIPT_DIR/test_dock_position_contract.py"; then
+    echo "Dock position contract tests failed."
+    exit 1
+fi
+
 echo "Running widget card shadow tests..."
 if ! python3 "$SCRIPT_DIR/test_card_shadow.py"; then
     echo "Widget card shadow tests failed."

--- a/dots/.config/quickshell/imi/tests/test_dock_position_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_dock_position_contract.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""The dock's position derives from one place, and nothing names a side twice.
+
+The dock used to spell its geometry out in four files that had to agree:
+Dock.qml's anchors and exclusive zone, and hand-written topMargin/bottomMargin
+pairs in the dock body, the separator and the app buttons. Four coordinated
+edits is how a mirror drifts - one file gets flipped and the others quietly
+keep pointing at the bottom of the screen.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+DOCK = ROOT / "modules/imi/dock/Dock.qml"
+GEOMETRY = ROOT / "modules/imi/dock/dock_geometry.js"
+CONFIG = ROOT / "modules/common/Config.qml"
+DEFAULTS = ROOT / "defaults/config.json"
+SETTINGS = ROOT / "modules/imi/settings/pages/BarConfig.qml"
+RULES = ROOT.parents[2] / ".config/hypr/hyprland/rules.lua"
+
+
+class DockPositionContractTest(unittest.TestCase):
+    def test_the_dock_reads_its_geometry_rather_than_spelling_it(self):
+        source = DOCK.read_text(encoding="utf-8")
+        self.assertIn("dock_geometry.js", source)
+        for derived in ("DockGeometry.thickness(", "DockGeometry.exclusiveZone(",
+                        "DockGeometry.anchors(", "DockGeometry.margins(",
+                        "DockGeometry.revealOffsets("):
+            self.assertIn(derived, source, f"{derived} is spelled out again")
+        # The arithmetic itself may not reappear in the QML.
+        self.assertNotIn("anchors { bottom: true; left: true; right: true }", source,
+                         "the anchors are literal again")
+
+    def test_the_edge_comes_from_config_and_survives_nonsense(self):
+        self.assertIn("property string edge:", CONFIG.read_text(encoding="utf-8"))
+        self.assertIn('"edge": "bottom"', DEFAULTS.read_text(encoding="utf-8"))
+        source = DOCK.read_text(encoding="utf-8")
+        self.assertIn("DockGeometry.normalizedEdge(", source,
+                      "a hand-edited config or an old preset must not unanchor the dock")
+
+    def test_the_settings_row_writes_the_string_directly(self):
+        source = SETTINGS.read_text(encoding="utf-8")
+        self.assertIn('text: Translation.tr("Dock position")', source)
+        self.assertIn("Config.options.dock.edge = newValue", source)
+        # The whole argument for a new key rather than parity with the bar's
+        # overloaded pair is that nothing has to open-code a bitfield.
+        row = source[source.index('Translation.tr("Dock position")'):]
+        row = row[:row.index("}\n                }")]
+        for edge in ('"top"', '"left"', '"bottom"', '"right"'):
+            self.assertIn(edge, row)
+        self.assertNotIn("& 1", row)
+        self.assertNotIn("| 2", row)
+
+    def test_what_follows_the_edge_derives_it_and_does_not_assume_bottom(self):
+        for path in (ROOT / "modules/common/widgets/DragApps.qml",
+                     ROOT / "modules/common/widgets/DockAppButton.qml",
+                     ROOT / "modules/common/widgets/DockContextMenu.qml"):
+            source = path.read_text(encoding="utf-8")
+            self.assertIn("dock.edge", source,
+                          f"{path.name} still assumes which edge the dock is on")
+
+    def test_the_slide_follows_the_surface_rather_than_naming_an_edge(self):
+        # `slide bottom` pinned the exit animation to one edge, so a top dock
+        # slid downward - into the screen - to leave.
+        source = RULES.read_text(encoding="utf-8")
+        rule = [line for line in source.splitlines()
+                if 'namespace = "quickshell:dock"' in line and "animation" in line]
+        self.assertEqual(len(rule), 1, "one animation rule for the dock")
+        self.assertIn('animation = "slide"', rule[0])
+        self.assertNotIn("slide bottom", rule[0])
+
+    def test_the_geometry_module_has_no_side_names_in_its_arithmetic(self):
+        # It maps direction onto side names in exactly one function; anywhere
+        # else is a second derivation waiting to disagree with the first.
+        source = GEOMETRY.read_text(encoding="utf-8")
+        body = source[source.index("function thickness"):]
+        for function in ("function thickness", "function exclusiveZone", "function insets",
+                         "function revealOffsets"):
+            start = body.index(function)
+            end = body.index("\n}", start)
+            chunk = body[start:end]
+            self.assertFalse(re.search(r'"(top|bottom|left|right)"', chunk),
+                             f"{function} names a side")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/dots/.config/quickshell/imi/tests/tst_dock_geometry.qml
+++ b/dots/.config/quickshell/imi/tests/tst_dock_geometry.qml
@@ -1,0 +1,101 @@
+import QtTest
+import "../modules/imi/dock/dock_geometry.js" as Geometry
+
+// Where the dock sits on each edge. The numbers are the part a test can
+// reach; the measured baseline below is what a regression has to argue with.
+TestCase {
+    name: "DockGeometryTest"
+
+    // The real defaults: dock.height 60, elevationMargin 10 (spacing.space125),
+    // hyprlandGapsOut 5. Read back live from the compositor at those values,
+    // `hyprctl monitors` reports reserved [0, 45, 0, 65] and a 5120x75 dock -
+    // so 75 and 65 below are measurements, not arithmetic that happens to
+    // agree with itself.
+    readonly property real dockHeight: 60
+    readonly property real elevation: 10
+    readonly property real gaps: 5
+
+    function test_the_reserved_zone_matches_the_measured_baseline() {
+        compare(Geometry.exclusiveZone(dockHeight, elevation, gaps), 65,
+                "the bottom dock's measured reservation");
+        // Whatever the edge, the same arithmetic: the zone is a property of
+        // the dock's thickness, not of which side it is on.
+        compare(Geometry.thickness(dockHeight, elevation, gaps), 75,
+                "and the dock's own measured size across its axis");
+    }
+
+    function test_every_edge_anchors_both_ends_of_its_long_axis() {
+        const bottom = Geometry.anchors("bottom");
+        verify(bottom.left && bottom.right && bottom.bottom && !bottom.top);
+        const top = Geometry.anchors("top");
+        verify(top.left && top.right && top.top && !top.bottom);
+        const left = Geometry.anchors("left");
+        verify(left.top && left.bottom && left.left && !left.right);
+        const right = Geometry.anchors("right");
+        verify(right.top && right.bottom && right.right && !right.left);
+    }
+
+    function test_the_margins_flip_with_the_edge() {
+        // The asymmetry is the point: an elevation margin INWARD for the drop
+        // shadow, the compositor's gap OUTWARD. A mirror that keeps the pair
+        // in place puts the shadow off-screen.
+        const bottom = Geometry.margins("bottom", elevation, gaps);
+        compare(bottom.top, elevation);
+        compare(bottom.bottom, gaps);
+        const top = Geometry.margins("top", elevation, gaps);
+        compare(top.top, gaps);
+        compare(top.bottom, elevation);
+        const left = Geometry.margins("left", elevation, gaps);
+        compare(left.left, gaps);
+        compare(left.right, elevation);
+        const right = Geometry.margins("right", elevation, gaps);
+        compare(right.left, elevation);
+        compare(right.right, gaps);
+    }
+
+    function test_the_margin_pair_never_lands_on_the_long_axis() {
+        for (const edge of ["top", "bottom"]) {
+            const m = Geometry.margins(edge, elevation, gaps);
+            compare(m.left, 0, edge + " has no horizontal inset");
+            compare(m.right, 0);
+        }
+        for (const edge of ["left", "right"]) {
+            const m = Geometry.margins(edge, elevation, gaps);
+            compare(m.top, 0, edge + " has no vertical inset");
+            compare(m.bottom, 0);
+        }
+    }
+
+    function test_the_reveal_is_one_number_at_every_edge() {
+        // hoverRegionHeight is 2 by default: the sliver is deliberately thin.
+        const offsets = Geometry.revealOffsets(75, 2);
+        compare(offsets.revealed, 0);
+        compare(offsets.peeking, 73, "a sliver the pointer can still hit");
+        compare(offsets.hidden, 76, "one past gone - stopping at the edge leaves a lit seam");
+        verify(Geometry.hideDirection("bottom") > 0);
+        verify(Geometry.hideDirection("top") < 0);
+        verify(Geometry.hideDirection("right") > 0);
+        verify(Geometry.hideDirection("left") < 0);
+    }
+
+    function test_a_popup_opens_away_from_the_edge() {
+        compare(Geometry.popupGravity("bottom"), "top");
+        compare(Geometry.popupGravity("top"), "bottom");
+        compare(Geometry.popupGravity("left"), "right");
+        compare(Geometry.popupGravity("right"), "left");
+    }
+
+    function test_an_unknown_edge_is_the_dock_we_already_ship() {
+        // A preset written before this setting existed, or a hand-edited
+        // config, must not produce an unanchored dock.
+        compare(Geometry.normalizedEdge("sideways"), "bottom");
+        compare(Geometry.popupGravity(""), "top");
+        const anchors = Geometry.anchors(undefined);
+        verify(anchors.bottom && anchors.left && anchors.right);
+    }
+
+    function test_vertical_is_only_the_two_side_edges() {
+        verify(Geometry.isVertical("left") && Geometry.isVertical("right"));
+        verify(!Geometry.isVertical("top") && !Geometry.isVertical("bottom"));
+    }
+}


### PR DESCRIPTION
Steps 1–6 of the dock-position spec (#181). The horizontal half: the dock can be put on the **top** edge, and everything positional now comes from one derivation. Vertical edges are the next PR — they are a different layout, not a rotation, and the spec says so.

## What changed

**`dock_geometry.js`** owns anchors, thickness, the reserved zone, the margin pair and the reveal offsets, for all four edges. Two ideas carry it:

- **Inward / outward**, not top / bottom. The dock's margins are asymmetric — an elevation margin inward for the drop shadow, the compositor's gap outward — and naming them by direction is what makes a flip a state change rather than four coordinated edits that can drift.
- **Thickness**, not height. The arithmetic does not change with the axis, only what it is applied to. `dock.height` and `hoverRegionHeight` keep their names for the preset reason below.

**`dock.edge`** is a new string key, not parity with the bar's `bottom` + `vertical` pair. Presets are never rewritten, so a new key needs no migration where renaming an existing one would lose every stored value — and the settings row writes the string directly instead of open-coding a bitfield the way the bar's three copies do.

**The mirror** is six things, all derived: anchors, the reveal offset's side, the margin swap, the running dots, the context menu's gravity, and the layer rule.

## Verified live, not by inspection

This is the change where a broken lookup produces `undefined` rather than an error, so each step was checked against the compositor:

| | reserved |
|---|---|
| bottom edge | `[0, 45, 0, 65]` |
| top edge | `[0, 110, 0, 0]` — the bar's 45 plus the dock's 65 on the same side |

The geometry module's test numbers are measurements, not arithmetic agreeing with itself: at defaults the compositor reports a 5120x75 dock reserving 65. My first version of that test asserted 65 against invented constants and failed, which is how I found the real ones.

**The dots took two attempts.** The first patch went to `DockAppButton`, which renders only *active unpinned* apps — every icon on this dock is pinned and comes from `DragApps`, so the change was correct and completely invisible. What found it was a diagnostic log line that never appeared.

**`slide bottom` → `slide`** in the layer rule: naming the edge pinned the exit animation, so a top dock slid *downward, into the screen*, to leave.

## Decisions from the spec's open questions

Answered by the user before implementation: media tile hidden at vertical edges, one tree with a vertical flag rather than two modules, and the settings UI will **refuse** a dock sharing an edge with an auto-hiding bar rather than arbitrating two reveal slivers. The first two land in the vertical PR; the third is its own commit after §3's measurement.

## Verification

- `tests/run_tests.sh`: 622 passed, 0 failed
- `tst_dock_geometry.qml`: 10 cases over all four edges, including the measured baseline
- `test_dock_position_contract.py`: pins the four files to reading the derivation, the settings row to writing the string, and the geometry module's arithmetic to not naming a side outside the one function that maps direction onto anchor names
- Deployed and screenshotted at both edges; dock renders correctly and the indicator dot sits adjacent to the screen edge in each

Docs: not needed — the spec at `docs/superpowers/specs/2026-08-13-dock-position-design.md` (PR #181) already documents this design and was updated there with how its open questions were settled; AGENT.md gains nothing that is not already enforced by `test_dock_position_contract.py`.