### PR TITLE
Widget behaviour: six switch rows become one toggle bar

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1211,6 +1211,20 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   *temporarily* inert (`enabledWhen`), which is a different thing.
   a03f1b266 ("feat(plugins): show a widget's own options above the host's"),
   008e51dc9 ("feat(plugins): offer a resizable widget's span as a settings row").
+  **The host's booleans in that section are a toggle bar, not rows — a new one is a
+  `behaviourRows` entry and nothing else.** Six `ConfigSwitch`es spent 212px of the card on six
+  bits; a `FlowButtonGroup` of `IconToolbarButton`s spends 72px, so adding a seventh host boolean
+  as a row would be both inconsistent and the expensive spelling. Two things about the bar do not
+  generalise from a row and are checked: a glyph cannot label itself, so every toggle carries a
+  `label` and the caption under the bar shows the hovered one — and, off-hover, which of them are
+  on, which is the half of a switch row's label that selected-state colour does not replace; and
+  the hovered label is cleared only by the toggle that wrote it, because a pointer crossing
+  between two toggles delivers the leave and the enter in an order nothing here controls. The
+  toggle is composed from `IconToolbarButton` precisely so the cursor, the toggled container
+  states and the *single* application of the interaction motion come from the control rather than
+  being re-earned (see the composites rules under
+  [Dynamic/data-driven QML gotchas](#dynamicdata-driven-qml-gotchas)).
+  b89908fef ("feat(plugins): draw the widget behaviour section as a toggle bar").
 - **A desktop widget opts out of the parallax pan by cancelling it, not by being offset less.**
   The widget canvas is one item whose `x`/`y` *are* the widget parallax (`Background.qml`), so
   every widget on it travels because its parent does. `followParallax: false` therefore adds

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginOptions.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginOptions.qml
@@ -100,31 +100,123 @@ ColumnLayout {
     // Every host row reads as one group rather than as more of the widget's own
     // settings. The same rows appear for every widget - that is the point, and
     // it is exactly why they should not sit among the plugin's.
+    //
+    // ...and it is also why they are a bar rather than rows. Six booleans as
+    // six full-width switch rows spent 196px of a popup whose scarce axis is
+    // vertical, on six settings whose entire content is on/off - the icon, the
+    // label and the track were three columns of chrome per bit. As icon
+    // toggles they are one 40px line: the selected container carries the
+    // state, and the caption under the bar carries the naming a glyph cannot.
     ContentSubsection {
+        id: behaviourSection
         title: Translation.tr("Widget behaviour")
 
-        // Not a pluginOption on purpose: preset application replaces those, and
-        // this flag decides whether they get replaced (see presets.sh --apply).
-        ConfigSwitch {
-            id: presetPersistSwitch
+        readonly property string presetPersistLabel: Translation.tr("Keep settings across presets")
+
+        // Written by whichever toggle the pointer is over, read by the caption.
+        // Cleared only by the toggle that wrote it: a pointer crossing from one
+        // toggle to the next delivers the leave and the enter in an order
+        // nothing here controls, so an unconditional clear on a leave blanks
+        // the label the enter just wrote.
+        property string hoveredLabel: ""
+
+        // What the six labels used to say without being pointed at: which of
+        // these are on. The selected container answers that too, but only once
+        // six glyphs have been learned, and this is the settings surface where
+        // they are met for the first time.
+        readonly property string enabledLabels: {
+            const on = [];
+            if (PluginState.presetPersisted(root.manifest.id))
+                on.push(behaviourSection.presetPersistLabel);
+            for (let index = 0; index < root.behaviourRows.length; ++index) {
+                const behaviourRow = root.behaviourRows[index];
+                if (PluginState.option(root.manifest.id, behaviourRow.key, behaviourRow.default))
+                    on.push(behaviourRow.label);
+            }
+            return on.join("  ·  ");
+        }
+
+        FlowButtonGroup {
+            id: behaviourBar
             Layout.fillWidth: true
-            leftPadding: 0
-            rightPadding: 0
-            buttonIcon: "push_pin"
-            text: Translation.tr("Keep settings across presets")
-            checked: PluginState.presetPersisted(root.manifest.id)
-            onToggleRequested: PluginState.setPresetPersist(root.manifest.id,
-                !PluginState.presetPersisted(root.manifest.id))
+            spacing: Appearance.spacing.space50
+
+            // Not a pluginOption on purpose: preset application replaces those,
+            // and this flag decides whether they get replaced (see
+            // presets.sh --apply). It leads the bar because it governs whether
+            // the rest of it survives a preset.
+            BehaviourToggle {
+                id: presetPersistToggle
+                label: behaviourSection.presetPersistLabel
+                buttonIcon: "push_pin"
+                toggled: PluginState.presetPersisted(root.manifest.id)
+                onClicked: PluginState.setPresetPersist(root.manifest.id,
+                    !PluginState.presetPersisted(root.manifest.id))
+            }
+
+            Repeater {
+                model: root.behaviourRows
+                delegate: BehaviourToggle {
+                    required property var modelData
+                    label: modelData.label
+                    buttonIcon: modelData.icon
+                    toggled: PluginState.option(root.manifest.id, modelData.key, modelData.default)
+                    onClicked: PluginState.setOption(root.manifest.id, modelData.key,
+                        !PluginState.option(root.manifest.id, modelData.key, modelData.default))
+                }
+            }
+        }
+
+        StyledText {
+            id: behaviourCaption
+            Layout.fillWidth: true
+            font.pixelSize: Appearance.font.pixelSize.smaller
+            color: Appearance.colors.colSubtext
+            elide: Text.ElideRight
+            // One label channel, not two. A tooltip answers "what is this one"
+            // and nothing else, after a hover apiece, drawn over the toggles
+            // beside it; this answers the same question in a fixed place while
+            // the pointer sweeps the bar, and answers the other one - which of
+            // these are on - while the pointer is nowhere near it.
+            text: behaviourSection.hoveredLabel.length > 0
+                ? behaviourSection.hoveredLabel
+                : (behaviourSection.enabledLabels.length > 0
+                    ? Translation.tr("On: %1").arg(behaviourSection.enabledLabels)
+                    : Translation.tr("Nothing on"))
         }
 
         Repeater {
             model: root.sizeRows
             delegate: optionRow
         }
+    }
 
-        Repeater {
-            model: root.behaviourRows
-            delegate: optionRow
+    // Composed, not written: `IconToolbarButton` is already an icon-only button
+    // whose `toggled` container states are M3's selected/unselected pair, and
+    // the `RippleButton` under it already owns the pointer shape and the single
+    // application of the shared interaction motion. Nothing here adds a hover
+    // scale or an enabled-dim of its own - both compose rather than replace,
+    // and both are lints (lint_interaction_motion_double, lint_disabled_opacity).
+    //
+    // The click is an intent in the same sense a ConfigSwitch's is: `toggled`
+    // is a pure binding on the store and the handler flips the value at its
+    // source, so nothing here can detach the toggle from what it displays.
+    component BehaviourToggle: IconToolbarButton {
+        id: toggle
+        // A glyph cannot label itself, and these six are not self-evident.
+        // The bar's caption names whichever one the pointer is over; this is
+        // the name it shows.
+        property string label: ""
+        property string buttonIcon: "tune"
+
+        implicitHeight: 40
+        text: toggle.buttonIcon
+
+        onHoveredChanged: {
+            if (toggle.hovered)
+                behaviourSection.hoveredLabel = toggle.label;
+            else if (behaviourSection.hoveredLabel === toggle.label)
+                behaviourSection.hoveredLabel = "";
         }
     }
 

--- a/dots/.config/quickshell/imi/tests/test_plugin_options_sections.py
+++ b/dots/.config/quickshell/imi/tests/test_plugin_options_sections.py
@@ -25,6 +25,18 @@ OPTIONS = ROOT / "modules/common/plugins/PluginOptions.qml"
 SUBSECTION_TITLE = "Widget behaviour"
 
 
+def without_comments(source):
+    """Source with `//` comments dropped.
+
+    A check that matches source text matches a commented-out line just as
+    happily as a live one - which is exactly how a mutation that deletes a
+    binding by commenting it out passes the check guarding that binding.
+    Proven by planting that mutation; the first version of this file did not
+    redden for it.
+    """
+    return re.sub(r"//[^\n]*", "", source)
+
+
 def block_extent(source, opener):
     """[start, end) of the QML block introduced by `opener` ("Foo {")."""
     start = source.index(opener)
@@ -111,7 +123,7 @@ class TheHostBooleansAreAToggleBar(unittest.TestCase):
     """
 
     def setUp(self):
-        self.source = OPTIONS.read_text(encoding="utf-8")
+        self.source = without_comments(OPTIONS.read_text(encoding="utf-8"))
         start, end = block_extent(self.source, "ContentSubsection {")
         self.section = self.source[start:end]
 

--- a/dots/.config/quickshell/imi/tests/test_plugin_options_sections.py
+++ b/dots/.config/quickshell/imi/tests/test_plugin_options_sections.py
@@ -83,12 +83,111 @@ class TheTwoGroupsStaySeparate(unittest.TestCase):
                         "the widget's own options must render above the shared "
                         "section - they are what the page was opened for")
 
-    def test_one_delegate_serves_every_repeater(self):
-        """Two copies of the row delegate is how the groups drift apart."""
+    def test_one_delegate_serves_every_group_of_rows(self):
+        """Two copies of the row delegate is how the groups drift apart.
+
+        The host's booleans are a toggle bar rather than rows now, so the
+        count is against the groups still drawn AS rows - the plugin's own
+        options and the size row - rather than against every Repeater in the
+        file.
+        """
         self.assertEqual(self.source.count("id: optionRow"), 1)
-        self.assertEqual(self.source.count("delegate: optionRow"),
-                         self.source.count("Repeater {"),
+        for model in ("root.widgetOptions", "root.sizeRows"):
+            self.assertRegex(
+                self.source,
+                rf"model: {re.escape(model)}\s*\n\s*delegate: optionRow",
+                f"{model} no longer draws through the shared row delegate")
+        self.assertEqual(self.source.count("delegate: optionRow"), 2,
                          "every group of rows draws through the one delegate")
+
+
+class TheHostBooleansAreAToggleBar(unittest.TestCase):
+    """Six booleans were six full-width switch rows - icon, label and track per
+    bit, 212px of a popup whose scarce axis is vertical. They are one wrapping
+    bar of icon toggles now (72px measured, five of the six rows' worth
+    reclaimed), which only works while three things hold: the toggles are
+    composed from the existing control rather than hand-rolled, a click stays
+    an intent, and every glyph is still named by something.
+    """
+
+    def setUp(self):
+        self.source = OPTIONS.read_text(encoding="utf-8")
+        start, end = block_extent(self.source, "ContentSubsection {")
+        self.section = self.source[start:end]
+
+    def test_the_bar_wraps(self):
+        """A row of six 40px toggles fits the settings card today and does not
+        fit every surface this page could end up on. `FlowButtonGroup` is a
+        Flow - a plain RowLayout would push the last toggles off the edge."""
+        self.assertIn("FlowButtonGroup {", self.section,
+                      "the toggles need a container that wraps")
+        bar_start, bar_end = block_extent(self.section, "FlowButtonGroup {")
+        bar = self.section[bar_start:bar_end]
+        self.assertIn("model: root.behaviourRows", bar,
+                      "every host boolean belongs in the one wrapping bar")
+
+    def test_the_toggle_is_composed_not_written(self):
+        """`IconToolbarButton` is already an icon-only button whose `toggled`
+        container states are M3's selected/unselected pair, and the
+        `RippleButton` under it already owns the pointer shape and the ONE
+        application of the shared interaction motion. A hand-rolled control
+        here would have to re-earn all three."""
+        self.assertIn("component BehaviourToggle: IconToolbarButton", self.source)
+
+    def test_the_toggles_add_no_motion_of_their_own(self):
+        """`lint_interaction_motion_double` and `lint_disabled_opacity` both
+        fail on this, and both key on an idiom - so pin it here too, where the
+        reason is written down."""
+        start, end = block_extent(self.source, "component BehaviourToggle: IconToolbarButton {")
+        toggle = self.source[start:end]
+        for doubled in ("scale:", "opacity:"):
+            self.assertNotIn(doubled, toggle,
+                             "the control already applies the interaction "
+                             "model; a second one composites with it")
+
+    def test_a_click_is_still_an_intent(self):
+        """The ConfigSwitch rule survives the control swap: `toggled` is a
+        pure binding on the store and the handler flips the value at its
+        source. An assignment to `toggled` would destroy that binding and
+        detach the toggle from what it displays, exactly as #158 did."""
+        self.assertIsNone(
+            re.search(r"\btoggled\s*=(?![=~])", self.source),
+            "a toggle assigns to `toggled` - that is the binding destroyed by hand")
+        self.assertIn("toggled: PluginState.option(root.manifest.id, modelData.key, "
+                      "modelData.default)", self.section)
+        self.assertIn("PluginState.setOption(root.manifest.id, modelData.key,", self.section)
+        self.assertIn("toggled: PluginState.presetPersisted(root.manifest.id)", self.section)
+        self.assertIn("PluginState.setPresetPersist(root.manifest.id,", self.section)
+
+    def test_no_host_boolean_is_a_row_any_more(self):
+        """The preset-persist switch was the sixth of them and the only one
+        not synthesized into `behaviourRows`; leaving it as a row would put a
+        full-width switch beside a bar of toggles that mean the same kind of
+        thing."""
+        self.assertNotIn("ConfigSwitch", self.section)
+
+    def test_every_toggle_carries_the_name_its_glyph_cannot(self):
+        """A pin, a grid, a lock, a hand, a droplet and a frame are not
+        self-evident. The caption below the bar names whichever one the pointer
+        is over, so a toggle with no `label` is an unlabelable control."""
+        self.assertIn("label: behaviourSection.presetPersistLabel", self.section)
+        self.assertIn("label: modelData.label", self.section)
+        self.assertIn("behaviourSection.hoveredLabel = toggle.label", self.source)
+
+    def test_the_caption_falls_back_to_what_is_on(self):
+        """Off-hover the caption answers the other question the six labels
+        used to answer for free: which of these are on. Selected-state colour
+        answers it too, but only once six glyphs have been learned."""
+        self.assertIn("readonly property string enabledLabels", self.section)
+        self.assertIn("behaviourSection.hoveredLabel.length > 0", self.section)
+        self.assertIn("behaviourSection.enabledLabels.length > 0", self.section)
+
+    def test_the_hover_label_is_cleared_only_by_the_toggle_that_wrote_it(self):
+        """A pointer crossing from one toggle to the next delivers the leave
+        and the enter in an order nothing here controls, so an unconditional
+        clear on a leave blanks the label the enter just wrote."""
+        self.assertIn(
+            "else if (behaviourSection.hoveredLabel === toggle.label)", self.source)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
"widget behaviour customization should be a toggle bar instead of each option taking a whole line."

The `Widget behaviour` section of a desktop widget's options was six full-width
`ConfigSwitch` rows — an icon, a label and a switch track spanning the card,
once per bit — for six booleans whose entire content is on/off. It is one
wrapping bar of icon toggles now, with a caption under it.

## What it saved

Measured on the clock widget's settings card, at the same window size (980x665),
by reading the rendered pixels rather than the source:

| | before | after |
|---|---|---|
| section ink extent (top of the `Widget behaviour` label → bottom of the last thing it paints) | **212px** | **72px** |
| from the last plugin-own row (`Quote`) to the card's bottom edge — everything above it identical | **260px** | **121px** |

**140px back**, two thirds of the section, in the surface whose scarce axis is
vertical and whose reason for being open is the plugin's *own* options — which
the section pushes down by exactly that much.

## Composed, not written

- `FlowButtonGroup` — the container that exists so `RippleButton`s can live in a
  `Flow`. The bar wraps rather than running off the edge of a narrower surface.
- `IconToolbarButton` — already an icon-only button whose `toggled` container
  states are M3's selected/unselected pair. Under it, `RippleButton` already
  owns the pointer shape and the *single* application of the shared interaction
  motion, so the toggle adds no hover scale and no enabled-dim of its own: both
  would composite with the control's rather than replace it
  (`lint_interaction_motion_double`, `lint_disabled_opacity`).

No new component, no new file. The inline `BehaviourToggle` is four bindings on
`IconToolbarButton`.

## Why the labelling is a caption and not a tooltip

A pin, a grid, a lock, a hand, a droplet and a frame are not self-evident, so
this had to be solved rather than inherited. A tooltip was the obvious option
and is the weaker one on both counts:

1. It answers only *"what is this one"*, once per hover, and draws itself over
   the toggles beside the one you are asking about.
2. It has nothing to say while the pointer is elsewhere — and the six switch
   rows were answering a second question for free the whole time: **which of
   these are on**. Selected-state colour answers that too, but only once six
   glyphs have been learned, and this settings card is where they are met for
   the first time.

The caption under the bar does both, in a fixed place that does not occlude the
row: it names whichever toggle the pointer is over, and off-hover it reads
`On: Blur background · Lock position`, or `Nothing on`. One label channel rather
than two — a tooltip *and* a caption for one hover is noise.

Two consequences worth naming:

- Every toggle carries a `label`, so a toggle nobody can name is a broken one.
  Checked.
- The hovered label is cleared **only by the toggle that wrote it**. A pointer
  crossing from one toggle to the next delivers the leave and the enter in an
  order nothing here controls, so an unconditional clear on a leave blanks the
  label the enter has just written.

The preset-persist switch joins the bar rather than staying a lone full-width
row above it. It is not a `pluginOption` — preset application replaces those,
and this flag decides whether they get replaced — but it is the same kind of
thing to the user. It leads the bar because it governs whether the rest of it
survives a preset. The Size row is untouched: a span is a choice, not a boolean,
and it keeps the shared row delegate.

## The rules this could have tripped

- **The interaction model is applied once, by the control.** Nothing here writes
  a scale or an `enabled`-dim on top of `RippleButton`'s.
- **A clickable thing sets a cursor.** `RippleButton`'s `HoverHandler` and
  `MouseArea` both do; verified on screen — the pointer is a hand over a toggle.
- **A click is an intent.** `toggled` is a pure binding on `PluginState` and the
  handler flips the value at its source, exactly as `onToggleRequested` does for
  a `ConfigSwitch`. Nothing assigns `toggled`, so nothing can detach a toggle
  from what it displays (#158).
- **No anchor changes with state, and no binding derives from a property its own
  component writes.** The caption reads `hoveredLabel`; the toggles write it.

## Verified live

Deployed to `~/.config/quickshell/imi` and restarted (`Configuration Loaded`, no
new `ERROR`/`WARN scene`), then driven through the real settings window:

- The section renders as one 40px bar of six toggles plus the caption; the
  screenshots above are measurements off those frames.
- Hovering `lock` shows a hand cursor, the hover container, and the caption
  reading `Lock position`.
- **Every toggle round-trips.** Clicked all six on, one at a time, reading
  `~/.config/immaterial-impulse/plugin-state.json` after each: `presetPersist`
  gained `clock: true`, and `pluginOptions.clock` gained `blurEnabled`,
  `positionLocked`, `clickThrough`, `keepTranslucent` and `followParallax: false`
  in that order, each on its own click and no other key touched.
- **The UI shows the stored state after a full restart.** Killed the shell,
  relaunched, reopened the card: five toggles selected, `followParallax` not,
  caption reading `On: Keep settings across presets · Blur background · Lock
  position · Click through · Stay transluc…`.
- Clicked all six back, confirming the off direction writes too, then restored
  `plugin-state.json` and `config.json` byte-for-byte from a `cp` backup
  (md5 unchanged, and unchanged again after a restart).

`tests/run_tests.sh` green: 757 passed, 0 failed.

## Tests

`tests/test_plugin_options_sections.py` owns how these two groups are presented,
so it grew the bar's contract: it wraps, the toggle is composed rather than
hand-rolled, it adds no motion of its own, a click is still an intent, no host
boolean is a row any more, every toggle carries a name, the caption falls back
to what is on, and the hover-clear is conditional. Its
`test_one_delegate_serves_every_repeater` counted `delegate: optionRow` against
every `Repeater {` in the file, which is false for a correct file now — it
counts against the groups still drawn *as* rows instead.

All nine assertions were mutation-checked by planting the edit each one names.
One did not redden: commenting out `label: modelData.label` — which is how a
binding gets deleted in practice — left the text in the file and `assertIn`
matched it happily, so the toggle would have shipped unlabelable with a green
suite. The checks read the file with `//` comments dropped now, and both
spellings of that mutation fail.

Docs: updated AGENT.md §Dynamic/data-driven QML gotchas — the entry describing
this section described rows, which is how the next agent adding a host boolean
adds a seventh switch to a bar of six toggles.
