### PR TITLE
Morph calendar and world-clock in one tree instead of rebuilding them per span

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1512,6 +1512,38 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   below. Any source-text check over a QML property has the same question to answer: is the value a
   line or a block?
   test(widgets): sweep for the settled-span rule instead of naming three files.
+- **A widget the host does not size gets neither of the host's two resize services, and the
+  absence of both is silent.** `PluginWidget`'s `Behavior on width`/`height` is
+  `enabled: gridResizeAnimated`, which is `gridSized && PluginState.ready`, and `boxInMotion`
+  compares the drawn box against `settledWidth`/`settledHeight` — which for a content-sized
+  widget *are* `rootWidget.width`/`height`, so it is false forever. A widget that declares no
+  manifest `grid` because its own handles own its size (calendar, world-clock) therefore snaps
+  between sizes **and** keeps its card's shadow re-blurring a copy of the body into a
+  reallocating layer for every frame of whatever motion it does perform — the exact cost
+  e5d243c5e removed for span widgets. Both halves belong to the widget: it animates its own
+  implicit size towards the settled span, and publishes its own `boxInMotion` for the card
+  (`hostMotionActive: root.hostBoxInMotion || root.boxInMotion`, so a host that ever does report
+  it still wins).
+  feat(calendar): morph the calendar in one tree instead of rebuilding it.
+- **A one-tree widget needs `WidgetCard.clipContent`, and a per-span Loader did not.** A
+  destroyed subtree stops existing when the card shrinks; a faded one does not. Calendar's day
+  grid and five of its six rows, and the world clock's local time and date, all sit below a short
+  card's bottom edge while they fade, and unclipped they paint onto the wallpaper for the whole
+  morph. The corollary is the reason a fading block must also **stand still**: pin it to its own
+  span's box rather than anchoring it to the card, or it reflows through every intermediate size
+  on the way out, which reads as the content being squeezed rather than as it leaving.
+  feat(world-clock): morph the world clock in one tree instead of rebuilding it.
+- **A desktop widget's frost drops out for the length of any box animation, and it is not the
+  morph's fault.** Measured frame by frame on the desktop: through a span change the card body
+  goes to its bare tint over a *sharp* wallpaper and the blur comes back only once the box
+  settles. This predates the one-tree work — the same burst on `nandoroid-weather`, which has
+  animated its box since fa1e2a8b5, shows it identically — it was simply invisible while calendar
+  and world-clock snapped. The likely mechanism is that `PluginWidget`'s frost `Repeater` takes
+  `pluginNode.blurRegions` as its model, and a card's `blurRegion` is a fresh object on every
+  frame of a resize, so the `WallpaperBlurSurface` delegates are destroyed and rebuilt per frame;
+  that is a reading of the source, not something anyone has proved, and the way to settle it is a
+  `Component.onCompleted`/`onDestruction` count on the delegate during a resize.
+  feat(calendar): morph the calendar in one tree instead of rebuilding it.
 - **An element that changes its TEXT across spans is two elements, not one.** The currency base
   code read "to USD" at 1x1 and "USD" at 2x1 from a single `StyledText`, so the content swapped in
   one frame in the middle of an otherwise continuous morph. "to" is its own element that fades,

--- a/docs/widget-grid.md
+++ b/docs/widget-grid.md
@@ -368,6 +368,28 @@ named in one place. A manifest's `defaultWidth`/`defaultHeight` floor is a size 
 the smallest span the widget can actually take, or the floor pins the widget off-grid no
 matter what the QML says.
 
+**Omitting `grid` also opts the widget out of the host's resize animation, so it has to bring
+its own.** `PluginWidget`'s `Behavior on width`/`height` is `enabled: gridResizeAnimated`
+(`gridSized && PluginState.ready`), and `boxInMotion` compares the drawn box with
+`settledWidth`/`settledHeight` — which for a content-sized widget *are* the widget's current
+width and height, so it never reports motion. A `grid`-less widget that changes size therefore
+snapped between its modes, and its card kept a live drop shadow through the change, until each
+of them animated its own implicit size towards the settled span and published its own
+`boxInMotion`:
+
+```qml
+readonly property real spanW: root.spanWidthOf(root.sizeMode)   // the settled span
+property real widgetWidth: root.spanW                            // the box travelling to it
+Behavior on widgetWidth { Expressive.SpanTravel {} }
+readonly property bool boxInMotion: Math.abs(root.widgetWidth - root.spanW) > 0.5 || ...
+implicitWidth: root.widgetWidth
+```
+
+The split matters beyond the animation: everything a one-tree widget places reads the **settled**
+span and never the travelling box, or the Behaviors carrying each element chase a target that
+moves every frame and never converge
+(`test_geometry_rects_come_from_the_settled_span_not_the_animating_box`).
+
 **A widget-owned `sizeMode` is not the same thing as the retired manifest option, and a
 migration keyed on the name alone destroys it.** `world-clock` and `calendar` declare no
 `grid` and drive a `sizeMode` of their own from their own toggles, so for them the key is

--- a/docs/widget-standards-audit-2026-08-16.md
+++ b/docs/widget-standards-audit-2026-08-16.md
@@ -176,6 +176,12 @@ the "anchor to `parent`, not to the card by id" trap `486272dbe` records for cal
 
 ### G3 — calendar and world-clock resize by destroy-and-rebuild (standard 1)
 
+**Fixed.** Both widgets morph in one tree now, off a geometry module each
+(`calendar_geometry.js`, `world_clock_geometry.js`), and both animate their own box; the line
+numbers below describe the code as it was. What closed it is recorded under §8.
+feat(calendar): morph the calendar in one tree instead of rebuilding it,
+feat(world-clock): morph the world clock in one tree instead of rebuilding it.
+
 `bundled/calendar/Widget.qml:236-245` dispatches three whole `Component`s through one `Loader`:
 
 ```qml
@@ -532,10 +538,10 @@ block is `visible: !root.chromeless` while the only instantiation of `DesktopMed
 
 ## 5. Ranked: what to fix first, by user-visible impact
 
-1. **G3 — calendar and world-clock resize by destroy-and-rebuild.** Two of twelve desktop widgets
-   cut where the other three morph, on the most-used interaction those widgets have, and their box
-   snaps as well because nothing animates it. Largest fix in the list and still first: it is the one
-   gap a user sees every time they touch the widget.
+1. ~~**G3 — calendar and world-clock resize by destroy-and-rebuild.**~~ **Done** — see §8. Two of
+   twelve desktop widgets cut where the other three morph, on the most-used interaction those
+   widgets have, and their box snapped as well because nothing animated it. Largest fix in the
+   list and still first: it is the one gap a user sees every time they touch the widget.
 2. **G2 — `notes` and `image-converter` cast no shadow.** Always on screen, no interaction needed.
    Two widgets sit flat on the wallpaper beside ten that do not.
 3. **G4 — discordVoice's doubled scale.** Every mute and deafen click, at five times the intended
@@ -612,3 +618,46 @@ the manifests declaring a `desktop-widget` capability, may not paint a blur-gate
 helper it names, while a tint on a surface *inside* the card stays free. Proven to fail on the two
 widgets as they stood before the fix, and to pass after
 (test(lint): the card-tint carve-out is scoped to content, not to a spelling).
+---
+
+## 8. What closed G3
+
+Both widgets are one tree now. Elements are declared once and travel between the rects a geometry
+module answers for, on the shared `SpanTravel`/`SpanFade` curves — no `Loader` keyed on the span,
+no `visible`-swapped duplicate subtree, and no element that stops existing between one span and
+the next.
+
+**calendar** (`calendar_geometry.js`, unit-tested in `tests/tst_calendar_geometry.qml`):
+
+| element | 1x1 | 2x1 | 2x2 |
+|---|---|---|---|
+| month surface | full-bleed band, card's top corners | pill | — (fades; the 2x2 title is plain) |
+| short month + weekday | in the band | — | — |
+| long month name | — | in the pill | on the card inset, a step larger |
+| month steppers | — | — | right of the title |
+| weekday letters | — | over the card's seven columns | over the day grid's seven |
+| day-grid surface | — | — | the `colLayer1` panel |
+| day cells (42) | today's alone, as the hero date | the current week's seven, in a row | all of them, in six rows |
+
+**world-clock** (`world_clock_geometry.js`, `tests/tst_world_clock_geometry.qml`): the four city
+tiles are the shared elements. A chip in the 2x2 grid and a dial in the 3x1 row are the same tile,
+carrying its surface, its colour and its city name; the offset, the digital time and the day/night
+glyph fade, and the hands fade in out of the chip's own box. The local place/time/date block and
+the settings back are pinned to the 2x2 box while they fade rather than anchored to a card on its
+way to 420x108.
+
+Two things the audit named as aggravating are also gone. Both widgets animate their own box, which
+the host does not do for a widget declaring no `grid` (see `docs/widget-grid.md`), and both publish
+their own `boxInMotion` so the card stops re-blurring its body into a reallocating layer for the
+length of the resize.
+
+Verified frame by frame on the running shell (`grim` bursts at ~36ms across each transition):
+every shared element stays on screen and travels, and nothing blinks out and reappears.
+
+One thing those bursts exposed that is **not** this gap: the desktop frost drops out for the
+length of any box animation, and the same burst on `nandoroid-weather` shows it identically. It
+predates the one-tree work and was simply invisible while these two snapped. Recorded in AGENT.md
+with the suspected mechanism and the way to settle it.
+
+`test_a_widget_that_owns_its_span_morphs_in_one_tree` is the guard: any widget declaring its own
+`sizeMode` may not let that name reach a `sourceComponent` or a `visible`.

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/calendar/Widget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/calendar/Widget.qml
@@ -1,12 +1,12 @@
 pragma ComponentBehavior: Bound
 
 import QtQuick
-import QtQuick.Layouts
 import qs.modules.common
 import qs.modules.common.functions
 import qs.modules.common.widgets
 import qs.modules.common.plugins
 import "../../designsystem/widgets" as Expressive
