### PR TITLE
Settings: Ctrl+K or / focuses the search; dock stops sizing itself from its parent

### DIFF
--- a/dots/.config/quickshell/imi/modules/imi/dock/Dock.qml
+++ b/dots/.config/quickshell/imi/modules/imi/dock/Dock.qml
@@ -168,16 +168,26 @@ Scope {
                         // Along the strip the body is the icons' size plus a
                         // 5px shoulder; across it, the dock's thickness less
                         // the two margins the body's own anchors then apply.
+                        // Across the strip: the dock's own thickness less the
+                        // two margins, taken from the SAME derivation the
+                        // window is sized by rather than from `parent`.
+                        //
+                        // Reading the parent here was a cycle - the parent's
+                        // implicit size comes from this item - and QML broke it
+                        // by leaving the size stale, which is why the dock drew
+                        // as a full-width black band instead of a centred pill.
+                        // dockThickness is dockHeight + elevation + gaps, so
+                        // this is the configured dock height, arrived at
+                        // through the one derivation everything else uses.
+                        readonly property real crossAxis: dockRoot.dockThickness
+                            - Appearance.sizes.elevationMargin
+                            - Appearance.sizes.hyprlandGapsOut
                         implicitWidth: root.vertical
-                            ? parent.width
-                                - Appearance.sizes.elevationMargin
-                                - Appearance.sizes.hyprlandGapsOut
+                            ? crossAxis
                             : dockRow.implicitWidth + 5 * 2
                         implicitHeight: root.vertical
                             ? dockRow.implicitHeight + 5 * 2
-                            : parent.height
-                                - Appearance.sizes.elevationMargin
-                                - Appearance.sizes.hyprlandGapsOut
+                            : crossAxis
                         width: implicitWidth
                         height: implicitHeight
 

--- a/dots/.config/quickshell/imi/modules/imi/settings/SettingsContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/SettingsContent.qml
@@ -1,4 +1,5 @@
 import QtQuick
+import QtQuick.Window
 import QtQuick.Controls
 import QtQuick.Layouts
 import Quickshell
@@ -194,9 +195,39 @@ Item {
         })
     }
 
