### PR TITLE
Weather: provider-aware icons, and a forecast from both providers

### DIFF
--- a/dots/.config/quickshell/imi/modules/common/Icons.qml
+++ b/dots/.config/quickshell/imi/modules/common/Icons.qml
@@ -95,4 +95,36 @@ Singleton {
         }
         return isNight() ? "clear_night" : "clear_day";
     }
+
+    // OpenWeatherMap reports its own condition ids, not the WWO codes
+    // weatherIconMap is keyed on, so an OWM id looked up there matches nothing
+    // and falls through to "clear" for every condition there is. The groups
+    // below are OWM's documented ranges; 800 is the only exact id it defines,
+    // and 801-804 are increasing cloud cover.
+    function getOwmWeatherIcon(code, night): string {
+        const id = Number(code);
+        if (id === 800) return night ? "clear_night" : "clear_day";
+        if (id === 801 || id === 802) return night ? "partly_cloudy_night" : "partly_cloudy_day";
+        if (id > 802 && id < 900) return "cloud";
+        if (id >= 200 && id < 300) return "thunderstorm";
+        if (id >= 300 && id < 400) return "rainy";
+        if (id >= 500 && id < 600) return "rainy";
+        if (id >= 600 && id < 700) return "snowing";
+        if (id >= 700 && id < 800) return "foggy";
+        return night ? "clear_night" : "clear_day";
+    }
+
+    // Which of the two schemes a code is in depends on which provider fetched
+    // it, and nothing in the code itself says - the ranges overlap. Callers that
+    // know their provider should come through here rather than guess.
+    function getProviderWeatherIcon(provider, code, night): string {
+        if (provider === "owm")
+            return getOwmWeatherIcon(code, night);
+        const key = String(code);
+        if (weatherIconMap.hasOwnProperty(key)) {
+            const icons = weatherIconMap[key];
+            return night ? icons.night : icons.day;
+        }
+        return night ? "clear_night" : "clear_day";
+    }
 }

