### PR TITLE
Widgets: notes and image-converter draw their surface on the shared card

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1328,14 +1328,31 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   surface a widget paints**: calendar still thins its 1x1 banner, its month pill, its day grid and
   today's highlight so the frost reads through the whole widget, and it does that with
   `transparentize` rather than the card's `applyAlpha` because `colLayer1` already carries an alpha
-  the widget must *scale* rather than overwrite — `lint_widget_card_tint.py` reserves the card's
-  spelling and deliberately does not match that one. And **the card routes children into its own
+  the widget must *scale* rather than overwrite — `lint_widget_card_tint.py` leaves a content tint
+  alone, and the next entry is how it now tells one from the card's own. And **the card routes children into its own
   content item**, so anything that anchored to the old `Rectangle` by id (calendar's two corner
   handles did) has to anchor to `parent` instead: an anchor may only name a parent or a sibling, and
   the card is now the grandparent. Neither of those is caught by the tint lint;
   `test_expressive_design_system.py` pins the composition and `test_calendar_card.py` renders it,
   because a content-sized widget whose card failed to resolve is a zero-size widget rather than an
   error. 486272dbe ("feat(calendar): draw the widget's surface on the shared card").
+- **A widget that paints its own root surface hides the card, so it has no shadow at all — and a
+  carve-out written as a spelling stops being a rule the moment someone spells it differently.**
+  `notes` and `image-converter` were both a root `Rectangle` painting
+  `blurEnabled ? transparentize(colSecondaryContainer, ...)`: the card's own surface, written in the
+  *content* tint's dialect. `lint_widget_card_tint.py` matched only
+  `useBlurBackground ? applyAlpha(` and waved both through, so they shipped as the two widgets on a
+  twelve-widget desktop casting no shadow — and neither could have lifted on hover or drag if one
+  had been added, since neither declared `hostDragging`. Note the cost is not the redundancy the
+  card was extracted to remove: a root surface is painted *over* the card, which is why the symptom
+  is absence rather than a second slightly-different tuning. The lint now decides by **position**
+  rather than by helper name — it reads the root object of every desktop widget's entry point,
+  found from the manifests' `desktop-widget` capability (so `discordVoice`, a bar/overlay panel and
+  not a desktop card, is out of scope by the data rather than by an allowlist), follows one level of
+  `color: root.someProperty` indirection, and flags a blur-gated tint there whichever helper it
+  calls. Content tints, which are surfaces *inside* the card, stay free.
+  test(lint): the card-tint carve-out is scoped to content, not to a spelling,
+  fix(notes): draw the widget's surface on the shared card.
 - **The resize grip accumulates tension; it does not pick the nearest span.** A widget holds its
   span while pull builds, gives one offered span per 60px breakaway with the remainder carried, and
   rubber-bands at a wall. `resize-tension.js` owns every constant and all of the arithmetic; the

--- a/docs/widget-standards-audit-2026-08-16.md
+++ b/docs/widget-standards-audit-2026-08-16.md
@@ -138,6 +138,14 @@ inferred". I read `currency_geometry.js`; it does return null. The finding stand
 
 ### G2 — `notes` and `image-converter` are the two desktop widgets with no shadow at all (standard 3)
 
+**Fixed.** Both widgets are an `Item` root composing one `Expressive.WidgetCard` now, with the
+frost record taken from that card and the host's drag and box-motion forwarded to it, and the lint
+below has been rescoped so the spelling that hid them cannot hide the next one
+(fix(notes): draw the widget's surface on the shared card,
+fix(image-converter): draw the widget's surface on the shared card,
+test(lint): the card-tint carve-out is scoped to content, not to a spelling). The reading that
+follows is what was there.
+
 `bundled/notes/Widget.qml:13,36-40` and `bundled/image-converter/Widget.qml:11,51-54` are both a
 `Rectangle` root painting their own surface:
 
@@ -586,3 +594,12 @@ Proven to fail, in a clean tree, on two plants, each reverted:
 The rule this does **not** mechanise, and why: tightening `lint_widget_card_tint.py` to catch G2's
 `blurEnabled ? transparentize(...)` spelling would redden the suite on two real files, and fixing
 those is a refactor rather than an audit. It is the right second lint, immediately after G2 lands.
+
+**That second lint has since landed with G2's fix**, and not as the wider spelling match this
+paragraph imagined — matching `transparentize` everywhere would redden every legitimate content
+tint (calendar's four, world-clock's, user-card's two, and `image-converter`'s own drop well). It
+decides by position instead: the ROOT object of each desktop widget's entry point, enumerated from
+the manifests declaring a `desktop-widget` capability, may not paint a blur-gated tint whichever
+helper it names, while a tint on a surface *inside* the card stays free. Proven to fail on the two
+widgets as they stood before the fix, and to pass after
+(test(lint): the card-tint carve-out is scoped to content, not to a spelling).

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/image-converter/Widget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/image-converter/Widget.qml
@@ -7,16 +7,28 @@ import qs.modules.common
 import qs.modules.common.functions
 import qs.modules.common.widgets
 import qs.modules.common.plugins
+import "../../designsystem/widgets" as Expressive
 