+    // Three ways to the search field, because three different habits reach for
+    // it: the platform's Find, the palette-style Ctrl+K, and the bare slash.
+    function focusSearch() {
+        settingsSearchField.forceActiveFocus();
+        // Select what is there rather than appending to it: the shortcut is
+        // pressed to start a NEW search far more often than to extend the last
+        // one, and a first keystroke that replaces is undone by one arrow key.
+        settingsSearchField.selectAll();
+    }
+
+    // A bare `/` has to yield to anything that takes typing, or a slash can
+    // never be entered into a field on any settings page - a path, a command,
+    // a URL. Text inputs are the things that expose `selectedText`; nothing
+    // else focusable in this window does.
+    readonly property bool typingSomewhere: {
+        const focused = root.Window.activeFocusItem;
+        return !!focused && focused.selectedText !== undefined;
+    }
+
     Shortcut {
         sequence: StandardKey.Find
-        onActivated: settingsSearchField.forceActiveFocus()
+        onActivated: root.focusSearch()
+    }
+
+    Shortcut {
+        sequences: ["Ctrl+K"]
+        onActivated: root.focusSearch()
+    }
+
+    Shortcut {
+        sequence: "/"
+        enabled: !root.typingSomewhere
+        onActivated: root.focusSearch()
     }
 
     Rectangle {
@@ -266,7 +297,11 @@ Item {
                     StyledText {
                         anchors.verticalCenter: parent.verticalCenter
                         visible: settingsSearchField.text.length === 0
-                        text: Translation.tr("Search settings and sections")
+                        // Names the shortcut, because a shortcut nobody is told
+                        // about is a shortcut nobody uses. `/` is the one worth
+                        // showing: it is the shorter reach and the one people
+                        // do not expect a settings window to have.
+                        text: Translation.tr("Search settings and sections  —  / or Ctrl+K")
                         color: Appearance.colors.colSubtext
                         font.pixelSize: Appearance.font.pixelSize.normal
                     }

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -278,6 +278,12 @@ if ! python3 "$SCRIPT_DIR/test_dock_position_contract.py"; then
     exit 1
 fi
 
+echo "Running settings search shortcut tests..."
+if ! python3 "$SCRIPT_DIR/test_settings_search_shortcuts.py"; then
+    echo "Settings search shortcut tests failed."
+    exit 1
+fi
+
 # A column of dock icons can lay out perfectly and still refuse to reorder,
 # because every slot centre shares an x - only real mouse events see that.
 # Brings its own headless weston.

--- a/dots/.config/quickshell/imi/tests/test_settings_search_shortcuts.py
+++ b/dots/.config/quickshell/imi/tests/test_settings_search_shortcuts.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+#
+# Contract for the settings search shortcuts.
+#
+# Three ways in - the platform Find, Ctrl+K, and a bare slash - and one rule
+# that is easy to lose in a refactor: the slash must be DISABLED while a text
+# input has focus. Without that gate no settings page can ever receive a typed
+# slash (a path, a command, a URL): the key would be swallowed to focus the
+# search field instead. That is the assertion worth keeping; the others are here
+# so the shortcuts do not quietly disappear.
+#
+# Static, because a Shortcut's activation needs a window, a compositor and a
+# keyboard. What can be checked without those is that the wiring says what it
+# should, and this catches the realistic regression: someone deleting the
+# `enabled` line while tidying.
+
+import re
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+CONTENT = ROOT / "modules" / "imi" / "settings" / "SettingsContent.qml"
+
+
+class SettingsSearchShortcutTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.source = CONTENT.read_text()
+
+    def shortcut_block(self, key_line):
+        """The Shortcut { ... } block whose sequence line matches."""
+        blocks = re.findall(r"Shortcut \{(.*?)\n    \}", self.source, re.S)
+        matching = [b for b in blocks if key_line in b]
+        self.assertEqual(len(matching), 1, f"expected exactly one Shortcut with {key_line!r}")
+        return matching[0]
+
+    def test_all_three_shortcuts_focus_the_search_field(self):
+        for key_line in ('sequence: StandardKey.Find', 'sequences: ["Ctrl+K"]', 'sequence: "/"'):
+            block = self.shortcut_block(key_line)
+            self.assertIn("focusSearch()", block,
+                          f"{key_line} does not reach the search field")
+
+    def test_slash_yields_while_a_text_input_has_focus(self):
+        block = self.shortcut_block('sequence: "/"')
+        self.assertIn("enabled: !root.typingSomewhere", block,
+                      "the bare slash is not gated on whether something is being typed into")
+
+    def test_the_gate_asks_the_focused_item_not_a_hardcoded_list(self):
+        # Duck-typed on `selectedText` so any text input counts, including ones
+        # added later; a list of type names would go stale silently.
+        self.assertIn("activeFocusItem", self.source)
+        self.assertIn("selectedText !== undefined", self.source)
+
+    def test_ctrl_f_is_not_replaced_by_the_new_bindings(self):
+        # The platform shortcut was there first and someone's fingers know it.
+        self.assertIn("StandardKey.Find", self.source)
+
+    def test_focusing_selects_what_is_already_there(self):
+        match = re.search(r"function focusSearch\(\) \{(.*?)\n    \}", self.source, re.S)
+        self.assertIsNotNone(match, "focusSearch() is gone")
+        body = match.group(1)
+        self.assertIn("forceActiveFocus()", body)
+        self.assertIn("selectAll()", body)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=1)


### PR DESCRIPTION
Two unrelated changes that happened to be in flight together; the dock commit is
first and stands alone if you would rather cherry-pick it.

**Dock: the body stops sizing itself from its own parent.** `dockBackground` took
its cross-axis size from `parent.height`, while the parent's implicit height came
from `dockBackground` — a cycle, logged at `Dock.qml:152` as a binding loop on
`implicitHeight`. QML breaks a cycle by leaving the value stale, and the stale
value drew the dock as a full-width black band across the screen instead of a
centred pill. It now takes that size from `dockRoot.dockThickness` — the same
derivation the window itself is sized by — less the two margins, which comes out
to the configured dock height through the one derivation everything else already
uses.

This fixes the **bottom** edge, verified by screenshot. The **vertical** edges are
broken in a different way — full-height band, no icons at all — and are NOT
addressed here; that is being worked on separately on `fix/dock-vertical-layout`,
with the measurements recorded there (layer surfaces are correct at every edge:
left `75x1440` @ x=0, right @ x=5045, top `5120x75` — so the fault is inside the
vertical layout, not the geometry that places the window).

**Settings: Ctrl+K or a bare slash focuses the search.** Ctrl+F was already bound
and stays bound; Ctrl+K is the palette habit, `/` is the shorter reach. The
placeholder now names both, because a shortcut nobody is told about is a shortcut
nobody uses.

The slash is disabled while a text input has focus — without that gate no settings
page could ever receive a typed slash (a path, a command, a URL), since the key
would be swallowed to focus the search instead. The gate asks the focused item
whether it exposes `selectedText` rather than matching a list of type names, so an
input added later is covered without anyone remembering. Focusing selects the
existing text: the shortcut starts a new search far more often than it extends the
last one.

`tests/test_settings_search_shortcuts.py` pins the gate specifically — deleting
the `enabled` line while tidying is the realistic regression. Proven to fail on
that exact mutation, then restored.

Suite 730 passing.

Docs: not needed — the shortcut is discoverable from the placeholder it now names
itself in, and the reasoning for each non-obvious choice (why the slash yields,
why the dock asks the thickness derivation instead of its parent) sits at the code
it applies to.