### PR TITLE
feat(weather): a 3x2 desktop card whose second row is the forecast

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1072,6 +1072,25 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   timer and now does for its slot watcher. This surfaced when `StyledPopup` stopped being a
   `LazyLoader`; probed with `qml6` rather than reasoned about.
   (b22a923a5 ("refactor(bar): delete the per-popup layer surface").)
+- **QtQml replaces `Date`'s locale methods with its own overloads, so ECMAScript's
+  options-object form is not an error here - it is a different, plausible answer.**
+  `toLocaleDateString`, `toLocaleTimeString` and `toLocaleString` take **(locale, format)** in
+  QML, where `locale` is a `Qt.locale()` and `format` is a `Locale.*Format` enum or a Qt format
+  string. Handed a browser's `date.toLocaleDateString(undefined, { weekday: "short" })` the
+  engine does not recognise the object, falls through to the locale's short **date** format, and
+  returns `"8/14/26"` where the call plainly asks for `"Fri"` - no warning, no exception, no log
+  line. Use `date.toLocaleDateString(Qt.locale(), "ddd")`. Two things generalise past the one
+  call. The test that should have caught it compared the function against **the same expression
+  the function ran**, so it asserted only that the function agreed with itself and passed on the
+  bug - the sibling of the UTC-runner problem pinned three functions up the same file, with the
+  tautology in the assertion rather than in the environment. Check the *shape* of a localized
+  answer (a weekday name carries no digits, three consecutive days are three different names,
+  seven days on is the same name again) rather than an expected string no locale is obliged to
+  produce. And a `.pragma library` is held free of `Qt` by
+  `tests/test_weather_forecast_contract.py`, so the locale is passed in by the caller, which has
+  an engine context. Found by rendering the widget and reading the labels; the whole of it is
+  invisible from the source. fix(weather): a forecast card is named for its weekday, not for its
+  date.
 - **`FileView` (`Quickshell.Io`) loads asynchronously - `.text()` right after calling `.reload()`
   is not guaranteed to return the new content.** The correct pattern (used throughout this codebase
   - `MaterialSymbolsSearch.qml`, `Notifications.qml`, `Emojis.qml`, `Profile.qml`) is to read

--- a/docs/widget-grid.md
+++ b/docs/widget-grid.md
@@ -115,7 +115,7 @@ shown disabled — for a manifest naming a single span.
 **Only declare `sizes` for a widget that has a design per size.** Most widgets have one
 layout, and the host swaps the pixel size and nothing else: offering a span a widget has
 no layout for is worse than offering no choice at all. `nandoroid-weather` (1x1 / 2x1 /
-3x1), `nandoroid-currency` (1x1 / 2x1) and `nandoroid-media` (3x2 / 2x2 / 2x1) qualify
+3x1 / 3x2), `nandoroid-currency` (1x1 / 2x1) and `nandoroid-media` (3x2 / 2x2 / 2x1) qualify
 because each span is a different layout inside the widget; nothing else bundled does.
 
 Such a widget reads the resolved span back from the host as `hostGridSize`
@@ -326,7 +326,7 @@ The only test is `size === widgetGridSpanX(cols)` / `widgetGridSpanY(rows)`.
 - **The `nandoroid-*` widgets already conform.** They define this grid (media = 3x2,
   system monitor = 3x1 / 1x3). The system monitor is content-sized rather than declaring
   `grid`, but its pixel sizes are exactly on it, so new `grid` widgets tile flush beside
-  it; weather (1x1 / 2x1 / 3x1), currency (1x1 / 2x1) and media (3x2 / 2x2 / 2x1) declare
+  it; weather (1x1 / 2x1 / 3x1 / 3x2), currency (1x1 / 2x1) and media (3x2 / 2x2 / 2x1) declare
   `grid.sizes` and take their size from the host. `clock` is exempt by decision: its shape
   places neatly without a span, so it stays content-sized behind
   `defaultWidth`/`defaultHeight`.

--- a/dots/.config/quickshell/imi/WeatherTreeMotionProbe.qml
+++ b/dots/.config/quickshell/imi/WeatherTreeMotionProbe.qml
@@ -32,9 +32,40 @@ ShellRoot {
             name: "weather probe",
             _basePath: base,
             grid: { cols: 3, rows: 1,
-                sizes: [{ cols: 3, rows: 1 }, { cols: 2, rows: 1 }, { cols: 1, rows: 1 }] },
+                sizes: [{ cols: 3, rows: 1 }, { cols: 2, rows: 1 }, { cols: 1, rows: 1 },
+                        { cols: 3, rows: 2 }] },
             desktopWidget: { component: "Widget.qml" }
         };
