### PR TITLE
Recording region: stop, pause and save-clip beside the capture

### DIFF
--- a/dots/.config/hypr/hyprland/rules.lua
+++ b/dots/.config/hypr/hyprland/rules.lua
@@ -161,6 +161,13 @@ hl.layer_rule({ match = { namespace = "quickshell:popup" }, xray = false}) -- No
 hl.layer_rule({ match = { namespace = "quickshell:popup" }, ignore_alpha = 1}) -- No weird color for bar tooltips (but somehow this is necessary)
 hl.layer_rule({ match = { namespace = "quickshell:mediaControls" }, ignore_alpha = 1}) -- Same as above
 hl.layer_rule({ match = { namespace = "quickshell:reloadPopup" }, animation = "slide"})
+-- The recording controls are a small toolbar in a window that is mostly
+-- transparent: the extra room is for the toolbar's own shadow. The
+-- catch-all above blurs anything over 5% alpha, which frosts that shadow
+-- into a haze the size of the window. Same treatment as the popup and
+-- overlay surfaces, and for the same reason.
+hl.layer_rule({ match = { namespace = "quickshell:recordingRegion" }, ignore_alpha = 1})
+hl.layer_rule({ match = { namespace = "quickshell:recordingRegion" }, no_anim = true})
 hl.layer_rule({ match = { namespace = "quickshell:regionSelector" }, no_anim = true})
 hl.layer_rule({ match = { namespace = "quickshell:screenshot" }, no_anim = true})
 hl.layer_rule({ match = { namespace = "quickshell:session" }, blur = true})

