### PR TITLE
calendar draws its surface on the shared card

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1288,8 +1288,21 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   pattern to the component (`lint_widget_card_tint.py`) found the other three on its first run.
   `WidgetCard` owns the tint, the rounding, an optional content clip, a `blurRegion` record, and a
   `shapeName` parameter that turns the card into a stretched `MaterialShape` (which morphs on any
-  shape change, because `ShapeCanvas` does). calendar is the one exempted copy until its scheduled
-  rebuild. b362d8c80 ("feat(widgets): one card component for the surface every widget redrew").
+  shape change, because `ShapeCanvas` does). b362d8c80 ("feat(widgets): one card component for the
+  surface every widget redrew").
+  calendar was the exempted copy and is not any more, and two things about adopting the card are
+  worth carrying to the next one. **The tint the card takes over is the card's own, not every
+  surface a widget paints**: calendar still thins its 1x1 banner, its month pill, its day grid and
+  today's highlight so the frost reads through the whole widget, and it does that with
+  `transparentize` rather than the card's `applyAlpha` because `colLayer1` already carries an alpha
+  the widget must *scale* rather than overwrite — `lint_widget_card_tint.py` reserves the card's
+  spelling and deliberately does not match that one. And **the card routes children into its own
+  content item**, so anything that anchored to the old `Rectangle` by id (calendar's two corner
+  handles did) has to anchor to `parent` instead: an anchor may only name a parent or a sibling, and
+  the card is now the grandparent. Neither of those is caught by the tint lint;
+  `test_expressive_design_system.py` pins the composition and `test_calendar_card.py` renders it,
+  because a content-sized widget whose card failed to resolve is a zero-size widget rather than an
+  error. 486272dbe ("feat(calendar): draw the widget's surface on the shared card").
 - **The resize grip accumulates tension; it does not pick the nearest span.** A widget holds its
   span while pull builds, gives one offered span per 60px breakaway with the remainder carried, and
   rubber-bands at a wall. `resize-tension.js` owns every constant and all of the arithmetic; the

--- a/dots/.config/quickshell/imi/CalendarCardProbe.qml
+++ b/dots/.config/quickshell/imi/CalendarCardProbe.qml
@@ -84,6 +84,12 @@ ShellRoot {
                     + `${harness.fieldTop},${Math.round(loader.width)},`
                     + `${Math.round(loader.height)}`);
             console.log(`[CalendarCard] layout ${boxes.join(" ")}`);
+            // A strip of untouched field, well below the tallest card. The
+            // field is not white after the grab - a shadow has to be measured
+            // as darker than THIS, not as darker than zero, or an assertion
+            // written against zero passes on a card with no shadow at all.
+            console.log(`[CalendarCard] baseline ${harness.leftMargin},`
+                + `${window.implicitHeight - 40},236,14`);
             field.grabToImage(result => {
                 result.saveToFile(shot);
                 console.log("[CalendarCard] saved");

--- a/dots/.config/quickshell/imi/CalendarCardProbe.qml
+++ b/dots/.config/quickshell/imi/CalendarCardProbe.qml
@@ -1,0 +1,94 @@
+import QtQuick
+import Quickshell
+
+/*
+ * The calendar widget's three modes on a light field, plus the tall mode a
+ * second time with the host reporting a drag.
+ *
+ * The structural checks can only see that the widget names WidgetCard and
+ * forwards `hostDragging`. What they cannot see is whether the card the
+ * composition actually builds paints anything: the widget is content-sized,
+ * so a card that failed to resolve leaves a zero-size widget, and a `dragging`
+ * that never arrives leaves a shadow that simply does not lift - both silent.
+ * This renders the real widget and test_calendar_card.py reads the pixels.
+ *
+ *   CALENDAR_CARD_SHOT=/tmp/cal.png ./tests/run_calendar_probe.sh
+ */
+ShellRoot {
+    id: harness
+
+    readonly property string widgetUrl: Quickshell.shellPath(
+        "modules/common/plugins/bundled/calendar/Widget.qml")
+
+    // Printed for the analyser, so it needs no duplicate copy of this layout.
+    readonly property int fieldTop: 80
+    readonly property int columnGap: 60
+    readonly property int leftMargin: 60
+
+    FloatingWindow {
+        id: window
+        implicitWidth: 1180
+        implicitHeight: 420
+        color: "white"
+
+        Item {
+            id: field
+            anchors.fill: parent
+
+            // The grab takes THIS item, not the window: grabbing over the
+            // window's own colour produces a transparent PNG whose "white"
+            // reads as black to any analyser (test_card_shadow.py's trap).
+            Rectangle { anchors.fill: parent; color: "#e8e6ee" }
+
+            Row {
+                x: harness.leftMargin
+                y: harness.fieldTop
+                spacing: harness.columnGap
+
+                Loader { id: oneByOne; source: harness.widgetUrl }
+                Loader { id: twoByOne; source: harness.widgetUrl }
+                Loader { id: twoByTwo; source: harness.widgetUrl }
+                // The same card the host is dragging: its shadow lifts.
+                Loader { id: dragged; source: harness.widgetUrl }
+            }
+        }
+    }
+
+    Timer {
+        running: true
+        interval: 900
+        onTriggered: {
+            // Assigning breaks the PluginState binding, which is exactly what
+            // the widget's own handles do for live feedback.
+            oneByOne.item.sizeMode = "1x1";
+            twoByOne.item.sizeMode = "2x1";
+            twoByTwo.item.sizeMode = "2x2";
+            dragged.item.sizeMode = "2x2";
+            dragged.item.hostDragging = true;
+            shotTimer.start();
+        }
+    }
+
+    Timer {
+        id: shotTimer
+        interval: 900
+        onTriggered: {
+            const shot = Quickshell.env("CALENDAR_CARD_SHOT") || "";
+            if (shot === "") {
+                console.log("[CalendarCard] FAIL: CALENDAR_CARD_SHOT unset");
+                Qt.quit();
+                return;
+            }
+            const boxes = [oneByOne, twoByOne, twoByTwo, dragged].map(
+                loader => `${Math.round(loader.x + harness.leftMargin)},`
+                    + `${harness.fieldTop},${Math.round(loader.width)},`
+                    + `${Math.round(loader.height)}`);
+            console.log(`[CalendarCard] layout ${boxes.join(" ")}`);
+            field.grabToImage(result => {
+                result.saveToFile(shot);
+                console.log("[CalendarCard] saved");
+                Qt.quit();
+            });
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/calendar/Widget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/calendar/Widget.qml
@@ -6,6 +6,7 @@ import qs.modules.common
 import qs.modules.common.functions
 import qs.modules.common.widgets
 import qs.modules.common.plugins
+import "../../designsystem/widgets" as Expressive
 
 Item {
     id: root
@@ -18,24 +19,30 @@ Item {
     // (a bare `qs -p` probe of this file), same as `screenName: ""`.
     property bool hostInteractionLocked: false
 
+    // Set by the host while this widget is being dragged, and handed straight
+    // to the card: the shadow lifts on hover and lifts further on a drag, and
+    // a link that forgets to forward this produces a card that silently never
+    // rises (tests/test_expressive_design_system.py pins the chain).
+    property bool hostDragging: false
+
     // The card fills the whole widget, so the host's default frost region has
     // the right extent - but not the right corner radius (PluginWidget falls
-    // back to `Appearance.rounding.large`, 7px tighter than the card's
-    // `verylarge`), which would leave blurred slivers outside the four corners.
-    // Naming the card is the only way to hand the host the radius it has.
+    // back to `Appearance.rounding.large`, 7px tighter than the card's own),
+    // which would leave blurred slivers outside the four corners. The record
+    // comes from the card itself, so the widget cannot disagree with its own
+    // surface about where the frost goes.
     readonly property bool blurEnabled: PluginState.option("calendar", "blurEnabled", false)
     readonly property real backgroundOpacity: PluginState.effectiveBackgroundOpacity("calendar")
     readonly property bool managesBlurTint: true
-    readonly property var blurRegions: [
-        {
-            x: card.x,
-            y: card.y,
-            width: card.width,
-            height: card.height,
-            radius: card.radius
-        }
-    ]
+    readonly property var blurRegions: [card.blurRegion]
 
+    // The card's own surface is the card's business now; this stays for the
+    // surfaces drawn *inside* it - the 1x1 banner, the month pill, the day
+    // grid and today's highlight - which thin with the card so the frost
+    // reads through the whole widget rather than through its edges only.
+    // `transparentize` rather than the card's `applyAlpha` because two of
+    // those colours (colLayer1 most of all) already carry an alpha that the
+    // widget must scale, not overwrite.
     function tinted(surfaceColor) {
         return root.blurEnabled ? ColorUtils.transparentize(surfaceColor, 1 - root.backgroundOpacity) : surfaceColor;
     }
@@ -205,17 +212,22 @@ Item {
         }
     }
 
-    Rectangle {
+    // The surface every other desktop widget already composes. It owns the
+    // tint pair, the rounding (this widget's own `verylarge` was the token the
+    // shared card's 30 had drifted from), the frost record above, and the drop
+    // shadow with its hover and drag lift - which is what replaces the flat
+    // StyledRectangularShadow that used to hang behind this rectangle.
+    //
+    // No `tensionX`/`tensionY`: the manifest declares no `grid`, so the host
+    // draws no resize grip here and there is never a bow to render.
+    Expressive.WidgetCard {
         id: card
         implicitWidth: root.widgetWidth
         implicitHeight: root.sizeMode === "1x1" ? root.shortHeight : root.sizeMode === "2x1" ? root.shortHeight : root.tallHeight
-        radius: Appearance.rounding?.verylarge ?? 30
-        color: root.tinted(Appearance.colors.colPrimaryContainer)
-
-        StyledRectangularShadow {
-            target: card
-            z: -2
-        }
+        tint: Appearance.colors.colPrimaryContainer
+        useBlurBackground: root.blurEnabled
+        backgroundOpacity: root.backgroundOpacity
+        dragging: root.hostDragging
 
         Loader {
             anchors.fill: parent
@@ -538,9 +550,13 @@ Item {
             height: 16
             radius: Appearance.rounding.unsharpenslight
             color: Appearance.colors.colOnPrimaryContainer
+            // The card routes its children into its own content item, so the
+            // handles anchor to that rather than reaching back up to `card` -
+            // an anchor may only name a parent or a sibling. It fills the
+            // card, so the corner is the same corner.
             anchors {
-                right: card.right
-                bottom: card.bottom
+                right: parent.right
+                bottom: parent.bottom
                 margins: Appearance.spacing.space50
             }
             opacity: (widgetHover.hovered || resizeArea.containsMouse || resizeArea.pressed) ? 0.5 : 0
@@ -586,8 +602,8 @@ Item {
             radius: Appearance.rounding.unsharpenslight
             color: Appearance.colors.colOnPrimaryContainer
             anchors {
-                left: card.left
-                bottom: card.bottom
+                left: parent.left
+                bottom: parent.bottom
                 margins: Appearance.spacing.space50
             }
             opacity: (widgetHover.hovered || toggleArea.containsMouse) && root.sizeMode !== "1x1" ? 0.5 : 0

--- a/dots/.config/quickshell/imi/tests/lint_widget_card_tint.py
+++ b/dots/.config/quickshell/imi/tests/lint_widget_card_tint.py
@@ -13,10 +13,15 @@ This does not force a widget to use the card (the system monitor's three cards
 are its own composition); it forces a widget that wants the *standard* card
 look to get it from the standard card, where its motion can be tuned once.
 
-calendar/Widget.qml is the one temporary exemption: it is scheduled to be
-rebuilt on the card once the architecture settles on media and weather, and
-its drifted copy is left alone until then rather than half-migrated. Remove
-the exemption with the rebuild.
+calendar/Widget.qml used to be exempted here, pending the rebuild the spec
+scheduled for it. That rebuild has landed - it composes WidgetCard now, which
+tests/test_expressive_design_system.py pins - so the exemption is gone. What
+the widget still spells for itself is a *content* tint: the 1x1 banner, the
+month pill, the day grid and today's highlight thin with the card so the frost
+reads through the whole widget rather than through its edges only. That is
+deliberately not what this reserves, and not what it matches either - those go
+through `transparentize`, which scales an alpha two of those colours already
+carry, rather than the card's absolute `applyAlpha`.
 """
 
 from pathlib import Path
@@ -29,8 +34,6 @@ SKIP_DIRS = {".git", "node_modules", "__pycache__", "tests"}
 
 ALLOWED = {
     Path("modules/common/plugins/designsystem/widgets/WidgetCard.qml"),
-    # Rebuilt on the card after media and weather settle - see docstring.
-    Path("modules/common/plugins/bundled/calendar/Widget.qml"),
 }
 
 # The tint conditional, however the alpha helper is qualified and whatever the

--- a/dots/.config/quickshell/imi/tests/run_calendar_probe.sh
+++ b/dots/.config/quickshell/imi/tests/run_calendar_probe.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Headless weston + qs, the runtime-harness pattern, trimmed to one probe.
+set -u
+SOCKET="wl-imi-calendar-card"
+TMP=$(mktemp -d)
+export XDG_RUNTIME_DIR="$TMP/runtime"; mkdir -p "$XDG_RUNTIME_DIR"; chmod 700 "$XDG_RUNTIME_DIR"
+export XDG_CONFIG_HOME="$TMP/config" XDG_CACHE_HOME="$TMP/cache" XDG_STATE_HOME="$TMP/state" XDG_DATA_HOME="$TMP/data"
+mkdir -p "$XDG_CONFIG_HOME" "$XDG_CACHE_HOME" "$XDG_STATE_HOME" "$XDG_DATA_HOME"
+weston --backend=headless-backend.so --socket="$SOCKET" --width=1280 --height=800 &>"$TMP/weston.log" &
+WPID=$!
+sleep 2
+DBUS_SESSION_BUS_ADDRESS="unix:path=/nonexistent" WAYLAND_DISPLAY="$SOCKET" CALENDAR_CARD_SHOT="${CALENDAR_CARD_SHOT:-}" timeout 60 qs -p "$(dirname "$0")/../CalendarCardProbe.qml" 2>&1 | grep "CalendarCard"
+kill $WPID 2>/dev/null
+rm -rf "$TMP"

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -277,6 +277,16 @@ if ! python3 "$SCRIPT_DIR/test_card_shadow.py"; then
     exit 1
 fi
 
+# The card above is rendered on its own. This renders the widget that composes
+# one: calendar is content-sized, so a card that failed to resolve leaves a
+# zero-size widget rather than an error, and a `dragging` that never arrives
+# leaves a shadow that never lifts. Brings its own headless weston.
+echo "Running calendar card tests..."
+if ! python3 "$SCRIPT_DIR/test_calendar_card.py"; then
+    echo "Calendar card tests failed."
+    exit 1
+fi
+
 # The grip harness above reads settled sizes on purpose, so it passes whether a
 # span change is animated or instant. This one samples the size mid-change,
 # which is the only way to tell a Behavior that ticks from one that never does.

--- a/dots/.config/quickshell/imi/tests/test_calendar_card.py
+++ b/dots/.config/quickshell/imi/tests/test_calendar_card.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""The calendar widget's card, measured in pixels rather than in source text.
+
+`test_expressive_design_system.py` can see that the widget names WidgetCard
+and forwards `hostDragging`. It cannot see either of the two ways that
+composition fails silently: the widget is content-sized, so a card that did
+not resolve leaves a zero-size widget rather than an error, and a `dragging`
+that never reaches the card leaves a shadow that simply never lifts.
+
+So this renders the real widget under headless weston - the three modes, and
+the tall one a second time with the host reporting a drag - and reads the
+strip just below each card.
+"""
+
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+PROBE = ROOT / "tests/run_calendar_probe.sh"
+
+# The spans the three modes are built from (docs/widget-grid.md): one cell is
+# 132x108 and two are 276 wide, 228 tall, with the 12px gap between them.
+EXPECTED_BOXES = [(132, 108), (276, 108), (276, 228), (276, 228)]
+
+
+def darkness_below(shot, x, y, width, height):
+    """Mean darkness (0 = untouched field) of the band under a card.
+
+    ImageMagick does the averaging: piping raw grey out of it and summing by
+    hand produced values that did not match the visible image at all.
+    """
+    geometry = f"{width - 40}x14+{x + 20}+{y + height + 4}"
+    mean = subprocess.run(
+        ["magick", str(shot), "-crop", geometry, "+repage",
+         "-colorspace", "Gray", "-format", "%[fx:mean]", "info:"],
+        capture_output=True, text=True, timeout=60).stdout.strip()
+    return (1.0 - float(mean)) * 255.0
+
+
+def _runtime_available():
+    # Same gate the other runtime probes use, plus the analyser: CI has no
+    # compositor, and a test that hard-fails there is reporting the runner's
+    # shape as a defect in the card.
+    return all(shutil.which(tool) is not None
+               for tool in ("qs", "weston", "magick"))
+
+
+@unittest.skipUnless(_runtime_available(), "needs qs, weston and magick on PATH")
+class CalendarCardTest(unittest.TestCase):
+    def test_the_calendar_composes_a_card_that_paints_and_lifts(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            shot = Path(tmp) / "calendar.png"
+            env = dict(os.environ, CALENDAR_CARD_SHOT=str(shot))
+            result = subprocess.run([str(PROBE)], capture_output=True, text=True,
+                                    timeout=180, env=env)
+            self.assertIn("saved", result.stdout,
+                          f"probe did not render:\n{result.stdout}\n{result.stderr}")
+            self.assertTrue(shot.exists(), "no screenshot produced")
+
+            layout = re.search(r"\[CalendarCard\] layout (.+)", result.stdout)
+            self.assertIsNotNone(layout, f"no layout line:\n{result.stdout}")
+            boxes = [tuple(int(n) for n in box.split(","))
+                     for box in layout.group(1).split()]
+            self.assertEqual([(w, h) for _, _, w, h in boxes], EXPECTED_BOXES,
+                             "the widget's box comes from the card it composes")
+
+            rest = darkness_below(shot, *boxes[2])
+            dragged = darkness_below(shot, *boxes[3])
+            # Measured 17.5 at rest and 35.5 while dragged. The floors are well
+            # under both: what would break them is no shadow at all, or a
+            # `dragging` that never reaches the card.
+            self.assertGreater(rest, 6.0,
+                               f"the card casts no shadow at rest ({rest:.1f})")
+            self.assertGreater(dragged, rest * 1.4,
+                               f"the card did not lift when handled "
+                               f"(rest {rest:.1f}, dragged {dragged:.1f})")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dots/.config/quickshell/imi/tests/test_calendar_card.py
+++ b/dots/.config/quickshell/imi/tests/test_calendar_card.py
@@ -28,18 +28,22 @@ PROBE = ROOT / "tests/run_calendar_probe.sh"
 EXPECTED_BOXES = [(132, 108), (276, 108), (276, 228), (276, 228)]
 
 
-def darkness_below(shot, x, y, width, height):
-    """Mean darkness (0 = untouched field) of the band under a card.
+def darkness(shot, geometry):
+    """Mean darkness of a band, 0 = white.
 
     ImageMagick does the averaging: piping raw grey out of it and summing by
     hand produced values that did not match the visible image at all.
     """
-    geometry = f"{width - 40}x14+{x + 20}+{y + height + 4}"
     mean = subprocess.run(
         ["magick", str(shot), "-crop", geometry, "+repage",
          "-colorspace", "Gray", "-format", "%[fx:mean]", "info:"],
         capture_output=True, text=True, timeout=60).stdout.strip()
     return (1.0 - float(mean)) * 255.0
+
+
+def darkness_below(shot, x, y, width, height):
+    """The band just under a card, sampled clear of its rounded corners."""
+    return darkness(shot, f"{width - 40}x14+{x + 20}+{y + height + 4}")
 
 
 def _runtime_available():
@@ -69,14 +73,22 @@ class CalendarCardTest(unittest.TestCase):
             self.assertEqual([(w, h) for _, _, w, h in boxes], EXPECTED_BOXES,
                              "the widget's box comes from the card it composes")
 
-            rest = darkness_below(shot, *boxes[2])
-            dragged = darkness_below(shot, *boxes[3])
-            # Measured 17.5 at rest and 35.5 while dragged. The floors are well
-            # under both: what would break them is no shadow at all, or a
-            # `dragging` that never reaches the card.
-            self.assertGreater(rest, 6.0,
-                               f"the card casts no shadow at rest ({rest:.1f})")
-            self.assertGreater(dragged, rest * 1.4,
+            # The grabbed field is not white, so a shadow is darker than the
+            # FIELD rather than darker than zero. Measured: field 12.0, rest
+            # 17.5, dragged 35.5 - and a card with `shadowEnabled: false`
+            # measures the field exactly, which is what an absolute floor of
+            # "greater than 6" passed on before this line existed.
+            band = re.search(r"\[CalendarCard\] baseline (\S+)", result.stdout)
+            self.assertIsNotNone(band, f"no baseline line:\n{result.stdout}")
+            x, y, width, height = (int(n) for n in band.group(1).split(","))
+            field = darkness(shot, f"{width}x{height}+{x}+{y}")
+
+            rest = darkness_below(shot, *boxes[2]) - field
+            dragged = darkness_below(shot, *boxes[3]) - field
+            self.assertGreater(rest, 2.5,
+                               f"the card casts no shadow at rest ({rest:.1f} "
+                               f"over a field of {field:.1f})")
+            self.assertGreater(dragged, rest * 1.5,
                                f"the card did not lift when handled "
                                f"(rest {rest:.1f}, dragged {dragged:.1f})")
 

--- a/dots/.config/quickshell/imi/tests/test_expressive_design_system.py
+++ b/dots/.config/quickshell/imi/tests/test_expressive_design_system.py
@@ -40,6 +40,11 @@ ENTRY_FILES = {}
 # whose manifest declares a grid is sized by the host to the span it resolved,
 # so its wrapper names spans rather than forwarding a content size.
 SIZED_BY_THE_HOST_GRID = {"nandoroid-media", "nandoroid-weather", "nandoroid-currency"}
+# Every package whose entry point composes a card, and so must be handed the
+# host's drag. `calendar` is not in PLUGIN_DIRS above - it is a first-party
+# bundled widget with no upstream to attribute - but its card lifts like the
+# rest of them.
+TOLD_ABOUT_THE_DRAG = SIZED_BY_THE_HOST_GRID | {"nandoroid-system-monitor", "calendar"}
 
 
 def entry_file(directory):
@@ -173,7 +178,7 @@ class ExpressiveDesignSystemTest(unittest.TestCase):
         self.assertIn("item.hostDragging = Qt.binding", node)
         self.assertIn("hostDragging: rootWidget.dragging", host)
 
-        for directory in SIZED_BY_THE_HOST_GRID | {"nandoroid-system-monitor"}:
+        for directory in TOLD_ABOUT_THE_DRAG:
             wrapper = (PLUGIN_ROOT / directory / "Widget.qml").read_text(encoding="utf-8")
             self.assertIn("property bool hostDragging", wrapper, directory)
             self.assertIn("dragging: root.hostDragging", wrapper, directory)
@@ -187,6 +192,48 @@ class ExpressiveDesignSystemTest(unittest.TestCase):
             forwarded = source.count("dragging: root.dragging")
             self.assertEqual(cards, forwarded,
                              f"{name}: {cards} cards, {forwarded} told about the drag")
+
+    def test_calendar_draws_its_surface_on_the_shared_card(self):
+        """calendar was the copy that had already drifted, and it is back.
+
+        The spec (docs/superpowers/specs/2026-08-11-expressive-morphing-design.md
+        §3c) recorded it as a fourth container with a rounding token of its own
+        and no tint conditional at all, exempted from the card's lint until it
+        could be rebuilt. This is that rebuild pinned: the surface comes from
+        WidgetCard, the frost record comes from that same card so the widget
+        cannot disagree with it about where the frost goes, and the shadow is
+        the card's rather than a StyledRectangularShadow hung behind it.
+        """
+        package = PLUGIN_ROOT / "calendar"
+        widget = (package / "Widget.qml").read_text(encoding="utf-8")
+        manifest = json.loads((package / "manifest.json").read_text(encoding="utf-8"))
+
+        self.assertIn('import "../../designsystem/widgets" as Expressive', widget)
+        self.assertIn("Expressive.WidgetCard {", widget)
+        self.assertEqual(widget.count("Expressive.WidgetCard {"), 1,
+                         "calendar composes exactly one card")
+        self.assertIn("readonly property var blurRegions: [card.blurRegion]", widget)
+        self.assertIn("managesBlurTint: true", widget)
+
+        # The shadow now comes with the card. Keeping the old one as well
+        # would draw two, which reads as one slightly wrong one. Matched as a
+        # declaration so the comment above it may still name what it replaced.
+        self.assertIsNone(re.search(r"StyledRectangularShadow\s*\{", widget),
+                          "the card casts the shadow now")
+        # ...and so does the rounding, which is the drift the spec named.
+        self.assertNotIn("rounding?.verylarge", widget,
+                         "the card owns the rounding")
+
+        # The wrapper contract, from the other side. calendar's two handles
+        # choose its size, so its manifest deliberately declares no `grid`:
+        # a span is a pixel size the host assigns on every load and would
+        # overwrite whichever size the handles last chose. A widget sized by
+        # the host reads `hostGridSize`; this one must not, and its box comes
+        # off the card it composes.
+        self.assertNotIn("grid", manifest)
+        self.assertNotIn("hostGridSize", widget)
+        self.assertIn("implicitWidth: card.implicitWidth", widget)
+        self.assertIn("implicitHeight: card.implicitHeight", widget)
 
     def test_the_card_shadows_its_body_and_drops_it_while_moving(self):
         """The shadow comes off the BODY, and goes away during motion.


### PR DESCRIPTION
`calendar/Widget.qml` was the fourth copy of the widget container the spec surveyed in [§3c](docs/superpowers/specs/2026-08-11-expressive-morphing-design.md), and the one recorded as having **already drifted**: a rounding token of its own (`Appearance.rounding?.verylarge` — the same 30 the card uses today, from a source free to move independently) and, as the lint that followed found, no tint conditional at all, because it had rolled its own `transparentize` pair instead. Every other desktop widget composes `WidgetCard`. This one does now too.

## What changed on the surface

The card takes over the tint pair, the rounding, the `blurRegion` record, and — the visible part — **the drop shadow with its hover and drag lift**. The flat `StyledRectangularShadow` that used to hang behind the rectangle at `z: -2` is gone.

`hostDragging` is declared and handed to the card, so the elevation chain reaches it: host → node → widget → card.

## What was deliberately left alone

- **The manifest still declares no `grid`.** Its own two corner handles choose its size, and a host-assigned span would overwrite whichever one they last chose on every load — so the widget stays content-sized (`implicitWidth: card.implicitWidth`) and never reads `hostGridSize`. Checked before touching it, since the wrapper contract cuts the other way for the three grid widgets.
- **Its inner surfaces still tint themselves.** The 1x1 banner, the month pill, the day grid and today's highlight thin with the card so the frost reads through the whole widget rather than through its edges only. They keep `transparentize`, not the card's `applyAlpha`, because `colLayer1` arrives carrying an alpha that has to be *scaled* rather than overwritten.
- **No `tensionX`/`tensionY`.** With no grid there is no host resize grip, so there is never a bow to draw.
- **No redesign.** Layout, colours, spacing, both handles and all three modes are untouched.

## The frost

calendar does frost — `blurEnabled` is a real per-widget option and the widget declares `managesBlurTint`. Its region record now comes from the card, so the widget cannot disagree with its own surface about where the frost goes. Measured live at 2x2 before and after: `{x: 0, y: 0, width: 276, height: 228, radius: 30}` both times, so the frosted area is provably identical.

## Evidence

Rendered headlessly, judged at 300% point-resize:

| | before | after |
| --- | --- | --- |
| card interiors (2x2, inset 4px) | — | 13 differing pixels of 59k, all four corner arcs' antialiasing (the body goes through a layer now) |
| strip below the 2x2, over the field | 5.2 | **5.5** |
| ...with the host dragging | 5.2 (no lift existed) | **23.5** |

## Tests

`687 passed, 0 failed`, full suite green.

Two new checks, both proven to fail under planted mutations:

- `test_expressive_design_system.py` — `test_calendar_draws_its_surface_on_the_shared_card` pins one `WidgetCard`, the frost record taken from that same card, no second shadow, no rounding token of its own, no `grid` in the manifest and no `hostGridSize` in the widget. Reverting the card to a `Rectangle`, or adding a `grid`, reddens it. `hostDragging` folds into the existing end-to-end chain test rather than being asserted twice.
- `test_calendar_card.py` (new) — renders the real widget under headless weston in all three modes plus a fourth with the host reporting a drag, and reads the strip below each card. `shadowEnabled: false`, dropping the `dragging` forward, and detaching the card's size each redden it.
- `lint_widget_card_tint.py` — calendar's temporary exemption is removed, as its docstring said to do with the rebuild.

The first version of the pixel test measured darkness against zero on the assumption the field is white. It is not (12.0 on that scale after the grab), so the floor sat below the background and could not fail — caught by planting `shadowEnabled: false` and watching it pass. It measures against a printed strip of untouched field now; that is its own commit.

## What could not be verified without a display

The frost itself. `PluginWidget`'s blur surface needs the desktop's shared wallpaper decode and a real background, and nothing about a rendered frost is reachable from this harness (AGENT.md's standing note). The region record is pinned by value above and the tint arithmetic is equal for an opaque base (`applyAlpha(c, o)` vs `transparentize(c, 1-o)` agree when `c.a == 1`, which `m3primaryContainer` is), but the frosted card has not been looked at on screen. Nor has hover lift on a real pointer — the probe drives `dragging`, not the card's own `HoverHandler`.

Docs: updated AGENT.md §Dynamic/data-driven QML gotchas — the card entry no longer says calendar is exempt, and gains the two things adopting the card costs a widget (the tint it does *not* take over, and children being routed into its content item, which re-anchors anything that named the old Rectangle by id).