### PR TITLE
The blur probe stops closing the developer's session

### DIFF
--- a/dots/.config/quickshell/imi/tests/lint_harness_compositor_reach.py
+++ b/dots/.config/quickshell/imi/tests/lint_harness_compositor_reach.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""No harness may reach the developer's own compositor.
+
+`hyprctl` chooses which Hyprland to talk to from HYPRLAND_INSTANCE_SIGNATURE
+alone. It does not consult WAYLAND_DISPLAY, so a script that starts a nested
+compositor, points WAYLAND_DISPLAY at it, and then calls plain `hyprctl` is
+still talking to the CALLER's session. `run_notification_blur_probe.sh` ended
+with `hyprctl dispatch exit` for exactly that reason: every isolation the
+script built - its own bus, its own XDG dirs, its own compositor - and the
+teardown reached out and closed the developer's desktop.
+
+The rule: a harness that invokes hyprctl must either fake the binary, or set
+the signature for the instance it means. Passing `-j` to read from a session
+the test did not create is also out - a test whose answer depends on the
+machine it runs on is not a test.
+
+Exits non-zero listing offenders. Wired into run_tests.sh.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+HARNESS_DIR = Path(__file__).resolve().parent
+# Deliberately narrow: an INVOCATION, not a mention. A shell line whose first
+# word is hyprctl, or a python line handing it to subprocess. Everything else
+# in these files - docstrings explaining what the shell does with hyprctl,
+# assertions about the shell's own source, fake binaries written to a temp
+# PATH - names it without ever reaching a compositor, and a lint that flags
+# those is one nobody can leave switched on.
+SHELL_INVOCATION = re.compile(r"^\s*(?!#)(?:[^#]*[;&|]\s*)?hyprctl\s")
+PYTHON_INVOCATION = re.compile(r"(subprocess|Popen|check_output|\brun\()[^\n]*[\"']hyprctl[\"']")
+
+
+def offenders():
+    found = []
+    for path in sorted(list(HARNESS_DIR.glob("*.sh")) + list(HARNESS_DIR.glob("*.py"))):
+        if path.name == Path(__file__).name:
+            continue
+        source = path.read_text(encoding="utf-8")
+        # A harness that sets the signature has said which instance it means.
+        if "HYPRLAND_INSTANCE_SIGNATURE" in source:
+            continue
+        matcher = SHELL_INVOCATION if path.suffix == ".sh" else PYTHON_INVOCATION
+        for number, line in enumerate(source.splitlines(), 1):
+            if matcher.search(line):
+                found.append((path.name, number, line.strip()))
+    return found
+
+
+def main():
+    found = offenders()
+    if found:
+        print("Harness compositor-reach lint FAILED: hyprctl resolves its "
+              "instance from HYPRLAND_INSTANCE_SIGNATURE, not WAYLAND_DISPLAY, "
+              "so these reach the caller's own session:", file=sys.stderr)
+        for name, number, line in found:
+            print(f"  {name}:{number}: {line}", file=sys.stderr)
+        return 1
+    scanned = len(list(HARNESS_DIR.glob("*.sh"))) + len(list(HARNESS_DIR.glob("*.py")))
+    print(f"Harness compositor-reach lint passed ({scanned} harness files)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dots/.config/quickshell/imi/tests/run_notification_blur_probe.sh
+++ b/dots/.config/quickshell/imi/tests/run_notification_blur_probe.sh
@@ -111,9 +111,17 @@ sleep 4
 grim "${OUT%.png}_third.png"
 
 kill $QPID 2>/dev/null
-hyprctl dispatch exit >/dev/null 2>&1
-sleep 1
+# Kill the nested compositor by PID, NOT `hyprctl dispatch exit`.
+#
+# hyprctl resolves which instance to talk to from HYPRLAND_INSTANCE_SIGNATURE
+# alone - it does not consult WAYLAND_DISPLAY, and nothing here sets the
+# signature. So this line targeted whichever Hyprland the CALLER is running:
+# on a developer's desktop that is their own session, and `dispatch exit`
+# ends it. Every isolation this script builds - its own bus, its own XDG
+# dirs, its own compositor - had one hole, and it was the teardown.
 kill $HPID 2>/dev/null
+sleep 1
+kill -9 $HPID 2>/dev/null
 kill "$DBUS_SESSION_BUS_PID" 2>/dev/null
 
 grep -E "ERROR|WARN scene" "$TMP/probe.log" | head -10

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -293,6 +293,12 @@ fi
 # Enumerated, not globbed - which is why these three could exist, pass by hand
 # and be enforced by nothing. Added when a review counted the files run_tests.sh
 # names against the files on disk.
+echo "Running harness compositor-reach lint..."
+if ! python3 "$SCRIPT_DIR/lint_harness_compositor_reach.py"; then
+    echo "Harness compositor-reach lint failed."
+    exit 1
+fi
+
 echo "Running settings search index tests..."
 if ! python3 "$SCRIPT_DIR/test_settings_search_index.py"; then
     echo "Settings search index tests failed."


### PR DESCRIPTION
Found by the integration-testing spec review (#200) and verified before acting on it.

## The hazard

`tests/run_notification_blur_probe.sh` builds real isolation to test something no other harness can see: its own D-Bus session, its own `XDG_*` directories, and a **nested Hyprland**, because weston has no `ext-background-effect` and the frost cannot be observed without one.

Its last act was:

```sh
hyprctl dispatch exit >/dev/null 2>&1
```

**`hyprctl` resolves which Hyprland to talk to from `HYPRLAND_INSTANCE_SIGNATURE` alone.** It does not consult `WAYLAND_DISPLAY`, and nothing under `tests/` sets the signature — confirmed by grep. So that line addressed whichever compositor the *caller* is running. Run this probe on a developer's desktop and it ends their session: every window, everything unsaved.

Every isolation the script goes to trouble to build had exactly one hole, and it was the teardown. The nested compositor is killed by the PID the script already holds.

## The check

A mistake that costs someone their session is worth mechanising rather than noting. `lint_harness_compositor_reach.py`: a harness may fake `hyprctl`, or set the signature for the instance it means — what it may not do is invoke it bare and hope `WAYLAND_DISPLAY` is enough.

It is deliberately narrow, and that took two attempts worth recording: **the first version matched the word anywhere** and flagged eleven docstrings explaining what the *shell* does with hyprctl, plus fake-binary fixtures. That is a lint nobody would leave switched on. It now matches a shell line whose command is `hyprctl`, or a python line handing it to `subprocess`, and it fails on the exact line this PR removes.

## Verification

- `lint_harness_compositor_reach.py` passes over 136 harness files, and fails when the removed line is put back
- `tests/run_tests.sh`: **704 passed, 0 failed**
- The probe itself was **not run** — running it is what this PR exists to make safe, and the one machine available is the user's live session

Docs: not needed — the reasoning lives beside the teardown it replaced and in the lint's own docstring; #200 records the same finding in the spec's §Hyprland integration for the wider audit.