### PR TITLE
fix(discordVoice): apply the interaction model once, and mechanise the rule

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1455,6 +1455,28 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   vacated the nested-dim rule for every component rooted on one - a detector that knows only one
   idiom stops detecting the moment the idiom changes.
   af09ed3b9 ("feat(widgets): one driver wires a control to the model").
+- **The model's motion is applied by the CONTROL, and a caller that adds its own composites with it
+  rather than replacing it.** `Item.scale` and a `Scale` transform multiply down the scene graph
+  exactly the way `opacity` does, so the mirror image of the doubled-dim rule above holds for the
+  transform: a `scale: down ? 0.88 : (hovered ? 1.08 : 1)` written on the contentItem of a
+  `RippleButton` does not override `interactionMotion.scale`, it stacks on it. discordVoice's overlay
+  shipped that on its mute and deafen glyphs — 1.02 × 1.08 on hover, 0.97 × 0.88 on press, roughly
+  five times the intended excursion, on `OutBack` instead of the model's curve, and with one duration
+  standing in for the five tiers. The same two buttons in that package's *popup* were written without
+  it, so two copies of one control disagreed about how hard it squishes. Take the control's motion;
+  where feedback is not a multiple of anything, read `hoverProgress`/`pressProgress` rather than the
+  raw flags. `tests/lint_interaction_motion_double.py` fails the suite on a scale-family property
+  written from a raw hover/press flag anywhere inside a control that applies the model — a *separate*
+  file from `lint_disabled_opacity.py` on purpose, since that one keys on a dim expression and was
+  blind to this for the whole life of the widget. It resolves which types apply the model rather than
+  naming them, reads a declaration whole (block-bodied values included), and self-checks against an
+  in-memory fixture so the machinery is proven independently of what the tree contains. Note what the
+  sweep that came with it found and did **not** fix: `modules/imi/sessionScreen/SessionActionButton.qml`
+  keys `buttonRadius` on `button.down`, which is the same doubling in the *radius* channel
+  (`RippleButton` already tightens by `pressRadiusScale` through `pressProgress`), tangled with a
+  `focus` shape the model has no state for.
+  f62673b7f ("fix(discordVoice): let the button own the hover and press motion"),
+  1d5d196fd ("test(lint): fail on a hover/press scale inside a control that already scales").
 - **A one-tree widget's geometry reads the SETTLED span's box, never the animating one.** Three
   trees were written with `spanW: root.implicitWidth`, and `implicitWidth` carries a Behavior: every
   rect became a per-frame target, so the Behaviors that carry the travel never converged, and any

--- a/docs/widget-standards-audit-2026-08-16.md
+++ b/docs/widget-standards-audit-2026-08-16.md
@@ -240,6 +240,15 @@ other control in the shell, and overshoot on release.
 
 **Size of fix:** small — delete two lines in each of two blocks.
 
+**Fixed**, and mechanised: `tests/lint_interaction_motion_double.py` fails the suite on a
+scale-family property written from a raw hover/press flag anywhere inside a control that applies
+`interactionMotion.scale`. Its sweep of both populations and the rest of the shell found no second
+copy of the *transform* form — but two neighbours in the same family, neither fixed here:
+`modules/imi/sessionScreen/SessionActionButton.qml:14` keys `buttonRadius` on `button.down`, which
+doubles the model's press tightening in the radius channel and is tangled with a `focus` shape the
+model has no state for; and the design system's own `RippleButton.qml:208` hand-rolls a state layer
+beside the model it drives (already recorded in §6).
+
 ### G5 — custom-image's resize animates a target that moves every frame (standard 4, *unverified at runtime*)
 
 `bundled/custom-image/Widget.qml:92-101`:

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/discordVoice/Widget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/discordVoice/Widget.qml
@@ -124,8 +124,6 @@ Rectangle {
                         fill: DiscordVoice.muted ? 1 : 0
                         color: DiscordVoice.muted ? Appearance.colors.colErrorContainer : Appearance.colors.colSecondaryContainer
                         colSymbol: DiscordVoice.muted ? Appearance.colors.colOnErrorContainer : Appearance.colors.colOnSecondaryContainer
-                        scale: parent?.down ? 0.88 : (parent?.hovered ? 1.08 : 1)
-                        Behavior on scale { NumberAnimation { duration: Appearance.animation.elementMoveFast.duration; easing.type: Easing.OutBack } }
                     }
                     StyledToolTip { text: DiscordVoice.muted ? "Unmute" : "Mute" }
                 }
