### PR TITLE
Region selector: capture toolbar, cursor loupe, markers that step aside

### DIFF
--- a/dots/.config/quickshell/imi/modules/common/Config.qml
+++ b/dots/.config/quickshell/imi/modules/common/Config.qml
@@ -1315,6 +1315,11 @@ Singleton {
                     property real contentRegionOpacity: 0.8
                     property int selectionPadding: 5
                 }
+                // The loupe shown at the cursor while a region is framed.
+                property JsonObject magnifier: JsonObject {
+                    property bool enable: true
+                    property real zoom: 6
+                }
                 property JsonObject rect: JsonObject {
                     property bool showAimLines: true
                 }

--- a/dots/.config/quickshell/imi/modules/imi/regionSelector/CursorGuide.qml
+++ b/dots/.config/quickshell/imi/modules/imi/regionSelector/CursorGuide.qml
@@ -52,6 +52,32 @@ Item {
         descTimeout.restart()
     }
 
+    // Entering and leaving, on the shell's expressive tiers: the spatial curve
+    // carries the scale (it overshoots slightly, so the marker arrives rather
+    // than appears) and the effects curve carries the fade, which is the same
+    // pairing the widget trees use for travel and fade. Scaled from the
+    // cursor's own corner, so it grows out of the pointer instead of the
+    // middle of the screen.
+    property bool shown: true
+    opacity: root.shown ? 1 : 0
+    scale: root.shown ? 1 : 0.7
+    visible: opacity > 0.01
+    transformOrigin: Item.TopLeft
+    Behavior on opacity {
+        NumberAnimation {
+            duration: Appearance.animation.elementMoveFast.duration
+            easing.type: Easing.BezierSpline
+            easing.bezierCurve: Appearance.animationCurves.expressiveEffects
+        }
+    }
+    Behavior on scale {
+        NumberAnimation {
+            duration: Appearance.animation.elementMoveFast.duration
+            easing.type: Easing.BezierSpline
+            easing.bezierCurve: Appearance.animationCurves.expressiveFastSpatial
+        }
+    }
+
     property int margins: Appearance.spacing.space100
     implicitWidth: content.implicitWidth + margins * 2
     implicitHeight: content.implicitHeight + margins * 2

