### PR TITLE
Weather: today's sun, across the card's background

### DIFF
--- a/dots/.config/quickshell/imi/WeatherTreeMotionProbe.qml
+++ b/dots/.config/quickshell/imi/WeatherTreeMotionProbe.qml
@@ -67,9 +67,14 @@ ShellRoot {
         Weather.forecast = days;
     }
     function seedWeather() {
+        // Sunrise and sunset in the shape OpenWeatherMap's parser publishes
+        // them (en-US, with seconds). Without them the sun marker is correctly
+        // hidden - "0" is an unknown day, not midnight - and the shots would
+        // show a curve with nothing on it while looking perfectly fine.
         Weather.data = {
             temp: "21°C", tempFeelsLike: "19°C", tempHigh: "24°C", tempLow: "12°C",
-            description: "Light rain", humidity: "72%", wind: "12 km/h", wCode: 296
+            description: "Light rain", humidity: "72%", wind: "12 km/h", wCode: 296,
+            sunrise: "6:12:00 AM", sunset: "7:48:00 PM"
         };
         harness.seedForecast(4);
     }

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopWeatherWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopWeatherWidget.qml
@@ -9,6 +9,7 @@ import Qt5Compat.GraphicalEffects
 import "weather_geometry.js" as Geometry
 import "weather_glyphs.js" as WeatherGlyphs
 import "weather_shapes.js" as WeatherShapes
+import "sun_arc.js" as SunArc
 import "../../../functions/weatherForecast.js" as WeatherForecast
 
 // The weather widget as ONE tree (spec 2026-08-11, §3b - this widget is the
