### PR TITLE
Review findings: four dead bindings, a shadow that never dropped, and a ring rebuilt every frame

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1347,6 +1347,16 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   elastic-resize canvas deliberately draws up to `2*BOW_PX` outside the card and a layer would cut
   it. The shadow is dropped while the card is moving and restored on settle, for the same reason the
   frost is: re-rendering a blurred copy of the body every frame of a morph is the expensive path.
+  **That last sentence shipped half-true, and the correction is the lesson.** `motionActive` had
+  exactly one producer - `WidgetCard` passing its own `underTension`, the grip's elastic bow - which
+  is the one motion that does NOT resize the layer. The span animation, which reallocates the FBO
+  and re-runs the gaussian every frame, and which every Size row in Settings takes with no grip
+  involved, ran with the shadow live throughout: `resizeBow` is already zero when the settle begins.
+  Neither probe could see it, because both ASSIGN `motionActive` rather than driving motion - the
+  parallax-opt-out shape, a harness that switches off the interaction it exists to score. The host
+  publishes `boxInMotion` (drawn box vs settled box) now, forwarded by the same duck-typed path as
+  `hostGridSize`, and `test_the_shadow_is_dropped_for_the_motion_that_actually_costs` pins the chain
+  end to end. e5d243c5e ("fix(widgets): the shadow drops for the motion that actually costs").
   Verification is pixels, not source text (`test_card_shadow.py`), and two traps live there:
   `ItemGrabResult.image` is not scriptable from QML, so analysis belongs outside; and `grabToImage`
   captures the ITEM, so a field relying on its WINDOW's colour grabs a transparent PNG whose "white"

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginNode.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginNode.qml
@@ -69,6 +69,9 @@ Item {
     // Whether the host is currently being dragged, for a widget that lifts
     // its cards while handled.
     property bool hostDragging: false
+    // Whether the host's own box is animating. A widget uses it to stop
+    // re-rendering effects that cost a frame each while it moves.
+    property bool hostBoxInMotion: false
 
     readonly property string effectiveBasePath: manifestNode?._basePath || basePath
     readonly property string componentPath: manifestNode?.component && effectiveBasePath
@@ -176,6 +179,8 @@ Item {
                     item.hostResizeBow = Qt.binding(() => rootNode.resizeBow);
                 if (item.hostDragging !== undefined)
                     item.hostDragging = Qt.binding(() => rootNode.hostDragging);
+                if (item.hostBoxInMotion !== undefined)
+                    item.hostBoxInMotion = Qt.binding(() => rootNode.hostBoxInMotion);
                 return;
             }
             if (manifestNode.props) {

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
@@ -179,6 +179,15 @@ AbstractBackgroundWidget {
         ? Appearance.animationCurves.expressiveFastSpatial
         : Appearance.animationCurves.expressiveDefaultSpatial
 
+    // In flight whenever the drawn box differs from the span's settled box, or
+    // while the grip is bowing it. Published so a widget can drop the work that
+    // is not worth doing mid-motion - the shadow's blurred copy of its own
+    // body, which otherwise re-renders into a reallocating FBO every frame of
+    // every resize.
+    readonly property bool boxInMotion: rootWidget.resizingGrid
+        || Math.abs(rootWidget.width - rootWidget.settledWidth) > 0.5
+        || Math.abs(rootWidget.height - rootWidget.settledHeight) > 0.5
+
     Behavior on width {
         enabled: rootWidget.gridResizeAnimated
         NumberAnimation {
@@ -683,6 +692,7 @@ AbstractBackgroundWidget {
         gridSize: rootWidget.shownGridSpan
         resizeBow: rootWidget.resizeBow
         hostDragging: rootWidget.dragging
+        hostBoxInMotion: rootWidget.boxInMotion
         anchors.centerIn: parent
     }
     }

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/calendar/Widget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/calendar/Widget.qml
@@ -24,6 +24,9 @@ Item {
     // a link that forgets to forward this produces a card that silently never
     // rises (tests/test_expressive_design_system.py pins the chain).
     property bool hostDragging: false
+    // Set by the host while its own box is animating; the cards drop their
+    // shadow for the duration rather than re-blurring into a resizing FBO.
+    property bool hostBoxInMotion: false
 
     // The card fills the whole widget, so the host's default frost region has
     // the right extent - but not the right corner radius (PluginWidget falls
@@ -228,6 +231,7 @@ Item {
         useBlurBackground: root.blurEnabled
         backgroundOpacity: root.backgroundOpacity
         dragging: root.hostDragging
+        hostMotionActive: root.hostBoxInMotion
 
         Loader {
             anchors.fill: parent

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-currency/Widget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-currency/Widget.qml
@@ -21,6 +21,9 @@ Item {
     property point hostResizeBow: Qt.point(0, 0)
     // Set by the host while this widget is being dragged; the cards lift.
     property bool hostDragging: false
+    // Set by the host while its own box is animating; the cards drop their
+    // shadow for the duration rather than re-blurring into a resizing FBO.
+    property bool hostBoxInMotion: false
     // Implicit from the SPAN; the content fills whatever the host gives -
     // the host's animating box is the resize (weather's wrapper shipped the
     // self-sized version of this and its card teleported).
@@ -44,6 +47,7 @@ Item {
         sizeMode: root.hostGridSize || "2x1"
         resizeBow: root.hostResizeBow
         dragging: root.hostDragging
+        boxInMotion: root.hostBoxInMotion
         useBlurBackground: PluginState.option("nandoroid_currency", "blurEnabled", false)
         backgroundOpacity: PluginState.effectiveBackgroundOpacity("nandoroid_currency")
         onBaseCurrencyRequested: value => PluginState.setOption("nandoroid_currency", "baseCurrency", value)

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/MediaSeeker.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/MediaSeeker.qml
@@ -75,12 +75,20 @@ Item {
         const pad = stroke;
         const cx = width / 2, cy = height / 2;
         const dia = Math.min(width, height) - stroke;
-        const cubics = MediaShapes.ringAt(root.ringT);
-        const measure = PathLength.measureCubics(cubics);
+        // Cached against ringT: rebuilding the Morph and re-measuring 24
+        // cubics here ran on every frame of the wave clock and on every mouse
+        // move through strokeDistance(), for a shape that changes twice.
+        const ring = MediaShapes.ringMeasuredAt(root.ringT, PathLength.measureCubics);
+        const cubics = ring.cubics;
+        const measure = ring.measure;
         const out = [];
         for (let i = 0; i <= N; i++) {
             const u = i / N;
             const line = { x: pad + u * (width - 2 * pad), y: cy };
+            // At 3x2 the baseline IS the line: bend is 0, so every ring point
+            // below was computed and then multiplied away. Measured, that was
+            // 42% of the seeker's per-frame cost at that span.
+            if (root.bend <= 0.0001) { out.push(line); continue; }
             const target = u * measure.total;
             let index = 0;
             while (index < cubics.length - 1 && measure.lengths[index + 1] < target) index++;

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/MediaTransportButton.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/MediaTransportButton.qml
@@ -275,8 +275,12 @@ Item {
                         const N = 160;
                         const stroke = Appearance.borderWidth.heavy * Appearance.effectiveScale;
                         const dia = Math.min(width, height) - stroke;
-                        const cubics = MediaShapes.ringAt(1);
-                        const measure = PathLength.measureCubics(cubics);
+                        // Same cache the seeker uses - this canvas was
+                        // rebuilding and re-measuring the identical constant
+                        // shape (ringAt(1)) once per frame beside it.
+                        const ring = MediaShapes.ringMeasuredAt(1, PathLength.measureCubics);
+                        const cubics = ring.cubics;
+                        const measure = ring.measure;
                         const amp = stroke * 0.6 * root.ringWaveLevel;
                         // VERBATIM the seeker's construction - arc-length
                         // samples, normals from RAW neighbours, sine along the

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/Widget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/Widget.qml
@@ -37,6 +37,9 @@ Item {
     property point hostResizeBow: Qt.point(0, 0)
     // Set by the host while this widget is being dragged; the cards lift.
     property bool hostDragging: false
+    // Set by the host while its own box is animating; the cards drop their
+    // shadow for the duration rather than re-blurring into a resizing FBO.
+    property bool hostBoxInMotion: false
 
     // The host's span-change cross-fade exists to hide a destroy. This tree
     // has no destroy: the shared elements re-derive their rects from the
@@ -95,6 +98,7 @@ Item {
         tensionX: root.hostResizeBow.x
         tensionY: root.hostResizeBow.y
         dragging: root.hostDragging
+        hostMotionActive: root.hostBoxInMotion
     }
 
     // ---- unshared content, entering and exiting per span -----------------

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/media_shapes.js
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/media_shapes.js
@@ -79,6 +79,30 @@ function ringAt(t) {
     return ringMorph().asCubics(Math.max(0, Math.min(1, t)));
 }
 
+// The ring's cubics AND their arc-length measure, cached against t.
+//
+// path-length.js states the contract this exists to keep: "The cost is per
+// geometry change, not per frame: a static shape pays it once, which is what
+// makes a progress ring stroked around a cookie's outline cost nothing to
+// animate." Both callers were rebuilding the Morph and re-measuring 24 cubics
+// on every paint of a 240Hz frame clock, and again on every mouse move through
+// the seeker's hit test - while `ringT` holds one of two values except during
+// a 300ms span change.
+//
+// Pure in t, so this trades no correctness property: same input, same cubics,
+// same lengths. One slot is enough - t moves monotonically through a
+// transition and rests at an endpoint.
+var _ringMeasureT = null;
+var _ringMeasured = null;
+function ringMeasuredAt(t, measureCubics) {
+    var clamped = Math.max(0, Math.min(1, t));
+    if (_ringMeasureT === clamped && _ringMeasured !== null) return _ringMeasured;
+    var cubics = ringAt(clamped);
+    _ringMeasureT = clamped;
+    _ringMeasured = { cubics: cubics, measure: measureCubics(cubics) };
+    return _ringMeasured;
+}
+
 // The live cookie: cookieRaw's own recipe with per-lobe inner radii, so the
 // breathing shape and the resting shape are one family in one space. Levels
 // are 0..1 per lobe; base and reach are VisualizerCookie's tuning, halved

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-system-monitor/Widget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-system-monitor/Widget.qml
@@ -5,6 +5,12 @@ import "../../designsystem/widgets" as Expressive
 import "ThirdCard.js" as ThirdCard
 
 Item {
+    // Without this the file's own `root.hostResizeBow` / `root.hostDragging`
+    // resolve by DYNAMIC SCOPE up the creation chain, where neither property
+    // exists - so both read undefined, the three cards never lift on a drag
+    // and never bow on a resize, and nothing warns. It is the only one of the
+    // thirteen bundled wrappers that was missing it.
+    id: root
     property point hostResizeBow: Qt.point(0, 0)
     // Set by the host while this widget is being dragged; the cards lift.
     property bool hostDragging: false

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-system-monitor/Widget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-system-monitor/Widget.qml
@@ -14,6 +14,9 @@ Item {
     property point hostResizeBow: Qt.point(0, 0)
     // Set by the host while this widget is being dragged; the cards lift.
     property bool hostDragging: false
+    // Set by the host while its own box is animating; the cards drop their
+    // shadow for the duration rather than re-blurring into a resizing FBO.
+    property bool hostBoxInMotion: false
     readonly property var blurRegions: content.blurRegions
     readonly property bool managesBlurTint: content.managesBlurTint
     implicitWidth: content.implicitWidth
@@ -24,6 +27,7 @@ Item {
         id: content
         resizeBow: root.hostResizeBow
         dragging: root.hostDragging
+        boxInMotion: root.hostBoxInMotion
         width: implicitWidth
         height: implicitHeight
         isVertical: PluginState.option("nandoroid_system_monitor", "vertical", false)

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-weather/Widget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-weather/Widget.qml
@@ -18,6 +18,9 @@ Item {
     property point hostResizeBow: Qt.point(0, 0)
     // Set by the host while this widget is being dragged; the cards lift.
     property bool hostDragging: false
+    // Set by the host while its own box is animating; the cards drop their
+    // shadow for the duration rather than re-blurring into a resizing FBO.
+    property bool hostBoxInMotion: false
 
     // Implicit size from the SPAN, and the content fills whatever the host
     // gives - the host's box is what animates a resize. The old wrapper set
@@ -40,6 +43,7 @@ Item {
         sizeMode: root.hostGridSize || "3x1"
         resizeBow: root.hostResizeBow
         dragging: root.hostDragging
+        boxInMotion: root.hostBoxInMotion
         useBlurBackground: PluginState.option("nandoroid_weather", "blurEnabled", false)
         backgroundOpacity: PluginState.effectiveBackgroundOpacity("nandoroid_weather")
     }

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopCurrencyWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopCurrencyWidget.qml
@@ -20,6 +20,8 @@ Item {
     property point resizeBow: Qt.point(0, 0)
     // Handled state, for the cards' elevation.
     property bool dragging: false
+    // The host's box is animating; the cards drop their shadow for it.
+    property bool boxInMotion: false
     // The host wrapper overrides this with its own plugin id; the fallback keeps
     // the toggle honoured for a component instantiated without one.
 
@@ -107,6 +109,7 @@ Item {
         tensionX: root.resizeBow.x
         tensionY: root.resizeBow.y
         dragging: root.dragging
+        hostMotionActive: root.boxInMotion
 
         // --- PAGE 1: View Mode ---
         Item {

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopMediaWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopMediaWidget.qml
@@ -528,8 +528,13 @@ Item {
                 onEntered: romajiToggleBtn.hovered = true
                 onExited: romajiToggleBtn.hovered = false
                 onClicked: {
+                    // Write the CONFIG, not the property bound to it: assigning
+                    // to `root.useRomaji` destroyed its binding on the first
+                    // click, after which the toggle showed local state that
+                    // never persisted and no preset could move.
                     if (Config.ready) {
-                        root.useRomaji = !root.useRomaji;
+                        Config.options.appearance.lyrics.lyricsUseRomaji =
+                            !Config.options.appearance.lyrics.lyricsUseRomaji;
                     }
                 }
             }

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopMediaWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopMediaWidget.qml
@@ -26,6 +26,8 @@ Item {
     property bool useBlurBackground: false
     // Handled state, for the card's elevation.
     property bool dragging: false
+    // The host's box is animating; the cards drop their shadow for it.
+    property bool boxInMotion: false
     // The host wrapper overrides this with its own plugin id; the fallback keeps
     // the toggle honoured for a component instantiated without one.
 
@@ -45,6 +47,7 @@ Item {
         visible: !root.chromeless
         anchors.fill: parent
         dragging: root.dragging
+        hostMotionActive: root.boxInMotion
         useBlurBackground: root.useBlurBackground
         backgroundOpacity: root.backgroundOpacity
     }

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopSystemMonitorWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopSystemMonitorWidget.qml
@@ -50,6 +50,8 @@ Item {
     property point resizeBow: Qt.point(0, 0)
     // Handled state, for the cards' elevation.
     property bool dragging: false
+    // The host's box is animating; the cards drop their shadow for it.
+    property bool boxInMotion: false
     readonly property var blurRegions: [
         cpuCard.blurRegion,
         ramCard.blurRegion,
@@ -68,6 +70,7 @@ Item {
             implicitWidth: root.cardWidth
             implicitHeight: root.cardHeight
             dragging: root.dragging
+            hostMotionActive: root.boxInMotion
             radius: Appearance.rounding.large
             tint: Appearance.colors.colPrimaryContainer
             useBlurBackground: root.useBlurBackground
@@ -160,6 +163,7 @@ Item {
             implicitWidth: root.cardWidth
             implicitHeight: root.cardHeight
             dragging: root.dragging
+            hostMotionActive: root.boxInMotion
             radius: Appearance.rounding.large
             tint: Appearance.colors.colSecondaryContainer
             useBlurBackground: root.useBlurBackground
@@ -258,6 +262,7 @@ Item {
             tensionX: root.resizeBow.x
             tensionY: root.resizeBow.y
             dragging: root.dragging
+            hostMotionActive: root.boxInMotion
 
             // Sisi Atas: Liquid Cookie12Sided (Centered Top)
             Item {

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopWeatherWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopWeatherWidget.qml
@@ -43,6 +43,8 @@ Item {
     property point resizeBow: Qt.point(0, 0)
     // Handled state, for the cards' elevation.
     property bool dragging: false
+    // The host's box is animating; the cards drop their shadow for it.
+    property bool boxInMotion: false
 
     property real backgroundOpacity: PluginState.effectiveBackgroundOpacity("", 0.1)
     readonly property bool managesBlurTint: true
@@ -158,6 +160,7 @@ Item {
         tensionX: root.resizeBow.x
         tensionY: root.resizeBow.y
         dragging: root.dragging
+        hostMotionActive: root.boxInMotion
 
         // ---- the sun's day, across the card's background --------------
         //

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/WidgetCard.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/WidgetCard.qml
@@ -86,7 +86,13 @@ Item {
     // layer over the content would have every label and glyph casting one too.
     property bool shadowEnabled: true
     property bool dragging: false
-    property bool motionActive: root.underTension
+    // Motion that is worth dropping the shadow for: the grip's bow, and the
+    // host's own resize animation, which the widget passes in. The bow alone
+    // was the only producer for a release - and it is the ONE motion that does
+    // not resize the layer, while the span animation, which reallocates the
+    // FBO every frame, was left casting a live shadow throughout.
+    property bool motionActive: root.underTension || root.hostMotionActive
+    property bool hostMotionActive: false
 
     // One frame around every body renderer, so one effect shadows all three:
     // the plain rectangle, the bowed canvas and a MaterialShape polygon all

--- a/dots/.config/quickshell/imi/modules/common/widgets/DockIconMotion.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/DockIconMotion.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import qs.modules.common
+import qs.modules.common.widgets
 import "../../imi/dock/dock_geometry.js" as DockGeometry
 
 /**
@@ -32,7 +33,18 @@ Item {
 
     default property alias content: contentContainer.data
 
-    readonly property real targetScale: dragging ? 1.0 : pressed ? pressScale : hovered ? hoverScale : 1.0
+    // The shared model carries the hover and press progress on the right tiers
+    // (a press is acknowledged faster than it is released, and a release
+    // animates even when the pointer has already left). The icon's own
+    // magnitudes stay its own - this reads the model's 0..1, not its scale.
+    readonly property InteractionMotion motion: InteractionMotion {
+        hovered: root.hovered && !root.dragging
+        down: root.pressed && !root.dragging
+    }
+    readonly property real targetScale: root.dragging
+        ? 1.0
+        : 1 + (root.hoverScale - 1) * root.motion.hoverProgress
+            + (root.pressScale - 1) * root.motion.pressProgress
 
     Component.onDestruction: {
         bounceAnimation.stop();
@@ -115,16 +127,12 @@ Item {
             x: (root.liftOffset + root.bounceOffset) * root.liftVector.x
             y: (root.liftOffset + root.bounceOffset) * root.liftVector.y
         }
-        Behavior on scale {
-            enabled: !root.dragging && !appearAnimation.running
-            NumberAnimation {
-                // Fast, non-bouncy on the way into a press; springy overshoot out.
-                duration: root.pressed ? Appearance.animation.elementMoveFast.duration
-                                       : Appearance.animation.elementMoveSmall.duration
-                easing.type: Easing.BezierSpline
-                easing.bezierCurve: root.pressed ? Appearance.animationCurves.expressiveEffects
-                                                 : Appearance.animationCurves.expressiveFastSpatial
-            }
-        }
+        // No `Behavior on scale` here on purpose. Selecting the tier through a
+        // binding on `duration`/`bezierCurve` hands the Behavior whichever tier
+        // was current BEFORE the state changed - measured, a press played the
+        // release's 999ms spring and a release played the press's 111ms curve,
+        // exactly backwards. The scale is animated by the shared interaction
+        // model instead, which writes the tier onto the animation and only then
+        // writes the target.
     }
 }

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -290,6 +290,27 @@ fi
 # one: calendar is content-sized, so a card that failed to resolve leaves a
 # zero-size widget rather than an error, and a `dragging` that never arrives
 # leaves a shadow that never lifts. Brings its own headless weston.
+# Enumerated, not globbed - which is why these three could exist, pass by hand
+# and be enforced by nothing. Added when a review counted the files run_tests.sh
+# names against the files on disk.
+echo "Running settings search index tests..."
+if ! python3 "$SCRIPT_DIR/test_settings_search_index.py"; then
+    echo "Settings search index tests failed."
+    exit 1
+fi
+
+echo "Running bar hover region tests..."
+if ! python3 "$SCRIPT_DIR/test_bar_hover_region.py"; then
+    echo "Bar hover region tests failed."
+    exit 1
+fi
+
+echo "Running cheatsheet width budget tests..."
+if ! python3 "$SCRIPT_DIR/test_cheatsheet_width_budget.py"; then
+    echo "Cheatsheet width budget tests failed."
+    exit 1
+fi
+
 echo "Running calendar card tests..."
 if ! python3 "$SCRIPT_DIR/test_calendar_card.py"; then
     echo "Calendar card tests failed."

--- a/dots/.config/quickshell/imi/tests/test_expressive_design_system.py
+++ b/dots/.config/quickshell/imi/tests/test_expressive_design_system.py
@@ -182,6 +182,13 @@ class ExpressiveDesignSystemTest(unittest.TestCase):
             wrapper = (PLUGIN_ROOT / directory / "Widget.qml").read_text(encoding="utf-8")
             self.assertIn("property bool hostDragging", wrapper, directory)
             self.assertIn("dragging: root.hostDragging", wrapper, directory)
+            # ...and that `root` is THIS file. Without the id, `root.hostDragging`
+            # resolves by dynamic scope up the creation chain, reads undefined,
+            # and the card silently never lifts - which is how the system
+            # monitor shipped with a dead drag while this very loop passed on
+            # the text being spelled correctly.
+            self.assertRegex(wrapper, r"(?m)^\s*id: root\s*$",
+                             f"{directory}: `root.` names nothing in this file")
 
         # ...and every card in the components those wrappers instantiate.
         for name in ("DesktopCurrencyWidget", "DesktopWeatherWidget",

--- a/dots/.config/quickshell/imi/tests/test_expressive_design_system.py
+++ b/dots/.config/quickshell/imi/tests/test_expressive_design_system.py
@@ -274,6 +274,37 @@ class ExpressiveDesignSystemTest(unittest.TestCase):
             self.assertIn("property bool dragging: false", source, style)
             self.assertIn("dragging: root.dragging", source, style)
 
+    def test_the_shadow_is_dropped_for_the_motion_that_actually_costs(self):
+        """`motionActive` had exactly one producer: the grip's elastic bow.
+
+        Which is the one motion that does NOT resize the layer. The span
+        animation - which reallocates the effect's FBO and re-runs a gaussian
+        every frame, and which every "Size" row in settings triggers with no
+        grip involved - ran with the shadow live throughout, because
+        `resizeBow` is already zero by the time it starts.
+
+        Both probes ASSIGN the flag rather than driving motion, so neither
+        could see it. This pins the chain instead: the host publishes its own
+        in-flight state, and it reaches every card.
+        """
+        host = (PLUGIN_ROOT.parent / "PluginWidget.qml").read_text(encoding="utf-8")
+        node = (PLUGIN_ROOT.parent / "PluginNode.qml").read_text(encoding="utf-8")
+        card = (DESIGN_SYSTEM / "widgets/WidgetCard.qml").read_text(encoding="utf-8")
+
+        # The host knows: the drawn box differs from the settled one.
+        self.assertIn("readonly property bool boxInMotion", host)
+        self.assertIn("settledWidth", host.split("boxInMotion")[1][:300])
+        self.assertIn("hostBoxInMotion: rootWidget.boxInMotion", host)
+        self.assertIn("item.hostBoxInMotion = Qt.binding", node)
+        # The card drops the shadow for the bow OR for the host's animation.
+        self.assertIn("root.underTension || root.hostMotionActive", card)
+
+        for directory in TOLD_ABOUT_THE_DRAG:
+            wrapper = (PLUGIN_ROOT / directory / "Widget.qml").read_text(encoding="utf-8")
+            self.assertIn("property bool hostBoxInMotion", wrapper, directory)
+            self.assertIn("hostBoxInMotion", wrapper.split("hostBoxInMotion", 1)[1],
+                          f"{directory}: declares the property but forwards it nowhere")
+
     def test_the_card_shadows_its_body_and_drops_it_while_moving(self):
         """The shadow comes off the BODY, and goes away during motion.
 


### PR DESCRIPTION
What three review passes over `v0.23.1..v0.24.0` turned up, fixed. Every finding below was verified independently before being acted on.

## Bugs that shipped

**The system monitor's drag and bow were dead.** Its wrapper is the only one of thirteen without `id: root`, so its own `root.hostResizeBow` / `root.hostDragging` resolved by *dynamic scope* up the creation chain — where neither property exists. Both read `undefined`: three cards that never lifted and never bowed. The live shell was printing `Unable to assign [undefined]` from those two lines; that count is now zero.

The guard passed the whole time, because it asserted the **text** `"dragging: root.hostDragging"` was present — which it was. It now also requires that `root` names *this* file, and fails on the shipped bug when the id is removed again.

**The romaji toggle destroyed its own binding.** `useRomaji` is bound to `appearance.lyrics.lyricsUseRomaji`; the click assigned to `useRomaji`. First press detached it permanently, after which the toggle showed local state that never persisted and no preset could move — and nothing in the tree wrote the key at all.

**Every dock icon played its press and release curves backwards.** The `Behavior` selected its tier through bindings on `duration`/`bezierCurve`, so it carried whichever tier was current *before* the state changed: measured, a press ran the release's 999 ms spring and a release ran the press's 111 ms curve. It adopts `InteractionMotion`, which exists for exactly this and writes the tier before the target.

**Three test files were invoked by nothing.** `run_tests.sh` enumerates by name rather than globbing, so a file never added is enforced by nothing — including one added in this release whose own docstring says "this test is the fix". All three pass; one fails under a planted mutation. Every `test_*.py` and `lint_*.py` in the directory is now named.

## A claim of mine that did not hold

`motionActive` had **exactly one producer**: `WidgetCard` passing its own `underTension` — the grip's elastic bow. That is the one motion which does *not* resize the layer. The span animation, which reallocates the effect's FBO and re-runs a gaussian every frame, ran with the shadow live throughout, because `resizeBow` is already zero when the settle begins — and every **Size** row in Settings takes that path with no grip involved at all.

Neither probe could catch it: both *assign* the flag rather than driving motion, which is the parallax-opt-out shape — a harness that switches off the interaction it exists to score. The host now publishes `boxInMotion` (drawn box vs settled box) down the same duck-typed path as `hostGridSize`, the card drops its shadow for the bow *or* the host's animation, and a test pins the chain end to end. AGENT.md carries the correction rather than the original claim.

## Measured waste

The seek ring rebuilt its Morph and re-measured 24 cubics **per frame** and **per mouse move**, in two canvases, against `path-length.js`'s own stated contract that this is pay-once-per-geometry-change. Cached against `ringT` (pure in `t`, so no correctness property is traded), and short-circuited at 3x2 where `bend` is 0 and every ring point was computed and then multiplied away — 42% of that span's per-frame cost by the reviewer's measurement.

## Verification

- `tests/run_tests.sh`: **704 passed, 0 failed**
- `tests/run_media_probe.sh`: 0 failures; ring renders identically at 2x2 and 2x1 (screenshots compared)
- Deployed to the live shell: loads clean, and the `Unable to assign [undefined]` warnings are gone
- Each new/hardened check proven to fail on the bug it names

Not addressed here, and worth their own change: the hardcoded OpenWeatherMap key (and that `presets.sh --save` ships your own key inside a shared preset), the currency timeout skipping its mirror host, and `*Probe.qml`/`*Playground.qml` installing into the live config dir.

Docs: updated AGENT.md §Dynamic/data-driven QML gotchas — corrects the shadow-dropped-during-motion claim to what the code actually did, and records why neither probe could see it.