### PR TITLE
Review sweep two: the copies the extraction missed, and two checks that could not fail

### DIFF
--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/MediaSeeker.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/MediaSeeker.qml
@@ -1,5 +1,6 @@
 import QtQuick
 import qs.modules.common
+import "../../designsystem/widgets" as Expressive
 import qs.modules.common.functions as Functions
 import qs.services
 import "../../designsystem/widgets/shapes/path-length.js" as PathLength
@@ -23,7 +24,7 @@ Item {
 
     // 0 = straight bar .. 1 = ring
     property real bend: root.span === "3x2" ? 0 : 1
-    Behavior on bend { NumberAnimation { duration: Appearance.animation.elementMove.duration; easing.type: Easing.BezierSpline; easing.bezierCurve: Appearance.animationCurves.expressiveDefaultSpatial } }
+    Behavior on bend { Expressive.SpanTravel {} }
     // 0 = circle .. 1 = cookie outline
     property real ringT: root.span === "2x1" ? 1 : 0
     // What the stroke sits ON decides its palette, not what shape it is: the
@@ -32,8 +33,8 @@ Item {
     // in on-primary. Keyed on bend, the 2x1 ring came out dark-on-dark the
     // moment the margin moved it off the body.
     property real onBody: root.span === "2x2" ? 1 : 0
-    Behavior on onBody { NumberAnimation { duration: Appearance.animation.elementMove.duration; easing.type: Easing.BezierSpline; easing.bezierCurve: Appearance.animationCurves.expressiveEffects } }
-    Behavior on ringT { NumberAnimation { duration: Appearance.animation.elementMove.duration; easing.type: Easing.BezierSpline; easing.bezierCurve: Appearance.animationCurves.expressiveDefaultSpatial } }
+    Behavior on onBody { Expressive.SpanFade {} }
+    Behavior on ringT { Expressive.SpanTravel {} }
 
     property real phase: 0
     // The travelling wave, alive only while something plays and the item is

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/MediaTransportButton.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/MediaTransportButton.qml
@@ -213,7 +213,7 @@ Item {
                 readonly property color washColor: Appearance.colors.colOnPrimary
 
                 property real morphT: root.span === "3x2" ? 0 : 1
-                Behavior on morphT { NumberAnimation { duration: Appearance.animation.elementMove.duration; easing.type: Easing.BezierSpline; easing.bezierCurve: Appearance.animationCurves.expressiveDefaultSpatial } }
+                Behavior on morphT { Expressive.SpanTravel {} }
                 readonly property color bodyColor: Appearance.colors.colPrimary
 
                 // ---- the breath: VisualizerCookie's pipeline, verbatim ----
@@ -373,7 +373,7 @@ Item {
                 anchors.centerIn: parent
                 width: root.span === "2x2" ? playRoot.side * 0.66 : 0
                 height: width
-                Behavior on width { NumberAnimation { duration: Appearance.animation.elementMove.duration; easing.type: Easing.BezierSpline; easing.bezierCurve: Appearance.animationCurves.expressiveDefaultSpatial } }
+                Behavior on width { Expressive.SpanTravel {} }
                 visible: width > 1
                 property bool artLoaded: false
 

--- a/dots/.config/quickshell/imi/tests/test_expressive_design_system.py
+++ b/dots/.config/quickshell/imi/tests/test_expressive_design_system.py
@@ -384,18 +384,34 @@ class ExpressiveDesignSystemTest(unittest.TestCase):
         looks slightly wrong next to the others - so the spelling is shared and
         the private ones may not come back.
         """
-        trees = {
-            "media": PLUGIN_ROOT / "nandoroid-media/Widget.qml",
-            "weather": DESIGN_SYSTEM / "widgets/DesktopWeatherWidget.qml",
-            "currency": DESIGN_SYSTEM / "widgets/DesktopCurrencyWidget.qml",
-        }
-        for name, path in trees.items():
+        # Swept, not named. The first version of this test listed three files
+        # by hand and five verbatim copies survived in the very package it was
+        # written for - MediaSeeker and MediaTransportButton, both added by the
+        # same release. A check that enumerates its subjects only ever guards
+        # the subjects someone remembered.
+        swept = sorted(
+            list((PLUGIN_ROOT / "nandoroid-media").glob("*.qml"))
+            + [DESIGN_SYSTEM / "widgets/DesktopWeatherWidget.qml",
+               DESIGN_SYSTEM / "widgets/DesktopCurrencyWidget.qml",
+               DESIGN_SYSTEM / "widgets/DesktopMediaWidget.qml"])
+        self.assertGreaterEqual(len(swept), 6, "the sweep found nothing to check")
+        carriers = 0
+        for path in swept:
             source = path.read_text(encoding="utf-8")
+            name = path.name
             self.assertNotIn("component TravelBehavior", source, name)
             self.assertNotIn("component FadeBehavior", source, name)
-            self.assertNotIn("expressiveDefaultSpatial", source,
-                             f"{name} spells the travel curve itself")
-            self.assertIn("SpanTravel {}", source, name)
+            # A whole-tier animation spelled inline. `ParallelAnimation`
+            # members that name a target/property are a different thing and
+            # SpanTravel cannot express them, so this looks for the Behavior
+            # body's shape rather than the curve name alone.
+            inline = ("NumberAnimation { duration: Appearance.animation.elementMove.duration"
+                      in source)
+            self.assertFalse(inline, f"{name} spells the span animation itself")
+            if "SpanTravel {}" in source:
+                carriers += 1
+        self.assertGreaterEqual(carriers, 3,
+                                "nothing in the sweep uses the shared spelling")
         for component in ("SpanTravel.qml", "SpanFade.qml"):
             self.assertTrue((DESIGN_SYSTEM / "widgets" / component).exists())
 

--- a/dots/.config/quickshell/imi/tests/tst_sun_arc.qml
+++ b/dots/.config/quickshell/imi/tests/tst_sun_arc.qml
@@ -149,13 +149,20 @@ TestCase {
         const rise = "06:00 AM", set = "06:00 PM";
         const u = SunArc.sunU(12 * 60, rise, set, window);
         fuzzyCompare(SunArc.curveY(u, window, 80, 45, 0.35), 80 - 45, 0.0001);
-        // ...and an hour either side of it, where the answer is not a
-        // landmark either function could have short-circuited to.
-        for (const minutes of [7 * 60, 11 * 60, 16 * 60]) {
+        // ...and at the quarter points, against ARITHMETIC rather than
+        // against the expression curveY runs. The previous version computed
+        // `80 - heightAt(phaseAt(u))` and compared it to curveY, which is
+        // literally that function's body - so any error inside heightAt or
+        // phaseAt appeared identically on both sides. Distorting the daylight
+        // curve by 30% left this file fully green.
+        //
+        // Daylight is 06:00-18:00, so 09:00 and 15:00 are phase 0.25 and 0.75
+        // (sin = √½) and 12:00 is the apex: 80 - 45·sin(φπ).
+        const quarters = [[9 * 60, 48.1802], [12 * 60, 35.0], [15 * 60, 48.1802]];
+        for (const [minutes, expected] of quarters) {
             const at = SunArc.sunU(minutes, rise, set, window);
-            const expected = 80 - SunArc.heightAt(
-                SunArc.phaseAt(at, window), 45, 0.35);
-            fuzzyCompare(SunArc.curveY(at, window, 80, 45, 0.35), expected, 0.0001);
+            fuzzyCompare(SunArc.curveY(at, window, 80, 45, 0.35), expected, 0.001,
+                         `curve at ${minutes / 60}:00`);
         }
     }
 


### PR DESCRIPTION
The second half of the review findings: duplication that survived the pass meant to end it, and assertions that could not have caught the thing they were written for.

## Five copies in the package the extraction was written for

v0.24.0 claimed one spelling of the travel animation and one of the fade. Five verbatim copies survived in `nandoroid-media` — the seeker's `bend`, its `ringT`, its palette crossfade, and the button's `morphT` and artwork `width` — every one added by the same release that did the extracting.

The seeker's `bend` and the button's `morphT` are *the same transition seen from two objects*: a curve change to `SpanTravel.qml` would have moved the tree and left the ring and the body behind, which is precisely the drift the extraction existed to prevent.

**Why they survived:** the enforcing test named three files by hand. A check that enumerates its subjects only ever guards the subjects someone remembered — so it now globs the media package, and matches the Behavior body's *shape* rather than the curve name, so `ParallelAnimation` members that `SpanTravel` cannot express are not swept up with it. Proven by putting a copy back and watching it fail.

## A sun-curve assertion that agreed with itself

```qml
const expected = 80 - SunArc.heightAt(SunArc.phaseAt(at, window), 45, 0.35);
fuzzyCompare(SunArc.curveY(at, window, 80, 45, 0.35), expected, 0.0001);
```

`curveY` **is** `horizonY - heightAt(phaseAt(u, window), apexRise, tailFlatten)`. Any error inside either helper appeared identically on both sides, so the comparison could only ever pass.

Demonstrated rather than asserted: a distortion crafted to vanish at phase 0, 0.5 and 1 — exactly the landmarks the file's other assertions check — bends the drawn arc by 30% at the quarter points and left all 18 cases green. The quarter points are now pinned to worked arithmetic (daylight 06:00–18:00 puts 09:00 and 15:00 at phase 0.25/0.75, so `80 − 45·sin(φπ)` = 48.18, midday 35), and that mutation fails at `curve at 9:00`.

## Verification

- `tests/run_tests.sh`: **704 passed, 0 failed**
- `run_media_probe.sh` and `run_weather_probe.sh`: 0 failures — the animations behave identically after the swap, which is the point of a shared spelling
- Both hardened checks proven to fail against the exact regressions they name

Docs: not needed — no rule changes; both lessons already have their AGENT.md entries (the extraction's "the check is the deliverable, not the module", and the ambient-coverage rule), and this is those rules being applied where they had not reached.