--- a/dots/.config/quickshell/imi/modules/common/Persistent.qml
+++ b/dots/.config/quickshell/imi/modules/common/Persistent.qml
@@ -89,6 +89,12 @@ Singleton {
 
             property JsonObject record: JsonObject {
                 property bool enable: false
+                // The geometry a region recording was started with, "X,Y WxH",
+                // or empty for a full-screen one. Persisted beside `enable`
+                // because the recording outlives the shell: record.sh owns the
+                // process, so a shell restart mid-capture has to be able to
+                // find its way back to the rectangle being recorded.
+                property string region: ""
             }
 
             property JsonObject overlay: JsonObject {

--- a/dots/.config/quickshell/imi/modules/common/widgets/RippleButton.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/RippleButton.qml
@@ -103,6 +103,16 @@ Button {
         easing.bezierCurve: Appearance?.animationCurves.standardDecel
     }
 
+    // The pointer shape, stated as a handler rather than left to the MouseArea.
+    //
+    // A handler attaches to the item it is declared in - handlers are not
+    // Items, so a Control's contentData rules never touch them - which makes
+    // this the one way to say "this whole button is clickable" that cannot be
+    // narrowed by a subclass replacing the contentItem.
+    HoverHandler {
+        cursorShape: root.pointingHandCursor ? Qt.PointingHandCursor : Qt.ArrowCursor
+    }
+
     MouseArea {
         // Parented to the button ITSELF, not left to default parenting.
         //

--- a/dots/.config/quickshell/imi/modules/common/widgets/RippleButton.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/RippleButton.qml
@@ -104,7 +104,19 @@ Button {
     }
 
     MouseArea {
-        anchors.fill: parent
+        // Parented to the button ITSELF, not left to default parenting.
+        //
+        // This is declared in the body of a Control, so Qt treats it as
+        // contentData and parents it into `contentItem`. With the default
+        // contentItem - a StyledText the Control sizes to its padded rect -
+        // that is almost the whole button and nobody noticed. Replace the
+        // contentItem with something that sizes itself, and the area collapses
+        // onto it: `IconToolbarButton` centres a 22px glyph, so every toolbar
+        // button in the shell was hoverable and clickable on the icon alone
+        // and dead across the rest of its 40px target. The pointer never
+        // changed, which is how it was found.
+        parent: root
+        anchors.fill: root
         cursorShape: root.pointingHandCursor ? Qt.PointingHandCursor : Qt.ArrowCursor
         acceptedButtons: Qt.LeftButton | Qt.RightButton | Qt.MiddleButton
         onPressed: (event) => { 

--- a/dots/.config/quickshell/imi/modules/common/widgets/ToolbarPairedFab.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/ToolbarPairedFab.qml
@@ -7,6 +7,14 @@ Item {
     signal clicked(event: var)
     property alias iconText: fabWidget.iconText
     property alias baseSize: fabWidget.baseSize
+    // The pairing is tertiary by default, which is what every existing caller
+    // wants. A destructive pair - stop a recording - needs the error role
+    // instead, and recolouring is the only difference, so it is four aliases
+    // rather than a second component that would drift from this one.
+    property alias colBackground: fabWidget.colBackground
+    property alias colBackgroundHover: fabWidget.colBackgroundHover
+    property alias colRipple: fabWidget.colRipple
+    property alias colOnBackground: fabWidget.colOnBackground
     default property alias fabData: fabWidget.data
     property bool enableShadow: true
 

--- a/dots/.config/quickshell/imi/modules/imi/recordingRegion/RecordingRegionPanel.qml
+++ b/dots/.config/quickshell/imi/modules/imi/recordingRegion/RecordingRegionPanel.qml
@@ -16,7 +16,14 @@ import "recording_region.js" as RecordingRegion
  * stop, pause and (while the replay buffer is armed) save-clip beside the
  * region, for as long as the recording runs.
  *
- * The window is exactly the size of the toolbar and sits OUTSIDE the region.
+ * Built from the same pieces as the region selector's own toolbar - `Toolbar`,
+ * `IconToolbarButton`, `ToolbarPairedFab` - so it is the shell's M3 expressive
+ * toolbar rather than a pill with icons in it: 56dp container on the surface
+ * container role, full corner, its own shadow, 22dp icons in 40dp targets, and
+ * the destructive action separated out as a paired FAB the way the selector
+ * separates its close.
+ *
+ * The window is exactly the size of the controls and sits OUTSIDE the region.
  * gsr records whatever the compositor shows inside the rectangle, so anything
  * drawn over it would be in every frame of a clip that cannot be re-taken -
  * see recording_region.js, which refuses to place the toolbar at all rather
@@ -27,6 +34,12 @@ Scope {
 
     readonly property var region: RecordingRegion.parseRegion(Persistent.states.record.region)
     readonly property bool active: ScreenRecord.recording && root.region !== null
+
+    // The room the shadows need around the controls. The window has to include
+    // it - a layer surface clips at its own bounds - and the gap to the region
+    // has to clear it too, because a soft shadow bleeding over the edge of the
+    // capture is as recorded as the toolbar itself would be.
+    readonly property real shadowMargin: Appearance.sizes.elevationMargin
 
     // The screen the region is on, by its top-left corner: a region dragged
     // across a monitor boundary belongs to the monitor it started on, which is
@@ -41,8 +54,22 @@ Scope {
         return Quickshell.screens[0] ?? null;
     }
 
-    readonly property real toolbarWidth: toolbarMetrics.implicitWidth
-    readonly property real toolbarHeight: toolbarMetrics.implicitHeight
+    // The controls' width, published by the instance inside the window.
+    //
+    // It cannot be measured out here: a layout that is not in a scene is never
+    // polished, so its implicit size stays zero, and placing the window from
+    // that would centre a zero-width toolbar. The window is therefore sized by
+    // its content and POSITIONED from the size that content reports - which is
+    // not circular, because the width does not depend on where the window is.
+    // Until the first report the window is off-centre by half its width for a
+    // frame, which is invisible: it is appearing at that moment anyway.
+    property real measuredWidth: 0
+
+    // The container height is fixed by the toolbar itself (Toolbar.qml's 56dp
+    // M3 expressive height), so the only question placement needs answered
+    // before the window exists - does it fit above or below - has a constant
+    // answer and does not wait on a measurement.
+    readonly property real controlsHeight: 56
 
     readonly property var spot: {
         if (!root.active || !root.targetScreen) return null;
@@ -50,20 +77,95 @@ Scope {
             root.region,
             { x: root.targetScreen.x, y: root.targetScreen.y,
               width: root.targetScreen.width, height: root.targetScreen.height },
-            { width: root.toolbarWidth, height: root.toolbarHeight },
-            Appearance.spacing.space100);
+            { width: root.measuredWidth, height: root.controlsHeight },
+            Appearance.spacing.space100 + root.shadowMargin);
     }
 
-    // Measured off-window so the placement has a size to work with before the
-    // window exists - the toolbar's own width decides where the window goes,
-    // and a window cannot be positioned by something it contains.
-    Item {
-        id: toolbarMetrics
-        visible: false
-        implicitWidth: Appearance.spacing.space100 * 2
-            + 36 * (2 + (ScreenRecord.replaying ? 1 : 0))
-            + Appearance.spacing.space50 * (1 + (ScreenRecord.replaying ? 1 : 0))
-        implicitHeight: 44
+    component RecordingControls: RowLayout {
+        spacing: Appearance.spacing.space100
+
+        Toolbar {
+            padding: Appearance.spacing.space100
+
+            // Non-interactive: what the capture is doing, in the one place the
+            // capture cannot show it. It breathes while running and holds
+            // still when paused, so the state is readable without reading.
+            Item {
+                Layout.fillHeight: true
+                Layout.leftMargin: Appearance.spacing.space50
+                implicitWidth: statusIcon.implicitWidth
+
+                MaterialSymbol {
+                    id: statusIcon
+                    anchors.centerIn: parent
+                    text: ScreenRecord.recordPaused ? "pause_circle" : "screen_record"
+                    iconSize: 22
+                    color: ScreenRecord.recordPaused
+                        ? Appearance.colors.colOnSurfaceVariant
+                        : Appearance.colors.colError
+                    animateChange: true
+
+                    SequentialAnimation on opacity {
+                        running: !ScreenRecord.recordPaused
+                        loops: Animation.Infinite
+                        alwaysRunToEnd: true
+                        NumberAnimation {
+                            to: 0.4
+                            duration: Appearance.animationCurves.expressiveDefaultSpatialDuration
+                            easing.type: Easing.BezierSpline
+                            easing.bezierCurve: Appearance.animationCurves.expressiveEffects
+                        }
+                        NumberAnimation {
+                            to: 1
+                            duration: Appearance.animationCurves.expressiveDefaultSpatialDuration
+                            easing.type: Easing.BezierSpline
+                            easing.bezierCurve: Appearance.animationCurves.expressiveEffects
+                        }
+                    }
+                }
+            }
+
+            IconToolbarButton {
+                text: ScreenRecord.recordPaused ? "play_arrow" : "pause"
+                toggled: ScreenRecord.recordPaused
+                releaseAction: () => ScreenRecord.togglePauseRecord()
+                StyledToolTip {
+                    text: ScreenRecord.recordPaused
+                        ? Translation.tr("Resume recording")
+                        : Translation.tr("Pause recording")
+                }
+            }
+
+            IconToolbarButton {
+                // Only while the replay ring buffer is armed: this dumps the
+                // last N seconds to their own clip and leaves both the buffer
+                // and this recording running.
+                visible: ScreenRecord.replaying
+                text: "save"
+                releaseAction: () => ScreenRecord.saveReplay()
+                StyledToolTip {
+                    text: Translation.tr("Save replay clip")
+                }
+            }
+        }
+
+        ToolbarPairedFab {
+            // Paired off to the side, the way the selector pairs its close: it
+            // ends the thing the rest of the toolbar is adjusting, so it should
+            // not sit in the same row of equals. Error rather than tertiary,
+            // because stopping is the one action here that cannot be undone.
+            Layout.alignment: Qt.AlignVCenter
+            iconText: "stop"
+            baseSize: 48
+            colBackground: Appearance.colors.colErrorContainer
+            colBackgroundHover: Appearance.colors.colErrorContainerHover
+            colRipple: Appearance.colors.colErrorContainerActive
+            colOnBackground: Appearance.colors.colOnErrorContainer
+            onClicked: ScreenRecord.stopRecord()
+            StyledToolTip {
+                text: Translation.tr("Stop recording")
+            }
+        }
     }
 
     LazyLoader {
@@ -78,84 +180,31 @@ Scope {
             WlrLayershell.layer: WlrLayer.Overlay
             WlrLayershell.keyboardFocus: WlrKeyboardFocus.None
             exclusionMode: ExclusionMode.Ignore
-            implicitWidth: root.toolbarWidth
-            implicitHeight: root.toolbarHeight
+            implicitWidth: controls.implicitWidth + root.shadowMargin * 2
+            implicitHeight: controls.implicitHeight + root.shadowMargin * 2
             // Anchored to the corner and pushed out by the margin, because a
             // layer surface has no coordinates of its own. The margins are
-            // screen-relative; the placement is in global coordinates.
+            // screen-relative and back off by the shadow inset, so the controls
+            // themselves land exactly where the placement put them.
             anchors { top: true; left: true }
             margins {
-                top: (root.spot?.y ?? 0) - (root.targetScreen?.y ?? 0)
-                left: (root.spot?.x ?? 0) - (root.targetScreen?.x ?? 0)
+                top: (root.spot?.y ?? 0) - (root.targetScreen?.y ?? 0) - root.shadowMargin
+                left: (root.spot?.x ?? 0) - (root.targetScreen?.x ?? 0) - root.shadowMargin
             }
 
-            Rectangle {
-                anchors.fill: parent
-                radius: Appearance.rounding.full
-                color: Appearance.colors.colLayer0
-                border.width: Appearance.borderWidth.standard
-                border.color: Appearance.colors.colLayer0Border
+            RecordingControls {
+                id: controls
+                anchors.centerIn: parent
+            }
 
-                RowLayout {
-                    anchors.centerIn: parent
-                    spacing: Appearance.spacing.space50
-
-                    // Says which of the two states the capture is in, in a
-                    // place where the recording itself cannot show it.
-                    MaterialSymbol {
-                        Layout.leftMargin: Appearance.spacing.space50
-                        text: ScreenRecord.recordPaused ? "pause_circle" : "screen_record"
-                        iconSize: Appearance.font.pixelSize.large
-                        color: ScreenRecord.recordPaused
-                            ? Appearance.colors.colOnSurfaceVariant
-                            : Appearance.colors.colError
-                    }
-
-                    RippleButton {
-                        implicitWidth: 36
-                        implicitHeight: 36
-                        buttonRadius: Appearance.rounding.full
-                        releaseAction: () => ScreenRecord.togglePauseRecord()
-                        MaterialSymbol {
-                            anchors.centerIn: parent
-                            text: ScreenRecord.recordPaused ? "play_arrow" : "pause"
-                            iconSize: Appearance.font.pixelSize.normal
-                            color: Appearance.colors.colOnSurfaceVariant
-                        }
-                    }
-
-                    RippleButton {
-                        // Stop keeps the file - record.sh writes it out on
-                        // stop, so there is no separate save for a recording.
-                        implicitWidth: 36
-                        implicitHeight: 36
-                        buttonRadius: Appearance.rounding.full
-                        releaseAction: () => ScreenRecord.stopRecord()
-                        MaterialSymbol {
-                            anchors.centerIn: parent
-                            text: "stop"
-                            iconSize: Appearance.font.pixelSize.normal
-                            color: Appearance.colors.colError
-                        }
-                    }
-
-                    RippleButton {
-                        // Only while the replay ring buffer is armed: this
-                        // dumps the last N seconds to their own clip and
-                        // leaves both the buffer and this recording running.
-                        visible: ScreenRecord.replaying
-                        implicitWidth: 36
-                        implicitHeight: 36
-                        buttonRadius: Appearance.rounding.full
-                        releaseAction: () => ScreenRecord.saveReplay()
-                        MaterialSymbol {
-                            anchors.centerIn: parent
-                            text: "save"
-                            iconSize: Appearance.font.pixelSize.normal
-                            color: Appearance.colors.colPrimary
-                        }
-                    }
-                }
+            // Reported back out so the placement can centre the window on the
+            // region. A Binding rather than an assignment, so the value tracks
+            // a toolbar that changes width - save-clip appearing when the
+            // replay buffer is armed mid-recording.
+            Binding {
+                target: root
+                property: "measuredWidth"
+                value: controls.implicitWidth
             }
         }
     }

--- a/dots/.config/quickshell/imi/modules/imi/recordingRegion/RecordingRegionPanel.qml
+++ b/dots/.config/quickshell/imi/modules/imi/recordingRegion/RecordingRegionPanel.qml
@@ -82,7 +82,11 @@ Scope {
     }
 
     component RecordingControls: RowLayout {
-        spacing: Appearance.spacing.space100
+        // Wider than the toolbar's internal rhythm on purpose: the FAB is a
+        // separate object paired WITH the toolbar, not another item in it, and
+        // at the same spacing as the buttons inside it reads as a crowded
+        // fourth button that happens to be red.
+        spacing: Appearance.spacing.space150
 
         Toolbar {
             padding: Appearance.spacing.space100
@@ -92,8 +96,9 @@ Scope {
             // still when paused, so the state is readable without reading.
             Item {
                 Layout.fillHeight: true
-                Layout.leftMargin: Appearance.spacing.space50
-                implicitWidth: statusIcon.implicitWidth
+                // No extra margin: the toolbar's padding is the inset, and
+                // adding to it here made the left end wider than the right.
+                implicitWidth: statusIcon.implicitWidth + Appearance.spacing.space50
 
                 MaterialSymbol {
                     id: statusIcon

--- a/dots/.config/quickshell/imi/modules/imi/recordingRegion/RecordingRegionPanel.qml
+++ b/dots/.config/quickshell/imi/modules/imi/recordingRegion/RecordingRegionPanel.qml
@@ -1,0 +1,162 @@
+import QtQuick
+import QtQuick.Layouts
+import Quickshell
+import Quickshell.Wayland
+import qs
+import qs.services
+import qs.modules.common
+import qs.modules.common.widgets
+import "recording_region.js" as RecordingRegion
+
+/**
+ * Controls for a region recording, parked against the rectangle being captured.
+ *
+ * A region recording gives no sign of itself inside the frame - which is the
+ * point, but it leaves stopping the capture as a trip to the bar. This puts
+ * stop, pause and (while the replay buffer is armed) save-clip beside the
+ * region, for as long as the recording runs.
+ *
+ * The window is exactly the size of the toolbar and sits OUTSIDE the region.
+ * gsr records whatever the compositor shows inside the rectangle, so anything
+ * drawn over it would be in every frame of a clip that cannot be re-taken -
+ * see recording_region.js, which refuses to place the toolbar at all rather
+ * than place it inside.
+ */
+Scope {
+    id: root
+
+    readonly property var region: RecordingRegion.parseRegion(Persistent.states.record.region)
+    readonly property bool active: ScreenRecord.recording && root.region !== null
+
+    // The screen the region is on, by its top-left corner: a region dragged
+    // across a monitor boundary belongs to the monitor it started on, which is
+    // also the one gsr attributed the capture to.
+    readonly property var targetScreen: {
+        if (!root.region) return null;
+        for (const screen of Quickshell.screens) {
+            if (root.region.x >= screen.x && root.region.x < screen.x + screen.width
+                && root.region.y >= screen.y && root.region.y < screen.y + screen.height)
+                return screen;
+        }
+        return Quickshell.screens[0] ?? null;
+    }
+
+    readonly property real toolbarWidth: toolbarMetrics.implicitWidth
+    readonly property real toolbarHeight: toolbarMetrics.implicitHeight
+
+    readonly property var spot: {
+        if (!root.active || !root.targetScreen) return null;
+        return RecordingRegion.placeToolbar(
+            root.region,
+            { x: root.targetScreen.x, y: root.targetScreen.y,
+              width: root.targetScreen.width, height: root.targetScreen.height },
+            { width: root.toolbarWidth, height: root.toolbarHeight },
+            Appearance.spacing.space100);
+    }
+
+    // Measured off-window so the placement has a size to work with before the
+    // window exists - the toolbar's own width decides where the window goes,
+    // and a window cannot be positioned by something it contains.
+    Item {
+        id: toolbarMetrics
+        visible: false
+        implicitWidth: Appearance.spacing.space100 * 2
+            + 36 * (2 + (ScreenRecord.replaying ? 1 : 0))
+            + Appearance.spacing.space50 * (1 + (ScreenRecord.replaying ? 1 : 0))
+        implicitHeight: 44
+    }
+
+    LazyLoader {
+        active: root.active && root.spot !== null
+
+        PanelWindow {
+            id: toolbarWindow
+            visible: true
+            screen: root.targetScreen
+            color: "transparent"
+            WlrLayershell.namespace: "quickshell:recordingRegion"
+            WlrLayershell.layer: WlrLayer.Overlay
+            WlrLayershell.keyboardFocus: WlrKeyboardFocus.None
+            exclusionMode: ExclusionMode.Ignore
+            implicitWidth: root.toolbarWidth
+            implicitHeight: root.toolbarHeight
+            // Anchored to the corner and pushed out by the margin, because a
+            // layer surface has no coordinates of its own. The margins are
+            // screen-relative; the placement is in global coordinates.
+            anchors { top: true; left: true }
+            margins {
+                top: (root.spot?.y ?? 0) - (root.targetScreen?.y ?? 0)
+                left: (root.spot?.x ?? 0) - (root.targetScreen?.x ?? 0)
+            }
+
+            Rectangle {
+                anchors.fill: parent
+                radius: Appearance.rounding.full
+                color: Appearance.colors.colLayer0
+                border.width: Appearance.borderWidth.standard
+                border.color: Appearance.colors.colLayer0Border
+
+                RowLayout {
+                    anchors.centerIn: parent
+                    spacing: Appearance.spacing.space50
+
+                    // Says which of the two states the capture is in, in a
+                    // place where the recording itself cannot show it.
+                    MaterialSymbol {
+                        Layout.leftMargin: Appearance.spacing.space50
+                        text: ScreenRecord.recordPaused ? "pause_circle" : "screen_record"
+                        iconSize: Appearance.font.pixelSize.large
+                        color: ScreenRecord.recordPaused
+                            ? Appearance.colors.colOnSurfaceVariant
+                            : Appearance.colors.colError
+                    }
+
+                    RippleButton {
+                        implicitWidth: 36
+                        implicitHeight: 36
+                        buttonRadius: Appearance.rounding.full
+                        releaseAction: () => ScreenRecord.togglePauseRecord()
+                        MaterialSymbol {
+                            anchors.centerIn: parent
+                            text: ScreenRecord.recordPaused ? "play_arrow" : "pause"
+                            iconSize: Appearance.font.pixelSize.normal
+                            color: Appearance.colors.colOnSurfaceVariant
+                        }
+                    }
+
+                    RippleButton {
+                        // Stop keeps the file - record.sh writes it out on
+                        // stop, so there is no separate save for a recording.
+                        implicitWidth: 36
+                        implicitHeight: 36
+                        buttonRadius: Appearance.rounding.full
+                        releaseAction: () => ScreenRecord.stopRecord()
+                        MaterialSymbol {
+                            anchors.centerIn: parent
+                            text: "stop"
+                            iconSize: Appearance.font.pixelSize.normal
+                            color: Appearance.colors.colError
+                        }
+                    }
+
+                    RippleButton {
+                        // Only while the replay ring buffer is armed: this
+                        // dumps the last N seconds to their own clip and
+                        // leaves both the buffer and this recording running.
+                        visible: ScreenRecord.replaying
+                        implicitWidth: 36
+                        implicitHeight: 36
+                        buttonRadius: Appearance.rounding.full
+                        releaseAction: () => ScreenRecord.saveReplay()
+                        MaterialSymbol {
+                            anchors.centerIn: parent
+                            text: "save"
+                            iconSize: Appearance.font.pixelSize.normal
+                            color: Appearance.colors.colPrimary
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/modules/imi/recordingRegion/RecordingRegionPanel.qml
+++ b/dots/.config/quickshell/imi/modules/imi/recordingRegion/RecordingRegionPanel.qml
@@ -23,6 +23,14 @@ import "recording_region.js" as RecordingRegion
  * the destructive action separated out as a paired FAB the way the selector
  * separates its close.
  *
+ * No tooltips on these buttons, deliberately. A StyledToolTip is a Controls
+ * Popup, and a Popup renders in the overlay of the window it belongs to - which
+ * here is a window the exact size of the toolbar. The tooltip has nowhere to go
+ * except on top of the buttons, it arrives with no delay, and while it is up it
+ * takes the pointer: arrow cursor, clicks swallowed. The selector's toolbar gets
+ * away with tooltips because its window is the whole screen and they have room
+ * above. If these controls ever need labels, they need a surface of their own.
+ *
  * The window is exactly the size of the controls and sits OUTSIDE the region.
  * gsr records whatever the compositor shows inside the rectangle, so anything
  * drawn over it would be in every frame of a clip that cannot be re-taken -
@@ -134,11 +142,6 @@ Scope {
                 text: ScreenRecord.recordPaused ? "play_arrow" : "pause"
                 toggled: ScreenRecord.recordPaused
                 releaseAction: () => ScreenRecord.togglePauseRecord()
-                StyledToolTip {
-                    text: ScreenRecord.recordPaused
-                        ? Translation.tr("Resume recording")
-                        : Translation.tr("Pause recording")
-                }
             }
 
             IconToolbarButton {
@@ -148,9 +151,6 @@ Scope {
                 visible: ScreenRecord.replaying
                 text: "save"
                 releaseAction: () => ScreenRecord.saveReplay()
-                StyledToolTip {
-                    text: Translation.tr("Save replay clip")
-                }
             }
         }
 
@@ -167,9 +167,6 @@ Scope {
             colRipple: Appearance.colors.colErrorContainerActive
             colOnBackground: Appearance.colors.colOnErrorContainer
             onClicked: ScreenRecord.stopRecord()
-            StyledToolTip {
-                text: Translation.tr("Stop recording")
-            }
         }
     }
 

--- a/dots/.config/quickshell/imi/modules/imi/recordingRegion/recording_region.js
+++ b/dots/.config/quickshell/imi/modules/imi/recordingRegion/recording_region.js
@@ -1,0 +1,73 @@
+.pragma library
+
+/**
+ * Where the controls for a region recording go, and how the region is read
+ * back from the string the recorder was started with.
+ *
+ * The one rule everything here follows: the toolbar must never overlap the
+ * region. A region recording captures whatever the compositor shows inside
+ * that rectangle, so a toolbar drawn over it is a toolbar recorded into the
+ * video - and worse, it is in every frame of a clip the user cannot re-take.
+ * Outside or not at all.
+ */
+
+// The geometry record.sh is handed: "X,Y WxH", as slurp writes it.
+const REGION_RE = /^(-?\d+),(-?\d+)\s+(\d+)x(\d+)$/;
+
+function parseRegion(text) {
+    const raw = (text === null || text === undefined) ? "" : String(text).trim();
+    const match = REGION_RE.exec(raw);
+    if (!match) return null;
+    const region = {
+        x: parseInt(match[1], 10),
+        y: parseInt(match[2], 10),
+        width: parseInt(match[3], 10),
+        height: parseInt(match[4], 10),
+    };
+    // A zero-sized region is not a region; it would put the toolbar at a point.
+    if (region.width <= 0 || region.height <= 0) return null;
+    return region;
+}
+
+/**
+ * Places the toolbar against the region, in screen coordinates.
+ *
+ * Below the region first, because that is where a caption belongs and where
+ * the eye already is after dragging a selection downward. Above when there is
+ * no room below. When neither side fits - a region tall enough to leave no gap,
+ * which in practice means a full-height or full-screen capture - the answer is
+ * `null`: no toolbar rather than one inside the frame. The bar's own recording
+ * indicator still offers stop in that case, so nothing is lost but the
+ * shortcut.
+ *
+ * Horizontally the toolbar is centred on the region and then clamped into the
+ * screen, so a region hard against an edge keeps all of its controls reachable.
+ */
+function placeToolbar(region, screen, toolbar, gap) {
+    if (!region || !screen || !toolbar) return null;
+    const spacing = (gap === undefined || gap === null) ? 8 : gap;
+
+    const below = region.y + region.height + spacing;
+    const above = region.y - spacing - toolbar.height;
+
+    let y;
+    let side;
+    if (below + toolbar.height <= screen.y + screen.height) {
+        y = below;
+        side = "below";
+    } else if (above >= screen.y) {
+        y = above;
+        side = "above";
+    } else {
+        return null;
+    }
+
+    const centred = region.x + (region.width - toolbar.width) / 2;
+    const leftLimit = screen.x + spacing;
+    const rightLimit = screen.x + screen.width - toolbar.width - spacing;
+    // Math.min first, then max: on a screen narrower than the toolbar the left
+    // edge wins, which keeps the first controls on screen rather than the last.
+    const x = Math.max(leftLimit, Math.min(centred, rightLimit));
+
+    return { x: Math.round(x), y: Math.round(y), side: side };
+}

--- a/dots/.config/quickshell/imi/panelFamilies/ImmaterialImpulseFamily.qml
+++ b/dots/.config/quickshell/imi/panelFamilies/ImmaterialImpulseFamily.qml
@@ -26,6 +26,7 @@ import qs.modules.imi.verticalBar
 import qs.modules.imi.wallpaperSelector
 import qs.modules.imi.desktopMenu
 import qs.modules.imi.dropShelf
+import qs.modules.imi.recordingRegion
 import qs.modules.imi.screenshotResult
 
 Scope {
@@ -57,4 +58,5 @@ Scope {
     PanelLoader { component: DesktopMenu {} }
     PanelLoader { component: DropShelfPanel {} }
     PanelLoader { component: ScreenshotResultPanel {} }
+    PanelLoader { component: RecordingRegionPanel {} }
 }

--- a/dots/.config/quickshell/imi/scripts/videos/record.sh
+++ b/dots/.config/quickshell/imi/scripts/videos/record.sh
@@ -15,12 +15,20 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 cfg() { jq -r "$1 // empty" "$CONFIG_FILE" 2>/dev/null; }
 
+# Writes the whole record.* block: the flag and the region it applies to.
+#
+# One writer, deliberately. The shell also owns this file, and it rewrites it
+# wholesale from its own in-memory copy - so a region written from QML right
+# after launching this script lands on top of the `enable = true` written here
+# milliseconds earlier, and the recording indicator never comes on. The region
+# is known here anyway; it has no business making the round trip.
 set_recording_state() {
-    local state=$1 tmp
+    local state=$1 region=${2-} tmp
     mkdir -p "$(dirname "$STATE_FILE")"
     [[ -f "$STATE_FILE" ]] || echo '{}' > "$STATE_FILE"
     tmp=$(mktemp)
-    jq ".record.enable = $state" "$STATE_FILE" > "$tmp" && mv "$tmp" "$STATE_FILE"
+    jq --arg region "$region" ".record.enable = $state | .record.region = \$region" \
+        "$STATE_FILE" > "$tmp" && mv "$tmp" "$STATE_FILE"
 }
 
 # Toggle: a recording we started is running -> stop it gracefully and exit.
@@ -174,7 +182,7 @@ fi
 "${ARGS[@]}" &
 GSR_PID=$!
 echo "$GSR_PID" > "$PIDFILE"
-set_recording_state true
+set_recording_state true "$REGION"
 notify-send "Recording started" "$(basename "$OUT")" -a 'Recorder' & disown
 
 # Block until gsr exits (stop toggle, crash, or logout) so the pidfile and the
@@ -182,4 +190,4 @@ notify-send "Recording started" "$(basename "$OUT")" -a 'Recorder' & disown
 # notification comes from the -sc hook with the real path.
 wait "$GSR_PID"
 rm -f "$PIDFILE"
-set_recording_state false
+set_recording_state false ""

--- a/dots/.config/quickshell/imi/tests/test_screen_record.py
+++ b/dots/.config/quickshell/imi/tests/test_screen_record.py
@@ -58,7 +58,18 @@ class RecordScriptTests(unittest.TestCase):
         self.assertEqual(out, "640x480+100+200")
 
     def test_maintains_recording_state_for_bar_indicator(self):
-        self.assertIn('".record.enable = $state"', self.script)
+        self.assertIn(".record.enable = $state", self.script)
+
+    def test_state_writes_the_flag_and_the_region_together(self):
+        # The shell rewrites this file wholesale from its own copy, so a region
+        # written from QML after launching the script lands on top of the
+        # `enable = true` written here and the recording indicator never comes
+        # on. One writer: the flag and the region go in the same jq update.
+        self.assertIn(".record.region = \\$region", self.script)
+        self.assertIn('jq --arg region "$region"', self.script)
+        # A full-screen capture stores no region, and must not inherit the last.
+        self.assertIn('set_recording_state true "$REGION"', self.script)
+        self.assertIn('set_recording_state false ""', self.script)
 
     def test_saved_hook_wired(self):
         self.assertIn("gsr-saved.sh", self.script)

--- a/dots/.config/quickshell/imi/tests/tst_recording_region.qml
+++ b/dots/.config/quickshell/imi/tests/tst_recording_region.qml
@@ -1,0 +1,104 @@
+import QtQuick
+import QtTest
+import "../modules/imi/recordingRegion/recording_region.js" as RecordingRegion
+
+// Behavioural tests for the recording-region toolbar's geometry.
+//
+// The load-bearing one is `test_toolbar_never_overlaps_the_region`: a region
+// recording captures whatever the compositor draws inside the rectangle, so a
+// toolbar that overlaps it is recorded into every frame of the clip. The rest
+// pin how the region string is read, since it comes back from a persisted
+// state file and is not necessarily what this shell wrote.
+TestCase {
+    name: "RecordingRegionTest"
+
+    readonly property var screen: ({ x: 0, y: 0, width: 1920, height: 1080 })
+    readonly property var toolbar: ({ width: 200, height: 40 })
+
+    // --- Reading the geometry the recorder was started with ---
+
+    function test_region_string_is_the_slurp_format() {
+        var region = RecordingRegion.parseRegion("100,200 640x480");
+        compare(region.x, 100);
+        compare(region.y, 200);
+        compare(region.width, 640);
+        compare(region.height, 480);
+    }
+
+    function test_a_region_that_is_not_one_reads_as_null() {
+        compare(RecordingRegion.parseRegion(""), null);
+        compare(RecordingRegion.parseRegion(null), null);
+        compare(RecordingRegion.parseRegion("garbage"), null);
+        compare(RecordingRegion.parseRegion("100,200 640x"), null);
+        // Zero-sized is not a region: it would place the toolbar at a point.
+        compare(RecordingRegion.parseRegion("100,200 0x480"), null);
+        compare(RecordingRegion.parseRegion("100,200 640x0"), null);
+    }
+
+    // --- Placement ---
+
+    function test_toolbar_sits_below_the_region_when_there_is_room() {
+        var region = { x: 400, y: 300, width: 600, height: 400 };
+        var spot = RecordingRegion.placeToolbar(region, screen, toolbar, 8);
+        compare(spot.side, "below");
+        compare(spot.y, 708);              // 300 + 400 + 8
+        compare(spot.x, 600);              // centred: 400 + (600 - 200) / 2
+    }
+
+    function test_toolbar_goes_above_when_the_region_reaches_the_bottom() {
+        var region = { x: 400, y: 300, width: 600, height: 770 };  // ends at 1070
+        var spot = RecordingRegion.placeToolbar(region, screen, toolbar, 8);
+        compare(spot.side, "above");
+        compare(spot.y, 252);              // 300 - 8 - 40
+    }
+
+    function test_no_toolbar_at_all_when_neither_side_fits() {
+        // A full-height region leaves nowhere outside it. The answer is no
+        // toolbar - the bar's recording indicator still stops the capture.
+        var region = { x: 0, y: 0, width: 1920, height: 1080 };
+        compare(RecordingRegion.placeToolbar(region, screen, toolbar, 8), null);
+    }
+
+    function test_toolbar_never_overlaps_the_region() {
+        // Every region that gets a toolbar, at a spread of sizes and positions:
+        // the toolbar's rect and the region's rect must not intersect.
+        var sizes = [40, 200, 700, 1000];
+        var positions = [0, 5, 250, 700, 1000];
+        for (var s = 0; s < sizes.length; s++) {
+            for (var p = 0; p < positions.length; p++) {
+                var region = { x: positions[p], y: positions[p], width: sizes[s], height: sizes[s] };
+                if (region.x + region.width > screen.width) continue;
+                if (region.y + region.height > screen.height) continue;
+                var spot = RecordingRegion.placeToolbar(region, screen, toolbar, 8);
+                if (spot === null) continue;
+                var overlaps = spot.x < region.x + region.width
+                    && spot.x + toolbar.width > region.x
+                    && spot.y < region.y + region.height
+                    && spot.y + toolbar.height > region.y;
+                verify(!overlaps,
+                    `toolbar at ${spot.x},${spot.y} overlaps region ${region.x},${region.y} ${region.width}x${region.height}`);
+            }
+        }
+    }
+
+    function test_toolbar_is_clamped_into_the_screen() {
+        // Hard against the left edge: centring would put it off-screen.
+        var left = RecordingRegion.placeToolbar({ x: 0, y: 100, width: 60, height: 60 }, screen, toolbar, 8);
+        compare(left.x, 8);
+        // Hard against the right edge.
+        var right = RecordingRegion.placeToolbar({ x: 1860, y: 100, width: 60, height: 60 }, screen, toolbar, 8);
+        compare(right.x, 1712);            // 1920 - 200 - 8
+    }
+
+    function test_placement_respects_a_screen_that_is_not_at_the_origin() {
+        // A second monitor to the right: the clamp is against THAT screen.
+        var secondary = { x: 1920, y: 0, width: 1920, height: 1080 };
+        var spot = RecordingRegion.placeToolbar({ x: 1920, y: 100, width: 60, height: 60 }, secondary, toolbar, 8);
+        compare(spot.x, 1928);             // 1920 + 8, not 8
+    }
+
+    function test_missing_inputs_place_nothing() {
+        compare(RecordingRegion.placeToolbar(null, screen, toolbar, 8), null);
+        compare(RecordingRegion.placeToolbar({ x: 0, y: 0, width: 10, height: 10 }, null, toolbar, 8), null);
+    }
+}


### PR DESCRIPTION
A region recording gives no sign of itself inside the frame — which is the point
— but that also made stopping one a trip to the bar for a control that could be
an inch from where you were already looking. This puts stop, pause and (while
the replay buffer is armed) save-clip against the rectangle being captured, for
as long as the recording runs.

**The toolbar is never inside the region.** gsr captures whatever the compositor
draws in that rectangle, so a toolbar over it is a toolbar in every frame of a
clip that cannot be re-taken. Placement goes below the region first, above when
there is no room below, and — when neither fits, i.e. a full-height or
full-screen capture — places nothing at all rather than place it inside. The bar
indicator still stops the recording in that case, so what is lost is a shortcut,
not the ability. The test sweeps a grid of sizes and positions asserting the two
rects never intersect; planting an overlapping placement fails four tests.

**One writer for the recording state.** The first version wrote the region from
QML right after launching `record.sh`. The shell rewrites that state file
wholesale from its own in-memory copy, so the write landed on top of the
`enable = true` the script had made milliseconds earlier and reverted it — the
recording ran with the shell believing nothing was recording. `record.sh` already
knows the region, so it now writes the flag and the region in one `jq` update and
the round trip is gone. A full-screen capture stores an empty region.

**Verified live through the selector**, not by calling the script:
- dragged out a region, recording started (`enable: true`, region `1,117 600x360`,
  gsr running with `-w region -region 600x360+1+117`)
- toolbar appeared below the region, centred and clear of it
- clicked **pause** → `paused: true`, indicator switched to `pause_circle`, the
  button became play
- clicked **stop** → recording ended, state cleared by the script, 3.9 MB / 40 s
  file written
- extracted a frame from the last two seconds of that clip, while the toolbar was
  on screen: only wallpaper, no toolbar

Suite 730 passing. One pre-existing flake seen once and not reproducible
(`test_present_settings_controls_reach_the_daemon`, a clight runtime test —
passes standalone, unrelated to these files).

Test recordings made during verification were deleted afterwards.

Docs: not needed — the constraint that makes this design what it is (a region
capture films the compositor, so controls must live outside the rectangle) is
recorded at the top of `recording_region.js`, next to the placement rule it
dictates, and the single-writer reasoning is in `record.sh` above the function
it applies to.