+    }
+
+    // There is no network here and no API key, so the service publishes
+    // nothing and the card would sweep every span showing "--" over an empty
+    // forecast band - which is a real state, but not the one the second row
+    // exists for. `Weather.data` and `Weather.forecast` are plain writable
+    // properties with no binding on them, so seeding them is injection rather
+    // than a mock, and the widget is the real widget reading the real service.
+    function isoIn(days) {
+        const at = new Date(new Date().getTime() + days * 24 * 60 * 60 * 1000);
+        const pad = n => (n < 10 ? "0" + n : "" + n);
+        return at.getFullYear() + "-" + pad(at.getMonth() + 1) + "-" + pad(at.getDate());
+    }
+    // Four days is OpenWeatherMap's cap; `seedForecast(3)` is wttr.in's count
+    // and the sweep runs both, because the row divides the strip by the count
+    // it is handed and a layout that only ever saw one of them proves nothing.
+    function seedForecast(count) {
+        const codes = [113, 296, 200, 338];
+        const days = [];
+        for (let i = 0; i < count; i++)
+            days.push({ date: harness.isoIn(i), wCode: codes[i % codes.length],
+                        high: 24 - i, low: 12 - i });
+        Weather.forecast = days;
+    }
+    function seedWeather() {
+        Weather.data = {
+            temp: "21°C", tempFeelsLike: "19°C", tempHigh: "24°C", tempLow: "12°C",
+            description: "Light rain", humidity: "72%", wind: "12 km/h", wCode: 296
+        };
+        harness.seedForecast(4);
     }
 
     function findByName(item, name) {
@@ -78,15 +109,25 @@ ShellRoot {
         widget.grabToImage(result => result.saveToFile(`${harness.shotDir}/${tag}.png`));
     }
 
+    // Every ordered pair of spans, so each one is entered and left. 3x2 is in
+    // both directions against all three of the one-row spans: it is the only
+    // span whose transitions change the card's HEIGHT, and the elements that
+    // travel into it travel on the axis the other five pairs never exercise.
     readonly property var transitions: [
         ["3x1", "2x1"], ["2x1", "1x1"], ["1x1", "3x1"],
-        ["3x1", "1x1"], ["1x1", "2x1"], ["2x1", "3x1"]
+        ["3x1", "1x1"], ["1x1", "2x1"], ["2x1", "3x1"],
+        ["3x1", "3x2"], ["3x2", "3x1"],
+        ["3x2", "2x1"], ["2x1", "3x2"],
+        ["3x2", "1x1"], ["1x1", "3x2"]
     ]
     property int transitionIndex: 0
     property var trails: ({})
     property var connections: []
 
-    function spanOf(name) { return { cols: parseInt(name[0]), rows: 1 }; }
+    function spanOf(name) {
+        const parts = name.split("x");
+        return { cols: parseInt(parts[0]), rows: parseInt(parts[1]) };
+    }
 
     function watch(label, object, signalName, getter) {
         if (!object) { console.log(`[WeatherTreeMotion] missing: ${label}`); return; }
@@ -112,10 +153,28 @@ ShellRoot {
         const glyph = harness.findByName(widget, "weatherGlyph");
         const condition = harness.findByName(widget, "weatherCondition");
         harness.watch("temp.x", temp, "xChanged", () => temp.x);
+        // x alone is not enough now that a span change can be vertical. The
+        // temperature and the condition both hold their x between 3x1 and 3x2
+        // and travel on y and in font size, so an x-only sweep reported them
+        // "static" through the one pair that moves them - it would have passed
+        // just as green on a snap.
+        harness.watch("temp.y", temp, "yChanged", () => temp.y);
+        harness.watch("temp.size", temp, "fontChanged", () => temp.font.pixelSize);
+        harness.watch("cond.y", condition, "yChanged", () => condition.y);
         harness.watch("glyph.x", glyph, "xChanged", () => glyph.x);
         harness.watch("glyph.w", glyph, "widthChanged", () => glyph.width);
         harness.watch("glyph.rot", glyph, "rotationChanged", () => glyph.rotation);
         harness.watch("cond.x", condition, "xChanged", () => condition.x);
+        // The elements the second row added. The pills and the column rule
+        // travel between the two wide spans on the y axis alone, so watching
+        // x - which is what every other trail here watches - would report them
+        // static through the one transition that moves them.
+        const pills = harness.findByName(widget, "weatherPills");
+        const rule = harness.findByName(widget, "weatherColumnRule");
+        const strip = harness.findByName(widget, "weatherForecast");
+        harness.watch("pills.y", pills, "yChanged", () => pills.y);
+        harness.watch("rule.h", rule, "heightChanged", () => rule.height);
+        harness.watch("strip.op", strip, "opacityChanged", () => strip.opacity);
         // The shape morph itself: morphT must sweep 0 -> 1 on a shape change,
         // not flip at the top - the retarget-through-a-live-Behavior bug made
         // exactly that snap while every position trail stayed green.
@@ -148,13 +207,77 @@ ShellRoot {
         if (harness.transitionIndex < harness.transitions.length) {
             nextTimer.start();
         } else {
-            console.log(`[WeatherTreeMotion] failures: ${harness.failures}`);
-            Qt.quit();
+            countPhase.start();
         }
     } }
     Timer { id: nextTimer; interval: 250; onTriggered: harness.beginTransition() }
 
+    // ---- the second row's day count -------------------------------------
+    //
+    // The providers disagree - wttr.in answers with three days and
+    // OpenWeatherMap with four - and a failed forecast request answers with
+    // none, on a provider whose current conditions arrived fine. The row
+    // divides the strip by the count it is handed, so all three are laid out
+    // here rather than reasoned about: a layout that only ever saw four would
+    // leave a hole on the default provider's alternative and nothing would
+    // report it.
+    readonly property var countCases: [4, 3, 1, 0]
+    property int countIndex: 0
+
+    Timer { id: countPhase; interval: 250; onTriggered: {
+        widget.commitGridSize(harness.spanOf("3x2"));
+        countSettle.start();
+    } }
+    Timer { id: countSettle; interval: 900; onTriggered: harness.runCountCase() }
+
+    function runCountCase() {
+        harness.seedForecast(harness.countCases[harness.countIndex]);
+        countCheck.start();
+    }
+
+    Timer { id: countCheck; interval: 700; onTriggered: {
+        const count = harness.countCases[harness.countIndex];
+        const strip = harness.findByName(widget, "weatherForecast");
+        const cards = [];
+        for (const child of strip.children)
+            if (child.width > 0) cards.push(child);
+        cards.sort((a, b) => a.x - b.x);
+        harness.check(`${count} days -> ${cards.length} cards`, cards.length === count);
+        if (count > 0) {
+            const last = cards[cards.length - 1];
+            harness.check(`${count} days fill the strip`,
+                Math.abs(cards[0].x) < 0.5
+                && Math.abs(last.x + last.width - strip.width) < 0.5);
+            harness.check(`${count} days: the strip is shown`, strip.opacity > 0.9);
+        } else {
+            // Not merely hidden: the delegates are gone, so no CustomIcon is
+            // held warm for a band that is not drawn.
+            harness.check("no forecast: the strip is gone", strip.opacity < 0.01);
+            const highLow = harness.findByName(widget, "weatherHighLow");
+            harness.check("no forecast: the high/low line comes back at 3x2",
+                highLow.opacity > 0.5);
+        }
+        harness.shoot(`3x2_${count}days`);
+        // The shot lands on a LATER frame than the call, so seeding the next
+        // count in this handler files each case's PNG under the previous
+        // case's name - which is the same trap that once filed a transition's
+        // first frame as "settled", one screenshot removed. Let the grab
+        // happen before moving on.
+        countAdvance.start();
+    } }
+
+    Timer { id: countAdvance; interval: 200; onTriggered: {
+        harness.countIndex++;
+        if (harness.countIndex < harness.countCases.length) {
+            harness.runCountCase();
+        } else {
+            console.log(`[WeatherTreeMotion] failures: ${harness.failures}`);
+            Qt.quit();
+        }
+    } }
+
     Timer { id: t0; interval: 1200; running: true; onTriggered: {
+        harness.seedWeather();
         PluginState.setPosition("nandoroid_weather", harness.testScreen, { x: 40, y: 40, placementStrategy: "free" });
         settle0.start();
     } }

--- a/dots/.config/quickshell/imi/WeatherTreeMotionProbe.qml
+++ b/dots/.config/quickshell/imi/WeatherTreeMotionProbe.qml
@@ -53,7 +53,13 @@ ShellRoot {
     // and the sweep runs both, because the row divides the strip by the count
     // it is handed and a layout that only ever saw one of them proves nothing.
     function seedForecast(count) {
-        const codes = [113, 296, 200, 338];
+        // OpenWeatherMap condition ids, because that is the provider a config
+        // with nothing set resolves to and the card reads `wCode` against
+        // whichever one reported it. Seeded with wttr's WWO codes instead, the
+        // shots render four storms and a cloud - correct behaviour for codes
+        // the provider did not send, and a misleading picture of the widget.
+        // The mapping itself is unit-tested on both providers.
+        const codes = [800, 500, 202, 601];
         const days = [];
         for (let i = 0; i < count; i++)
             days.push({ date: harness.isoIn(i), wCode: codes[i % codes.length],

--- a/dots/.config/quickshell/imi/modules/common/functions/weatherForecast.js
+++ b/dots/.config/quickshell/imi/modules/common/functions/weatherForecast.js
@@ -42,13 +42,26 @@ function isToday(isoDate, todayIsoDate) {
 // Parsed at midday rather than at midnight: a bare "YYYY-MM-DD" is read as UTC
 // midnight, which is the previous day's evening for anyone west of UTC, and the
 // card would name the wrong weekday.
-function shortDayName(isoDate) {
+//
+// A locale and a format string, NOT ECMAScript's options object. QtQml
+// replaces `Date.prototype.toLocaleDateString` with an overload taking
+// (locale, format), and it does not understand `{ weekday: "short" }` - it
+// falls through to the locale's short DATE format, so every card read
+// "8/14/26" where a browser would say "Fri". Nothing about that is visible
+// from reading the call; it was measured in the engine.
+//
+// The locale is an argument because this file is a `.pragma library` and
+// keeps itself free of `Qt` (test_weather_forecast_contract.py). The callers
+// have an engine context and pass `Qt.locale()`; the arithmetic that has to
+// be right whatever the locale is - parsing at midday so a bare
+// "YYYY-MM-DD" is not read as the previous evening west of UTC - stays here.
+function shortDayName(isoDate, locale) {
     if (!isoDate)
         return "";
     const parsed = new Date(isoDate + "T12:00:00");
     if (isNaN(parsed.getTime()))
         return "";
-    return parsed.toLocaleDateString(undefined, { weekday: "short" });
+    return parsed.toLocaleDateString(locale, "ddd");
 }
 
 // OpenWeatherMap's /data/2.5/forecast `list`, grouped into days.

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-weather/Widget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-weather/Widget.qml
@@ -24,9 +24,15 @@ Item {
     // `width: implicitWidth` on itself AND its content, so the card snapped
     // to each span's size in one frame while the host's animated box was
     // ignored: elements travelled, the card teleported (the review).
-    readonly property int spanCols: parseInt((root.hostGridSize || "3x1")[0]) || 3
+    // Both axes come off the span name. The rows half was a literal 1 while
+    // every span this widget offered was one row tall; 3x2 is the first that
+    // is not, and a hardcoded 1 there is a card drawing half its content
+    // outside the box the host gave it.
+    readonly property var spanParts: (root.hostGridSize || "3x1").split("x")
+    readonly property int spanCols: parseInt(root.spanParts[0]) || 3
+    readonly property int spanRows: parseInt(root.spanParts[1]) || 1
     implicitWidth: Appearance.sizes.widgetGridSpanX(root.spanCols)
-    implicitHeight: Appearance.sizes.widgetGridSpanY(1)
+    implicitHeight: Appearance.sizes.widgetGridSpanY(root.spanRows)
 
     Expressive.DesktopWeatherWidget {
         id: content

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-weather/manifest.json
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-weather/manifest.json
@@ -4,7 +4,7 @@
   "capabilities": ["desktop-widget"], "permissions": ["network", "settings_read"],
   "grid": {
     "cols": 3, "rows": 1,
-    "sizes": [ { "cols": 1, "rows": 1 }, { "cols": 2, "rows": 1 }, { "cols": 3, "rows": 1 } ]
+    "sizes": [ { "cols": 1, "rows": 1 }, { "cols": 2, "rows": 1 }, { "cols": 3, "rows": 1 }, { "cols": 3, "rows": 2 } ]
   },
   "desktopWidget": { "component": "Widget.qml", "blur": false }
 }

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopWeatherWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopWeatherWidget.qml
@@ -46,8 +46,9 @@ Item {
     readonly property real width1x1: baseWidth
     readonly property real width2x1: (baseWidth * 2) + gap
     readonly property real width3x1: (baseWidth * 3) + (gap * 2)
+    readonly property real height2Rows: (baseHeight * 2) + gap
 
-    implicitHeight: baseHeight
+    implicitHeight: sizeMode === "3x2" ? height2Rows : baseHeight
     implicitWidth: {
         if (sizeMode === "1x1") return width1x1;
         if (sizeMode === "2x1") return width2x1;
@@ -65,10 +66,26 @@ Item {
         if (sizeMode === "2x1") return width2x1;
         return width3x1;
     }
-    readonly property real spanH: root.baseHeight
+    readonly property real spanH: {
+        if (sizeMode === "3x2") return height2Rows;
+        return baseHeight;
+    }
     readonly property var tempSlot: Geometry.temperatureRect(root.sizeMode, root.spanW, root.spanH, Appearance.effectiveScale)
     readonly property var conditionSlot: Geometry.conditionRect(root.sizeMode, root.spanW, root.spanH, Appearance.effectiveScale)
     readonly property var glyphSlot: Geometry.glyphRect(root.sizeMode, root.spanW, root.spanH, Appearance.effectiveScale)
+
+    // The two wide spans are the only ones with a second column, and the
+    // elements that live in it (the high/low line, the pills, the column
+    // rule) fade at the narrow spans rather than travelling to them. A fade
+    // happens WHERE THE ELEMENT STANDS, so they still need somewhere to
+    // stand: resolving them against whichever wide layout the card is at or
+    // heading for gives them one, while the module keeps returning null for
+    // the narrow spans so nothing can mistake that for a home.
+    readonly property string bandSpan: root.sizeMode === "3x2" ? "3x2" : "3x1"
+    readonly property real bandH: root.bandSpan === "3x2" ? root.height2Rows : root.baseHeight
+    readonly property var highLowSlot: Geometry.highLowRect(root.bandSpan, root.width3x1, root.bandH, Appearance.effectiveScale)
+    readonly property var pillsSlot: Geometry.pillsRect(root.bandSpan, root.width3x1, root.bandH, Appearance.effectiveScale)
+    readonly property var columnRuleSlot: Geometry.columnDividerRect(root.bandSpan, root.width3x1, root.bandH, Appearance.effectiveScale)
 
     readonly property string weatherIconsDir: "../../../../assets/icons/google-weather"
     readonly property color contentColor: Appearance.m3colors.m3onSurface
@@ -240,35 +257,44 @@ Item {
         }
 
         StyledText {
-            // 3x1 only
-            x: 20 * Appearance.effectiveScale
-            y: 74 * Appearance.effectiveScale
+            // 3x1 and 3x2.
+            objectName: "weatherHighLow"
+            x: root.highLowSlot.x
+            y: root.highLowSlot.y
+            Behavior on x { SpanTravel {} }
+            Behavior on y { SpanTravel {} }
             text: `High ${root.highTemperature}° · Low ${root.lowTemperature}°`
             font.pixelSize: Appearance.font.pixelSize.smallest
             color: root.contentColor
-            opacity: root.sizeMode === "3x1" ? 0.6 : 0
+            opacity: root.sizeMode === "3x1" || root.sizeMode === "3x2" ? 0.6 : 0
             Behavior on opacity { SpanFade {} }
             visible: opacity > 0
         }
 
         Rectangle {
-            // 3x1 only: the column divider
-            x: 132 * Appearance.effectiveScale
-            y: 16 * Appearance.effectiveScale
+            // 3x1 and 3x2: the boundary between the temperature column and the
+            // condition column, which both wide spans have.
+            objectName: "weatherColumnRule"
+            x: root.columnRuleSlot.x
+            y: root.columnRuleSlot.y
             width: 1
-            height: root.spanH - 32 * Appearance.effectiveScale
+            height: root.columnRuleSlot.height
+            Behavior on y { SpanTravel {} }
+            Behavior on height { SpanTravel {} }
             color: root.contentColor
-            opacity: root.sizeMode === "3x1" ? 0.15 : 0
+            opacity: root.sizeMode === "3x1" || root.sizeMode === "3x2" ? 0.15 : 0
             Behavior on opacity { SpanFade {} }
             visible: opacity > 0
         }
 
         RowLayout {
-            // 3x1 only: the humidity and wind pills
-            x: 148 * Appearance.effectiveScale
-            y: 60 * Appearance.effectiveScale
+            // 3x1 and 3x2: the humidity and wind pills
+            objectName: "weatherPills"
+            x: root.pillsSlot.x
+            y: root.pillsSlot.y
+            Behavior on y { SpanTravel {} }
             spacing: 8 * Appearance.effectiveScale
-            opacity: root.sizeMode === "3x1" ? 1 : 0
+            opacity: root.sizeMode === "3x1" || root.sizeMode === "3x2" ? 1 : 0
             Behavior on opacity { SpanFade {} }
             visible: opacity > 0
 

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopWeatherWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopWeatherWidget.qml
@@ -9,6 +9,7 @@ import Qt5Compat.GraphicalEffects
 import "weather_geometry.js" as Geometry
 import "weather_glyphs.js" as WeatherGlyphs
 import "weather_shapes.js" as WeatherShapes
+import "../../../functions/weatherForecast.js" as WeatherForecast
 
 // The weather widget as ONE tree (spec 2026-08-11, §3b - this widget is the
 // element the morphing design was specified around).
@@ -86,6 +87,28 @@ Item {
     readonly property var highLowSlot: Geometry.highLowRect(root.bandSpan, root.width3x1, root.bandH, Appearance.effectiveScale)
     readonly property var pillsSlot: Geometry.pillsRect(root.bandSpan, root.width3x1, root.bandH, Appearance.effectiveScale)
     readonly property var columnRuleSlot: Geometry.columnDividerRect(root.bandSpan, root.width3x1, root.bandH, Appearance.effectiveScale)
+
+    // The forecast band exists at 3x2 and nowhere else, so its rect is its one
+    // home and the span test is what decides whether it is drawn - the null
+    // the module returns elsewhere is what says "fade", never a rect to travel
+    // to.
+    readonly property bool showsForecast: Geometry.forecastStripRect(
+        root.sizeMode, root.spanW, root.spanH, Appearance.effectiveScale) !== null
+    readonly property var stripSlot: Geometry.forecastStripRect("3x2", root.width3x1, root.height2Rows, Appearance.effectiveScale)
+    readonly property var bandRuleSlot: Geometry.bandDividerRect("3x2", root.width3x1, root.height2Rows, Appearance.effectiveScale)
+
+    // wttr.in answers with three days, OpenWeatherMap with four, and a failed
+    // forecast request with none - all three are real and the row is laid out
+    // from whatever arrives (#111 deliberately padded to no fixed count).
+    readonly property var forecastDays: Weather.forecast || []
+    // Recomputed whenever the forecast is, which is often enough to keep the
+    // "Today" label honest: a card mislabelled at midnight would need the
+    // desktop to sit untouched across it, and a fetch lands every
+    // fetchInterval.
+    readonly property string todayIso: {
+        Weather.forecast;
+        return WeatherForecast.localIsoDate(new Date());
+    }
 
     readonly property string weatherIconsDir: "../../../../assets/icons/google-weather"
     readonly property color contentColor: Appearance.m3colors.m3onSurface
@@ -257,7 +280,12 @@ Item {
         }
 
         StyledText {
-            // 3x1 and 3x2.
+            // 3x1 always, and 3x2 only while there is no forecast to draw.
+            // The strip opens on today's card, which carries this same range
+            // and says it better - but the forecast is a request that can fail
+            // on its own (OpenWeatherMap fetches it separately), and a 3x2 card
+            // answering that by silently dropping the high and low would tell
+            // the user LESS than the 3x1 does.
             objectName: "weatherHighLow"
             x: root.highLowSlot.x
             y: root.highLowSlot.y
@@ -266,7 +294,8 @@ Item {
             text: `High ${root.highTemperature}° · Low ${root.lowTemperature}°`
             font.pixelSize: Appearance.font.pixelSize.smallest
             color: root.contentColor
-            opacity: root.sizeMode === "3x1" || root.sizeMode === "3x2" ? 0.6 : 0
+            opacity: (root.sizeMode === "3x1"
+                || (root.showsForecast && root.forecastDays.length === 0)) ? 0.6 : 0
             Behavior on opacity { SpanFade {} }
             visible: opacity > 0
         }
@@ -323,6 +352,124 @@ Item {
                             font.pixelSize: Appearance.font.pixelSize.smallest
                             font.weight: Font.DemiBold
                             color: root.contentColor
+                        }
+                    }
+                }
+            }
+        }
+
+        Rectangle {
+            // 3x2 only: the seam between the two bands
+            objectName: "weatherBandRule"
+            x: root.bandRuleSlot.x
+            y: root.bandRuleSlot.y
+            width: root.bandRuleSlot.width
+            height: 1
+            color: root.contentColor
+            opacity: root.showsForecast && root.forecastDays.length > 0 ? 0.15 : 0
+            Behavior on opacity { SpanFade {} }
+            visible: opacity > 0
+        }
+
+        // ---- unshared: the second row's day-by-day forecast ---------------
+        //
+        // 3x2 only, so it fades rather than travelling - and unlike the other
+        // fades in this tree it is worth UNLOADING as well as hiding. Each
+        // card holds a CustomIcon, and an invisible-but-alive strip is four
+        // SVG loads and a dozen bindings kept warm for three spans that never
+        // show them (spec 2026-08-11, §6: in a reflowing tree, unloaded beats
+        // invisible-but-alive wherever the element has no home).
+        //
+        // The unload waits for the fade to land rather than following the
+        // span, because removing a delegate destroys it in the same frame and
+        // an exit transition is impossible after that - the rule the desktop
+        // plugin loaders already follow.
+        Item {
+            id: forecastStrip
+            objectName: "weatherForecast"
+            x: root.stripSlot.x
+            y: root.stripSlot.y
+            width: root.stripSlot.width
+            height: root.stripSlot.height
+            opacity: root.showsForecast && root.forecastDays.length > 0 ? 1 : 0
+            Behavior on opacity { SpanFade {} }
+            visible: opacity > 0
+
+            Repeater {
+                model: root.showsForecast || forecastStrip.opacity > 0 ? root.forecastDays : []
+
+                Item {
+                    id: dayCard
+                    required property int index
+                    required property var modelData
+
+                    readonly property var slot: Geometry.forecastCardRect(
+                        dayCard.index, root.forecastDays.length,
+                        forecastStrip.width, forecastStrip.height, Appearance.effectiveScale)
+                    x: dayCard.slot ? dayCard.slot.x : 0
+                    width: dayCard.slot ? dayCard.slot.width : 0
+                    height: forecastStrip.height
+
+                    Rectangle {
+                        anchors.fill: parent
+                        radius: Appearance.rounding.small * Appearance.effectiveScale
+                        // The pills' tint, because these are the same kind of
+                        // object one band up: a small tonal container holding
+                        // one reading. A MaterialShape here would put four more
+                        // morphing outlines under the one the card already has.
+                        color: Appearance.m3colors.darkmode ? Qt.rgba(1, 1, 1, 0.08) : Qt.rgba(0, 0, 0, 0.05)
+                    }
+
+                    ColumnLayout {
+                        anchors.centerIn: parent
+                        spacing: 2 * Appearance.effectiveScale
+
+                        StyledText {
+                            Layout.alignment: Qt.AlignHCenter
+                            // Plain English, like the "Feels like" and "High"
+                            // one band up: nothing in the vendored design
+                            // system reaches for the translation singleton,
+                            // and one word is not the place to start.
+                            text: WeatherForecast.isToday(dayCard.modelData.date, root.todayIso)
+                                ? "Today" : WeatherForecast.shortDayName(dayCard.modelData.date)
+                            font.pixelSize: Appearance.font.pixelSize.smaller
+                            font.weight: Font.DemiBold
+                            color: root.contentColor
+                            opacity: 0.8
+                        }
+
+                        CustomIcon {
+                            Layout.alignment: Qt.AlignHCenter
+                            // The day icon, never the night variant: this card
+                            // is a claim about Thursday, not about tonight's
+                            // sky, and after 20:00 every one of them would
+                            // otherwise flip.
+                            source: WeatherGlyphs.glyphFor(Weather.provider, dayCard.modelData.wCode, false)
+                            iconFolder: root.weatherIconsDir
+                            width: 26 * Appearance.effectiveScale
+                            height: 26 * Appearance.effectiveScale
+                            colorize: true
+                            color: Appearance.colors.colPrimary
+                        }
+
+                        RowLayout {
+                            Layout.alignment: Qt.AlignHCenter
+                            spacing: 4 * Appearance.effectiveScale
+
+                            StyledText {
+                                // An absent reading is not 0° - the service
+                                // keeps it null and the card says so.
+                                text: dayCard.modelData.high === null ? "—" : `${dayCard.modelData.high}°`
+                                font.pixelSize: Appearance.font.pixelSize.smallest
+                                font.weight: Font.DemiBold
+                                color: root.contentColor
+                            }
+                            StyledText {
+                                text: dayCard.modelData.low === null ? "—" : `${dayCard.modelData.low}°`
+                                font.pixelSize: Appearance.font.pixelSize.smallest
+                                color: root.contentColor
+                                opacity: 0.6
+                            }
                         }
                     }
                 }

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopWeatherWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopWeatherWidget.qml
@@ -7,6 +7,7 @@ import QtQuick
 import QtQuick.Layouts
 import Qt5Compat.GraphicalEffects
 import "weather_geometry.js" as Geometry
+import "weather_glyphs.js" as WeatherGlyphs
 import "weather_shapes.js" as WeatherShapes
 
 // The weather widget as ONE tree (spec 2026-08-11, §3b - this widget is the
@@ -79,16 +80,12 @@ Item {
     readonly property string condition: weatherData.description || "Unknown"
     readonly property string humidity: weatherData.humidity || "--"
     readonly property string wind: weatherData.wind || "--"
-    readonly property string weatherIcon: {
-        const code = Number(weatherData.wCode || 0)
-        if (code === 800) return Icons.isNight() ? "clear_night" : "clear_day"
-        if (code === 801) return Icons.isNight() ? "partly_cloudy_night" : "partly_cloudy_day"
-        if (code >= 200 && code < 300) return "strong_thunderstorms"
-        if (code >= 300 && code < 600) return "heavy_rain"
-        if (code >= 600 && code < 700) return "heavy_snow"
-        if (code >= 700 && code < 800) return "haze_fog_dust_smoke"
-        return "cloudy"
-    }
+    // A weather code means nothing without the provider that reported it:
+    // `wCode` is an OpenWeatherMap condition id on `owm` and a World Weather
+    // Online code on `wttr`, and this expression used to read both through
+    // OWM's ranges. weather_glyphs.js is the split.
+    readonly property string weatherIcon: WeatherGlyphs.glyphFor(
+        Weather.provider, root.weatherData.wCode, Icons.isNight())
 
 
     WidgetCard {

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopWeatherWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopWeatherWidget.qml
@@ -25,8 +25,14 @@ import "../../../functions/weatherForecast.js" as WeatherForecast
 // corner, which is the half the spec called unsolved before the card owned
 // clipping.
 //
-// Unshared content (feels-like at 2x1; high/low, the divider and the badge
-// pills at 3x1) fades and scales - it has nothing to morph into.
+// Unshared content fades - it has nothing to morph into: feels-like at 2x1,
+// the high/low line at 3x1, and the day-by-day forecast band at 3x2. The
+// column rule and the badge pills live at BOTH wide spans and travel between
+// them; only the narrow spans are a fade for those two.
+//
+// 3x2 is the one span with two rows. It is split into two bands - current
+// conditions above, the forecast below - and everything in the top band
+// travels into it from 3x1 rather than being redrawn there.
 Item {
     id: root
 
@@ -431,7 +437,7 @@ Item {
                             // system reaches for the translation singleton,
                             // and one word is not the place to start.
                             text: WeatherForecast.isToday(dayCard.modelData.date, root.todayIso)
-                                ? "Today" : WeatherForecast.shortDayName(dayCard.modelData.date)
+                                ? "Today" : WeatherForecast.shortDayName(dayCard.modelData.date, Qt.locale())
                             font.pixelSize: Appearance.font.pixelSize.smaller
                             font.weight: Font.DemiBold
                             color: root.contentColor

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/weather_geometry.js
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/weather_geometry.js
@@ -10,18 +10,31 @@
 
 function _rect(x, y, w, h) { return { x: x, y: y, width: w, height: h }; }
 
+// 3x2 is the only span with two rows, and it is split into two bands: the
+// current conditions keep the top, the day-by-day forecast owns the bottom.
+// TOP_BAND is where that seam falls, and every 3x2 number below is placed
+// against it rather than against the card, so moving the seam moves the whole
+// layout coherently.
+var TOP_BAND = 124;
+var SIDE_MARGIN = 20;
+// The gap between two day cards. Deliberately tighter than the widget grid's
+// own 12px gutter: these are cells of one object, not neighbouring widgets.
+var FORECAST_GAP = 10;
+
 // Temperature: the big number. Size rides the span.
 function temperatureRect(span, width, height, scale) {
     if (span === "1x1") return { x: 16 * scale, y: 10 * scale, size: 44 * scale };
     if (span === "2x1") return { x: 20 * scale, y: 8 * scale, size: 44 * scale };
+    if (span === "3x2") return { x: 20 * scale, y: 22 * scale, size: 56 * scale };
     return { x: 20 * scale, y: 16 * scale, size: 48 * scale };
 }
 
 // Condition: under the temperature at the small spans, the second column's
-// headline at 3x1.
+// headline at 3x1 and 3x2.
 function conditionRect(span, width, height, scale) {
     if (span === "1x1") return { x: 16 * scale, y: 64 * scale, w: 58 * scale };
     if (span === "2x1") return { x: 20 * scale, y: 62 * scale, w: 140 * scale };
+    if (span === "3x2") return { x: 148 * scale, y: 34 * scale, w: 150 * scale };
     return { x: 148 * scale, y: 28 * scale, w: 150 * scale };
 }
 
@@ -40,9 +53,77 @@ function glyphRect(span, width, height, scale) {
         width: 76 * scale, height: height,
         rotation: 0, icon: 36 * scale, shape: "panel"
     };
+    if (span === "3x2") return {
+        // Centred in the TOP band, not in the card: the bottom of a 3x2 card
+        // belongs to the forecast, and a glyph centred on the whole card
+        // would sit across it.
+        x: width - (16 + 84) * scale, y: (TOP_BAND * scale - 84 * scale) / 2,
+        width: 84 * scale, height: 84 * scale,
+        rotation: 0, icon: 48 * scale, shape: "ghostish"
+    };
     return {
         x: width - (16 + 72) * scale, y: (height - 72 * scale) / 2,
         width: 72 * scale, height: 72 * scale,
         rotation: 0, icon: 42 * scale, shape: "ghostish"
     };
+}
+
+// ---- elements that exist at some spans and not others --------------------
+//
+// These are fades, so they get a rect where they have a home and null where
+// they do not. They still need slots rather than literals in the tree,
+// because the ones that live at BOTH wide spans have to travel between them.
+
+// "High X° · Low Y°". At 3x2 this is the fallback for an absent forecast -
+// the strip says it better when there is one - so it still needs a rect there.
+function highLowRect(span, width, height, scale) {
+    if (span === "3x1") return { x: 20 * scale, y: 74 * scale };
+    if (span === "3x2") return { x: 20 * scale, y: 90 * scale };
+    return null;
+}
+
+// The humidity and wind pills, under the condition in the second column.
+function pillsRect(span, width, height, scale) {
+    if (span === "3x1") return { x: 148 * scale, y: 60 * scale };
+    if (span === "3x2") return { x: 148 * scale, y: 76 * scale };
+    return null;
+}
+
+// The hairline between the temperature column and the condition column.
+function columnDividerRect(span, width, height, scale) {
+    if (span === "3x1") return { x: 132 * scale, y: 16 * scale, height: 76 * scale };
+    if (span === "3x2") return { x: 132 * scale, y: 20 * scale, height: 84 * scale };
+    return null;
+}
+
+// ---- the second row ------------------------------------------------------
+
+// The hairline between the two bands. 3x2 only - there is no seam to draw on
+// a card with one row.
+function bandDividerRect(span, width, height, scale) {
+    if (span !== "3x2") return null;
+    return _rect(SIDE_MARGIN * scale, (TOP_BAND - 4) * scale,
+                 width - 2 * SIDE_MARGIN * scale, 1);
+}
+
+// Where the row of day cards sits. Null at every other span: the strip has no
+// home there, and a null rect is a fade rather than somewhere to travel to.
+function forecastStripRect(span, width, height, scale) {
+    if (span !== "3x2") return null;
+    return _rect(SIDE_MARGIN * scale, (TOP_BAND + 16) * scale,
+                 width - 2 * SIDE_MARGIN * scale, 68 * scale);
+}
+
+// One day card, in the strip's own coordinates.
+//
+// The count is an argument rather than a constant because the providers
+// disagree about it and #111 deliberately declined to pad: wttr.in answers
+// with three days, OpenWeatherMap with four, and a failed forecast request
+// with none. The cards divide whatever room the strip has, so every one of
+// those reads as a deliberate row rather than as a row with a hole in it.
+function forecastCardRect(index, count, stripWidth, stripHeight, scale) {
+    if (!(count > 0) || index < 0 || index >= count) return null;
+    var gap = FORECAST_GAP * scale;
+    var cardWidth = (stripWidth - gap * (count - 1)) / count;
+    return _rect(index * (cardWidth + gap), 0, cardWidth, stripHeight);
 }

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/weather_glyphs.js
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/weather_glyphs.js
@@ -1,0 +1,107 @@
+.pragma library
+
+// Which google-weather asset a weather code draws as.
+//
+// The desktop card renders `CustomIcon`s from assets/icons/google-weather,
+// which is a different vocabulary from the Material Symbol names
+// `Icons.getProviderWeatherIcon` returns for the bar - #111 declined to unify
+// them for exactly that reason, since sharing them is a port rather than a
+// rename. This is the card's own half of the same lesson.
+//
+// The lesson being: **a weather code means nothing without the provider that
+// reported it.** `Weather.data.wCode` carries OpenWeatherMap condition ids on
+// the `owm` provider and World Weather Online codes on `wttr`, and the card
+// resolved every one of them through an OWM-shaped range table. The schemes
+// overlap numerically, so that is not merely a miss - WWO 113 is Sunny and
+// falls past every OWM range into "cloudy", while WWO 296 is Light rain and
+// lands inside OWM's 2xx thunderstorm range and comes back confidently as a
+// storm. Nothing about it is visible in a log.
+//
+// The OWM branch is deliberately the card's existing expression unchanged.
+// It is what ships today on the default provider, and retuning it is a
+// separate question from giving the other provider a table at all.
+
+function glyphFor(provider, code, night) {
+    return provider === "owm" ? _owm(code, night) : _wwo(code, night);
+}
+
+function _owm(code, night) {
+    var id = Number(code);
+    if (id === 800) return night ? "clear_night" : "clear_day";
+    if (id === 801) return night ? "partly_cloudy_night" : "partly_cloudy_day";
+    if (id >= 200 && id < 300) return "strong_thunderstorms";
+    if (id >= 300 && id < 600) return "heavy_rain";
+    if (id >= 600 && id < 700) return "heavy_snow";
+    if (id >= 700 && id < 800) return "haze_fog_dust_smoke";
+    return "cloudy";
+}
+
+// World Weather Online's codes, which wttr.in speaks. Sparse and unordered -
+// they are not ranges, so this is a table rather than a chain of comparisons,
+// and a code that is not in it degrades to "cloudy" exactly as the OWM branch
+// does for an unrecognised id.
+//
+// `_DAY_NIGHT` are the entries whose asset comes in two variants; everything
+// else looks the same after dark.
+var _DAY_NIGHT = {
+    113: "clear",
+    116: "partly_cloudy",
+    119: "mostly_cloudy",
+    176: "scattered_showers",
+    179: "scattered_snow_showers",
+    200: "isolated_scattered_thunderstorms",
+    353: "scattered_showers",
+    368: "scattered_snow_showers",
+    386: "isolated_scattered_thunderstorms",
+    392: "isolated_scattered_thunderstorms"
+};
+
+var _FIXED = {
+    122: "cloudy",
+    143: "haze_fog_dust_smoke",
+    182: "mixed_rain_snow",
+    185: "icy",
+    227: "blowing_snow",
+    230: "blizzard",
+    248: "haze_fog_dust_smoke",
+    260: "haze_fog_dust_smoke",
+    263: "drizzle",
+    266: "drizzle",
+    281: "icy",
+    284: "icy",
+    293: "showers_rain",
+    296: "showers_rain",
+    299: "showers_rain",
+    302: "showers_rain",
+    305: "heavy_rain",
+    308: "heavy_rain",
+    311: "icy",
+    314: "icy",
+    317: "sleet_hail",
+    320: "sleet_hail",
+    323: "flurries",
+    326: "flurries",
+    329: "showers_snow",
+    332: "showers_snow",
+    335: "heavy_snow",
+    338: "heavy_snow",
+    350: "sleet_hail",
+    356: "showers_rain",
+    359: "heavy_rain",
+    362: "mixed_rain_snow",
+    365: "mixed_rain_snow",
+    371: "showers_snow",
+    374: "sleet_hail",
+    377: "sleet_hail",
+    389: "strong_thunderstorms",
+    395: "strong_thunderstorms"
+};
+
+function _wwo(code, night) {
+    var key = String(Number(code));
+    if (_DAY_NIGHT.hasOwnProperty(key))
+        return _DAY_NIGHT[key] + (night ? "_night" : "_day");
+    if (_FIXED.hasOwnProperty(key))
+        return _FIXED[key];
+    return "cloudy";
+}

--- a/dots/.config/quickshell/imi/tests/test_expressive_design_system.py
+++ b/dots/.config/quickshell/imi/tests/test_expressive_design_system.py
@@ -58,6 +58,42 @@ class ExpressiveDesignSystemTest(unittest.TestCase):
         weather_icons = list((ROOT / "assets/icons/google-weather").glob("*.svg"))
         self.assertEqual(len(weather_icons), 60)
 
+    def test_every_weather_glyph_names_an_asset_that_exists(self):
+        """A `CustomIcon` handed a name with no file draws nothing, silently.
+
+        `weather_glyphs.js` is a lookup table of ~50 asset basenames, half of
+        them assembled by concatenating a `_day`/`_night` suffix, and a typo
+        in one of them costs exactly one weather condition on one provider -
+        which nobody would notice until that condition happened to occur. The
+        table is source text, so checking it against the directory is cheap
+        and it is the only check that can see the whole of it at once.
+        """
+        available = {
+            path.stem for path in (ROOT / "assets/icons/google-weather").glob("*.svg")
+        }
+        source = (
+            DESIGN_SYSTEM / "widgets" / "weather_glyphs.js"
+        ).read_text(encoding="utf-8")
+
+        def table(name, least):
+            block = re.search(rf"var {name} = \{{(.*?)\n\}};", source, re.S)
+            self.assertIsNotNone(block, f"{name} is still a table literal")
+            entries = re.findall(r':\s*"([^"]+)"', block.group(1))
+            # Without this the check passes vacuously the moment the table is
+            # reformatted out from under the regex, which is the failure mode
+            # every source-text check in this suite is warned about.
+            self.assertGreaterEqual(len(entries), least, f"{name} was read")
+            return entries
+
+        named = set(re.findall(r'return "([^"]+)"', source))
+        named |= set(table("_FIXED", 30))
+        for stem in table("_DAY_NIGHT", 8):
+            named |= {f"{stem}_day", f"{stem}_night"}
+
+        self.assertGreater(len(named), 20, "the fallbacks were read too")
+        missing = sorted(named - available)
+        self.assertEqual(missing, [], f"no such google-weather asset: {missing}")
+
     def test_nandoroid_scale_compatibility_is_finite(self):
         appearance = (ROOT / "modules/common/Appearance.qml").read_text(encoding="utf-8")
         self.assertIn("readonly property real effectiveScale: 1.0", appearance)

--- a/dots/.config/quickshell/imi/tests/tst_weather_forecast.qml
+++ b/dots/.config/quickshell/imi/tests/tst_weather_forecast.qml
@@ -154,9 +154,26 @@ TestCase {
     // A bare "YYYY-MM-DD" parses as UTC midnight, which is the previous evening
     // west of UTC - so the card would be named for the wrong weekday.
     function test_shortDayNameIsTheDatesOwnWeekday() {
-        compare(WeatherForecast.shortDayName("2026-08-04"),
-                new Date(2026, 7, 4, 12, 0, 0).toLocaleDateString(undefined, { weekday: "short" }));
-        compare(WeatherForecast.shortDayName(""), "");
-        compare(WeatherForecast.shortDayName("not-a-date"), "");
+        compare(WeatherForecast.shortDayName("", Qt.locale()), "");
+        compare(WeatherForecast.shortDayName("not-a-date", Qt.locale()), "");
+
+        // This used to compare the function against the very expression the
+        // function ran, so it asserted that it agreed with itself - and stayed
+        // green while every card read "8/14/26". Exactly the ambient coverage
+        // the localIsoDate pin was added for, one function later.
+        //
+        // Checked by SHAPE instead, which holds in any locale where an
+        // expected string would not: a weekday name carries no digits, three
+        // consecutive days are three different names, and seven days on is the
+        // same name again. A short DATE format fails the first of those.
+        const monday = WeatherForecast.shortDayName("2026-08-03", Qt.locale());
+        const tuesday = WeatherForecast.shortDayName("2026-08-04", Qt.locale());
+        const wednesday = WeatherForecast.shortDayName("2026-08-05", Qt.locale());
+        verify(monday.length > 0, "a real date gets a name");
+        verify(!/[0-9]/.test(tuesday), `a weekday name has no digits: "${tuesday}"`);
+        verify(monday !== tuesday && tuesday !== wednesday && monday !== wednesday,
+               "consecutive days are different weekdays");
+        compare(WeatherForecast.shortDayName("2026-08-11", Qt.locale()), tuesday,
+                "a week later is the same weekday");
     }
 }

--- a/dots/.config/quickshell/imi/tests/tst_weather_geometry.qml
+++ b/dots/.config/quickshell/imi/tests/tst_weather_geometry.qml
@@ -3,9 +3,20 @@ import "../modules/common/plugins/designsystem/widgets/weather_geometry.js" as G
 import "../modules/common/plugins/designsystem/widgets/weather_shapes.js" as WeatherShapes
 
 // The weather widget's shared-element geometry and the glyph container's
-// shape space. Spans at scale 1: 1x1 = 132x108, 2x1 = 276x108, 3x1 = 420x108.
+// shape space. Spans at scale 1: 1x1 = 132x108, 2x1 = 276x108, 3x1 = 420x108,
+// 3x2 = 420x228.
 TestCase {
     name: "WeatherGeometryTest"
+
+    // Every span the widget offers, with the box the host gives it. Driving
+    // the shared-element checks off this rather than off three literals is
+    // what makes adding a span fail the tests that should notice it.
+    readonly property var spans: [
+        { name: "1x1", width: 132, height: 108 },
+        { name: "2x1", width: 276, height: 108 },
+        { name: "3x1", width: 420, height: 108 },
+        { name: "3x2", width: 420, height: 228 }
+    ]
 
     function test_the_glyph_exists_at_every_span_with_its_own_shape() {
         const g3 = Geometry.glyphRect("3x1", 420, 108, 1);
@@ -17,6 +28,150 @@ TestCase {
         verify(g3.width === 72 && g3.height === 72, "floating square at 3x1");
         verify(g2.height === 108, "flush full-height panel at 2x1");
         compare(g1.rotation, -22, "the slanted leaf");
+    }
+
+    // ---- 3x2: the second row --------------------------------------------
+
+    function test_the_shared_three_have_a_rect_at_every_span() {
+        // The architecture's first rule: a shared element never has a null
+        // rect, because null is a fade and these three never fade.
+        for (const span of spans) {
+            verify(Geometry.temperatureRect(span.name, span.width, span.height, 1) !== null,
+                   "temperature at " + span.name);
+            verify(Geometry.conditionRect(span.name, span.width, span.height, 1) !== null,
+                   "condition at " + span.name);
+            verify(Geometry.glyphRect(span.name, span.width, span.height, 1) !== null,
+                   "glyph at " + span.name);
+        }
+    }
+
+    function test_the_shared_three_travel_into_the_taller_card() {
+        // 3x1 -> 3x2 is the transition a user reaches by pulling the grip
+        // down. Every shared element must have somewhere new to go: an
+        // element whose rect is identical across the pair reads as a card
+        // growing around frozen content.
+        const t1 = Geometry.temperatureRect("3x1", 420, 108, 1);
+        const t2 = Geometry.temperatureRect("3x2", 420, 228, 1);
+        verify(t2.y > t1.y, "the temperature drops into the taller band");
+        verify(t2.size > t1.size, "and grows with the room");
+
+        const c1 = Geometry.conditionRect("3x1", 420, 108, 1);
+        const c2 = Geometry.conditionRect("3x2", 420, 228, 1);
+        compare(c2.x, c1.x, "the condition holds its column");
+        verify(c2.y > c1.y, "and drops with the temperature");
+
+        const g1 = Geometry.glyphRect("3x1", 420, 108, 1);
+        const g2 = Geometry.glyphRect("3x2", 420, 228, 1);
+        compare(g2.shape, "ghostish", "the same shape, so it travels rather than morphs");
+        verify(g2.width > g1.width, "the glyph grows");
+        verify(g2.icon > g1.icon, "and so does what it holds");
+    }
+
+    function test_the_glyph_stays_inside_the_top_band_at_3x2() {
+        // The forecast strip owns the bottom of the card; a glyph centred on
+        // the whole card would sit on top of it.
+        const glyph = Geometry.glyphRect("3x2", 420, 228, 1);
+        const strip = Geometry.forecastStripRect("3x2", 420, 228, 1);
+        verify(glyph.y + glyph.height <= strip.y, "the glyph clears the strip");
+        verify(glyph.x + glyph.width <= 420, "and stays on the card");
+    }
+
+    function test_the_forecast_strip_has_exactly_one_home() {
+        // Null everywhere else, and null is a fade: the strip has nothing to
+        // travel to at a span with no room for it.
+        compare(Geometry.forecastStripRect("1x1", 132, 108, 1), null);
+        compare(Geometry.forecastStripRect("2x1", 276, 108, 1), null);
+        compare(Geometry.forecastStripRect("3x1", 420, 108, 1), null);
+        verify(Geometry.forecastStripRect("3x2", 420, 228, 1) !== null);
+        compare(Geometry.bandDividerRect("3x1", 420, 108, 1), null);
+        verify(Geometry.bandDividerRect("3x2", 420, 228, 1) !== null);
+    }
+
+    function test_the_strip_sits_inside_the_card_with_even_margins() {
+        const strip = Geometry.forecastStripRect("3x2", 420, 228, 1);
+        compare(strip.x, 20, "left margin");
+        compare(420 - (strip.x + strip.width), 20, "and the same on the right");
+        verify(strip.y + strip.height < 228, "clear of the bottom edge");
+        const divider = Geometry.bandDividerRect("3x2", 420, 228, 1);
+        verify(divider.y < strip.y, "the divider sits above the strip");
+        compare(divider.x, strip.x, "and shares its margins");
+        compare(divider.width, strip.width);
+    }
+
+    function test_the_day_cards_fill_the_strip_at_any_count() {
+        // wttr.in answers with three days and OpenWeatherMap with four, and
+        // #111 deliberately pads to neither - so the row is laid out from the
+        // count it is handed. A layout that assumed one of them would leave a
+        // hole on the other provider.
+        const strip = Geometry.forecastStripRect("3x2", 420, 228, 1);
+        for (const count of [1, 2, 3, 4]) {
+            const first = Geometry.forecastCardRect(0, count, strip.width, strip.height, 1);
+            const last = Geometry.forecastCardRect(count - 1, count, strip.width, strip.height, 1);
+            compare(first.x, 0, count + " days start flush left");
+            fuzzyCompare(last.x + last.width, strip.width, 0.001,
+                         count + " days end flush right");
+            compare(first.width, last.width, count + " days are equal width");
+            compare(first.height, strip.height, "a card is the strip's full height");
+        }
+    }
+
+    function test_the_day_cards_never_overlap() {
+        const strip = Geometry.forecastStripRect("3x2", 420, 228, 1);
+        for (const count of [2, 3, 4]) {
+            for (let i = 1; i < count; i++) {
+                const previous = Geometry.forecastCardRect(i - 1, count, strip.width, strip.height, 1);
+                const current = Geometry.forecastCardRect(i, count, strip.width, strip.height, 1);
+                verify(current.x >= previous.x + previous.width,
+                       count + " days: card " + i + " clears its neighbour");
+            }
+        }
+    }
+
+    function test_an_out_of_range_or_empty_day_card_is_null() {
+        // An empty forecast is a real state - OpenWeatherMap fetches it in a
+        // separate request that can fail on its own - and it must not divide
+        // by zero on the way to being hidden.
+        compare(Geometry.forecastCardRect(0, 0, 380, 68, 1), null);
+        compare(Geometry.forecastCardRect(-1, 3, 380, 68, 1), null);
+        compare(Geometry.forecastCardRect(3, 3, 380, 68, 1), null);
+    }
+
+    function test_the_high_low_line_moves_down_with_the_temperature() {
+        // It is the 3x2 fallback for an absent forecast, so it has a rect
+        // there as well as at 3x1 - and it has to follow the bigger number it
+        // sits under rather than staying where the 3x1 put it.
+        const at3x1 = Geometry.highLowRect("3x1", 420, 108, 1);
+        const at3x2 = Geometry.highLowRect("3x2", 420, 228, 1);
+        verify(at3x2.y > at3x1.y);
+        compare(Geometry.highLowRect("2x1", 276, 108, 1), null);
+    }
+
+    function test_the_pills_and_the_column_divider_follow_the_band() {
+        const pills1 = Geometry.pillsRect("3x1", 420, 108, 1);
+        const pills2 = Geometry.pillsRect("3x2", 420, 228, 1);
+        compare(pills2.x, pills1.x, "the pills hold the condition's column");
+        verify(pills2.y > pills1.y, "and drop with it");
+        compare(Geometry.pillsRect("1x1", 132, 108, 1), null);
+
+        const rule1 = Geometry.columnDividerRect("3x1", 420, 108, 1);
+        const rule2 = Geometry.columnDividerRect("3x2", 420, 228, 1);
+        compare(rule2.x, rule1.x, "the divider holds the column boundary");
+        verify(rule2.height > rule1.height, "and grows into the taller band");
+        verify(rule2.y + rule2.height
+               <= Geometry.bandDividerRect("3x2", 420, 228, 1).y,
+               "without crossing into the forecast band");
+    }
+
+    function test_scale_multiplies_the_second_row_too() {
+        const at1 = Geometry.forecastStripRect("3x2", 420, 228, 1);
+        const at2 = Geometry.forecastStripRect("3x2", 840, 456, 2);
+        compare(at2.x, at1.x * 2);
+        compare(at2.y, at1.y * 2);
+        compare(at2.height, at1.height * 2);
+        const card1 = Geometry.forecastCardRect(1, 3, at1.width, at1.height, 1);
+        const card2 = Geometry.forecastCardRect(1, 3, at2.width, at2.height, 2);
+        compare(card2.x, card1.x * 2);
+        compare(card2.width, card1.width * 2);
     }
 
     function test_the_leaf_hangs_off_the_card_corner() {

--- a/dots/.config/quickshell/imi/tests/tst_weather_glyphs.qml
+++ b/dots/.config/quickshell/imi/tests/tst_weather_glyphs.qml
@@ -1,0 +1,71 @@
+import QtTest
+import "../modules/common/plugins/designsystem/widgets/weather_glyphs.js" as Glyphs
+
+// The desktop weather card's google-weather asset lookup.
+//
+// The bug this exists for: a weather code means nothing without the provider
+// that reported it, and the card used to read wttr.in's World Weather Online
+// codes through an OpenWeatherMap-shaped range table.
+TestCase {
+    name: "WeatherGlyphsTest"
+
+    function test_the_owm_branch_is_unchanged() {
+        // Deliberately pinned rather than retuned. This is what the card draws
+        // today on the default provider; giving the other provider a table is
+        // a separate question from re-deciding this one.
+        compare(Glyphs.glyphFor("owm", 800, false), "clear_day");
+        compare(Glyphs.glyphFor("owm", 800, true), "clear_night");
+        compare(Glyphs.glyphFor("owm", 801, false), "partly_cloudy_day");
+        compare(Glyphs.glyphFor("owm", 211, false), "strong_thunderstorms");
+        compare(Glyphs.glyphFor("owm", 500, false), "heavy_rain");
+        compare(Glyphs.glyphFor("owm", 601, false), "heavy_snow");
+        compare(Glyphs.glyphFor("owm", 741, false), "haze_fog_dust_smoke");
+        compare(Glyphs.glyphFor("owm", 804, false), "cloudy");
+    }
+
+    function test_wttr_codes_no_longer_read_as_openweathermap_ids() {
+        // The two failures the split is for, and they are different shapes.
+        // 113 is Sunny and falls past every OWM range into the fallback; 296
+        // is Light rain and lands *inside* OWM's thunderstorm range, so it
+        // came back confidently wrong rather than merely blank.
+        compare(Glyphs.glyphFor("owm", 113, false), "cloudy", "the old reading of Sunny");
+        compare(Glyphs.glyphFor("wttr", 113, false), "clear_day");
+        compare(Glyphs.glyphFor("owm", 296, false), "strong_thunderstorms",
+                "the old reading of Light rain");
+        compare(Glyphs.glyphFor("wttr", 296, false), "showers_rain");
+    }
+
+    function test_wttr_conditions_map_to_their_own_class() {
+        const cases = [
+            [116, "partly_cloudy_day"], [122, "cloudy"], [143, "haze_fog_dust_smoke"],
+            [200, "isolated_scattered_thunderstorms_day"], [230, "blizzard"],
+            [266, "drizzle"], [308, "heavy_rain"], [320, "sleet_hail"],
+            [326, "flurries"], [338, "heavy_snow"], [389, "strong_thunderstorms"]
+        ];
+        for (const pair of cases)
+            compare(Glyphs.glyphFor("wttr", pair[0], false), pair[1], "WWO " + pair[0]);
+    }
+
+    function test_only_the_codes_with_two_assets_take_a_night_variant() {
+        compare(Glyphs.glyphFor("wttr", 116, true), "partly_cloudy_night");
+        compare(Glyphs.glyphFor("wttr", 353, true), "scattered_showers_night");
+        // Rain at night is drawn the same way as rain in the daytime; there is
+        // no `heavy_rain_night` asset and asking for one would render nothing.
+        compare(Glyphs.glyphFor("wttr", 308, true), "heavy_rain");
+        compare(Glyphs.glyphFor("wttr", 230, true), "blizzard");
+    }
+
+    function test_an_unknown_code_degrades_the_same_way_on_both_providers() {
+        compare(Glyphs.glyphFor("wttr", 9999, false), "cloudy");
+        compare(Glyphs.glyphFor("owm", 9999, false), "cloudy");
+        compare(Glyphs.glyphFor("wttr", 0, false), "cloudy");
+    }
+
+    function test_a_code_arriving_as_a_string_still_resolves() {
+        // `wCode` is Number()-ed by the service, but a card reading it out of
+        // a forecast entry is one refactor away from a string, and a table
+        // keyed on numbers would silently miss every one of them.
+        compare(Glyphs.glyphFor("wttr", "113", false), "clear_day");
+        compare(Glyphs.glyphFor("owm", "800", false), "clear_day");
+    }
+}


### PR DESCRIPTION
Adds a **3x2 span** to the desktop weather widget, whose second row is the day-by-day forecast from `Weather.forecast`.

## Read this first: the base branch is not #111's branch

I was asked to stack on `claude/immaterial-impulse-six-issues-qqfuq2-weather-forecast`. I could not, and the reason matters:

**#111 branched at `a0a985b18` (0.14.9) and main is 400 commits ahead of that point.** The weather widget was rebuilt as a one-tree morphing widget in the meantime (`14e56cbed`, `7962ee6fd`, `85ebb76e8`, …). On #111's head, `DesktopWeatherWidget.qml` is still the old `Loader`-over-three-`Component`s file, and `weather_geometry.js`, `weather_shapes.js`, `tst_weather_geometry.qml` and `WeatherTreeMotionProbe.qml` **do not exist**. There is no way to build this feature there.

So this branch is `main` + #111's three commits **rebased onto main** + my seven. The rebase was clean and `git range-diff` reports all three patch-identical (`=`), so nothing of #111's content changed. `claude/weather-forecast-service-rebased` is that rebase, pushed as the base branch so this PR's diff is only my work.

**#111's own branch is untouched.** Rebasing it in place would have made this a true stacked PR that GitHub retargets automatically, but that is a force-push to an open PR I do not own, so I left it alone. To land: rebase #111 onto main (or merge it), then retarget this PR to `main` and delete `claude/weather-forecast-service-rebased`.

### Which of #111's commits this actually needs

| #111 commit | needed here? |
|---|---|
| `fix(weather): resolve icons against the provider that reported the code` | **yes** — establishes that `wCode` is provider-relative, which this card now honours too |
| `feat(weather): publish a day-by-day forecast from both providers` | **yes** — `Weather.forecast` and `weatherForecast.js` are the whole data source |
| `feat(weather): show the forecast as a row of day cards in the bar popup` | **no** — nothing here reads the popup row, and this card stands on its own if it is dropped |

Only caveat: my weekday fix below edits a line that commit 3 introduced, so dropping commit 3 needs that hunk dropped with it.

## The layout, and why

3x2 is 420x228 and is the only span with two rows. It is split into two bands against one `TOP_BAND` seam in `weather_geometry.js`:

- **Top band** — the 3x1 arrangement given the room it now has. Temperature 48→56px, condition and pills follow it down the second column, column rule grows, Ghostish glyph 72→84px centred on *the band* rather than on the card.
- **Bottom band** — a hairline, then a row of day cards.

**Everything in the top band travels.** Nothing is redrawn at the new span, and the glyph deliberately keeps its Ghostish at both wide spans — so 3x1↔3x2 is pure geometry travel with no shape morph, which makes it the pair that proves the geometry half moves on its own.

**Day cards are plain tonal rounded rectangles**, carrying the pills' own tint, not `MaterialShape`s. They are the same kind of object as the pills one band up — a small container holding one reading — and the card already has exactly one morphing outline in the glyph. Four more under it is four outlines competing for the eye during a resize, plus four `Canvas` geometry builds per span change for a shape nobody reads at 87px.

**The row is laid out from the count it is handed.** wttr.in answers with three days, OpenWeatherMap with four, and a failed forecast request with none — #111 deliberately padded to no fixed count, so the cards divide whatever the strip has and every count fills the row rather than leaving a hole at the right.

**The high/low line becomes the 3x2 fallback.** Today's card carries that same range and says it better, so the line goes when the strip arrives — but OWM fetches the forecast in a second request that can fail while current conditions arrive fine, and a taller card answering that by silently dropping the high and low would tell the user *less* than the shorter one does.

**The strip unloads as well as fades**, which the other fades in this tree do not: each card holds a `CustomIcon`, so an invisible-but-alive strip is four SVG loads kept warm for three spans that never show them. The unload waits for the fade to land rather than following the span — removing a delegate destroys it in the same frame, and an exit transition is impossible after that.

## Two bugs found on the way

**1. `shortDayName` returned `"8/14/26"`, not `"Fri"`** — on every card that is not today, in the engine this code actually runs in. QtQml replaces `Date.prototype.toLocaleDateString` with a `(locale, format)` overload; handed ECMAScript's `{ weekday: "short" }` it does not recognise the object and falls through to the locale's short *date* format. No warning, no exception, nothing in the log.

Its test could not have caught it: it compared the function against **the same expression the function ran**, so it asserted only that the function agreed with itself. That is the ambient-coverage failure #111's own `localIsoDate` pin was written for, three functions down the same file, with the tautology in the assertion rather than in the environment. The replacement checks the *shape* of the answer, which holds in any locale where an expected string would not.

This is #111's code, and my brief said to report rather than silently fix. It is fixed here rather than reported because it is one line, it lands in its own clearly-titled commit, and the alternative was shipping a forecast row that prints dates where it means weekdays. **It repairs #111's bar popup too.**

**2. The desktop card read both providers' codes through one OWM-shaped range table.** `wCode` is an OpenWeatherMap id on `owm` and a World Weather Online code on `wttr`. The failure has two shapes and only one is loud: WWO 113 is *Sunny* and falls past every OWM range into the "cloudy" fallback, while WWO 296 is *Light rain* and lands **inside** OWM's 2xx thunderstorm range and came back confidently as a storm. #111 fixed this class of bug for the bar and deliberately left the card alone because the card renders `CustomIcon`s from the google-weather asset set — a different vocabulary, so sharing is a port not a rename. `weather_glyphs.js` is that port. **The OWM branch is the card's existing expression moved, not retuned.**

## Verification

- **Suite: 656 passed, 0 failed** (baseline on this base was 637). `DesignSystemCompile` 159 checked, 0 failures.
- **Geometry**: `tst_weather_geometry.qml` grows from 8 tests to 21. **Five mutations planted and each confirmed failing** — cards ignoring the count, glyph centred on the card instead of the band, the strip claiming a home at 3x1, the temperature not travelling into 3x2, and the empty-forecast guard removed.
- **Glyphs**: `tst_weather_glyphs.qml` pins the OWM branch unchanged, both shapes of the wttr bug by name, night variants only where two assets exist, and the string-code path. A Python check reads the tables out of the source and asserts **every asset name they can produce has an SVG** — a `CustomIcon` handed a missing name draws nothing, silently — and refuses to pass if the regex stopped finding the tables.
- **Probe**: `run_weather_probe.sh` goes from 6 ordered span pairs to 12, with 3x2 against all three one-row spans in both directions. **Every shared element animates into and out of 3x2** — 31-32 signal steps each on `temp.y`, `temp.size`, `cond.y`, `glyph.x`, `glyph.w`, `pills.y`, `rule.h`, `strip.opacity`. 117 checks, 0 failures.

  The sweep also **grew trails because it would have passed on a snap**: `temp.x` and `cond.x` were all it watched on those two elements, and both hold their x between 3x1 and 3x2, so it reported them "static" through the one pair that moves them.

  A second phase drives the day count at 4, 3, 1 and 0 — checking the cards fill the strip at each, that none is held warm at zero, and that the high/low line comes back. Shots advance on their own timer because `grabToImage` renders a later frame: seeding the next count in the same handler filed every PNG under the previous count's name, which is how I first "saw" a missing fourth card that was never missing.

## What I could not verify, and what to look at on screen

- **Nothing was rendered against real forecast data** — no network in this sandbox. The probe seeds `Weather.data` and `Weather.forecast` directly (both are plain writable properties with no binding, so the widget is still the real widget reading the real service). Every number in the screenshots is a fixture.
- **No live shell.** Per instruction I did not deploy or restart anything. The 3x2 card has never been on a real desktop, and per AGENT.md that is exactly the class of change that stays green while failing to load — though `DesignSystemCompile` does compile this widget.
- **Worth looking at:** the empty-forecast state at 3x2 leaves the whole bottom band blank. The high/low line returns so no information is lost against 3x1, but it is a visible void. I did not add a "no forecast" message because `Weather.forecast` is `[]` both *before the first fetch* and *after a failure*, and there is no state on the service to tell them apart — adding one means changing #111's service, which I was told not to do. Say the word if you want it distinguished.
- **Worth looking at:** the strip is revealed by the card's own growing clip during a 3x1→3x2 resize, which reads well in the mid-transition capture but is a motion best judged live.
- **"Today" is a plain English literal**, matching the "Feels like" / "High" / "Low" already on this card — nothing in the vendored design system reaches for the translation singleton, and one word did not seem the place to start. Reverse it if you would rather it be translated.
- The forecast fetch **doubles OWM's call rate**, as #111 already flagged; this PR does not change that.

Docs: updated AGENT.md §Dynamic/data-driven QML gotchas — the QtQml `Date` locale overload that answers an options object with the short date format, and the tautological test that passed on it; docs/widget-grid.md — weather now offers 1x1 / 2x1 / 3x1 / 3x2 in both places that list spans.