--- a/dots/.config/quickshell/imi/modules/common/functions/weatherForecast.js
+++ b/dots/.config/quickshell/imi/modules/common/functions/weatherForecast.js
@@ -1,0 +1,120 @@
+.pragma library
+
+// Neither weather provider describes a forecast as days, so turning one into a
+// row of day cards is arithmetic over a flat list rather than a field lookup.
+//
+// wttr.in's `?format=j1` response already carries three days in `weather[]`,
+// each with its own min/max and eight three-hourly entries - the forecast comes
+// free with the request the service already makes. OpenWeatherMap splits it:
+// /data/2.5/weather is current conditions only, and /data/2.5/forecast is a
+// flat list of three-hourly entries that has to be grouped into days here.
+//
+// Both shapes collapse to the same `{ date, wCode, high, low }`, with `date` as
+// a local "YYYY-MM-DD" so the caller can label it and temperatures already in
+// whichever unit system was asked for.
+
+// Four fits the popup's width at both providers' resolutions. wttr.in only ever
+// returns three days, so that is what it shows; OWM's five-day list is cut here.
+const MAX_DAYS = 4;
+
+// The hour a day's icon is taken from. Not the first entry of the day: a
+// forecast keyed off the 00:00 observation reads as clear-and-cold for a day
+// that is in fact raining from lunchtime on, which is the opposite of what the
+// row is for.
+const ICON_HOUR = 12;
+
+// Local calendar date as "YYYY-MM-DD".
+//
+// Deliberately not `toISOString().slice(0, 10)`, which is UTC: anywhere east or
+// west of it that flips "today" hours early or late, and the row would put
+// today's label on tomorrow's card for part of every day.
+function localIsoDate(date) {
+    const pad = (value) => (value < 10 ? "0" + value : String(value));
+    return date.getFullYear() + "-" + pad(date.getMonth() + 1) + "-" + pad(date.getDate());
+}
+
+function isToday(isoDate, todayIsoDate) {
+    return !!isoDate && isoDate === todayIsoDate;
+}
+
+// Short weekday name for a "YYYY-MM-DD" date, or "" if it is not one.
+//
+// Parsed at midday rather than at midnight: a bare "YYYY-MM-DD" is read as UTC
+// midnight, which is the previous day's evening for anyone west of UTC, and the
+// card would name the wrong weekday.
+function shortDayName(isoDate) {
+    if (!isoDate)
+        return "";
+    const parsed = new Date(isoDate + "T12:00:00");
+    if (isNaN(parsed.getTime()))
+        return "";
+    return parsed.toLocaleDateString(undefined, { weekday: "short" });
+}
+
+// OpenWeatherMap's /data/2.5/forecast `list`, grouped into days.
+//
+// Temperatures are already in the unit system the request asked for. Each entry
+// carries a `temp_min`/`temp_max` for its own three-hour window, so a day's
+// range is the extremes across all of its entries - reading either off a single
+// entry gives that window's range and calls it the day's.
+function dailyFromOwm(list) {
+    const byDate = {};
+    (list || []).forEach(entry => {
+        const stamp = entry && entry.dt_txt;
+        if (typeof stamp !== "string" || stamp.length < 13)
+            return;
+        const date = stamp.slice(0, 10);
+        if (!byDate[date])
+            byDate[date] = { date: date, wCode: 0, high: null, low: null, iconDistance: Infinity };
+        const day = byDate[date];
+
+        const high = Number(entry && entry.main && entry.main.temp_max);
+        const low = Number(entry && entry.main && entry.main.temp_min);
+        if (isFinite(high))
+            day.high = (day.high === null) ? high : Math.max(day.high, high);
+        if (isFinite(low))
+            day.low = (day.low === null) ? low : Math.min(day.low, low);
+
+        const distance = Math.abs(Number(stamp.slice(11, 13)) - ICON_HOUR);
+        if (isFinite(distance) && distance < day.iconDistance) {
+            day.iconDistance = distance;
+            day.wCode = Number(entry && entry.weather && entry.weather[0] && entry.weather[0].id) || 0;
+        }
+    });
+    return Object.keys(byDate).sort().slice(0, MAX_DAYS).map(date => _round(byDate[date]));
+}
+
+// wttr.in's `weather[]`, which is already one element per day.
+//
+// The min/max come ready-made; only the icon has to be chosen, from `hourly[]`
+// whose `time` is an hhmm string without a separator ("0", "300" ... "2100").
+// wttr already speaks the WWO codes Icons.weatherIconMap keys on, so the code
+// passes straight through.
+function dailyFromWttr(weather, useUSCS) {
+    return (weather || []).slice(0, MAX_DAYS).map(day => {
+        const entry = { date: (day && day.date) || "", wCode: 0, high: null, low: null };
+        let iconDistance = Infinity;
+        ((day && day.hourly) || []).forEach(hour => {
+            const distance = Math.abs(Math.floor(Number((hour && hour.time) || 0) / 100) - ICON_HOUR);
+            if (isFinite(distance) && distance < iconDistance) {
+                iconDistance = distance;
+                entry.wCode = Number(hour && hour.weatherCode) || 0;
+            }
+        });
+        const high = Number(useUSCS ? (day && day.maxtempF) : (day && day.maxtempC));
+        const low = Number(useUSCS ? (day && day.mintempF) : (day && day.mintempC));
+        entry.high = isFinite(high) ? high : null;
+        entry.low = isFinite(low) ? low : null;
+        return _round(entry);
+    });
+}
+
+// A card shows whole degrees. `null` stays null - an absent reading is not 0°.
+function _round(day) {
+    return {
+        date: day.date,
+        wCode: day.wCode,
+        high: day.high === null ? null : Math.round(day.high),
+        low: day.low === null ? null : Math.round(day.low)
+    };
+}