+import "calendar_geometry.js" as Geometry
 
 Item {
     id: root
@@ -26,6 +26,9 @@ Item {
     property bool hostDragging: false
     // Set by the host while its own box is animating; the cards drop their
     // shadow for the duration rather than re-blurring into a resizing FBO.
+    // It is always false here - the host only animates a box it sizes itself,
+    // and this widget declares no `grid` - so the widget publishes its own
+    // `boxInMotion` below and the card takes both.
     property bool hostBoxInMotion: false
 
     // The card fills the whole widget, so the host's default frost region has
@@ -40,7 +43,7 @@ Item {
     readonly property var blurRegions: [card.blurRegion]
 
     // The card's own surface is the card's business now; this stays for the
-    // surfaces drawn *inside* it - the 1x1 banner, the month pill, the day
+    // surfaces drawn *inside* it - the month band, the month pill, the day
     // grid and today's highlight - which thin with the card so the frost
     // reads through the whole widget rather than through its edges only.
     // `transparentize` rather than the card's `applyAlpha` because two of
@@ -89,33 +92,44 @@ Item {
         PluginState.setOption("calendar", "sizeMode", mode);
     }
 
-    property real widgetWidth: {
-        switch (root.sizeMode) {
-        case "1x1":
-            return root.snapWidth1;
-        case "2x1":
-            return root.snapWidth2;
-        default:
-            return root.snapWidth2;
-        }
+    // The month steppers only exist at 2x2, and the two smaller spans are both
+    // about *today* - the hero date and the current week. Leaving a shift on
+    // when the card shrinks would show a week of some other month with today's
+    // date nowhere in it, and would leave the hero cell with no home at all.
+    onSizeModeChanged: if (root.sizeMode !== "2x2") root.monthShift = 0
+
+    // ---- the span, and the box travelling towards it ---------------------
+    //
+    // Geometry evaluates at the span's SETTLED box; the Behaviors below carry
+    // the travel. Reading `implicitWidth` here instead would retarget every
+    // element on every frame, and a Behavior whose target keeps moving never
+    // converges (test_geometry_rects_come_from_the_settled_span_not_the_
+    // animating_box).
+    function spanWidthOf(span) {
+        return span === "1x1" ? root.snapWidth1 : root.snapWidth2;
     }
+    function spanHeightOf(span) {
+        return span === "2x2" ? root.tallHeight : root.shortHeight;
+    }
+    readonly property real spanW: root.spanWidthOf(root.sizeMode)
+    readonly property real spanH: root.spanHeightOf(root.sizeMode)
+    readonly property real uiScale: Appearance.effectiveScale
 
-    // One padding for every mode, so the three sizes read as the same card at
-    // different scales. space150 rather than the space200 the notes tile uses:
-    // a 228-tall card has to seat a title row, a weekday strip and six week
-    // rows, and the 8px space200 would take comes straight off the day grid,
-    // which has less of it to give than the card edge does.
-    readonly property real cardInset: Appearance.spacing.space150
+    property real widgetWidth: root.spanW
+    property real widgetHeight: root.spanH
+    Behavior on widgetWidth { Expressive.SpanTravel {} }
+    Behavior on widgetHeight { Expressive.SpanTravel {} }
 
-    // Padding between the day-grid surface and the block of day pills inside
-    // it. The pills are centred in their columns, so the *visible* gap is this
-    // plus half a column's slack; space50 lands that at roughly the same 7px
-    // the compressed row pitch leaves above and below (see twoByTwoContent).
-    readonly property real dayGridInset: Appearance.spacing.space50
+    // The host publishes `boxInMotion` only for a box it sizes itself, and a
+    // content-sized widget's box is this one - so the card would never drop its
+    // shadow for the one motion that reallocates the layer every frame.
+    readonly property bool boxInMotion: Math.abs(root.widgetWidth - root.spanW) > 0.5
+        || Math.abs(root.widgetHeight - root.spanH) > 0.5
 
-    // Column width for the wide-short mode, which has no inner surface: the
-    // card's own content width split seven ways.
-    readonly property real weekColumnWidth: (root.snapWidth2 - root.cardInset * 2) / 7
+    implicitWidth: root.widgetWidth
+    implicitHeight: root.widgetHeight
+
+    // ---- the month matrix ------------------------------------------------
 
     property int monthShift: 0
     readonly property var today: new Date()
@@ -153,36 +167,46 @@ Item {
         }
 
         let nextDay = 1;
-        while (cells.length < 42) {
+        while (cells.length < Geometry.CELLS)
             cells.push({
                 day: nextDay++,
                 currentMonth: false,
                 isToday: false
             });
-        }
-
-        let weeks = [];
-        for (let i = 0; i < cells.length; i += 7)
-            weeks.push(cells.slice(i, i + 7));
-        return weeks;
+        return cells;
     }
 
-    function getCurrentWeek() {
-        const matrix = getMonthMatrix(viewingDate);
-        for (let w = 0; w < matrix.length; w++) {
-            if (matrix[w].some(c => c.isToday))
-                return matrix[w];
-        }
-        return matrix[0];
+    // A flat forty-two, because the cells are the shared elements: the same
+    // delegate has to be the one in the month grid, the one in the week strip
+    // and - for today's - the hero date. A model of six week rows would give
+    // each span a different set of items to destroy and rebuild, which is the
+    // whole thing this replaces.
+    property var cells: root.getMonthMatrix(root.viewingDate)
+
+    readonly property int todayIndex: {
+        for (let i = 0; i < root.cells.length; i++)
+            if (root.cells[i].isToday)
+                return i;
+        return -1;
     }
+    // The row the 2x1 span keeps. Today's, whenever today is on the card at
+    // all; the first otherwise, which is what the destroyed layout's
+    // `getCurrentWeek()` fell back to.
+    readonly property int weekRow: root.todayIndex >= 0
+        ? Math.floor(root.todayIndex / Geometry.COLUMNS) : 0
 
-    property var weeks: getMonthMatrix(viewingDate)
+    readonly property string monthLongText: root.viewingDate.toLocaleDateString(Qt.locale(), "MMMM yyyy")
 
-    implicitWidth: card.implicitWidth
-    implicitHeight: card.implicitHeight
-
-    Behavior on widgetWidth {
-        animation: Appearance.animation.elementResize.numberAnimation.createObject(this)
+    // The pill hugs its label, so it needs the label's width at the pill's OWN
+    // font rather than at the animating one a morph is part-way through. Same
+    // component and so the same metrics, which a TextMetrics with hand-copied
+    // font settings would only approximate.
+    StyledText {
+        id: monthPillRuler
+        visible: false
+        text: root.monthLongText
+        font.pixelSize: Math.round(Geometry.MONTH_FONT_PILL * root.uiScale)
+        font.weight: Font.Bold
     }
 
     // The host (PluginWidget) is the MouseArea that drags this widget; a
@@ -191,359 +215,285 @@ Item {
         id: widgetHover
     }
 
-    component DayCell: Rectangle {
-        id: dayCell
-        property int day: 0
-        property bool currentMonth: true
-        property bool isToday: false
-        property bool bold: false
-        // Set by the caller so today's pill frosts with the rest of the card.
-        property color highlightColor: Appearance.colors.colPrimary
-
-        implicitWidth: 28
-        implicitHeight: 28
-        radius: Appearance.rounding.full
-        color: dayCell.isToday ? dayCell.highlightColor : "transparent"
-
-        StyledText {
-            anchors.centerIn: parent
-            text: dayCell.day
-            font.pixelSize: Appearance.font.pixelSize.smaller
-            font.weight: dayCell.bold || dayCell.isToday ? Font.Bold : Font.Normal
-            color: dayCell.isToday ? Appearance.colors.colOnPrimary : Appearance.colors.colOnLayer0
-            opacity: dayCell.currentMonth ? 1.0 : 0.3
-        }
-    }
-
     // The surface every other desktop widget already composes. It owns the
     // tint pair, the rounding (this widget's own `verylarge` was the token the
     // shared card's 30 had drifted from), the frost record above, and the drop
-    // shadow with its hover and drag lift - which is what replaces the flat
-    // StyledRectangularShadow that used to hang behind this rectangle.
+    // shadow with its hover and drag lift.
+    //
+    // `clipContent`, because a one-tree widget's elements do not stop existing
+    // when the card shrinks past them: the day grid's surface and five of its
+    // six rows fade out below a 2x1 card's bottom edge, and an unclipped fade
+    // paints them onto the wallpaper for the length of the morph.
     //
     // No `tensionX`/`tensionY`: the manifest declares no `grid`, so the host
     // draws no resize grip here and there is never a bow to render.
     Expressive.WidgetCard {
         id: card
-        implicitWidth: root.widgetWidth
-        implicitHeight: root.sizeMode === "1x1" ? root.shortHeight : root.sizeMode === "2x1" ? root.shortHeight : root.tallHeight
+        anchors.fill: parent
+        clipContent: true
         tint: Appearance.colors.colPrimaryContainer
         useBlurBackground: root.blurEnabled
         backgroundOpacity: root.backgroundOpacity
         dragging: root.hostDragging
-        hostMotionActive: root.hostBoxInMotion
+        hostMotionActive: root.hostBoxInMotion || root.boxInMotion
 
-        Loader {
-            anchors.fill: parent
-            sourceComponent: {
-                if (root.sizeMode === "1x1")
-                    return oneByOneContent;
-                if (root.sizeMode === "2x1")
-                    return twoByOneContent;
-                return twoByTwoContent;
+        // ---- the month surface: the 1x1 band, the 2x1 pill ---------------
+        //
+        // One element with two homes and one absence. At 2x2 the month is a
+        // plain title on the card, so the surface fades out where it stood
+        // rather than travelling to a place it does not have.
+        Rectangle {
+            id: monthSurface
+            readonly property bool present: root.sizeMode !== "2x2"
+            readonly property string homeSpan: root.sizeMode === "2x2" ? "2x1" : root.sizeMode
+            readonly property var slot: Geometry.monthSurfaceRect(
+                monthSurface.homeSpan,
+                root.spanWidthOf(monthSurface.homeSpan),
+                root.spanHeightOf(monthSurface.homeSpan),
+                root.uiScale,
+                monthPillRuler.paintedWidth,
+                card.radius)
+
+            x: slot.x
+            y: slot.y
+            width: slot.width
+            height: slot.height
+            Behavior on x { Expressive.SpanTravel {} }
+            Behavior on y { Expressive.SpanTravel {} }
+            Behavior on width { Expressive.SpanTravel {} }
+            Behavior on height { Expressive.SpanTravel {} }
+
+            // The corners ARE the morph: a band whose top corners are the
+            // card's own and whose bottom edge is square becomes a stadium.
+            property real cornerTop: monthSurface.slot.radiusTop
+            property real cornerBottom: monthSurface.slot.radiusBottom
+            Behavior on cornerTop { Expressive.SpanTravel {} }
+            Behavior on cornerBottom { Expressive.SpanTravel {} }
+            topLeftRadius: monthSurface.cornerTop
+            topRightRadius: monthSurface.cornerTop
+            bottomLeftRadius: monthSurface.cornerBottom
+            bottomRightRadius: monthSurface.cornerBottom
+
+            color: root.tinted(Appearance.colors.colPrimary)
+            opacity: monthSurface.present ? 1 : 0
+            Behavior on opacity { Expressive.SpanFade {} }
+            visible: opacity > 0
+
+            // The band's own label, which says the month in short form beside
+            // the weekday. It is not the long month name travelling in from
+            // 2x1 - one element cannot swap its text mid-morph without a
+            // content snap - so it is its own pair, riding the surface.
+            Row {
+                anchors.centerIn: parent
+                spacing: Appearance.spacing.space50
+                opacity: root.sizeMode === "1x1" ? 1 : 0
+                Behavior on opacity { Expressive.SpanFade {} }
+                visible: opacity > 0
+
+                StyledText {
+                    text: root.today.toLocaleDateString(Qt.locale(), "MMM").toUpperCase()
+                    font.pixelSize: Appearance.font.pixelSize.normal
+                    font.weight: Font.Bold
+                    color: Appearance.colors.colOnPrimary
+                }
+                StyledText {
+                    text: root.today.toLocaleDateString(Qt.locale(), "ddd").toUpperCase()
+                    font.pixelSize: Appearance.font.pixelSize.normal
+                    font.weight: Font.Bold
+                    color: Appearance.colors.colOnPrimary
+                    opacity: 0.7
+                }
             }
         }
 
-        // 1x1. Two full-bleed bands, so there is no card inset here - the
-        // banner is the padding. Its height is its own label plus space100
-        // above and below rather than a fraction of the card: a fraction
-        // silently re-tunes the banner's padding every time the card is
-        // resized, which is how it survived being sized to a 120px cell that
-        // was really 108 without anyone noticing.
-        Component {
-            id: oneByOneContent
-            ColumnLayout {
-                anchors.fill: parent
-                spacing: Appearance.spacing.space0
+        // ---- the long month name, out of the pill and up to the title ----
+        StyledText {
+            id: monthLabel
+            objectName: "calendarMonthLabel"
+            readonly property bool present: root.sizeMode !== "1x1"
+            readonly property string homeSpan: root.sizeMode === "1x1" ? "2x2" : root.sizeMode
+            readonly property var slot: Geometry.monthLabelRect(
+                monthLabel.homeSpan,
+                root.spanWidthOf(monthLabel.homeSpan),
+                root.spanHeightOf(monthLabel.homeSpan),
+                root.uiScale)
 
-                Rectangle {
-                    Layout.fillWidth: true
-                    implicitHeight: bannerRow.implicitHeight + Appearance.spacing.space100 * 2
-                    color: root.tinted(Appearance.colors.colPrimary)
-                    topLeftRadius: card.radius
-                    topRightRadius: card.radius
+            x: slot.x
+            y: slot.y
+            height: slot.height
+            Behavior on x { Expressive.SpanTravel {} }
+            Behavior on y { Expressive.SpanTravel {} }
+            Behavior on height { Expressive.SpanTravel {} }
 
-                    RowLayout {
-                        id: bannerRow
-                        anchors.centerIn: parent
-                        spacing: Appearance.spacing.space50
-                        StyledText {
-                            text: root.today.toLocaleDateString(Qt.locale(), "MMM").toUpperCase()
-                            font.pixelSize: Appearance.font.pixelSize.normal
-                            font.weight: Font.Bold
-                            color: Appearance.colors.colOnPrimary
-                        }
-                        StyledText {
-                            text: root.today.toLocaleDateString(Qt.locale(), "ddd").toUpperCase()
-                            font.pixelSize: Appearance.font.pixelSize.normal
-                            font.weight: Font.Bold
-                            color: Appearance.colors.colOnPrimary
-                            opacity: 0.7
-                        }
-                    }
-                }
-
-                Item {
-                    Layout.fillWidth: true
-                    Layout.fillHeight: true
-
-                    StyledText {
-                        anchors.centerIn: parent
-                        text: root.today.getDate()
-                        font.pixelSize: 54
-                        font.weight: Font.Bold
-                        color: Appearance.colors.colOnPrimaryContainer
-                    }
-                }
-            }
+            text: root.monthLongText
+            font.pixelSize: Math.round(monthLabel.slot.size)
+            Behavior on font.pixelSize { Expressive.SpanTravel {} }
+            font.weight: root.sizeMode === "2x2" ? Font.Medium : Font.Bold
+            Behavior on font.weight { Expressive.SpanTravel {} }
+            color: root.sizeMode === "2x1"
+                ? Appearance.colors.colOnPrimary
+                : Appearance.colors.colOnPrimaryContainer
+            Behavior on color { ColorAnimation { duration: Appearance.animation.elementMove.duration } }
+            opacity: monthLabel.present ? 1 : 0
+            Behavior on opacity { Expressive.SpanFade {} }
+            visible: opacity > 0
         }
 
-        // 2x1. The same three-step rhythm as the 2x2: cardInset (space150)
-        // around the card, space100 between the month pill and the week strip
-        // it heads, space50 between the weekday letters and the day row they
-        // label. That comes to 84px of content, and the column is *centred*
-        // rather than filled so the remaining 24px lands as 12 above and 12
-        // below - exactly the card inset - instead of piling up under a
-        // trailing fillHeight spacer and leaving the card bottom-heavy.
-        Component {
-            id: twoByOneContent
-            Item {
-                anchors.fill: parent
+        // ---- the two month steppers, 2x2 only ----------------------------
+        Repeater {
+            model: 2
+            delegate: Rectangle {
+                id: navButton
+                required property int index
+                readonly property bool present: root.sizeMode === "2x2"
+                readonly property var slot: Geometry.navButtonRect(
+                    navButton.index, "2x2", root.snapWidth2, root.tallHeight, root.uiScale)
 
-                ColumnLayout {
+                x: slot.x
+                y: slot.y
+                width: slot.width
+                height: slot.height
+                Behavior on x { Expressive.SpanTravel {} }
+                Behavior on y { Expressive.SpanTravel {} }
+
+                radius: Appearance.rounding.full
+                color: "transparent"
+                border.width: Appearance.borderWidth.standard
+                border.color: Appearance.colors.colPrimary
+                opacity: navButton.present ? 1 : 0
+                Behavior on opacity { Expressive.SpanFade {} }
+                visible: opacity > 0
+
+                MaterialSymbol {
                     anchors.centerIn: parent
-                    width: parent.width - root.cardInset * 2
-                    spacing: Appearance.spacing.space100
-
-                    Rectangle {
-                        implicitHeight: 28
-                        implicitWidth: monthText.implicitWidth + Appearance.spacing.space150 * 2
-                        radius: Appearance.rounding.full
-                        color: root.tinted(Appearance.colors.colPrimary)
-
-                        StyledText {
-                            id: monthText
-                            anchors.centerIn: parent
-                            text: root.today.toLocaleDateString(Qt.locale(), "MMMM yyyy")
-                            font.pixelSize: Appearance.font.pixelSize.small
-                            font.weight: Font.Bold
-                            color: Appearance.colors.colOnPrimary
-                        }
-                    }
-
-                    Grid {
-                        columns: 7
-                        rowSpacing: Appearance.spacing.space50
-                        columnSpacing: Appearance.spacing.space0
-                        Layout.fillWidth: true
-
-                        Repeater {
-                            model: ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"]
-                            delegate: Item {
-                                id: weekdayHeaderCell
-                                required property var modelData
-                                implicitWidth: root.weekColumnWidth
-                                implicitHeight: 16
-                                StyledText {
-                                    anchors.centerIn: parent
-                                    text: weekdayHeaderCell.modelData
-                                    font.pixelSize: Appearance.font.pixelSize.smaller
-                                    font.weight: Font.Bold
-                                    color: Appearance.colors.colOnPrimaryContainer
-                                    opacity: 0.5
-                                }
-                            }
-                        }
-
-                        Repeater {
-                            model: root.getCurrentWeek()
-                            delegate: Item {
-                                id: weekDayCell
-                                required property var modelData
-                                implicitWidth: root.weekColumnWidth
-                                implicitHeight: 28
-
-                                Rectangle {
-                                    anchors.centerIn: parent
-                                    width: 28
-                                    height: 28
-                                    radius: Appearance.rounding.full
-                                    color: weekDayCell.modelData.isToday ? root.tinted(Appearance.colors.colPrimary) : "transparent"
-
-                                    StyledText {
-                                        anchors.centerIn: parent
-                                        text: weekDayCell.modelData.day
-                                        font.pixelSize: Appearance.font.pixelSize.smaller
-                                        font.weight: weekDayCell.modelData.isToday ? Font.Bold : Font.Normal
-                                        color: weekDayCell.modelData.isToday ? Appearance.colors.colOnPrimary : Appearance.colors.colOnPrimaryContainer
-                                        opacity: weekDayCell.modelData.currentMonth ? 1.0 : 0.3
-                                    }
-                                }
-                            }
-                        }
-                    }
+                    text: navButton.index === 0 ? "chevron_left" : "chevron_right"
+                    iconSize: Appearance.font.pixelSize.normal
+                    color: Appearance.colors.colOnPrimaryContainer
+                }
+                MouseArea {
+                    anchors.fill: parent
+                    cursorShape: Qt.PointingHandCursor
+                    onClicked: root.monthShift += navButton.index === 0 ? -1 : 1
                 }
             }
         }
 
-        // 2x2. Three consecutive steps of the scale, each one naming a real
-        // relationship rather than whatever made the pixels add up:
+        // ---- the seven weekday letters -----------------------------------
+        Repeater {
+            model: Geometry.COLUMNS
+            delegate: StyledText {
+                id: weekdayHeader
+                required property int index
+                readonly property bool present: root.sizeMode !== "1x1"
+                readonly property string homeSpan: root.sizeMode === "1x1" ? "2x2" : root.sizeMode
+                readonly property var slot: Geometry.weekdayHeaderRect(
+                    weekdayHeader.index, weekdayHeader.homeSpan,
+                    root.spanWidthOf(weekdayHeader.homeSpan),
+                    root.spanHeightOf(weekdayHeader.homeSpan),
+                    root.uiScale)
+
+                x: slot.x
+                y: slot.y
+                width: slot.width
+                height: slot.height
+                Behavior on x { Expressive.SpanTravel {} }
+                Behavior on y { Expressive.SpanTravel {} }
+                Behavior on width { Expressive.SpanTravel {} }
+
+                horizontalAlignment: Text.AlignHCenter
+                text: ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"][weekdayHeader.index]
+                font.pixelSize: Appearance.font.pixelSize.smaller
+                font.weight: Font.Bold
+                color: Appearance.colors.colOnPrimaryContainer
+                opacity: weekdayHeader.present ? (root.sizeMode === "2x2" ? 0.6 : 0.5) : 0
+                Behavior on opacity { Expressive.SpanFade {} }
+                visible: opacity > 0
+            }
+        }
+
+        // ---- the surface the month grid is drawn on, 2x2 only ------------
+        Rectangle {
+            id: dayGridSurface
+            readonly property var slot: Geometry.dayGridSurfaceRect(
+                "2x2", root.snapWidth2, root.tallHeight, root.uiScale, card.radius)
+
+            x: slot.x
+            y: slot.y
+            width: slot.width
+            height: slot.height
+            radius: slot.radius
+            color: root.tinted(Appearance.colors.colLayer1)
+            opacity: root.sizeMode === "2x2" ? 1 : 0
+            Behavior on opacity { Expressive.SpanFade {} }
+            visible: opacity > 0
+        }
+
+        // ---- the forty-two day cells -------------------------------------
         //
-        //   space150  cardInset - the card's edge padding
-        //   space100  between the month title block and the calendar block
-        //   space50   between the weekday letters and the grid they label
-        //
-        // Grouping the weekday strip with the grid inside one column is what
-        // makes those last two different: the strip is a header for the grid,
-        // not a third peer of the title, and reading it as a peer is why every
-        // gap in here used to be the same space50.
-        Component {
-            id: twoByTwoContent
-            ColumnLayout {
-                anchors {
-                    fill: parent
-                    margins: root.cardInset
-                }
-                spacing: Appearance.spacing.space100
+        // The morph itself. Every cell has a home at 2x2; the current week's
+        // seven travel up into the 2x1 row while the other thirty-five fade
+        // where they stand; and at 1x1 today's alone survives, growing into
+        // the hero date as its highlight shrinks away under it.
+        Repeater {
+            model: Geometry.CELLS
+            delegate: Item {
+                id: dayCell
+                required property int index
+                readonly property var cell: root.cells[dayCell.index]
+                readonly property var slot: Geometry.dayCellRect(
+                    dayCell.index, root.sizeMode, root.spanW, root.spanH,
+                    root.uiScale, root.weekRow, root.todayIndex)
+                readonly property bool present: dayCell.slot !== null
+                // A fade happens where the element stands, so a cell with no
+                // home still needs somewhere to be - and 2x2 is where every
+                // cell has one, which is also the span the corner handle
+                // reaches from 1x1.
+                readonly property var homeSlot: dayCell.present ? dayCell.slot
+                    : Geometry.dayCellRect(dayCell.index, "2x2", root.snapWidth2,
+                        root.tallHeight, root.uiScale, root.weekRow, root.todayIndex)
 
-                RowLayout {
-                    Layout.fillWidth: true
-                    spacing: Appearance.spacing.space50
+                x: homeSlot.x
+                y: homeSlot.y
+                width: homeSlot.width
+                height: homeSlot.height
+                Behavior on x { Expressive.SpanTravel {} }
+                Behavior on y { Expressive.SpanTravel {} }
+                Behavior on width { Expressive.SpanTravel {} }
+                Behavior on height { Expressive.SpanTravel {} }
+                opacity: dayCell.present ? 1 : 0
+                Behavior on opacity { Expressive.SpanFade {} }
+                visible: opacity > 0
 
-                    StyledText {
-                        Layout.fillWidth: true
-                        font.pixelSize: Appearance.font.pixelSize.normal
-                        font.weight: Font.Medium
-                        color: Appearance.colors.colOnPrimaryContainer
-                        text: root.viewingDate.toLocaleDateString(Qt.locale(), "MMMM yyyy")
-                    }
-
-                    Rectangle {
-                        implicitWidth: 24
-                        implicitHeight: 24
-                        radius: Appearance.rounding.full
-                        color: "transparent"
-                        border.width: Appearance.borderWidth.standard
-                        border.color: Appearance.colors.colPrimary
-                        MaterialSymbol {
-                            anchors.centerIn: parent
-                            text: "chevron_left"
-                            iconSize: Appearance.font.pixelSize.normal
-                            color: Appearance.colors.colOnPrimaryContainer
-                        }
-                        MouseArea {
-                            anchors.fill: parent
-                            cursorShape: Qt.PointingHandCursor
-                            onClicked: root.monthShift--
-                        }
-                    }
-
-                    Rectangle {
-                        implicitWidth: 24
-                        implicitHeight: 24
-                        radius: Appearance.rounding.full
-                        color: "transparent"
-                        border.width: Appearance.borderWidth.standard
-                        border.color: Appearance.colors.colPrimary
-                        MaterialSymbol {
-                            anchors.centerIn: parent
-                            text: "chevron_right"
-                            iconSize: Appearance.font.pixelSize.normal
-                            color: Appearance.colors.colOnPrimaryContainer
-                        }
-                        MouseArea {
-                            anchors.fill: parent
-                            cursorShape: Qt.PointingHandCursor
-                            onClicked: root.monthShift++
-                        }
-                    }
+                // Today's highlight, which is a box rather than a flag: on the
+                // way to the hero date it shrinks to nothing under the growing
+                // number instead of blinking off at the far end of the morph.
+                Rectangle {
+                    id: todayPill
+                    property real pill: dayCell.homeSlot.pill
+                    Behavior on pill { Expressive.SpanTravel {} }
+                    anchors.centerIn: parent
+                    width: todayPill.pill
+                    height: todayPill.pill
+                    radius: Appearance.rounding.full
+                    color: root.tinted(Appearance.colors.colPrimary)
+                    visible: dayCell.cell.isToday && todayPill.pill > 0.5
                 }
 
-                // The weekday strip and the grid it labels, as one block.
-                ColumnLayout {
-                    Layout.fillWidth: true
-                    Layout.fillHeight: true
-                    spacing: Appearance.spacing.space50
-
-                    // Seven equal columns across the full content width, inset
-                    // by dayGridInset so the letters sit exactly over the day
-                    // columns inside the surface below. They used to be a
-                    // fixed 28px block centred in a much wider row, which left
-                    // the strip and the grid on two different column pitches.
-                    RowLayout {
-                        Layout.fillWidth: true
-                        Layout.leftMargin: root.dayGridInset
-                        Layout.rightMargin: root.dayGridInset
-                        spacing: Appearance.spacing.space0
-                        Repeater {
-                            model: ["Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"]
-                            delegate: StyledText {
-                                id: weekdayHeader
-                                required property var modelData
-                                Layout.fillWidth: true
-                                horizontalAlignment: Text.AlignHCenter
-                                font.pixelSize: Appearance.font.pixelSize.smaller
-                                font.weight: Font.Bold
-                                color: Appearance.colors.colOnPrimaryContainer
-                                opacity: 0.6
-                                text: weekdayHeader.modelData
-                            }
-                        }
-                    }
-
-                    Rectangle {
-                        Layout.fillWidth: true
-                        Layout.fillHeight: true
-                        color: root.tinted(Appearance.colors.colLayer1)
-                        // Nested inside the card at cardInset, so the corners
-                        // stay concentric with the card's own.
-                        radius: card.radius - root.cardInset
-
-                        ColumnLayout {
-                            anchors {
-                                left: parent.left
-                                right: parent.right
-                                verticalCenter: parent.verticalCenter
-                                leftMargin: root.dayGridInset
-                                rightMargin: root.dayGridInset
-                            }
-                            // Six 28px day pills do not fit in the 150-odd px
-                            // this surface gets, so the rows deliberately
-                            // overlap: the pill is a 28px hit/highlight target
-                            // but the row *pitch* is 22. The glyphs are 12px
-                            // and centred, so they still clear each other, and
-                            // only today's pill is ever filled. The negated
-                            // token is the documented form for this.
-                            spacing: -Appearance.spacing.space75
-
-                            Repeater {
-                                model: root.weeks
-                                delegate: RowLayout {
-                                    id: weekRow
-                                    required property var modelData
-                                    Layout.fillWidth: true
-                                    spacing: Appearance.spacing.space0
-                                    Repeater {
-                                        model: weekRow.modelData
-                                        delegate: Item {
-                                            id: dayColumn
-                                            required property var modelData
-                                            Layout.fillWidth: true
-                                            implicitHeight: 28
-
-                                            DayCell {
-                                                anchors.centerIn: parent
-                                                day: dayColumn.modelData.day
-                                                currentMonth: dayColumn.modelData.currentMonth
-                                                isToday: dayColumn.modelData.isToday
-                                                highlightColor: root.tinted(Appearance.colors.colPrimary)
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
+                StyledText {
+                    anchors.centerIn: parent
+                    text: dayCell.cell.day
+                    font.pixelSize: Math.round(dayCell.homeSlot.size)
+                    Behavior on font.pixelSize { Expressive.SpanTravel {} }
+                    font.weight: dayCell.cell.isToday ? Font.Bold : Font.Normal
+                    // Off the SETTLED slot, not off the shrinking pill: keyed
+                    // on the live one the ink would hold its on-primary colour
+                    // over a highlight that is already most of the way gone,
+                    // and flip in the last frames of the morph.
+                    color: dayCell.cell.isToday && dayCell.present && dayCell.slot.pill > 0
+                        ? Appearance.colors.colOnPrimary
+                        : Appearance.colors.colOnPrimaryContainer
+                    Behavior on color { ColorAnimation { duration: Appearance.animation.elementMove.duration } }
+                    opacity: dayCell.cell.currentMonth ? 1.0 : 0.3
                 }
             }
         }
@@ -580,7 +530,10 @@ Item {
                 property real startWidth: 0
                 property real startX: 0
                 onPressed: mouse => {
-                    resizeArea.startWidth = root.widgetWidth;
+                    // The SETTLED width, never the animating one: a press
+                    // landing mid-morph would otherwise measure the gesture
+                    // against a box that is still moving.
+                    resizeArea.startWidth = root.spanW;
                     resizeArea.startX = resizeArea.mapToItem(null, mouse.x, mouse.y).x;
                 }
                 onPositionChanged: mouse => {

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/calendar/calendar_geometry.js
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/calendar/calendar_geometry.js
@@ -1,0 +1,188 @@
+.pragma library
+
+// Where every shared element of the calendar widget sits, per span.
+//
+// Three spans, each a real component-grid box (docs/widget-grid.md), at scale 1:
+//
+//   1x1  132x108  the month banner and today's date, alone
+//   2x1  276x108  the month pill, the weekday letters and the current week
+//   2x2  276x228  the month title, the weekday letters and the whole month
+//
+// Numbers measured off a render of the three destroyed-and-rebuilt layouts this
+// replaces rather than read out of their source: the two text-row heights (the
+// banner's, the 2x2 weekday strip's) are font metrics of a laid-out column, not
+// literals anyone wrote down, and the day grid's own top is a centring
+// remainder. `null` means the span has no home for the element - a fade, never
+// a morph.
+
+var CARD_INSET = 12;         // space150, the card's edge padding at every span
+var BANNER_H = 36.5;         // the 1x1 band: one `normal` row plus space100 above and below
+var PILL_H = 28;             // the 2x1 month pill
+var HEADER_H = 24;           // the 2x2 title row, which is the height of its chevrons
+var BLOCK_GAP = 8;           // space100, between the title block and the calendar block
+var LABEL_GAP = 4;           // space50, between the weekday letters and what they label
+var GRID_INSET = 4;          // space50, between the day-grid surface and its columns
+var STRIP_H_WIDE = 15;       // a `smaller` text row, as the 2x2 column lays it out
+var STRIP_H_SHORT = 16;      // ...and as the 2x1 Grid's own header row does
+var DAY = 28;                // the day pill, which is also the day cell's box
+var ROW_PITCH = 22;          // six 28px pills in 138px: the rows deliberately overlap
+var NAV = 24;                // a chevron button
+var PILL_PADDING = 12;       // space150, either side of the month name inside its pill
+
+var DAY_FONT = 12;           // pixelSize.smaller
+var HERO_FONT = 54;          // today's date, alone on the 1x1 card
+var MONTH_FONT_PILL = 15;    // pixelSize.small
+var MONTH_FONT_TITLE = 16;   // pixelSize.normal
+
+var ROWS = 6;
+var COLUMNS = 7;
+var CELLS = ROWS * COLUMNS;
+
+function _rect(x, y, w, h) { return { x: x, y: y, width: w, height: h }; }
+
+// The seven day columns are divided out of different widths at the two wide
+// spans: at 2x1 the card's own content width, at 2x2 the day-grid surface's,
+// which is itself inset inside that. Getting these two on one pitch is what the
+// 2x2 strip's `dayGridInset` was for.
+function columnWidth(span, width, scale) {
+    if (span === "2x2")
+        return (width - (CARD_INSET + GRID_INSET) * 2 * scale) / COLUMNS;
+    return (width - CARD_INSET * 2 * scale) / COLUMNS;
+}
+
+function columnLeft(span, scale) {
+    return (span === "2x2" ? CARD_INSET + GRID_INSET : CARD_INSET) * scale;
+}
+
+// Where the 2x2 weekday strip sits, and so where everything under it starts.
+function _stripTop(scale) { return (CARD_INSET + HEADER_H + BLOCK_GAP) * scale; }
+
+// ---- the month surface ---------------------------------------------------
+//
+// One element with two homes and one absence: the full-bleed accent band at
+// 1x1, the pill at 2x1, and nothing at 2x2, where the month is a plain title on
+// the card. It carries its corner radii because that IS the morph - a band
+// whose top corners are the card's own becomes a stadium and back.
+//
+// `labelWidth` is the settled width of the month name inside it (measured by
+// the caller against the pill's own font, never against the animating one), so
+// the pill hugs "May 2026" and "September 2026" differently.
+function monthSurfaceRect(span, width, height, scale, labelWidth, cardRadius) {
+    if (span === "1x1") return {
+        x: 0, y: 0, width: width, height: BANNER_H * scale,
+        radiusTop: cardRadius, radiusBottom: 0
+    };
+    if (span === "2x1") return {
+        x: CARD_INSET * scale, y: CARD_INSET * scale,
+        width: labelWidth + PILL_PADDING * 2 * scale, height: PILL_H * scale,
+        radiusTop: PILL_H / 2 * scale, radiusBottom: PILL_H / 2 * scale
+    };
+    return null;
+}
+
+// The month name in long form ("August 2026"), which lives at both wide spans
+// and travels between them: out of the pill and up to the card's own inset,
+// growing a step and changing ink. It has no home at 1x1, where the banner
+// says the month in short form as its own element - swapping one label's text
+// mid-morph is the content snap this architecture exists to kill.
+function monthLabelRect(span, width, height, scale) {
+    if (span === "1x1") return null;
+    if (span === "2x1") return {
+        x: (CARD_INSET + PILL_PADDING) * scale, y: CARD_INSET * scale,
+        height: PILL_H * scale, size: MONTH_FONT_PILL * scale
+    };
+    return {
+        x: CARD_INSET * scale, y: CARD_INSET * scale,
+        height: HEADER_H * scale, size: MONTH_FONT_TITLE * scale
+    };
+}
+
+// The 2x2 month steppers. index 0 is the previous month, 1 the next, and they
+// sit at the right end of the title row in that order.
+function navButtonRect(index, span, width, height, scale) {
+    if (span !== "2x2") return null;
+    var fromRight = (1 - index) * (NAV + LABEL_GAP) * scale;
+    return {
+        x: width - CARD_INSET * scale - NAV * scale - fromRight,
+        y: CARD_INSET * scale, width: NAV * scale, height: NAV * scale
+    };
+}
+
+// A weekday letter, over the column it labels. Present at both wide spans.
+function weekdayHeaderRect(index, span, width, height, scale) {
+    if (span === "1x1") return null;
+    var column = columnWidth(span, width, scale);
+    if (span === "2x1") return _rect(
+        columnLeft(span, scale) + index * column,
+        (CARD_INSET + PILL_H + BLOCK_GAP) * scale,
+        column, STRIP_H_SHORT * scale);
+    return _rect(columnLeft(span, scale) + index * column,
+        _stripTop(scale), column, STRIP_H_WIDE * scale);
+}
+
+function _surfaceBox(width, height, scale) {
+    var top = _stripTop(scale) + (STRIP_H_WIDE + LABEL_GAP) * scale;
+    return _rect(CARD_INSET * scale, top,
+        width - CARD_INSET * 2 * scale, height - top - CARD_INSET * scale);
+}
+
+// The surface the month grid is drawn on. 2x2 only - the 2x1 week is drawn on
+// the card itself. Its radius stays concentric with the card's.
+function dayGridSurfaceRect(span, width, height, scale, cardRadius) {
+    if (span !== "2x2") return null;
+    var rect = _surfaceBox(width, height, scale);
+    rect.radius = cardRadius - CARD_INSET * scale;
+    return rect;
+}
+
+// The top of the six-row block inside that surface, which is centred in it.
+function _gridTop(width, height, scale) {
+    var surface = _surfaceBox(width, height, scale);
+    var block = (ROWS * DAY - (ROWS - 1) * (DAY - ROW_PITCH)) * scale;
+    return surface.y + (surface.height - block) / 2;
+}
+
+// ---- the day cells -------------------------------------------------------
+//
+// Forty-two of them, one per cell of the month matrix, and the whole morph is
+// which of those have a home:
+//
+//   2x2  all of them, in six rows
+//   2x1  the seven of `weekRow`, which travel up into one row
+//   1x1  `todayIndex` alone, which grows into the hero date and loses its pill
+//
+// `pill` is the highlight's box rather than a flag, so today's marker shrinks
+// to nothing on the way to the hero rather than blinking off: a fill of zero
+// size is a fill that has finished leaving.
+function dayCellRect(index, span, width, height, scale, weekRow, todayIndex) {
+    if (index < 0 || index >= CELLS) return null;
+    var row = Math.floor(index / COLUMNS);
+    var column = index % COLUMNS;
+
+    if (span === "1x1") {
+        if (index !== todayIndex) return null;
+        return {
+            x: 0, y: BANNER_H * scale,
+            width: width, height: height - BANNER_H * scale,
+            size: HERO_FONT * scale, pill: 0
+        };
+    }
+
+    var columnW = columnWidth(span, width, scale);
+    var x = columnLeft(span, scale) + column * columnW + (columnW - DAY * scale) / 2;
+
+    if (span === "2x1") {
+        if (row !== weekRow) return null;
+        return {
+            x: x, y: (CARD_INSET + PILL_H + BLOCK_GAP + STRIP_H_SHORT + LABEL_GAP) * scale,
+            width: DAY * scale, height: DAY * scale,
+            size: DAY_FONT * scale, pill: DAY * scale
+        };
+    }
+
+    return {
+        x: x, y: _gridTop(width, height, scale) + row * ROW_PITCH * scale,
+        width: DAY * scale, height: DAY * scale,
+        size: DAY_FONT * scale, pill: DAY * scale
+    };
+}

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/world-clock/Widget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/world-clock/Widget.qml
@@ -8,6 +8,7 @@ import qs.modules.common.functions
 import qs.modules.common.widgets
 import qs.modules.common.plugins
 import qs.modules.common.plugins.designsystem.widgets as Expressive
+import "world_clock_geometry.js" as Geometry
 
 Item {
     id: root
@@ -22,6 +23,10 @@ Item {
     // The host's drag, forwarded to the card so it lifts while it is handled.
     // A card never told about the drag silently never lifts.
     property bool hostDragging: false
+    // ...and the host's own box animation, which is always false here: the
+    // host only reports motion for a box it sizes itself, and this widget
+    // declares no `grid`. It publishes its own `boxInMotion` below.
+    property bool hostBoxInMotion: false
 
     // The card fills the whole widget, so the host's default region already has
     // the right extent - but not the right corner radius (it falls back to
@@ -59,18 +64,39 @@ Item {
 
     property string sizeMode: root.normalizeSizeMode(PluginState.option("world-clock", "sizeMode", "2x2"))
 
-    property real widgetWidth:  sizeMode === "2x2" ? Appearance.sizes.widgetGridSpanX(2) : Appearance.sizes.widgetGridSpanX(3)
-    property real widgetHeight: sizeMode === "2x2" ? Appearance.sizes.widgetGridSpanY(2) : Appearance.sizes.widgetGridSpanY(1)
+    // ---- the span, and the box travelling towards it ---------------------
+    //
+    // Geometry evaluates at the span's SETTLED box; the Behaviors below carry
+    // the travel. Reading `implicitWidth` here instead would retarget every
+    // element on every frame, and a Behavior whose target keeps moving never
+    // converges (test_geometry_rects_come_from_the_settled_span_not_the_
+    // animating_box).
+    function spanWidthOf(span) {
+        return span === "3x1"
+            ? Appearance.sizes.widgetGridSpanX(3) : Appearance.sizes.widgetGridSpanX(2);
+    }
+    function spanHeightOf(span) {
+        return span === "3x1"
+            ? Appearance.sizes.widgetGridSpanY(1) : Appearance.sizes.widgetGridSpanY(2);
+    }
+    readonly property real spanW: root.spanWidthOf(root.sizeMode)
+    readonly property real spanH: root.spanHeightOf(root.sizeMode)
+    readonly property real uiScale: Appearance.effectiveScale
+
+    property real widgetWidth: root.spanW
+    property real widgetHeight: root.spanH
+    Behavior on widgetWidth { Expressive.SpanTravel {} }
+    Behavior on widgetHeight { Expressive.SpanTravel {} }
+
+    readonly property bool boxInMotion: Math.abs(root.widgetWidth - root.spanW) > 0.5
+        || Math.abs(root.widgetHeight - root.spanH) > 0.5
+
+    implicitWidth: root.widgetWidth
+    implicitHeight: root.widgetHeight
 
     // The card's own padding, shared by the 2x2 face and its settings back.
-    // The wide mode deliberately does not use it - see the 3x1 layout below.
+    // The wide mode deliberately does not use it - see world_clock_geometry.js.
     readonly property real cardInset: Appearance.spacing.space150
-
-    Behavior on widgetWidth  { animation: Appearance.animation.elementResize.numberAnimation.createObject(this) }
-    Behavior on widgetHeight { animation: Appearance.animation.elementResize.numberAnimation.createObject(this) }
-
-    implicitWidth:  widgetWidth
-    implicitHeight: widgetHeight
 
     property string localCityName: Weather.data?.city ?? "..."
     property string localTime: DateTime.time
@@ -82,6 +108,11 @@ Item {
     // PluginState directly.
     property var worldCities: WorldClock.entries
     property bool showingSettings: false
+
+    // The settings face is reachable only from the 2x2's own settings button,
+    // and it is drawn at the 2x2 box. Leaving it up while the card becomes a
+    // row of dials would show four timezone pickers inside a 108px strip.
+    onSizeModeChanged: if (root.sizeMode !== "2x2") root.showingSettings = false
 
     function toggleFlip() { flipAnim.start() }
 
@@ -121,193 +152,314 @@ Item {
         // rectangle filling the widget with everything drawn inside it. It
         // takes the component rather than only the tokens, so its surface,
         // its rounding and its shadow are the ones every other card has.
+        //
+        // `clipContent`, because a one-tree widget's elements do not stop
+        // existing when the card shrinks past them: the local time, the date
+        // and the bottom row of chips all fade out below a 3x1 card's bottom
+        // edge, and an unclipped fade paints them onto the wallpaper for the
+        // length of the morph.
         Expressive.WidgetCard {
             id: contentRect
             anchors.fill: parent
+            clipContent: true
             tint: Appearance.colors.colPrimaryContainer
             useBlurBackground: root.blurEnabled
             backgroundOpacity: root.backgroundOpacity
             dragging: root.hostDragging
-            radius: Appearance.rounding?.verylarge ?? 30
+            hostMotionActive: root.hostBoxInMotion || root.boxInMotion
 
-            // 2x2. Two steps of the scale: cardInset (space150) at the card
-            // edge, space100 between the three blocks inside it. The inset is
-            // what keeps the four city chips clear of a 30px corner radius -
-            // at the space100 it had, the bottom two chips ran into the
-            // rounding.
+            // ---- the 2x2's own chrome ------------------------------------
             //
-            // This side has always been over-budget: at the built-in's 252 the
-            // content came to 258, and at 228 it came to 234, so the bottom
-            // row of chips sat 2px off the card edge instead of on the margin.
-            // Two things fix that rather than shaving gaps again. The chip
-            // grid is Layout.fillHeight, so it takes whatever is left over
-            // instead of pushing past the bottom margin whenever a font is a
-            // little taller than the one this was tuned against; and the local
-            // time drops 42 -> 36, which is where the room actually comes from.
-            // It is still 2.4x the largest text under it, so it still reads as
-            // the hero.
-            ColumnLayout {
-                id: mainColumn
-                anchors { fill: parent; margins: root.cardInset }
-                spacing: Appearance.spacing.space100
-                visible: root.sizeMode === "2x2" && !root.showingSettings
+            // Place, time and date have no home on a row of dials, so they
+            // fade - and a fade happens where the element stands, which is why
+            // this block is pinned to the 2x2 box rather than anchored to a
+            // card that is on its way to 420x108. Anchored, it would reflow
+            // through every intermediate size while fading out, which reads as
+            // the text being squeezed rather than as it leaving.
+            Item {
+                id: localChrome
+                width: root.spanWidthOf("2x2")
+                height: root.spanHeightOf("2x2")
+                opacity: (root.sizeMode === "2x2" && !root.showingSettings) ? 1 : 0
+                Behavior on opacity { Expressive.SpanFade {} }
+                visible: opacity > 0
 
-                RowLayout {
-                    Layout.fillWidth: true
-                    spacing: Appearance.spacing.space50
-
-                    MaterialSymbol {
-                        iconSize: Appearance.font.pixelSize.hugeass
-                        text: "location_on"
-                        color: Appearance.colors.colOnPrimaryContainer
-                        opacity: 0.6
-                    }
-                    ColumnLayout {
-                        Layout.fillWidth: true
-                        spacing: -Appearance.spacing.space25
-                        StyledText {
-                            // Carries the weather provider's own city string, so
-                            // it must not be parsed as markup.
-                            textFormat: Text.PlainText
-                            font.pixelSize: Appearance.font.pixelSize.normal
-                            font.weight: Font.Medium
-                            color: Appearance.colors.colOnPrimaryContainer
-                            text: root.localCityName
-                        }
-                    }
-                    Item { Layout.fillWidth: true }
-                    Rectangle {
-                        id: settingsButton
-                        radius: Appearance.rounding.full
-                        color: root.tinted(Appearance.colors.colSurfaceContainerLow)
-                        implicitWidth: 24; implicitHeight: 24
-                        MaterialSymbol {
-                            anchors.centerIn: parent
-                            iconSize: Appearance.font.pixelSize.normal
-                            text: "settings"
-                            color: Appearance.colors.colOnSurfaceVariant
-                        }
-                        MouseArea {
-                            anchors.fill: parent
-                            cursorShape: Qt.PointingHandCursor
-                            onClicked: root.toggleFlip()
-                        }
-                    }
-                }
-
+                // Two steps of the scale: cardInset (space150) at the card
+                // edge, space100 between the blocks inside it. The inset is
+                // what keeps the four city chips clear of a 30px corner radius
+                // - at the space100 it had, the bottom two chips ran into the
+                // rounding.
+                //
+                // The local time is 36 rather than the 42 it was: at 42 the
+                // content came to 234 in a 228 card and the bottom row of chips
+                // sat 2px off the card edge. It is still 2.4x the largest text
+                // under it, so it still reads as the hero.
                 ColumnLayout {
-                    Layout.fillWidth: true
-                    Layout.alignment: Qt.AlignRight
-                    spacing: -Appearance.spacing.space50
-                    StyledText {
-                        Layout.alignment: Qt.AlignRight
-                        font.pixelSize: 36; font.weight: Font.Bold
-                        font.features: { "tnum": 1 }
-                        color: Appearance.colors.colOnPrimaryContainer
-                        text: root.localTime
-                    }
-                    StyledText {
-                        Layout.alignment: Qt.AlignRight
-                        font.pixelSize: Appearance.font.pixelSize.small
-                        color: Appearance.colors.colOnPrimaryContainer
-                        opacity: 0.7
-                        text: root.localDate
-                    }
-                }
+                    id: mainColumn
+                    anchors { fill: parent; margins: root.cardInset }
+                    spacing: Appearance.spacing.space100
 
-                // The chips used to be a fixed 120px wide, centred - 246px of
-                // grid inside 260px of content, so they sat 7px inboard of the
-                // header and the time above them and nothing lined up down
-                // either edge. They divide the content width instead now, and
-                // take the column's leftover height rather than a fixed 50,
-                // which is what stops the bottom row overshooting the margin.
-                GridLayout {
-                    Layout.fillWidth: true
-                    Layout.fillHeight: true
-                    columns: 2
-                    rowSpacing: Appearance.spacing.space75
-                    columnSpacing: Appearance.spacing.space75
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: Appearance.spacing.space50
 
-                    Repeater {
-                        model: root.worldCities
-                        delegate: Rectangle {
-                            id: cityCard
-                            required property var modelData
-                            required property int index
+                        MaterialSymbol {
+                            iconSize: Appearance.font.pixelSize.hugeass
+                            text: "location_on"
+                            color: Appearance.colors.colOnPrimaryContainer
+                            opacity: 0.6
+                        }
+                        ColumnLayout {
                             Layout.fillWidth: true
-                            Layout.fillHeight: true
-                            radius: Appearance.rounding.normal
-                            color: root.tinted(cityCard.modelData.isDay
-                                ? Appearance.colors.colPrimary
-                                : Appearance.colors.colSurfaceContainerLow)
-                            property color fg: cityCard.modelData.isDay
-                                ? Appearance.colors.colOnPrimary
-                                : Appearance.colors.colOnLayer0
-                            Behavior on color { ColorAnimation { duration: 400 } }
-
-                            ColumnLayout {
-                                // A chip inside the card, so its padding is a
-                                // step under the card's own inset. The two text
-                                // rows carry their own leading, so they need no
-                                // gap between them on top of that.
-                                //
-                                // Horizontally it takes a step more than that:
-                                // the chip's `normal` radius is 17px, so at a
-                                // uniform space75 the city name and the offset
-                                // start inside the corner curve and read as
-                                // stuck to the edge. space150 clears the arc.
-                                anchors {
-                                    fill: parent
-                                    topMargin: Appearance.spacing.space75
-                                    bottomMargin: Appearance.spacing.space75
-                                    leftMargin: Appearance.spacing.space150
-                                    rightMargin: Appearance.spacing.space150
-                                }
-                                spacing: Appearance.spacing.space0
-                                RowLayout {
-                                    Layout.fillWidth: true
-                                    StyledText {
-                                        Layout.fillWidth: true
-                                        // Derived from a timezone id in the user's
-                                        // config, so it must not render as markup.
-                                        textFormat: Text.PlainText
-                                        font.pixelSize: Appearance.font.pixelSize.smaller
-                                        font.weight: Font.Medium
-                                        color: cityCard.fg
-                                        text: cityCard.modelData.name
-                                        elide: Text.ElideRight
-                                    }
-                                    StyledText {
-                                        font.pixelSize: Appearance.font.pixelSize.smallest
-                                        color: cityCard.fg; opacity: 0.6
-                                        text: cityCard.modelData.offset
-                                    }
-                                }
-                                RowLayout {
-                                    Layout.fillWidth: true; spacing: Appearance.spacing.space50
-                                    StyledText {
-                                        font.pixelSize: Appearance.font.pixelSize.normal
-                                        font.weight: Font.Bold
-                                        font.features: { "tnum": 1 }
-                                        color: cityCard.fg
-                                        text: cityCard.modelData.time
-                                    }
-                                    Item { Layout.fillWidth: true }
-                                    MaterialSymbol {
-                                        iconSize: Appearance.font.pixelSize.smaller
-                                        text: cityCard.modelData.isDay ? "wb_sunny" : "bedtime"
-                                        color: cityCard.fg
-                                    }
-                                }
+                            spacing: -Appearance.spacing.space25
+                            StyledText {
+                                // Carries the weather provider's own city string, so
+                                // it must not be parsed as markup.
+                                textFormat: Text.PlainText
+                                font.pixelSize: Appearance.font.pixelSize.normal
+                                font.weight: Font.Medium
+                                color: Appearance.colors.colOnPrimaryContainer
+                                text: root.localCityName
                             }
                         }
+                        Item { Layout.fillWidth: true }
+                        Rectangle {
+                            id: settingsButton
+                            radius: Appearance.rounding.full
+                            color: root.tinted(Appearance.colors.colSurfaceContainerLow)
+                            implicitWidth: 24; implicitHeight: 24
+                            MaterialSymbol {
+                                anchors.centerIn: parent
+                                iconSize: Appearance.font.pixelSize.normal
+                                text: "settings"
+                                color: Appearance.colors.colOnSurfaceVariant
+                            }
+                            MouseArea {
+                                anchors.fill: parent
+                                cursorShape: Qt.PointingHandCursor
+                                onClicked: root.toggleFlip()
+                            }
+                        }
+                    }
+
+                    ColumnLayout {
+                        Layout.fillWidth: true
+                        Layout.alignment: Qt.AlignRight
+                        spacing: -Appearance.spacing.space50
+                        StyledText {
+                            Layout.alignment: Qt.AlignRight
+                            font.pixelSize: 36; font.weight: Font.Bold
+                            font.features: { "tnum": 1 }
+                            color: Appearance.colors.colOnPrimaryContainer
+                            text: root.localTime
+                        }
+                        StyledText {
+                            Layout.alignment: Qt.AlignRight
+                            font.pixelSize: Appearance.font.pixelSize.small
+                            color: Appearance.colors.colOnPrimaryContainer
+                            opacity: 0.7
+                            text: root.localDate
+                        }
+                    }
+
+                    // The chip grid used to be the third child and took the
+                    // leftover height; the chips are absolutely placed elements
+                    // of the one tree now, so something still has to absorb it
+                    // or the two blocks above are stretched down the card.
+                    Item { Layout.fillWidth: true; Layout.fillHeight: true }
+                }
+            }
+
+            // ---- the four cities, which are the morph ---------------------
+            //
+            // One tile per city, declared once: a chip in the 2x2's grid and a
+            // dial in the 3x1's row are the same element in two places, so the
+            // surface travels and changes shape while the words it carries fade
+            // out and the hands fade in.
+            Repeater {
+                model: Geometry.TILES
+                delegate: Item {
+                    id: cityTile
+                    required property int index
+                    readonly property var city: root.worldCities[cityTile.index] ?? null
+
+                    function tileBox(span) {
+                        return Geometry.cityTileRect(cityTile.index, span,
+                            root.spanWidthOf(span), root.spanHeightOf(span), root.uiScale);
+                    }
+                    readonly property var slot: cityTile.tileBox(root.sizeMode)
+                    readonly property var chipBox: cityTile.tileBox("2x2")
+
+                    readonly property bool isDay: cityTile.city?.isDay ?? true
+                    readonly property color ink: cityTile.isDay
+                        ? Appearance.colors.colOnPrimary
+                        : Appearance.colors.colOnLayer0
+
+                    x: slot.x
+                    y: slot.y
+                    width: slot.width
+                    height: slot.height
+                    Behavior on x { Expressive.SpanTravel {} }
+                    Behavior on y { Expressive.SpanTravel {} }
+                    Behavior on width { Expressive.SpanTravel {} }
+                    Behavior on height { Expressive.SpanTravel {} }
+
+                    // The offset's own width decides where the name has to
+                    // stop, and it has to be the SETTLED width - a ruler at the
+                    // chip's font, not the label itself, which is mid-fade
+                    // exactly when the name is deciding where to sit.
+                    StyledText {
+                        id: offsetRuler
+                        visible: false
+                        text: cityTile.city?.offset ?? ""
+                        font.pixelSize: Math.round(Geometry.OFFSET_FONT * root.uiScale)
+                    }
+
+                    Rectangle {
+                        id: tileSurface
+                        anchors.fill: parent
+                        property real corner: cityTile.slot.radius
+                        Behavior on corner { Expressive.SpanTravel {} }
+                        radius: tileSurface.corner
+                        color: root.tinted(cityTile.isDay
+                            ? Appearance.colors.colPrimary
+                            : Appearance.colors.colSurfaceContainerLow)
+                        Behavior on color { ColorAnimation { duration: 400 } }
+                    }
+
+                    // The hands. They have a rect at both spans - the chip's
+                    // own box at 2x2 - so they grow out of the tile rather than
+                    // arriving at full size over one that is still small.
+                    AndroidClock {
+                        id: dial
+                        readonly property var slot: Geometry.dialRect(root.sizeMode,
+                            cityTile.slot.width, cityTile.slot.height, root.uiScale)
+                        x: dial.slot.x
+                        y: dial.slot.y
+                        width: dial.slot.width
+                        height: dial.slot.height
+                        Behavior on width { Expressive.SpanTravel {} }
+                        Behavior on height { Expressive.SpanTravel {} }
+
+                        // The tile paints the surface and carries the name, so
+                        // the component draws neither: its own label band would
+                        // be a second copy of an element that already travels.
+                        backgroundColor: "transparent"
+                        label: ""
+                        contentInset: Geometry.DIAL_INSET * root.uiScale
+                        handColor: cityTile.ink
+                        centerDotColor: cityTile.ink
+                        autoTime: false
+                        hourAngle: {
+                            if (!cityTile.city?.time) return 0;
+                            const parts = cityTile.city.time.split(":");
+                            return (parseInt(parts[0]) % 12) * 30 + parseInt(parts[1]) * 0.5;
+                        }
+                        minuteAngle: {
+                            if (!cityTile.city?.time) return 0;
+                            const parts = cityTile.city.time.split(":");
+                            return parseInt(parts[1]) * 6;
+                        }
+                        opacity: Geometry.dialShown(root.sizeMode) ? 1 : 0
+                        Behavior on opacity { Expressive.SpanFade {} }
+                        visible: opacity > 0
+                    }
+
+                    // The city name: the one thing a chip and a dial both say,
+                    // and so the one element inside the tile that travels.
+                    StyledText {
+                        id: cityName
+                        objectName: "worldClockCityName" + cityTile.index
+                        readonly property var slot: Geometry.tileNameRect(root.sizeMode,
+                            cityTile.slot.width, cityTile.slot.height, root.uiScale,
+                            offsetRuler.paintedWidth)
+                        x: cityName.slot.x
+                        y: cityName.slot.y
+                        width: cityName.slot.width
+                        height: cityName.slot.height
+                        Behavior on x { Expressive.SpanTravel {} }
+                        Behavior on y { Expressive.SpanTravel {} }
+                        Behavior on width { Expressive.SpanTravel {} }
+
+                        // Derived from a timezone id in the user's config, so it
+                        // must not render as markup.
+                        textFormat: Text.PlainText
+                        text: cityTile.city?.name ?? ""
+                        elide: Text.ElideRight
+                        horizontalAlignment: cityName.slot.centred
+                            ? Text.AlignHCenter : Text.AlignLeft
+                        font.pixelSize: Math.round(cityName.slot.size)
+                        Behavior on font.pixelSize { Expressive.SpanTravel {} }
+                        // A chip names its city in the same weight as the
+                        // reading beside it; the dial's own label was drawn at
+                        // the family's default, and matching it is what keeps
+                        // the settled 3x1 the picture it always was.
+                        font.weight: cityName.slot.centred ? Font.Normal : Font.Medium
+                        Behavior on font.weight { Expressive.SpanTravel {} }
+                        color: cityTile.ink
+                        opacity: cityName.slot.centred ? 0.75 : 1
+                        Behavior on opacity { Expressive.SpanFade {} }
+                    }
+
+                    // ---- what only a chip says ------------------------------
+                    StyledText {
+                        id: cityOffset
+                        readonly property var slot: Geometry.tileOffsetRect("2x2",
+                            cityTile.chipBox.width, cityTile.chipBox.height, root.uiScale,
+                            offsetRuler.paintedWidth)
+                        x: cityOffset.slot.x
+                        y: cityOffset.slot.y
+                        height: cityOffset.slot.height
+                        text: cityTile.city?.offset ?? ""
+                        font.pixelSize: Math.round(cityOffset.slot.size)
+                        color: cityTile.ink
+                        opacity: root.sizeMode === "2x2" ? 0.6 : 0
+                        Behavior on opacity { Expressive.SpanFade {} }
+                        visible: opacity > 0
+                    }
+
+                    StyledText {
+                        id: cityTime
+                        readonly property var slot: Geometry.tileTimeRect("2x2",
+                            cityTile.chipBox.width, cityTile.chipBox.height, root.uiScale)
+                        x: cityTime.slot.x
+                        y: cityTime.slot.y
+                        height: cityTime.slot.height
+                        text: cityTile.city?.time ?? ""
+                        font.pixelSize: Math.round(cityTime.slot.size)
+                        font.weight: Font.Bold
+                        font.features: { "tnum": 1 }
+                        color: cityTile.ink
+                        opacity: root.sizeMode === "2x2" ? 1 : 0
+                        Behavior on opacity { Expressive.SpanFade {} }
+                        visible: opacity > 0
+                    }
+
+                    MaterialSymbol {
+                        id: cityDayIcon
+                        readonly property var slot: Geometry.tileIconRect("2x2",
+                            cityTile.chipBox.width, cityTile.chipBox.height, root.uiScale)
+                        x: cityDayIcon.slot.x
+                        y: cityDayIcon.slot.y
+                        iconSize: Appearance.font.pixelSize.smaller
+                        text: cityTile.isDay ? "wb_sunny" : "bedtime"
+                        color: cityTile.ink
+                        opacity: root.sizeMode === "2x2" ? 1 : 0
+                        Behavior on opacity { Expressive.SpanFade {} }
+                        visible: opacity > 0
                     }
                 }
             }
 
+            // ---- the settings back, which the flip shows -------------------
+            //
+            // Gated on the flip alone: it is reachable only from the 2x2's
+            // settings button, and `sizeMode` clears it on the way out of 2x2.
+            // Pinned to the 2x2 box for the same reason the front chrome is.
             Item {
-                anchors.fill: parent
-                visible: root.sizeMode === "2x2" && root.showingSettings
+                width: root.spanWidthOf("2x2")
+                height: root.spanHeightOf("2x2")
+                visible: root.showingSettings
 
                 // Four 40px pickers plus a 24px header row is 184px of content
                 // that cannot shrink, which leaves 20px to spend inside a 228
@@ -384,57 +536,6 @@ Item {
                 }
             }
 
-            // 3x1. Deliberately *not* cardInset: the dials are full-bleed
-            // tiles rather than content on a surface, and at space100 the
-            // card's 30px rounding minus the inset (22) lands on the dial's
-            // own `large` radius (23), so the four tiles nest concentrically
-            // in the corners. At cardInset they would be 30-12=18 against 23
-            // and the corners would visibly fight.
-            RowLayout {
-                anchors { fill: parent; margins: Appearance.spacing.space100 }
-                spacing: Appearance.spacing.space100
-                visible: root.sizeMode !== "2x2"
-
-                Repeater {
-                    model: Math.min(root.worldCities.length, 4)
-                    delegate: AndroidClock {
-                        required property int index
-                        property var cityData: root.worldCities[index] ?? null
-
-                        Layout.fillHeight: true
-                        Layout.fillWidth:  true
-
-                        backgroundColor: root.tinted(cityData?.isDay ?? true
-                            ? Appearance.colors.colPrimary
-                            : Appearance.colors.colSurfaceContainerLow)
-                        handColor: cityData?.isDay ?? true
-                            ? Appearance.colors.colOnPrimary
-                            : Appearance.colors.colOnLayer0
-                        centerDotColor: cityData?.isDay ?? true
-                            ? Appearance.colors.colOnPrimary
-                            : Appearance.colors.colOnLayer0
-                        label:       cityData?.name ?? ""
-                        labelColor:  Qt.rgba(
-                            (cityData?.isDay ?? true ? Appearance.colors.colOnPrimary : Appearance.colors.colOnLayer0).r,
-                            (cityData?.isDay ?? true ? Appearance.colors.colOnPrimary : Appearance.colors.colOnLayer0).g,
-                            (cityData?.isDay ?? true ? Appearance.colors.colOnPrimary : Appearance.colors.colOnLayer0).b,
-                            0.75)
-                        labelSpacing: Appearance.spacing.space75
-                        autoTime:    false
-                        hourAngle: {
-                            if (!cityData?.time) return 0
-                            const p = cityData.time.split(":")
-                            return (parseInt(p[0]) % 12) * 30 + parseInt(p[1]) * 0.5
-                        }
-                        minuteAngle: {
-                            if (!cityData?.time) return 0
-                            const p = cityData.time.split(":")
-                            return parseInt(p[1]) * 6
-                        }
-                    }
-                }
-            }
-
             Rectangle {
                 id: toggleHandle
                 width: 16; height: 16; radius: Appearance.rounding.unsharpenslight
@@ -457,11 +558,8 @@ Item {
                     anchors.fill: parent
                     hoverEnabled: true
                     cursorShape: Qt.PointingHandCursor
-                    onClicked: {
-                        if (root.showingSettings) root.showingSettings = false
-                        PluginState.setOption("world-clock", "sizeMode",
-                            root.sizeMode === "2x2" ? "3x1" : "2x2")
-                    }
+                    onClicked: PluginState.setOption("world-clock", "sizeMode",
+                        root.sizeMode === "2x2" ? "3x1" : "2x2")
                 }
             }
         }

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/world-clock/world_clock_geometry.js
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/world-clock/world_clock_geometry.js
@@ -1,0 +1,167 @@
+.pragma library
+
+// Where every shared element of the world clock sits, per span.
+//
+// Two spans, both real component-grid boxes (docs/widget-grid.md), at scale 1:
+//
+//   2x2  276x228  the local card: place, time, date, and four city chips
+//   3x1  420x108  four analog dials in a row
+//
+// The four cities are what the two spans have in common, so the tile is the
+// element that travels: a chip in a 2x2 grid becomes a dial in a row of four,
+// carrying its surface, its colour and its name with it. Everything the chip
+// says in words - the offset, the digital time, the day/night glyph - has no
+// home on a dial and fades, and the dial's hands have no home on a chip.
+//
+// Numbers measured off a render of the two `visible`-swapped subtrees this
+// replaces: the chip grid's top is what is left after a header row, a 36px
+// time and a date line have taken their natural heights, which is a font
+// metric rather than anything anyone wrote down.
+
+var CARD_INSET = 12;      // space150, the 2x2 card's edge padding
+var CHIP_GAP = 6;         // space75, between chips in the 2x2 grid
+var GRID_TOP = 117;       // measured: below the header, the time and the date
+var CHIP_RADIUS = 17;     // rounding.normal
+var CHIP_COLUMNS = 2;
+
+// The 3x1 row is deliberately not on CARD_INSET: the dials are full-bleed
+// tiles rather than content on a surface, and at space100 the card's 30px
+// rounding minus the inset lands on the tile's own `large` radius, so the four
+// nest concentrically in the corners.
+var ROW_INSET = 8;        // space100
+var ROW_GAP = 8;          // space100
+var TILE_RADIUS = 23;     // rounding.large
+
+// AndroidClock's own layout, restated here because the dial is now drawn
+// label-less inside a box this module hands it: the component reserves a band
+// at the bottom for its label and centres the dial in what is left, and the
+// tile's name label - which travels in from the chip - is that band.
+var DIAL_INSET = 8;          // AndroidClock.contentInset, space100
+var DIAL_LABEL_FONT = 11;    // its labelPixelSize at this tile size
+var DIAL_LABEL_SPACING = 6;  // space75, its labelSpacing
+// What AndroidClock reserves under the dial, and where inside that band it
+// actually puts the glyphs: half the spacing clear of the dial, and the rest
+// of the band below. Restated rather than guessed at, because a name that
+// travels in from the chip has to land exactly where the component used to
+// draw its own.
+var LABEL_BAND = DIAL_LABEL_FONT + DIAL_LABEL_SPACING;
+
+// Inside a 2x2 chip.
+var CHIP_PAD_X = 12;      // space150: the chip's `normal` radius is 17, and at
+                          // a uniform space75 the name starts inside the curve
+var CHIP_PAD_Y = 6;       // space75
+var CHIP_LABEL_GAP = 4;   // space50, between the name and the offset beside it
+var NAME_H = 15.5;        // a `smaller` text row
+var NAME_FONT = 12;       // pixelSize.smaller
+var OFFSET_FONT = 10;     // pixelSize.smallest
+var TIME_ROW_Y = 21.5;
+var TIME_ROW_H = 19;
+var TIME_FONT = 16;       // pixelSize.normal
+var ICON = 12;            // the day/night glyph, at pixelSize.smaller
+
+var TILES = 4;
+
+function _rect(x, y, w, h) { return { x: x, y: y, width: w, height: h }; }
+
+// ---- the tile ------------------------------------------------------------
+//
+// The one element with a home at both spans, and so the one that carries the
+// morph. Its radius travels too: a chip's corner is a step tighter than a
+// dial's.
+function cityTileRect(index, span, width, height, scale) {
+    if (index < 0 || index >= TILES) return null;
+
+    if (span === "3x1") {
+        var tileW = (width - ROW_INSET * 2 * scale - ROW_GAP * (TILES - 1) * scale) / TILES;
+        return {
+            x: ROW_INSET * scale + index * (tileW + ROW_GAP * scale),
+            y: ROW_INSET * scale,
+            width: tileW, height: height - ROW_INSET * 2 * scale,
+            radius: TILE_RADIUS * scale
+        };
+    }
+
+    var column = index % CHIP_COLUMNS;
+    var row = Math.floor(index / CHIP_COLUMNS);
+    var chipW = (width - CARD_INSET * 2 * scale - CHIP_GAP * scale) / CHIP_COLUMNS;
+    var chipH = (height - (GRID_TOP + CARD_INSET) * scale - CHIP_GAP * scale) / 2;
+    return {
+        x: CARD_INSET * scale + column * (chipW + CHIP_GAP * scale),
+        y: GRID_TOP * scale + row * (chipH + CHIP_GAP * scale),
+        width: chipW, height: chipH,
+        radius: CHIP_RADIUS * scale
+    };
+}
+
+// ---- what sits inside a tile ---------------------------------------------
+//
+// All of these are in the tile's own coordinates and take the tile's SETTLED
+// box, never the one currently travelling: an inner rect measured off an
+// animating box is a target that moves every frame, and a Behavior chasing one
+// of those never converges.
+
+// The city name, the one thing a chip and a dial both say. Top-left of the
+// chip beside its offset; centred in the dial's label band.
+function tileNameRect(span, tileWidth, tileHeight, scale, offsetWidth) {
+    if (span === "3x1") {
+        var band = (LABEL_BAND - DIAL_LABEL_SPACING / 2) * scale;
+        return {
+            x: DIAL_INSET * scale,
+            y: tileHeight - DIAL_INSET * scale - band,
+            width: tileWidth - DIAL_INSET * 2 * scale,
+            height: band,
+            size: DIAL_LABEL_FONT * scale, centred: true
+        };
+    }
+    return {
+        x: CHIP_PAD_X * scale, y: CHIP_PAD_Y * scale,
+        width: tileWidth - CHIP_PAD_X * 2 * scale - offsetWidth - CHIP_LABEL_GAP * scale,
+        height: NAME_H * scale,
+        size: NAME_FONT * scale, centred: false
+    };
+}
+
+// The UTC offset, right of the name. Words a dial cannot say, so 2x2 only.
+function tileOffsetRect(span, tileWidth, tileHeight, scale, offsetWidth) {
+    if (span !== "2x2") return null;
+    return {
+        x: tileWidth - CHIP_PAD_X * scale - offsetWidth,
+        y: CHIP_PAD_Y * scale, width: offsetWidth, height: NAME_H * scale,
+        size: OFFSET_FONT * scale
+    };
+}
+
+// The digital time. The dial says this with its hands instead.
+function tileTimeRect(span, tileWidth, tileHeight, scale) {
+    if (span !== "2x2") return null;
+    return {
+        x: CHIP_PAD_X * scale, y: TIME_ROW_Y * scale,
+        height: TIME_ROW_H * scale, size: TIME_FONT * scale
+    };
+}
+
+// The day/night glyph, at the right end of the time row.
+function tileIconRect(span, tileWidth, tileHeight, scale) {
+    if (span !== "2x2") return null;
+    return {
+        x: tileWidth - (CHIP_PAD_X + ICON) * scale,
+        y: TIME_ROW_Y * scale + (TIME_ROW_H - ICON) / 2 * scale,
+        width: ICON * scale, height: ICON * scale
+    };
+}
+
+// The dial. It has a rect at both spans rather than a null at 2x2, because
+// what it grows out of IS the chip: fading in from the chip's own box means
+// the hands arrive at the size the tile is, instead of a full-size clock
+// appearing over a tile that has not finished growing yet.
+//
+// At 3x1 the box stops short of the name below it - AndroidClock centres its
+// dial in whatever box it is given, and the band the name occupies is not part
+// of it.
+function dialRect(span, tileWidth, tileHeight, scale) {
+    if (span === "3x1")
+        return _rect(0, 0, tileWidth, tileHeight - LABEL_BAND * scale);
+    return _rect(0, 0, tileWidth, tileHeight);
+}
+
+function dialShown(span) { return span === "3x1"; }

--- a/dots/.config/quickshell/imi/tests/test_expressive_design_system.py
+++ b/dots/.config/quickshell/imi/tests/test_expressive_design_system.py
@@ -281,12 +281,18 @@ class ExpressiveDesignSystemTest(unittest.TestCase):
         # choose its size, so its manifest deliberately declares no `grid`:
         # a span is a pixel size the host assigns on every load and would
         # overwrite whichever size the handles last chose. A widget sized by
-        # the host reads `hostGridSize`; this one must not, and its box comes
-        # off the card it composes.
+        # the host reads `hostGridSize`; this one must not.
         self.assertNotIn("grid", manifest)
         self.assertNotIn("hostGridSize", widget)
-        self.assertIn("implicitWidth: card.implicitWidth", widget)
-        self.assertIn("implicitHeight: card.implicitHeight", widget)
+        # The box used to be read back off the card (`implicitWidth:
+        # card.implicitWidth`), which was right while the card held a per-span
+        # Loader and was the only thing that knew how big a mode was. It is the
+        # wrong direction for one tree: the span decides the box, the box
+        # animates towards it, and the card fills whatever the box currently is
+        # - so the card cannot also be the thing that reports it.
+        self.assertIn("implicitWidth: root.widgetWidth", widget)
+        self.assertIn("implicitHeight: root.widgetHeight", widget)
+
     def test_the_five_folded_widgets_are_told_when_they_are_handled(self):
         """The same chain, for the widgets that were never cards.
 

--- a/dots/.config/quickshell/imi/tests/test_expressive_design_system.py
+++ b/dots/.config/quickshell/imi/tests/test_expressive_design_system.py
@@ -67,18 +67,35 @@ def span_declarations(source):
     CONTRIBUTING.md warns every source-text check about.
     """
     for match in SPAN_DECLARATION.finditer(source):
-        rest = source[match.end():]
-        body = rest.lstrip(" \t")
-        if not body.startswith("{"):
-            yield match.group(1), rest.split("\n", 1)[0]
-            continue
-        opening = len(rest) - len(body)
-        depth = 0
-        for index in range(opening, len(rest)):
-            depth += {"{": 1, "}": -1}.get(rest[index], 0)
-            if depth == 0:
-                yield match.group(1), rest[:index + 1]
-                break
+        yield match.group(1), whole_binding(source, match.end())
+
+
+def whole_binding(source, start):
+    """The whole right-hand side of a binding starting at `start`.
+
+    Brace-balanced when the value is a block, the rest of the line otherwise.
+    Extracted from `span_declarations` because the same question - is the value
+    a line or a block? - decides whether every other source-text check over a
+    QML binding in this file is real or vacuous.
+    """
+    rest = source[start:]
+    body = rest.lstrip(" \t")
+    if not body.startswith("{"):
+        return rest.split("\n", 1)[0]
+    opening = len(rest) - len(body)
+    depth = 0
+    for index in range(opening, len(rest)):
+        depth += {"{": 1, "}": -1}.get(rest[index], 0)
+        if depth == 0:
+            return rest[:index + 1]
+    return rest
+
+
+# A widget that owns its own size names it here; the host's own spans arrive as
+# `hostGridSize` instead.
+OWN_SIZE_MODE = re.compile(r"^[ \t]*property\s+string\s+sizeMode\s*:", re.M)
+# The two ways a span used to decide what EXISTS rather than where it sits.
+SPAN_DISPATCH = re.compile(r"^[ \t]*(sourceComponent|visible)\s*:", re.M)
 
 
 class ExpressiveDesignSystemTest(unittest.TestCase):
@@ -210,6 +227,46 @@ class ExpressiveDesignSystemTest(unittest.TestCase):
                         f"{declaration.strip()}")
         self.assertEqual(sorted(path.name for path in known - swept), [],
                          "the sweep stopped seeing a tree that declares a span")
+
+    def test_a_widget_that_owns_its_span_morphs_in_one_tree(self):
+        """A span may decide where an element sits, never whether it exists.
+
+        docs/widget-standards-audit-2026-08-16.md's gap #1: calendar dispatched
+        three whole `Component`s through one `Loader` keyed on `sizeMode`, and
+        world-clock switched three subtrees with `visible`. Both destroy the
+        content and rebuild it in a single frame in the middle of a resize,
+        which is the interaction those widgets are used through - and both were
+        invisible to every check here, because
+        `test_the_media_tree_answers_the_blur_contract_itself` names the media
+        package and nothing else.
+
+        So this sweeps instead of naming: any widget declaring its own
+        `sizeMode` must not let that name reach a `sourceComponent` or a
+        `visible`. Read whole rather than by line, because calendar's Loader
+        wrote its dispatch as a block and a line-scoped check would have seen
+        `sourceComponent: {` and passed.
+
+        `opacity` is deliberately not on the list. An element with no home at a
+        span fades where it stands, which is the mechanism this asks for; what
+        it forbids is the element ceasing to exist.
+        """
+        swept = {}
+        for path in sorted(PLUGIN_ROOT.rglob("Widget.qml")):
+            source = path.read_text(encoding="utf-8")
+            if not OWN_SIZE_MODE.search(source):
+                continue
+            package = path.parent.name
+            swept[package] = path
+            for match in SPAN_DISPATCH.finditer(source):
+                binding = whole_binding(source, match.end())
+                self.assertNotIn(
+                    "sizeMode", binding,
+                    f"{package}/{path.name}: `{match.group(1)}` is decided by "
+                    f"the span, so the span destroys and rebuilds the content:"
+                    f"\n{binding.strip()}")
+
+        self.assertEqual(sorted(swept), ["calendar", "world-clock"],
+                         "the sweep stopped seeing a widget that owns its span")
 
     def test_every_card_is_told_when_its_widget_is_handled(self):
         """A card that never receives `dragging` silently never lifts.
@@ -445,8 +502,14 @@ class ExpressiveDesignSystemTest(unittest.TestCase):
             list((PLUGIN_ROOT / "nandoroid-media").glob("*.qml"))
             + [DESIGN_SYSTEM / "widgets/DesktopWeatherWidget.qml",
                DESIGN_SYSTEM / "widgets/DesktopCurrencyWidget.qml",
-               DESIGN_SYSTEM / "widgets/DesktopMediaWidget.qml"])
-        self.assertGreaterEqual(len(swept), 6, "the sweep found nothing to check")
+               DESIGN_SYSTEM / "widgets/DesktopMediaWidget.qml",
+               # The two that stopped rebuilding per span. They join the sweep
+               # rather than each carrying a private copy of the curve, which
+               # is how a fifth tree would end up moving at its own speed
+               # beside four that agree.
+               PLUGIN_ROOT / "calendar/Widget.qml",
+               PLUGIN_ROOT / "world-clock/Widget.qml"])
+        self.assertGreaterEqual(len(swept), 8, "the sweep found nothing to check")
         carriers = 0
         for path in swept:
             source = path.read_text(encoding="utf-8")

--- a/dots/.config/quickshell/imi/tests/test_widget_grid_lattice.py
+++ b/dots/.config/quickshell/imi/tests/test_widget_grid_lattice.py
@@ -141,22 +141,36 @@ class RootSizesGoThroughTheGridHelpers(unittest.TestCase):
 class PortedWidgetsDeclareTheSpansTheyActuallyOccupy(unittest.TestCase):
     """The two widgets this test was written for, pinned mode by mode."""
 
-    def test_world_clock_is_2x2_or_3x1(self):
-        src = (BUNDLED / "world-clock/Widget.qml").read_text(encoding="utf-8")
+    # `widgetWidth`/`widgetHeight` used to name the spans on their own line.
+    # They are the ANIMATING box now - both widgets morph in one tree, so the
+    # box travels towards a settled span rather than snapping to it - and the
+    # span helpers moved one step back, into the `spanWidthOf`/`spanHeightOf`
+    # every element's geometry is evaluated at. Both halves are still pinned:
+    # the file reaches the lattice through the helpers, and the animating box
+    # follows a span rather than a literal.
+    def assertBoxFollowsTheSpan(self, src, name):
         width = re.search(r"property real widgetWidth:\s*(.+)", src).group(1)
         height = re.search(r"property real widgetHeight:\s*(.+)", src).group(1)
-        self.assertIn("widgetGridSpanX(2)", width)
-        self.assertIn("widgetGridSpanX(3)", width,
+        self.assertEqual(width.strip(), "root.spanW",
+                         f"{name}'s animating box must follow the settled span")
+        self.assertEqual(height.strip(), "root.spanH", name)
+
+    def test_world_clock_is_2x2_or_3x1(self):
+        src = (BUNDLED / "world-clock/Widget.qml").read_text(encoding="utf-8")
+        self.assertIn("widgetGridSpanX(2)", src)
+        self.assertIn("widgetGridSpanX(3)", src,
                       "the wide mode is 420px, which is three columns")
-        self.assertIn("widgetGridSpanY(2)", height)
-        self.assertIn("widgetGridSpanY(1)", height,
+        self.assertIn("widgetGridSpanY(2)", src)
+        self.assertIn("widgetGridSpanY(1)", src,
                       "the wide mode is one row, so 108 tall - not 120")
+        self.assertBoxFollowsTheSpan(src, "world-clock")
 
     def test_calendar_is_1x1_2x1_or_2x2(self):
         src = (BUNDLED / "calendar/Widget.qml").read_text(encoding="utf-8")
         for call in ("widgetGridSpanX(1)", "widgetGridSpanX(2)",
                      "widgetGridSpanY(1)", "widgetGridSpanY(2)"):
             self.assertIn(call, src, f"calendar must size through {call}")
+        self.assertBoxFollowsTheSpan(src, "calendar")
 
 
 class ManifestFloorsAreRealSpans(unittest.TestCase):

--- a/dots/.config/quickshell/imi/tests/tst_calendar_geometry.qml
+++ b/dots/.config/quickshell/imi/tests/tst_calendar_geometry.qml
@@ -133,11 +133,14 @@ TestCase {
     function test_the_surviving_week_travels_up_into_one_row() {
         const rows = [];
         for (let column = 0; column < Geometry.COLUMNS; column++) {
-            const wide = day(14 + column, "2x2");
-            const short = day(14 + column, "2x1");
-            rows.push(short.y);
-            verify(short.y < wide.y, "column " + column + " travels up");
-            compare(short.width, wide.width, "and keeps its size");
+            const inGrid = day(14 + column, "2x2");
+            // Not `short`: it is a future-reserved word that this Qt's QML
+            // parser accepts and the CI runner's rejects, with an error that
+            // names the file and not the line.
+            const inRow = day(14 + column, "2x1");
+            rows.push(inRow.y);
+            verify(inRow.y < inGrid.y, "column " + column + " travels up");
+            compare(inRow.width, inGrid.width, "and keeps its size");
         }
         for (const y of rows)
             compare(y, rows[0], "the seven land on one line");

--- a/dots/.config/quickshell/imi/tests/tst_calendar_geometry.qml
+++ b/dots/.config/quickshell/imi/tests/tst_calendar_geometry.qml
@@ -1,0 +1,180 @@
+import QtTest
+import "../modules/common/plugins/bundled/calendar/calendar_geometry.js" as Geometry
+
+// The calendar widget's shared-element geometry: where each element sits at
+// each of the three spans, and which spans have no home for it.
+//
+// Spans at scale 1: 1x1 = 132x108, 2x1 = 276x108, 2x2 = 276x228.
+// The card's radius is 30 at that scale (WidgetCard's own default).
+TestCase {
+    name: "CalendarGeometryTest"
+
+    readonly property real cardRadius: 30
+    readonly property real pillLabel: 84   // a plausible "August 2026"
+
+    function widthOf(span) { return span === "1x1" ? 132 : 276; }
+    function heightOf(span) { return span === "2x2" ? 228 : 108; }
+
+    function surface(span) {
+        return Geometry.monthSurfaceRect(span, widthOf(span), heightOf(span), 1,
+            pillLabel, cardRadius);
+    }
+    function label(span) {
+        return Geometry.monthLabelRect(span, widthOf(span), heightOf(span), 1);
+    }
+    function nav(index, span) {
+        return Geometry.navButtonRect(index, span, widthOf(span), heightOf(span), 1);
+    }
+    function weekday(index, span) {
+        return Geometry.weekdayHeaderRect(index, span, widthOf(span), heightOf(span), 1);
+    }
+    function grid(span) {
+        return Geometry.dayGridSurfaceRect(span, widthOf(span), heightOf(span), 1, cardRadius);
+    }
+    // Today is the 16th of a month starting on a Saturday, so it is cell 20 -
+    // row 2, column 6 - which is the case the probe renders.
+    function day(index, span) {
+        return Geometry.dayCellRect(index, span, widthOf(span), heightOf(span), 1, 2, 20);
+    }
+
+    function test_the_month_surface_is_a_band_a_pill_and_then_nothing() {
+        const band = surface("1x1");
+        compare(band.x, 0, "full bleed");
+        compare(band.width, 132);
+        compare(band.radiusTop, cardRadius, "its top corners are the card's own");
+        compare(band.radiusBottom, 0, "and its bottom edge is square");
+
+        const pill = surface("2x1");
+        compare(pill.x, 12, "on the card inset");
+        compare(pill.radiusTop, pill.height / 2, "a stadium");
+        compare(pill.radiusTop, pill.radiusBottom);
+        compare(pill.width, pillLabel + 24, "it hugs its label");
+
+        compare(surface("2x2"), null,
+                "the 2x2 month is a plain title, so the surface fades");
+    }
+
+    function test_the_month_name_travels_between_the_two_wide_spans() {
+        compare(label("1x1"), null, "the 1x1 band says the month in short form");
+        const inPill = label("2x1");
+        const asTitle = label("2x2");
+        verify(inPill.x > asTitle.x,
+               "out of the pill's padding and back onto the card inset");
+        verify(asTitle.size > inPill.size, "and a step larger as a title");
+        compare(asTitle.x, 12);
+    }
+
+    function test_the_month_name_starts_inside_its_pill() {
+        const pill = surface("2x1");
+        const inPill = label("2x1");
+        verify(inPill.x > pill.x, "the label is inset in the pill");
+        verify(inPill.x + pillLabel <= pill.x + pill.width + 0.01,
+               "and the pill is wide enough for it");
+        compare(inPill.y, pill.y, "one line");
+        compare(inPill.height, pill.height);
+    }
+
+    function test_the_month_steppers_exist_only_at_2x2_and_in_order() {
+        compare(nav(0, "1x1"), null);
+        compare(nav(0, "2x1"), null);
+        const prev = nav(0, "2x2");
+        const next = nav(1, "2x2");
+        verify(prev.x < next.x, "previous, then next");
+        compare(next.x + next.width, 276 - 12, "flush with the card inset");
+        verify(prev.x + prev.width < next.x, "and they do not overlap");
+    }
+
+    function test_the_weekday_letters_divide_their_own_content_width() {
+        compare(weekday(0, "1x1"), null, "no strip on the 1x1 card");
+        const short0 = weekday(0, "2x1");
+        const short6 = weekday(6, "2x1");
+        compare(short0.x, 12);
+        compare(short0.x + 7 * short0.width, 276 - 12,
+                "seven columns across the card's content width");
+        compare(short6.x + short6.width, 276 - 12);
+
+        // 2x2 divides the day-grid SURFACE's width, inset one step further, so
+        // the letters sit over the columns inside it rather than on a pitch of
+        // their own - which is what the destroyed layout's dayGridInset was for.
+        const wide0 = weekday(0, "2x2");
+        verify(wide0.x > short0.x);
+        verify(wide0.width < short0.width);
+        compare(wide0.x + 7 * wide0.width, 276 - 16);
+    }
+
+    function test_the_day_grid_surface_exists_only_at_2x2() {
+        compare(grid("1x1"), null);
+        compare(grid("2x1"), null);
+        const surfaceRect = grid("2x2");
+        compare(surfaceRect.x, 12);
+        compare(surfaceRect.width, 252);
+        compare(surfaceRect.y + surfaceRect.height, 228 - 12,
+                "down to the card inset");
+        compare(surfaceRect.radius, cardRadius - 12,
+                "concentric with the card's own corners");
+    }
+
+    function test_every_cell_has_a_home_at_2x2() {
+        for (let i = 0; i < Geometry.CELLS; i++)
+            verify(day(i, "2x2") !== null, "cell " + i);
+        compare(day(-1, "2x2"), null);
+        compare(day(Geometry.CELLS, "2x2"), null);
+    }
+
+    function test_the_2x1_keeps_one_week_and_the_1x1_keeps_one_day() {
+        for (let i = 0; i < Geometry.CELLS; i++) {
+            const inWeek = Math.floor(i / Geometry.COLUMNS) === 2;
+            compare(day(i, "2x1") !== null, inWeek,
+                    "cell " + i + " at 2x1 - null is a fade, never a morph");
+            compare(day(i, "1x1") !== null, i === 20, "cell " + i + " at 1x1");
+        }
+    }
+
+    function test_the_surviving_week_travels_up_into_one_row() {
+        const rows = [];
+        for (let column = 0; column < Geometry.COLUMNS; column++) {
+            const wide = day(14 + column, "2x2");
+            const short = day(14 + column, "2x1");
+            rows.push(short.y);
+            verify(short.y < wide.y, "column " + column + " travels up");
+            compare(short.width, wide.width, "and keeps its size");
+        }
+        for (const y of rows)
+            compare(y, rows[0], "the seven land on one line");
+    }
+
+    function test_the_grid_rows_fit_inside_the_surface_they_are_drawn_on() {
+        const surfaceRect = grid("2x2");
+        const first = day(0, "2x2");
+        const last = day(Geometry.CELLS - 1, "2x2");
+        verify(first.y >= surfaceRect.y, "the first row is on the surface");
+        verify(last.y + last.height <= surfaceRect.y + surfaceRect.height + 0.01,
+               "and so is the last");
+        // Centred: the slack above the first row equals the slack below the last.
+        fuzzyCompare(first.y - surfaceRect.y,
+                     surfaceRect.y + surfaceRect.height - (last.y + last.height), 0.01);
+    }
+
+    function test_the_cells_stay_inside_the_card_at_both_wide_spans() {
+        for (const span of ["2x1", "2x2"]) {
+            for (let column = 0; column < Geometry.COLUMNS; column++) {
+                const cell = day(14 + column, span);
+                verify(cell.x >= 12, span + " column " + column + " off the left edge");
+                verify(cell.x + cell.width <= widthOf(span) - 12 + 0.01,
+                       span + " column " + column + " off the right edge");
+            }
+        }
+    }
+
+    function test_today_grows_into_the_hero_and_loses_its_highlight() {
+        const inGrid = day(20, "2x2");
+        const hero = day(20, "1x1");
+        verify(hero.size > inGrid.size * 4, "a caption becomes the whole card");
+        compare(inGrid.pill, 28, "a highlight in the grid");
+        compare(hero.pill, 0,
+                "and no highlight at 1x1 - a fill of zero size has finished leaving");
+        compare(hero.x, 0);
+        compare(hero.width, 132, "centred across the whole card");
+        compare(hero.y + hero.height, 108, "under the band, down to the card edge");
+    }
+}

--- a/dots/.config/quickshell/imi/tests/tst_world_clock_geometry.qml
+++ b/dots/.config/quickshell/imi/tests/tst_world_clock_geometry.qml
@@ -1,0 +1,131 @@
+import QtTest
+import "../modules/common/plugins/bundled/world-clock/world_clock_geometry.js" as Geometry
+
+// The world clock's shared-element geometry: the four city tiles, which are
+// the only thing the two spans have in common, and what each of them carries.
+//
+// Spans at scale 1: 2x2 = 276x228, 3x1 = 420x108.
+TestCase {
+    name: "WorldClockGeometryTest"
+
+    readonly property real offsetWidth: 34   // a plausible "UTC+10"
+
+    function widthOf(span) { return span === "3x1" ? 420 : 276; }
+    function heightOf(span) { return span === "3x1" ? 108 : 228; }
+
+    function tile(index, span) {
+        return Geometry.cityTileRect(index, span, widthOf(span), heightOf(span), 1);
+    }
+    function name(span, index) {
+        const box = tile(index, span);
+        return Geometry.tileNameRect(span, box.width, box.height, 1, offsetWidth);
+    }
+
+    function test_all_four_cities_have_a_tile_at_both_spans() {
+        for (const span of ["2x2", "3x1"])
+            for (let i = 0; i < Geometry.TILES; i++)
+                verify(tile(i, span) !== null, span + " tile " + i);
+        compare(tile(-1, "2x2"), null);
+        compare(tile(Geometry.TILES, "3x1"), null);
+    }
+
+    function test_the_chip_grid_is_two_by_two_inside_the_card_inset() {
+        const first = tile(0, "2x2");
+        const second = tile(1, "2x2");
+        const third = tile(2, "2x2");
+        compare(first.x, 12);
+        compare(first.y, third.y - first.height - 6, "one row gap apart");
+        compare(second.x, first.x + first.width + 6, "one column gap apart");
+        compare(tile(3, "2x2").x + tile(3, "2x2").width, 276 - 12,
+                "flush with the card inset");
+        compare(tile(3, "2x2").y + tile(3, "2x2").height, 228 - 12);
+        compare(first.width, second.width);
+        compare(first.height, third.height);
+    }
+
+    function test_the_dial_row_is_four_across_on_its_own_tighter_inset() {
+        const tiles = [0, 1, 2, 3].map(i => tile(i, "3x1"));
+        compare(tiles[0].x, 8, "not the card inset - the dials are full-bleed tiles");
+        compare(tiles[3].x + tiles[3].width, 420 - 8);
+        compare(tiles[0].y, 8);
+        compare(tiles[0].height, 108 - 16);
+        for (let i = 1; i < 4; i++) {
+            compare(tiles[i].width, tiles[0].width, "equal tiles");
+            compare(tiles[i].x, tiles[i - 1].x + tiles[i - 1].width + 8);
+        }
+    }
+
+    function test_a_chip_becomes_a_dial_rather_than_being_replaced_by_one() {
+        for (let i = 0; i < Geometry.TILES; i++) {
+            const chip = tile(i, "2x2");
+            const dial = tile(i, "3x1");
+            verify(dial.height > chip.height, "tile " + i + " grows tall");
+            verify(dial.radius > chip.radius,
+                   "tile " + i + " opens its corners on the way");
+        }
+    }
+
+    function test_the_city_name_is_the_one_thing_both_spans_say() {
+        for (let i = 0; i < Geometry.TILES; i++) {
+            verify(name("2x2", i) !== null, "chip " + i);
+            verify(name("3x1", i) !== null, "dial " + i);
+        }
+        const chip = name("2x2", 0);
+        const dial = name("3x1", 0);
+        verify(!chip.centred, "top-left of the chip, beside its offset");
+        verify(dial.centred, "centred under the dial");
+        verify(dial.y > chip.y, "and travels to the bottom of the tile");
+    }
+
+    function test_the_name_stops_where_the_offset_beside_it_starts() {
+        const box = tile(0, "2x2");
+        const label = Geometry.tileNameRect("2x2", box.width, box.height, 1, offsetWidth);
+        const offset = Geometry.tileOffsetRect("2x2", box.width, box.height, 1, offsetWidth);
+        compare(offset.x + offset.width, box.width - 12, "on the chip's own padding");
+        verify(label.x + label.width <= offset.x, "the two never overlap");
+        compare(label.y, offset.y, "one row");
+    }
+
+    function test_what_only_a_chip_can_say_has_no_home_on_a_dial() {
+        const box = tile(0, "3x1");
+        compare(Geometry.tileOffsetRect("3x1", box.width, box.height, 1, offsetWidth), null);
+        compare(Geometry.tileTimeRect("3x1", box.width, box.height, 1), null);
+        compare(Geometry.tileIconRect("3x1", box.width, box.height, 1), null);
+    }
+
+    function test_the_chip_rows_stay_inside_the_chip() {
+        const box = tile(0, "2x2");
+        const time = Geometry.tileTimeRect("2x2", box.width, box.height, 1);
+        const icon = Geometry.tileIconRect("2x2", box.width, box.height, 1);
+        const label = Geometry.tileNameRect("2x2", box.width, box.height, 1, offsetWidth);
+        compare(time.x, label.x, "the name and the time share a left edge");
+        verify(time.y > label.y + label.height - 0.01, "and the time is the row below");
+        verify(time.y + time.height <= box.height, "inside the chip");
+        compare(icon.x + icon.width, box.width - 12, "on the chip's own padding");
+    }
+
+    function test_the_dial_reserves_the_band_the_name_lands_in() {
+        const box = tile(0, "3x1");
+        const dial = Geometry.dialRect("3x1", box.width, box.height, 1);
+        const label = Geometry.tileNameRect("3x1", box.width, box.height, 1, offsetWidth);
+        compare(dial.width, box.width);
+        verify(dial.height < box.height, "the label band is not part of the dial");
+        // AndroidClock insets its own drawing inside the box it is given, so
+        // the face ends a `contentInset` above the box's bottom - which is
+        // where the name band begins.
+        verify(label.y >= dial.height - Geometry.DIAL_INSET,
+               "the name sits under the face, not across it");
+        verify(label.y + label.height <= box.height, "inside the tile");
+    }
+
+    function test_the_hands_grow_out_of_the_chip_rather_than_landing_on_it() {
+        // A null at 2x2 would fade the dial in at its 3x1 size over a tile
+        // that has not finished growing. Its 2x2 home is the chip's own box.
+        const chip = tile(0, "2x2");
+        const onChip = Geometry.dialRect("2x2", chip.width, chip.height, 1);
+        compare(onChip.width, chip.width);
+        compare(onChip.height, chip.height);
+        verify(!Geometry.dialShown("2x2"), "shown at 3x1 only");
+        verify(Geometry.dialShown("3x1"));
+    }
+}


### PR DESCRIPTION
Closes the audit's gap #1: `calendar` and `world-clock` resized by
destroy-and-rebuild — a per-span `Loader` in one, three `visible`-swapped
subtrees in the other — against a box that snapped. Both morph in one tree now,
like `nandoroid-weather` and `nandoroid-currency` beside them on the desktop.

## What each widget is made of now

Elements are declared once and travel between the rects a geometry module
answers for, on the shared `SpanTravel` / `SpanFade` curves. `null` from the
module means "no home at this span", which is a fade, never a morph.

**calendar** — `calendar_geometry.js`, `tests/tst_calendar_geometry.qml`

| element | 1x1 | 2x1 | 2x2 |
|---|---|---|---|
| month surface | full-bleed band, card's own top corners | pill | — (fades; the 2x2 title is plain) |
| short month + weekday | in the band | — | — |
| long month name | — | in the pill | on the card inset, a step larger |
| month steppers | — | — | right of the title |
| weekday letters | — | over the card's seven columns | over the day grid's seven |
| day-grid surface | — | — | the `colLayer1` panel |
| **day cells (42)** | today's alone, as the hero date | the current week's seven, in a row | all of them, in six rows |

The day cells are the morph. Going 2x2 → 2x1 the current week's seven travel up
into one row while the other thirty-five fade where they stand; going on to 1x1
today's alone survives, growing into the hero date while its highlight shrinks
to nothing *under* it — a highlight that is a box rather than a flag is what
stops it blinking off at the end.

**world-clock** — `world_clock_geometry.js`, `tests/tst_world_clock_geometry.qml`

The four city tiles are the shared elements: a chip in the 2x2 grid and a dial
in the 3x1 row are the same tile, carrying its surface, its colour, its opening
corners and its city name from one to the other. The offset, the digital time
and the day/night glyph fade; the hands fade in **out of the chip's own box**,
because a dial standing at its 3x1 size over a tile that has not finished
growing is a full-grown clock hanging off a chip for the length of the morph.

## Frame-by-frame evidence

`grim` bursts at ~36ms across each transition on the running shell, at the
widgets' real desktop positions. Four transitions shot: calendar 2x2→2x1,
2x2→1x1, 1x1→2x2, 2x1→2x2, and world-clock 2x2↔3x1 both ways.

- calendar 2x2 → 2x1: the current week (10..16) is legible in **every** frame
  and travels continuously up the card; the month title rides into the pill as
  the pill grows around it; the day-grid surface, the five other rows and the
  chevrons fade where they stand. No frame is missing an element that both spans
  have.
- calendar 2x2 → 1x1: "16" is on screen in every frame, growing from a 12px
  glyph in a 28px pill to the 54px hero while the pill shrinks under it and the
  band's "AUG SUN" fades in above.
- world-clock 2x2 ↔ 3x1: all four tiles and all four city names are on screen in
  every frame; the names travel from the chip's top-left to the dial's label
  band and back, and the hands cross-fade with the digital times.

Nothing blinks out and reappears in any of the six bursts.

**One thing those bursts exposed that is not this gap.** The desktop frost drops
out for the length of any box animation — the card body goes to its bare tint
over a *sharp* wallpaper and the blur returns only once the box settles. The
same burst on `nandoroid-weather`, whose box has animated since `fa1e2a8b5`,
shows it identically, so it predates this work and was only invisible while
these two widgets snapped. Recorded in AGENT.md with the suspected mechanism
(`PluginWidget`'s frost `Repeater` takes `blurRegions` as its model, and a
card's `blurRegion` is a fresh object every frame of a resize) marked as a
reading of the source rather than a finding, plus the measurement that would
settle it. Not fixed here.

## The two things the audit called "aggravating"

Both widgets' boxes animate for the first time, and both publish their own
`boxInMotion`. Neither comes from the host: `gridResizeAnimated` is
`gridSized && PluginState.ready`, and `boxInMotion` compares the drawn box
against a `settledWidth` that, for a content-sized widget, *is* the drawn box.
So a widget declaring no manifest `grid` — which both do deliberately, because
their own handles own their size — snapped, and its card kept re-blurring its
body into a reallocating layer throughout. Both halves now live in the widget.

Geometry reads the **settled** span (`spanW`/`spanH` are functions of the span
name alone) with the animating box as a separate property, so
`test_geometry_rects_come_from_the_settled_span_not_the_animating_box` — which
sweeps rather than names — covers both new trees. No element uses the
`slot ?? ({ x: x, ... })` shape that gap G1 records as a binding loop; an
element with no home stands at a span that has one, which is weather's
`arcSpan` rule.

## The new check, proven to fail

`test_a_widget_that_owns_its_span_morphs_in_one_tree`: any widget declaring its
own `sizeMode` may not let that name reach a `sourceComponent` or a `visible`.
A span may decide where an element sits, never whether it exists. `opacity` is
deliberately not on the list — fading an element with no home is the mechanism
being asked for.

Read whole rather than by line, because calendar's Loader wrote its dispatch as
a block; the brace-balancing is factored out of `span_declarations`, which had
already been caught by exactly that.

Planted twice in a clean tree, each reverted:

| plant | result |
|---|---|
| `visible: root.sizeMode === "2x2" && root.showingSettings` on world-clock's settings back (the line this PR removes) | **FAILED** — ``world-clock/Widget.qml: `visible` is decided by the span`` |
| a `Loader { sourceComponent: { if (root.sizeMode === "1x1") ... } }` in calendar, written as a block | **FAILED** — ``calendar/Widget.qml: `sourceComponent` is decided by the span`` |

## Settled design

Rendered at every span through the existing `CalendarCardProbe` and a scratch
probe for world-clock, and compared against a render of the destroyed-and-
rebuilt version. All five settled spans are unchanged bar sub-pixel text
placement; the geometry numbers were measured off those renders precisely
because two of them (the 1x1 band's height, the 2x2 weekday strip's) are font
metrics of a laid-out column rather than literals anyone wrote down.

## Tests

`tests/run_tests.sh` green: **757 passed**, up from 731 — 26 new geometry
assertions across the two modules.

Three existing tests changed, each because the thing it pinned moved rather than
because it was in the way:

- `test_calendar_draws_its_surface_on_the_shared_card` asserted
  `implicitWidth: card.implicitWidth`. Right while the card held the per-span
  Loader and was the only thing that knew how big a mode was; the wrong
  direction for one tree, where the span decides the box and the card fills it.
  Turned around, not dropped.
- `test_widget_grid_lattice` read the spans off the `widgetWidth` line. That is
  the animating box now and the helpers moved one step back, so it reads the
  file for the helpers and pins the box to the settled span separately — both
  halves of what it was checking.
- `test_the_trees_share_one_spelling_of_the_span_animations` sweeps the two new
  trees, so neither can grow a private copy of the curve.

Verified on the live shell: `Configuration Loaded`, zero `Binding loop`
detections. `config.json` and `plugin-state.json` were copied byte-for-byte
before the widgets were enabled and restored with `cp` afterwards (md5 matches).

Docs: updated AGENT.md §Dynamic/data-driven QML gotchas (three entries: a
grid-less widget brings its own box animation and `boxInMotion`; a one-tree
widget needs `clipContent` and a fading block must stand still; the frost
dropout, marked as measured but undiagnosed), docs/widget-grid.md (what
omitting `grid` costs), docs/widget-standards-audit-2026-08-16.md (gap #1 marked
done, plus §8 recording element-by-element what replaced it)