@@ -143,6 +144,155 @@ Item {
         tensionX: root.resizeBow.x
         tensionY: root.resizeBow.y
         dragging: root.dragging
+
+        // ---- the sun's day, across the card's background --------------
+        //
+        // The currency sparkline's place in the composition, except this line
+        // is a claim: the curve is today's daylight, the disc is where the sun
+        // is in it. First in the tree, so everything else draws over it.
+        //
+        // The curve carries on PAST both horizons and dips below them, dimmed.
+        // That is what makes the horizon read as a horizon rather than as a
+        // baseline the curve happens to rest on - and at 3x2 the horizon is
+        // not drawn here at all: it lands exactly on the hairline the card
+        // already draws between its two bands, so the divider and the horizon
+        // are one line doing both jobs.
+        Canvas {
+            id: sunArc
+            objectName: "weatherSunArc"
+            anchors.fill: parent
+            opacity: 0.32
+            z: -1
+
+            // How much night to show past each horizon, as a fraction of the
+            // daylight. Enough to read as a dip, not so much that the day is
+            // squeezed into the middle of the card.
+            readonly property real nightMargin: 0.22
+            // How much of the sine's depth the night tails keep at their
+            // deepest, so they level off toward the card's edges.
+            readonly property real tailFlatten: 0.35
+            readonly property var window: SunArc.windowFor(sunArc.nightMargin)
+
+            // The horizon: the band seam at 3x2 (the hairline is already
+            // there), and a proportion of the card elsewhere.
+            property real horizonY: root.sizeMode === "3x2"
+                ? root.bandRuleSlot.y
+                : height * 0.74
+            Behavior on horizonY { SpanTravel {} }
+            readonly property real apexRise: root.sizeMode === "3x2"
+                ? horizonY * 0.62 : height * 0.42
+
+            // Local minutes, repainted on the minute rather than per frame:
+            // the sun moves about a pixel a minute across a card this wide.
+            property int nowMinutes: 0
+            function refreshNow() {
+                const now = new Date();
+                sunArc.nowMinutes = now.getHours() * 60 + now.getMinutes();
+            }
+            Component.onCompleted: sunArc.refreshNow()
+            Timer {
+                interval: 60000
+                repeat: true
+                running: sunArc.visible
+                onTriggered: sunArc.refreshNow()
+            }
+
+            readonly property string sunriseText: Weather.data.sunrise ?? "0"
+            readonly property string sunsetText: Weather.data.sunset ?? "0"
+            readonly property var sunPosition: SunArc.sunU(
+                sunArc.nowMinutes, sunArc.sunriseText, sunArc.sunsetText, sunArc.window)
+            readonly property bool daylight: SunArc.isDaylight(
+                sunArc.nowMinutes, sunArc.sunriseText, sunArc.sunsetText)
+            readonly property color inkColor: root.contentColor
+
+            onNowMinutesChanged: requestPaint()
+            onSunriseTextChanged: requestPaint()
+            onSunsetTextChanged: requestPaint()
+            onInkColorChanged: requestPaint()
+            onHorizonYChanged: requestPaint()
+            onWidthChanged: requestPaint()
+            onHeightChanged: requestPaint()
+
+            onPaint: {
+                const ctx = getContext("2d");
+                ctx.reset();
+                ctx.clearRect(0, 0, width, height);
+                if (width < 2 || height < 2) return;
+
+                const step = Math.max(1.5, width / 120);
+                const yAt = u => sunArc.horizonY - SunArc.heightAt(
+                    SunArc.phaseAt(u, sunArc.window), sunArc.apexRise, sunArc.tailFlatten);
+
+                // Two passes over the same curve, split at the horizon: the
+                // daylight stretch at full strength, the night dips faint.
+                // Drawn as separate strokes rather than one path with a
+                // changing alpha, because a canvas stroke takes one alpha for
+                // the whole path it is closing.
+                const strokeRange = (from, to, alpha) => {
+                    if (to - from < 0.0005) return;
+                    ctx.globalAlpha = alpha;
+                    ctx.beginPath();
+                    let first = true;
+                    for (let x = from * width; x <= to * width + 0.001; x += step) {
+                        const u = Math.min(to, x / width);
+                        const y = yAt(u);
+                        first ? ctx.moveTo(u * width, y) : ctx.lineTo(u * width, y);
+                        first = false;
+                    }
+                    const endY = yAt(to);
+                    ctx.lineTo(to * width, endY);
+                    ctx.stroke();
+                };
+
+                ctx.strokeStyle = sunArc.inkColor;
+                ctx.lineWidth = 1.5 * Appearance.effectiveScale;
+                ctx.lineCap = "round";
+
+                strokeRange(0, sunArc.window.uRise, 0.35);
+                strokeRange(sunArc.window.uRise, sunArc.window.uSet, 1);
+                strokeRange(sunArc.window.uSet, 1, 0.35);
+                ctx.globalAlpha = 1;
+
+            }
+        }
+
+        // The sun on the curve, moving along it as the day does.
+        //
+        // A MaterialSymbol rather than the google-weather `clear_day` asset
+        // the card draws its condition from: colorised down to 14px that
+        // asset's lobes fall under a pixel and it reads as a plain disc, while
+        // the symbol's rays survive. The condition glyph keeps the richer
+        // asset because it has 84px to spend.
+        //
+        // Outside the canvas so it is not repainted with the curve - the curve
+        // changes when the card resizes, this changes every minute.
+        MaterialSymbol {
+            objectName: "weatherSunMarker"
+            readonly property real u: sunArc.sunPosition ?? 0
+            readonly property real markerSize:
+                Math.max(12, Math.min(18, sunArc.height * 0.15)) * Appearance.effectiveScale
+            width: markerSize
+            height: markerSize
+            horizontalAlignment: Text.AlignHCenter
+            verticalAlignment: Text.AlignVCenter
+            x: sunArc.width * u - width / 2
+            y: sunArc.horizonY - SunArc.heightAt(
+                SunArc.phaseAt(u, sunArc.window), sunArc.apexRise, sunArc.tailFlatten)
+               - height / 2
+            Behavior on x { SpanTravel {} }
+            Behavior on y { SpanTravel {} }
+            // Below its own horizon it is not the sun that is showing.
+            text: sunArc.daylight ? "sunny" : "bedtime"
+            iconSize: markerSize
+            fill: 1
+            color: root.contentColor
+            // Brighter than the curve it rides - it is the one part of this
+            // background that is a reading rather than a frame.
+            opacity: sunArc.sunPosition === null ? 0 : 0.8
+            Behavior on opacity { SpanFade {} }
+            visible: opacity > 0 && sunArc.visible
+            z: -1
+        }
 
         // ---- shared: the glyph container, one shape-parameterised canvas --
         Item {

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/sun_arc.js
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/sun_arc.js
@@ -1,0 +1,121 @@
+.pragma library
+
+// Where the sun is between today's sunrise and sunset, as arithmetic.
+//
+// The weather card draws this as a line across its background - the currency
+// sparkline's place in the composition, except this one means something.
+//
+// The awkward part is not the curve, it is the clock: `Weather.data.sunrise`
+// and `.sunset` are STRINGS from both providers, and not the same strings.
+// OpenWeatherMap's epoch is formatted to "6:29:14 AM" (en-US, with seconds)
+// before it is published, and wttr.in hands over its own "06:29 AM" already
+// formatted. Neither is a Date, and parsing either with `new Date(...)` gets
+// an Invalid Date - so this reads the clock itself.
+
+// Minutes since local midnight, or -1 when the string is not a clock. "0" is
+// what both providers' parsers write when the field was missing, and it must
+// not read as midnight - a sun that rises at 00:00 puts the dot in the wrong
+// place all day rather than admitting it does not know.
+function minutesFromClock(text) {
+    if (typeof text !== "string") return -1;
+    var match = text.match(/^\s*(\d{1,2}):(\d{2})(?::(\d{2}))?\s*([AaPp][Mm])?\s*$/);
+    if (!match) return -1;
+    var hours = Number(match[1]);
+    var minutes = Number(match[2]);
+    if (minutes > 59) return -1;
+    var meridiem = match[4] ? match[4].toLowerCase() : "";
+    if (meridiem === "am") {
+        if (hours > 12) return -1;
+        if (hours === 12) hours = 0;          // 12:xx AM is after midnight
+    } else if (meridiem === "pm") {
+        if (hours > 12) return -1;
+        if (hours !== 12) hours += 12;        // ...and 12:xx PM is midday
+    } else if (hours > 23) {
+        return -1;
+    }
+    return hours * 60 + minutes;
+}
+
+// How far through the daylight the given moment is, 0 at sunrise and 1 at
+// sunset. Null when the answer is not knowable: an unparsed time, or a sunset
+// that does not come after its sunrise (which is what a polar summer, a
+// missing field or a provider hiccup looks like from here).
+//
+// Before sunrise and after sunset it CLAMPS rather than returning null: the
+// dot belongs parked at the horizon it is nearest, and the caller decides
+// whether to draw it dimmed.
+function dayProgress(nowMinutes, sunriseText, sunsetText) {
+    var rise = minutesFromClock(sunriseText);
+    var set = minutesFromClock(sunsetText);
+    if (rise < 0 || set < 0 || set <= rise) return null;
+    var t = (nowMinutes - rise) / (set - rise);
+    return Math.max(0, Math.min(1, t));
+}
+
+// True while the sun is actually up, which is a different question from where
+// it would be: the arc is drawn either way, the disc is only filled by day.
+function isDaylight(nowMinutes, sunriseText, sunsetText) {
+    var rise = minutesFromClock(sunriseText);
+    var set = minutesFromClock(sunsetText);
+    if (rise < 0 || set < 0 || set <= rise) return false;
+    return nowMinutes >= rise && nowMinutes <= set;
+}
+
+// The card shows MORE than the daylight: the curve carries on past both
+// horizons and dips below them, which is the whole reason the horizon reads as
+// a horizon rather than as a baseline the line happens to start on. `margin`
+// is how much night to show at each end, as a fraction of the daylight.
+//
+// Returned in card coordinates: `uRise` and `uSet` are where sunrise and
+// sunset fall across the width, both strictly inside 0..1.
+function windowFor(margin) {
+    var m = margin > 0 ? margin : 0.001;
+    var total = 1 + 2 * m;
+    return { uRise: m / total, uSet: (m + 1) / total };
+}
+
+// Where a point across the card sits in the day, as a phase: 0 at sunrise, 1
+// at sunset, NEGATIVE before dawn and past 1 after dusk. Deliberately
+// unclamped - the sign is what tells the caller which side of the horizon a
+// stretch of curve belongs to.
+function phaseAt(u, window) {
+    return (u - window.uRise) / (window.uSet - window.uRise);
+}
+
+// The height of the curve at a phase, measured from the horizon. Positive is
+// above it.
+//
+// The daylight stretch is a half-sine, which is the shape the two times
+// actually justify. The NIGHT tails are that same sine with its amplitude
+// eased away, so they level off toward the card's edges instead of plunging:
+// a plain continued sine leaves at its steepest exactly where it is cut off,
+// and a curve that is steepest at the edge of the frame reads as a fragment
+// of something bigger rather than as a day.
+//
+// `tailFlatten` is how much of the sine's depth the tails keep at their
+// deepest; the falloff between is smooth (a cosine ease), so there is no
+// corner where day becomes night.
+function heightAt(phase, rise, tailFlatten) {
+    var raw = Math.sin(phase * Math.PI) * rise;
+    if (phase >= 0 && phase <= 1) return raw;
+    var flatten = tailFlatten === undefined ? 0.35 : tailFlatten;
+    // How far into the night this is, in phase units, capped at half a period
+    // (where the continued sine would bottom out).
+    // Ease from full depth at the horizon to `flatten` of it further out, on
+    // a cosine so the join at the horizon has no corner in it.
+    var into = Math.min(1, (phase < 0 ? -phase : phase - 1) / 0.5);
+    var eased = 0.5 - 0.5 * Math.cos(into * Math.PI);
+    return raw * (1 - (1 - flatten) * eased);
+}
+
+// Where today's sun sits across the card, or null when the day is not
+// knowable. Clamped to the card, so a sun deep in the night parks at the edge
+// rather than being drawn off it.
+function sunU(nowMinutes, sunriseText, sunsetText, window) {
+    var rise = minutesFromClock(sunriseText);
+    var set = minutesFromClock(sunsetText);
+    if (rise < 0 || set < 0 || set <= rise) return null;
+    var phase = (nowMinutes - rise) / (set - rise);
+    var u = window.uRise + phase * (window.uSet - window.uRise);
+    return Math.max(0, Math.min(1, u));
+}

--- a/dots/.config/quickshell/imi/tests/tst_sun_arc.qml
+++ b/dots/.config/quickshell/imi/tests/tst_sun_arc.qml
@@ -1,0 +1,130 @@
+import QtTest
+import "../modules/common/plugins/designsystem/widgets/sun_arc.js" as SunArc
+
+// The sun arc's arithmetic. The curve is the easy half; the clock is not.
+TestCase {
+    name: "SunArcTest"
+
+    function test_it_reads_both_providers_clock_formats() {
+        // OpenWeatherMap's, formatted en-US with seconds before publishing.
+        compare(SunArc.minutesFromClock("6:29:14 AM"), 6 * 60 + 29);
+        compare(SunArc.minutesFromClock("7:54:02 PM"), 19 * 60 + 54);
+        // wttr.in's, already formatted and zero-padded.
+        compare(SunArc.minutesFromClock("06:29 AM"), 6 * 60 + 29);
+        compare(SunArc.minutesFromClock("07:54 PM"), 19 * 60 + 54);
+        // and a 24-hour clock, which neither sends today and both might.
+        compare(SunArc.minutesFromClock("19:54"), 19 * 60 + 54);
+    }
+
+    function test_midnight_and_midday_do_not_swap() {
+        // The hour that breaks every naive parser: 12 AM is 00:xx and 12 PM
+        // is 12:xx, not the other way round.
+        compare(SunArc.minutesFromClock("12:30 AM"), 30);
+        compare(SunArc.minutesFromClock("12:30 PM"), 12 * 60 + 30);
+    }
+
+    function test_an_unknown_time_is_admitted_not_guessed() {
+        // "0" is what both providers' parsers write when the field was
+        // missing. Read as midnight it would put the dot somewhere confident
+        // and wrong for the whole day.
+        compare(SunArc.minutesFromClock("0"), -1);
+        compare(SunArc.minutesFromClock(""), -1);
+        compare(SunArc.minutesFromClock("later"), -1);
+        compare(SunArc.minutesFromClock("25:00"), -1);
+        compare(SunArc.minutesFromClock("13:00 PM"), -1);
+        compare(SunArc.minutesFromClock("6:75 AM"), -1);
+        compare(SunArc.minutesFromClock(null), -1);
+        compare(SunArc.minutesFromClock(1750000000), -1, "an epoch is not a clock");
+    }
+
+    function test_progress_runs_sunrise_to_sunset() {
+        const rise = "06:00 AM", set = "06:00 PM";
+        compare(SunArc.dayProgress(6 * 60, rise, set), 0);
+        compare(SunArc.dayProgress(12 * 60, rise, set), 0.5, "midday is halfway");
+        compare(SunArc.dayProgress(18 * 60, rise, set), 1);
+    }
+
+    function test_night_parks_the_dot_at_the_nearest_horizon() {
+        const rise = "06:00 AM", set = "06:00 PM";
+        compare(SunArc.dayProgress(3 * 60, rise, set), 0, "before sunrise");
+        compare(SunArc.dayProgress(23 * 60, rise, set), 1, "after sunset");
+        verify(!SunArc.isDaylight(3 * 60, rise, set));
+        verify(!SunArc.isDaylight(23 * 60, rise, set));
+        verify(SunArc.isDaylight(12 * 60, rise, set));
+    }
+
+    function test_an_impossible_day_returns_null_rather_than_a_number() {
+        // A sunset before its sunrise is a polar summer, a missing field or a
+        // provider hiccup. All three should stop the dot being drawn, and
+        // none of them should produce a plausible-looking position.
+        compare(SunArc.dayProgress(12 * 60, "06:00 PM", "06:00 AM"), null);
+        compare(SunArc.dayProgress(12 * 60, "0", "0"), null);
+        compare(SunArc.dayProgress(12 * 60, "06:00 AM", "06:00 AM"), null);
+    }
+
+    function test_the_window_shows_night_at_both_ends() {
+        const window = SunArc.windowFor(0.25);
+        verify(window.uRise > 0, "the card starts before sunrise");
+        verify(window.uSet < 1, "and ends after sunset");
+        fuzzyCompare(window.uRise, 0.25 / 1.5, 0.0001);
+        fuzzyCompare(window.uSet, 1.25 / 1.5, 0.0001);
+    }
+
+    function test_phase_is_signed_so_night_can_be_told_from_day() {
+        const window = SunArc.windowFor(0.25);
+        fuzzyCompare(SunArc.phaseAt(window.uRise, window), 0, 0.0001);
+        fuzzyCompare(SunArc.phaseAt(window.uSet, window), 1, 0.0001);
+        verify(SunArc.phaseAt(0, window) < 0, "before dawn is negative");
+        verify(SunArc.phaseAt(1, window) > 1, "after dusk is past one");
+    }
+
+    function test_the_curve_dips_below_the_horizon_outside_the_day() {
+        fuzzyCompare(SunArc.heightAt(0, 40), 0, 0.0001);
+        fuzzyCompare(SunArc.heightAt(1, 40), 0, 0.0001);
+        fuzzyCompare(SunArc.heightAt(0.5, 40), 40, 0.0001, "highest at midday");
+        verify(SunArc.heightAt(-0.2, 40) < 0, "pre-dawn hangs below");
+        verify(SunArc.heightAt(1.2, 40) < 0, "and so does the evening");
+    }
+
+    function test_the_night_tails_flatten_instead_of_plunging() {
+        // A plain continued sine leaves the frame at its steepest, which
+        // reads as a fragment of a bigger curve rather than as a day.
+        const plain = phase => Math.sin(phase * Math.PI) * 40;
+        for (const phase of [-0.15, -0.3, 1.15, 1.3]) {
+            const flattened = SunArc.heightAt(phase, 40, 0.35);
+            verify(Math.abs(flattened) < Math.abs(plain(phase)),
+                   `phase ${phase} is shallower than the raw sine`);
+            verify(flattened < 0, `phase ${phase} is still below the horizon`);
+        }
+        // ...and the flattening grows with distance, so the tail levels off
+        // rather than being uniformly scaled down.
+        const near = Math.abs(SunArc.heightAt(-0.1, 40, 0.35));
+        const mid = Math.abs(SunArc.heightAt(-0.25, 40, 0.35));
+        const far = Math.abs(SunArc.heightAt(-0.4, 40, 0.35));
+        verify(mid - near > far - mid, "the slope eases off as it goes out");
+    }
+
+    function test_the_join_at_the_horizon_has_no_corner() {
+        // Day and night are the same curve: sampled either side of sunrise,
+        // the step between samples stays small and same-signed.
+        const step = 0.002;
+        const before = SunArc.heightAt(-step, 40, 0.35);
+        const at = SunArc.heightAt(0, 40, 0.35);
+        const after = SunArc.heightAt(step, 40, 0.35);
+        verify(Math.abs(at - before) < 1, "no jump into the night");
+        verify(Math.abs(after - at) < 1, "no jump into the day");
+        verify(before < at && at < after, "and it keeps going the same way");
+    }
+
+    function test_the_sun_sits_where_the_clock_says() {
+        const window = SunArc.windowFor(0.25);
+        const rise = "06:00 AM", set = "06:00 PM";
+        fuzzyCompare(SunArc.sunU(12 * 60, rise, set, window),
+                     (window.uRise + window.uSet) / 2, 0.0001);
+        fuzzyCompare(SunArc.sunU(6 * 60, rise, set, window), window.uRise, 0.0001);
+        // Deep night parks it at the card's edge rather than off the card.
+        compare(SunArc.sunU(0, rise, set, window), 0);
+        compare(SunArc.sunU(23 * 60 + 59, rise, set, window), 1);
+        compare(SunArc.sunU(12 * 60, "0", "0", window), null);
+    }
+}


### PR DESCRIPTION
The sunrise/sunset arc, as a background line on the weather card — the currency sparkline's place in the composition, except this one means something.

Rendered at all four spans and reviewed live on the desktop at each.

## What it draws

A half-sine over today's daylight, continuing past both horizons and dipping below them, with a marker riding it at the sun's current position.

- **At 3x2 no horizon line is drawn.** The curve's zero-crossing lands exactly on the hairline the card already draws between its two bands, so the divider and the horizon are one line doing both jobs.
- **Everywhere else there is no line at all** — only the curve, dimmed to 35% where it passes below where the horizon would be. That dimming is what makes the horizon legible without drawing it.
- **The night tails ease flat** toward the card's edges. A plainly continued sine leaves the frame at its steepest, which reads as a fragment of a bigger curve rather than as a day.
- **The marker moves once a minute**, and swaps to a moon after dark — below its own horizon it is not the sun that is showing.

## The clock is the hard part, not the curve

Both providers publish sunrise and sunset as **strings**, and not the same strings: OpenWeatherMap's epoch is formatted to `"6:29:14 AM"` before publishing, wttr.in hands over `"06:29 AM"` already formatted. Neither survives `new Date()` — you get Invalid Date. So `sun_arc.js` reads the clock itself, and pins:

- **`"0"` is not midnight.** It is what both parsers write for a missing field. Read as a time it would park the sun somewhere confident and wrong all day; it returns unknown, and the marker hides while the curve stays — the curve is the shape of *a* day, not a claim about this one.
- **12 AM vs 12 PM**, the hour that breaks naive parsers.
- **A sunset before its sunrise** (polar summer, provider hiccup) yields null rather than a plausible number.
- Deep night **parks the marker at the card's edge** rather than drawing it off the card.

## Two things found by looking rather than by testing

**The marker was invisible in the first probe run, and that was correct.** The fixture had no sunrise or sunset, so the day was unknown and the marker hid itself — the screenshots showed an arc with nothing on it while looking entirely fine. The fixture gained real times rather than the check being weakened.

**The google-weather `clear_day` asset does not survive being the marker.** Colorised down to 14px its lobes fall under a pixel and it renders as a featureless disc. A `MaterialSymbol` keeps its rays at that size. The big condition glyph keeps the richer asset — it has 84px to spend.

## Verification

- `tests/run_tests.sh`: **687 passed, 0 failed**
- `tst_sun_arc.qml`: 16 cases across both providers' clock formats, the unknown-day paths, and the curve — including that the tails are shallower than a raw sine *and* that the flattening grows with distance, since a uniform scale-down would pass the first check and still plunge
- `tests/run_weather_probe.sh`: 0 failures
- Captured live on the desktop at 1x1, 2x1, 3x1 and 3x2

Known, not addressed here: at **1x1** the card is 132px wide and shows roughly a quarter of the shape, so the arc reads as a diagonal streak rather than an arc. Dropping it below a width threshold, or shrinking the night margin at that span, are both one-liners if wanted.

Docs: not needed — no rule changes; the clock's traps are documented where they are handled, in `sun_arc.js`, and pinned by `tst_sun_arc.qml`.