### PR TITLE
The sun arc has no home at 1x1, so it fades there

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1251,6 +1251,21 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   every mutation of the motion. fa1e2a8b5 ("feat(plugins): animate a resizable widget's size
   between its offered spans"), 4e33a332a ("test(widgets): score a span change as in flight, not
   as a snap").
+- **A sweep over ordered PAIRS is not a walk, and a trail's floor is in the trail's own units.**
+  Two ways a span-motion harness reports confidently about a transition it never ran.
+  `WeatherTreeMotionProbe` drives a list of `[from, to]` pairs but only ever committed `to` — so
+  `3x2 -> 2x1`, which follows `3x2 -> 3x1` in the list, started from 3x1: the sweep measured
+  `3x1 -> 2x1`, printed a green trail for every element under the `3x2->2x1` label, filed its
+  settled shot as `3x2_settled.png`, and the one pair whose card shrinks in **both** axes was
+  never exercised at all. A pair the sweep names has to be a pair the sweep runs — reposition to
+  `from` first, on its own settle. Separately, the "did this move" floor was `0.5` for every
+  trail, which is right for a position, a size or a font and nonsense for an opacity: the weather
+  card's sun arc leaves 1x1 by fading `0.32 -> 0`, a complete disappearance and a change of
+  `0.32`, so the pixel floor filed the one trail that had to move as `static`. Note the failure
+  direction on both — neither reddens, both go *quiet*, and a probe that says nothing about an
+  element reads exactly like a probe with nothing to say about it.
+  test(weather): the probe runs the pairs it names,
+  test(weather): the probe scores the arc's fade, its travel and an unknown day.
 - **A change handler that writes the state its own binding reads is a binding loop, and Qt
   drops the re-evaluation rather than erroring where you are looking.** `PluginWidget` repairs a
   resized widget's stored position from `onStoredGridSpanChanged`, and that repair calls

--- a/dots/.config/quickshell/imi/WeatherTreeMotionProbe.qml
+++ b/dots/.config/quickshell/imi/WeatherTreeMotionProbe.qml
@@ -134,6 +134,14 @@ ShellRoot {
     property int transitionIndex: 0
     property var trails: ({})
     property var connections: []
+    // Which span the card is actually at. The list above is a list of ORDERED
+    // PAIRS, not a walk: `3x2 -> 2x1` follows `3x2 -> 3x1`, so the card is at
+    // 3x1 when that pair starts. Nothing put it back, so the sweep ran
+    // 3x1 -> 2x1 under the label `3x2->2x1`, filed its settled shot as
+    // `3x2_settled.png`, and the real 3x2 -> 2x1 was never run at all - the one
+    // pair whose card SHRINKS in both axes. A pair the sweep names has to be a
+    // pair the sweep runs.
+    property string currentSpan: "3x1"
 
     function spanOf(name) {
         const parts = name.split("x");
@@ -155,7 +163,23 @@ ShellRoot {
 
     Timer { id: midShot; interval: 160; onTriggered: harness.shoot(`${harness.transitions[harness.transitionIndex][0]}-to-${harness.transitions[harness.transitionIndex][1]}_mid`) }
 
+    // Put the card at the pair's starting span before running the pair. The
+    // reposition is a span change like any other, so it gets its own settle
+    // rather than being folded into the transition being measured.
     function beginTransition() {
+        const pair = harness.transitions[harness.transitionIndex];
+        if (harness.currentSpan !== pair[0]) {
+            widget.commitGridSize(harness.spanOf(pair[0]));
+            harness.currentSpan = pair[0];
+            repositionSettle.start();
+            return;
+        }
+        harness.runTransition();
+    }
+
+    Timer { id: repositionSettle; interval: 1100; onTriggered: harness.runTransition() }
+
+    function runTransition() {
         const pair = harness.transitions[harness.transitionIndex];
         harness.shoot(`${pair[0]}_settled`);
         midShot.start();
@@ -194,6 +218,7 @@ ShellRoot {
             harness.watch("glyph.morphT", canvas, "morphTChanged", () => canvas.morphT);
         }
         widget.commitGridSize(harness.spanOf(pair[1]));
+        harness.currentSpan = pair[1];
         settleTimer.start();
     }
 
@@ -237,6 +262,7 @@ ShellRoot {
 
     Timer { id: countPhase; interval: 250; onTriggered: {
         widget.commitGridSize(harness.spanOf("3x2"));
+        harness.currentSpan = "3x2";
         countSettle.start();
     } }
     Timer { id: countSettle; interval: 900; onTriggered: harness.runCountCase() }

--- a/dots/.config/quickshell/imi/WeatherTreeMotionProbe.qml
+++ b/dots/.config/quickshell/imi/WeatherTreeMotionProbe.qml
@@ -66,16 +66,20 @@ ShellRoot {
                         high: 24 - i, low: 12 - i });
         Weather.forecast = days;
     }
-    function seedWeather() {
-        // Sunrise and sunset in the shape OpenWeatherMap's parser publishes
-        // them (en-US, with seconds). Without them the sun marker is correctly
-        // hidden - "0" is an unknown day, not midnight - and the shots would
-        // show a curve with nothing on it while looking perfectly fine.
+    // Sunrise and sunset in the shape OpenWeatherMap's parser publishes them
+    // (en-US, with seconds). Without them the sun marker is correctly hidden -
+    // "0" is an unknown day, not midnight - and the shots would show a curve
+    // with nothing on it while looking perfectly fine. Which is also a state
+    // worth driving, so the times are arguments.
+    function seedSun(sunrise, sunset) {
         Weather.data = {
             temp: "21°C", tempFeelsLike: "19°C", tempHigh: "24°C", tempLow: "12°C",
             description: "Light rain", humidity: "72%", wind: "12 km/h", wCode: 296,
-            sunrise: "6:12:00 AM", sunset: "7:48:00 PM"
+            sunrise: sunrise, sunset: sunset
         };
+    }
+    function seedWeather() {
+        harness.seedSun("6:12:00 AM", "7:48:00 PM");
         harness.seedForecast(4);
     }
 
@@ -204,6 +208,16 @@ ShellRoot {
         // travel between the two wide spans on the y axis alone, so watching
         // x - which is what every other trail here watches - would report them
         // static through the one transition that moves them.
+        // The background arc. 1x1 is the one span with no home for it, so the
+        // pairs that enter and leave 1x1 must show the opacity moving through
+        // its middle rather than a value that is 0.32 in one frame and 0 in
+        // the next - and its horizon has to travel into and out of the taller
+        // card, which is the axis the six one-row pairs never exercise.
+        const arc = harness.findByName(widget, "weatherSunArc");
+        const marker = harness.findByName(widget, "weatherSunMarker");
+        harness.watch("arc.op", arc, "opacityChanged", () => arc.opacity);
+        harness.watch("arc.horizon", arc, "horizonYChanged", () => arc.horizonY);
+        harness.watch("sun.y", marker, "yChanged", () => marker.y);
         const pills = harness.findByName(widget, "weatherPills");
         const rule = harness.findByName(widget, "weatherColumnRule");
         const strip = harness.findByName(widget, "weatherForecast");
@@ -229,9 +243,16 @@ ShellRoot {
         for (const label in harness.trails) {
             const trail = harness.trails[label];
             const first = trail[0], last = trail[trail.length - 1];
+            // Half a pixel is the floor for a position, a size or a font, and
+            // it is nonsense for an opacity: the sun arc leaves 1x1 by going
+            // 0.32 -> 0, which is a complete disappearance and a change of
+            // 0.32, so the pixel floor filed the one trail that had to move as
+            // "static" and printed nothing at all about it. A trail's units
+            // decide its floor.
+            const floor = label.endsWith(".op") ? 0.02 : 0.5;
             const moved = label === "glyph.morphT"
                 ? trail.some(v => v > 0.05 && v < 0.95)
-                : Math.abs(last - first) > 0.5;
+                : Math.abs(last - first) > floor;
             if (label === "glyph.morphT" && trail.length > 1 && !moved) {
                 harness.check(`${tag} glyph.morphT sweeps instead of flipping`, false);
                 continue;
@@ -239,6 +260,13 @@ ShellRoot {
             if (!moved) { console.log(`[WeatherTreeMotion] ${tag} ${label}: static`); continue; }
             harness.check(`${tag} ${label} animates (${trail.length} steps)`, trail.length >= 4);
         }
+        // Motion trails score the journey; this scores where it arrived. An
+        // arc that faded out and back in on every pair would pass every trail
+        // above and still be wrong at rest.
+        const arc = harness.findByName(widget, "weatherSunArc");
+        const gone = pair[1] === "1x1";
+        harness.check(`${tag} the arc ${gone ? "is gone" : "is drawn"} at ${pair[1]}`,
+            gone ? arc.opacity < 0.01 : arc.opacity > 0.3);
         harness.transitionIndex++;
         if (harness.transitionIndex < harness.transitions.length) {
             nextTimer.start();
@@ -308,9 +336,37 @@ ShellRoot {
         if (harness.countIndex < harness.countCases.length) {
             harness.runCountCase();
         } else {
-            console.log(`[WeatherTreeMotion] failures: ${harness.failures}`);
-            Qt.quit();
+            unknownPhase.start();
         }
+    } }
+
+    // ---- a day the provider did not report -------------------------------
+    //
+    // "0" is what both providers' parsers write for a missing sunrise or
+    // sunset, and it must not read as midnight: the marker hides and the curve
+    // stays. That is a different reason to be invisible from 1x1's, and the
+    // two are now expressed in one binding, so a rewrite that collapsed them
+    // would put a confident sun at the card's left edge all day - or take the
+    // curve away with it - and neither would warn.
+    Timer { id: unknownPhase; interval: 250; onTriggered: {
+        widget.commitGridSize(harness.spanOf("3x1"));
+        harness.currentSpan = "3x1";
+        harness.seedSun("0", "0");
+        unknownCheck.start();
+    } }
+
+    Timer { id: unknownCheck; interval: 900; onTriggered: {
+        const arc = harness.findByName(widget, "weatherSunArc");
+        const marker = harness.findByName(widget, "weatherSunMarker");
+        harness.check("an unknown sunrise hides the marker", marker.opacity < 0.01);
+        harness.check("...and leaves the curve drawn", arc.opacity > 0.3);
+        harness.shoot("3x1_unknown-day");
+        finish.start();
+    } }
+
+    Timer { id: finish; interval: 200; onTriggered: {
+        console.log(`[WeatherTreeMotion] failures: ${harness.failures}`);
+        Qt.quit();
     } }
 
     Timer { id: t0; interval: 1200; running: true; onTriggered: {

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopWeatherWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopWeatherWidget.qml
@@ -220,8 +220,8 @@ Item {
                 if (width < 2 || height < 2) return;
 
                 const step = Math.max(1.5, width / 120);
-                const yAt = u => sunArc.horizonY - SunArc.heightAt(
-                    SunArc.phaseAt(u, sunArc.window), sunArc.apexRise, sunArc.tailFlatten);
+                const yAt = u => SunArc.curveY(u, sunArc.window,
+                    sunArc.horizonY, sunArc.apexRise, sunArc.tailFlatten);
 
                 // Two passes over the same curve, split at the horizon: the
                 // daylight stretch at full strength, the night dips faint.
@@ -276,9 +276,8 @@ Item {
             horizontalAlignment: Text.AlignHCenter
             verticalAlignment: Text.AlignVCenter
             x: sunArc.width * u - width / 2
-            y: sunArc.horizonY - SunArc.heightAt(
-                SunArc.phaseAt(u, sunArc.window), sunArc.apexRise, sunArc.tailFlatten)
-               - height / 2
+            y: SunArc.curveY(u, sunArc.window, sunArc.horizonY,
+                sunArc.apexRise, sunArc.tailFlatten) - height / 2
             Behavior on x { SpanTravel {} }
             Behavior on y { SpanTravel {} }
             // Below its own horizon it is not the sun that is showing.

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopWeatherWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopWeatherWidget.qml
@@ -205,8 +205,11 @@ Item {
             // The clock is only read while the arc is on screen, so a card
             // that spent the afternoon at 1x1 comes back holding a stale
             // minute until the timer's next tick - up to a minute of the sun
-            // sitting where it was an hour ago.
-            onVisibleChanged: if (visible) sunArc.refreshNow()
+            // sitting where it was an hour ago. The repaint is the same
+            // thought for the canvas: every return from 1x1 happens to change
+            // the width, which requests one, but that is a property of 1x1
+            // being the only span of its width rather than a rule.
+            onVisibleChanged: if (visible) { sunArc.refreshNow(); sunArc.requestPaint(); }
             Timer {
                 interval: 60000
                 repeat: true

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopWeatherWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopWeatherWidget.qml
@@ -104,6 +104,20 @@ Item {
     readonly property var stripSlot: Geometry.forecastStripRect("3x2", root.width3x1, root.height2Rows, Appearance.effectiveScale)
     readonly property var bandRuleSlot: Geometry.bandDividerRect("3x2", root.width3x1, root.height2Rows, Appearance.effectiveScale)
 
+    // The sun arc has a home at every span but 1x1, where the card is fully
+    // occupied and the module returns null (its comment has the numbers). So
+    // it fades there, like every other element with nowhere to be - and a fade
+    // happens WHERE THE ELEMENT STANDS, so it still needs somewhere to stand.
+    // 2x1 is the nearest span that has a home for it, and the three one-row
+    // spans share a height, so standing there means the curve holds exactly
+    // the shape it is fading out of and comes back on it rather than arriving
+    // from somewhere.
+    readonly property bool showsSunArc: Geometry.sunArcRect(
+        root.sizeMode, root.spanW, root.spanH, Appearance.effectiveScale) !== null
+    readonly property string arcSpan: root.sizeMode === "1x1" ? "2x1" : root.sizeMode
+    readonly property var sunArcSlot: Geometry.sunArcRect(
+        root.arcSpan, root.spanW, root.spanH, Appearance.effectiveScale)
+
     // wttr.in answers with three days, OpenWeatherMap with four, and a failed
     // forecast request with none - all three are real and the row is laid out
     // from whatever arrives (#111 deliberately padded to no fixed count).
@@ -161,26 +175,24 @@ Item {
             id: sunArc
             objectName: "weatherSunArc"
             anchors.fill: parent
-            opacity: 0.32
+            // 1x1 has no home for the arc, so it leaves the way anything else
+            // in this tree leaves a span it does not live at.
+            opacity: root.showsSunArc ? 0.32 : 0
+            Behavior on opacity { SpanFade {} }
+            visible: opacity > 0
             z: -1
 
-            // How much night to show past each horizon, as a fraction of the
-            // daylight. Enough to read as a dip, not so much that the day is
-            // squeezed into the middle of the card.
-            readonly property real nightMargin: 0.22
-            // How much of the sine's depth the night tails keep at their
-            // deepest, so they level off toward the card's edges.
-            readonly property real tailFlatten: 0.35
+            readonly property real nightMargin: SunArc.NIGHT_MARGIN
+            readonly property real tailFlatten: SunArc.TAIL_FLATTEN
             readonly property var window: SunArc.windowFor(sunArc.nightMargin)
 
-            // The horizon: the band seam at 3x2 (the hairline is already
-            // there), and a proportion of the card elsewhere.
-            property real horizonY: root.sizeMode === "3x2"
-                ? root.bandRuleSlot.y
-                : height * 0.74
+            // The horizon and the apex come from the SETTLED span's box, like
+            // every other rect in this tree, and travel on their own
+            // Behaviors - the card's animating height is not the box.
+            property real horizonY: root.sunArcSlot.horizonY
             Behavior on horizonY { SpanTravel {} }
-            readonly property real apexRise: root.sizeMode === "3x2"
-                ? horizonY * 0.62 : height * 0.42
+            property real apexRise: root.sunArcSlot.apexRise
+            Behavior on apexRise { SpanTravel {} }
 
             // Local minutes, repainted on the minute rather than per frame:
             // the sun moves about a pixel a minute across a card this wide.
@@ -190,6 +202,11 @@ Item {
                 sunArc.nowMinutes = now.getHours() * 60 + now.getMinutes();
             }
             Component.onCompleted: sunArc.refreshNow()
+            // The clock is only read while the arc is on screen, so a card
+            // that spent the afternoon at 1x1 comes back holding a stale
+            // minute until the timer's next tick - up to a minute of the sun
+            // sitting where it was an hour ago.
+            onVisibleChanged: if (visible) sunArc.refreshNow()
             Timer {
                 interval: 60000
                 repeat: true
@@ -210,6 +227,7 @@ Item {
             onSunsetTextChanged: requestPaint()
             onInkColorChanged: requestPaint()
             onHorizonYChanged: requestPaint()
+            onApexRiseChanged: requestPaint()
             onWidthChanged: requestPaint()
             onHeightChanged: requestPaint()
 
@@ -287,7 +305,12 @@ Item {
             color: root.contentColor
             // Brighter than the curve it rides - it is the one part of this
             // background that is a reading rather than a frame.
-            opacity: sunArc.sunPosition === null ? 0 : 0.8
+            //
+            // Two separate reasons to be invisible, and they must stay
+            // separate: an unknown sunrise ("0" from either provider) hides
+            // the marker while the curve stays, and 1x1 takes both away.
+            opacity: sunArc.sunPosition === null ? 0
+                : root.showsSunArc ? 0.8 : 0
             Behavior on opacity { SpanFade {} }
             visible: opacity > 0 && sunArc.visible
             z: -1

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/sun_arc.js
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/sun_arc.js
@@ -12,6 +12,15 @@
 // formatted. Neither is a Date, and parsing either with `new Date(...)` gets
 // an Invalid Date - so this reads the clock itself.
 
+// How much night the card shows past each horizon, as a fraction of the
+// daylight, and how much of the sine's depth the night tails keep at their
+// deepest. Named here rather than left as literals on the canvas because the
+// arc's ASPECT - how wide the day is against how far the curve rises in it -
+// is what decides whether a span can carry the arc at all, and a test cannot
+// ask that question of a number sitting in a QML binding.
+var NIGHT_MARGIN = 0.22;
+var TAIL_FLATTEN = 0.35;
+
 // Minutes since local midnight, or -1 when the string is not a clock. "0" is
 // what both providers' parsers write when the field was missing, and it must
 // not read as midnight - a sun that rises at 00:00 puts the dot in the wrong
@@ -98,7 +107,7 @@ function phaseAt(u, window) {
 function heightAt(phase, rise, tailFlatten) {
     var raw = Math.sin(phase * Math.PI) * rise;
     if (phase >= 0 && phase <= 1) return raw;
-    var flatten = tailFlatten === undefined ? 0.35 : tailFlatten;
+    var flatten = tailFlatten === undefined ? TAIL_FLATTEN : tailFlatten;
     // How far into the night this is, in phase units, capped at half a period
     // (where the continued sine would bottom out).
     // Ease from full depth at the horizon to `flatten` of it further out, on

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/sun_arc.js
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/sun_arc.js
@@ -108,6 +108,18 @@ function heightAt(phase, rise, tailFlatten) {
     return raw * (1 - (1 - flatten) * eased);
 }
 
+// Where the curve is at a point across the card, in CARD coordinates - y
+// grows downward, so the apex is the smallest number this returns.
+//
+// The marker rides the line the canvas strokes, and this is the one place
+// that line is spelled. Written out at both call sites instead, the two agree
+// only for as long as nobody edits one of them: a marker floating a few pixels
+// off its own curve is not an error, does not warn, and looks like a rounding
+// artefact rather than like two expressions that have drifted apart.
+function curveY(u, window, horizonY, apexRise, tailFlatten) {
+    return horizonY - heightAt(phaseAt(u, window), apexRise, tailFlatten);
+}
+
 // Where today's sun sits across the card, or null when the day is not
 // knowable. Clamped to the card, so a sun deep in the night parks at the edge
 // rather than being drawn off it.

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/weather_geometry.js
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/weather_geometry.js
@@ -96,6 +96,38 @@ function columnDividerRect(span, width, height, scale) {
     return null;
 }
 
+// ---- the sun's day, across the card's background -------------------------
+//
+// The arc is a background layer rather than one of the shared three, but it
+// obeys the same rule as everything else in this file: a rect where it has a
+// home, null where it does not.
+//
+// `horizonY` is where the curve crosses from day into night, and `apexRise`
+// is how far above it the midday sine reaches. Both are measured from the
+// card's top edge.
+//
+// **1x1 is the null.** The curve always draws one whole day plus a night
+// margin at each end across whatever width it is given, so at 132px the
+// daylight stretch is 92px wide while the apex still rises 45px: a 2:1 arc,
+// steep enough that what shows either side of the 44px temperature reads as a
+// diagonal streak through the card rather than as a day. Making it fit is not
+// the answer either - flattening it to a readable ~4:1 puts the whole curve
+// in the 28px strip below the condition line, where the leaf glyph swallows
+// the sunset half and the marker lands on the text. The 1x1 card is fully
+// occupied; the arc has nowhere to be, which is what null means here.
+function sunArcRect(span, width, height, scale) {
+    if (span === "1x1") return null;
+    if (span === "3x2") {
+        // No separate horizon is drawn at 3x2: the curve's zero-crossing lands
+        // on the hairline the card already draws between its two bands, so the
+        // divider and the horizon are one line doing both jobs. Derived from
+        // that rect rather than restated, so moving the seam moves the horizon.
+        var seam = bandDividerRect(span, width, height, scale).y;
+        return { horizonY: seam, apexRise: seam * 0.62 };
+    }
+    return { horizonY: height * 0.74, apexRise: height * 0.42 };
+}
+
 // ---- the second row ------------------------------------------------------
 
 // The hairline between the two bands. 3x2 only - there is no seam to draw on

--- a/dots/.config/quickshell/imi/tests/tst_sun_arc.qml
+++ b/dots/.config/quickshell/imi/tests/tst_sun_arc.qml
@@ -1,9 +1,18 @@
 import QtTest
 import "../modules/common/plugins/designsystem/widgets/sun_arc.js" as SunArc
+import "../modules/common/plugins/designsystem/widgets/weather_geometry.js" as Geometry
 
 // The sun arc's arithmetic. The curve is the easy half; the clock is not.
 TestCase {
     name: "SunArcTest"
+
+    // The card the arc is drawn on, per span, at scale 1.
+    readonly property var spans: [
+        { name: "1x1", width: 132, height: 108 },
+        { name: "2x1", width: 276, height: 108 },
+        { name: "3x1", width: 420, height: 108 },
+        { name: "3x2", width: 420, height: 228 }
+    ]
 
     function test_it_reads_both_providers_clock_formats() {
         // OpenWeatherMap's, formatted en-US with seconds before publishing.
@@ -148,6 +157,31 @@ TestCase {
                 SunArc.phaseAt(at, window), 45, 0.35);
             fuzzyCompare(SunArc.curveY(at, window, 80, 45, 0.35), expected, 0.0001);
         }
+    }
+
+    function test_the_arc_reads_as_an_arc_at_every_span_it_lives_at() {
+        // The bug this pins: at 1x1 the curve drew a whole day plus a night
+        // margin at each end across 132px while still rising 45px, so what
+        // showed either side of the temperature was a diagonal streak. What
+        // separates a day from a streak is the ASPECT - how wide the daylight
+        // stretch is against how far the curve rises in it - and three to one
+        // is where the two visibly part company on this card.
+        const window = SunArc.windowFor(SunArc.NIGHT_MARGIN);
+        const dayFraction = window.uSet - window.uRise;
+        const readable = 3;
+        for (const span of spans) {
+            const arc = Geometry.sunArcRect(span.name, span.width, span.height, 1);
+            if (arc === null) continue;
+            const aspect = (span.width * dayFraction) / arc.apexRise;
+            verify(aspect >= readable,
+                   `${span.name} carries the arc at ${aspect.toFixed(2)}:1`);
+        }
+        // ...and 1x1 is the span that cannot, which is the whole reason it has
+        // no home: it would keep the shape it stands at while fading, and the
+        // three one-row spans share that shape.
+        const stands = Geometry.sunArcRect("2x1", 276, 108, 1);
+        const at1x1 = (132 * dayFraction) / stands.apexRise;
+        verify(at1x1 < readable, `1x1 would only manage ${at1x1.toFixed(2)}:1`);
     }
 
     function test_the_sun_sits_where_the_clock_says() {

--- a/dots/.config/quickshell/imi/tests/tst_sun_arc.qml
+++ b/dots/.config/quickshell/imi/tests/tst_sun_arc.qml
@@ -116,6 +116,40 @@ TestCase {
         verify(before < at && at < after, "and it keeps going the same way");
     }
 
+    // ---- the curve as card coordinates --------------------------------
+
+    function test_the_curve_meets_the_horizon_at_both_horizons() {
+        // y grows downward, so "on the horizon" is literally horizonY.
+        const window = SunArc.windowFor(0.22);
+        fuzzyCompare(SunArc.curveY(window.uRise, window, 80, 45, 0.35), 80, 0.0001);
+        fuzzyCompare(SunArc.curveY(window.uSet, window, 80, 45, 0.35), 80, 0.0001);
+    }
+
+    function test_the_curve_hangs_below_the_horizon_at_the_cards_edges() {
+        const window = SunArc.windowFor(0.22);
+        verify(SunArc.curveY(0, window, 80, 45, 0.35) > 80, "dawn side dips");
+        verify(SunArc.curveY(1, window, 80, 45, 0.35) > 80, "dusk side dips");
+    }
+
+    function test_the_marker_rides_the_line_the_canvas_strokes() {
+        // The marker and the curve read the same expression, so the sun at
+        // midday is ON the apex rather than near it - the failure this pins
+        // is two spellings of one line drifting a few pixels apart, which
+        // reads as a rounding artefact and never warns.
+        const window = SunArc.windowFor(0.22);
+        const rise = "06:00 AM", set = "06:00 PM";
+        const u = SunArc.sunU(12 * 60, rise, set, window);
+        fuzzyCompare(SunArc.curveY(u, window, 80, 45, 0.35), 80 - 45, 0.0001);
+        // ...and an hour either side of it, where the answer is not a
+        // landmark either function could have short-circuited to.
+        for (const minutes of [7 * 60, 11 * 60, 16 * 60]) {
+            const at = SunArc.sunU(minutes, rise, set, window);
+            const expected = 80 - SunArc.heightAt(
+                SunArc.phaseAt(at, window), 45, 0.35);
+            fuzzyCompare(SunArc.curveY(at, window, 80, 45, 0.35), expected, 0.0001);
+        }
+    }
+
     function test_the_sun_sits_where_the_clock_says() {
         const window = SunArc.windowFor(0.25);
         const rise = "06:00 AM", set = "06:00 PM";

--- a/dots/.config/quickshell/imi/tests/tst_weather_geometry.qml
+++ b/dots/.config/quickshell/imi/tests/tst_weather_geometry.qml
@@ -87,6 +87,70 @@ TestCase {
         verify(Geometry.bandDividerRect("3x2", 420, 228, 1) !== null);
     }
 
+    // ---- the sun arc's background layer ---------------------------------
+
+    function test_the_sun_arc_has_no_home_at_1x1() {
+        // The one span the curve does not fit: it always draws a whole day
+        // plus a night margin at each end across whatever width it is given,
+        // and at 132px that is steep enough to read as a diagonal streak
+        // rather than as a day. Null is a fade, which is how the tree gets rid
+        // of an element with nowhere to be.
+        compare(Geometry.sunArcRect("1x1", 132, 108, 1), null);
+        for (const span of spans) {
+            if (span.name === "1x1") continue;
+            verify(Geometry.sunArcRect(span.name, span.width, span.height, 1) !== null,
+                   "the arc lives at " + span.name);
+        }
+    }
+
+    function test_the_arcs_horizon_is_the_band_seam_at_3x2() {
+        // No separate horizon is drawn at 3x2 - the curve's zero-crossing is
+        // the hairline the card already draws between its bands. Derived, so
+        // moving the seam cannot leave the curve crossing somewhere else.
+        const arc = Geometry.sunArcRect("3x2", 420, 228, 1);
+        const seam = Geometry.bandDividerRect("3x2", 420, 228, 1);
+        compare(arc.horizonY, seam.y);
+    }
+
+    function test_the_arcs_apex_clears_the_horizon_without_leaving_the_card() {
+        for (const span of spans) {
+            const arc = Geometry.sunArcRect(span.name, span.width, span.height, 1);
+            if (arc === null) continue;
+            verify(arc.apexRise > 0, "the curve rises at " + span.name);
+            verify(arc.horizonY - arc.apexRise > 0,
+                   "and its apex is still inside the card at " + span.name);
+            verify(arc.horizonY < span.height,
+                   "the horizon is inside the card at " + span.name);
+        }
+    }
+
+    function test_the_arc_travels_into_the_taller_card() {
+        // The same rule as the shared three: an element present on both sides
+        // of a span change must have somewhere new to go, or the card grows
+        // around a frozen curve.
+        const one = Geometry.sunArcRect("3x1", 420, 108, 1);
+        const two = Geometry.sunArcRect("3x2", 420, 228, 1);
+        verify(two.horizonY > one.horizonY, "the horizon drops into the second row");
+        verify(two.apexRise > one.apexRise, "and the curve rises further with it");
+    }
+
+    function test_the_one_row_spans_share_the_arcs_shape() {
+        // 1x1 fades to where 2x1 stands, so the two must agree: a curve that
+        // came back at a different height would be a snap wearing a fade's
+        // clothes.
+        const two = Geometry.sunArcRect("2x1", 276, 108, 1);
+        const three = Geometry.sunArcRect("3x1", 420, 108, 1);
+        compare(two.horizonY, three.horizonY);
+        compare(two.apexRise, three.apexRise);
+    }
+
+    function test_scale_multiplies_the_arc() {
+        const plain = Geometry.sunArcRect("3x2", 420, 228, 1);
+        const scaled = Geometry.sunArcRect("3x2", 630, 342, 1.5);
+        fuzzyCompare(scaled.horizonY, plain.horizonY * 1.5, 0.0001);
+        fuzzyCompare(scaled.apexRise, plain.apexRise * 1.5, 0.0001);
+    }
+
     function test_the_strip_sits_inside_the_card_with_even_margins() {
         const strip = Geometry.forecastStripRect("3x2", 420, 228, 1);
         compare(strip.x, 20, "left margin");


### PR DESCRIPTION
The weather card's sun arc works at 2x1, 3x1 and 3x2 and does not at 1x1. The curve draws one whole day plus a night margin at each end across whatever width it is handed, and never reconsiders: at 132x108 that is a 92px daylight stretch under a 45px rise — a 2:1 arc, of which the parts not behind the 44px temperature or the leaf glyph read as a diagonal streak through the card.

## The route, and the one not taken

**Both cheap routes were tried before choosing.** Flattening it to a readable ~4:1 (`nightMargin` 0.08, horizon at 0.90 of the card, apex at 0.20) *does* produce an arc — the probe shot at 300% shows a legible shallow curve. It is not shippable for a different reason: at that flattening the whole curve lives in the 28px strip below the condition line, the leaf glyph swallows the sunset half, and the sun marker lands on top of "Light rain".

The 1x1 card is fully occupied — `21°` owns the top half, the condition the next band, the leaf the bottom-right corner. There is no background left to be a background layer on, which is what an element with no home at a span **is**. So it fades, the way this tree's other homeless elements do.

## How it is expressed

`weather_geometry.js` gains `sunArcRect(span, …)`, beside every other rect that is null at the spans it has no home at, returning `{horizonY, apexRise}` — and `null` at 1x1. Two things fell out of moving the decision there:

- **The horizon at 3x2 is now derived from `bandDividerRect` rather than restated.** The claim that the band seam and the horizon are one line doing both jobs is structural instead of a comment.
- **The horizon and the apex read the settled span's box**, per 189caa6ff, and travel on their own `SpanTravel` Behaviors. They were reading the card's animating height.

The arc stands at 2x1's rect while it fades, and the three one-row spans share a shape, so the curve leaves and returns on exactly the line it was on. The marker keeps its two reasons to be invisible separate: an unknown sunrise (`"0"` from either provider) hides it while the curve stays; 1x1 takes both.

`sun_arc.js` also gains `curveY()`. The canvas's `yAt` and the marker's `y` spelled the same line twice — the pair that has to stay consistent with each other — and two spellings agree only until somebody edits one.

## Verification

`tests/run_tests.sh`: **697 passed, 0 failed** (687 before).

The probe (`tests/run_weather_probe.sh`) now scores the arc, and fixing it turned up two ways it was reporting confidently about transitions it never ran:

- **The sweep is a list of ordered pairs, not a walk.** `3x2 -> 2x1` follows `3x2 -> 3x1`, so the card was at 3x1 when that pair started: it measured `3x1 -> 2x1` under the `3x2->2x1` label, filed its settled shot as `3x2_settled.png`, and the one pair whose card shrinks in **both** axes was never exercised.
- **The "did this move" floor was `0.5` for every trail**, which is right for a position and nonsense for an opacity. The arc leaves 1x1 by fading `0.32 -> 0` — a complete disappearance and a change of 0.32 — so the pixel floor filed the one trail that had to move as `static`.

With both fixed, every pair touching 1x1 shows a 31–32 step fade and every other pair is `static`, plus a settled check per pair (`the arc is gone at 1x1` / `is drawn at 2x1`) and a closing phase that seeds `sunrise: "0"` and confirms the marker hides while the curve stays. `failures: 0`.

Every new check was proven able to fail: 1x1 given a home back reddens `test_the_sun_arc_has_no_home_at_1x1` and `test_the_arc_reads_as_an_arc_at_every_span_it_lives_at` (`1x1 carries the arc at 2.02:1`); the `Behavior on opacity` removed reddens six probe pairs at 2 steps each; `curveY` offset by 3px reddens two `tst_sun_arc.qml` cases.

Docs: updated AGENT.md §Dynamic/data-driven QML gotchas — added the ordered-pair sweep trap and the trail-floor-in-the-wrong-units trap, both of which fail by going quiet rather than red.