--- a/dots/.config/quickshell/imi/modules/imi/bar/WeatherPopup.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/WeatherPopup.qml
@@ -8,6 +8,7 @@ import qs.modules.imi.bar
 StyledPopup {
     id: root
 
+
     ColumnLayout {
         id: mainLayout
         implicitWidth: 340 
@@ -75,7 +76,10 @@ StyledPopup {
                     anchors.top: parent.top
                     anchors.topMargin: -Appearance.spacing.space50
                     shape: MaterialShape.Shape.Sunny
-                    text: Icons.getWeatherIcon(Weather.data.wCode) ?? "cloud"
+                    // Provider-aware: OpenWeatherMap's condition ids are not the
+                    // WWO codes getWeatherIcon() is keyed on, so this drew a
+                    // clear sky through every storm for anyone on that provider.
+                    text: Icons.getProviderWeatherIcon(Weather.provider, Weather.data.wCode, Icons.isNight()) ?? "cloud"
                     iconSize: 40
                     implicitSize: 64
                     color: Qt.alpha(Appearance.colors.colOnLayer0, 0.15)
@@ -123,6 +127,7 @@ StyledPopup {
                 }
             }
         }
+
 
         GridLayout {
             id: gridLayout

--- a/dots/.config/quickshell/imi/services/Weather.qml
+++ b/dots/.config/quickshell/imi/services/Weather.qml
@@ -7,6 +7,7 @@ import QtQuick
 import QtPositioning
 
 import qs.modules.common
+import "../modules/common/functions/weatherForecast.js" as WeatherForecast
 
 Singleton {
     id: root
@@ -53,6 +54,14 @@ Singleton {
         tempLow: "",
         lastRefresh: ""
     })
+
+    // Day-by-day outlook, `[{ date, wCode, high, low }]` with `date` a local
+    // "YYYY-MM-DD" and the temperatures whole degrees in the configured unit
+    // system. Empty until a forecast has been parsed, which consumers must
+    // treat as "no forecast" rather than "no weather" - wttr.in carries one in
+    // the response the current conditions already come from, but OWM needs a
+    // second request that can fail on its own.
+    property var forecast: []
 
     function refineData(data) {
         let temp = {}
@@ -151,6 +160,9 @@ Singleton {
         temp.lastRefresh = DateTime.time + " • " + DateTime.date
 
         root.data = temp
+        // Already in the response the current conditions came from - wttr.in
+        // returns three days of it whether or not anything asks.
+        root.forecast = WeatherForecast.dailyFromWttr(data?.weather, root.useUSCS)
     }
 
     function getData() {
@@ -188,6 +200,37 @@ Singleton {
         // hole. curl receives the URL literally here, no shell parsing.
         fetcher.command = ["curl", "-s", url]
         fetcher.running = true
+
+        root.getForecastOwm()
+    }
+
+    // OpenWeatherMap's current-conditions endpoint carries no outlook at all,
+    // so the forecast is a second request against /data/2.5/forecast (free
+    // tier, five days at three-hour resolution). It doubles this provider's
+    // call rate - once per fetchInterval, so ~288/day at the 10 minute default
+    // against a 1M/month allowance. wttr.in needs no equivalent; its one
+    // response already carries both.
+    function getForecastOwm() {
+        let apiKey = root.apiKey !== "" ? root.apiKey : root.owmFallbackApiKey
+        if (apiKey === "")
+            return
+
+        let url = "https://api.openweathermap.org/data/2.5/forecast?"
+
+        if (root.gpsActive && root.location.valid) {
+            url += `lat=${root.location.lat}&lon=${root.location.lon}`
+        } else {
+            url += `q=${formatCityName(root.city)}`
+        }
+
+        url += `&units=${root.useUSCS ? "imperial" : "metric"}`
+        url += `&appid=${apiKey}`
+
+        // Same hardening as every other call here: the location comes from
+        // config (and shareable presets), so the URL is only ever a curl argv
+        // element and is never spliced into a shell string.
+        forecastFetcher.command = ["curl", "-s", url]
+        forecastFetcher.running = true
     }
 
     function getDataWttr() {
@@ -244,6 +287,31 @@ Singleton {
                     root.refineData(parsedData)
                 } catch (e) {
                     console.error("[WeatherService] JSON parse error:", e.message)
+                }
+            }
+        }
+    }
+
+    Process {
+        id: forecastFetcher
+        command: ["curl", "-s", ""]
+        stdout: StdioCollector {
+            onStreamFinished: {
+                if (text.length === 0)
+                    return
+
+                try {
+                    const parsedData = JSON.parse(text)
+                    // OWM reports its errors in the body with HTTP 200, and
+                    // `cod` is a string on this endpoint where it is a number
+                    // on the current-conditions one.
+                    if (parsedData.cod && Number(parsedData.cod) !== 200) {
+                        console.error("[WeatherService] Forecast API error:", parsedData.message)
+                        return
+                    }
+                    root.forecast = WeatherForecast.dailyFromOwm(parsedData.list)
+                } catch (e) {
+                    console.error("[WeatherService] Forecast JSON parse error:", e.message)
                 }
             }
         }

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -714,6 +714,15 @@ if ! python3 "$SCRIPT_DIR/test_lyrics_widget_contract.py"; then
     exit 1
 fi
 
+# Re-runs tst_weather_forecast.qml under a far-east and a far-west timezone.
+# On a UTC runner - which is CI - a local date and a UTC one are the same
+# string, so the unit test cannot tell them apart on its own.
+echo "Running weather forecast contract tests..."
+if ! python3 "$SCRIPT_DIR/test_weather_forecast_contract.py"; then
+    echo "Weather forecast contract tests failed."
+    exit 1
+fi
+
 echo "Running currency service safety tests..."
 if ! python3 "$SCRIPT_DIR/test_currency_service_contract.py"; then
     echo "Currency service safety tests failed."

--- a/dots/.config/quickshell/imi/tests/test_weather_forecast_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_weather_forecast_contract.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Weather forecast pins: the wiring the unit tests cannot see.
+
+`tst_weather_forecast.qml` proves the day-grouping arithmetic and
+`tst_weather_icons.qml` proves the provider-aware icon lookup, both against the
+real sources. Neither can see the service that has to call them or the second
+OpenWeatherMap request the forecast depends on, and each of those can break on
+its own without failing a single unit test.
+
+The URL pins are the load-bearing ones. `city` comes from config and from
+shareable presets, and the existing calls carry a comment recording that they
+were once spliced into a double-quoted `curl -s "${url}"` where `$()` and
+backticks still expand. A new request built the old way would reopen that hole
+in a file whose other three calls look correct.
+"""
+import os
+import re
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+TESTS = ROOT / "tests"
+FORECAST_QML_TEST = TESTS / "tst_weather_forecast.qml"
+SERVICE = ROOT / "services/Weather.qml"
+ICONS = ROOT / "modules/common/Icons.qml"
+FORECAST_JS = ROOT / "modules/common/functions/weatherForecast.js"
+
+
+def _function_body(source, name):
+    """The body of a top-level `function <name>()`, by its closing indent.
+
+    Not brace counting: these bodies contain template literals whose `${...}`
+    braces defeat a naive count, which is how the first version of this pin
+    matched nothing at all.
+    """
+    match = re.search(r"function " + re.escape(name) + r"\(.*?\n    \}", source, re.S)
+    return match.group(0) if match else None
+
+
+def _without_comments(source):
+    """Prose about a singleton is not a use of one."""
+    return re.sub(r"//[^\n]*", "", source)
+
+
+# Same search order as run_tests.sh, which is the only thing that guarantees
+# this binary exists at all.
+_RUNNER_CANDIDATES = (
+    "/usr/lib/qt6/bin/qmltestrunner",
+    "/usr/lib64/qt6/bin/qmltestrunner",
+    "/usr/lib/x86_64-linux-gnu/qt6/bin/qmltestrunner",
+    "qmltestrunner-qt6",
+    "qmltestrunner6",
+    "qmltestrunner",
+)
+
+
+def _qmltestrunner():
+    for candidate in _RUNNER_CANDIDATES:
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            return candidate
+        found = shutil.which(candidate)
+        if found:
+            return found
+    return None
+
+
+class WeatherServiceForecastTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.service = SERVICE.read_text(encoding="utf-8")
+
+    def test_the_service_exposes_a_forecast(self):
+        self.assertRegex(self.service, r"property\s+var\s+forecast\s*:",
+                         "Weather no longer publishes a forecast for widgets to read.")
+
+    def test_both_providers_populate_it(self):
+        """wttr.in gets it free; OWM needs a request of its own.
+
+        A provider that never fills the property leaves that half of the users
+        with a permanently empty row and nothing in the log.
+        """
+        self.assertIn("dailyFromWttr", self.service,
+                      "the wttr.in response already carries three days of "
+                      "forecast; not reading them wastes a request already made.")
+        self.assertIn("dailyFromOwm", self.service,
+                      "OpenWeatherMap's current-conditions endpoint has no "
+                      "outlook, so /data/2.5/forecast has to be parsed.")
+
+    def test_the_owm_forecast_request_is_actually_issued(self):
+        """Parsing a response nothing asks for is a permanently empty row."""
+        self.assertIn("api.openweathermap.org/data/2.5/forecast", self.service)
+        body = _function_body(self.service, "getDataOwm")
+        self.assertIsNotNone(body, "getDataOwm should exist")
+        self.assertIn(
+            "getForecastOwm()", body,
+            "the forecast request must be issued alongside the current "
+            "conditions, or it only ever runs if something else calls it.")
+
+    def test_every_curl_call_passes_the_url_as_an_argv_element(self):
+        """The city reaches these URLs from config and from shared presets.
+
+        `curl -s "${url}"` through a shell still expands `$()` and backticks -
+        a command-injection hole this file was hardened against once already.
+        A new endpoint built the old way reopens it.
+        """
+        commands = re.findall(r"^\s*\w*\.?command\s*:?=\s*(.+)$", self.service, re.M)
+        self.assertTrue(commands, "expected the service to build curl commands")
+        for command in commands:
+            self.assertRegex(
+                command.strip(), r'^\["curl",\s*"-s",\s*[^"]*\]$|^\["curl",\s*"-s",\s*""\]$',
+                f"a curl command is not a plain argv list ({command.strip()!r}); "
+                "the URL must never be spliced into a shell string.")
+        self.assertNotRegex(
+            self.service, r'"\s*curl[^"]*\$\{',
+            "a URL is being interpolated into a shell command string.")
+
+    def test_the_forecast_endpoint_carries_the_key_and_the_unit_system(self):
+        """A forecast in the wrong unit system next to a correct current
+        temperature reads as the forecast being wrong, not the request."""
+        body = _function_body(self.service, "getForecastOwm")
+        self.assertIsNotNone(body, "getForecastOwm should exist")
+        self.assertIn("appid=", body, "the forecast endpoint needs the API key too")
+        self.assertIn("units=", body, "the forecast must be fetched in the "
+                                      "configured unit system")
+        self.assertIn("useUSCS", body)
+
+
+class WeatherIconLookupTests(unittest.TestCase):
+    def test_the_provider_aware_lookup_exists_and_is_not_a_wrapper(self):
+        """It has to branch, or it is the WWO table with extra steps."""
+        icons = ICONS.read_text(encoding="utf-8")
+        self.assertIn("function getProviderWeatherIcon", icons)
+        self.assertIn("function getOwmWeatherIcon", icons)
+        body = _function_body(icons, "getProviderWeatherIcon")
+        self.assertIsNotNone(body)
+        self.assertIn("owm", body,
+                      "the provider-aware lookup does not branch on the provider.")
+
+    def test_the_forecast_library_stays_free_of_qml(self):
+        """`.pragma library` has no QML engine context - no `Qt`, no singletons.
+
+        Reaching for one throws at call time rather than at load time, so the
+        forecast would simply stop being populated, with a line in the log and
+        a widget that looks like the provider returned nothing.
+        """
+        source = FORECAST_JS.read_text(encoding="utf-8")
+        self.assertTrue(source.lstrip().startswith(".pragma library"))
+        code = _without_comments(source)
+        self.assertNotRegex(code, r"\bQt\.", "a library JS file cannot use `Qt`.")
+        for singleton in ("Appearance", "Config", "Translation", "Icons"):
+            self.assertNotIn(
+                singleton + ".", code,
+                f"weatherForecast.js reaches the {singleton} singleton, which a "
+                "`.pragma library` file has no engine context for.")
+
+
+class LocalDateAcrossTimezonesTests(unittest.TestCase):
+    """`localIsoDate` must be local, and only a non-UTC clock can prove it.
+
+    This exists because of a mutation that *survived*. Replacing the function's
+    body with `date.toISOString().slice(0, 10)` - the exact bug it is written to
+    avoid - left `tst_weather_forecast.qml` fully green, because CI and this
+    container both run on UTC, where the two are the same string for every
+    instant. The unit test was real but its coverage of this one function was
+    ambient, and would have shipped a pin that could never fire.
+
+    Re-running that same file under a far-east and a far-west zone is what makes
+    the difference observable: at UTC+14 a local early morning is still the
+    previous UTC day, and at UTC-11 a local late evening is already the next one.
+    Both are in the test's own fixtures.
+    """
+
+    ZONES = ("Pacific/Kiritimati", "Pacific/Niue")   # UTC+14 and UTC-11
+
+    def test_the_forecast_unit_test_passes_east_and_west_of_utc(self):
+        runner = _qmltestrunner()
+        self.assertIsNotNone(
+            runner,
+            "qmltestrunner was not found, so this check cannot run - and it must "
+            "not pass quietly. run_tests.sh needs the same binary.")
+        for zone in self.ZONES:
+            with self.subTest(timezone=zone):
+                if not Path("/usr/share/zoneinfo", zone).exists():
+                    self.fail(f"tzdata has no {zone}; this check needs a real "
+                              "non-UTC zone to mean anything.")
+                env = dict(os.environ, TZ=zone,
+                           QT_QPA_PLATFORM=os.environ.get("QT_QPA_PLATFORM", "offscreen"))
+                proc = subprocess.run(
+                    [runner,
+                     "-import", str(TESTS / "mocks"),
+                     "-import", str(TESTS / "imports"),
+                     "-input", str(FORECAST_QML_TEST)],
+                    env=env, capture_output=True, text=True)
+                self.assertEqual(
+                    proc.returncode, 0,
+                    f"tst_weather_forecast.qml fails under TZ={zone}, so a "
+                    "forecast card is labelled with the wrong day for part of "
+                    f"every day there.\n{proc.stdout}\n{proc.stderr}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dots/.config/quickshell/imi/tests/tst_weather_forecast.qml
+++ b/dots/.config/quickshell/imi/tests/tst_weather_forecast.qml
@@ -1,0 +1,162 @@
+import QtTest
+import "../modules/common/functions/weatherForecast.js" as WeatherForecast
+
+// Turning either provider's response into a row of day cards is arithmetic over
+// a flat list, and every way of getting it wrong produces a plausible-looking
+// row rather than an error: the wrong day's icon, one window's temperature
+// range presented as the day's, or today's label on tomorrow's card.
+TestCase {
+    name: "WeatherForecastTest"
+
+    function owmEntry(stamp, low, high, id) {
+        return { dt_txt: stamp, main: { temp_min: low, temp_max: high }, weather: [{ id: id }] };
+    }
+
+    // OWM's list is three-hourly, so a day is eight entries and its range is the
+    // extremes across all of them. Reading either off one entry reports that
+    // three-hour window's range as the whole day's.
+    function test_owmDayRangeSpansEveryEntryOfTheDay() {
+        const days = WeatherForecast.dailyFromOwm([
+            owmEntry("2026-08-04 00:00:00", 11, 14, 800),
+            owmEntry("2026-08-04 12:00:00", 18, 24, 500),
+            owmEntry("2026-08-04 21:00:00", 9, 16, 802)
+        ]);
+        compare(days.length, 1);
+        compare(days[0].date, "2026-08-04");
+        compare(days[0].high, 24, "the day's high is the highest of its entries");
+        compare(days[0].low, 9, "the day's low is the lowest of its entries");
+    }
+
+    // A row keyed off the 00:00 entry says clear-and-cold for a day that rains
+    // from lunchtime on, which is the opposite of what a forecast is for.
+    function test_owmIconComesFromNearestMidday() {
+        const days = WeatherForecast.dailyFromOwm([
+            owmEntry("2026-08-04 00:00:00", 11, 14, 800),
+            owmEntry("2026-08-04 09:00:00", 15, 19, 801),
+            owmEntry("2026-08-04 15:00:00", 18, 24, 500),
+            owmEntry("2026-08-04 21:00:00", 9, 16, 802)
+        ]);
+        compare(days[0].wCode, 801, "09:00 and 15:00 are both 3h out; the earlier wins the tie");
+
+        const exact = WeatherForecast.dailyFromOwm([
+            owmEntry("2026-08-04 00:00:00", 11, 14, 800),
+            owmEntry("2026-08-04 12:00:00", 18, 24, 500)
+        ]);
+        compare(exact[0].wCode, 500, "an entry at midday beats one nine hours away");
+    }
+
+    // The first day of an OWM response is whatever is left of today, so it can
+    // be a single evening entry. That is still a day and still gets a card.
+    function test_owmGroupsIntoSeparateDaysInOrder() {
+        const days = WeatherForecast.dailyFromOwm([
+            owmEntry("2026-08-04 21:00:00", 9, 16, 802),
+            owmEntry("2026-08-05 12:00:00", 12, 20, 500),
+            owmEntry("2026-08-06 12:00:00", 13, 21, 600)
+        ]);
+        compare(days.length, 3);
+        compare(days.map(day => day.date), ["2026-08-04", "2026-08-05", "2026-08-06"]);
+        compare(days[0].high, 16, "a day with one entry takes that entry's range");
+    }
+
+    // OWM returns five days; the popup shows four.
+    function test_owmIsCappedAtFourDays() {
+        const entries = [];
+        for (let day = 4; day <= 9; ++day)
+            entries.push(owmEntry("2026-08-0" + day + " 12:00:00", 10, 20, 800));
+        const days = WeatherForecast.dailyFromOwm(entries);
+        compare(days.length, 4);
+        compare(days[0].date, "2026-08-04", "the cap drops the far end, not the near one");
+    }
+
+    function test_owmSurvivesAJunkResponse() {
+        compare(WeatherForecast.dailyFromOwm(undefined), []);
+        compare(WeatherForecast.dailyFromOwm([]), []);
+        compare(WeatherForecast.dailyFromOwm([{}, { dt_txt: 42 }, { dt_txt: "short" }]), []);
+    }
+
+    function wttrDay(date, lowC, highC, lowF, highF, hourly) {
+        return {
+            date: date, mintempC: lowC, maxtempC: highC, mintempF: lowF, maxtempF: highF,
+            hourly: hourly
+        };
+    }
+
+    // wttr.in already speaks the WWO codes Icons.weatherIconMap keys on, and its
+    // `time` is an hhmm string with no separator - "300" is 03:00, not 300.
+    function test_wttrPicksTheMiddayHourlyCode() {
+        const days = WeatherForecast.dailyFromWttr([
+            wttrDay("2026-08-04", "9", "21", "48", "70", [
+                { time: "0", weatherCode: "113" },
+                { time: "300", weatherCode: "116" },
+                { time: "1200", weatherCode: "296" },
+                { time: "2100", weatherCode: "119" }
+            ])
+        ], false);
+        compare(days.length, 1);
+        compare(days[0].wCode, 296);
+        compare(days[0].high, 21);
+        compare(days[0].low, 9);
+    }
+
+    function test_wttrFollowsTheUnitSetting() {
+        const day = wttrDay("2026-08-04", "9", "21", "48", "70", []);
+        compare(WeatherForecast.dailyFromWttr([day], false)[0].high, 21, "metric");
+        compare(WeatherForecast.dailyFromWttr([day], true)[0].high, 70, "US customary");
+        compare(WeatherForecast.dailyFromWttr([day], true)[0].low, 48, "US customary");
+    }
+
+    function test_wttrSurvivesAJunkResponse() {
+        compare(WeatherForecast.dailyFromWttr(undefined, false), []);
+        const days = WeatherForecast.dailyFromWttr([{}], false);
+        compare(days.length, 1);
+        compare(days[0].wCode, 0, "no hourly entries means no icon, not a crash");
+        compare(days[0].high, null, "an absent reading is null, never 0 degrees");
+        compare(days[0].low, null);
+    }
+
+    // A card shows whole degrees, but rounding null to 0 would print a
+    // confident 0° for a reading that is simply not there.
+    function test_absentReadingsStayNull() {
+        const days = WeatherForecast.dailyFromOwm([
+            { dt_txt: "2026-08-04 12:00:00", weather: [{ id: 800 }] }
+        ]);
+        compare(days[0].high, null);
+        compare(days[0].low, null);
+        compare(days[0].wCode, 800, "a missing temperature does not cost the icon");
+    }
+
+    function test_temperaturesAreRoundedToWholeDegrees() {
+        const days = WeatherForecast.dailyFromOwm([
+            owmEntry("2026-08-04 12:00:00", 9.4, 20.6, 800)
+        ]);
+        compare(days[0].high, 21);
+        compare(days[0].low, 9);
+    }
+
+    // toISOString() is UTC. Using it would flip "today" hours early or late for
+    // anyone not on UTC, and the row would label the wrong card for that window.
+    // A UTC runner cannot tell the two apart at all, which is why
+    // test_weather_forecast_contract.py re-runs this file east and west of it.
+    function test_localIsoDateIsLocalNotUtc() {
+        const date = new Date(2026, 7, 4, 23, 30, 0);   // local 4 Aug, 23:30
+        compare(WeatherForecast.localIsoDate(date), "2026-08-04");
+        compare(WeatherForecast.localIsoDate(new Date(2026, 0, 9, 0, 5, 0)), "2026-01-09",
+                "single-digit months and days are padded");
+    }
+
+    function test_isTodayComparesTheWholeDate() {
+        verify(WeatherForecast.isToday("2026-08-04", "2026-08-04"));
+        verify(!WeatherForecast.isToday("2026-08-05", "2026-08-04"));
+        verify(!WeatherForecast.isToday("", "2026-08-04"), "a dateless card is not today");
+        verify(!WeatherForecast.isToday(undefined, "2026-08-04"));
+    }
+
+    // A bare "YYYY-MM-DD" parses as UTC midnight, which is the previous evening
+    // west of UTC - so the card would be named for the wrong weekday.
+    function test_shortDayNameIsTheDatesOwnWeekday() {
+        compare(WeatherForecast.shortDayName("2026-08-04"),
+                new Date(2026, 7, 4, 12, 0, 0).toLocaleDateString(undefined, { weekday: "short" }));
+        compare(WeatherForecast.shortDayName(""), "");
+        compare(WeatherForecast.shortDayName("not-a-date"), "");
+    }
+}

--- a/dots/.config/quickshell/imi/tests/tst_weather_icons.qml
+++ b/dots/.config/quickshell/imi/tests/tst_weather_icons.qml
@@ -1,0 +1,87 @@
+import QtTest
+import qs.modules.common
+
+// The two weather providers report conditions in different, overlapping code
+// schemes, and nothing in a code itself says which. An OpenWeatherMap id looked
+// up in the WWO table matches nothing and falls through to "clear" - so the bar
+// popup drew a clear sky through every storm for anyone on that provider, with
+// no error anywhere.
+TestCase {
+    name: "WeatherIconTest"
+
+    function test_owmCodesNoLongerFallThroughToClear() {
+        // Real OWM conditions, none of them clear, all of which missed the WWO
+        // table entirely and came back as a clear sky.
+        const missed = [502, 601, 741, 804];
+        for (const code of missed) {
+            const wwo = Icons.getWeatherIcon(code);
+            verify(wwo === "clear_day" || wwo === "clear_night",
+                   "OWM code " + code + " is expected to miss the WWO table, got " + wwo);
+            const owm = Icons.getProviderWeatherIcon("owm", code, false);
+            verify(owm !== "clear_day" && owm !== "clear_night",
+                   "OWM code " + code + " still resolves to a clear sky: " + owm);
+        }
+    }
+
+    // Falling through to clear is only the loud half. The two schemes overlap
+    // numerically, so some OWM ids land on a WWO entry and come back confidently
+    // wrong instead - which no "is it clear?" check would ever notice.
+    function test_anOwmCodeThatCollidesWithAWwoEntryIsStillWrong() {
+        // OWM 302 is heavy drizzle. WWO 302 is moderate rain *shown as hail*.
+        compare(Icons.getWeatherIcon(302), "weather_hail",
+                "the collision this guards against");
+        compare(Icons.getProviderWeatherIcon("owm", 302, false), "rainy");
+
+        // OWM 200 is a thunderstorm and so is WWO 200, so that one agrees by
+        // luck. Pinned so the agreement is on the record as a coincidence.
+        compare(Icons.getWeatherIcon(200), "thunderstorm");
+        compare(Icons.getProviderWeatherIcon("owm", 200, false), "thunderstorm");
+    }
+
+    function test_owmGroupsMapToTheirConditions() {
+        compare(Icons.getProviderWeatherIcon("owm", 200, false), "thunderstorm");
+        compare(Icons.getProviderWeatherIcon("owm", 302, false), "rainy", "drizzle");
+        compare(Icons.getProviderWeatherIcon("owm", 502, false), "rainy");
+        compare(Icons.getProviderWeatherIcon("owm", 601, false), "snowing");
+        compare(Icons.getProviderWeatherIcon("owm", 741, false), "foggy", "atmosphere");
+        compare(Icons.getProviderWeatherIcon("owm", 804, false), "cloud", "overcast");
+    }
+
+    // 800 is the only exact id OWM defines; 801-804 are increasing cloud cover,
+    // so the boundary between "partly cloudy" and "cloudy" is a real decision.
+    function test_owmCloudCoverBoundary() {
+        compare(Icons.getProviderWeatherIcon("owm", 800, false), "clear_day");
+        compare(Icons.getProviderWeatherIcon("owm", 801, false), "partly_cloudy_day");
+        compare(Icons.getProviderWeatherIcon("owm", 802, false), "partly_cloudy_day");
+        compare(Icons.getProviderWeatherIcon("owm", 803, false), "cloud");
+    }
+
+    function test_owmHonoursTheNightVariant() {
+        compare(Icons.getProviderWeatherIcon("owm", 800, true), "clear_night");
+        compare(Icons.getProviderWeatherIcon("owm", 801, true), "partly_cloudy_night");
+        compare(Icons.getProviderWeatherIcon("owm", 502, true), "rainy",
+                "rain looks the same at night");
+    }
+
+    // wttr.in speaks WWO already, so its codes must keep resolving exactly as
+    // they did through the existing table.
+    function test_wttrCodesStillGoThroughTheWwoTable() {
+        compare(Icons.getProviderWeatherIcon("wttr", 113, false), "clear_day");
+        compare(Icons.getProviderWeatherIcon("wttr", 113, true), "clear_night");
+        compare(Icons.getProviderWeatherIcon("wttr", 296, false), "rainy");
+        compare(Icons.getProviderWeatherIcon("wttr", 395, false), "snowing");
+        compare(Icons.getProviderWeatherIcon("wttr", 200, false), "thunderstorm");
+    }
+
+    // A day card must never take the night variant: Thursday's forecast is not
+    // about what the sky looks like tonight.
+    function test_theNightFlagIsTheCallersToChoose() {
+        compare(Icons.getProviderWeatherIcon("wttr", 113, false), "clear_day");
+        compare(Icons.getProviderWeatherIcon("owm", 800, false), "clear_day");
+    }
+
+    function test_anUnknownCodeStillDegradesToClear() {
+        compare(Icons.getProviderWeatherIcon("owm", 0, false), "clear_day");
+        compare(Icons.getProviderWeatherIcon("wttr", 99999, true), "clear_night");
+    }
+}


### PR DESCRIPTION
The two halves of #111 that are wanted, without the third.

#111 has sat open because its bar-popup forecast row has nowhere to go without spoiling that bar's look. Its other two commits are not about the popup at all, and one of them is a real bug fix — so they land here and #111 is left holding exactly one commit: the row itself, to accept or reject on its own merits.

Both commits are #111's, cherry-picked unchanged (`a95eb665a`, `42dd73935` on the rebased branch).

## What lands

**Provider-aware icons.** `Weather.data.wCode` carries OpenWeatherMap condition ids on the `owm` provider and World Weather Online codes on `wttr`, and the popup resolved every one of them through the WWO-keyed `weatherIconMap` — drawing a clear sky through every storm for anyone on the default provider. Nothing about that is visible in a log.

**A day-by-day forecast in the service.** `Weather.forecast` is `[{ date, wCode, high, low }]` — local `YYYY-MM-DD`, whole degrees in the configured unit system, identical for both providers. wttr costs nothing (`?format=j1` already returned three days that were being thrown away); OWM needs a second request to `/data/2.5/forecast`, grouped into days here.

Two details from #111 worth repeating, because they are the kind that look like noise until they are wrong: a day's icon comes from the entry nearest **local midday**, not the first entry of the day (keyed off 00:00, a day that rains from lunchtime renders clear and cold); and a day's range is the extremes **across all** its entries, since each OWM entry's `temp_min`/`temp_max` describes only its own three-hour window.

## Why this is worth landing on its own

The desktop 3x2 weather card (#189) consumes `Weather.forecast` and needs exactly these two commits — it does not need the popup row. Verified live: with this service deployed, the card renders a real four-day forecast from OpenWeatherMap.

## Verification

- `tests/run_tests.sh`: 654 passed, 0 failed
- Includes #111's own timezone pin, which re-runs the forecast unit tests under `Pacific/Kiritimati` (UTC+14) and `Pacific/Niue` (UTC-11) — without it, a mutation replacing `localIsoDate` with `toISOString()` left the suite fully green, because CI runs on UTC

Docs: not needed — no rule changes; both commits keep the documentation they arrived with, and the popup row's own docs stay with #111.