-Rectangle {
+Item {
     id: root
 
     // Frost handling mirrors the other desktop widgets: the host PluginWidget
-    // blurs the wallpaper region behind us, and this card supplies the tint on
-    // top. With no custom blurRegions the host frosts the whole card.
+    // blurs the wallpaper region behind us, and the card below supplies the
+    // tint on top. The region comes from that same card, so the widget cannot
+    // disagree with its own surface about where the frost goes - the host's
+    // fallback is `Appearance.rounding.large`, 7px tighter than the card's own
+    // corner, which leaves blurred slivers outside all four of them.
     readonly property bool blurEnabled: PluginState.option("image-converter", "blurEnabled", false)
     readonly property real backgroundOpacity: PluginState.effectiveBackgroundOpacity("image-converter")
     readonly property bool managesBlurTint: true
+    readonly property var blurRegions: [card.blurRegion]
+
+    // Set by the host while this widget is being dragged, and handed straight
+    // to the card: the shadow lifts on hover and lifts further on a drag.
+    property bool hostDragging: false
+    // Set by the host while its own box is animating; the card drops its
+    // shadow for the duration rather than re-blurring into a resizing FBO.
+    property bool hostBoxInMotion: false
 
     property list<var> formatOptions: [
         { displayName: "PNG",  icon: "image",            value: "png"  },
@@ -48,10 +60,6 @@ Rectangle {
     implicitWidth: Appearance.sizes.widgetGridSpanX(2)
     implicitHeight: Appearance.sizes.widgetGridSpanY(2)
     anchors.fill: parent
-    radius: Appearance.rounding.verylarge
-    color: root.blurEnabled
-        ? ColorUtils.transparentize(Appearance.colors.colPrimaryContainer, 1 - root.backgroundOpacity)
-        : Appearance.colors.colPrimaryContainer
 
     Process {
         id: converter
@@ -155,176 +163,198 @@ Rectangle {
         converter.running = true
     }
 
-    ColumnLayout {
-        id: columnLayout
+    // The surface every other desktop widget already composes. It owns the
+    // tint pair, the rounding (this widget's own `verylarge` was the same 30
+    // spelled twice), the frost record above, and the drop shadow with its
+    // hover and drag lift - which is what this widget had none of while the
+    // root Rectangle painted the card's surface over the top of it.
+    //
+    // No `tensionX`/`tensionY`: the manifest offers one span, so the host
+    // draws no resize grip here and there is never a bow to render.
+    Expressive.WidgetCard {
+        id: card
         anchors.fill: parent
-        anchors.margins: Appearance.spacing.space200
-        spacing: Appearance.spacing.space150
+        tint: Appearance.colors.colPrimaryContainer
+        useBlurBackground: root.blurEnabled
+        backgroundOpacity: root.backgroundOpacity
+        dragging: root.hostDragging
+        hostMotionActive: root.hostBoxInMotion
 
-        StyledText {
-            Layout.fillWidth: true
-            horizontalAlignment: Text.AlignHCenter
-            font.pixelSize: Appearance.font.pixelSize.smaller
-            color: Appearance.colors.colOnPrimaryContainer
-            opacity: 0.4
-            text: "PNG · JPG · WEBP · AVIF · BMP · PDF · TIFF"
-        }
-
-        Rectangle {
-            id: dropZone
-            Layout.fillWidth: true
-            // The built-in pinned this to 144px inside a 252px card. Filling the
-            // remaining height instead keeps the card on the grid span without
-            // moving anything else in the column.
-            Layout.fillHeight: true
-            radius: Appearance.rounding.large
-
-            // Split out from `color` so the frost tint can be applied to
-            // whichever state colour is current without repeating the switch.
-            readonly property color baseColor: {
-                switch (root.dropStatus) {
-                    case "hover":      return Appearance.colors.colPrimaryContainer
-                    case "converting": return Appearance.colors.colSecondaryContainer
-                    case "done":       return Appearance.colors.colTertiaryContainer
-                    case "error":      return Qt.rgba(
-                                            Appearance.colors.colError.r,
-                                            Appearance.colors.colError.g,
-                                            Appearance.colors.colError.b, 0.15)
-                    default:           return Appearance.colors.colSurfaceContainerLow
-                }
-            }
-            color: root.blurEnabled
-                ? ColorUtils.transparentize(dropZone.baseColor, 1 - root.backgroundOpacity)
-                : dropZone.baseColor
-            border.color: {
-                switch (root.dropStatus) {
-                    case "hover":      return Appearance.colors.colPrimary
-                    case "converting": return Appearance.colors.colSecondary
-                    case "done":       return Appearance.colors.colTertiary
-                    case "error":      return Appearance.colors.colError
-                    default:           return Appearance.colors.colOnPrimaryContainer
-                }
-            }
-            border.width: root.dropStatus === "hover" ? 2 : 1
-
-            Behavior on color        { animation: Appearance.animation.elementMoveFast.colorAnimation.createObject(this) }
-            Behavior on border.color { animation: Appearance.animation.elementMoveFast.colorAnimation.createObject(this) }
-
-            MaterialLoadingIndicator {
-                anchors.centerIn: parent
-                anchors.verticalCenterOffset: -14
-                visible: root.dropStatus === "converting"
-                loading: root.dropStatus === "converting"
-                colBg: Appearance.colors.colPrimary
-                colShape: Appearance.colors.colOnPrimary
-                implicitSize: 48
-            }
-
-            MaterialSymbol {
-                anchors.centerIn: parent
-                anchors.verticalCenterOffset: -14
-                visible: root.dropStatus !== "converting"
-                iconSize: 32
-                fill: root.dropStatus === "done" ? 1 : 0
-                color: {
-                    switch (root.dropStatus) {
-                        case "hover": return Appearance.colors.colPrimary
-                        case "done":  return Appearance.colors.colTertiary
-                        case "error": return Appearance.colors.colError
-                        default:      return Appearance.colors.colOnLayer1
-                    }
-                }
-                text: {
-                    switch (root.dropStatus) {
-                        case "hover": return "download"
-                        case "done":  return "check_circle"
-                        case "error": return "error"
-                        default:      return root.selectedFormat === "pdf" ? "picture_as_pdf" : "image"
-                    }
-                }
-            }
+        ColumnLayout {
+            id: columnLayout
+            anchors.fill: parent
+            anchors.margins: Appearance.spacing.space200
+            spacing: Appearance.spacing.space150
 
             StyledText {
-                anchors.centerIn: parent
-                anchors.verticalCenterOffset: 22
-                horizontalAlignment: Text.AlignHCenter
-                font.pixelSize: Appearance.font.pixelSize.small
-                width: parent.width - 24
-                wrapMode: Text.WrapAtWordBoundaryOrAnywhere
-                color: {
-                    switch (root.dropStatus) {
-                        case "hover":  return Appearance.colors.colPrimary
-                        case "done":   return Appearance.colors.colTertiary
-                        case "error":  return Appearance.colors.colError
-                        default:       return Appearance.colors.colOnLayer1
-                    }
-                }
-                opacity: root.dropStatus === "idle" ? 0.6 : 1.0
-                text: {
-                    switch (root.dropStatus) {
-                        case "idle":       return "Drop image(s) here\nto convert to ." + root.selectedFormat.toUpperCase()
-                        case "hover":      return "Release to convert to ." + root.selectedFormat.toUpperCase()
-                        case "converting": return root.statusMessage
-                        case "done":       return root.statusMessage
-                        case "error":      return root.statusMessage
-                        default:           return ""
-                    }
-                }
-                Behavior on opacity { animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this) }
-            }
-
-            DropArea {
-                anchors.fill: parent
-                keys: ["text/uri-list"]
-                onEntered: (drag) => {
-                    drag.accept(Qt.CopyAction)
-                    root.dropStatus = "hover"
-                }
-                onExited: {
-                    if (root.dropStatus === "hover")
-                        root.dropStatus = "idle"
-                }
-                onDropped: (drop) => {
-                    if (drop.hasUrls && drop.urls.length > 0) {
-                        root.enqueueFiles(drop.urls)
-                    } else {
-                        root.dropStatus = "error"
-                        root.statusMessage = "Could not read file path."
-                        resetTimer.start()
-                    }
-                }
-            }
-        }
-
-        RowLayout {
-            Layout.fillWidth: true
-            spacing: Appearance.spacing.space100
-
-            StyledText {
-                Layout.leftMargin: Appearance.spacing.space50
-                text: "Convert to:"
-                font.pixelSize: Appearance.font.pixelSize.small
-                color: Appearance.colors.colOnLayer1
-                opacity: 0.7
-                Layout.alignment: Qt.AlignVCenter
-            }
-
-            StyledComboBox {
                 Layout.fillWidth: true
-                model: root.formatOptions
-                colBackground: Appearance.colors.colSurfaceContainerLow
-                colBackgroundHover: Appearance.colors.colSurfaceContainerLow
-                colBackgroundActive: Appearance.colors.colSurfaceContainerLow // same color, the hover was distracting
-                textRole: "displayName"
-                valueRole: "value"
-                currentIndex: {
-                    for (var i = 0; i < model.length; i++) {
-                        if (model[i].value === root.selectedFormat) return i;
+                horizontalAlignment: Text.AlignHCenter
+                font.pixelSize: Appearance.font.pixelSize.smaller
+                color: Appearance.colors.colOnPrimaryContainer
+                opacity: 0.4
+                text: "PNG · JPG · WEBP · AVIF · BMP · PDF · TIFF"
+            }
+
+            Rectangle {
+                id: dropZone
+                Layout.fillWidth: true
+                // The built-in pinned this to 144px inside a 252px card. Filling the
+                // remaining height instead keeps the card on the grid span without
+                // moving anything else in the column.
+                Layout.fillHeight: true
+                radius: Appearance.rounding.large
+
+                // Split out from `color` so the frost tint can be applied to
+                // whichever state colour is current without repeating the
+                // switch. This is a *content* tint - the drop well drawn inside
+                // the card, thinning with it so the frost reads through the
+                // whole widget - not the card's own surface, which is the
+                // card's business now.
+                readonly property color baseColor: {
+                    switch (root.dropStatus) {
+                        case "hover":      return Appearance.colors.colPrimaryContainer
+                        case "converting": return Appearance.colors.colSecondaryContainer
+                        case "done":       return Appearance.colors.colTertiaryContainer
+                        case "error":      return Qt.rgba(
+                                                Appearance.colors.colError.r,
+                                                Appearance.colors.colError.g,
+                                                Appearance.colors.colError.b, 0.15)
+                        default:           return Appearance.colors.colSurfaceContainerLow
                     }
-                    return 0;
                 }
-                onActivated: (index) => {
-                    root.selectedFormat = model[index].value
+                color: root.blurEnabled
+                    ? ColorUtils.transparentize(dropZone.baseColor, 1 - root.backgroundOpacity)
+                    : dropZone.baseColor
+                border.color: {
+                    switch (root.dropStatus) {
+                        case "hover":      return Appearance.colors.colPrimary
+                        case "converting": return Appearance.colors.colSecondary
+                        case "done":       return Appearance.colors.colTertiary
+                        case "error":      return Appearance.colors.colError
+                        default:           return Appearance.colors.colOnPrimaryContainer
+                    }
+                }
+                border.width: root.dropStatus === "hover" ? 2 : 1
+
+                Behavior on color        { animation: Appearance.animation.elementMoveFast.colorAnimation.createObject(this) }
+                Behavior on border.color { animation: Appearance.animation.elementMoveFast.colorAnimation.createObject(this) }
+
+                MaterialLoadingIndicator {
+                    anchors.centerIn: parent
+                    anchors.verticalCenterOffset: -14
+                    visible: root.dropStatus === "converting"
+                    loading: root.dropStatus === "converting"
+                    colBg: Appearance.colors.colPrimary
+                    colShape: Appearance.colors.colOnPrimary
+                    implicitSize: 48
+                }
+
+                MaterialSymbol {
+                    anchors.centerIn: parent
+                    anchors.verticalCenterOffset: -14
+                    visible: root.dropStatus !== "converting"
+                    iconSize: 32
+                    fill: root.dropStatus === "done" ? 1 : 0
+                    color: {
+                        switch (root.dropStatus) {
+                            case "hover": return Appearance.colors.colPrimary
+                            case "done":  return Appearance.colors.colTertiary
+                            case "error": return Appearance.colors.colError
+                            default:      return Appearance.colors.colOnLayer1
+                        }
+                    }
+                    text: {
+                        switch (root.dropStatus) {
+                            case "hover": return "download"
+                            case "done":  return "check_circle"
+                            case "error": return "error"
+                            default:      return root.selectedFormat === "pdf" ? "picture_as_pdf" : "image"
+                        }
+                    }
+                }
+
+                StyledText {
+                    anchors.centerIn: parent
+                    anchors.verticalCenterOffset: 22
+                    horizontalAlignment: Text.AlignHCenter
+                    font.pixelSize: Appearance.font.pixelSize.small
+                    width: parent.width - 24
+                    wrapMode: Text.WrapAtWordBoundaryOrAnywhere
+                    color: {
+                        switch (root.dropStatus) {
+                            case "hover":  return Appearance.colors.colPrimary
+                            case "done":   return Appearance.colors.colTertiary
+                            case "error":  return Appearance.colors.colError
+                            default:       return Appearance.colors.colOnLayer1
+                        }
+                    }
+                    opacity: root.dropStatus === "idle" ? 0.6 : 1.0
+                    text: {
+                        switch (root.dropStatus) {
+                            case "idle":       return "Drop image(s) here\nto convert to ." + root.selectedFormat.toUpperCase()
+                            case "hover":      return "Release to convert to ." + root.selectedFormat.toUpperCase()
+                            case "converting": return root.statusMessage
+                            case "done":       return root.statusMessage
+                            case "error":      return root.statusMessage
+                            default:           return ""
+                        }
+                    }
+                    Behavior on opacity { animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this) }
+                }
+
+                DropArea {
+                    anchors.fill: parent
+                    keys: ["text/uri-list"]
+                    onEntered: (drag) => {
+                        drag.accept(Qt.CopyAction)
+                        root.dropStatus = "hover"
+                    }
+                    onExited: {
+                        if (root.dropStatus === "hover")
+                            root.dropStatus = "idle"
+                    }
+                    onDropped: (drop) => {
+                        if (drop.hasUrls && drop.urls.length > 0) {
+                            root.enqueueFiles(drop.urls)
+                        } else {
+                            root.dropStatus = "error"
+                            root.statusMessage = "Could not read file path."
+                            resetTimer.start()
+                        }
+                    }
+                }
+            }
+
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: Appearance.spacing.space100
+
+                StyledText {
+                    Layout.leftMargin: Appearance.spacing.space50
+                    text: "Convert to:"
+                    font.pixelSize: Appearance.font.pixelSize.small
+                    color: Appearance.colors.colOnLayer1
+                    opacity: 0.7
+                    Layout.alignment: Qt.AlignVCenter
+                }
+
+                StyledComboBox {
+                    Layout.fillWidth: true
+                    model: root.formatOptions
+                    colBackground: Appearance.colors.colSurfaceContainerLow
+                    colBackgroundHover: Appearance.colors.colSurfaceContainerLow
+                    colBackgroundActive: Appearance.colors.colSurfaceContainerLow // same color, the hover was distracting
+                    textRole: "displayName"
+                    valueRole: "value"
+                    currentIndex: {
+                        for (var i = 0; i < model.length; i++) {
+                            if (model[i].value === root.selectedFormat) return i;
+                        }
+                        return 0;
+                    }
+                    onActivated: (index) => {
+                        root.selectedFormat = model[index].value
+                    }
                 }
             }
         }

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/notes/Widget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/notes/Widget.qml
@@ -9,16 +9,28 @@ import qs.modules.common
 import qs.modules.common.functions
 import qs.modules.common.widgets
 import qs.modules.common.plugins
+import "../../designsystem/widgets" as Expressive
 
-Rectangle {
+Item {
     id: root
 
     // Frost handling mirrors the other desktop widgets: the host PluginWidget
-    // blurs the wallpaper region behind us, and this card supplies the tint on
-    // top. With no custom blurRegions the host frosts the whole card.
+    // blurs the wallpaper region behind us, and the card below supplies the
+    // tint on top. The region comes from that same card, so the widget cannot
+    // disagree with its own surface about where the frost goes - the host's
+    // fallback is `Appearance.rounding.large`, 7px tighter than the card's own
+    // corner, which leaves blurred slivers outside all four of them.
     readonly property bool blurEnabled: PluginState.option("notes", "blurEnabled", false)
     readonly property real backgroundOpacity: PluginState.effectiveBackgroundOpacity("notes")
     readonly property bool managesBlurTint: true
+    readonly property var blurRegions: [card.blurRegion]
+
+    // Set by the host while this widget is being dragged, and handed straight
+    // to the card: the shadow lifts on hover and lifts further on a drag.
+    property bool hostDragging: false
+    // Set by the host while its own box is animating; the card drops its
+    // shadow for the duration rather than re-blurring into a resizing FBO.
+    property bool hostBoxInMotion: false
 
     // "list" | "edit". The card flips between the two rather than growing a
     // second surface - it is a 2x2 tile, there is no room for both.
@@ -33,12 +45,6 @@ Rectangle {
     implicitWidth: Appearance.sizes.widgetGridSpanX(2)
     implicitHeight: Appearance.sizes.widgetGridSpanY(2)
     anchors.fill: parent
-    radius: Appearance.rounding.verylarge
-    // Matugen-tinted card (secondary container) instead of a neutral surface.
-    color: root.blurEnabled
-        ? ColorUtils.transparentize(Appearance.colors.colSecondaryContainer, 1 - root.backgroundOpacity)
-        : Appearance.colors.colSecondaryContainer
-    border.width: 0
 
     // The objectNames below are how NotesSurfacesRuntimeTest.qml finds these
     // controls to click them; ids are not reachable from outside the component.
@@ -47,6 +53,12 @@ Rectangle {
     // (PluginWidget hover + descendant focus), so this widget needs no per-field
     // OnDemand wiring - clicking the editor grabs Wayland keyboard focus.
 
+    // A *content* tint, not the card's: the list well and the editor well are
+    // surfaces drawn inside the card, and they thin with it so the frost reads
+    // through the whole widget rather than through its edges only. Calendar is
+    // the precedent, and `transparentize` rather than the card's `applyAlpha`
+    // for the same reason it gives - colLayer2 already carries an alpha this
+    // must scale rather than overwrite.
     readonly property color colSurface: root.blurEnabled
         ? ColorUtils.transparentize(Appearance.colors.colLayer2, 1 - root.backgroundOpacity)
         : Appearance.colors.colLayer1
@@ -79,226 +91,244 @@ Rectangle {
         flipAnim.start();
     }
 
-    Item {
-        id: cardWrapper
+    // The surface every other desktop widget already composes. It owns the
+    // tint pair, the rounding (this widget's own `verylarge` was the same 30
+    // spelled twice), the frost record above, and the drop shadow with its
+    // hover and drag lift - which is what this widget had none of while the
+    // root Rectangle painted the card's surface over the top of it.
+    //
+    // No `tensionX`/`tensionY`: the manifest offers one span, so the host
+    // draws no resize grip here and there is never a bow to render.
+    Expressive.WidgetCard {
+        id: card
         anchors.fill: parent
+        tint: Appearance.colors.colSecondaryContainer
+        useBlurBackground: root.blurEnabled
+        backgroundOpacity: root.backgroundOpacity
+        dragging: root.hostDragging
+        hostMotionActive: root.hostBoxInMotion
 
-        transform: Scale {
-            id: flipScale
-            origin.x: cardWrapper.width / 2
-            origin.y: cardWrapper.height / 2
-            xScale: 1
-        }
-
-        SequentialAnimation {
-            id: flipAnim
-            NumberAnimation {
-                target: flipScale
-                property: "xScale"
-                to: 0
-                duration: Appearance.animation.elementMoveFaster.duration
-                easing.type: Easing.InQuad
-            }
-            ScriptAction {
-                script: root.mode = (root.mode === "list" ? "edit" : "list")
-            }
-            NumberAnimation {
-                target: flipScale
-                property: "xScale"
-                to: 1
-                duration: Appearance.animation.elementMoveFaster.duration
-                easing.type: Easing.OutQuad
-            }
-        }
-
-        ColumnLayout {
-            id: listPage
+        Item {
+            id: cardWrapper
             anchors.fill: parent
-            anchors.margins: Appearance.spacing.space200
-            spacing: Appearance.spacing.space150
-            visible: root.mode === "list"
 
-            RowLayout {
-                Layout.fillWidth: true
-                spacing: Appearance.spacing.space100
+            transform: Scale {
+                id: flipScale
+                origin.x: cardWrapper.width / 2
+                origin.y: cardWrapper.height / 2
+                xScale: 1
+            }
 
-                MaterialShapeWrappedMaterialSymbol {
-                    shape: MaterialShape.Shape.Clover
-                    text: "sticky_note_2"
-                    iconSize: Appearance.font.pixelSize.large
-                    implicitSize: 36
-                    color: Appearance.colors.colPrimaryContainer
-                    colSymbol: Appearance.colors.colPrimary
+            SequentialAnimation {
+                id: flipAnim
+                NumberAnimation {
+                    target: flipScale
+                    property: "xScale"
+                    to: 0
+                    duration: Appearance.animation.elementMoveFaster.duration
+                    easing.type: Easing.InQuad
                 }
-
-                StyledText {
-                    Layout.fillWidth: true
-                    text: Translation.tr("Notes")
-                    font.family: Appearance.font.family.expressive
-                    font.pixelSize: Appearance.font.pixelSize.large
-                    font.weight: Font.DemiBold
-                    color: Appearance.colors.colOnSecondaryContainer
+                ScriptAction {
+                    script: root.mode = (root.mode === "list" ? "edit" : "list")
                 }
-
-                ToolbarPairedFab {
-                    id: addNoteButton
-                    objectName: "addNoteButton"
-                    Layout.alignment: Qt.AlignVCenter
-                    baseSize: 34
-                    iconText: "add"
-                    onClicked: root.openNewNote()
+                NumberAnimation {
+                    target: flipScale
+                    property: "xScale"
+                    to: 1
+                    duration: Appearance.animation.elementMoveFaster.duration
+                    easing.type: Easing.OutQuad
                 }
             }
 
-            Rectangle {
-                Layout.fillWidth: true
-                Layout.fillHeight: true
-                radius: Appearance.rounding.normal
-                color: root.colSurface
+            ColumnLayout {
+                id: listPage
+                anchors.fill: parent
+                anchors.margins: Appearance.spacing.space200
+                spacing: Appearance.spacing.space150
+                visible: root.mode === "list"
 
-                StyledText {
-                    anchors.centerIn: parent
-                    visible: Notes.list.length === 0
-                    text: Translation.tr("No notes yet")
-                    color: Appearance.colors.colSubtext
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing: Appearance.spacing.space100
+
+                    MaterialShapeWrappedMaterialSymbol {
+                        shape: MaterialShape.Shape.Clover
+                        text: "sticky_note_2"
+                        iconSize: Appearance.font.pixelSize.large
+                        implicitSize: 36
+                        color: Appearance.colors.colPrimaryContainer
+                        colSymbol: Appearance.colors.colPrimary
+                    }
+
+                    StyledText {
+                        Layout.fillWidth: true
+                        text: Translation.tr("Notes")
+                        font.family: Appearance.font.family.expressive
+                        font.pixelSize: Appearance.font.pixelSize.large
+                        font.weight: Font.DemiBold
+                        color: Appearance.colors.colOnSecondaryContainer
+                    }
+
+                    ToolbarPairedFab {
+                        id: addNoteButton
+                        objectName: "addNoteButton"
+                        Layout.alignment: Qt.AlignVCenter
+                        baseSize: 34
+                        iconText: "add"
+                        onClicked: root.openNewNote()
+                    }
                 }
 
-                StyledListView {
-                    id: notesList
-                    objectName: "notesList"
-                    anchors.fill: parent
-                    anchors.margins: Appearance.spacing.space100
-                    clip: true
-                    spacing: Appearance.spacing.space75
-                    model: Notes.list
+                Rectangle {
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    radius: Appearance.rounding.normal
+                    color: root.colSurface
 
-                    delegate: Rectangle {
-                        id: noteRow
-                        required property var modelData
+                    StyledText {
+                        anchors.centerIn: parent
+                        visible: Notes.list.length === 0
+                        text: Translation.tr("No notes yet")
+                        color: Appearance.colors.colSubtext
+                    }
 
-                        width: notesList.width
-                        implicitHeight: 40
-                        radius: Appearance.rounding.small
-                        color: noteRowArea.containsMouse
-                            ? Appearance.colors.colLayer2Hover
-                            : Appearance.colors.colLayer2
+                    StyledListView {
+                        id: notesList
+                        objectName: "notesList"
+                        anchors.fill: parent
+                        anchors.margins: Appearance.spacing.space100
+                        clip: true
+                        spacing: Appearance.spacing.space75
+                        model: Notes.list
 
-                        MouseArea {
-                            id: noteRowArea
-                            anchors.fill: parent
-                            hoverEnabled: true
-                            cursorShape: Qt.PointingHandCursor
-                            onClicked: root.openNote(noteRow.modelData)
-                        }
+                        delegate: Rectangle {
+                            id: noteRow
+                            required property var modelData
 
-                        RowLayout {
-                            anchors.fill: parent
-                            anchors.leftMargin: Appearance.spacing.space125
-                            anchors.rightMargin: Appearance.spacing.space50
-                            spacing: Appearance.spacing.space50
+                            width: notesList.width
+                            implicitHeight: 40
+                            radius: Appearance.rounding.small
+                            color: noteRowArea.containsMouse
+                                ? Appearance.colors.colLayer2Hover
+                                : Appearance.colors.colLayer2
 
-                            StyledText {
-                                Layout.fillWidth: true
-                                // A note's body is user content read off disk;
-                                // StyledText is a bare Text and would render
-                                // markup in it without this.
-                                textFormat: Text.PlainText
-                                text: noteRow.modelData.content
-                                color: Appearance.colors.colOnLayer2
-                                elide: Text.ElideRight
-                                maximumLineCount: 1
+                            MouseArea {
+                                id: noteRowArea
+                                anchors.fill: parent
+                                hoverEnabled: true
+                                cursorShape: Qt.PointingHandCursor
+                                onClicked: root.openNote(noteRow.modelData)
                             }
 
-                            RippleButton {
-                                id: deleteNoteButton
-                                objectName: "deleteNoteButton"
-                                Layout.alignment: Qt.AlignVCenter
-                                implicitWidth: 28
-                                implicitHeight: 28
-                                buttonRadius: Appearance.rounding.full
-                                onClicked: Notes.deleteNote(noteRow.modelData.id)
+                            RowLayout {
+                                anchors.fill: parent
+                                anchors.leftMargin: Appearance.spacing.space125
+                                anchors.rightMargin: Appearance.spacing.space50
+                                spacing: Appearance.spacing.space50
 
-                                contentItem: MaterialSymbol {
-                                    anchors.centerIn: parent
-                                    horizontalAlignment: Text.AlignHCenter
-                                    text: "delete"
-                                    iconSize: Appearance.font.pixelSize.normal
+                                StyledText {
+                                    Layout.fillWidth: true
+                                    // A note's body is user content read off disk;
+                                    // StyledText is a bare Text and would render
+                                    // markup in it without this.
+                                    textFormat: Text.PlainText
+                                    text: noteRow.modelData.content
                                     color: Appearance.colors.colOnLayer2
+                                    elide: Text.ElideRight
+                                    maximumLineCount: 1
+                                }
+
+                                RippleButton {
+                                    id: deleteNoteButton
+                                    objectName: "deleteNoteButton"
+                                    Layout.alignment: Qt.AlignVCenter
+                                    implicitWidth: 28
+                                    implicitHeight: 28
+                                    buttonRadius: Appearance.rounding.full
+                                    onClicked: Notes.deleteNote(noteRow.modelData.id)
+
+                                    contentItem: MaterialSymbol {
+                                        anchors.centerIn: parent
+                                        horizontalAlignment: Text.AlignHCenter
+                                        text: "delete"
+                                        iconSize: Appearance.font.pixelSize.normal
+                                        color: Appearance.colors.colOnLayer2
+                                    }
                                 }
                             }
                         }
                     }
                 }
             }
-        }
 
-        ColumnLayout {
-            id: editPage
-            anchors.fill: parent
-            anchors.margins: Appearance.spacing.space200
-            spacing: Appearance.spacing.space150
-            visible: root.mode === "edit"
+            ColumnLayout {
+                id: editPage
+                anchors.fill: parent
+                anchors.margins: Appearance.spacing.space200
+                spacing: Appearance.spacing.space150
+                visible: root.mode === "edit"
 
-            RowLayout {
-                Layout.fillWidth: true
-                spacing: Appearance.spacing.space100
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing: Appearance.spacing.space100
 
-                RippleButton {
-                    id: backButton
-                    implicitWidth: 30
-                    implicitHeight: 30
-                    buttonRadius: Appearance.rounding.full
-                    onClicked: root.saveAndBack()
+                    RippleButton {
+                        id: backButton
+                        implicitWidth: 30
+                        implicitHeight: 30
+                        buttonRadius: Appearance.rounding.full
+                        onClicked: root.saveAndBack()
 
-                    contentItem: MaterialSymbol {
-                        anchors.centerIn: parent
-                        horizontalAlignment: Text.AlignHCenter
-                        text: "arrow_back"
-                        iconSize: Appearance.font.pixelSize.normal
+                        contentItem: MaterialSymbol {
+                            anchors.centerIn: parent
+                            horizontalAlignment: Text.AlignHCenter
+                            text: "arrow_back"
+                            iconSize: Appearance.font.pixelSize.normal
+                            color: Appearance.colors.colOnSecondaryContainer
+                        }
+                    }
+
+                    StyledText {
+                        Layout.fillWidth: true
+                        text: root.editingId.length === 0 ? Translation.tr("New note") : Translation.tr("Edit note")
+                        font.family: Appearance.font.family.expressive
+                        font.pixelSize: Appearance.font.pixelSize.normal
+                        font.weight: Font.DemiBold
                         color: Appearance.colors.colOnSecondaryContainer
+                    }
+
+                    ToolbarPairedFab {
+                        id: saveNoteButton
+                        objectName: "saveNoteButton"
+                        Layout.alignment: Qt.AlignVCenter
+                        baseSize: 34
+                        iconText: "save"
+                        onClicked: root.saveAndBack()
                     }
                 }
 
-                StyledText {
+                Rectangle {
                     Layout.fillWidth: true
-                    text: root.editingId.length === 0 ? Translation.tr("New note") : Translation.tr("Edit note")
-                    font.family: Appearance.font.family.expressive
-                    font.pixelSize: Appearance.font.pixelSize.normal
-                    font.weight: Font.DemiBold
-                    color: Appearance.colors.colOnSecondaryContainer
-                }
+                    Layout.fillHeight: true
+                    radius: Appearance.rounding.normal
+                    color: root.colSurface
 
-                ToolbarPairedFab {
-                    id: saveNoteButton
-                    objectName: "saveNoteButton"
-                    Layout.alignment: Qt.AlignVCenter
-                    baseSize: 34
-                    iconText: "save"
-                    onClicked: root.saveAndBack()
-                }
-            }
+                    ScrollView {
+                        anchors.fill: parent
+                        anchors.margins: Appearance.spacing.space100
+                        clip: true
 
-            Rectangle {
-                Layout.fillWidth: true
-                Layout.fillHeight: true
-                radius: Appearance.rounding.normal
-                color: root.colSurface
-
-                ScrollView {
-                    anchors.fill: parent
-                    anchors.margins: Appearance.spacing.space100
-                    clip: true
-
-                    StyledTextArea {
-                        id: editArea
-                        objectName: "editArea"
-                        background: null
-                        wrapMode: TextEdit.Wrap
-                        // Same reason as the list row: never interpret a note's
-                        // own text as markup.
-                        textFormat: TextEdit.PlainText
-                        placeholderText: Translation.tr("Jot a note…")
-                        color: Appearance.colors.colOnLayer1
+                        StyledTextArea {
+                            id: editArea
+                            objectName: "editArea"
+                            background: null
+                            wrapMode: TextEdit.Wrap
+                            // Same reason as the list row: never interpret a note's
+                            // own text as markup.
+                            textFormat: TextEdit.PlainText
+                            placeholderText: Translation.tr("Jot a note…")
+                            color: Appearance.colors.colOnLayer1
+                        }
                     }
                 }
             }

--- a/dots/.config/quickshell/imi/tests/lint_widget_card_tint.py
+++ b/dots/.config/quickshell/imi/tests/lint_widget_card_tint.py
@@ -19,18 +19,37 @@ tests/test_expressive_design_system.py pins - so the exemption is gone. What
 the widget still spells for itself is a *content* tint: the 1x1 banner, the
 month pill, the day grid and today's highlight thin with the card so the frost
 reads through the whole widget rather than through its edges only. That is
-deliberately not what this reserves, and not what it matches either - those go
-through `transparentize`, which scales an alpha two of those colours already
-carry, rather than the card's absolute `applyAlpha`.
+deliberately not what this reserves - those go through `transparentize`, which
+scales an alpha two of those colours already carry, rather than the card's
+absolute `applyAlpha`.
+
+That carve-out was a spelling, and a spelling is not a rule. `notes` and
+`image-converter` were both a root `Rectangle` painting
+`blurEnabled ? transparentize(colSecondaryContainer, ...)`: the *card's* own
+surface, written in the content tint's dialect, and so waved straight through
+by a check matching only `useBlurBackground ? applyAlpha(`. The cost was not
+redundancy - a widget that paints its own root surface hides the card
+underneath it, so those two were the only desktop widgets on the desktop
+casting no shadow at all, and neither could have lifted on hover or drag if
+one had been added. The carve-out is now scoped to where it was earned: a
+content tint is a surface *inside* the card, so the second rule below reads
+only the ROOT object of each desktop widget's entry point, whatever helper the
+tint is spelled with. Nested tints stay free.
+
+b362d8c80 ("feat(widgets): one card component for the surface every widget
+redrew"), 486272dbe ("feat(calendar): draw the widget's surface on the shared
+card"), and the audit that found the hole: docs/widget-standards-audit-2026-08-16.md G2.
 """
 
 from pathlib import Path
+import json
 import re
 import sys
 
 
 ROOT = Path(__file__).resolve().parents[1]
 SKIP_DIRS = {".git", "node_modules", "__pycache__", "tests"}
+BUNDLED = ROOT / "modules/common/plugins/bundled"
 
 ALLOWED = {
     Path("modules/common/plugins/designsystem/widgets/WidgetCard.qml"),
@@ -39,6 +58,139 @@ ALLOWED = {
 # The tint conditional, however the alpha helper is qualified and whatever the
 # tint colour is: `useBlurBackground ? <something>applyAlpha(...)`.
 TINT_PAIR = re.compile(r"useBlurBackground\s*\?\s*[\w.]*applyAlpha\s*\(", re.I)
+
+# Either alpha helper, however qualified. A card tint is recognised by where it
+# is painted, not by which of the two spellings a widget reached for.
+TINT_HELPER = re.compile(r"\b(?:applyAlpha|transparentize)\s*\(")
+
+# `color: <something>` in a root object's body.
+COLOR_BINDING = re.compile(r"^\s*color\s*:\s*(.*)$")
+# Anything that starts a new binding, property or child object, which is what
+# ends the previous binding's value - a QML binding has no terminator. The
+# continuation lines of a wrapped ternary (`? ...`, `: ...`) match none of it.
+STATEMENT_START = re.compile(
+    r"^\s*(?:readonly\s+)?(?:required\s+)?(?:property\s+[\w<>.]+\s+)?"
+    r"[\w.]+\s*(?::|\{)\s*")
+# A binding that is nothing but a name: `color: root.cardColor`. One level of
+# that indirection is followed, because renaming the expression into a property
+# is the one-line way to put the surface back.
+NAME_ONLY = re.compile(r"^(?:root\.)?([A-Za-z_]\w*)$")
+PROPERTY_DECL = re.compile(
+    r"^\s*(?:readonly\s+)?property\s+[\w<>.]+\s+(\w+)\s*:\s*(.*)$")
+
+
+def strip_noise(text):
+    """Comments and string literals blanked out, newlines preserved.
+
+    A brace inside either would move the depth counter, and the depth is how
+    the root object's own body is told from everything nested inside it.
+    """
+    out = []
+    i = 0
+    while i < len(text):
+        ch = text[i]
+        if ch == "/" and text[i:i + 2] == "//":
+            end = text.find("\n", i)
+            end = len(text) if end == -1 else end
+            out.append(" " * (end - i))
+            i = end
+        elif ch == "/" and text[i:i + 2] == "/*":
+            end = text.find("*/", i + 2)
+            end = len(text) if end == -1 else end + 2
+            out.append("".join(c if c == "\n" else " " for c in text[i:end]))
+            i = end
+        elif ch in "\"'":
+            j = i + 1
+            while j < len(text) and text[j] != ch:
+                j += 2 if text[j] == "\\" else 1
+            j = min(j + 1, len(text))
+            out.append("".join(c if c == "\n" else " " for c in text[i:j]))
+            i = j
+        else:
+            out.append(ch)
+            i += 1
+    return "".join(out)
+
+
+def root_body_lines(text):
+    """(line number, line) for every line inside the root object's own body.
+
+    Depth 1 relative to the root's opening brace. A widget's card surface is
+    painted here; a content tint is painted deeper.
+    """
+    clean = strip_noise(text)
+    depth = 0
+    root_open = None
+    lines = []
+    line_no = 1
+    line_start_depth = 0
+    line_start = 0
+    for i, ch in enumerate(clean):
+        if ch == "\n":
+            if root_open is not None and line_start_depth == 1:
+                lines.append((line_no, clean[line_start:i]))
+            line_no += 1
+            line_start = i + 1
+            line_start_depth = depth
+        elif ch == "{":
+            depth += 1
+            if root_open is None:
+                root_open = i
+                line_start_depth = 1
+                line_start = i + 1
+        elif ch == "}":
+            depth -= 1
+    return lines
+
+
+def binding_value(lines, index):
+    """The whole of a binding's value, wrapped ternary included."""
+    value = [COLOR_BINDING.match(lines[index][1]).group(1).strip()]
+    for _, line in lines[index + 1:]:
+        if not line.strip() or STATEMENT_START.match(line):
+            break
+        value.append(line.strip())
+    return " ".join(value).strip()
+
+
+def resolve_once(lines, value):
+    """`color: root.cardColor` followed to that property's own value."""
+    name = NAME_ONLY.match(value)
+    if not name:
+        return value
+    for index, (_, line) in enumerate(lines):
+        declaration = PROPERTY_DECL.match(line)
+        if declaration and declaration.group(1) == name.group(1):
+            parts = [declaration.group(2).strip()]
+            for _, following in lines[index + 1:]:
+                if not following.strip() or STATEMENT_START.match(following):
+                    break
+                parts.append(following.strip())
+            return " ".join(parts).strip()
+    return value
+
+
+def desktop_widget_entry_points():
+    """Every bundled manifest's desktop-widget component, from the manifest.
+
+    Read from the manifests rather than listed here, so a new desktop widget
+    is covered on the day it ships. Bar and overlay widgets are deliberately
+    out of scope: `discordVoice` is a panel, not a card on the desktop, and
+    standard 3 does not reach it.
+    """
+    for manifest_path in sorted(BUNDLED.glob("*/manifest.json")):
+        try:
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            continue
+        if "desktop-widget" not in (manifest.get("capabilities") or []):
+            continue
+        component = (manifest.get("desktopWidget") or {}).get("component")
+        if not component:
+            continue
+        entry = manifest_path.parent / component
+        if entry.exists():
+            yield entry
 
 
 def main() -> int:
@@ -58,13 +210,35 @@ def main() -> int:
                 f"(tint/useBlurBackground/backgroundOpacity) so the surface and "
                 f"its motion are tuned in one place.")
 
+    for entry in desktop_widget_entry_points():
+        rel = entry.relative_to(ROOT)
+        if rel in ALLOWED:
+            continue
+        try:
+            text = entry.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+        lines = root_body_lines(text)
+        for index, (line_no, line) in enumerate(lines):
+            if not COLOR_BINDING.match(line):
+                continue
+            value = resolve_once(lines, binding_value(lines, index))
+            if "?" in value and TINT_HELPER.search(value):
+                failures.append(
+                    f"{rel}:{line_no}: the widget's ROOT paints a blur-thinned "
+                    f"tint - that is the card's surface, and painting it here "
+                    f"hides the card, its corner and its shadow. Compose "
+                    f"WidgetCard; a *content* tint belongs on a surface inside "
+                    f"it.")
+
     if failures:
         print("Widget card tint lint failed:\n", file=sys.stderr)
         for failure in failures:
             print(f"  {failure}", file=sys.stderr)
         return 1
 
-    print("Widget card tint lint passed: the tint conditional lives in WidgetCard only")
+    print("Widget card tint lint passed: the tint conditional lives in "
+          "WidgetCard, and no desktop widget paints its own root")
     return 0
 
 


### PR DESCRIPTION
Closes the audit's G2 (`docs/widget-standards-audit-2026-08-16.md`): `notes` and `image-converter`
were the two desktop widgets casting no shadow at all, and the lint that should have caught them
was matching a spelling rather than a rule.

## What was wrong

Both were a root `Rectangle` painting `blurEnabled ? transparentize(<container>, 1 - opacity)` —
the *card's* own surface, hand-rolled. That is not the redundancy `WidgetCard` was extracted to
remove: a root surface is painted **over** the card, so the card, its corner and its shadow were
underneath it and invisible. Neither widget declared `hostDragging` either, so no lift could have
been added without the host link.

`tests/lint_widget_card_tint.py` matched only `useBlurBackground ? applyAlpha(` and waved both
through. `transparentize` was deliberately unmatched — it is what calendar's *content* tints use,
scaling an alpha `colLayer1` already carries — and these two used the content tint's dialect for
their card.

## What changed

- Both roots become a plain `Item` composing one `Expressive.WidgetCard`, with the content routed
  into the card's content item.
- The frost record comes from the card (`blurRegions: [card.blurRegion]`). The host's fallback
  radius is `Appearance.rounding.large`, 7px tighter than the card's 30, which would leave blurred
  slivers outside all four corners.
- `hostDragging` / `hostBoxInMotion` are declared so `PluginNode`'s duck-typed link can write them,
  and are handed to the card.
- The genuine content tints stay: notes' list and editor wells, image-converter's drop well.
- The lint now decides by **position** rather than by helper name — the root object of every
  desktop widget's entry point, enumerated from the manifests declaring a `desktop-widget`
  capability (so `discordVoice` and `docker`, a bar and an overlay panel, are out of scope by the
  data rather than by an allowlist). It follows one level of `color: root.someProperty`
  indirection. Nested content tints stay free.

## The lint fails before it passes

Run against the two widgets exactly as they stood on `main`, then against the fix:

| tree | result |
|---|---|
| `main` (both widgets unchanged) | **FAILED** — `image-converter/Widget.qml:52: the widget's ROOT paints a blur-thinned tint`, `notes/Widget.qml:38: …` |
| this branch | **passed** — "the tint conditional lives in WidgetCard, and no desktop widget paints its own root" |

The old check reported OK on both.

## Measured, not asserted

**On a white field, the method `tests/test_card_shadow.py` uses** (mean darkness of the 14px band
below each card, `magick` doing the averaging), both widgets rendered three times — at rest, with
`hostDragging`, and with `hostBoxInMotion`:

| widget | tree | rest | handled | in motion |
|---|---|---|---|---|
| `notes` | pre-fix | 0.00 | 0.00 | 0.00 |
| `notes` | fixed | 6.02 | 25.88 | 0.00 |
| `image-converter` | pre-fix | 0.00 | 0.00 | 0.00 |
| `image-converter` | fixed | 6.02 | 25.88 | 0.00 |

`test_card_shadow.py`'s own thresholds are rest > 3.0, handled > 1.2 × rest, moving < 1.0. Pre-fix
the drag column is identical to rest, which is the other half of the gap: nothing to lift.

**On the real desktop** (5120x1440, DP-1, the wallpaper the widgets actually sit on), the same band
below `notes`, captured with the pre-fix build deployed and again with this branch deployed, plus a
hover capture with the pointer on the card:

| band | pre-fix | rest | hover |
|---|---|---|---|
| 0–14px below the card | 24.33 | 22.32 (−2.01) | 20.41 (−3.92) |
| 14–28px below | 27.66 | 27.84 (+0.18) | 27.14 (−0.52) |
| control, 48–62px below | 56.04 | 56.76 | 56.05 |
| control, left of the card | 12.84 | 12.74 | 12.74 |

The hover darkening is 1.95× the resting one against `Appearance.elevation.hoverLift: 1.94`, and it
reaches a band the resting shadow does not. The two controls move by less than 0.8, so this is the
shadow and not a capture drift. `image-converter`, same method: band 40.57 → 35.49 (−5.07) with its
controls at −0.20 and 0.00.

A live drag was also driven (press, 23px of pointer travel, capture, release) and the card visibly
sits in a deeper halo, but the drag turns on the canvas grid and snap lines, so the white-field
`handled` column above is the number worth quoting for it.

Every live capture was bracketed by `diff -rq <worktree> ~/.config/quickshell/imi/` immediately
before and after — two other agents are deploying to the same shell, and one set of hover captures
was discarded when that check showed their build had landed underneath it. `config.json` and
`plugin-state.json` were backed up before the two widgets were enabled and restored with `cp`;
both still hash to their pre-run md5 after the shell restarted.

`tests/run_tests.sh`: 731 passed, 0 failed — the same count as `main` — with
`DesignSystemCompile` at `checked=168 failures=0`.

Docs: updated AGENT.md §Dynamic/data-driven QML gotchas (the widget-card entry, plus a new one on a
widget painting its own root) and docs/widget-standards-audit-2026-08-16.md (G2 marked fixed, §7's
scheduled second lint recorded as landed).
