### PR TITLE
The dock lives on any edge: the vertical layout, and the one refusal

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1496,6 +1496,47 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   `FadeLoader`, rather than repeating only the enabled ids. Removing a model delegate destroys it
   immediately and makes an M3 exit transition impossible; keep disabled loaders dormant until their
   fade-and-scale exit reaches zero opacity.
+- **A comparison that is correct on one axis is INERT on the other, not merely wrong — and a
+  layout that turns is where you meet that.** The dock now lives on any of the four edges
+  (`modules/imi/dock/dock_geometry.js` derives anchors, thickness, exclusive zone, margins by
+  INWARD/OUTWARD direction, reveal offsets and popup gravity from one `OPPOSITE` table; one tree
+  with a `vertical` flag rather than the bar's two modules, so an orientation change reflows the
+  icons instead of destroying and rebuilding them). Three things about that turn are worth not
+  re-deriving:
+  - **The drag reorder was `Math.abs(dragX - centre.x)` throughout.** In a column every slot
+    centre has the *same* x, so the distance is zero for all of them, the "nearest" slot is
+    whichever the loop reached first, and the swap test compares a number with itself: it fires
+    on the press and unfires on the next event, for as long as the pointer moves at all. Nothing
+    errors, the column lays out and spaces perfectly, and a screenshot is no help — the icons
+    simply refuse to move past each other. `DragApps` chooses the axis once (`alongAxis`), and
+    the check that can see it is `DockEdgeRuntimeTest.qml` (driven by
+    `tests/test_dock_edge_runtime.py`, headless weston, in `run_tests.sh`): it drags ALONG the
+    strip and requires a swap, then ACROSS it and requires none, with the horizontal edge first
+    as the control — "nothing happened" is also what a harness that stopped delivering events
+    reports. It reaches the dock's *content* tree only; weston implements no wlr-layer-shell, so
+    anchors, the exclusive zone, the reveal push and the compositor's inferred slide are all
+    invisible to it.
+  - **A control sized "width from height" cannot be turned.** `DockButton` derived its width from
+    its height minus the *vertical* insets, which in a column is the axis the layout owns. Both
+    axes are now written out against a span, so there is no direction to get backwards, and the
+    insets are named `insetInward`/`insetOutward` rather than top/bottom — a widget that decides
+    which side the elevation margin lands on is correct at one edge in four, and
+    `tests/test_dock_position_contract.py` fails on a margin or inset bound to a named side while
+    naming `elevationMargin` or `hyprlandGapsOut`.
+  - **`DockSeparator` and `DockAppButton` still reach `dockRow.padding` and
+    `dockVisualBackground.margin` by dynamic scope through the dock's tree.** The ids are
+    deliberately unchanged: a failed lookup there is `undefined`, then NaN geometry, then a
+    relayout that never converges and a pegged core — see the Design-language note on the missing
+    `import qs.modules.common`. Restructure above them and nothing warns.
+
+  The same contract test carries the "one derivation" lint (the analogue of
+  `lint_bar_popup_overlay_static.py`'s rule for `barEdge`): a file may read
+  `Config.options.dock.edge`, but only straight into `normalizedEdge()`, and nothing may compare
+  the stored value to a side. `modules/imi/bar/DocktoPanel.qml` renders the same `pinnedApps`
+  inside the bar and must keep following the *bar*; that is pinned too.
+  6b082ea16 ("feat(dock): the geometry module answers for the two side edges"),
+  8e608cb61 ("feat(dock): the dock strip lays out along whichever edge it is on"),
+  c7efc6db4 ("test(dock): the vertical edges get a contract and a real drag").
 - **`MouseArea.drag` cannot accurately drag a target the MouseArea itself follows.** QQuickDrag
   rebases its press origin when the grab is established, silently swallowing the arming move's
   delta — a few threshold pixels under a real pointer, invisible behind the widget lattice's 12px
@@ -1831,7 +1872,9 @@ Shared building blocks to reach for before writing something from scratch: `Styl
 widget's hover popup: a declaration plus a hover state machine, *not* a window - its content is
 hosted on `modules/imi/bar/BarPopupOverlay.qml`'s shared card, b22a923a5 ("refactor(bar): delete
 the per-popup layer surface")), `StyledRectangularShadow`, `DockIconMotion` (wraps a dock icon's visuals with hover-lift /
-press-squish / launch-bounce / appear-pop feedback, driven by `services/DockLaunchTracker`),
+press-squish / launch-bounce / appear-pop feedback, driven by `services/DockLaunchTracker`; the
+lift and the bounce are magnitudes travelling along `dock_geometry.js`'s inward vector, not a
+negative y),
 `SchemePaletteCircle` (an Android 12-style palette circle for a colour scheme, fed from
 `services/SchemePreview`, with the scheme's glyph as the fallback while the colour venv has not
 answered). All in `modules/common/widgets/`.

--- a/dots/.config/quickshell/imi/DesignSystemCompile.qml
+++ b/dots/.config/quickshell/imi/DesignSystemCompile.qml
@@ -79,7 +79,20 @@ ShellRoot {
                 Quickshell.shellPath("modules/imi/bar/DiscordVoicePlugin.qml"),
                 Quickshell.shellPath("modules/common/plugins/bundled/docker/DockerPopup.qml"),
                 Quickshell.shellPath("modules/common/plugins/bundled/docker/DockerWidget.qml"),
-                Quickshell.shellPath("modules/common/plugins/bundled/discordVoice/DiscordVoicePopup.qml")
+                Quickshell.shellPath("modules/common/plugins/bundled/discordVoice/DiscordVoicePopup.qml"),
+                // The dock. It is opt-in - dock.enable defaults to false - so
+                // on a shell without it a FINAL override or a missing import in
+                // any of these passes every test and is found by whoever
+                // switches the dock on. Now that all four edges reach one tree,
+                // that is every user of it rather than the ones who moved it.
+                Quickshell.shellPath("modules/imi/dock/Dock.qml"),
+                Quickshell.shellPath("modules/imi/dock/DockMedia.qml"),
+                Quickshell.shellPath("modules/common/widgets/DockButton.qml"),
+                Quickshell.shellPath("modules/common/widgets/DockAppButton.qml"),
+                Quickshell.shellPath("modules/common/widgets/DockSeparator.qml"),
+                Quickshell.shellPath("modules/common/widgets/DockIconMotion.qml"),
+                Quickshell.shellPath("modules/common/widgets/DockContextMenu.qml"),
+                Quickshell.shellPath("modules/common/widgets/DragApps.qml")
             ]);
             for (const path of paths) {
                 const component = Qt.createComponent(`file://${path}`, Component.PreferSynchronous);

--- a/dots/.config/quickshell/imi/DockEdgeRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/DockEdgeRuntimeTest.qml
@@ -143,8 +143,9 @@ ShellRoot {
     }
 
     function scoreReordered(label, expected) {
-        harness.check(`${label}: ${expected.join(",")}`,
-                      harness.sameOrder(harness.pinned(), expected));
+        const actual = harness.pinned();
+        harness.check(`${label}: want ${expected.join(",")}, got ${actual.join(",")}`,
+                      harness.sameOrder(actual, expected));
     }
 
     readonly property var steps: [

--- a/dots/.config/quickshell/imi/DockEdgeRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/DockEdgeRuntimeTest.qml
@@ -1,0 +1,221 @@
+import QtQuick
+import QtTest
+import Quickshell
+import qs.modules.common
+import qs.modules.common.widgets
+
+/**
+ * Drives the dock's pinned-app reorder with real mouse events, at a horizontal
+ * edge and at a vertical one.
+ *
+ * This exists because of the specific way a vertical dock can be broken. The
+ * layout is the visible half and the easy half: a column of icons that lays
+ * out, spaces correctly and looks finished can still have its reorder
+ * completely inert, because every comparison in `DragApps` used to be an x.
+ * In a column every slot centre has the SAME x, so the "nearest other slot"
+ * loop returns whichever index it reached first and the swap test compares a
+ * number against itself. Nothing errors, nothing logs, and the icons simply
+ * refuse to move past each other.
+ *
+ * So the discriminating check here is not "does the column reorder" - it is
+ * the pair: a drag ALONG the strip must reorder, and a drag ACROSS it must
+ * not. The second is what the old code got wrong in both directions at once
+ * (it swapped on any sideways twitch, then swapped back).
+ *
+ * The horizontal edge is the control. Three "nothing happened" results prove
+ * nothing if the harness quietly stopped delivering events, so the run starts
+ * by reordering a row.
+ *
+ * What this CANNOT see: it builds the dock's content tree in a FloatingWindow,
+ * not on a layer surface. Weston implements no wlr-layer-shell, so the
+ * anchors, the exclusive zone, the reveal push and the compositor's inferred
+ * slide direction are all invisible to it - as are the running dots' position,
+ * the icon sizing and every other thing that is a look rather than a
+ * behaviour. Those are `hyprctl layers -j` plus a pair of eyes.
+ *
+ * Run it against a throwaway config:
+ *   XDG_CONFIG_HOME=$(mktemp -d) XDG_STATE_HOME=$(mktemp -d) qs -p DockEdgeRuntimeTest.qml
+ */
+ShellRoot {
+    id: harness
+
+    property int failures: 0
+    readonly property var order: ["alpha", "beta", "gamma"]
+
+    function check(label, ok) {
+        console.log(`[DockEdge] ${label}: ${ok ? "ok" : "FAIL"}`);
+        if (!ok)
+            harness.failures++;
+    }
+
+    function pinned() {
+        return (Config.options.dock.pinnedApps ?? []).slice();
+    }
+
+    function sameOrder(a, b) {
+        if (a.length !== b.length)
+            return false;
+        for (let i = 0; i < a.length; i++)
+            if (a[i] !== b[i])
+                return false;
+        return true;
+    }
+
+    function resetOrder() {
+        Config.options.dock.pinnedApps = harness.order.slice();
+    }
+
+    FloatingWindow {
+        visible: true
+        implicitWidth: 700
+        implicitHeight: 700
+        color: "black"
+
+        TestCase {
+            id: driver
+            when: false
+            name: "DockEdgeDriver"
+        }
+
+        // The strip turns with the dock, exactly as the dock body does: the
+        // long axis is the icons', the short one is the dock's thickness.
+        Item {
+            id: strip
+            x: 200
+            y: 60
+            width: slots.vertical ? 60 : 520
+            height: slots.vertical ? 520 : 60
+
+            DragApps {
+                id: slots
+                btnSize: 46
+                btnSpacing: 1
+                buttonPadding: 8
+            }
+        }
+    }
+
+    // ---- gestures --------------------------------------------------------
+    //
+    // Slot i sits i steps ALONG the strip, which is the placement under test,
+    // so the gesture is derived from the same two numbers the layout is - a
+    // changed btnSize moves the press with it rather than leaving it pointing
+    // at the gap between two icons.
+    function slotCenter(index) {
+        const along = index * (slots.btnSize + slots.btnSpacing) + slots.btnSize / 2;
+        return slots.vertical
+            ? Qt.point(slots.width / 2, along)
+            : Qt.point(along, slots.height / 2);
+    }
+
+    function dragSlot(index, dx, dy) {
+        const p = harness.slotCenter(index);
+        driver.mousePress(slots, p.x, p.y, Qt.LeftButton);
+        driver.mouseMove(slots, p.x + dx * 0.35, p.y + dy * 0.35, 20, Qt.LeftButton);
+        driver.mouseMove(slots, p.x + dx * 0.7, p.y + dy * 0.7, 20, Qt.LeftButton);
+        driver.mouseMove(slots, p.x + dx, p.y + dy, 20, Qt.LeftButton);
+        driver.mouseRelease(slots, p.x + dx, p.y + dy, Qt.LeftButton);
+    }
+
+    // ---- the checks ------------------------------------------------------
+
+    // A slot is recognised by the property that places it, so a harness that
+    // finds nothing is a harness pointed at a tree that no longer places its
+    // slots - which is a failure, not an empty pass.
+    function slotItem(index) {
+        for (const child of slots.children)
+            if (child.slotOffset !== undefined && child.index === index)
+                return child;
+        return null;
+    }
+
+    function scoreLayout(label, expectVertical) {
+        const first = harness.slotItem(0);
+        const second = harness.slotItem(1);
+        if (!first || !second) {
+            harness.check(`${label}: the slots exist`, false);
+            return;
+        }
+        harness.check(`${label}: the slots stack along the strip`,
+                      expectVertical
+                          ? (second.y > first.y && second.x === first.x)
+                          : (second.x > first.x && second.y === first.y));
+    }
+
+    function scoreReordered(label, expected) {
+        harness.check(`${label}: ${expected.join(",")}`,
+                      harness.sameOrder(harness.pinned(), expected));
+    }
+
+    readonly property var steps: [
+        // The control, and the proof events are arriving at all.
+        () => harness.scoreLayout("a bottom dock", false),
+        () => harness.dragSlot(0, 60, 0),
+        () => harness.scoreReordered("dragging along a row swaps",
+                                     ["beta", "alpha", "gamma"]),
+
+        () => { harness.resetOrder(); Config.options.dock.edge = "left"; },
+        () => harness.scoreLayout("a left dock", true),
+
+        // The half a plausible-looking column silently loses.
+        () => harness.dragSlot(0, 0, 60),
+        () => harness.scoreReordered("dragging along a column swaps",
+                                     ["beta", "alpha", "gamma"]),
+
+        // ...and the half the old x-only comparison got wrong in the other
+        // direction: with every slot centre sharing an x, a sideways twitch
+        // swapped, then swapped back, for as long as the pointer moved.
+        () => harness.resetOrder(),
+        () => harness.dragSlot(0, 25, 0),
+        () => harness.scoreReordered("dragging across a column does not",
+                                     harness.order),
+
+        // Back to the shipped default, so a leftover edge cannot make the
+        // last check pass for the wrong reason.
+        () => { harness.resetOrder(); Config.options.dock.edge = "bottom"; },
+        () => harness.scoreLayout("back at the bottom", false),
+        () => harness.dragSlot(1, -60, 0),
+        () => harness.scoreReordered("and a row still swaps after the round trip",
+                                     ["beta", "alpha", "gamma"])
+    ]
+
+    property int stepIndex: 0
+
+    Timer {
+        id: setup
+        interval: 250
+        repeat: true
+        running: true
+        onTriggered: {
+            if (!Config.ready)
+                return;
+            Config.options.dock.edge = "bottom";
+            if (!harness.sameOrder(harness.pinned(), harness.order)) {
+                harness.resetOrder();
+                return;
+            }
+            setup.running = false;
+            runner.running = true;
+        }
+    }
+
+    // One step per tick. The slots carry a Behavior on x and y, so a check
+    // sharing a frame with the release it scores would read a position the
+    // animation is still travelling through - and an edge change reflows the
+    // whole strip, which is a layout pass rather than a property write.
+    Timer {
+        id: runner
+        interval: 600
+        repeat: true
+        running: false
+        onTriggered: {
+            if (harness.stepIndex >= harness.steps.length) {
+                runner.running = false;
+                console.log(`[DockEdge] failures: ${harness.failures}`);
+                Qt.exit(harness.failures === 0 ? 0 : 1);
+                return;
+            }
+            harness.steps[harness.stepIndex++]();
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/modules/common/widgets/ConfigSelectionArray.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/ConfigSelectionArray.qml
@@ -72,6 +72,11 @@ RowLayout {
                 buttonIcon: modelData.icon || ""
                 buttonText: modelData.displayName
                 toggled: root.currentValue == modelData.value
+                // An option the shell declines. It is still drawn, and still
+                // drawn as current if a stored config already holds it -
+                // dropping it from the model would silently shorten the row
+                // with nothing on screen saying why.
+                enabled: root.enabled && !(modelData.disabled ?? false)
                 onClicked: {
                     root.selected(modelData.value);
                 }

--- a/dots/.config/quickshell/imi/modules/common/widgets/DockAppButton.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/DockAppButton.qml
@@ -7,6 +7,7 @@ import QtQuick
 import QtQuick.Layouts
 import Quickshell
 import Quickshell.Widgets
+import "../../imi/dock/dock_geometry.js" as DockGeometry
 
 DockButton {
     id: root
@@ -25,7 +26,15 @@ DockButton {
     property var desktopEntry: liveDeskEntry.entry
     enabled: !isSeparator
     hoverEnabled: true
-    implicitWidth: isSeparator ? 1 : implicitHeight - topInset - bottomInset
+
+    // A separator is a hairline ACROSS the strip, so which axis it collapses
+    // on is the dock's business, not the button's.
+    implicitWidth: root.dockVertical
+        ? root.span + leftInset + rightInset
+        : (root.isSeparator ? 1 : root.span)
+    implicitHeight: root.dockVertical
+        ? (root.isSeparator ? 1 : root.span)
+        : root.span + topInset + bottomInset
 
     LiveDesktopEntry {
         id: liveDeskEntry
@@ -34,10 +43,21 @@ DockButton {
 
     Loader {
         active: isSeparator
+        // dockVisualBackground and dockRow resolve by DYNAMIC SCOPE through the
+        // dock's own tree - renaming or reparenting either yields undefined and
+        // NaN geometry rather than an error. Read AGENT.md's note on the CPU
+        // spin that follows before restructuring anything above this.
+        readonly property var separatorMargins: DockGeometry.axisMargins(
+            root.dockEdge,
+            dockVisualBackground.margin + dockRow.padding + Appearance.rounding.normal,
+            dockVisualBackground.margin + dockRow.padding + Appearance.rounding.normal,
+            0)
         anchors {
             fill: parent
-            topMargin: dockVisualBackground.margin + dockRow.padding + Appearance.rounding.normal
-            bottomMargin: dockVisualBackground.margin + dockRow.padding + Appearance.rounding.normal
+            topMargin: separatorMargins.top
+            bottomMargin: separatorMargins.bottom
+            leftMargin: separatorMargins.left
+            rightMargin: separatorMargins.right
         }
         sourceComponent: DockSeparator {}
     }
@@ -138,29 +158,44 @@ DockButton {
                     }
                 }
 
-                RowLayout {
+                Flow {
                     spacing: Appearance.spacing.space50
                     // The running dots sit between the icon and the screen
                     // edge, so they swap sides with the dock: below the icon
-                    // at the bottom edge, above it at the top.
-                    readonly property bool dockAtTop: (Config.options?.dock.edge ?? "bottom") === "top"
+                    // at the bottom edge, above it at the top, and BESIDE it
+                    // at either side edge - where a row under the icon points
+                    // into its neighbour rather than out of the dock.
+                    readonly property string dotSide: DockGeometry.outwardSide(root.dockEdge)
+                    flow: root.dockVertical ? Flow.TopToBottom : Flow.LeftToRight
                     anchors {
-                        top: dockAtTop ? undefined : iconImageLoader.bottom
-                        bottom: dockAtTop ? iconImageLoader.top : undefined
-                        topMargin: dockAtTop ? 0 : Appearance.spacing.space25
-                        bottomMargin: dockAtTop ? Appearance.spacing.space25 : 0
-                        horizontalCenter: parent.horizontalCenter
+                        top: dotSide === "bottom" ? iconImageLoader.bottom : undefined
+                        bottom: dotSide === "top" ? iconImageLoader.top : undefined
+                        left: dotSide === "right" ? iconImageLoader.right : undefined
+                        right: dotSide === "left" ? iconImageLoader.left : undefined
+                        topMargin: dotSide === "bottom" ? Appearance.spacing.space25 : 0
+                        bottomMargin: dotSide === "top" ? Appearance.spacing.space25 : 0
+                        leftMargin: dotSide === "right" ? Appearance.spacing.space25 : 0
+                        rightMargin: dotSide === "left" ? Appearance.spacing.space25 : 0
+                        horizontalCenter: root.dockVertical ? undefined : parent.horizontalCenter
+                        verticalCenter: root.dockVertical ? parent.verticalCenter : undefined
                     }
                     Repeater {
                         model: Math.min(appToplevel.toplevels.length, 3)
                         delegate: Rectangle {
                             required property int index
+                            // The pill runs ALONG the strip and stays thin
+                            // across it, so it reads as an underline at every
+                            // edge. Circles when there are too many to count.
+                            readonly property real pillLength: (appToplevel.toplevels.length <= 3)
+                                ? root.countDotWidth : root.countDotHeight
                             radius: Appearance.rounding.full
-                            implicitWidth: (appToplevel.toplevels.length <= 3) ?
-                                root.countDotWidth : root.countDotHeight // Circles when too many
-                            implicitHeight: root.countDotHeight
+                            implicitWidth: root.dockVertical ? root.countDotHeight : pillLength
+                            implicitHeight: root.dockVertical ? pillLength : root.countDotHeight
                             color: appIsActive ? Appearance.colors.colPrimary : ColorUtils.transparentize(Appearance.colors.colOnLayer0, 0.4)
                             Behavior on implicitWidth {
+                                animation: Appearance.animation.elementMoveSmall.numberAnimation.createObject(this)
+                            }
+                            Behavior on implicitHeight {
                                 animation: Appearance.animation.elementMoveSmall.numberAnimation.createObject(this)
                             }
                             Behavior on color {

--- a/dots/.config/quickshell/imi/modules/common/widgets/DockButton.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/DockButton.qml
@@ -2,12 +2,52 @@ import qs.modules.common
 import qs.modules.common.widgets
 import QtQuick
 import QtQuick.Layouts
+import "../../imi/dock/dock_geometry.js" as DockGeometry
 
 RippleButton {
-    Layout.fillHeight: true
-    Layout.topMargin: Appearance.sizes.elevationMargin - Appearance.sizes.hyprlandGapsOut
-    implicitWidth: implicitHeight - topInset - bottomInset
-    buttonRadius: Appearance.rounding.normal
+    id: root
 
-    background.implicitHeight: 50
+    readonly property string dockEdge: DockGeometry.normalizedEdge(
+        Config.options?.dock.edge ?? "bottom")
+    readonly property bool dockVertical: DockGeometry.isVertical(root.dockEdge)
+
+    // The insets are named by DIRECTION, not by side. `topInset` runs across
+    // the dock's thickness at a horizontal edge and along the strip at a
+    // vertical one, so a caller spelling it out is correct at two edges and
+    // silently wrong at the other two - it eats into the row of icons instead
+    // of into the dock's depth.
+    property real insetInward: 0
+    property real insetOutward: 0
+    readonly property var dockInsets: DockGeometry.directedSides(
+        root.dockEdge, root.insetInward, root.insetOutward)
+    topInset: root.dockInsets.top
+    bottomInset: root.dockInsets.bottom
+    leftInset: root.dockInsets.left
+    rightInset: root.dockInsets.right
+
+    // The same for the layout margin, which used to be a bare Layout.topMargin
+    // of elevationMargin - hyprlandGapsOut: the amount the body's asymmetric
+    // margins pull the button back off the shadow side.
+    property real crossMargin: Appearance.sizes.elevationMargin - Appearance.sizes.hyprlandGapsOut
+    readonly property var dockCrossMargins: DockGeometry.directedSides(
+        root.dockEdge, root.crossMargin, 0)
+    Layout.topMargin: root.dockCrossMargins.top
+    Layout.bottomMargin: root.dockCrossMargins.bottom
+    Layout.leftMargin: root.dockCrossMargins.left
+    Layout.rightMargin: root.dockCrossMargins.right
+
+    // The strip's long axis is the layout's to fill; the button measures
+    // itself across the dock's thickness.
+    Layout.fillHeight: !root.dockVertical
+    Layout.fillWidth: root.dockVertical
+
+    // 50 across the thickness, plus whatever the insets take out of the
+    // surface. At a horizontal edge that is a height and the width follows; at
+    // a vertical one the two swap, which is why neither can be written as
+    // "width from height".
+    property real span: 50
+    implicitWidth: root.dockVertical ? root.span + leftInset + rightInset : root.span
+    implicitHeight: root.dockVertical ? root.span : root.span + topInset + bottomInset
+
+    buttonRadius: Appearance.rounding.normal
 }

--- a/dots/.config/quickshell/imi/modules/common/widgets/DockContextMenu.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/DockContextMenu.qml
@@ -6,6 +6,7 @@ import qs.services
 import qs.modules.common
 import qs.modules.common.widgets
 import qs.modules.common.functions
+import "../../imi/dock/dock_geometry.js" as DockGeometry
 
 /**
  * Right-click context menu for dock app icons (ported from upstream
@@ -18,6 +19,10 @@ import qs.modules.common.functions
  */
 Item {
     id: root
+
+    readonly property string dockEdge: DockGeometry.normalizedEdge(
+        Config.options?.dock.edge ?? "bottom")
+    readonly property bool dockVertical: DockGeometry.isVertical(root.dockEdge)
 
     property var appToplevel: null
     // Authoritative app id for pin/launch actions. For pinned apps this is the
@@ -66,13 +71,19 @@ Item {
             visible: true
 
             // Away from the edge the dock is on: a menu that opens upward
-            // from a top dock is drawn off the screen.
-            readonly property bool dockAtTop: (Config.options?.dock.edge ?? "bottom") === "top"
+            // from a top dock is drawn off the screen, and one that opens
+            // upward from a side dock runs off the top of a tall strip.
+            readonly property string openSide: DockGeometry.popupGravity(root.dockEdge)
+            readonly property int openFlag: contextPopup.openSide === "top" ? Edges.Top
+                : contextPopup.openSide === "bottom" ? Edges.Bottom
+                : contextPopup.openSide === "left" ? Edges.Left : Edges.Right
             anchor {
                 item: root.targetButton
-                gravity: contextPopup.dockAtTop ? Edges.Bottom : Edges.Top
-                edges: contextPopup.dockAtTop ? Edges.Bottom : Edges.Top
-                adjustment: PopupAdjustment.SlideX
+                gravity: contextPopup.openFlag
+                edges: contextPopup.openFlag
+                // Slide along the screen edge the menu is running out of, not
+                // along the one it opened away from.
+                adjustment: root.dockVertical ? PopupAdjustment.SlideY : PopupAdjustment.SlideX
             }
 
             color: "transparent"
@@ -93,12 +104,23 @@ Item {
                 id: menuBackground
                 property real contentPadding: Appearance.spacing.space50
 
+                // The card hugs the side of its surface that faces the dock,
+                // pushed off it by the elevation margin so the shadow has
+                // somewhere to fall.
+                readonly property string dockSide: DockGeometry.outwardSide(root.dockEdge)
+                readonly property var cardMargins: DockGeometry.directedSides(
+                    root.dockEdge, 0, Appearance.sizes.elevationMargin)
                 anchors {
-                    top: contextPopup.dockAtTop ? parent.top : undefined
-                    bottom: contextPopup.dockAtTop ? undefined : parent.bottom
-                    horizontalCenter: parent.horizontalCenter
-                    topMargin: contextPopup.dockAtTop ? Appearance.sizes.elevationMargin : 0
-                    bottomMargin: contextPopup.dockAtTop ? 0 : Appearance.sizes.elevationMargin
+                    top: menuBackground.dockSide === "top" ? parent.top : undefined
+                    bottom: menuBackground.dockSide === "bottom" ? parent.bottom : undefined
+                    left: menuBackground.dockSide === "left" ? parent.left : undefined
+                    right: menuBackground.dockSide === "right" ? parent.right : undefined
+                    horizontalCenter: root.dockVertical ? undefined : parent.horizontalCenter
+                    verticalCenter: root.dockVertical ? parent.verticalCenter : undefined
+                    topMargin: menuBackground.cardMargins.top
+                    bottomMargin: menuBackground.cardMargins.bottom
+                    leftMargin: menuBackground.cardMargins.left
+                    rightMargin: menuBackground.cardMargins.right
                 }
                 color: Appearance.m3colors.m3surfaceContainer
                 radius: Appearance.rounding.normal

--- a/dots/.config/quickshell/imi/modules/common/widgets/DockIconMotion.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/DockIconMotion.qml
@@ -23,8 +23,9 @@ Item {
     // They used to be bare negative y, which is correct at exactly one edge:
     // at the top it drives the icon into the screen edge, and at a side edge
     // it slides along the strip instead of rising out of it.
-    readonly property var liftVector: DockGeometry.inwardVector(
+    readonly property string dockEdge: DockGeometry.normalizedEdge(
         Config.options?.dock.edge ?? "bottom")
+    readonly property var liftVector: DockGeometry.inwardVector(root.dockEdge)
 
     property real hoverScale: 1.15
     property real pressScale: 0.92

--- a/dots/.config/quickshell/imi/modules/common/widgets/DockIconMotion.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/DockIconMotion.qml
@@ -1,10 +1,12 @@
 import QtQuick
 import qs.modules.common
+import "../../imi/dock/dock_geometry.js" as DockGeometry
 
 /**
  * M3 Expressive feedback motion for a dock icon. Wrap the icon's visuals in
  * this and drive it with declarative state; it owns transforms only (scale +
- * vertical translate), never layout size, so the dock row width cannot churn.
+ * a translate along the dock's own axis), never layout size, so the dock
+ * strip's thickness cannot churn.
  *
  * Priority: dragging suppresses everything; press squish beats hover lift;
  * the launch bounce runs independently on its own translate offset.
@@ -16,6 +18,13 @@ Item {
     property bool pressed: false
     property bool launching: false
     property bool dragging: false
+
+    // Both offsets below are MAGNITUDES, and this is the direction they take.
+    // They used to be bare negative y, which is correct at exactly one edge:
+    // at the top it drives the icon into the screen edge, and at a side edge
+    // it slides along the strip instead of rising out of it.
+    readonly property var liftVector: DockGeometry.inwardVector(
+        Config.options?.dock.edge ?? "bottom")
 
     property real hoverScale: 1.15
     property real pressScale: 0.92
@@ -30,7 +39,7 @@ Item {
     }
 
     // Hover lift target; springs via its own Behavior.
-    property real liftOffset: (!dragging && hovered && !pressed) ? -Appearance.spacing.space50 : 0
+    property real liftOffset: (!dragging && hovered && !pressed) ? Appearance.spacing.space50 : 0
     Behavior on liftOffset {
         NumberAnimation {
             duration: Appearance.animation.elementMoveSmall.duration
@@ -49,7 +58,7 @@ Item {
         NumberAnimation {
             target: root
             property: "bounceOffset"
-            to: -Appearance.spacing.space100
+            to: Appearance.spacing.space100
             duration: Appearance.animation.elementMoveFast.duration
             easing.type: Easing.BezierSpline
             easing.bezierCurve: Appearance.animationCurves.expressiveEffects
@@ -102,7 +111,8 @@ Item {
         scale: root.targetScale * root.appearScale
         opacity: root.appearOpacity
         transform: Translate {
-            y: root.liftOffset + root.bounceOffset
+            x: (root.liftOffset + root.bounceOffset) * root.liftVector.x
+            y: (root.liftOffset + root.bounceOffset) * root.liftVector.y
         }
         Behavior on scale {
             enabled: !root.dragging && !appearAnimation.running

--- a/dots/.config/quickshell/imi/modules/common/widgets/DockSeparator.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/DockSeparator.qml
@@ -2,11 +2,34 @@ import qs.modules.common
 import qs.modules.common.functions
 import QtQuick
 import QtQuick.Layouts
+import "../../imi/dock/dock_geometry.js" as DockGeometry
 
 Rectangle {
-    Layout.topMargin: Appearance.sizes.elevationMargin + dockRow.padding + Appearance.rounding.normal - 4
-    Layout.bottomMargin: Appearance.sizes.hyprlandGapsOut + dockRow.padding + Appearance.rounding.normal
-    Layout.fillHeight: true
-    implicitWidth: 1
+    id: root
+
+    readonly property string dockEdge: DockGeometry.normalizedEdge(
+        Config.options?.dock.edge ?? "bottom")
+    readonly property bool dockVertical: DockGeometry.isVertical(root.dockEdge)
+
+    // The inset pair is asymmetric because the dock body's margins are: the
+    // elevation margin is inward (the shadow is drawn there), the compositor's
+    // gap outward. Spelled as top/bottom this was a separator that reached
+    // across a bottom dock and along a left one.
+    readonly property var dockMargins: DockGeometry.directedSides(
+        root.dockEdge,
+        Appearance.sizes.elevationMargin + dockRow.padding + Appearance.rounding.normal - 4,
+        Appearance.sizes.hyprlandGapsOut + dockRow.padding + Appearance.rounding.normal)
+
+    Layout.topMargin: root.dockMargins.top
+    Layout.bottomMargin: root.dockMargins.bottom
+    Layout.leftMargin: root.dockMargins.left
+    Layout.rightMargin: root.dockMargins.right
+
+    // A hairline across the strip, filling the dock's depth.
+    Layout.fillHeight: !root.dockVertical
+    Layout.fillWidth: root.dockVertical
+    implicitWidth: root.dockVertical ? 0 : 1
+    implicitHeight: root.dockVertical ? 1 : 0
+
     color: Appearance.colors.colOutlineVariant
 }

--- a/dots/.config/quickshell/imi/modules/common/widgets/DragApps.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/DragApps.qml
@@ -125,9 +125,11 @@ Item {
                 z: 1000
                 width:  root.btnSize
                 height: root.btnSize
-                anchors.verticalCenter: root.vertical ? undefined : parent.verticalCenter
-                anchors.horizontalCenter: root.vertical ? parent.horizontalCenter : undefined
-
+                // Both coordinates are explicit rather than one anchored: an
+                // anchor on the axis the ghost is NOT travelling along would
+                // silently overwrite whichever of x and y the other branch
+                // wrote, and which one that is changes with the edge.
+                //
                 // The ghost follows the pointer along the strip only, so a
                 // sideways wobble does not drag the icon out of the dock.
                 readonly property point localPointer: dragHandler.active
@@ -135,8 +137,12 @@ Item {
                         dragHandler.centroid.scenePosition.x,
                         dragHandler.centroid.scenePosition.y)
                     : Qt.point(0, 0)
-                x: root.vertical ? 0 : (dragHandler.active ? localPointer.x - width / 2 : 0)
-                y: root.vertical ? (dragHandler.active ? localPointer.y - height / 2 : 0) : 0
+                x: root.vertical
+                    ? (slotItem.width - width) / 2
+                    : (dragHandler.active ? localPointer.x - width / 2 : 0)
+                y: root.vertical
+                    ? (dragHandler.active ? localPointer.y - height / 2 : 0)
+                    : (slotItem.height - height) / 2
 
                 scale: dragHandler.active ? 1.15 : 0.9
                 Behavior on scale {

--- a/dots/.config/quickshell/imi/modules/common/widgets/DragApps.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/DragApps.qml
@@ -12,9 +12,17 @@ import Quickshell.Io
 import Quickshell
 import Quickshell.Widgets
 import Quickshell.Wayland
+import "../../imi/dock/dock_geometry.js" as DockGeometry
 
 Item {
     id: root
+
+    readonly property string dockEdge: DockGeometry.normalizedEdge(
+        Config.options?.dock.edge ?? "bottom")
+    // The reorder is one axis and one comparison, chosen here. It used to be
+    // x throughout - a column of slots that lays out perfectly while every
+    // drag compares the one coordinate that never changes.
+    readonly property bool vertical: DockGeometry.isVertical(root.dockEdge)
 
     property real btnSize: 46
     property real btnSpacing: Appearance.spacing.space25
@@ -39,12 +47,19 @@ Item {
         }
     }
 
-    implicitWidth:  _workOrder.length * btnSize + Math.max(0, _workOrder.length - 1) * btnSpacing
-    implicitHeight: parent?.height ?? btnSize
+    // How far the slots reach along the strip; across it the widget takes
+    // whatever the dock's thickness leaves.
+    readonly property real slotRun: _workOrder.length * btnSize
+        + Math.max(0, _workOrder.length - 1) * btnSpacing
+    implicitWidth:  root.vertical ? (parent?.width ?? btnSize) : slotRun
+    implicitHeight: root.vertical ? slotRun : (parent?.height ?? btnSize)
 
-    function popupCenterXForButton(button) {
+    // Where the preview popup centres itself on the hovered button: along the
+    // strip, so it is an x at a horizontal edge and a y at a vertical one.
+    function popupCenterForButton(button) {
         if (!button || !root.QsWindow) return 0
-        return root.QsWindow.mapFromItem(button, button.width / 2, 0).x
+        const centre = root.QsWindow.mapFromItem(button, button.width / 2, button.height / 2)
+        return root.vertical ? centre.y : centre.x
     }
 
     function swapSlots(fromPos, toPos) {
@@ -83,11 +98,19 @@ Item {
                 appId: slotItem.appId
             }
 
-            width:  root.btnSize
-            height: root.implicitHeight
-            x:      index * (root.btnSize + root.btnSpacing)
+            // Slot i sits i steps along the strip; the other axis is the
+            // dock's whole thickness.
+            readonly property real slotOffset: index * (root.btnSize + root.btnSpacing)
+            width:  root.vertical ? root.implicitWidth : root.btnSize
+            height: root.vertical ? root.btnSize : root.implicitHeight
+            x:      root.vertical ? 0 : slotOffset
+            y:      root.vertical ? slotOffset : 0
 
             Behavior on x {
+                enabled: root.activeDragVisualIndex !== slotItem.index
+                animation: Appearance.animation.elementMoveSmall.numberAnimation.createObject(this)
+            }
+            Behavior on y {
                 enabled: root.activeDragVisualIndex !== slotItem.index
                 animation: Appearance.animation.elementMoveSmall.numberAnimation.createObject(this)
             }
@@ -102,15 +125,18 @@ Item {
                 z: 1000
                 width:  root.btnSize
                 height: root.btnSize
-                anchors.verticalCenter: parent.verticalCenter
+                anchors.verticalCenter: root.vertical ? undefined : parent.verticalCenter
+                anchors.horizontalCenter: root.vertical ? parent.horizontalCenter : undefined
 
-                x: {
-                    if (!dragHandler.active) return 0
-                    var lp = slotItem.mapFromItem(null,
+                // The ghost follows the pointer along the strip only, so a
+                // sideways wobble does not drag the icon out of the dock.
+                readonly property point localPointer: dragHandler.active
+                    ? slotItem.mapFromItem(null,
                         dragHandler.centroid.scenePosition.x,
                         dragHandler.centroid.scenePosition.y)
-                    return lp.x - width / 2
-                }
+                    : Qt.point(0, 0)
+                x: root.vertical ? 0 : (dragHandler.active ? localPointer.x - width / 2 : 0)
+                y: root.vertical ? (dragHandler.active ? localPointer.y - height / 2 : 0) : 0
 
                 scale: dragHandler.active ? 1.15 : 0.9
                 Behavior on scale {
@@ -145,10 +171,8 @@ Item {
 
                 property var appToplevel: slotItem.appEntry
 
-                topInset:    Appearance.sizes.hyprlandGapsOut + Appearance.spacing.space100
-                bottomInset: Appearance.sizes.hyprlandGapsOut + Appearance.spacing.space100
-
-                implicitWidth: implicitHeight - topInset - bottomInset
+                insetInward:  Appearance.sizes.hyprlandGapsOut + Appearance.spacing.space100
+                insetOutward: Appearance.sizes.hyprlandGapsOut + Appearance.spacing.space100
 
                 hoverEnabled: true
                 onHoveredChanged: {
@@ -231,31 +255,47 @@ Item {
                             }
                         }
 
-                        RowLayout {
+                        Flow {
                             spacing: Appearance.spacing.space50
                             // The running dots sit between the icon and the
-                            // screen edge, so they swap sides with the dock.
-                            readonly property bool dockAtTop:
-                                (Config.options?.dock.edge ?? "bottom") === "top"
+                            // screen edge, so they swap sides with the dock -
+                            // and stack beside the icon at a side edge, where
+                            // a row under it points into the next icon.
+                            //
+                            // These are the PINNED apps' dots. DockAppButton
+                            // carries a second copy for the running unpinned
+                            // ones, and a dock of pinned icons shows nothing of
+                            // a change made only there.
+                            readonly property string dotSide: DockGeometry.outwardSide(root.dockEdge)
+                            flow: root.vertical ? Flow.TopToBottom : Flow.LeftToRight
                             anchors {
-                                top: dockAtTop ? undefined : appIcon.bottom
-                                bottom: dockAtTop ? appIcon.top : undefined
-                                topMargin: dockAtTop ? 0 : Appearance.spacing.space25
-                                bottomMargin: dockAtTop ? Appearance.spacing.space25 : 0
-                                horizontalCenter: parent.horizontalCenter
+                                top: dotSide === "bottom" ? appIcon.bottom : undefined
+                                bottom: dotSide === "top" ? appIcon.top : undefined
+                                left: dotSide === "right" ? appIcon.right : undefined
+                                right: dotSide === "left" ? appIcon.left : undefined
+                                topMargin: dotSide === "bottom" ? Appearance.spacing.space25 : 0
+                                bottomMargin: dotSide === "top" ? Appearance.spacing.space25 : 0
+                                leftMargin: dotSide === "right" ? Appearance.spacing.space25 : 0
+                                rightMargin: dotSide === "left" ? Appearance.spacing.space25 : 0
+                                horizontalCenter: root.vertical ? undefined : parent.horizontalCenter
+                                verticalCenter: root.vertical ? parent.verticalCenter : undefined
                             }
                             Repeater {
                                 model: Math.min(slotItem.appEntry?.toplevels?.length ?? 0, 3)
                                 delegate: Rectangle {
                                     required property int index
+                                    readonly property real pillLength:
+                                        (slotItem.appEntry?.toplevels?.length ?? 0) <= 3 ? 10 : 4
                                     radius:         Appearance.rounding.full
-                                    implicitWidth:  (slotItem.appEntry?.toplevels?.length ?? 0) <= 3
-                                                    ? 10 : 4
-                                    implicitHeight: 4
+                                    implicitWidth:  root.vertical ? 4 : pillLength
+                                    implicitHeight: root.vertical ? pillLength : 4
                                     color: slotItem.appActive
                                            ? Appearance.colors.colPrimary
                                            : ColorUtils.transparentize(Appearance.colors.colOnLayer0, 0.4)
                                     Behavior on implicitWidth {
+                                        animation: Appearance.animation.elementMoveSmall.numberAnimation.createObject(this)
+                                    }
+                                    Behavior on implicitHeight {
                                         animation: Appearance.animation.elementMoveSmall.numberAnimation.createObject(this)
                                     }
                                     Behavior on color {
@@ -285,12 +325,21 @@ Item {
                     root.commitOrder()
                 }
 
+                // Everything below compares ONE coordinate: the one the slots
+                // are laid out along. Comparing x in a column is not a subtly
+                // wrong reorder, it is an inert one - every centre has the
+                // same x, so the nearest slot is always whichever the loop
+                // reached first and nothing ever swaps.
+                function alongAxis(point) {
+                    return root.vertical ? point.y : point.x
+                }
+
                 onCentroidChanged: {
                     if (!active) return
                     const currentVisualIdx = root.activeDragVisualIndex
                     if (currentVisualIdx < 0) return
 
-                    const dragX = dragHandler.centroid.scenePosition.x
+                    const dragPos = alongAxis(dragHandler.centroid.scenePosition)
                     let minDist    = Infinity
                     let nearestIdx = currentVisualIdx
 
@@ -299,17 +348,18 @@ Item {
                         const child = slotRepeater.itemAt(i)
                         if (!child) continue
                         const cc   = child.mapToItem(null, child.width / 2, child.height / 2)
-                        const dist = Math.abs(dragX - cc.x)
+                        const dist = Math.abs(dragPos - alongAxis(cc))
                         if (dist < minDist) { minDist = dist; nearestIdx = i }
                     }
 
                     if (nearestIdx !== currentVisualIdx) {
                         const neighbor = slotRepeater.itemAt(nearestIdx)
                         if (!neighbor) return
-                        const nc = neighbor.mapToItem(null, neighbor.width / 2, neighbor.height / 2)
+                        const nc = alongAxis(
+                            neighbor.mapToItem(null, neighbor.width / 2, neighbor.height / 2))
                         const shouldSwap = (nearestIdx > currentVisualIdx)
-                            ? (dragX >= nc.x)
-                            : (dragX <= nc.x)
+                            ? (dragPos >= nc)
+                            : (dragPos <= nc)
 
                         if (shouldSwap) {
                             root.swapSlots(currentVisualIdx, nearestIdx)
@@ -333,17 +383,19 @@ Item {
                                   && appTopLevel.toplevels.length > 0
 
         property bool show: false
-        property real cachedCenterX: 0
+        // The hovered button's centre ALONG the strip - an x at a horizontal
+        // edge, a y at a vertical one.
+        property real cachedCenter: 0
 
         Connections {
             target: root
             function onLastHoveredButtonChanged() {
                 if (root.lastHoveredButton && root.QsWindow)
-                    previewPopup.cachedCenterX = root.popupCenterXForButton(root.lastHoveredButton)
+                    previewPopup.cachedCenter = root.popupCenterForButton(root.lastHoveredButton)
             }
             function onButtonHoveredChanged() {
                 if (root.buttonHovered && root.lastHoveredButton && root.QsWindow)
-                    previewPopup.cachedCenterX = root.popupCenterXForButton(root.lastHoveredButton)
+                    previewPopup.cachedCenter = root.popupCenterForButton(root.lastHoveredButton)
                 updateTimer.restart()
             }
         }
@@ -360,29 +412,58 @@ Item {
             }
         }
 
+        // The corner of the dock's own surface the popup hangs off, and the
+        // way it grows from there - both inward, or it opens into the screen
+        // edge and the compositor clips it. Named sides come from the one
+        // derivation; only the mapping onto Quickshell's flags is local,
+        // because a .pragma library has no QML enums in scope.
+        readonly property var anchorSides: DockGeometry.popupAnchorSides(root.dockEdge)
+        function edgeFlags(names) {
+            let flags = 0
+            for (const name of names) {
+                flags |= name === "top" ? Edges.Top
+                    : name === "bottom" ? Edges.Bottom
+                    : name === "left" ? Edges.Left : Edges.Right
+            }
+            return flags
+        }
+
         anchor {
             window: root.QsWindow.window
             adjustment: PopupAdjustment.None
-            gravity: Edges.Top | Edges.Right
-            edges: Edges.Top | Edges.Left
+            gravity: previewPopup.edgeFlags(previewPopup.anchorSides.gravity)
+            edges: previewPopup.edgeFlags(previewPopup.anchorSides.edges)
         }
 
         visible: popupBackground.opacity > 0
         color: "transparent"
-        implicitWidth: root.QsWindow.window?.width ?? 1
-        implicitHeight: popupMouseArea.implicitHeight
-                        + root.windowControlsHeight
-                        + Appearance.sizes.elevationMargin * 2
+        // The popup spans the dock's own long axis so the card can be placed
+        // anywhere along it, and is content-sized across.
+        implicitWidth: root.vertical
+            ? popupMouseArea.implicitWidth + Appearance.sizes.elevationMargin * 2
+            : (root.QsWindow.window?.width ?? 1)
+        implicitHeight: root.vertical
+            ? (root.QsWindow.window?.height ?? 1)
+            : popupMouseArea.implicitHeight
+                + root.windowControlsHeight
+                + Appearance.sizes.elevationMargin * 2
 
         MouseArea {
             id: popupMouseArea
-            anchors.bottom: parent.bottom
+            // Pinned to the popup's own inward side, which is the side facing
+            // the dock.
+            readonly property string dockSide: DockGeometry.outwardSide(root.dockEdge)
+            anchors.bottom: dockSide === "bottom" ? parent.bottom : undefined
+            anchors.top: dockSide === "top" ? parent.top : undefined
+            anchors.left: dockSide === "left" ? parent.left : undefined
+            anchors.right: dockSide === "right" ? parent.right : undefined
             implicitWidth:  popupBackground.implicitWidth + Appearance.sizes.elevationMargin * 2
             implicitHeight: root.maxWindowPreviewHeight
                             + root.windowControlsHeight
                             + Appearance.sizes.elevationMargin * 2
             hoverEnabled: true
-            x: previewPopup.cachedCenterX - width / 2
+            x: root.vertical ? 0 : previewPopup.cachedCenter - width / 2
+            y: root.vertical ? previewPopup.cachedCenter - height / 2 : 0
 
             StyledRectangularShadow {
                 target: popupBackground
@@ -404,9 +485,20 @@ Item {
                 clip: true
                 color: Appearance.m3colors.m3surfaceContainer
                 radius: Appearance.rounding.normal
-                anchors.bottom: parent.bottom
-                anchors.bottomMargin: Appearance.sizes.elevationMargin
-                anchors.horizontalCenter: parent.horizontalCenter
+                // Pushed off the side facing the dock by the elevation margin,
+                // so the shadow has somewhere to fall.
+                readonly property var cardMargins: DockGeometry.directedSides(
+                    root.dockEdge, 0, Appearance.sizes.elevationMargin)
+                anchors.bottom: popupMouseArea.dockSide === "bottom" ? parent.bottom : undefined
+                anchors.top: popupMouseArea.dockSide === "top" ? parent.top : undefined
+                anchors.left: popupMouseArea.dockSide === "left" ? parent.left : undefined
+                anchors.right: popupMouseArea.dockSide === "right" ? parent.right : undefined
+                anchors.bottomMargin: cardMargins.bottom
+                anchors.topMargin: cardMargins.top
+                anchors.leftMargin: cardMargins.left
+                anchors.rightMargin: cardMargins.right
+                anchors.horizontalCenter: root.vertical ? undefined : parent.horizontalCenter
+                anchors.verticalCenter: root.vertical ? parent.verticalCenter : undefined
                 implicitHeight: previewRowLayout.implicitHeight + padding * 2
                 implicitWidth:  previewRowLayout.implicitWidth  + padding * 2
                 Behavior on implicitWidth {

--- a/dots/.config/quickshell/imi/modules/imi/dock/Dock.qml
+++ b/dots/.config/quickshell/imi/modules/imi/dock/Dock.qml
@@ -22,6 +22,11 @@ Scope {
     readonly property string edge: DockGeometry.normalizedEdge(
         Config.options?.dock.edge ?? "bottom")
 
+    // One tree, not two modules. An orientation change reflows the icons in
+    // place, so icon state, hover state and DockLaunchTracker's bookkeeping
+    // survive it - the bar rebuilds instead, and loses all three.
+    readonly property bool vertical: DockGeometry.isVertical(root.edge)
+
     Variants {
         model: Quickshell.screens
 
@@ -67,11 +72,14 @@ Scope {
                 left: DockGeometry.anchors(root.edge).left
                 right: DockGeometry.anchors(root.edge).right
             }
-            implicitWidth: dockBackground.implicitWidth
             WlrLayershell.namespace: "quickshell:dock"
             color: "transparent"
 
-            implicitHeight: dockRoot.dockThickness
+            // The thickness lands on whichever axis the anchors left free;
+            // the other one is spanned and the compositor ignores what is
+            // asked for there.
+            implicitWidth: root.vertical ? dockRoot.dockThickness : dockBackground.implicitWidth
+            implicitHeight: root.vertical ? dockBackground.implicitHeight : dockRoot.dockThickness
 
             mask: Region { item: dockMouseArea }
 
@@ -94,27 +102,38 @@ Scope {
 
             MouseArea {
                 id: dockMouseArea
-                height: parent.height
+                // The strip fills the dock's thickness across its own axis and
+                // is sized by the icons along it.
+                width: root.vertical ? parent.width : implicitWidth
+                height: root.vertical ? implicitHeight : parent.height
                 // The reveal is one number: revealed, a sliver, or one past
                 // gone. Which margin it lands on is the edge's business.
                 readonly property var revealOffsets: DockGeometry.revealOffsets(
-                    dockRoot.implicitHeight, Config.options?.dock.hoverRegionHeight ?? 2)
+                    dockRoot.dockThickness, Config.options?.dock.hoverRegionHeight ?? 2)
                 readonly property real revealOffset: dockRoot.reveal
                     ? revealOffsets.revealed
                     : (Config.options?.dock.hoverToReveal
                         ? revealOffsets.peeking : revealOffsets.hidden)
 
-                // The offset lands on the side the dock lives on: a top dock
-                // that pushed its topMargin would slide further onto the
-                // screen to hide.
+                // The body hangs off the dock's INWARD side and the offset
+                // grows from there, so it travels toward the screen edge to
+                // leave. A dock anchored on its outward side would slide
+                // further onto the screen to hide.
+                readonly property string revealSide: DockGeometry.revealAnchorSide(root.edge)
                 anchors {
-                    top: root.edge === "bottom" ? parent.top : undefined
-                    bottom: root.edge === "top" ? parent.bottom : undefined
-                    topMargin: root.edge === "bottom" ? dockMouseArea.revealOffset : 0
-                    bottomMargin: root.edge === "top" ? dockMouseArea.revealOffset : 0
-                    horizontalCenter: parent.horizontalCenter
+                    top: dockMouseArea.revealSide === "top" ? parent.top : undefined
+                    bottom: dockMouseArea.revealSide === "bottom" ? parent.bottom : undefined
+                    left: dockMouseArea.revealSide === "left" ? parent.left : undefined
+                    right: dockMouseArea.revealSide === "right" ? parent.right : undefined
+                    topMargin: dockMouseArea.revealSide === "top" ? dockMouseArea.revealOffset : 0
+                    bottomMargin: dockMouseArea.revealSide === "bottom" ? dockMouseArea.revealOffset : 0
+                    leftMargin: dockMouseArea.revealSide === "left" ? dockMouseArea.revealOffset : 0
+                    rightMargin: dockMouseArea.revealSide === "right" ? dockMouseArea.revealOffset : 0
+                    horizontalCenter: root.vertical ? undefined : parent.horizontalCenter
+                    verticalCenter: root.vertical ? parent.verticalCenter : undefined
                 }
                 implicitWidth: dockHoverRegion.implicitWidth + Appearance.sizes.elevationMargin * 2
+                implicitHeight: dockHoverRegion.implicitHeight + Appearance.sizes.elevationMargin * 2
                 hoverEnabled: true
 
                 Behavior on anchors.topMargin {
@@ -123,23 +142,44 @@ Scope {
                 Behavior on anchors.bottomMargin {
                     animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
                 }
+                Behavior on anchors.leftMargin {
+                    animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
+                }
+                Behavior on anchors.rightMargin {
+                    animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
+                }
 
                 Item {
                     id: dockHoverRegion
                     anchors.fill: parent
                     implicitWidth: dockBackground.implicitWidth
+                    implicitHeight: dockBackground.implicitHeight
 
                     Item {
                         id: dockBackground
                         anchors {
-                            top: parent.top
-                            bottom: parent.bottom
-                            horizontalCenter: parent.horizontalCenter
+                            top: root.vertical ? undefined : parent.top
+                            bottom: root.vertical ? undefined : parent.bottom
+                            left: root.vertical ? parent.left : undefined
+                            right: root.vertical ? parent.right : undefined
+                            horizontalCenter: root.vertical ? undefined : parent.horizontalCenter
+                            verticalCenter: root.vertical ? parent.verticalCenter : undefined
                         }
-                        implicitWidth: dockRow.implicitWidth + 5 * 2
-                        height: parent.height
-                            - Appearance.sizes.elevationMargin
-                            - Appearance.sizes.hyprlandGapsOut
+                        // Along the strip the body is the icons' size plus a
+                        // 5px shoulder; across it, the dock's thickness less
+                        // the two margins the body's own anchors then apply.
+                        implicitWidth: root.vertical
+                            ? parent.width
+                                - Appearance.sizes.elevationMargin
+                                - Appearance.sizes.hyprlandGapsOut
+                            : dockRow.implicitWidth + 5 * 2
+                        implicitHeight: root.vertical
+                            ? dockRow.implicitHeight + 5 * 2
+                            : parent.height
+                                - Appearance.sizes.elevationMargin
+                                - Appearance.sizes.hyprlandGapsOut
+                        width: implicitWidth
+                        height: implicitHeight
 
                         StyledRectangularShadow {
                             target: dockVisualBackground
@@ -152,6 +192,8 @@ Scope {
                             anchors.fill: parent
                             anchors.topMargin:    dockRoot.dockMargins.top
                             anchors.bottomMargin: dockRoot.dockMargins.bottom
+                            anchors.leftMargin:   dockRoot.dockMargins.left
+                            anchors.rightMargin:  dockRoot.dockMargins.right
                             color: Config.options.dock.showBackground
                                    ? Appearance.colors.colLayer0 : "transparent"
                             border.width: Config.options.dock.showBackground ? 1 : 0
@@ -159,23 +201,38 @@ Scope {
                             radius: Appearance.rounding.normal + 6
                         }
 
-                        RowLayout {
+                        // A GridLayout with a flow rather than a RowLayout, so
+                        // the strip turns without the children being destroyed
+                        // and rebuilt: one tree, per the spec's §9 Q2. Its id
+                        // and its `padding` are reached by DYNAMIC SCOPE from
+                        // DockSeparator and DockAppButton - renaming either
+                        // yields undefined and NaN geometry, with no error.
+                        GridLayout {
                             id: dockRow
-                            anchors.top: parent.top
-                            anchors.bottom: parent.bottom
-                            anchors.horizontalCenter: parent.horizontalCenter
-                            spacing: Appearance.spacing.space50
+                            flow: root.vertical ? GridLayout.TopToBottom : GridLayout.LeftToRight
+                            anchors.top: root.vertical ? undefined : parent.top
+                            anchors.bottom: root.vertical ? undefined : parent.bottom
+                            anchors.left: root.vertical ? parent.left : undefined
+                            anchors.right: root.vertical ? parent.right : undefined
+                            anchors.horizontalCenter: root.vertical ? undefined : parent.horizontalCenter
+                            anchors.verticalCenter: root.vertical ? parent.verticalCenter : undefined
+                            rowSpacing: Appearance.spacing.space50
+                            columnSpacing: Appearance.spacing.space50
                             property real padding: Appearance.spacing.space100
                             property bool hasPinnedApps: (Config.options?.dock.pinnedApps?.length ?? 0) > 0
 
                             VerticalButtonGroup {
-                                Layout.topMargin: Appearance.spacing.space50
-                                Layout.leftMargin:  root.pinned
-                                    ? Appearance.sizes.hyprlandGapsOut + 4
-                                    : Appearance.sizes.hyprlandGapsOut
-                                Layout.rightMargin: root.pinned
-                                    ? Appearance.sizes.hyprlandGapsOut + 4
-                                    : Appearance.sizes.hyprlandGapsOut
+                                // space50 across the dock's thickness, the
+                                // compositor's gap at both ends of the strip.
+                                readonly property var pinMargins: DockGeometry.axisMargins(
+                                    root.edge, Appearance.spacing.space50, 0,
+                                    root.pinned
+                                        ? Appearance.sizes.hyprlandGapsOut + 4
+                                        : Appearance.sizes.hyprlandGapsOut)
+                                Layout.topMargin: pinMargins.top
+                                Layout.bottomMargin: pinMargins.bottom
+                                Layout.leftMargin: pinMargins.left
+                                Layout.rightMargin: pinMargins.right
 
                                 GroupButton {
                                     baseWidth: 35; baseHeight: 35
@@ -196,17 +253,33 @@ Scope {
                             }
 
                             DockSeparator {
+                                // dockMedia.visible, not the showMedia option:
+                                // the tile is absent at a vertical edge and a
+                                // separator that reads the option instead of
+                                // the tile hides against nothing.
                                 visible: Config.options.dock.showPinButton
                                     && (dockRow.hasPinnedApps
-                                        || !(Config.options.dock.showMedia && dockMedia.hasTrack))
+                                        || !(dockMedia.visible && dockMedia.hasTrack))
                             }
 
                             DragApps {
                                 id: dragSlots
                                 visible: dockRow.hasPinnedApps
+                                // space25 across the thickness; the negative
+                                // margin is a pull-in at the LEADING end of the
+                                // strip, closing the gap an absent pin button
+                                // leaves - so it is not the symmetric pair
+                                // axisMargins() hands out.
+                                readonly property var slotInset: DockGeometry.directedSides(
+                                    root.edge, Appearance.spacing.space25, 0)
+                                readonly property real slotPull: Config.options.dock.showPinButton
+                                    ? 0 : -Appearance.spacing.space200
                                 Layout.fillHeight: false
-                                Layout.topMargin: Appearance.spacing.space25
-                                Layout.leftMargin: Config.options.dock.showPinButton ? 0 : -Appearance.spacing.space200
+                                Layout.fillWidth: false
+                                Layout.topMargin: root.vertical ? slotPull : slotInset.top
+                                Layout.bottomMargin: root.vertical ? 0 : slotInset.bottom
+                                Layout.leftMargin: root.vertical ? slotInset.left : slotPull
+                                Layout.rightMargin: root.vertical ? slotInset.right : 0
                                 pinnedApps:    Config.options?.dock.pinnedApps ?? []
                                 contextMenu:   dockContextMenu
                                 buttonPadding: dockRow.padding
@@ -215,13 +288,17 @@ Scope {
                             }
 
                             DockSeparator {
-                                visible: dockRow.hasPinnedApps && (activeAppsArea.activeUnpinned.length > 0 || (Config.options.dock.showMedia && MprisController.activePlayer !== null))
+                                visible: dockRow.hasPinnedApps
+                                    && (activeAppsArea.activeUnpinned.length > 0
+                                        || (dockMedia.visible && MprisController.activePlayer !== null))
                             }
 
                             Item {
                                 id: activeAppsArea
-                                Layout.fillHeight: true
+                                Layout.fillHeight: !root.vertical
+                                Layout.fillWidth: root.vertical
                                 Layout.topMargin: 0
+                                Layout.leftMargin: 0
                                 property bool requestDockShow: false
 
                                 property var activeUnpinned: {
@@ -233,21 +310,32 @@ Scope {
                                 }
                                 property bool hasActiveUnpinned: activeUnpinned.length > 0 || dockMedia.visible
 
-                                implicitWidth:  activeRow.implicitWidth
-                                implicitHeight: parent.height
+                                implicitWidth:  root.vertical ? parent.width : activeRow.implicitWidth
+                                implicitHeight: root.vertical ? activeRow.implicitHeight : parent.height
 
                                 Behavior on implicitWidth {
                                     animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
                                 }
+                                Behavior on implicitHeight {
+                                    enabled: root.vertical
+                                    animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
+                                }
 
-                                RowLayout {
+                                GridLayout {
                                     id: activeRow
                                     anchors.fill: parent
-                                    spacing: -Appearance.spacing.space50
+                                    flow: root.vertical ? GridLayout.TopToBottom : GridLayout.LeftToRight
+                                    rowSpacing: -Appearance.spacing.space50
+                                    columnSpacing: -Appearance.spacing.space50
 
                                     DockMedia {
                                         id: dockMedia
-                                        visible: Config.options.dock.showMedia
+                                        // A 240x60 card has no 60x240 form.
+                                        // The vertical dock omits it the way
+                                        // the vertical bar omits what does not
+                                        // fit; a richer vertical media tile is
+                                        // its own spec (§9 Q1).
+                                        visible: Config.options.dock.showMedia && !root.vertical
                                         Layout.fillHeight: true
                                         Layout.topMargin: Appearance.spacing.space150
                                         Layout.bottomMargin: Appearance.spacing.space100
@@ -260,12 +348,11 @@ Scope {
                                         delegate: DockAppButton {
                                             required property var modelData
                                             appToplevel: modelData
-                                            Layout.fillHeight: true
-                                            Layout.topMargin: Appearance.spacing.space25
                                             appListRoot: appListBridge
                                             contextMenu: dockContextMenu
-                                            topInset:    dockRow.padding + Appearance.spacing.space100
-                                            bottomInset: dockRow.padding + Appearance.spacing.space100
+                                            crossMargin: Appearance.spacing.space25
+                                            insetInward:  dockRow.padding + Appearance.spacing.space100
+                                            insetOutward: dockRow.padding + Appearance.spacing.space100
                                         }
                                     }
                                 }
@@ -279,20 +366,18 @@ Scope {
 
                             DockSeparator {
                                 visible: Config.options.dock.showAppsButton
-                                Layout.leftMargin: Config.options.dock.showAppsButton ? 0 : -Appearance.spacing.space50
                             }
 
                             DockButton {
-                                Layout.fillHeight: true
-                                Layout.topMargin: 0
+                                crossMargin: 0
                                 visible: Config.options.dock.showAppsButton
                                 onClicked: GlobalStates.overviewOpen = !GlobalStates.overviewOpen
-                                topInset:    dockRow.padding + 10
-                                bottomInset: dockRow.padding + 7
+                                insetInward:  dockRow.padding + 10
+                                insetOutward: dockRow.padding + 7
                                 contentItem: MaterialSymbol {
                                     anchors.fill: parent
                                     horizontalAlignment: Text.AlignHCenter
-                                    font.pixelSize: parent.width / 2
+                                    font.pixelSize: Math.min(parent.width, parent.height) / 2
                                     text: "apps"
                                     color: Appearance.colors.colOnLayer0
                                 }

--- a/dots/.config/quickshell/imi/modules/imi/dock/Dock.qml
+++ b/dots/.config/quickshell/imi/modules/imi/dock/Dock.qml
@@ -233,11 +233,21 @@ Scope {
                                 Layout.bottomMargin: pinMargins.bottom
                                 Layout.leftMargin: pinMargins.left
                                 Layout.rightMargin: pinMargins.right
+                                // A layout item that does not fill defaults to
+                                // AlignLeft, which at a vertical edge is the
+                                // OUTWARD side: the pin hung half off the
+                                // painted body. Everything else in the strip
+                                // fills its cross axis and never showed it.
+                                Layout.alignment: Qt.AlignCenter
 
                                 GroupButton {
                                     baseWidth: 35; baseHeight: 35
                                     visible: Config.options.dock.showPinButton
-                                    clickedWidth: baseWidth; clickedHeight: baseHeight + 20
+                                    // The press stretches along the strip, so
+                                    // the grown edge is the one the strip runs
+                                    // in - at a side edge that is the width.
+                                    clickedWidth: root.vertical ? baseWidth + 20 : baseWidth
+                                    clickedHeight: root.vertical ? baseHeight : baseHeight + 20
                                     buttonRadius: Appearance.rounding.normal
                                     toggled: root.pinned
                                     onClicked: root.pinned = !root.pinned
@@ -374,9 +384,21 @@ Scope {
                                 onClicked: GlobalStates.overviewOpen = !GlobalStates.overviewOpen
                                 insetInward:  dockRow.padding + 10
                                 insetOutward: dockRow.padding + 7
+                                // Centred in what is PAINTED, not in the item:
+                                // the insets are asymmetric (they compensate
+                                // the body's elevation-vs-gap margins), so a
+                                // glyph filling the whole rect sits off-centre
+                                // by half their difference. Vertically nobody
+                                // saw it; at a side edge it reads as a glyph
+                                // pushed sideways.
                                 contentItem: MaterialSymbol {
                                     anchors.fill: parent
+                                    anchors.topMargin: parent.topInset
+                                    anchors.bottomMargin: parent.bottomInset
+                                    anchors.leftMargin: parent.leftInset
+                                    anchors.rightMargin: parent.rightInset
                                     horizontalAlignment: Text.AlignHCenter
+                                    verticalAlignment: Text.AlignVCenter
                                     font.pixelSize: Math.min(parent.width, parent.height) / 2
                                     text: "apps"
                                     color: Appearance.colors.colOnLayer0

--- a/dots/.config/quickshell/imi/modules/imi/dock/dock_geometry.js
+++ b/dots/.config/quickshell/imi/modules/imi/dock/dock_geometry.js
@@ -21,12 +21,29 @@
 
 var EDGES = ["top", "bottom", "left", "right"];
 
+// The only table in this file. INWARD and OUTWARD are the whole vocabulary,
+// and every side name below is read out of here rather than spelled again -
+// a popup's gravity, the reveal's anchor, the shadow margin and the hover
+// lift's direction are all one relation asked four different ways.
+var OPPOSITE = { top: "bottom", bottom: "top", left: "right", right: "left" };
+
 function isVertical(edge) {
     return edge === "left" || edge === "right";
 }
 
 function normalizedEdge(edge) {
     return EDGES.indexOf(edge) === -1 ? "bottom" : edge;
+}
+
+// Toward the screen edge the dock is on. Which is the edge itself - named so
+// a caller reads its intent rather than the coincidence.
+function outwardSide(edge) {
+    return normalizedEdge(edge);
+}
+
+// Toward the middle of the screen.
+function inwardSide(edge) {
+    return OPPOSITE[normalizedEdge(edge)];
 }
 
 // Which sides the layer surface anchors to: both ends of the long axis, plus
@@ -60,16 +77,27 @@ function insets(elevationMargin, gapsOut) {
     return { inward: elevationMargin, outward: gapsOut };
 }
 
-// The same pair mapped onto the anchor names an Item actually uses, so a
-// caller writes `anchors.topMargin: Geometry.margins(edge, ...).top` and the
-// flip costs nothing.
+// Any inward/outward pair mapped onto the four side names an Item actually
+// uses for its anchors, margins and insets. Sides on the dock's LONG axis get
+// zero: an inset there would eat into the strip rather than into its
+// thickness, which is the mistake that reads as "the icons drifted".
+//
+// This is the one place a direction becomes a side name. A widget that spells
+// out `topMargin` for the shadow and `bottomMargin` for the gap is correct at
+// exactly one edge and silently wrong at the other three.
+function directedSides(edge, inward, outward) {
+    var sides = { top: 0, bottom: 0, left: 0, right: 0 };
+    sides[inwardSide(edge)] = inward;
+    sides[outwardSide(edge)] = outward;
+    return sides;
+}
+
+// The dock body's own margin pair, mapped onto side names, so a caller writes
+// `anchors.topMargin: Geometry.margins(edge, ...).top` and the flip costs
+// nothing.
 function margins(edge, elevationMargin, gapsOut) {
-    var e = normalizedEdge(edge);
     var pair = insets(elevationMargin, gapsOut);
-    if (e === "bottom") return { top: pair.inward, bottom: pair.outward, left: 0, right: 0 };
-    if (e === "top") return { top: pair.outward, bottom: pair.inward, left: 0, right: 0 };
-    if (e === "left") return { left: pair.outward, right: pair.inward, top: 0, bottom: 0 };
-    return { left: pair.inward, right: pair.outward, top: 0, bottom: 0 };
+    return directedSides(edge, pair.inward, pair.outward);
 }
 
 // How far the dock is pushed off-screen when hidden, and how far it peeks
@@ -87,14 +115,59 @@ function revealOffsets(dockThickness, hoverRegion) {
     };
 }
 
+// Which side of its own surface the reveal push lands on. A dock anchors the
+// body to its INWARD side and grows the margin there to shove it out: a
+// bottom dock that pushed its bottomMargin would slide further onto the
+// screen to hide.
+function revealAnchorSide(edge) {
+    return inwardSide(edge);
+}
+
 // Which way a popup opens from a dock on this edge: away from the edge, or
 // the menu opens into it and is clipped.
 function popupGravity(edge) {
+    return inwardSide(edge);
+}
+
+// A popup anchored to the dock's whole SURFACE rather than to one button -
+// the window-preview popup - needs a corner and a direction, not one side. It
+// attaches at the start of the dock's long axis on the inward side, and grows
+// inward and along that axis.
+//
+// Side names rather than Quickshell's `Edges` flags: a `.pragma library` has
+// no QML enums in scope, so the caller maps the names. It does not get to
+// decide them.
+function popupAnchorSides(edge) {
     var e = normalizedEdge(edge);
-    if (e === "bottom") return "top";
-    if (e === "top") return "bottom";
-    if (e === "left") return "right";
-    return "left";
+    var axisStart = isVertical(e) ? "top" : "left";
+    var axisEnd = isVertical(e) ? "bottom" : "right";
+    return { edges: [inwardSide(e), axisStart], gravity: [inwardSide(e), axisEnd] };
+}
+
+// The direction a dock icon lifts on hover and bounces on launch: inward, so
+// the icon rises out of the dock rather than into the screen edge. One vector
+// instead of four call sites each choosing an axis and a sign.
+function inwardVector(edge) {
+    var toward = inwardSide(edge);
+    return {
+        x: toward === "left" ? -1 : (toward === "right" ? 1 : 0),
+        y: toward === "top" ? -1 : (toward === "bottom" ? 1 : 0)
+    };
+}
+
+// The bar's edge, said in the dock's vocabulary. The bar stores a pair of
+// booleans in which `bottom` stops meaning bottom and starts meaning RIGHT
+// once `vertical` is set (VerticalBar.qml anchors left/right off it), and
+// three files already re-derive a name from that pair.
+//
+// This is not a fourth copy of that for the bar's benefit. It exists so the
+// dock's settings row can ask whether it is being sent to an edge an
+// auto-hiding bar already owns, and a comparison between two vocabularies
+// means nothing.
+function barEdge(barVertical, barBottom) {
+    if (!barVertical)
+        return barBottom ? "bottom" : "top";
+    return barBottom ? "right" : "left";
 }
 
 // The sign the reveal travels in: a bottom dock hides DOWNWARD (positive y),

--- a/dots/.config/quickshell/imi/modules/imi/dock/dock_geometry.js
+++ b/dots/.config/quickshell/imi/modules/imi/dock/dock_geometry.js
@@ -92,6 +92,23 @@ function directedSides(edge, inward, outward) {
     return sides;
 }
 
+// A margin or inset trio said in the dock's OWN axes. ACROSS the dock is the
+// inward/outward pair above; ALONG it is the gap at both ends of the strip.
+// §1's "written in terms of along and across rather than width and height",
+// written once so a widget does not have to decide which of `topMargin` and
+// `leftMargin` its number means this time.
+function axisMargins(edge, inward, outward, along) {
+    var sides = directedSides(edge, inward, outward);
+    if (isVertical(edge)) {
+        sides.top = along;
+        sides.bottom = along;
+    } else {
+        sides.left = along;
+        sides.right = along;
+    }
+    return sides;
+}
+
 // The dock body's own margin pair, mapped onto side names, so a caller writes
 // `anchors.topMargin: Geometry.margins(edge, ...).top` and the flip costs
 // nothing.

--- a/dots/.config/quickshell/imi/modules/imi/settings/pages/BarConfig.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/pages/BarConfig.qml
@@ -7,6 +7,7 @@ import qs.modules.common.widgets
 import qs.modules.common.plugins
 import Quickshell.Hyprland
 import "../../../common/functions/screenSelection.js" as ScreenSelection
+import "../../dock/dock_geometry.js" as DockGeometry
 
 ContentPage {
     id: page
@@ -668,17 +669,40 @@ ContentPage {
                     onToggleRequested: Config.options.dock.enable = !Config.options.dock.enable
                 }
                 ConfigSelectionArray {
-                    text: Translation.tr("Dock position")
+                    id: dockEdgeRow
+                    // The shell DECLINES a dock on the same edge as an
+                    // auto-hiding bar rather than arbitrating the two 2px
+                    // reveal slivers that would then share one row of pixels
+                    // (spec §3, settled as §9 Q3). Two strips fighting over
+                    // the same line is not a layout that can be tuned into
+                    // working: whichever loses, the bar becomes unrevealable
+                    // and nothing on screen says why.
+                    //
+                    // Only auto-hide collides. A bottom bar plus a pinned dock
+                    // is a legitimate arrangement the compositor lays out
+                    // cumulatively, and refusing that would forbid something
+                    // that works.
+                    readonly property string blockedEdge: Config.options.bar.autoHide.enable
+                        ? DockGeometry.barEdge(Config.options.bar.vertical,
+                                               Config.options.bar.bottom)
+                        : ""
+                    text: dockEdgeRow.blockedEdge === ""
+                        ? Translation.tr("Dock position")
+                        : Translation.tr("Dock position (not the auto-hiding bar's edge)")
                     icon: "swap_vert"
                     // The value IS the stored string - no bitfield to
                     // open-code, which is the whole argument for the new key.
                     currentValue: Config.options.dock.edge
                     onSelected: newValue => { Config.options.dock.edge = newValue; }
                     options: [
-                        { displayName: Translation.tr("Top"),    icon: "arrow_upward",   value: "top" },
-                        { displayName: Translation.tr("Left"),   icon: "arrow_back",     value: "left" },
-                        { displayName: Translation.tr("Bottom"), icon: "arrow_downward", value: "bottom" },
-                        { displayName: Translation.tr("Right"),  icon: "arrow_forward",  value: "right" }
+                        { displayName: Translation.tr("Top"),    icon: "arrow_upward",   value: "top",
+                          disabled: dockEdgeRow.blockedEdge === "top" },
+                        { displayName: Translation.tr("Left"),   icon: "arrow_back",     value: "left",
+                          disabled: dockEdgeRow.blockedEdge === "left" },
+                        { displayName: Translation.tr("Bottom"), icon: "arrow_downward", value: "bottom",
+                          disabled: dockEdgeRow.blockedEdge === "bottom" },
+                        { displayName: Translation.tr("Right"),  icon: "arrow_forward",  value: "right",
+                          disabled: dockEdgeRow.blockedEdge === "right" }
                     ]
                 }
                 ConfigSwitch {

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -263,14 +263,23 @@ if ! python3 "$SCRIPT_DIR/test_widget_resize_grip_runtime.py"; then
     exit 1
 fi
 
-# Renders real cards and reads the pixels under them: the shadow is not
-# reachable from a source-text check. Brings its own headless weston.
 echo "Running dock position contract tests..."
 if ! python3 "$SCRIPT_DIR/test_dock_position_contract.py"; then
     echo "Dock position contract tests failed."
     exit 1
 fi
 
+# A column of dock icons can lay out perfectly and still refuse to reorder,
+# because every slot centre shares an x - only real mouse events see that.
+# Brings its own headless weston.
+echo "Running dock edge runtime tests..."
+if ! python3 "$SCRIPT_DIR/test_dock_edge_runtime.py"; then
+    echo "Dock edge runtime tests failed."
+    exit 1
+fi
+
+# Renders real cards and reads the pixels under them: the shadow is not
+# reachable from a source-text check. Brings its own headless weston.
 echo "Running widget card shadow tests..."
 if ! python3 "$SCRIPT_DIR/test_card_shadow.py"; then
     echo "Widget card shadow tests failed."

--- a/dots/.config/quickshell/imi/tests/test_dock_edge_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_dock_edge_runtime.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Drives the dock's pinned-app reorder with real mouse events, on both axes.
+
+`DockEdgeRuntimeTest.qml` builds a real `DragApps` and drags its slots at a
+horizontal edge and at a vertical one. This module is the driver: it stands up
+a headless weston, points throwaway XDG dirs at it, and fails the suite on any
+check the harness reports.
+
+Why a runtime harness and not another source contract: a vertical dock's
+failure mode is not a layout that looks wrong. `test_dock_position_contract.py`
+can see that the reorder names an axis, and `tst_dock_geometry.qml` can see
+that the geometry answers for four edges - neither can see whether a press and
+a drag actually move an icon past its neighbour. The reorder used to compare x
+everywhere, and in a column every slot centre has the same x: the comparison is
+a number against itself, so the icons refuse to move past each other with
+nothing in any log.
+
+The discriminating pair is a drag ALONG the strip (must reorder) and a drag
+ACROSS it (must not). The horizontal edge runs first as the control, because
+"nothing happened" is what a harness that stopped delivering events reports.
+
+What it cannot answer: the harness opens a FloatingWindow, and weston
+implements no wlr-layer-shell, so the dock's anchors, exclusive zone, reveal
+push and the compositor's inferred slide direction are all invisible to it -
+along with everything that is a look rather than a behaviour. Those are
+`hyprctl layers -j` plus `hyprctl monitors -j`, against the baseline recorded
+in the design doc.
+
+Skips when weston or qs is missing, as in CI.
+"""
+
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HARNESS = ROOT / "DockEdgeRuntimeTest.qml"
+SOCKET = "wayland-imi-dock-edge"
+
+
+def _stop(proc):
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+
+
+def _runtime_available():
+    return shutil.which("qs") is not None and shutil.which("weston") is not None
+
+
+@unittest.skipUnless(_runtime_available(), "needs qs and weston on PATH")
+class DockEdgeRuntimeTest(unittest.TestCase):
+    def setUp(self):
+        self.home = Path(tempfile.mkdtemp(prefix="imi-dock-edge-"))
+        self.addCleanup(shutil.rmtree, self.home, ignore_errors=True)
+
+    def test_the_reorder_follows_the_axis_the_slots_run_along(self):
+        env = dict(os.environ)
+        env.setdefault("XDG_RUNTIME_DIR", f"/run/user/{os.getuid()}")
+        env["WAYLAND_DISPLAY"] = SOCKET
+        env.pop("DISPLAY", None)
+
+        weston = subprocess.Popen(
+            ["weston", "--backend=headless", "--renderer=pixman",
+             f"--socket={SOCKET}", "--width=900", "--height=900"],
+            env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        self.addCleanup(_stop, weston)
+
+        socket_path = Path(env["XDG_RUNTIME_DIR"]) / SOCKET
+        deadline = time.monotonic() + 15
+        while not socket_path.exists() and time.monotonic() < deadline:
+            time.sleep(0.2)
+        self.assertTrue(socket_path.exists(), "headless weston never came up")
+
+        # This box's headless EGL has no driver, so force software rendering.
+        env["LIBGL_ALWAYS_SOFTWARE"] = "1"
+        env["QT_QUICK_BACKEND"] = "software"
+        env["XDG_CONFIG_HOME"] = str(self.home / "config")
+        env["XDG_STATE_HOME"] = str(self.home / "state")
+
+        proc = subprocess.run(["qs", "-p", str(HARNESS)], cwd=str(ROOT), env=env,
+                              capture_output=True, text=True, timeout=180)
+        output = proc.stdout + proc.stderr
+        failed = [line for line in output.splitlines() if "FAIL" in line]
+        self.assertEqual(failed, [], f"harness reported failures:\n{output}")
+        self.assertIn("[DockEdge] failures: 0", output,
+                      f"harness did not finish cleanly:\n{output}")
+
+        # A size bound back through the item it measures shows up here rather
+        # than as a failed check: the strip would still reorder, it would just
+        # never settle, and NaN geometry in this tree is a pegged core.
+        self.assertNotIn("Binding loop", output,
+                         f"the dock tree grew a binding loop:\n{output}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dots/.config/quickshell/imi/tests/test_dock_position_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_dock_position_contract.py
@@ -6,6 +6,13 @@ Dock.qml's anchors and exclusive zone, and hand-written topMargin/bottomMargin
 pairs in the dock body, the separator and the app buttons. Four coordinated
 edits is how a mirror drifts - one file gets flipped and the others quietly
 keep pointing at the bottom of the screen.
+
+The vertical edges made that worse rather than merely wider, which is why the
+spec asked for a lint before the second layout existed (§7 step 6, folded in
+here): a horizontal dock spelling out `topMargin` is correct and a vertical one
+spelling out the same thing is not wrong-looking, it is wrong on the axis the
+layout owns - the inset eats into the strip of icons instead of into the dock's
+depth, and nothing errors.
 """
 
 import re
@@ -20,14 +27,38 @@ DEFAULTS = ROOT / "defaults/config.json"
 SETTINGS = ROOT / "modules/imi/settings/pages/BarConfig.qml"
 RULES = ROOT.parents[2] / ".config/hypr/hyprland/rules.lua"
 
+WIDGETS = ROOT / "modules/common/widgets"
+DRAG_APPS = WIDGETS / "DragApps.qml"
+APP_BUTTON = WIDGETS / "DockAppButton.qml"
+BUTTON = WIDGETS / "DockButton.qml"
+SEPARATOR = WIDGETS / "DockSeparator.qml"
+ICON_MOTION = WIDGETS / "DockIconMotion.qml"
+CONTEXT_MENU = WIDGETS / "DockContextMenu.qml"
+DOCK_TO_PANEL = ROOT / "modules/imi/bar/DocktoPanel.qml"
+
+# Everything that has to know which way the dock is facing. DockAppButton is
+# rooted on DockButton and inherits `dockEdge`/`dockVertical` from it, which is
+# the only sanctioned way to not read the config yourself.
+EDGE_AWARE = [DOCK, BUTTON, SEPARATOR, APP_BUTTON, ICON_MOTION, DRAG_APPS, CONTEXT_MENU]
+
+# A margin, inset or anchor bound to a named side while naming one of the two
+# tokens whose asymmetry the edge decides.
+SIDE_BOUND_TOKEN = re.compile(
+    r"(top|bottom|left|right)(Margin|Inset)\s*:[^\n]*"
+    r"(elevationMargin|hyprlandGapsOut)")
+
 
 class DockPositionContractTest(unittest.TestCase):
+    def qml_sources(self):
+        for path in sorted(ROOT.glob("modules/**/*.qml")):
+            yield path, path.read_text(encoding="utf-8")
+
     def test_the_dock_reads_its_geometry_rather_than_spelling_it(self):
         source = DOCK.read_text(encoding="utf-8")
         self.assertIn("dock_geometry.js", source)
         for derived in ("DockGeometry.thickness(", "DockGeometry.exclusiveZone(",
                         "DockGeometry.anchors(", "DockGeometry.margins(",
-                        "DockGeometry.revealOffsets("):
+                        "DockGeometry.revealOffsets(", "DockGeometry.revealAnchorSide("):
             self.assertIn(derived, source, f"{derived} is spelled out again")
         # The arithmetic itself may not reappear in the QML.
         self.assertNotIn("anchors { bottom: true; left: true; right: true }", source,
@@ -40,26 +71,156 @@ class DockPositionContractTest(unittest.TestCase):
         self.assertIn("DockGeometry.normalizedEdge(", source,
                       "a hand-edited config or an old preset must not unanchor the dock")
 
+    # ---- one derivation, and only one -----------------------------------
+
+    def test_nothing_derives_the_docks_edge_a_second_way(self):
+        # The direct analogue of lint_bar_popup_overlay_static.py's rule for
+        # barEdge. A file may read the stored key, but only straight into
+        # normalizedEdge() - anything else is a second answer to "which way is
+        # the dock facing", and the one that rots is whichever is off screen.
+        for path, source in self.qml_sources():
+            if "dock.edge" not in source:
+                continue
+            self.assertIn("dock_geometry.js", source,
+                          f"{path.name} reads dock.edge without the one derivation")
+            if path == SETTINGS:
+                # The settings row shows and writes the stored value because it
+                # IS the setting, not a consequence of it. Normalising there
+                # would silently rewrite a hand-edited config on page open.
+                continue
+            for read in re.finditer(r"Config\.options\??\.dock\.edge", source):
+                window = source[max(0, read.start() - 120):read.start()]
+                self.assertIn("DockGeometry.normalizedEdge(", window,
+                              f"{path.name} reads dock.edge outside normalizedEdge()")
+
+    def test_nobody_compares_the_stored_edge_to_a_side(self):
+        # The shape this replaced: `(Config.options?.dock.edge ?? "bottom") === "top"`,
+        # which is a derivation wearing a comparison's clothes - it answers
+        # "top or not top", which is the whole question at two edges and half
+        # of it at four.
+        for path, source in self.qml_sources():
+            self.assertIsNone(
+                re.search(r'dock\.edge[^\n]*\?\?[^\n]*"\s*\)?\s*(===|==|!==|!=)', source),
+                f"{path.name} compares the stored edge to a side instead of deriving it")
+
+    def test_the_bars_pair_becomes_an_edge_in_exactly_one_place(self):
+        # Three files already re-derive a name from bar.bottom + bar.vertical.
+        # Anything that has to compare the dock's edge against the bar's goes
+        # through the module, or the comparison is between two vocabularies.
+        for path, source in self.qml_sources():
+            if "dock.edge" not in source:
+                continue
+            if "bar.vertical" not in source or "bar.bottom" not in source:
+                continue
+            self.assertIn("DockGeometry.barEdge(", source,
+                          f"{path.name} spells the bar's overloaded pair out again")
+
+    def test_the_bar_widget_keeps_following_the_bar(self):
+        # DocktoPanel renders the same pinnedApps inside the bar. Its placement
+        # follows the BAR and must keep doing so (spec §8).
+        source = DOCK_TO_PANEL.read_text(encoding="utf-8")
+        self.assertNotIn("dock.edge", source,
+                         "the bar's dock strip must not follow the dock's edge")
+
+    def test_no_widget_binds_the_asymmetric_pair_to_a_named_side(self):
+        # elevationMargin inward, hyprlandGapsOut outward - which side each
+        # lands on is the edge's business, and a widget that decides is correct
+        # at one edge out of four.
+        for path in EDGE_AWARE:
+            source = path.read_text(encoding="utf-8")
+            offender = SIDE_BOUND_TOKEN.search(source)
+            self.assertIsNone(
+                offender,
+                f"{path.name} binds the elevation/gap pair to a side: "
+                f"{offender.group(0) if offender else ''}")
+
+    # ---- the vertical layout --------------------------------------------
+
+    def test_the_strip_flows_with_the_edge_rather_than_being_rebuilt(self):
+        # One tree with an orientation (§9 Q2): an orientation change reflows
+        # the icons rather than destroying and recreating them, so icon state,
+        # hover state and DockLaunchTracker's bookkeeping survive it.
+        source = DOCK.read_text(encoding="utf-8")
+        self.assertIn("DockGeometry.isVertical(", source)
+        self.assertIn("flow: root.vertical ? GridLayout.TopToBottom : GridLayout.LeftToRight",
+                      source, "the icon strip does not turn with the dock")
+        self.assertNotIn("RowLayout {\n                            id: dockRow", source,
+                         "the strip is a RowLayout again and cannot turn")
+
+    def test_the_reorder_compares_the_axis_the_slots_run_along(self):
+        # A vertical layout that lays out plausibly can still have the reorder
+        # inert: in a column every slot centre has the same x, so an x-only
+        # comparison never finds a different nearest slot and nothing swaps.
+        source = DRAG_APPS.read_text(encoding="utf-8")
+        self.assertIn("function alongAxis(", source)
+        self.assertNotIn("dragHandler.centroid.scenePosition.x\n", source,
+                         "the drag still reads one hardcoded axis")
+        self.assertIn("root.vertical ? slotOffset : 0", source,
+                      "the slots are still placed along x only")
+
+    def test_the_running_dots_answer_for_both_places_they_live(self):
+        # The pinned apps' dots are in DragApps and the running unpinned ones
+        # in DockAppButton. A dock of pinned icons shows nothing of a change
+        # made only to the second.
+        for path in (DRAG_APPS, APP_BUTTON):
+            source = path.read_text(encoding="utf-8")
+            self.assertIn("DockGeometry.outwardSide(", source,
+                          f"{path.name}'s running dots do not follow the edge")
+            self.assertTrue(
+                re.search(r"flow: root\.(vertical|dockVertical) \? Flow\.TopToBottom", source),
+                f"{path.name}'s running dots cannot stack beside the icon")
+
+    def test_the_hover_lift_is_a_magnitude_and_a_direction(self):
+        source = ICON_MOTION.read_text(encoding="utf-8")
+        self.assertIn("DockGeometry.inwardVector(", source)
+        self.assertIn("root.liftVector.x", source)
+        self.assertIn("root.liftVector.y", source)
+        self.assertNotIn("to: -Appearance.spacing.space100", source,
+                         "the launch bounce is a bare negative y again")
+
+    def test_the_media_tile_is_absent_at_a_vertical_edge(self):
+        # A 240x60 card has no 60x240 form; §9 Q1 hides it rather than holding
+        # the position work up for a new component.
+        source = DOCK.read_text(encoding="utf-8")
+        self.assertIn("Config.options.dock.showMedia && !root.vertical", source)
+        # ...and the separators that flank it must read the tile rather than
+        # the option, or they hide themselves against something absent.
+        self.assertNotIn("!(Config.options.dock.showMedia && dockMedia.hasTrack)", source)
+
+    # ---- the settings row ------------------------------------------------
+
     def test_the_settings_row_writes_the_string_directly(self):
         source = SETTINGS.read_text(encoding="utf-8")
-        self.assertIn('text: Translation.tr("Dock position")', source)
+        self.assertIn('Translation.tr("Dock position")', source)
         self.assertIn("Config.options.dock.edge = newValue", source)
         # The whole argument for a new key rather than parity with the bar's
         # overloaded pair is that nothing has to open-code a bitfield.
         row = source[source.index('Translation.tr("Dock position")'):]
-        row = row[:row.index("}\n                }")]
+        row = row[:row.index("\n                ConfigSwitch")]
         for edge in ('"top"', '"left"', '"bottom"', '"right"'):
             self.assertIn(edge, row)
         self.assertNotIn("& 1", row)
         self.assertNotIn("| 2", row)
 
-    def test_what_follows_the_edge_derives_it_and_does_not_assume_bottom(self):
-        for path in (ROOT / "modules/common/widgets/DragApps.qml",
-                     ROOT / "modules/common/widgets/DockAppButton.qml",
-                     ROOT / "modules/common/widgets/DockContextMenu.qml"):
-            source = path.read_text(encoding="utf-8")
-            self.assertIn("dock.edge", source,
-                          f"{path.name} still assumes which edge the dock is on")
+    def test_the_settings_row_refuses_the_auto_hiding_bars_edge(self):
+        # Settled as §9 Q3: the shell declines the combination rather than
+        # arbitrating two 2px reveal slivers over one row of pixels. Only
+        # auto-hide collides - a bottom bar plus a pinned dock is a legitimate
+        # arrangement the compositor stacks, and refusing that would forbid
+        # something that works.
+        source = SETTINGS.read_text(encoding="utf-8")
+        self.assertIn("Config.options.bar.autoHide.enable", source,
+                      "the refusal is not gated on auto-hide")
+        self.assertIn("DockGeometry.barEdge(", source)
+        row = source[source.index('Translation.tr("Dock position")'):]
+        row = row[:row.index("\n                ConfigSwitch")]
+        for edge in ("top", "left", "bottom", "right"):
+            self.assertIn(f'disabled: dockEdgeRow.blockedEdge === "{edge}"', row,
+                          f"the {edge} option can still be chosen under an auto-hiding bar")
+        # The control has to honour it, or the row is decoration.
+        widget = (WIDGETS / "ConfigSelectionArray.qml").read_text(encoding="utf-8")
+        self.assertIn("modelData.disabled", widget,
+                      "ConfigSelectionArray ignores a declined option")
 
     def test_the_slide_follows_the_surface_rather_than_naming_an_edge(self):
         # `slide bottom` pinned the exit animation to one edge, so a top dock
@@ -77,7 +238,8 @@ class DockPositionContractTest(unittest.TestCase):
         source = GEOMETRY.read_text(encoding="utf-8")
         body = source[source.index("function thickness"):]
         for function in ("function thickness", "function exclusiveZone", "function insets",
-                         "function revealOffsets"):
+                         "function revealOffsets", "function directedSides",
+                         "function axisMargins", "function margins"):
             start = body.index(function)
             end = body.index("\n}", start)
             chunk = body[start:end]

--- a/dots/.config/quickshell/imi/tests/tst_dock_geometry.qml
+++ b/dots/.config/quickshell/imi/tests/tst_dock_geometry.qml
@@ -98,4 +98,112 @@ TestCase {
         verify(Geometry.isVertical("left") && Geometry.isVertical("right"));
         verify(!Geometry.isVertical("top") && !Geometry.isVertical("bottom"));
     }
+
+    // --- the two side edges -------------------------------------------------
+
+    function test_thickness_is_the_same_arithmetic_on_either_axis() {
+        // A vertical dock is 75px WIDE and reserves 65 of them. The dock's
+        // `height` key keeps its name and means thickness at every edge, so
+        // there is no second number to get wrong - only a different axis to
+        // apply the one number to.
+        for (const edge of ["top", "bottom", "left", "right"]) {
+            compare(Geometry.thickness(dockHeight, elevation, gaps), 75,
+                    edge + " is the same thickness");
+            compare(Geometry.exclusiveZone(dockHeight, elevation, gaps), 65,
+                    edge + " reserves the same");
+        }
+        // ...and the axis it lands on is the one the anchors leave free.
+        for (const edge of ["left", "right"]) {
+            const a = Geometry.anchors(edge);
+            verify(a.top && a.bottom, edge + " spans the screen's height");
+            verify(!(a.left && a.right), edge + " leaves its width to the thickness");
+        }
+    }
+
+    function test_the_margin_pair_lands_on_the_horizontal_axis_at_a_side_edge() {
+        // The asymmetry that is load-bearing for the blur region: the
+        // elevation margin is inward (it is where the shadow is drawn), the
+        // compositor's gap outward. At a side edge that pair is left/right.
+        const left = Geometry.margins("left", elevation, gaps);
+        compare(left.right, elevation, "the shadow falls toward the screen");
+        compare(left.left, gaps, "and the compositor's gap toward the edge");
+        const right = Geometry.margins("right", elevation, gaps);
+        compare(right.left, elevation);
+        compare(right.right, gaps);
+        // Not merely different - genuinely swapped between the two.
+        verify(left.left !== right.left && left.right !== right.right);
+    }
+
+    function test_inward_and_outward_are_one_relation_asked_four_ways() {
+        compare(Geometry.inwardSide("bottom"), "top");
+        compare(Geometry.inwardSide("left"), "right");
+        compare(Geometry.outwardSide("left"), "left");
+        // The reveal anchors inward and pushes the body outward from there; a
+        // dock that anchored its outward side would slide ONTO the screen to
+        // hide.
+        for (const edge of ["top", "bottom", "left", "right"])
+            compare(Geometry.revealAnchorSide(edge), Geometry.inwardSide(edge),
+                    edge + " reveals along its inward side");
+        // ...and a popup opens the same way, so neither can drift.
+        for (const edge of ["top", "bottom", "left", "right"])
+            compare(Geometry.popupGravity(edge), Geometry.inwardSide(edge));
+    }
+
+    function test_a_directed_pair_never_touches_the_long_axis() {
+        const left = Geometry.directedSides("left", 7, 3);
+        compare(left.right, 7);
+        compare(left.left, 3);
+        compare(left.top, 0, "an inset on the long axis eats the strip, not its thickness");
+        compare(left.bottom, 0);
+        const bottom = Geometry.directedSides("bottom", 7, 3);
+        compare(bottom.top, 7);
+        compare(bottom.bottom, 3);
+        compare(bottom.left, 0);
+        compare(bottom.right, 0);
+    }
+
+    function test_a_surface_anchored_popup_takes_a_corner_and_a_direction() {
+        // The window-preview popup hangs off the dock's whole surface, so one
+        // side is not enough: it needs the corner it attaches to and the way
+        // it grows. Both start inward - a popup opening into the screen edge
+        // is a popup the compositor clips.
+        const bottom = Geometry.popupAnchorSides("bottom");
+        compare(bottom.edges, ["top", "left"]);
+        compare(bottom.gravity, ["top", "right"]);
+        const left = Geometry.popupAnchorSides("left");
+        compare(left.edges, ["right", "top"]);
+        compare(left.gravity, ["right", "bottom"]);
+        const right = Geometry.popupAnchorSides("right");
+        compare(right.edges, ["left", "top"]);
+        compare(right.gravity, ["left", "bottom"]);
+        for (const edge of ["top", "bottom", "left", "right"]) {
+            const sides = Geometry.popupAnchorSides(edge);
+            compare(sides.edges[0], Geometry.inwardSide(edge));
+            compare(sides.gravity[0], Geometry.inwardSide(edge));
+        }
+    }
+
+    function test_the_hover_lift_rises_out_of_the_dock_at_every_edge() {
+        // -y only is correct at exactly one edge. At the top it drives the
+        // icon into the screen edge; at a side edge it moves along the strip
+        // instead of out of it.
+        compare(Geometry.inwardVector("bottom"), { x: 0, y: -1 });
+        compare(Geometry.inwardVector("top"), { x: 0, y: 1 });
+        compare(Geometry.inwardVector("left"), { x: 1, y: 0 });
+        compare(Geometry.inwardVector("right"), { x: -1, y: 0 });
+        for (const edge of ["left", "right"])
+            compare(Geometry.inwardVector(edge).y, 0,
+                    edge + " must not lift along its own strip");
+    }
+
+    function test_the_bars_overloaded_pair_reads_as_an_edge() {
+        // `bottom` stops meaning bottom once `vertical` is set. The dock only
+        // needs this to notice it is being sent where an auto-hiding bar
+        // already lives, and a comparison across two vocabularies means
+        // nothing.
+        compare(Geometry.barEdge(false, false), "top");
+        compare(Geometry.barEdge(false, true), "bottom");
+        compare(Geometry.barEdge(true, false), "left");
+        compare(Geometry.barEdge(true, true), "right");
+    }
 }


### PR DESCRIPTION
Steps 7 and 9 of `docs/superpowers/specs/2026-08-13-dock-position-design.md`: the dock
lays out on all four edges, and the settings UI declines the one arrangement that cannot
work. Steps 1-6 landed in #188.

## What the vertical dock does with each element

**One tree with a `vertical` flag, not a second module** (§9 Q2). `dockRow` is a
`GridLayout` whose `flow` follows the edge, so an orientation change reflows the icons
rather than destroying and rebuilding them — icon state, hover state and
`DockLaunchTracker`'s bookkeeping all survive it.

| element | at a side edge |
| --- | --- |
| the strip | flows top-to-bottom; the body is anchored left/right and centred vertically |
| icon sizing | `DockButton` is square *across* the dock's thickness on whichever axis that is. Nothing is written as "width from height" any more, so there is no branch to get backwards |
| insets and margins | named `insetInward`/`insetOutward` and resolved through `directedSides()`; `axisMargins()` adds the along-the-strip pair. The elevation/gap asymmetry no longer names a side anywhere outside the module |
| running dots | stack *beside* the icon on the outward side, pill running along the strip. Both copies — `DragApps` for pinned apps, `DockAppButton` for running unpinned ones — ported from `DocktoPanel.qml`'s flow-switching `Flow` |
| drag reorder | slot placement, the ghost's travel, the reorder comparison and the preview popup's centring all go through one axis choice |
| popups | the context menu opens inward with `SlideY`; the window-preview popup takes a corner and a direction from `popupAnchorSides()` |
| hover lift / launch bounce | magnitudes multiplied by the edge's inward vector, so the icon rises *out* of the dock at every edge |
| media tile | hidden (§9 Q1). The two separators that flanked it read `dockMedia.visible` rather than the `showMedia` option, or they hide themselves against a tile that is not there |

**Ported vs written.** Ported from `DocktoPanel.qml`: the flow switch, the running dots'
side-and-shape swap, the drag's axis selection. Written here: everything that needs to
know *which* side edge (`DocktoPanel` only knows vertical-or-not, because it follows the
bar) — the dots' outward side, the popup corners, the lift vector, the inset directions —
plus `dock_geometry.js`'s `directedSides`/`axisMargins`/`popupAnchorSides`/`inwardVector`/
`barEdge`, all built on the one `OPPOSITE` table the module already implied.

## Step 9: the refusal

The settings row declines the edge an **auto-hiding** bar occupies rather than arbitrating
two 2px reveal slivers over one row of pixels (§9 Q3). Only auto-hide collides: a bottom
bar plus a pinned dock is a legitimate arrangement the compositor stacks, and greying that
out would forbid something that works. The declined option stays in the row and stays shown
as current if a stored config already holds it; the row's label carries the reason.
`ConfigSelectionArray` learned an optional per-option `disabled`.

## Tests

- `tst_dock_geometry.qml` +9 cases: thickness and reserved zone on either axis, the
  margin pair landing on the horizontal axis at a side edge and genuinely swapping between
  left and right, inward/outward as one relation, a directed pair never touching the long
  axis, the surface-anchored popup's corner, the lift vector, `barEdge()`.
- `test_dock_position_contract.py` +10 checks, including the lint step 6 asked for, folded
  in here rather than as its own file: nothing may derive the dock's edge a second way,
  nothing may compare the stored value to a side, `DocktoPanel` must keep following the
  *bar*, no edge-aware widget may bind the elevation/gap pair to a named side.
- `DockEdgeRuntimeTest.qml` + `test_dock_edge_runtime.py`: real mouse events on a real
  `DragApps`. Drags along a row (the control), along a column, and — the discriminating
  case — *across* a column, requiring that nothing moves.
- `DesignSystemCompile.qml` now sweeps the eight dock files. The dock is opt-in, so
  nothing in the suite had ever compiled any of them.

Every new check was proven to fail: ten planted mutations, each reddening the intended
check and nothing else, and the runtime harness reported `failures: 2` with the axis
choice reverted to x — the along-column drag stopped swapping *and* the across-column drag
started swapping, while the horizontal control stayed green.

Full suite green.

## What still needs a look on screen

Nothing below is reachable from a test, and none of it is claimed as verified:

- **Anything about the surface at a side edge.** `qmltestrunner` cannot construct
  Quickshell types and weston implements no wlr-layer-shell, so the anchors, the exclusive
  zone, the reveal push and the compositor's inferred slide direction are all invisible to
  both harnesses. Worth a `hyprctl layers -j` plus `hyprctl monitors -j` readback against
  the spec's baseline (`bottom` reserves 65, surface 5120x75): a left dock should report a
  75-wide surface reserving 65 on the left.
- **How it looks.** Icon spacing along a column, whether the running dots beside an icon
  read as an underline or as clutter, the pin button and apps button at the ends of a
  vertical strip, and the context menu opening sideways.
- **`GridLayout` vs `RowLayout` at the horizontal edges.** They share Qt's layout engine
  and a single-row `GridLayout` should be identical, but this is a container swap under
  every existing dock, so the bottom edge deserves a glance as much as the new ones.
- **The blur region.** `WindowBlurRegion` tracks `dockVisualBackground`, whose margins now
  come from the derivation — it should follow, but a region over the wrong rect frosts bare
  wallpaper and `lint_blur_region_pairing.py` cannot see it.
- **Bar/dock stacking on the same edge without auto-hide.** §3 argues the compositor lays
  the two out cumulatively; that is the arrangement this PR deliberately permits, and it
  has not been measured.

Docs: updated AGENT.md §Dynamic/data-driven QML gotchas — the inert-comparison, width-from-height and dynamic-scope traps a turning layout brings, the one-derivation lint, and the new dock runtime harness; §Design language — DockIconMotion's lift travels the inward vector
