### PR TITLE
Dock: the turn is a size, not a different set of anchors

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1617,6 +1617,34 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
     deliberately unchanged: a failed lookup there is `undefined`, then NaN geometry, then a
     relayout that never converges and a pegged core — see the Design-language note on the missing
     `import qs.modules.common`. Restructure above them and nothing warns.
+  - **An item that turns must express the turn as a SIZE, never as a different set of anchors —
+    Qt punishes an axis holding two anchors in two different ways and neither is loud.** Writing
+    `left`/`right` for one orientation and `horizontalCenter` for the other reads as mutually
+    exclusive and is not: during the turn all three are live for a moment. `QQuickAnchors` then
+    **refuses the whole horizontal update and reverts the anchor it was setting**, so the item
+    keeps the anchors of *both* orientations and fills its parent in both axes — measured at
+    5120x1440 inside a 75x1440 layer surface, i.e. a full-height dark band with the icons spread
+    over a screen's width of which a side edge shows 75px. The only log line is `Cannot specify
+    left, right, and horizontalCenter anchors at the same time`, which names an item, not a
+    consequence. The *pair* is worse than the triple, because Qt honours it: `right` +
+    `horizontalCenter` is a legal way to state a width, so the anchor **writes** the item's width
+    as `2 * (right - hcenter)` — evaluated while the surface is still the size it had before the
+    compositor reconfigured it — and that write latches, because the size binding it clobbered has
+    finished changing by then and never re-evaluates to overwrite it. Nothing at all is logged for
+    that one: no binding loop, no warning, and QML that reads correctly. Which axis is ruined
+    depends on which one the turn landed on, so it presents as intermittent and as two unrelated
+    bugs. Everything in the dock now centres at every edge and takes its box from
+    `DockGeometry.contentBox()`, with the reveal push as a `horizontalCenterOffset`/
+    `verticalCenterOffset` times `DockGeometry.hideDirection()`; a centre offset is a number and
+    cannot occupy an axis. `tests/test_dock_position_contract.py` fails on any item in the dock's
+    tree binding a centre anchor together with either edge anchor of the same axis — its first run
+    found four more copies of the idiom (both sets of running dots, the window-preview card, the
+    context menu's card) that nobody had looked at. Note what this cost before it was found: the
+    dark band is also exactly what an empty layer surface looks like under the compositor's blur,
+    and two attempts went after `rules.lua` instead.
+    ("Dock: the body and the icon strip stop re-anchoring on the turn"),
+    ("Dock: the reveal becomes an offset, not an anchor that moves"),
+    ("Dock: one axis, one anchor - checked, because it was silent").
 
   The same contract test carries the "one derivation" lint (the analogue of
   `lint_bar_popup_overlay_static.py`'s rule for `barEdge`): a file may read

--- a/AGENT.md
+++ b/AGENT.md
@@ -1645,6 +1645,20 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
     ("Dock: the body and the icon strip stop re-anchoring on the turn"),
     ("Dock: the reveal becomes an offset, not an anchor that moves"),
     ("Dock: one axis, one anchor - checked, because it was silent").
+  - **A `PopupAnchor` given a `window` and no `rect` anchors to a POINT, so all four of its
+    `edges` mean the same place.** The window-preview popup names the corner it wants
+    (`popupAnchorSides()` — the inward side plus the start of the long axis) and got the window's
+    origin every time. That is correct at exactly two edges out of four, which is what made it
+    read as a vertical-dock bug: a bottom dock asks for top-LEFT and a right dock for left-TOP,
+    and both of those *are* (0, 0), while a left dock wants `(width, 0)` and a top dock
+    `(0, height)` — so on those two the popup opened **on top of the dock**, covering the icons it
+    belongs to (measured: a 247x1440 surface placed at x=0 against a 75x1440 dock). Every other
+    popup here passes an `item` as well, which is why none of them showed it. Pass an explicit
+    `rect` whenever the anchor is a window and the edges are meant to differ. Note the second,
+    separate fault stacked on top of it: the card *inside* that popup wrote one coordinate as a
+    binding and let an anchor write the other, and which axis is which swaps with the edge — see
+    the anchor-writes-a-property note above. ("Dock: the preview popup anchors to the dock's rect,
+    not to a point"), ("Dock: the preview card's own coordinates stop being half anchor").
 
   The same contract test carries the "one derivation" lint (the analogue of
   `lint_bar_popup_overlay_static.py`'s rule for `barEdge`): a file may read

--- a/dots/.config/quickshell/imi/modules/common/widgets/DockAppButton.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/DockAppButton.qml
@@ -167,18 +167,23 @@ DockButton {
                     // into its neighbour rather than out of the dock.
                     readonly property string dotSide: DockGeometry.outwardSide(root.dockEdge)
                     flow: root.dockVertical ? Flow.TopToBottom : Flow.LeftToRight
-                    anchors {
-                        top: dotSide === "bottom" ? iconImageLoader.bottom : undefined
-                        bottom: dotSide === "top" ? iconImageLoader.top : undefined
-                        left: dotSide === "right" ? iconImageLoader.right : undefined
-                        right: dotSide === "left" ? iconImageLoader.left : undefined
-                        topMargin: dotSide === "bottom" ? Appearance.spacing.space25 : 0
-                        bottomMargin: dotSide === "top" ? Appearance.spacing.space25 : 0
-                        leftMargin: dotSide === "right" ? Appearance.spacing.space25 : 0
-                        rightMargin: dotSide === "left" ? Appearance.spacing.space25 : 0
-                        horizontalCenter: root.dockVertical ? undefined : parent.horizontalCenter
-                        verticalCenter: root.dockVertical ? parent.verticalCenter : undefined
-                    }
+                    // Hung off the icon by an OFFSET rather than by an anchor
+                    // on the outward side. The anchor version moved between
+                    // sides when the dock turned, and for that turn the new
+                    // side and the centre anchor it replaces share one axis -
+                    // which Qt answers by writing the item's own width from
+                    // the two anchors instead of by ignoring one of them. See
+                    // Dock.qml's own strip, where the same pair left a 5120px
+                    // wide item inside a 75px surface.
+                    readonly property real dotPushX:
+                        (iconImageLoader.width + width) / 2 + Appearance.spacing.space25
+                    readonly property real dotPushY:
+                        (iconImageLoader.height + height) / 2 + Appearance.spacing.space25
+                    anchors.centerIn: parent
+                    anchors.horizontalCenterOffset: dotSide === "right" ? dotPushX
+                        : (dotSide === "left" ? -dotPushX : 0)
+                    anchors.verticalCenterOffset: dotSide === "bottom" ? dotPushY
+                        : (dotSide === "top" ? -dotPushY : 0)
                     Repeater {
                         model: Math.min(appToplevel.toplevels.length, 3)
                         delegate: Rectangle {

--- a/dots/.config/quickshell/imi/modules/common/widgets/DockContextMenu.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/DockContextMenu.qml
@@ -104,24 +104,13 @@ Item {
                 id: menuBackground
                 property real contentPadding: Appearance.spacing.space50
 
-                // The card hugs the side of its surface that faces the dock,
-                // pushed off it by the elevation margin so the shadow has
-                // somewhere to fall.
-                readonly property string dockSide: DockGeometry.outwardSide(root.dockEdge)
-                readonly property var cardMargins: DockGeometry.directedSides(
-                    root.dockEdge, 0, Appearance.sizes.elevationMargin)
-                anchors {
-                    top: menuBackground.dockSide === "top" ? parent.top : undefined
-                    bottom: menuBackground.dockSide === "bottom" ? parent.bottom : undefined
-                    left: menuBackground.dockSide === "left" ? parent.left : undefined
-                    right: menuBackground.dockSide === "right" ? parent.right : undefined
-                    horizontalCenter: root.dockVertical ? undefined : parent.horizontalCenter
-                    verticalCenter: root.dockVertical ? parent.verticalCenter : undefined
-                    topMargin: menuBackground.cardMargins.top
-                    bottomMargin: menuBackground.cardMargins.bottom
-                    leftMargin: menuBackground.cardMargins.left
-                    rightMargin: menuBackground.cardMargins.right
-                }
+                // The surface is the card plus an elevation margin on every
+                // side, so centring IS the old "hug the side facing the dock
+                // and push off it by the elevation margin" - it lands on the
+                // same pixel at all four edges, and it does so without an
+                // anchor that has to move to another side when the dock turns
+                // (see Dock.qml's strip for what that costs).
+                anchors.centerIn: parent
                 color: Appearance.m3colors.m3surfaceContainer
                 radius: Appearance.rounding.normal
                 implicitWidth: menuColumn.implicitWidth + contentPadding * 2

--- a/dots/.config/quickshell/imi/modules/common/widgets/DragApps.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/DragApps.qml
@@ -274,18 +274,20 @@ Item {
                             // a change made only there.
                             readonly property string dotSide: DockGeometry.outwardSide(root.dockEdge)
                             flow: root.vertical ? Flow.TopToBottom : Flow.LeftToRight
-                            anchors {
-                                top: dotSide === "bottom" ? appIcon.bottom : undefined
-                                bottom: dotSide === "top" ? appIcon.top : undefined
-                                left: dotSide === "right" ? appIcon.right : undefined
-                                right: dotSide === "left" ? appIcon.left : undefined
-                                topMargin: dotSide === "bottom" ? Appearance.spacing.space25 : 0
-                                bottomMargin: dotSide === "top" ? Appearance.spacing.space25 : 0
-                                leftMargin: dotSide === "right" ? Appearance.spacing.space25 : 0
-                                rightMargin: dotSide === "left" ? Appearance.spacing.space25 : 0
-                                horizontalCenter: root.vertical ? undefined : parent.horizontalCenter
-                                verticalCenter: root.vertical ? parent.verticalCenter : undefined
-                            }
+                            // The icon is centred in this slot, so hanging the
+                            // dots off it is a push from the same centre - and
+                            // an offset, unlike an anchor, cannot land on an
+                            // axis that already holds one when the dock turns.
+                            // See DockAppButton, which carries the other copy.
+                            readonly property real dotPushX:
+                                (appIcon.width + width) / 2 + Appearance.spacing.space25
+                            readonly property real dotPushY:
+                                (appIcon.height + height) / 2 + Appearance.spacing.space25
+                            anchors.centerIn: parent
+                            anchors.horizontalCenterOffset: dotSide === "right" ? dotPushX
+                                : (dotSide === "left" ? -dotPushX : 0)
+                            anchors.verticalCenterOffset: dotSide === "bottom" ? dotPushY
+                                : (dotSide === "top" ? -dotPushY : 0)
                             Repeater {
                                 model: Math.min(slotItem.appEntry?.toplevels?.length ?? 0, 3)
                                 delegate: Rectangle {
@@ -492,19 +494,20 @@ Item {
                 color: Appearance.m3colors.m3surfaceContainer
                 radius: Appearance.rounding.normal
                 // Pushed off the side facing the dock by the elevation margin,
-                // so the shadow has somewhere to fall.
-                readonly property var cardMargins: DockGeometry.directedSides(
-                    root.dockEdge, 0, Appearance.sizes.elevationMargin)
-                anchors.bottom: popupMouseArea.dockSide === "bottom" ? parent.bottom : undefined
-                anchors.top: popupMouseArea.dockSide === "top" ? parent.top : undefined
-                anchors.left: popupMouseArea.dockSide === "left" ? parent.left : undefined
-                anchors.right: popupMouseArea.dockSide === "right" ? parent.right : undefined
-                anchors.bottomMargin: cardMargins.bottom
-                anchors.topMargin: cardMargins.top
-                anchors.leftMargin: cardMargins.left
-                anchors.rightMargin: cardMargins.right
-                anchors.horizontalCenter: root.vertical ? undefined : parent.horizontalCenter
-                anchors.verticalCenter: root.vertical ? parent.verticalCenter : undefined
+                // so the shadow has somewhere to fall - said as a push from
+                // the centre rather than as an anchor on that side, for the
+                // reason the running dots above carry: the side an anchor
+                // lands on moves when the dock turns, and it moves onto the
+                // axis the centre anchor was holding.
+                readonly property real cardPushX:
+                    (parent.width - width) / 2 - Appearance.sizes.elevationMargin
+                readonly property real cardPushY:
+                    (parent.height - height) / 2 - Appearance.sizes.elevationMargin
+                anchors.centerIn: parent
+                anchors.horizontalCenterOffset: popupMouseArea.dockSide === "right" ? cardPushX
+                    : (popupMouseArea.dockSide === "left" ? -cardPushX : 0)
+                anchors.verticalCenterOffset: popupMouseArea.dockSide === "bottom" ? cardPushY
+                    : (popupMouseArea.dockSide === "top" ? -cardPushY : 0)
                 implicitHeight: previewRowLayout.implicitHeight + padding * 2
                 implicitWidth:  previewRowLayout.implicitWidth  + padding * 2
                 Behavior on implicitWidth {

--- a/dots/.config/quickshell/imi/modules/common/widgets/DragApps.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/DragApps.qml
@@ -471,17 +471,24 @@ Item {
             // Pinned to the popup's own inward side, which is the side facing
             // the dock.
             readonly property string dockSide: DockGeometry.outwardSide(root.dockEdge)
-            anchors.bottom: dockSide === "bottom" ? parent.bottom : undefined
-            anchors.top: dockSide === "top" ? parent.top : undefined
-            anchors.left: dockSide === "left" ? parent.left : undefined
-            anchors.right: dockSide === "right" ? parent.right : undefined
             implicitWidth:  popupBackground.implicitWidth + Appearance.sizes.elevationMargin * 2
             implicitHeight: root.maxWindowPreviewHeight
                             + root.windowControlsHeight
                             + Appearance.sizes.elevationMargin * 2
             hoverEnabled: true
-            x: root.vertical ? 0 : previewPopup.cachedCenter - width / 2
-            y: root.vertical ? previewPopup.cachedCenter - height / 2 : 0
+            // Hugs the side of the surface facing the dock, and centres on the
+            // hovered button along the strip. Both coordinates are written
+            // out, because the side an anchor lands on moves with the edge and
+            // an anchor WRITES the coordinate it pins - so after a turn from a
+            // side edge to a horizontal one, `x` stayed latched at what
+            // anchors.left had written and this binding never ran again. The
+            // card sat at the start of the strip rather than under the pointer
+            // - measured at x = 0 with cachedCenter reading 2413. Same fault
+            // as Dock.qml's own strip, one surface up.
+            readonly property real acrossX: dockSide === "right" ? parent.width - width : 0
+            readonly property real acrossY: dockSide === "bottom" ? parent.height - height : 0
+            x: root.vertical ? acrossX : previewPopup.cachedCenter - width / 2
+            y: root.vertical ? previewPopup.cachedCenter - height / 2 : acrossY
 
             StyledRectangularShadow {
                 target: popupBackground

--- a/dots/.config/quickshell/imi/modules/common/widgets/DragApps.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/DragApps.qml
@@ -438,6 +438,16 @@ Item {
 
         anchor {
             window: root.QsWindow.window
+            // The edges below are edges OF THIS RECT, and without it the rect
+            // is the window's origin - a point - so all four "edges" are the
+            // same place and only a corner that happens to be (0, 0) lands
+            // right. A bottom dock anchors top-left and a right dock
+            // left-top, so those two were correct by accident; a left dock
+            // wants (width, 0) and a top dock (0, height), and both opened
+            // ON TOP of the dock instead of beside it.
+            rect: Qt.rect(0, 0,
+                root.QsWindow.window?.width ?? 0,
+                root.QsWindow.window?.height ?? 0)
             adjustment: PopupAdjustment.None
             gravity: previewPopup.edgeFlags(previewPopup.anchorSides.gravity)
             edges: previewPopup.edgeFlags(previewPopup.anchorSides.edges)

--- a/dots/.config/quickshell/imi/modules/imi/dock/Dock.qml
+++ b/dots/.config/quickshell/imi/modules/imi/dock/Dock.qml
@@ -103,49 +103,51 @@ Scope {
             MouseArea {
                 id: dockMouseArea
                 // The strip fills the dock's thickness across its own axis and
-                // is sized by the icons along it.
-                width: root.vertical ? parent.width : implicitWidth
-                height: root.vertical ? implicitHeight : parent.height
+                // is sized by the icons along it. Across the axis that is
+                // exactly the surface, so centring is the same placement the
+                // reveal anchor used to give - with a membership that never
+                // changes.
+                readonly property var box: DockGeometry.contentBox(
+                    root.edge, dockRoot.dockThickness, implicitWidth, implicitHeight)
+                width: box.width
+                height: box.height
+
                 // The reveal is one number: revealed, a sliver, or one past
-                // gone. Which margin it lands on is the edge's business.
+                // gone. Which way it travels is the edge's business.
                 readonly property var revealOffsets: DockGeometry.revealOffsets(
                     dockRoot.dockThickness, Config.options?.dock.hoverRegionHeight ?? 2)
                 readonly property real revealOffset: dockRoot.reveal
                     ? revealOffsets.revealed
                     : (Config.options?.dock.hoverToReveal
                         ? revealOffsets.peeking : revealOffsets.hidden)
+                // Toward the screen edge the dock is on, so it travels off the
+                // screen to leave. A push the other way would slide it
+                // further ONTO the screen to hide.
+                readonly property real revealPush: dockMouseArea.revealOffset
+                    * DockGeometry.hideDirection(root.edge)
 
-                // The body hangs off the dock's INWARD side and the offset
-                // grows from there, so it travels toward the screen edge to
-                // leave. A dock anchored on its outward side would slide
-                // further onto the screen to hide.
-                readonly property string revealSide: DockGeometry.revealAnchorSide(root.edge)
-                anchors {
-                    top: dockMouseArea.revealSide === "top" ? parent.top : undefined
-                    bottom: dockMouseArea.revealSide === "bottom" ? parent.bottom : undefined
-                    left: dockMouseArea.revealSide === "left" ? parent.left : undefined
-                    right: dockMouseArea.revealSide === "right" ? parent.right : undefined
-                    topMargin: dockMouseArea.revealSide === "top" ? dockMouseArea.revealOffset : 0
-                    bottomMargin: dockMouseArea.revealSide === "bottom" ? dockMouseArea.revealOffset : 0
-                    leftMargin: dockMouseArea.revealSide === "left" ? dockMouseArea.revealOffset : 0
-                    rightMargin: dockMouseArea.revealSide === "right" ? dockMouseArea.revealOffset : 0
-                    horizontalCenter: root.vertical ? undefined : parent.horizontalCenter
-                    verticalCenter: root.vertical ? parent.verticalCenter : undefined
-                }
+                // The strip used to anchor to its inward side and grow that
+                // margin to push itself out, which means the anchor moves to
+                // another side when the dock turns. During the turn the new
+                // side and the old centre anchor are both live on ONE axis,
+                // and Qt answers `right` + `horizontalCenter` by WRITING the
+                // item's width (2 * (right - hcenter)) - measured at 5120 on
+                // a surface that was already 75 wide. That write outlives the
+                // binding it clobbered, because `box` has finished changing
+                // by then and never re-evaluates. Centre at every edge and
+                // push with an offset instead: same placement, one membership.
+                anchors.centerIn: parent
+                anchors.horizontalCenterOffset: root.vertical ? dockMouseArea.revealPush : 0
+                anchors.verticalCenterOffset: root.vertical ? 0 : dockMouseArea.revealPush
+
                 implicitWidth: dockHoverRegion.implicitWidth + Appearance.sizes.elevationMargin * 2
                 implicitHeight: dockHoverRegion.implicitHeight + Appearance.sizes.elevationMargin * 2
                 hoverEnabled: true
 
-                Behavior on anchors.topMargin {
+                Behavior on anchors.horizontalCenterOffset {
                     animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
                 }
-                Behavior on anchors.bottomMargin {
-                    animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
-                }
-                Behavior on anchors.leftMargin {
-                    animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
-                }
-                Behavior on anchors.rightMargin {
+                Behavior on anchors.verticalCenterOffset {
                     animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
                 }
 

--- a/dots/.config/quickshell/imi/modules/imi/dock/Dock.qml
+++ b/dots/.config/quickshell/imi/modules/imi/dock/Dock.qml
@@ -157,39 +157,29 @@ Scope {
 
                     Item {
                         id: dockBackground
-                        anchors {
-                            top: root.vertical ? undefined : parent.top
-                            bottom: root.vertical ? undefined : parent.bottom
-                            left: root.vertical ? parent.left : undefined
-                            right: root.vertical ? parent.right : undefined
-                            horizontalCenter: root.vertical ? undefined : parent.horizontalCenter
-                            verticalCenter: root.vertical ? parent.verticalCenter : undefined
-                        }
-                        // Along the strip the body is the icons' size plus a
-                        // 5px shoulder; across it, the dock's thickness less
-                        // the two margins the body's own anchors then apply.
-                        // Across the strip: the dock's own thickness less the
-                        // two margins, taken from the SAME derivation the
-                        // window is sized by rather than from `parent`.
-                        //
-                        // Reading the parent here was a cycle - the parent's
-                        // implicit size comes from this item - and QML broke it
-                        // by leaving the size stale, which is why the dock drew
-                        // as a full-width black band instead of a centred pill.
-                        // dockThickness is dockHeight + elevation + gaps, so
-                        // this is the configured dock height, arrived at
-                        // through the one derivation everything else uses.
-                        readonly property real crossAxis: dockRoot.dockThickness
-                            - Appearance.sizes.elevationMargin
-                            - Appearance.sizes.hyprlandGapsOut
-                        implicitWidth: root.vertical
-                            ? crossAxis
-                            : dockRow.implicitWidth + 5 * 2
-                        implicitHeight: root.vertical
-                            ? dockRow.implicitHeight + 5 * 2
-                            : crossAxis
-                        width: implicitWidth
-                        height: implicitHeight
+                        // One anchor at every edge, because the turn is a
+                        // change of size rather than of anchors. The body used
+                        // to anchor both ends of its across axis and centre on
+                        // the other, which means the SET of anchors changes
+                        // when the dock turns - and Qt refuses the moment when
+                        // left, right and horizontalCenter are all live rather
+                        // than re-applying once the third clears. It kept both
+                        // orientations' anchors and filled the surface in both
+                        // axes: a full-screen pill with the icons spread over
+                        // 5120px, of which a side edge shows 75.
+                        anchors.centerIn: parent
+
+                        // The dock's whole thickness across its own axis - the
+                        // visual background insets the two margins out of it -
+                        // and the icons plus a 5px shoulder along the strip.
+                        readonly property var box: DockGeometry.contentBox(
+                            root.edge, dockRoot.dockThickness,
+                            dockRow.implicitWidth + 5 * 2,
+                            dockRow.implicitHeight + 5 * 2)
+                        implicitWidth: box.width
+                        implicitHeight: box.height
+                        width: box.width
+                        height: box.height
 
                         StyledRectangularShadow {
                             target: dockVisualBackground
@@ -220,12 +210,16 @@ Scope {
                         GridLayout {
                             id: dockRow
                             flow: root.vertical ? GridLayout.TopToBottom : GridLayout.LeftToRight
-                            anchors.top: root.vertical ? undefined : parent.top
-                            anchors.bottom: root.vertical ? undefined : parent.bottom
-                            anchors.left: root.vertical ? parent.left : undefined
-                            anchors.right: root.vertical ? parent.right : undefined
-                            anchors.horizontalCenter: root.vertical ? undefined : parent.horizontalCenter
-                            anchors.verticalCenter: root.vertical ? parent.verticalCenter : undefined
+                            // Same reasoning as the body above: the strip is
+                            // centred at every edge and takes its size from
+                            // the module, so no anchor has to appear or
+                            // disappear when the dock turns.
+                            anchors.centerIn: parent
+                            readonly property var box: DockGeometry.contentBox(
+                                root.edge, dockRoot.dockThickness,
+                                implicitWidth, implicitHeight)
+                            width: box.width
+                            height: box.height
                             rowSpacing: Appearance.spacing.space50
                             columnSpacing: Appearance.spacing.space50
                             property real padding: Appearance.spacing.space100

--- a/dots/.config/quickshell/imi/modules/imi/dock/dock_geometry.js
+++ b/dots/.config/quickshell/imi/modules/imi/dock/dock_geometry.js
@@ -117,6 +117,23 @@ function margins(edge, elevationMargin, gapsOut) {
     return directedSides(edge, pair.inward, pair.outward);
 }
 
+// The box of anything that spans the dock's thickness and is sized by its
+// content along the strip: the thickness ACROSS the dock's own axis, the
+// item's own implicit size ALONG it.
+//
+// This exists so the turn is a change of SIZE. An item that anchors the two
+// ends of its across axis and centres on the other has to change WHICH
+// anchors it uses when the dock turns, and Qt refuses a set that is
+// momentarily {left, right, horizontalCenter} instead of re-applying it once
+// the third clears - the item keeps the anchors of both orientations and
+// fills the whole surface. Handing the size over means the anchors can stay
+// `centerIn: parent` at every edge, which is a membership that never changes.
+function contentBox(edge, thickness, alongWidth, alongHeight) {
+    return isVertical(edge)
+        ? { width: thickness, height: alongHeight }
+        : { width: alongWidth, height: thickness };
+}
+
 // How far the dock is pushed off-screen when hidden, and how far it peeks
 // when the pointer is near. Both are the INWARD margin's value, so the reveal
 // is one animated number at every edge.

--- a/dots/.config/quickshell/imi/modules/imi/dock/dock_geometry.js
+++ b/dots/.config/quickshell/imi/modules/imi/dock/dock_geometry.js
@@ -149,14 +149,6 @@ function revealOffsets(dockThickness, hoverRegion) {
     };
 }
 
-// Which side of its own surface the reveal push lands on. A dock anchors the
-// body to its INWARD side and grows the margin there to shove it out: a
-// bottom dock that pushed its bottomMargin would slide further onto the
-// screen to hide.
-function revealAnchorSide(edge) {
-    return inwardSide(edge);
-}
-
 // Which way a popup opens from a dock on this edge: away from the edge, or
 // the menu opens into it and is clipped.
 function popupGravity(edge) {

--- a/dots/.config/quickshell/imi/tests/test_dock_position_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_dock_position_contract.py
@@ -47,6 +47,40 @@ SIDE_BOUND_TOKEN = re.compile(
     r"(top|bottom|left|right)(Margin|Inset)\s*:[^\n]*"
     r"(elevationMargin|hyprlandGapsOut)")
 
+# The anchor LINES, which decide an item's geometry. `centerIn`, the margins
+# and the two centre offsets are deliberately absent: they are numbers and a
+# whole-item shorthand, and neither can put two anchors on one axis.
+ANCHOR_LINES = ("top", "bottom", "left", "right",
+                "horizontalCenter", "verticalCenter")
+AXES = (({"left", "right"}, "horizontalCenter"),
+        ({"top", "bottom"}, "verticalCenter"))
+
+
+def anchor_groups(source):
+    """The anchor-line names each item binds, one set per declaration site."""
+    for opening in re.finditer(r"\banchors\s*\{", source):
+        index, depth = opening.end(), 1
+        while depth and index < len(source):
+            depth += {"{": 1, "}": -1}.get(source[index], 0)
+            index += 1
+        block = source[opening.end():index - 1]
+        yield ({name for name in ANCHOR_LINES
+                if re.search(rf"(?:^|\n)\s*{name}\s*:", block)}, block)
+
+    # ...and the same declarations written out one `anchors.x:` line at a
+    # time, which is one item's anchors exactly when the lines are adjacent.
+    names, lines = set(), []
+    for line in source.splitlines() + [""]:
+        dotted = re.match(r"\s*anchors\.(\w+)\s*:", line)
+        if dotted:
+            if dotted.group(1) in ANCHOR_LINES:
+                names.add(dotted.group(1))
+            lines.append(line)
+            continue
+        if names:
+            yield names, "\n".join(lines)
+        names, lines = set(), []
+
 
 class DockPositionContractTest(unittest.TestCase):
     def qml_sources(self):
@@ -134,6 +168,36 @@ class DockPositionContractTest(unittest.TestCase):
                 offender,
                 f"{path.name} binds the elevation/gap pair to a side: "
                 f"{offender.group(0) if offender else ''}")
+
+    def test_the_turn_never_moves_an_anchor_onto_an_occupied_axis(self):
+        # The dock's body, its strip and its hover area each anchored the two
+        # ends of whichever axis they spanned and centred on the other, so the
+        # SET of anchors changed when the dock turned. Qt does not merely
+        # ignore an axis holding two anchors during that turn:
+        #
+        #   left + right + horizontalCenter is refused outright, and the item
+        #   keeps the anchors of BOTH orientations - measured at 5120x1440
+        #   inside a 75x1440 surface, which is a full-height dark band with
+        #   the icons spread over a screen's width, of which a side edge shows
+        #   75px;
+        #
+        #   right + horizontalCenter alone makes the ANCHOR write the item's
+        #   width (2 * (right - hcenter)) - measured at 5120 against a content
+        #   item that was already 75 wide - and that write outlives the size
+        #   binding it clobbered, because the binding has finished changing by
+        #   then and never re-evaluates.
+        #
+        # Both are silent: no error, no binding loop, and QML that reads
+        # correctly. So the check is structural - one axis, one anchor - and
+        # the turn is expressed as a size (DockGeometry.contentBox) and an
+        # offset (DockGeometry.hideDirection) instead.
+        for path in EDGE_AWARE:
+            for names, block in anchor_groups(path.read_text(encoding="utf-8")):
+                for ends, centre in AXES:
+                    if centre in names and names & ends:
+                        self.fail(
+                            f"{path.name} anchors {sorted(names & ends)} and "
+                            f"{centre} on one axis:\n{block.strip()}")
 
     # ---- the vertical layout --------------------------------------------
 

--- a/dots/.config/quickshell/imi/tests/test_dock_position_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_dock_position_contract.py
@@ -55,6 +55,18 @@ ANCHOR_LINES = ("top", "bottom", "left", "right",
 AXES = (({"left", "right"}, "horizontalCenter"),
         ({"top", "bottom"}, "verticalCenter"))
 
+# One anchor line and whatever it is bound to.
+ANCHOR_LINE_BINDING = re.compile(
+    r"(?:^|\n)\s*(?:anchors\.)?(" + "|".join(ANCHOR_LINES) + r")\s*:([^\n]*)")
+# ...bound to something that varies with the dock's edge. `Side` catches the
+# derived names (outwardSide, dotSide, revealSide, dockSide); `vertical` needs
+# its word boundary or it matches `verticalCenter`.
+EDGE_DEPENDENT = re.compile(r"\b(vertical|dockVertical|dockEdge|edge)\b|Side\b")
+# The layer surface's own anchors are the exception: booleans the compositor
+# applies to a surface, not QQuickAnchors, and the one thing that genuinely
+# does have to change with the edge.
+SURFACE_ANCHORS = "DockGeometry.anchors("
+
 
 def anchor_groups(source):
     """The anchor-line names each item binds, one set per declaration site."""
@@ -198,6 +210,29 @@ class DockPositionContractTest(unittest.TestCase):
                         self.fail(
                             f"{path.name} anchors {sorted(names & ends)} and "
                             f"{centre} on one axis:\n{block.strip()}")
+
+    def test_no_anchor_in_the_dock_changes_with_the_edge(self):
+        # The general form of the rule above, and the one that catches the
+        # second way an anchor ruins a property: an anchor WRITES whatever it
+        # pins, so one that appears when the dock turns overwrites the binding
+        # that owns that coordinate, and the binding never runs again to take
+        # it back. The window-preview card's `x` was left at 0 that way - it
+        # had been written by an `anchors.left` that only exists while the dock
+        # is on a side edge, and afterwards the card sat at the end of the
+        # strip instead of under the icon the pointer was on.
+        #
+        # So: the turn is a size, an offset or a coordinate, never an anchor.
+        # The layer surface's own anchors are exempt - those are booleans the
+        # compositor applies, and they are the one thing that has to change.
+        for path in EDGE_AWARE:
+            source = path.read_text(encoding="utf-8")
+            for line, expression in ANCHOR_LINE_BINDING.findall(source):
+                if SURFACE_ANCHORS in expression:
+                    continue
+                self.assertIsNone(
+                    EDGE_DEPENDENT.search(expression),
+                    f"{path.name} makes the `{line}` anchor follow the edge:"
+                    f"{expression}")
 
     # ---- the vertical layout --------------------------------------------
 

--- a/dots/.config/quickshell/imi/tests/test_dock_position_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_dock_position_contract.py
@@ -58,7 +58,8 @@ class DockPositionContractTest(unittest.TestCase):
         self.assertIn("dock_geometry.js", source)
         for derived in ("DockGeometry.thickness(", "DockGeometry.exclusiveZone(",
                         "DockGeometry.anchors(", "DockGeometry.margins(",
-                        "DockGeometry.revealOffsets(", "DockGeometry.revealAnchorSide("):
+                        "DockGeometry.revealOffsets(", "DockGeometry.hideDirection(",
+                        "DockGeometry.contentBox("):
             self.assertIn(derived, source, f"{derived} is spelled out again")
         # The arithmetic itself may not reappear in the QML.
         self.assertNotIn("anchors { bottom: true; left: true; right: true }", source,

--- a/dots/.config/quickshell/imi/tests/tst_dock_geometry.qml
+++ b/dots/.config/quickshell/imi/tests/tst_dock_geometry.qml
@@ -159,15 +159,15 @@ TestCase {
         compare(Geometry.inwardSide("bottom"), "top");
         compare(Geometry.inwardSide("left"), "right");
         compare(Geometry.outwardSide("left"), "left");
-        // The reveal anchors inward and pushes the body outward from there; a
-        // dock that anchored its outward side would slide ONTO the screen to
-        // hide.
-        for (const edge of ["top", "bottom", "left", "right"])
-            compare(Geometry.revealAnchorSide(edge), Geometry.inwardSide(edge),
-                    edge + " reveals along its inward side");
-        // ...and a popup opens the same way, so neither can drift.
-        for (const edge of ["top", "bottom", "left", "right"])
+        // The reveal pushes the body OUTWARD from where it rests, and a popup
+        // opens inward, so the two are one relation read in both directions.
+        for (const edge of ["top", "bottom", "left", "right"]) {
             compare(Geometry.popupGravity(edge), Geometry.inwardSide(edge));
+            const push = Geometry.hideDirection(edge);
+            const outward = Geometry.outwardSide(edge);
+            compare(push > 0, outward === "bottom" || outward === "right",
+                    edge + " hides toward its own edge, not onto the screen");
+        }
     }
 
     function test_a_directed_pair_never_touches_the_long_axis() {

--- a/dots/.config/quickshell/imi/tests/tst_dock_geometry.qml
+++ b/dots/.config/quickshell/imi/tests/tst_dock_geometry.qml
@@ -78,6 +78,27 @@ TestCase {
         verify(Geometry.hideDirection("left") < 0);
     }
 
+    function test_the_turn_is_a_size_rather_than_a_set_of_anchors() {
+        // contentBox exists so an item that spans the dock's thickness never
+        // has to change WHICH anchors it uses when the dock turns: the
+        // thickness lands across the dock's own axis and the item's own
+        // implicit size along it.
+        const horizontal = Geometry.contentBox("bottom", 75, 613, 397);
+        compare(horizontal.width, 613, "along the strip it is the icons' size");
+        compare(horizontal.height, 75, "across it, the dock's whole thickness");
+        const vertical = Geometry.contentBox("left", 75, 613, 397);
+        compare(vertical.width, 75);
+        compare(vertical.height, 397);
+        // The two axes genuinely swap - the same call at opposite edges must
+        // not agree on either dimension.
+        verify(horizontal.width !== vertical.width
+               && horizontal.height !== vertical.height);
+        // An unknown edge is the dock we already ship, here too.
+        const nonsense = Geometry.contentBox("diagonal", 75, 613, 397);
+        compare(nonsense.width, horizontal.width);
+        compare(nonsense.height, horizontal.height);
+    }
+
     function test_a_popup_opens_away_from_the_edge() {
         compare(Geometry.popupGravity("bottom"), "top");
         compare(Geometry.popupGravity("top"), "bottom");


### PR DESCRIPTION
At a left or right edge the dock rendered as a full-height dark band with no
icons, and the window preview opened on top of the dock instead of beside it.
Both are the same class of fault, met three times: **an anchor that changes with
the edge**.

## What was measured

The layer surface was never wrong. `hyprctl layers -j` reports 75x1440 at x=0
for left, 75x1440 at x=5045 for right, 5120x75 at y=0 for top. The fault was
entirely in what the surface contains, and there are three distinct ones.

**1. An axis holding two anchors, refused.** `dockBackground` and `dockRow` each
anchored both ends of the axis they span and centred on the other, so the *set*
of anchors differs between a horizontal edge and a vertical one. Turning between
them puts `left`, `right` and `horizontalCenter` live at the same moment;
QQuickAnchors refuses the whole update rather than picking one, and the item
keeps the anchors of **both** orientations. Measured at 5120x1440 inside a
75x1440 surface — a full-screen pill with the icons laid out across a screen's
width, of which a side edge shows 75px. One log line, naming an item and not a
consequence.

**2. An axis holding two anchors, honoured.** The hover strip anchored to the
dock's inward side and grew that margin to push itself out. That side moves with
the edge, and it moves onto the axis the centre anchor already held. `right` +
`horizontalCenter` is a legal way to state a width, so the anchor **writes** the
item's width as `2 * (right - hcenter)` — evaluated while the surface is still
the size it had before the compositor reconfigured it. Measured, with the shell
settled at the left edge: content item 75x1440, the strip's own derivation says
75x397, and the strip is 5120 wide at x=-5045. The write outlives the binding it
clobbered, because that binding has finished changing by then and never
re-evaluates. Nothing at all is logged.

**3. A window anchor with no rect.** The preview popup names the corner it wants
and never gave the anchor a `rect`, so the default is the window's *origin* — a
point, where all four "edges" are the same place. Correct at exactly two edges
out of four (a bottom dock asks for top-left and a right dock for left-top, and
both of those *are* `(0, 0)`), which is why it read as a vertical-dock bug: a
247x1440 popup placed at x=0 against a 75x1440 dock, i.e. over the icons. The
card inside it had fault 2 as well — one coordinate a binding, the other an
anchor, trading places on every turn — and sat at x=0 while the hovered icon's
centre read 2413.

## The fix

The turn is a **size**, an **offset** or a **coordinate**, never an anchor.
Everything centres at every edge and takes its box from
`DockGeometry.contentBox()`; the reveal push is a centre offset times
`DockGeometry.hideDirection()`, which had a test and no caller and is exactly
this number. `revealAnchorSide()` goes with the anchor it named. The same pair
was written in four more places — both sets of running dots, the preview card
and the context menu's card — and each is now a push from the centre.

Geometry is preserved, not approximated. Bottom edge, before and after: body
613x75 at (10,0) inside a 633x75 hover region, strip 603x75 at (5,0) inside it.

## Verification

Deployed and driven through every edge and every transition between them, with
the surface read from `hyprctl` and the result read off the screen:

- **bottom, top, left, right** — pill and icons render at each; running dots on
  the screen-edge side (below at the bottom, above at the top, beside the icons
  at left and right).
- **transitions** — `bottom → left → right → top → bottom → left → right → top →
  bottom` in a live shell, no restart; every one reflows in place, and the
  anchor-conflict warnings are gone.
- **reveal** — unpinned, the peeking strip sits at `x=-73` at the left edge,
  `+73` at the right, `y=-73` at the top and `+73` at the bottom, revealed at 0.
- **window previews** — hovered an icon at each of the four edges; the card sits
  above the strip at the bottom, below it at the top, beside it at left and
  right, centred on the pointer every time.
- **context menu** — opened at the left edge, renders beside the icon.

## Tests

`tests/test_dock_position_contract.py` gains two checks, both proven to fail by
planting the code they forbid:

- no item in the dock's tree may bind a centre anchor together with either edge
  anchor of the same axis;
- no anchor in the dock's tree may follow the edge at all — the layer surface's
  own anchors are exempt and named, because those are booleans the compositor
  applies.

The second one's first run against the real tree is what found the four other
copies of the idiom. `tests/tst_dock_geometry.qml` covers `contentBox()`.
731 passing, unchanged.

Docs: updated AGENT.md §The dock's four edges — what an axis holding two anchors costs in each of its two forms, and that a `PopupAnchor` with a window and no `rect` anchors to a point
