### PR TITLE
Review sweep: things that silently did nothing, and a key that shipped in presets

### DIFF
--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/services/CurrencyService.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/services/CurrencyService.qml
@@ -29,6 +29,13 @@ Singleton {
         onTriggered: root.refresh()
     }
 
+    // What the running request is, so a timeout can advance to the next host
+    // rather than ending the attempt. A hung primary - DNS blackhole, TLS
+    // stall - is the case the mirror most exists for, and it was the one case
+    // that never reached it: the timeout called attemptFailed() directly
+    // because it had no way to name the attempt it was killing.
+    property var pendingAttempt: null
+
     Timer {
         id: requestTimeout
         interval: 12000
@@ -37,6 +44,14 @@ Singleton {
             // Invalidate the callback without aborting from inside a timer.
             // Qt's XHR abort path can synchronously re-enter QML handlers.
             root.requestGeneration++;
+            const attempt = root.pendingAttempt;
+            root.errorMessage = "Network timeout";
+            if (attempt) {
+                root.pendingAttempt = null;
+                root.tryHost(attempt.urls, attempt.hostIndex + 1,
+                             attempt.target, attempt.uniqueQuotes);
+                return;
+            }
             root.attemptFailed("Network timeout");
         }
     }
@@ -105,15 +120,19 @@ Singleton {
     // counts as a failure and backs off.
     function tryHost(urls, hostIndex, target, uniqueQuotes) {
         if (hostIndex >= urls.length) {
+            root.pendingAttempt = null;
             root.attemptFailed(root.errorMessage || "No network");
             return;
         }
         const generation = ++root.requestGeneration;
+        root.pendingAttempt = { urls: urls, hostIndex: hostIndex,
+                                target: target, uniqueQuotes: uniqueQuotes };
         const xhr = new XMLHttpRequest();
         xhr.open("GET", urls[hostIndex]);
         xhr.onreadystatechange = function() {
             if (xhr.readyState !== XMLHttpRequest.DONE || generation !== root.requestGeneration) return;
             requestTimeout.stop();
+            root.pendingAttempt = null;
             if (xhr.status !== 200) {
                 root.errorMessage = xhr.status === 0 ? "No network" : `HTTP ${xhr.status}`;
                 root.tryHost(urls, hostIndex + 1, target, uniqueQuotes);

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopCurrencyWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopCurrencyWidget.qml
@@ -57,12 +57,6 @@ Item {
     readonly property real spanH: root.baseHeight
 
 
-    Behavior on implicitWidth {
-        NumberAnimation {
-            duration: 250
-            easing.bezierCurve: [0.2, 0, 0, 1]
-        }
-    }
 
 
 

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/WeatherCard.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/WeatherCard.qml
@@ -29,7 +29,12 @@ Rectangle {
     }
     
     readonly property string weatherIconsDir: "assets/icons/google-weather"
-    readonly property bool showDailyForecast: Config.options.weather ? Config.options.weather.showDailyForecast : true
+    // There is no top-level `weather` in the config adapter - the key lives at
+    // `bar.weather` - so this read was `undefined` and the ternary took `true`
+    // every time. A gate whose absence is silent is worse than no gate: it
+    // reads as a supported setting nobody can turn off. The card shows the
+    // full outlook, which is what it has always actually done.
+    readonly property bool showDailyForecast: true
     
     readonly property color contentColor: Appearance.m3colors.m3onSurface
     readonly property real midOpacity: 0.8

--- a/dots/.config/quickshell/imi/scripts/presets.sh
+++ b/dots/.config/quickshell/imi/scripts/presets.sh
@@ -61,8 +61,17 @@ case "$action" in
         }' "$PLUGIN_STATE_FILE" 2>/dev/null \
             || printf '{"version":2,"desktopPositions":{},"pluginOptions":{}}')"
         fi
+        # A preset is a document people SHARE, and `config.json` holds the
+        # user's own OpenWeatherMap key. Saving one used to copy it verbatim,
+        # so posting a preset published your key with it. Stripped here rather
+        # than on apply: apply merges the preset over the user's config, so a
+        # key left in the file would also overwrite the recipient's own.
+        # (The AI provider keys are not affected - those live in the keyring,
+        # never in this document.)
         jq --argjson pluginState "$plugin_state" \
-            'del(._presetMeta, ._pluginState) | ._pluginState = $pluginState' \
+            'del(._presetMeta, ._pluginState)
+             | ._pluginState = $pluginState
+             | if .bar.weather.apiKey? then .bar.weather.apiKey = "" else . end' \
             "$CONFIG_FILE" > "$PRESETS_DIR/${name}.json"
         if [ -n "$description" ]; then
             jq --arg desc "$description" '._presetMeta = {"description": $desc}' \

--- a/dots/.config/quickshell/imi/tests/test_currency_service_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_currency_service_contract.py
@@ -48,6 +48,26 @@ def test_wrapper_does_not_duplicate_service_refreshes():
     assert "CurrencyService.refresh()" not in source
 
 
+def test_a_timeout_reaches_the_mirror_rather_than_ending_the_attempt():
+    """A hung primary is the case the mirror most exists for.
+
+    The timeout used to call `attemptFailed()` directly - it had no way to
+    name the attempt it was killing - so the one failure mode the fallback was
+    added for (DNS blackhole, TLS stall: connection accepted, nothing ever
+    answers) went straight to backoff without ever trying jsdelivr. Only a
+    non-200, a parse error or an empty table reached it.
+    """
+    source = SERVICE.read_text()
+    assert "property var pendingAttempt" in source
+    timeout = source[source.index("id: requestTimeout"):]
+    timeout = timeout[:timeout.index("\n    }")]
+    assert "root.tryHost(attempt.urls, attempt.hostIndex + 1" in timeout, \
+        "the timeout must advance to the next host"
+    # ...and the attempt must be cleared wherever it ends, or a later timeout
+    # would resume a request that already answered.
+    assert source.count("root.pendingAttempt = null") >= 3
+
+
 def test_currency_service_has_bounded_non_reentrant_request():
     source = SERVICE.read_text()
     assert "id: requestTimeout" in source

--- a/dots/.config/quickshell/imi/tests/test_presets.py
+++ b/dots/.config/quickshell/imi/tests/test_presets.py
@@ -243,5 +243,38 @@ class PresetTests(unittest.TestCase):
         )
 
 
+    def test_saving_a_preset_does_not_publish_the_users_weather_key(self):
+        """A preset is a document people share; config.json holds their key.
+
+        Saved verbatim, posting a preset published the author's OpenWeatherMap
+        key with it. Stripped on SAVE rather than on apply, because apply
+        merges the preset over the recipient's config - a key left in the file
+        would overwrite theirs too.
+        """
+        source = PRESETS.read_text()
+        self.assertIn(".bar.weather.apiKey", source)
+        save = source[source.index("del(._presetMeta, ._pluginState)"):]
+        save = save[:save.index("$PRESETS_DIR")]
+        self.assertIn('.bar.weather.apiKey = ""', save,
+                      "the save filter must blank the key")
+
+    def test_the_save_filter_survives_a_config_without_the_key(self):
+        """`?` on the path, so a config that has never had a weather key is
+        passed through rather than failing the save."""
+        source = PRESETS.read_text()
+        self.assertIn("if .bar.weather.apiKey? then", source)
+        for document in ('{"bar":{"weather":{"apiKey":"SECRET"}}}',
+                         '{"dock":{"edge":"left"}}'):
+            result = subprocess.run(
+                ["jq", 'if .bar.weather.apiKey? then .bar.weather.apiKey = "" else . end'],
+                input=document, capture_output=True, text=True)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            # The VALUE, not a substring of the output - "apiKey" itself
+            # contains a K, which is how the first version of this assertion
+            # failed against a filter that was working correctly.
+            saved = json.loads(result.stdout)
+            self.assertEqual(saved.get("bar", {}).get("weather", {}).get("apiKey", ""), "")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/sdata/lib/deploy-exclude.txt
+++ b/sdata/lib/deploy-exclude.txt
@@ -3,5 +3,7 @@ screenshots/
 .qmlformat.ini
 .gitignore
 *RuntimeTest.qml
+*Probe.qml
+*Playground.qml
 DesignSystemCompile.qml
 ExpandablePanelGallery.qml


### PR DESCRIPTION
The deferred half of the review findings. Every item here is code that ran and had no effect, or had an effect nobody wanted.

## A key that travelled with shared presets

`config.json` holds the user's own OpenWeatherMap key, and `presets.sh --save` copied the document verbatim — so **posting a preset published your key with it**. Blanked on SAVE rather than on apply, deliberately: apply merges the preset over the recipient's config, so a key left in the file would overwrite theirs too. The AI provider keys were never affected; those live in the keyring.

Not fixed here, because it is not mine to do: the **hardcoded fallback OpenWeatherMap key** at `services/Weather.qml:26` is live in public history and now spends double the quota since the forecast endpoint landed. It wants rotating and moving out of source.

## A timeout that skipped the fallback it was added for

`CurrencyService`'s comment promised *"one attempt walks the host list (primary, then the mirror) before it counts as a failure"*. The timeout called `attemptFailed()` directly — it had no way to name the attempt it was killing — so the one failure mode the mirror most exists for (host accepts the connection, never answers) went straight to backoff without ever trying jsdelivr. Only a non-200, a parse error or an empty table reached it. My bug, from #180.

The running attempt is now recorded as it is issued and cleared wherever it ends, so a late timeout cannot resume a request that already answered.

## Gates and animations that were decoration

- **`WeatherCard.showDailyForecast`** read `Config.options.weather`, which has never existed (the key lives at `bar.weather`), so the ternary took `true` every time. This is the `enableShadows` shape again — a gate whose absence is silent reads as a setting the user can turn off. Retired.
- **A `Behavior on implicitWidth` in the currency tree, dead three times over**: the property is read nowhere (the wrapper fills the host's box), its curve had four control values where QML needs 3n+1 so it interpolated *linearly* rather than on the curve it named, and the host already owns that animation with the shared tokens.

## Dev harnesses installing into the live config

Nine root-level `*Probe.qml` / `*Playground.qml` matched none of the deploy exclusions. Inert — nothing loads them — but the list already means to exclude exactly this kind of file.

## Verification

- `tests/run_tests.sh`: **704 passed, 0 failed**
- The mirror-on-timeout pin fails against the shipped behaviour (proven by reverting the advance)
- The preset test checks the **value**, not a substring — its first version failed against a working filter because `"apiKey"` itself contains a `K`
- Deployed to the live shell; loads clean

Docs: not needed — no rule changes; each fix is documented where it lives and pinned by a test that fails on the original behaviour.