@@ -145,8 +143,6 @@ Rectangle {
                         fill: DiscordVoice.deafened ? 1 : 0
                         color: DiscordVoice.deafened ? Appearance.colors.colErrorContainer : Appearance.colors.colTertiaryContainer
                         colSymbol: DiscordVoice.deafened ? Appearance.colors.colOnErrorContainer : Appearance.colors.colOnTertiaryContainer
-                        scale: parent?.down ? 0.88 : (parent?.hovered ? 1.08 : 1)
-                        Behavior on scale { NumberAnimation { duration: Appearance.animation.elementMoveFast.duration; easing.type: Easing.OutBack } }
                     }
                     StyledToolTip { text: DiscordVoice.deafened ? "Undeafen" : "Deafen" }
                 }

--- a/dots/.config/quickshell/imi/tests/lint_interaction_motion_double.py
+++ b/dots/.config/quickshell/imi/tests/lint_interaction_motion_double.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+#
+# Regression guard: the shared interaction model's hover/press motion is applied
+# ONCE, by the control, and callers take what it gives them.
+#
+# `Item.scale` and a `Scale` transform COMPOSITE down the scene graph exactly the
+# way `opacity` does, so a caller writing its own `scale: down ? a : (hovered ? b
+# : 1)` inside a control that already applies `interactionMotion.scale` does not
+# replace the model - it multiplies with it. `discordVoice`'s overlay shipped
+# that on its mute and deafen glyphs: 1.02 x 1.08 on hover and 0.97 x 0.88 on
+# press, roughly five times the intended excursion, on `OutBack` instead of the
+# model's curve, and with one duration standing in for the five tiers
+# `interaction_motion.js` exists to distinguish.
+#
+# This is `lint_disabled_opacity.py`'s rule with `scale` in place of `opacity`,
+# and it is a separate file rather than a branch of that one because the two
+# recognise different things: that lint keys on an `enabled`-conditioned dim
+# expression and is blind to a transform, which is why the doubled scale sat
+# beside a green suite for the whole life of the widget. A detector that knows
+# one idiom stops detecting the moment the idiom changes.
+#
+# The rule: inside a control that applies the interaction model's `scale`, no
+# descendant (and not the control itself) may write a scale-family property from
+# a raw hover/press flag. The sanctioned channels are the driver's own outputs -
+# `scale`, `hoverProgress`, `pressProgress` - which carry the right tier because
+# `InteractionMotion.qml` writes the tier onto the animation BEFORE the target.
+#
+# Exits non-zero listing offenders. Wired into run_tests.sh / CI.
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+MODULES = ROOT / "modules"
+
+# The scale-family properties. A transform is a transform however it is spelled:
+# `scale` on an Item, or `xScale`/`yScale` inside a `Scale {}`.
+SCALE_PROP = re.compile(r"^\s*(scale|xScale|yScale)\s*:(.*)$")
+
+# The raw interaction flags a control exposes. Deliberately NOT `hoverProgress`
+# or `pressProgress`: those are the model's own animated channels and reading
+# them is the adoption this check wants, not the doubling it forbids.
+STATE_FLAG = re.compile(
+    r"\b(hovered|hoveredNow|hovering|down|pressed|isPressed|isHovered"
+    r"|containsMouse|containsPress)\b"
+)
+
+# A file declares itself an interaction-model control by driving an
+# `InteractionMotion` and applying its `scale`. Both halves are required: a file
+# that merely declares one may be using only `pressProgress` for a radius, which
+# composites with nothing.
+DRIVES_MOTION = re.compile(r"\bInteractionMotion\s*\{")
+APPLIES_MOTION_SCALE = re.compile(
+    r"^\s*(?:scale|xScale|yScale)\s*:.*\.\s*scale\b"
+)
+
+TYPE_BEFORE_BRACE = re.compile(r"([A-Z]\w*)\s*$")
+
+# An expression continues onto the next line whenever it cannot stand alone yet.
+CONTINUES = re.compile(r"(\?|:|\|\||&&|[-+*/,(\[]|\breturn\b)\s*$")
+STARTS_CONTINUATION = re.compile(r"^\s*([?:.]|\|\||&&|[-+*/)\]}])")
+
+
+def strip_noise(line):
+    """Blank out string literals and line comments so brace counting is honest."""
+    out = []
+    quote = None
+    index = 0
+    while index < len(line):
+        char = line[index]
+        if quote:
+            if char == "\\":
+                out.append(" ")
+                index += 2
+                out.append(" ")
+                continue
+            out.append(" " if char != quote else char)
+            if char == quote:
+                quote = None
+            index += 1
+            continue
+        if char in "\"'":
+            quote = char
+            out.append(char)
+            index += 1
+            continue
+        if char == "/" and index + 1 < len(line) and line[index + 1] == "/":
+            break
+        out.append(char)
+        index += 1
+    return "".join(out)
+
+
+def enclosing_types(lines):
+    """Type-name stack in effect at each line, by brace depth.
+
+    A `{` is attributed to the identifier immediately before it, so
+    `contentItem: MaterialShapeWrappedMaterialSymbol {` pushes the type while
+    `onClicked: {` and `function f() {` push nothing.
+    """
+    stack = []
+    per_line = []
+    for line in lines:
+        per_line.append(tuple(name for name in stack if name))
+        clean = strip_noise(line)
+        for position, char in enumerate(clean):
+            if char == "{":
+                match = TYPE_BEFORE_BRACE.search(clean[:position])
+                stack.append(match.group(1) if match else None)
+            elif char == "}" and stack:
+                stack.pop()
+    return per_line
+
+
+def declaration_value(lines, index, first_fragment):
+    """The WHOLE right-hand side, not the line that opens it.
+
+    A source-text check over a QML property has to answer whether the value is a
+    line or a block - the settled-span check was vacuous for the largest tree it
+    named because it read only the line, and `readonly property real spanW: {`
+    says nothing at all.
+    """
+    value = strip_noise(first_fragment)
+    depth = value.count("{") - value.count("}")
+    depth += value.count("(") - value.count(")")
+    depth += value.count("[") - value.count("]")
+    cursor = index + 1
+    while cursor < len(lines):
+        stripped = value.strip()
+        if depth <= 0 and not CONTINUES.search(stripped):
+            nxt = strip_noise(lines[cursor])
+            if not STARTS_CONTINUATION.match(nxt) or not nxt.strip():
+                break
+        nxt = strip_noise(lines[cursor])
+        value += "\n" + nxt
+        depth += nxt.count("{") - nxt.count("}")
+        depth += nxt.count("(") - nxt.count(")")
+        depth += nxt.count("[") - nxt.count("]")
+        cursor += 1
+    return value
+
+
+def motion_controls(sources):
+    """Type names (file stems) whose declaration applies the model's scale."""
+    return {
+        path
+        for path, lines in sources.items()
+        if any(DRIVES_MOTION.search(line) for line in lines)
+        and any(APPLIES_MOTION_SCALE.match(line) for line in lines)
+    }
+
+
+def scan(sources, controls):
+    """(violations, files that opened a motion-control block)."""
+    violations = []
+    hosts = set()
+    for path, lines in sources.items():
+        stacks = enclosing_types(lines)
+        own_type = path.stem
+        for number, line in enumerate(lines, 1):
+            enclosing = set(stacks[number - 1])
+            if path.stem in controls:
+                enclosing.add(own_type)
+            inside = enclosing & controls
+            if inside:
+                hosts.add(path)
+            match = SCALE_PROP.match(line)
+            if not match or not inside:
+                continue
+            value = declaration_value(lines, number - 1, match.group(2))
+            if STATE_FLAG.search(value):
+                violations.append((path, number, sorted(inside)[0],
+                                   " ".join(value.split())[:90]))
+    return violations, hosts
+
+
+# The check matches source text over a tree it does not control, so both halves
+# of it are proven against a fixture that cannot drift: a doubled scale written
+# as a plain ternary, one written as a block, and the two spellings that must
+# NOT redden - the driver's own output, and a scale outside any control.
+SELF_CHECK = {
+    "Control.qml": """
+Button {
+    property InteractionMotion interactionMotion: InteractionMotion {
+        hovered: root.hovered
+    }
+    transform: Scale {
+        xScale: root.interactionMotion.scale
+        yScale: root.interactionMotion.scale
+    }
+}
+""",
+    "CallSite.qml": """
+Item {
+    Control {
+        contentItem: Glyph {
+            scale: parent?.down ? 0.88 : (parent?.hovered ? 1.08 : 1)
+        }
+        Label {
+            scale: {
+                if (parent.hovered)
+                    return 1.2;
+                return 1;
+            }
+        }
+        Icon {
+            scale: root.motion.scale
+        }
+    }
+    Loose {
+        scale: hoverArea.containsMouse ? 1.1 : 1
+    }
+}
+""",
+}
+
+
+def self_check():
+    sources = {Path(name): text.splitlines()
+               for name, text in SELF_CHECK.items()}
+    controls = {path.stem for path in motion_controls(sources)}
+    if controls != {"Control"}:
+        return (f"the interaction-model control detector resolved {controls or 'nothing'} "
+                "on a fixture declaring exactly one")
+    violations, hosts = scan(sources, controls)
+    found = {(path.name, number) for path, number, _, _ in violations}
+    if found != {("CallSite.qml", 5), ("CallSite.qml", 8)}:
+        return (f"the scan resolved {sorted(found)} on a fixture holding a "
+                "ternary doubling at 5 and a block doubling at 8")
+    if Path("CallSite.qml") not in hosts:
+        return "the block parser did not see the control instantiated at the call site"
+    return None
+
+
+def main():
+    broken = self_check()
+    if broken:
+        print("Interaction-motion lint FAILED its own self-check: "
+              f"{broken}. The check below cannot be trusted.", file=sys.stderr)
+        return 1
+
+    files = sorted(MODULES.rglob("*.qml"))
+    sources = {path: path.read_text(encoding="utf-8").splitlines()
+               for path in files}
+
+    control_files = motion_controls(sources)
+    controls = {path.stem for path in control_files}
+
+    # Pin what the detector is supposed to have found, by FILE rather than by
+    # type name: the plugin design system ships its own `RippleButton`, so a
+    # name-level guard stays satisfied by the copy while the mainline one loses
+    # its transform - the state in which flagging inner scales is exactly wrong.
+    expected_controls = {
+        "common/widgets/RippleButton.qml",
+        "common/plugins/designsystem/widgets/RippleButton.qml",
+        "common/plugins/bundled/nandoroid-media/MediaTransportButton.qml",
+    }
+    found_controls = {str(path.relative_to(MODULES)) for path in control_files}
+    missing = expected_controls - found_controls
+    if missing:
+        print("Interaction-motion lint FAILED: the scan found no applied "
+              f"`interactionMotion.scale` in {sorted(missing)} - either those "
+              "controls stopped driving the model, or the detector's shape "
+              "assumption broke and every call site below is now unguarded.",
+              file=sys.stderr)
+        return 1
+
+    violations, hosts = scan(sources, controls)
+
+    # ...and pin that the nesting analysis resolves against the real tree, not
+    # only against the fixture. One file whose ROOT is a control, one that
+    # instantiates them as children - the two shapes the stack has to get right.
+    expected_hosts = {
+        "common/widgets/ConfigSwitch.qml",
+        "common/plugins/bundled/discordVoice/Widget.qml",
+    }
+    found_hosts = {str(path.relative_to(MODULES)) for path in hosts}
+    missing_hosts = expected_hosts - found_hosts
+    if missing_hosts:
+        print("Interaction-motion lint FAILED: the brace-depth scan no longer "
+              f"places anything inside a control in {sorted(missing_hosts)}, so "
+              "it would report a clean tree whatever those files contain.",
+              file=sys.stderr)
+        return 1
+
+    if violations:
+        print("Interaction-motion lint FAILED: a transform composites, so a "
+              "hover/press scale written inside a control that already applies "
+              "`interactionMotion.scale` MULTIPLIES with the model instead of "
+              "replacing it - and carries one hand-picked duration where the "
+              "model has five tiers. Delete it; the control already scales the "
+              "whole subtree:", file=sys.stderr)
+        for path, number, control, value in violations:
+            rel = path.relative_to(MODULES)
+            print(f"  {rel}:{number}: inside {control}: {value}", file=sys.stderr)
+        return 1
+
+    print(f"Interaction-motion lint passed ({len(files)} QML files, "
+          f"{len(controls)} interaction-model controls, "
+          f"{len(hosts)} files hosting one)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dots/.config/quickshell/imi/tests/lint_interaction_motion_double.py
+++ b/dots/.config/quickshell/imi/tests/lint_interaction_motion_double.py
@@ -57,9 +57,13 @@ APPLIES_MOTION_SCALE = re.compile(
 
 TYPE_BEFORE_BRACE = re.compile(r"([A-Z]\w*)\s*$")
 
-# An expression continues onto the next line whenever it cannot stand alone yet.
+# An expression continues onto the next line whenever it cannot stand alone yet:
+# it ends on an operator, or the next line opens with one. Brackets are handled
+# by depth instead - treating a leading `}` as a continuation swallows the line
+# that CLOSES the enclosing object, which puts a sibling's text into this
+# declaration's value.
 CONTINUES = re.compile(r"(\?|:|\|\||&&|[-+*/,(\[]|\breturn\b)\s*$")
-STARTS_CONTINUATION = re.compile(r"^\s*([?:.]|\|\||&&|[-+*/)\]}])")
+STARTS_CONTINUATION = re.compile(r"^\s*([?:.]|\|\||&&|[-+*/])")
 
 
 def strip_noise(line):

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -99,6 +99,16 @@ if ! python3 "$SCRIPT_DIR/lint_disabled_opacity.py"; then
     exit 1
 fi
 
+# Static lint: the same rule for the interaction model's transform. A scale
+# composites exactly the way an opacity does, and the lint above recognises a
+# doubled dim by its opacity EXPRESSION - so the doubled scale discordVoice
+# shipped was invisible to it for the whole life of the widget.
+echo "Running interaction-motion lint..."
+if ! python3 "$SCRIPT_DIR/lint_interaction_motion_double.py"; then
+    echo "Interaction-motion lint failed."
+    exit 1
+fi
+
 # Static lint: a bar widget that answers a primary click says so with the
 # pointer. The shared button types always did; every hand-written MouseArea in
 # the bar forgot separately.


### PR DESCRIPTION
Closes the widget-standards audit's **G4**: `discordVoice` applied the shared interaction model twice.

## The bug

`bundled/discordVoice/Widget.qml` gave its mute and deafen glyphs their own

```qml
scale: parent?.down ? 0.88 : (parent?.hovered ? 1.08 : 1)
Behavior on scale { NumberAnimation { duration: ...elementMoveFast...; easing.type: Easing.OutBack } }
```

on the contentItem of a `RippleButton`, which already drives an `InteractionMotion` and applies
`interactionMotion.scale` through its own `Scale` transform. `Item.scale` composites with an
ancestor transform rather than replacing it, so the two multiplied. Both lines are gone from both
blocks; the button's motion is the only motion.

The curve and the clock were wrong with the amplitude: one hand-rolled `OutBack` animation carried
all five state transitions on one duration, where `interaction_motion.js` distinguishes press (the
fastest tier there is) from release (longer, springy) precisely so a `pressed -> rest` after
dragging off the button is not treated as a hover-out. The same two buttons in this package's
*popup* were already drawn without the ternary, so two copies of one control disagreed about how
hard it squishes; they agree now.

## Measured, not argued

The claim is an amplitude, so it was read off a real rendered scene graph — a disposable `qs -p`
probe under its own headless weston (the `run_card_shadow_probe.sh` pattern, isolated from the
session), rendering the real `RippleButton` + `MaterialShapeWrappedMaterialSymbol` in two columns,
and reporting `mapToItem(null, ...)` across the glyph, which composes the glyph's own `scale` with
the button's `Scale` exactly the way the renderer does:

| state | shipping (model only) | with the deleted ternary | rendered px (46px glyph) |
|---|---|---|---|
| rest | 1.0000x | 1.0000x | 46.0 / 46.0 |
| hover | **1.0200x** | **1.1016x** | 46.9 / 50.7 |
| press | **0.9700x** | **0.8536x** | 44.6 / 39.3 |

That is 1.02 x 1.08 and 0.97 x 0.88 to four decimals — the audit's arithmetic, confirmed against
pixels rather than reasoning. Excursion: **5.1x** the model on hover, **4.9x** on press.

The probe was temporary and is not in this branch. First measurement attempt was wrong in a way
worth recording: the composed scale was written as a property *binding* on `mapToItem`, which is an
invokable, so it evaluated once at construction and reported 1.0000 for all six cells — AGENT.md's
own "a binding on an invokable does not re-evaluate" rule, met from the inside.

## Seen on the live shell

Deployed to `~/.config/quickshell/imi` and restarted: `Configuration Loaded`, no `ERROR:` from the
shell. Overlay opened via `qs -c imi ipc call overlay toggle`; both buttons render. Hover was driven
for real with `ydotool` — note for the next agent, **relative** moves compound pointer acceleration
and a correction loop never converges (a 20px step became 19, 17, 60, 193, 205 on consecutive
tries), while `ydotool mousemove --absolute` maps at exactly **2x** on this output, so halving the
target and correcting in absolute lands within 1px on the first try. With the pointer on the mute
button the tooltip and the pointing-hand cursor confirm hover fired, and the glyph measures 28 ->
29px against its un-hovered neighbour: ~1px of growth on a 28px blob, consistent with 1.02 and not
with the 1.10 that would have been ~3px.

Three other agents were deploying to the same live shell, so every capture is bracketed by a
`diff -rq` of `modules/` against this worktree, before and after; all reported identical.

## The lint

`tests/lint_interaction_motion_double.py` — the scale form of `lint_disabled_opacity.py`'s rule. A
separate file on purpose: that lint recognises a doubled dim by its opacity **expression** and was
blind to this for the whole life of the widget, which is `af09ed3b9`'s own lesson ("a detector that
knows only one idiom stops detecting the moment the idiom changes") landing on the detector itself.

It resolves which types apply `interactionMotion.scale` rather than naming them (both `RippleButton`s
and `MediaTransportButton` today), walks every QML file with a brace-depth stack so it knows which
control a binding sits inside, and fails on a scale-family property (`scale`/`xScale`/`yScale`)
written from a raw hover/press flag anywhere in that subtree — including on the control itself. The
driver's own channels (`scale`, `hoverProgress`, `pressProgress`) do not match, because reading them
is the adoption this wants.

Three refusals to be vacuous:

- it reads the **whole** declaration, brace-balanced when the value is a block — the settled-span
  check was vacuous for the largest tree it named because it read only the line;
- it **self-checks** against an in-memory fixture carrying one ternary doubling, one block doubling,
  and the two spellings that must not redden, so the machinery is proven independently of what the
  tree happens to contain;
- it pins the controls it must find **by file** (the design system ships its own `RippleButton`, so
  a name-level guard stays satisfied by the copy) and pins two files the nesting analysis must place
  bindings inside — one rooted on a control, one instantiating them as children.

### Proven to fail, in a clean tree, on three plants, each reverted

| Plant | `lint_disabled_opacity.py` | new lint |
|---|---|---|
| the exact line removed from `discordVoice/Widget.qml` | **OK** | **FAILED** — `discordVoice/Widget.qml:127: inside RippleButton: parent?.down ? 0.88 : (parent?.hovered ? 1.08 : 1)` |
| a **block-bodied** `scale: { if (root.hovered) return 1.15; ... }` on `ConfigSwitch` (whose root *is* a `RippleButton`) | **OK** | **FAILED** — `ConfigSwitch.qml:9: inside RippleButton` |
| a `Scale { xScale: probeArea.containsMouse ? 1.3 : 1 }` nested three levels down, written across three lines | **OK** | **FAILED** — `discordVoice/Widget.qml:132: inside RippleButton` |

## The sweep

Run over the whole shell (634 QML files, 97 of them hosting a control that applies the model).
**No second copy of the transform form exists** — the other `Scale`/`xScale` animations in the tree
are flips, popup entrances and wallpaper transitions, none hover- or press-driven. Widening the same
machinery to *any* property written from a raw hover/press flag inside such a control turned up 23
bindings, of which four touch geometry or paint. Three are colour/opacity reveals and the audit's
already-recorded "adopts the model and then works around it". The fourth is a real second instance
of this defect in a different channel, **not fixed here**:

- **`modules/imi/sessionScreen/SessionActionButton.qml:14`** —
  `buttonRadius: (button.focus || button.down) ? size / 2 : Appearance.rounding.verylarge`.
  `RippleButton` already tightens the corner on press (`buttonRadiusPressed` = `buttonRadius *
  pressRadiusScale`, arrived at through `pressProgress`), so keying the *rest* radius on `down` too
  makes the press excursion 20 -> 51 instead of 20 -> 17, on two animations running on two different
  clocks. It is left alone because the `focus` half of that expression is legitimate and the model
  has no focused state at all — deciding what a focused session button should look like is a design
  call, not an audit fix. Recorded in AGENT.md and in the audit so it is not re-found from scratch.
- `modules/common/plugins/designsystem/widgets/RippleButton.qml:208` hand-rolls a state layer beside
  the model it drives — already §6 of the audit, in a file the shell does not build.

## Tests

`tests/run_tests.sh` green: **731 passed, 0 failed**. Two runs in between failed on
`test_widget_resize_grip_runtime` / `test_kboptions_migration_runtime`; both pass in isolation and
both are headless-weston harnesses that were racing two other agents' probes on this machine at the
time (three `weston` processes and a second `qs -p` were live) — not this branch.

Docs: updated AGENT.md §Dynamic/data-driven QML gotchas (the interaction-model entry), and recorded
G4's resolution plus the sweep's leftovers in `docs/widget-standards-audit-2026-08-16.md`.
