### PR TITLE
Currency quote cells: hold the last rect instead of reading it back

### DIFF
--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopCurrencyWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopCurrencyWidget.qml
@@ -352,7 +352,33 @@ Item {
                     id: quoteCell
                     required property int index
                     readonly property var slot: Geometry.quoteCellRect(index, root.sizeMode, root.spanW, root.spanH, Appearance.effectiveScale)
-                    readonly property var lastSlot: slot ?? ({ x: x, y: y, width: width, height: height, stacked: true })
+                    // Held, not read back. The fallback used to be
+                    // `{ x: x, y: y, width: width, height: height }` - the very
+                    // four properties it feeds - so while the slot was null the
+                    // cell's geometry depended on itself. `quoteCellRect`
+                    // returns null for cells 3 and 4 at 1x1
+                    // (currency_geometry.js:51), so that state is reached every
+                    // time the widget is shrunk, not in theory.
+                    //
+                    // Same fault, same file: the "to" label fifty lines up was
+                    // fixed and this sibling was missed. Holding the last
+                    // settled rect lets the cell fade out from where it was
+                    // without asking itself where that is.
+                    property real heldX: 0
+                    property real heldY: 0
+                    property real heldWidth: 0
+                    property real heldHeight: 0
+                    property bool heldStacked: true
+                    onSlotChanged: if (slot !== null) {
+                        heldX = slot.x;
+                        heldY = slot.y;
+                        heldWidth = slot.width;
+                        heldHeight = slot.height;
+                        heldStacked = slot.stacked ?? true;
+                    }
+                    readonly property var lastSlot: slot ?? ({
+                        x: heldX, y: heldY, width: heldWidth, height: heldHeight, stacked: heldStacked
+                    })
                     readonly property string quoteCurrency:
                         index === 0 ? CurrencyService.quote1
                         : index === 1 ? CurrencyService.quote2


### PR DESCRIPTION
Gap #4 from `docs/widget-standards-audit-2026-08-16.md`, and the second half of a
fix that landed incomplete in #206.

The quote cell's fallback while its slot was null was
`{ x: x, y: y, width: width, height: height }` — the very four properties it
feeds — so the cell's geometry depended on itself. Not hypothetical:
`quoteCellRect` returns null for cells 3 and 4 at 1x1
(`currency_geometry.js:51`), so the state is reached every time the widget is
shrunk to its smallest span.

Same fault, same file, fifty lines from the one already fixed. That one was
named by QML in a binding-loop warning and repaired; this sibling was in the same
grep output at the time and was left alone. It took a full widget audit to come
back to it, which is a poor way to find the second half of a fix — worth
remembering the next time a warning names one instance of a shape.

The cell now holds its last settled rect in plain properties, written whenever a
real one arrives, so it fades out from where it was without asking itself where
that is.

**Verification.** Suite 731 passing. I have deliberately NOT deployed this to the
live shell to watch the warning disappear: two other agents are mid-measurement
on that shell right now, and a deploy underneath them would corrupt exactly the
kind of pixel measurement they are taking. The change is structurally identical
to the one verified at runtime in #206 — same file, same idiom, same fix — so the
static case is strong, but the runtime confirmation is honestly outstanding and I
will run it once the shell is free.

Docs: not needed — the reasoning sits at the code, and the audit entry this
closes is already recorded in `docs/widget-standards-audit-2026-08-16.md`.