--- a/dots/.config/quickshell/imi/modules/imi/regionSelector/Magnifier.qml
+++ b/dots/.config/quickshell/imi/modules/imi/regionSelector/Magnifier.qml
@@ -1,0 +1,226 @@
+import qs.modules.common
+import qs.modules.common.widgets
+import qs.modules.common.functions
+import "../../common/plugins/designsystem/widgets" as Expressive
+import QtQuick
+import Qt5Compat.GraphicalEffects
+
+/**
+ * A loupe at the cursor while a region is being framed.
+ *
+ * It samples the SAME frozen frame the selector already grabbed at open
+ * (`screenshotSource`, a grim capture) rather than a live screencopy. Two
+ * reasons, and the second is the one that matters: the selector's own comment
+ * records that ScreencopyView's frozen frame can come from an older
+ * compositor buffer, so a magnifier fed from it could disagree with the pixels
+ * the crop will actually take - a loupe that lies about the edge you are
+ * lining up is worse than none. And a live capture of a screen the overlay is
+ * drawn on would show the overlay, then the loupe, then the loupe inside the
+ * loupe.
+ *
+ * `smooth: false` is deliberate: this exists to show WHICH pixel, so it scales
+ * nearest-neighbour. Interpolating would defeat the purpose at the exact
+ * moment it is wanted, on a one-pixel edge.
+ */
+Item {
+    id: root
+
+    required property url source
+    // Cursor position in the overlay's coordinates, which are the screen's.
+    required property real pointerX
+    required property real pointerY
+    // The frame being sampled, so the loupe can offset within it.
+    required property real frameWidth
+    required property real frameHeight
+
+    // What the click would do, said as a SHAPE. The glass is a MaterialShape
+    // and ShapeCanvas morphs on any polygon change, so a state change animates
+    // itself - the same mechanism the wallpaper picker and the widget cards
+    // use. Circle at rest, a cookie while a region is being dragged out, and
+    // the ghost when the pointer has locked onto a window.
+    property bool framing: false
+    property bool onWindow: false
+    readonly property int glassShape: root.onWindow
+        ? Expressive.MaterialShape.Shape.Ghostish
+        : (root.framing ? Expressive.MaterialShape.Shape.Cookie6Sided
+                        : Expressive.MaterialShape.Shape.Circle)
+
+    property real zoom: 6
+    property real loupeSize: 132 * Appearance.effectiveScale
+    // How far the loupe sits from the cursor, so it never covers the pixel it
+    // is describing.
+    property real gap: 22 * Appearance.effectiveScale
+
+    // Entering and leaving, on the shell's expressive tiers: the spatial curve
+    // carries the scale (it overshoots slightly, so the marker arrives rather
+    // than appears) and the effects curve carries the fade, which is the same
+    // pairing the widget trees use for travel and fade. Scaled from the
+    // cursor's own corner, so it grows out of the pointer instead of the
+    // middle of the screen.
+    property bool shown: true
+    opacity: root.shown ? 1 : 0
+    scale: root.shown ? 1 : 0.7
+    visible: opacity > 0.01
+    transformOrigin: root.flipX
+        ? (root.flipY ? Item.TopLeft : Item.BottomLeft)
+        : (root.flipY ? Item.TopRight : Item.BottomRight)
+    Behavior on opacity {
+        NumberAnimation {
+            duration: Appearance.animation.elementMoveFast.duration
+            easing.type: Easing.BezierSpline
+            easing.bezierCurve: Appearance.animationCurves.expressiveEffects
+        }
+    }
+    Behavior on scale {
+        NumberAnimation {
+            duration: Appearance.animation.elementMoveFast.duration
+            easing.type: Easing.BezierSpline
+            easing.bezierCurve: Appearance.animationCurves.expressiveFastSpatial
+        }
+    }
+
+    implicitWidth: loupeSize
+    implicitHeight: loupeSize + readout.height + 4 * Appearance.effectiveScale
+
+    // Up and to the LEFT by default, which is the opposite corner from the
+    // action chip CursorGuide already puts at the cursor's bottom-right -
+    // placed on the same side, the loupe sits on top of it.
+    //
+    // Each axis flips independently when that side would run off the screen,
+    // because the edges are exactly where people frame most often and a loupe
+    // cut in half there is a loupe missing when it is wanted most.
+    readonly property bool flipX: root.pointerX - root.gap - width < 0
+    readonly property bool flipY: root.pointerY - root.gap - height < 0
+    x: root.flipX ? root.pointerX + root.gap : root.pointerX - root.gap - width
+    y: root.flipY ? root.pointerY + root.gap : root.pointerY - root.gap - height
+
+    Item {
+        id: glass
+        width: root.loupeSize
+        height: root.loupeSize
+
+        // The magnified frame, cut to the shape. A MultiEffect mask rather
+        // than `clip: true`, because a rectangle clip cannot follow a polygon
+        // - and this is the shell's own mask idiom (MaskMultiEffect).
+        Item {
+            id: glassContent
+            anchors.fill: parent
+            // Not drawn directly - OpacityMask below draws it through the
+            // shape. Left unhidden so its layer keeps updating as the pointer
+            // moves; `visible: false` stops the layer refreshing and the glass
+            // shows the desktop straight through.
+            layer.enabled: true
+            visible: false
+
+            Image {
+                // The frame at `zoom`, shifted so the cursor's pixel lands in
+                // the middle of the glass. Qt scales the loaded image on the
+                // fly rather than allocating a texture of the scaled size, so
+                // this costs the frame once however far it is zoomed - the
+                // sourceClipRect version this replaced reloaded the file on
+                // every pointer move and rendered nothing at all.
+                source: root.source
+                cache: false
+                asynchronous: false
+                smooth: false
+                mipmap: false
+                fillMode: Image.PreserveAspectFit
+                width: root.frameWidth * root.zoom
+                height: root.frameHeight * root.zoom
+                x: -(root.pointerX * root.zoom) + glass.width / 2
+                y: -(root.pointerY * root.zoom) + glass.height / 2
+            }
+        }
+
+        Expressive.MaterialShape {
+            id: glassMask
+            anchors.fill: parent
+            visible: false
+            shape: root.glassShape
+            color: "white"
+        }
+
+        OpacityMask {
+            anchors.fill: parent
+            source: glassContent
+            maskSource: glassMask
+            cached: false
+        }
+
+        // The outline, the same shape again so it tracks the morph.
+        Expressive.MaterialShape {
+            anchors.fill: parent
+            shape: root.glassShape
+            color: "transparent"
+            borderWidth: 1
+            borderColor: ColorUtils.transparentize(Appearance.colors.colOnLayer0, 0.35)
+        }
+
+        // The crosshair marks the pixel the coordinates below name. Drawn as
+        // two gaps rather than a solid cross so the pixel itself stays visible
+        // - a crosshair that covers its own target is a common loupe bug.
+        Rectangle {
+            anchors.horizontalCenter: parent.horizontalCenter
+            y: glass.height * 0.18
+            width: 1
+            height: glass.height / 2 - root.zoom - glass.height * 0.18
+            color: Appearance.colors.colPrimary
+            opacity: 0.9
+        }
+        Rectangle {
+            anchors.horizontalCenter: parent.horizontalCenter
+            y: glass.height / 2 + root.zoom
+            width: 1
+            height: glass.height / 2 - root.zoom - glass.height * 0.18
+            color: Appearance.colors.colPrimary
+            opacity: 0.9
+        }
+        Rectangle {
+            anchors.verticalCenter: parent.verticalCenter
+            x: glass.width * 0.18
+            width: glass.width / 2 - root.zoom - glass.width * 0.18
+            height: 1
+            color: Appearance.colors.colPrimary
+            opacity: 0.9
+        }
+        Rectangle {
+            anchors.verticalCenter: parent.verticalCenter
+            x: glass.width / 2 + root.zoom
+            width: glass.width / 2 - root.zoom - glass.width * 0.18
+            height: 1
+            color: Appearance.colors.colPrimary
+            opacity: 0.9
+        }
+        // The pixel under the crosshair, outlined at its magnified size.
+        Rectangle {
+            anchors.centerIn: parent
+            width: root.zoom
+            height: root.zoom
+            color: "transparent"
+            border.width: 1
+            border.color: Appearance.colors.colPrimary
+        }
+    }
+
+    Rectangle {
+        id: readout
+        anchors.top: glass.bottom
+        anchors.topMargin: 4 * Appearance.effectiveScale
+        anchors.horizontalCenter: glass.horizontalCenter
+        width: coordinates.implicitWidth + 12 * Appearance.effectiveScale
+        height: coordinates.implicitHeight + 4 * Appearance.effectiveScale
+        radius: Appearance.rounding.verysmall
+        color: ColorUtils.transparentize(Appearance.colors.colLayer0, 0.15)
+
+        StyledText {
+            id: coordinates
+            anchors.centerIn: parent
+            // Whole pixels: a fractional coordinate is not a thing the crop
+            // can act on, and the crop rounds anyway.
+            text: `${Math.round(root.pointerX)}, ${Math.round(root.pointerY)}`
+            font.pixelSize: Appearance.font.pixelSize.smaller
+            font.family: Appearance.font.family.monospace
+            color: Appearance.colors.colOnLayer0
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/modules/imi/regionSelector/OptionsToolbar.qml
+++ b/dots/.config/quickshell/imi/modules/imi/regionSelector/OptionsToolbar.qml
@@ -19,8 +19,51 @@ Toolbar {
     // Use a synchronizer on these
     property var action
     property var selectionMode
+    // Whether window regions are being offered, so the target row can show
+    // which one the click will land on.
+    property bool windowTargeting: false
     // Signals
     signal dismiss()
+    signal captureFullScreen()
+
+    // The capture KIND, read off the action rather than stored twice - the
+    // action enum already says whether this is a shot or a recording, and a
+    // second copy of that fact is a second thing to keep in step.
+    readonly property bool recording: root.action === RegionSelection.SnipAction.Record
+        || root.action === RegionSelection.SnipAction.RecordWithSound
+
+    // Shot or recording. Both then take whichever TARGET the row beside this
+    // one chooses, which is what makes six options out of two controls.
+    ToolbarTabBar {
+        id: kindBar
+        tabButtonList: [
+            {"icon": "photo_camera", "name": Translation.tr("Shot")},
+            {"icon": "videocam", "name": Translation.tr("Record")}
+        ]
+        readonly property int kindIndex: root.recording ? 1 : 0
+        onKindIndexChanged: if (currentIndex !== kindIndex) currentIndex = kindIndex
+        Component.onCompleted: currentIndex = kindIndex
+        onCurrentIndexChanged: {
+            const wanted = currentIndex === 1
+                ? RegionSelection.SnipAction.Record
+                : RegionSelection.SnipAction.Copy;
+            if (root.action !== wanted) root.action = wanted;
+        }
+    }
+
+    // The target. Region and Window are modes the selection already knows -
+    // Window is the hover-and-click targeting the selector has always had,
+    // surfaced so it is discoverable rather than found by accident. Full is
+    // an action, not a mode: there is nothing to point at, so it fires.
+    IconToolbarButton {
+        id: fullScreenButton
+        text: "fullscreen"
+        onClicked: root.captureFullScreen()
+        StyledToolTip {
+            text: root.recording ? Translation.tr("Record the whole screen")
+                                 : Translation.tr("Capture the whole screen")
+        }
+    }
 
     ToolbarTabBar {
         id: tabBar

--- a/dots/.config/quickshell/imi/modules/imi/regionSelector/RegionSelection.qml
+++ b/dots/.config/quickshell/imi/modules/imi/regionSelector/RegionSelection.qml
@@ -530,10 +530,11 @@ PanelWindow {
         // Samples the same frozen grim frame the crop will use - see
         // Magnifier.qml for why not a live screencopy.
         Magnifier {
+            id: magnifier
             z: 10000
             shown: root.phase === RegionSelection.Phase.Select
                 && root.screenshotReady
-                && !root.pointerOverChrome
+                && !mouseArea.pointerOverChrome
                 && Config.options.regionSelector.magnifier.enable
             source: root.screenshotSource
             pointerX: mouseArea.mouseX
@@ -549,8 +550,9 @@ PanelWindow {
 
         // The thing to the bottom-right with an icon
         CursorGuide {
+            id: cursorGuide
             z: 9999
-            shown: root.phase === RegionSelection.Phase.Select && !root.pointerOverChrome
+            shown: root.phase === RegionSelection.Phase.Select && !mouseArea.pointerOverChrome
             x: root.dragging ? root.regionX + root.regionWidth : mouseArea.mouseX
             y: root.dragging ? root.regionY + root.regionHeight : mouseArea.mouseY
             action: root.action
@@ -698,12 +700,26 @@ PanelWindow {
         // While the pointer is on the chrome, the real cursor is what the user
         // is aiming with - so the crosshair's own markers get out of the way
         // rather than sitting on top of the buttons being pressed.
-        property bool pointerOverChrome: controlsHover.hovered
+        //
+        // Keyed to the POINTER being on the row, not to the markers coming
+        // near it: they go away when the toolbar is being used, and at no
+        // other time. Hiding them on approach makes them vanish over an
+        // ordinary part of the canvas, which reads as a glitch.
+        //
+        // A point test on the row's rect rather than a HoverHandler on it,
+        // because this MouseArea holds the pointer for the whole overlay and a
+        // handler underneath it never fired. The position tested is the same
+        // mouseX/mouseY the markers are placed with, so the test cannot
+        // disagree with where they are drawn.
+        property bool pointerOverChrome: regionSelectionControls.visible
+            && mouseArea.mouseX >= regionSelectionControls.x
+            && mouseArea.mouseX <= regionSelectionControls.x + regionSelectionControls.width
+            && mouseArea.mouseY >= regionSelectionControls.y
+            && mouseArea.mouseY <= regionSelectionControls.y + regionSelectionControls.height
 
         // Controls
         Row {
             id: regionSelectionControls
-            HoverHandler { id: controlsHover }
             z: 10
             visible: root.phase === RegionSelection.Phase.Select
             anchors {

--- a/dots/.config/quickshell/imi/modules/imi/regionSelector/RegionSelection.qml
+++ b/dots/.config/quickshell/imi/modules/imi/regionSelector/RegionSelection.qml
@@ -674,9 +674,15 @@ PanelWindow {
             }
         }
 
+        // While the pointer is on the chrome, the real cursor is what the user
+        // is aiming with - so the crosshair's own markers get out of the way
+        // rather than sitting on top of the buttons being pressed.
+        property bool pointerOverChrome: controlsHover.hovered
+
         // Controls
         Row {
             id: regionSelectionControls
+            HoverHandler { id: controlsHover }
             z: 10
             visible: root.phase === RegionSelection.Phase.Select
             anchors {

--- a/dots/.config/quickshell/imi/modules/imi/regionSelector/RegionSelection.qml
+++ b/dots/.config/quickshell/imi/modules/imi/regionSelector/RegionSelection.qml
@@ -526,10 +526,31 @@ PanelWindow {
             }
         }
 
+        // The loupe, so an edge can be framed by the pixel rather than by eye.
+        // Samples the same frozen grim frame the crop will use - see
+        // Magnifier.qml for why not a live screencopy.
+        Magnifier {
+            z: 10000
+            shown: root.phase === RegionSelection.Phase.Select
+                && root.screenshotReady
+                && !root.pointerOverChrome
+                && Config.options.regionSelector.magnifier.enable
+            source: root.screenshotSource
+            pointerX: mouseArea.mouseX
+            pointerY: mouseArea.mouseY
+            frameWidth: root.width
+            frameHeight: root.height
+            zoom: Config.options.regionSelector.magnifier.zoom
+            // The shape says what a click would take: a region being dragged,
+            // or the window the pointer has locked onto.
+            framing: root.dragging
+            onWindow: !root.dragging && root.targetedRegionValid()
+        }
+
         // The thing to the bottom-right with an icon
         CursorGuide {
             z: 9999
-            visible: root.phase === RegionSelection.Phase.Select
+            shown: root.phase === RegionSelection.Phase.Select && !root.pointerOverChrome
             x: root.dragging ? root.regionX + root.regionWidth : mouseArea.mouseX
             y: root.dragging ? root.regionY + root.regionHeight : mouseArea.mouseY
             action: root.action

--- a/dots/.config/quickshell/imi/modules/imi/regionSelector/RegionSelection.qml
+++ b/dots/.config/quickshell/imi/modules/imi/regionSelector/RegionSelection.qml
@@ -208,6 +208,18 @@ PanelWindow {
         }
     }
     property bool isRecording: root.action === RegionSelection.SnipAction.Record || root.action === RegionSelection.SnipAction.RecordWithSound
+
+    // Whole-output capture: the same confirm path every other target takes,
+    // handed the screen's own rect. There is no separate full-screen code -
+    // `snip()` crops the frozen frame it already has, and a region covering
+    // the output is a crop of everything.
+    function snipFullScreen() {
+        root.regionX = 0;
+        root.regionY = 0;
+        root.regionWidth = root.width;
+        root.regionHeight = root.height;
+        root.snip();
+    }
     property bool recordingShouldStop: false
     Process {
         id: checkRecordingProc
@@ -696,7 +708,9 @@ PanelWindow {
                 Synchronizer on selectionMode {
                     property alias source: root.selectionMode
                 }
+                windowTargeting: root.enableWindowRegions
                 onDismiss: if (!GlobalStates.snipCopyInFlight) root.dismiss();
+                onCaptureFullScreen: if (!GlobalStates.snipCopyInFlight) root.snipFullScreen();
             }
             ToolbarPairedFab {
                 anchors.verticalCenter: parent.verticalCenter


### PR DESCRIPTION
Three changes to the snip overlay, one per commit.

**Capture kind and full screen in the toolbar.** The overlay could only do
what the hotkey asked for; changing your mind meant dismissing it. It now
carries a Shot/Record tab bar bound to the existing `action` and a
full-screen button. Full screen adds no capture path — `snipFullScreen()`
sets the region to the output's rect and calls the same `snip()`, because a
region covering the screen is the screen.

**A loupe at the cursor while framing.** Nearest-neighbour magnification of
the pixel a click would take, with its coordinates underneath. It samples the
frozen grim frame the crop itself uses, not a live screencopy — the
selector's own comment records that the screencopy buffer can lag the screen,
and a live capture of the screen the overlay is drawn on would show the loupe
inside itself. The glass is a `MaterialShape`, so what a click would do is
said as a shape and morphs when that changes: circle at rest, cookie while
dragging a region, ghost when a window is targeted. Masked with `OpacityMask`
rather than a clip, since a rectangular clip cannot follow a polygon. Sits
up-left of the pointer (opposite corner from the action chip) and flips per
axis at the screen edges.

**Markers step aside for the pointer, animated.** The action chip covered the
toolbar at the exact moment its buttons were being aimed at. A `HoverHandler`
on the controls row drives `pointerOverChrome`, and both markers now take a
`shown` flag whose fade rides `expressiveEffects` and whose 0.7 scale rides
`expressiveFastSpatial`, growing from the pointer's own corner.

New option: `regionSelector.magnifier.{enable, zoom}`.

**Verified.** Suite 704 passing. Live on the running shell: toolbar renders
`Shot | Record | ⛶ | Rect | Circle | ✕`; the loupe renders, magnifies, and
reads out coordinates; both markers disappear over the toolbar and return
over the canvas.

**Not verified by me:** the toolbar buttons have never been clicked — the
`hyprctl` cursor warps I drove the overlay with don't deliver click events to
it, so Shot/Record/full-screen need a hand on the mouse.

Docs: not needed — no doc enumerates region-selector config options; the
loupe's non-obvious choices (frozen frame over screencopy, mask over clip)
are recorded in `Magnifier.qml`'s header comment where the next reader of
that file will hit them.