### PR TITLE
Fix four binding loops, and say what shape they share

### DIFF
--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopCurrencyWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopCurrencyWidget.qml
@@ -285,7 +285,22 @@ Item {
                 id: basePrefix
                 objectName: "currencyBasePrefix"
                 readonly property var slot: Geometry.basePrefixRect(root.sizeMode, root.spanW, root.spanH, Appearance.effectiveScale)
-                readonly property var lastSlot: slot ?? ({ x: x, y: y, size: font.pixelSize })
+                // The last settled slot, HELD rather than read back off the
+                // item. `slot ?? ({ ..., size: font.pixelSize })` looks like
+                // the same thing, but while the slot is null the fallback
+                // reads the very property it feeds - QML reported the loop on
+                // font.pixelSize. Holding the values means the element still
+                // fades out from exactly where it was, without asking itself
+                // where that is.
+                property real heldX: 0
+                property real heldY: 0
+                property real heldSize: font.pixelSize
+                onSlotChanged: if (slot !== null) {
+                    heldX = slot.x;
+                    heldY = slot.y;
+                    heldSize = slot.size;
+                }
+                readonly property var lastSlot: slot ?? ({ x: heldX, y: heldY, size: heldSize })
                 x: lastSlot.x
                 y: lastSlot.y
                 Behavior on x { SpanTravel {} }

--- a/dots/.config/quickshell/imi/modules/imi/recordingRegion/RecordingRegionPanel.qml
+++ b/dots/.config/quickshell/imi/modules/imi/recordingRegion/RecordingRegionPanel.qml
@@ -79,14 +79,36 @@ Scope {
     // answer and does not wait on a measurement.
     readonly property real controlsHeight: 56
 
-    readonly property var spot: {
+    // Two placements, split on purpose.
+    //
+    // `fit` answers "is there room, and on which side" using only the fixed
+    // container height, so it does NOT depend on the measured width - and the
+    // window's existence depends only on `fit`. Feeding the loader from a
+    // value that the loader's own content produces is a cycle, and QML said so:
+    // "Binding loop detected for property spot".
+    //
+    // `spot` then adds the horizontal placement, which does use the measured
+    // width. Nothing gates on it, so a width that arrives a frame later moves
+    // the window instead of re-creating it.
+    readonly property var fit: {
         if (!root.active || !root.targetScreen) return null;
         return RecordingRegion.placeToolbar(
             root.region,
             { x: root.targetScreen.x, y: root.targetScreen.y,
               width: root.targetScreen.width, height: root.targetScreen.height },
+            { width: 0, height: root.controlsHeight },
+            Appearance.spacing.space100 + root.shadowMargin);
+    }
+
+    readonly property var spot: {
+        if (!root.fit || !root.targetScreen) return null;
+        const placed = RecordingRegion.placeToolbar(
+            root.region,
+            { x: root.targetScreen.x, y: root.targetScreen.y,
+              width: root.targetScreen.width, height: root.targetScreen.height },
             { width: root.measuredWidth, height: root.controlsHeight },
             Appearance.spacing.space100 + root.shadowMargin);
+        return placed ?? root.fit;
     }
 
     component RecordingControls: RowLayout {
@@ -171,7 +193,7 @@ Scope {
     }
 
     LazyLoader {
-        active: root.active && root.spot !== null
+        active: root.active && root.fit !== null
 
         PanelWindow {
             id: toolbarWindow

--- a/dots/.config/quickshell/imi/modules/imi/regionSelector/OptionsToolbar.qml
+++ b/dots/.config/quickshell/imi/modules/imi/regionSelector/OptionsToolbar.qml
@@ -27,10 +27,30 @@ Toolbar {
     signal captureFullScreen()
 
     // The capture KIND, read off the action rather than stored twice - the
-    // action enum already says whether this is a shot or a recording, and a
-    // second copy of that fact is a second thing to keep in step.
-    readonly property bool recording: root.action === RegionSelection.SnipAction.Record
-        || root.action === RegionSelection.SnipAction.RecordWithSound
+    // action enum already says whether this is a shot or a recording.
+    //
+    // Recomputed in a handler rather than bound. `action` is a two-way
+    // Synchronizer property: this toolbar writes it and the selector writes it
+    // back, so a binding derived from it has its own dependency reassigned
+    // partway through the chain it starts - which is what QML was reporting as
+    // a binding loop on this property and on the tab bars' index below.
+    property bool recording: false
+    function kindFromAction() {
+        root.recording = root.action === RegionSelection.SnipAction.Record
+            || root.action === RegionSelection.SnipAction.RecordWithSound;
+        const index = root.recording ? 1 : 0;
+        if (kindBar.currentIndex !== index) kindBar.currentIndex = index;
+    }
+    function modeFromSelection() {
+        const index = root.selectionMode === RegionSelection.SelectionMode.RectCorners ? 0 : 1;
+        if (tabBar.currentIndex !== index) tabBar.currentIndex = index;
+    }
+    onActionChanged: root.kindFromAction()
+    onSelectionModeChanged: root.modeFromSelection()
+    Component.onCompleted: {
+        root.kindFromAction();
+        root.modeFromSelection();
+    }
 
     // Shot or recording. Both then take whichever TARGET the row beside this
     // one chooses, which is what makes six options out of two controls.
@@ -40,9 +60,6 @@ Toolbar {
             {"icon": "photo_camera", "name": Translation.tr("Shot")},
             {"icon": "videocam", "name": Translation.tr("Record")}
         ]
-        readonly property int kindIndex: root.recording ? 1 : 0
-        onKindIndexChanged: if (currentIndex !== kindIndex) currentIndex = kindIndex
-        Component.onCompleted: currentIndex = kindIndex
         onCurrentIndexChanged: {
             const wanted = currentIndex === 1
                 ? RegionSelection.SnipAction.Record
@@ -71,13 +88,9 @@ Toolbar {
             {"icon": "activity_zone", "name": Translation.tr("Rect")},
             {"icon": "gesture", "name": Translation.tr("Circle")}
         ]
-        // currentIndex aliases TabBar's own property, which the TabBar writes to
-        // as well, so binding it here while also writing back from the change
-        // handler is a binding loop. Sync both directions imperatively instead.
-        readonly property int modeIndex: root.selectionMode === RegionSelection.SelectionMode.RectCorners ? 0 : 1
-
-        onModeIndexChanged: if (currentIndex !== modeIndex) currentIndex = modeIndex
-        Component.onCompleted: currentIndex = modeIndex
+        // Driven from the toolbar's own handlers (see modeFromSelection): the
+        // index is never bound to `selectionMode`, only assigned to it and
+        // from it, so neither direction is a binding that can loop.
         onCurrentIndexChanged: {
             const newMode = currentIndex === 0 ? RegionSelection.SelectionMode.RectCorners : RegionSelection.SelectionMode.Circle;
             if (root.selectionMode !== newMode)


### PR DESCRIPTION
Four of the five binding loops the shell logs at startup, with the two shapes
that produced them.

**Derived from a two-way property** — `OptionsToolbar`. `action` and
`selectionMode` are `Synchronizer` properties: the toolbar writes them, the
selector writes them back. A `readonly property` derived from one has its own
dependency reassigned partway through the chain it starts, which QML reported
three times over (`recording`, `modeIndex`, the kind bar's index). The imperative
guards were already there and were never the problem — the derived bindings were.
Both bars are now driven from handlers on the toolbar, and `recording` is
assigned rather than bound.

**Gated on what it produces** — `RecordingRegionPanel`. `spot` needed the
controls' measured width, the window was positioned from `spot`, and the
`LazyLoader` creating that window was gated on `spot` — so the value deciding
whether the window exists came from the window's own content. Split: `fit`
answers "is there room, and on which side" from the fixed container height alone
and is the only thing the loader gates on; `spot` adds the horizontal placement
and nothing gates on it.

**Reading back the property it feeds** — `DesktopCurrencyWidget`. The fading "to"
fell back to `{ ..., size: font.pixelSize }` while its slot was null. It now holds
the last settled slot in plain properties.

**Verified** by capturing the shell's own log across a restart and exercising the
region selector: before, five `Binding loop detected` warnings; after, one.

**Still open — not fixed here.** `Dock.qml:152`, `implicitHeight`.
`dockHoverRegion.implicitHeight` comes from `dockBackground.implicitHeight`,
which in the horizontal case is `parent.height - margins` — the parent being
`dockHoverRegion` itself. The fix is to source that cross-axis size from
`dockRoot.dockThickness`, which already exists and is independent, rather than
from the parent. I left it alone because dock margins have a spec I'd want to
re-measure against rather than eyeball, and this PR is already the loop sweep.

Suite 730 passing.

Docs: not needed — each fix is explained at the site it applies to, including
why the obvious-looking version is the loop.