### PR TITLE
docs(research): correct the quick-toggle finding, and two more claims about our own tree

### DIFF
--- a/docs/p3drovfx-research-2026-08-16.md
+++ b/docs/p3drovfx-research-2026-08-16.md
@@ -598,11 +598,11 @@ Ordered by value to the user per unit of work. Sizes are new-code estimates for
 | 5 | **DNS-over-TLS** | Fills a real privacy gap; no credentials, no network calls of its own, one polkit rule, one quick toggle | Small, ~350 lines |
 | 6 | **App-search frecency (`AppUsage`)** | The launcher stops offering the wrong app; pure logic, trivially testable | Small, ~200 lines + 4 call sites |
 | 7 | **Launcher: qalc gate + `Qt.callLater` result rebuild** | Stops spawning a `qalc` process per keystroke from inside a live binding — the biggest correctness win available in our launcher | Small, ~60 lines |
-| 8 | **OLED saver** | Best effort/value ratio of any *module* surveyed: one property, one window, one keybind | Small, ~280 lines |
-| 9 | **Launcher: system controls with two-step confirm** | Real, useful, no external dependency. Needs a `key` on `LauncherSearchResult`, a guard on our unconditional overview close (`SearchItem.qml:108-110`), and a `restart` that is `qs -c imi`-aware rather than a bare `Quickshell.reload()` | Small-medium, ~120 lines |
-| 10 | **EasyEffects state verification** | Fixes a toggle of ours that lies when the launch fails | Tiny, ~70-line diff |
-| 11 | **Local plugin registration + reload IPC verb** | The friction that keeps third-party widgets from existing; does not weaken our installer's security model | Small-medium, ~200 lines |
-| 12 | **Idle: timed keep-awake sessions** | Composes with our `autoOnExternalMonitor`; the absolute-epoch-deadline detail is worth copying verbatim | Small, ~180 net-new + chips UI |
+| 8 | **Launcher: system controls with two-step confirm** | Real, useful, no external dependency. Needs a `key` on `LauncherSearchResult`, a guard on our unconditional overview close (`SearchItem.qml:108-110`), and a `restart` that is `qs -c imi`-aware rather than a bare `Quickshell.reload()` | Small-medium, ~120 lines |
+| 9 | **EasyEffects state verification** | Fixes a toggle of ours that lies when the launch fails | Tiny, ~70-line diff |
+| 10 | **Local plugin registration + reload IPC verb** | The friction that keeps third-party widgets from existing; does not weaken our installer's security model | Small-medium, ~200 lines |
+| 11 | **Idle: timed keep-awake sessions** | Composes with our `autoOnExternalMonitor`; the absolute-epoch-deadline detail is worth copying verbatim | Small, ~180 net-new + chips UI |
+| 12 | **OLED saver: finish the one we have** (§2.4) | Not a new module — bind a key to the `show`/`hide`/`toggle` verbs `modules/imi/screensaver/` already exposes, let it target one monitor instead of all of them, and give it an idle inhibitor so a deliberate blank does not fall through hypridle's lock/DPMS/suspend ladder. Ranked here, not at 8: that rank priced it as a new module on a survey row that wrongly read "none" | Small, ~80–120 lines against an existing module |
 | 13 | **`CommandsService` + a cheatsheet page** | A genuinely new feature with no equivalent anywhere in ours | Medium, ~550 lines |
 | 14 | **In-UI update log via `systemd-run`** | Solves the shell-kills-its-own-updater problem properly and removes hardcoded `kitty`/`fish`. Pair with an update-available indicator, which is *easier* for us since we keep a real checkout | Medium, ~330 lines |
 | 15 | **Scratchpad-empty overlay** | Cheapest self-contained module in their tree | Small, ~170 lines |

--- a/docs/p3drovfx-research-2026-08-16.md
+++ b/docs/p3drovfx-research-2026-08-16.md
@@ -596,14 +596,14 @@ Ordered by value to the user per unit of work. Sizes are new-code estimates for
 | 6 | **App-search frecency (`AppUsage`)** | The launcher stops offering the wrong app; pure logic, trivially testable | Small, ~200 lines + 4 call sites |
 | 7 | **Launcher: qalc gate + `Qt.callLater` result rebuild** | Stops spawning a `qalc` process per keystroke from inside a live binding — the biggest correctness win available in our launcher | Small, ~60 lines |
 | 8 | **OLED saver** | Best effort/value ratio of any *module* surveyed: one property, one window, one keybind | Small, ~280 lines |
-| 9 | **Quick-toggle draft/commit boundary, staged** (§3.3 #3) | Replaces in-place mutation of a `JsonObject` array with a validated single write path and a cancel | Small-medium, ~400–600 lines |
-| 10 | **Launcher: system controls with two-step confirm** | Real, useful, no external dependency. Needs a `key` on `LauncherSearchResult`, a guard on our unconditional overview close (`SearchItem.qml:108-110`), and a `restart` that is `qs -c imi`-aware rather than a bare `Quickshell.reload()` | Small-medium, ~120 lines |
-| 11 | **EasyEffects state verification** | Fixes a toggle of ours that lies when the launch fails | Tiny, ~70-line diff |
-| 12 | **Local plugin registration + reload IPC verb** | The friction that keeps third-party widgets from existing; does not weaken our installer's security model | Small-medium, ~200 lines |
-| 13 | **Idle: timed keep-awake sessions** | Composes with our `autoOnExternalMonitor`; the absolute-epoch-deadline detail is worth copying verbatim | Small, ~180 net-new + chips UI |
-| 14 | **`CommandsService` + a cheatsheet page** | A genuinely new feature with no equivalent anywhere in ours | Medium, ~550 lines |
-| 15 | **In-UI update log via `systemd-run`** | Solves the shell-kills-its-own-updater problem properly and removes hardcoded `kitty`/`fish`. Pair with an update-available indicator, which is *easier* for us since we keep a real checkout | Medium, ~330 lines |
-| 16 | **Scratchpad-empty overlay** | Cheapest self-contained module in their tree | Small, ~170 lines |
+| 9 | **Launcher: system controls with two-step confirm** | Real, useful, no external dependency. Needs a `key` on `LauncherSearchResult`, a guard on our unconditional overview close (`SearchItem.qml:108-110`), and a `restart` that is `qs -c imi`-aware rather than a bare `Quickshell.reload()` | Small-medium, ~120 lines |
+| 10 | **EasyEffects state verification** | Fixes a toggle of ours that lies when the launch fails | Tiny, ~70-line diff |
+| 11 | **Local plugin registration + reload IPC verb** | The friction that keeps third-party widgets from existing; does not weaken our installer's security model | Small-medium, ~200 lines |
+| 12 | **Idle: timed keep-awake sessions** | Composes with our `autoOnExternalMonitor`; the absolute-epoch-deadline detail is worth copying verbatim | Small, ~180 net-new + chips UI |
+| 13 | **`CommandsService` + a cheatsheet page** | A genuinely new feature with no equivalent anywhere in ours | Medium, ~550 lines |
+| 14 | **In-UI update log via `systemd-run`** | Solves the shell-kills-its-own-updater problem properly and removes hardcoded `kitty`/`fish`. Pair with an update-available indicator, which is *easier* for us since we keep a real checkout | Medium, ~330 lines |
+| 15 | **Scratchpad-empty overlay** | Cheapest self-contained module in their tree | Small, ~170 lines |
+| 16 | **Quick-toggle draft/commit boundary, staged** (§3.3 #3) | Adds validation and a cancel to layout editing that has neither. Ranked here, not at 9 as an earlier draft had it: it repairs nothing — the in-place mutation it was said to fix is correct (26b625905) — so it buys a cancel and a guard rail for ~500 lines | Small-medium, ~400–600 lines |
 | 17 | **Dynamic island** (minimal: surface + registry + 5–6 widgets, on our card) | Their signature feature and the most visible thing they have that we do not; we already own the morph engine. Decide single-screen vs per-screen up front, and do **not** absorb search or the OSD | Medium-large, ~600–900 lines |
 | 18 | **Screen-shader browser** | Turns our one-shader feature into a catalogue, and is the right place to land #1 | Medium, ~470 lines + dialog |
 | 19 | **Media downloader** (their service, our panel) | High user value, clean argv, `yt-dlp` + `ffmpeg` only | Medium, ~600 lines + our own panel |

--- a/docs/p3drovfx-research-2026-08-16.md
+++ b/docs/p3drovfx-research-2026-08-16.md
@@ -70,6 +70,18 @@ before it lands.** Every estimate below includes the check the change would need
 
 ## 2. What they have that we do not
 
+> **Re-verify the "Ours" column before you act on a row.** This survey read their
+> tree far more carefully than it read ours, and the tables are asymmetric because
+> of it: every claim about *their* code came from opening the file, while a good
+> number of "none"s in the Ours column came from a search that did not find
+> something. Three were wrong and are corrected in place — the OLED saver (§2.4),
+> the Bluetooth connect UI (§2.2) and the quick-toggle editor (§3.3 #3, where a
+> pattern of ours was called a defect that this repo had already measured and
+> cleared). Two more were undercounts. Nothing here says the remaining rows are
+> wrong; it says they carry less evidence than they look like they do. Before
+> porting anything, grep our tree for the capability under a name we would have
+> chosen, not under theirs, and read the module you find.
+
 ### 2.1 The dynamic island — their signature feature
 
 `modules/ii/dynamicIsland/` — 18 files, **8,068 lines**. First commit `P3DROVFX`,
@@ -701,7 +713,30 @@ Their repository was cloned to `/tmp/p3drovfx` — outside this repo and any
 worktree. Six parallel read-only investigations covered the dynamic island and
 popup cluster; the search launcher; phone and audio devices; window management and
 session behaviour; settings and configuration infrastructure; and the long tail of
-integrations. Every claim above is grounded in a file that was opened; the four
-findings in §3.3 were each re-verified by hand in our tree.
+integrations. Every claim about *their* tree is grounded in a file that was
+opened; the four findings in §3.3 were each re-verified by hand in ours.
+
+**Where the method was weak, stated plainly: the "Ours" column.** Their side was
+read; our side was largely searched. That produced two distinct failures, both
+corrected above and both worth naming because they will recur in the next survey.
+
+- **A search that finds nothing became "none".** §2.4 priced their OLED saver as a
+  new module for us while `modules/imi/screensaver/` was sitting in the tree —
+  per-screen, OLED-purposed in its own comment, with IPC verbs — and the row
+  contradicted itself in the same cell without that being noticed. §2.2's Bluetooth
+  row did the same thing one step further along: it opened *a* file of ours
+  (`services/BluetoothStatus.qml`), correctly observed no connect signals there,
+  and concluded we cannot connect, when the UI does it through Quickshell's own
+  `BluetoothDevice`. Search our tree for the *capability* under a name we would
+  have chosen, and when a search comes back empty, say "not found" rather than
+  "none".
+- **Reading a pattern is not knowing its history.** §3.3 #3 confirmed that the
+  quick-toggle editor's code says what the finding said it says, and stopped —
+  inheriting a premise about QML list notification that this repo had already
+  measured and disproved, in commits a `git log -S` over the same file would have
+  surfaced. `CONTRIBUTING.md`'s "A missing thing is a decision until proven
+  otherwise" applies to a shape that looks wrong as much as to a thing that is
+  absent: before calling one a defect, find out whether someone already changed it
+  and why it changed back.
 
 `tests/run_tests.sh` on this branch: **757 passed, 0 failed, 0 skipped**.

--- a/docs/p3drovfx-research-2026-08-16.md
+++ b/docs/p3drovfx-research-2026-08-16.md
@@ -127,10 +127,10 @@ Region-masked content` idiom, single-screen:
 
 | Their module | Lines | Ours |
 |---|---|---|
-| `bluetoothConnectionPopup/` | 572 | none — our `services/BluetoothStatus.qml` (58) has no connect/disconnect signals at all |
+| `bluetoothConnectionPopup/` | 572 | **not none** — `modules/imi/sidebarRight/bluetoothDevices/` (`BluetoothDialog.qml` 76 + `BluetoothDeviceItem.qml` 125) is a full pair/connect/disconnect dialog with discovery and Connecting/Disconnecting states. It calls `device.connect()`/`device.disconnect()` on `Quickshell.Bluetooth`'s own `BluetoothDevice` (`BluetoothDeviceItem.qml:102-118`), which is why `services/BluetoothStatus.qml` (58) carries no such signals — that observation was true and the conclusion drawn from it was not. What we lack is the *popup on a connection event*, not the ability to connect |
 | `keyboardLayoutTransitionPopup/` | 422 | yes, as an OSD indicator — `modules/imi/onScreenDisplay/indicators/KeyboardLayoutIndicator.qml` |
 | `localSendPopup/` | 479 | none |
-| `colorPickerPopup/` | 1,026 | none — we just `execDetached(["hyprpicker","-a"])` from `modules/imi/bar/UtilButtons.qml:63` |
+| `colorPickerPopup/` | 1,026 | none — we just `execDetached(["hyprpicker","-a"])`, from three places: `modules/imi/bar/UtilButtons.qml:63` and `:69`, and the `ColorPickerToggle` quick toggle (`modules/common/models/quickToggles/ColorPickerToggle.qml:24`) |
 | `screenshotOverlay/` | 463 | yes — `modules/imi/screenshotResult/ScreenshotResultPanel.qml` (242) |
 | `scratchpadOverlay/` | 167 | none |
 | `alarmRingingPopup/` | 137 | none |
@@ -181,7 +181,7 @@ that it has no shell-injection surface; do not regress that.
 | **Touch gestures** — edge swipes on a physical touchscreen with a follow-the-finger overlay | `services/TouchGestureService.qml`, `modules/common/TouchGestureActionRegistry.qml` (250), Rust helper (601) | 867 / ~3,160 | P3DROVFX, 2026-08-14 | none |
 | **Workspace profiles** — snapshot/restore named window layouts | `services/WorkspaceProfileService.qml`, Rust `workspace_profile_manager` (951) | 533 / ~4,600 | Scrimas, 2026-06-19 | none |
 | **Per-app usage & energy** — screen time, watt-hours, CPU/GPU time per app, from a Rust daemon over `/proc`, DRM fdinfo and RAPL | `services/AppStats.qml`, `modules/ii/usage/` (4,032), Rust (2,263) | 806 / ~8,600 | Scrimas, 2026-08-01 | none |
-| **Dock live preview** — a pinned live miniature of a chosen window in the dock | `services/DockLivePreviewService.qml` | 219 / ~920 | — | none in the dock. We use `ScreencopyView` in four other places |
+| **Dock live preview** — a pinned live miniature of a chosen window in the dock | `services/DockLivePreviewService.qml` | 219 / ~920 | — | none in the dock. We use `ScreencopyView` in five other places (`Magnifier.qml`, `RegionSelection.qml`, `ScreenTranslatorPanel.qml`, `OverviewWindow.qml`, `DragApps.qml`) |
 | **Screen-shader browser** — one owner of `decoration:screen_shader`, merging built-ins, extra dirs and `hyprshade`'s catalogue | `services/ScreenShader.qml` | 298 / ~790 | — | `services/HyprlandAntiFlashbangShader.qml` (56) is the whole feature for us |
 | **OSK auto-show** — raise the on-screen keyboard only when a text field is focused by finger or pen, via a `zwp_input_method_v2` observer | `services/OskAutoShow.qml` (172) + Rust (257) | 172 / 430 | — | we have the OSK, no auto-show |
 | **Idle: timed keep-awake** — `inhibitFor(minutes)` on an absolute epoch deadline (deliberately not a decrementing timer, so suspend cannot skew it), pre-expiry warning, MRU duration chips | `services/Idle.qml` (282) | ~180 net-new | — | our `services/Idle.qml` (101) instead has `autoOnExternalMonitor`. The two halves compose |

--- a/docs/p3drovfx-research-2026-08-16.md
+++ b/docs/p3drovfx-research-2026-08-16.md
@@ -356,8 +356,10 @@ all.
    only on `Config.ready`.
 3. **Stable settings-page ids.** Theirs are strings; ours are translated display
    names. See §3.3.
-4. **The quick-toggle draft/commit controller.** A real transaction boundary with
-   validation and cancel, against our in-place array mutation. See §3.3.
+4. **The quick-toggle draft/commit controller.** A real transaction boundary —
+   validation and a cancel path — where each of our editor's gestures is its own
+   write straight to the config. A capability we lack, not a bug of ours; see
+   §3.3, which spells out why the in-place mutation itself is *not* the finding.
 5. **`services/AppUsage.qml` frecency.** Our app search ranks purely on edit
    distance. 190 lines and five call sites for a launcher that stops offering the
    wrong Firefox.
@@ -391,7 +393,9 @@ all.
 ### 3.3 Findings in *our* tree, surfaced by the comparison
 
 None of these were fixed here — this is a research branch. Each is worth its own
-issue.
+issue. Note that #1, #2 and #4 are defects; **#3 is a gap in our design, not a
+defect**, and an earlier draft of this section got that wrong — the correction is
+written out there because it is the kind of finding that gets re-raised.
 
 1. **The anti-flashbang weak shader does not exist.**
    `services/HyprlandAntiFlashbangShader.qml:13` declares
@@ -407,14 +411,48 @@ issue.
    and every `p.name` at `:167-183` is a `Translation.tr(...)`. Any stored or
    IPC-supplied `GlobalStates.settingsPage` value — `"Bar & Dock"` — stops
    resolving the moment the user switches language.
-3. **The quick-toggle editor mutates the config array in place.**
+3. **The quick-toggle layout editor has no validation and no cancel path.**
    `modules/imi/sidebarRight/quickToggles/androidStyle/AndroidQuickToggleButton.qml`
-   does `toggleList[myIdx] = toggleList[sibIdx]` (:217-219), `toggleList.push(...)`
-   (:260) and `toggleList.splice(idx, 1)` (:302) on the array handed out by the
-   `JsonObject`, with no reassignment, no validation and no cancel path. Given
-   `AGENT.md`'s `JsonAdapter` notes, "it appears to work today" is not the same as
-   "the write boundary is defined" — this wants a look regardless of whether the
-   full draft/commit controller is ever ported.
+   edits `Config.options.sidebar.quickToggles.android.toggles` at four sites — a
+   swap (`:217-219`), an add (`:262`), a delete (`:304`) and a resize (`:363`) —
+   and each gesture is its own write straight to the config. Nothing sits between
+   the drag and the stored layout: no shape or duplicate check, no legality check
+   against the catalog, no batching of a session of edits, and no way to abandon
+   one. Their `QuickToggleEditController`'s `beginTransaction`/`persist`/`rejected`
+   boundary is therefore a **feature we do not have**, worth considering on its own
+   merits. It is not a repair for a defect.
+
+   **Explicitly not a finding: the in-place mutation.** An earlier draft of this
+   section read "the quick-toggle editor mutates the config array in place" and
+   called the missing reassignment a defect. It is not, and this repo already
+   settled it. 031cd3d32 ("fix(sidebar): make quick toggle edits actually notify")
+   made exactly the change that framing recommends — an `updateToggles()` helper
+   that copies the list, applies the edit and assigns the result back, at all four
+   sites — and 26b625905 reverted it, having measured against a real `Config` that
+   a QML list property **does** notify on in-place mutation: `push`, `splice`,
+   element assignment, mutating a property of an element, and whole-list assignment
+   all emit the change signal. The revert also deleted
+   `tests/lint_config_list_mutation.py`, added by the same series, as a lint
+   enforcing a rule that does not exist and rejecting correct code. (That revert's
+   own subject carries quotes, so it is not written here in the usual
+   `<sha> ("<subject>")` citation form; it is
+   `Revert "fix(sidebar): make quick toggle edits actually notify" and follow-ups`.)
+
+   The bug that series was chasing — every tile rendering the *previous* tile's
+   icon, name and action — was the delegate.
+   81379796b ("fix(sidebar): choose a delegate for the toggle each row entry now holds")
+   is the fix: `DelegateChooser` picks a component only when a delegate is
+   *created* and never re-picks for one that survives, while `ScriptModel` exists
+   precisely to keep delegates alive across updates, so a row entry that changed
+   identity in place kept the old component while carrying the new entry's data.
+   The row `ScriptModel`s became plain array models, which reset the `Repeater`.
+   e4a0a1f3f ("test(sidebar): render the quick toggle panel through real layout edits")
+   covers it by driving the real panel through the edits that reflow rows — a
+   cross-row swap of differently sized toggles, a resize, a remove and an add
+   (`tests/test_quick_toggles_layout_runtime.py` + `QuickTogglesLayoutRuntimeTest.qml`).
+   So: reassigning the array is a change that was tried, measured and undone.
+   Anything ported here adds a transaction boundary for validation and cancel; it
+   must not be justified as fixing the mutation.
 4. **`get.sh` can silently discard local commits.** `get.sh:29-31` does
    `git fetch --depth 1 origin "$REF"` then `git reset --hard FETCH_HEAD` into
    `~/.local/share/immaterial-impulse/src`. Anyone who has committed in that
@@ -505,7 +543,8 @@ them:
   is `{type, size}`, single-page. A full port needs a config migration and lands at
   2,500–3,500 lines. A *staged* version — the `EditController`'s draft/commit
   boundary wrapped around our existing swap-and-splice, no pages, no 2-D resize —
-  is 400–600 lines and fixes the part that actually bites (§3.3 item 3).
+  is 400–600 lines and adds the part we genuinely lack (§3.3 item 3): validation
+  and a cancel. It repairs nothing — our swap-and-splice is correct as written.
 - **`wrappedFrame`.** 443 lines that read cheap and are the most coupled item
   surveyed: it imports their bar modules, reads `BarThemes`/`barBackgroundStyle`,
   and depends on eight `GlobalStates` properties (`animatedLeftSidebarWidth`,

--- a/docs/p3drovfx-research-2026-08-16.md
+++ b/docs/p3drovfx-research-2026-08-16.md
@@ -408,9 +408,9 @@ written out there because it is the kind of finding that gets re-raised.
 2. **Settings deep links compare translated page names.**
    `modules/imi/settings/SettingsContent.qml:135` does
    `root.pages.findIndex(p => p.name.toLowerCase() === pageName.toLowerCase())`,
-   and every `p.name` at `:167-183` is a `Translation.tr(...)`. Any stored or
-   IPC-supplied `GlobalStates.settingsPage` value — `"Bar & Dock"` — stops
-   resolving the moment the user switches language.
+   and every `p.name` in the page list at `:169-182` is a `Translation.tr(...)`.
+   Any stored or IPC-supplied `GlobalStates.settingsPage` value — `"Bar & Dock"` —
+   stops resolving the moment the user switches language.
 3. **The quick-toggle layout editor has no validation and no cancel path.**
    `modules/imi/sidebarRight/quickToggles/androidStyle/AndroidQuickToggleButton.qml`
    edits `Config.options.sidebar.quickToggles.android.toggles` at four sites — a

--- a/docs/p3drovfx-research-2026-08-16.md
+++ b/docs/p3drovfx-research-2026-08-16.md
@@ -176,7 +176,7 @@ that it has no shell-injection surface; do not regress that.
 
 | Feature | Their files | Lines (core / total) | Provenance | Ours |
 |---|---|---|---|---|
-| **OLED saver** — a key blacks out one monitor as a true-black layer surface, holding its own sleep inhibitor separate from the user's keep-awake | `modules/ii/oledSaver/OledSaver.qml` | 178 / 280 | Scrimas, 2026-07-14 | none. Our `modules/imi/screensaver/` is idle-triggered, not on-demand per-monitor |
+| **OLED saver** — a key blacks out one monitor as a true-black layer surface, holding its own sleep inhibitor separate from the user's keep-awake | `modules/ii/oledSaver/OledSaver.qml` | 178 / 280 | Scrimas, 2026-07-14 | **we have this** — `modules/imi/screensaver/` (`Screensaver.qml` 103 + `ScreensaverContent.qml`), an OLED blackout by design (`ScreensaverContent.qml:22`: "pixels off for OLED burn-in protection in both modes"), already one `Overlay` surface per screen (`Variants` over `Quickshell.screens`, namespace `quickshell:screensaver`, `WlrKeyboardFocus.Exclusive`), with a black/drifting-clock pixel-shift mode, an arming timer so mapping it under the cursor cannot self-dismiss it, config at `Config.qml:1257` and a settings row at `LockIdleConfig.qml:177`, **and** `show`/`hide`/`toggle` IPC verbs (`Screensaver.qml:83-102`). Three real deltas: (1) nothing binds those verbs to a key — no `GlobalShortcut` in the module and no `screensaver` binding anywhere in `dots/.config/hypr/`, so the only caller today is `hypridle.conf`'s 240s listener; (2) it arms every screen at once, not one chosen monitor; (3) it holds no idle inhibitor, so hypridle's ladder (lock 300s, DPMS off 600s, suspend 900s) runs on underneath it |
 | **Tiling assistant** — KDE-style snap zones on `SUPER`+drag, keyboard tiling, divider drag | `services/TilingAssistant.qml`, `modules/common/functions/tiling.js` (659), `modules/ii/tilingAssistant/`, `scripts/hyprland/drag_monitor.py` (538) | 1,125 / ~3,600 | Scrimas, 2026-08-03 | none |
 | **Touch gestures** — edge swipes on a physical touchscreen with a follow-the-finger overlay | `services/TouchGestureService.qml`, `modules/common/TouchGestureActionRegistry.qml` (250), Rust helper (601) | 867 / ~3,160 | P3DROVFX, 2026-08-14 | none |
 | **Workspace profiles** — snapshot/restore named window layouts | `services/WorkspaceProfileService.qml`, Rust `workspace_profile_manager` (951) | 533 / ~4,600 | Scrimas, 2026-06-19 | none |
@@ -483,9 +483,12 @@ them:
 
 - `modules/common/PanelSchedule.qml` (42) + the `PanelLoader` ticket gate. Pure
   scheduling; touches nothing visual.
-- `modules/ii/oledSaver/OledSaver.qml` (178). One `GlobalStates` property, a
-  `Variants` blackout window, its own `IdleInhibitor`, a `GlobalShortcut` and an
-  `IpcHandler`.
+- ~~`modules/ii/oledSaver/OledSaver.qml` (178)~~ — **not a port at all; see §2.4.**
+  We already have the module, and it is the same shape: one `GlobalStates`
+  property, a `Variants` blackout window, an `IpcHandler`. Dropping their file in
+  would ship a second screensaver. What is worth taking is the two pieces ours
+  lacks — their `IdleInhibitor` and their `GlobalShortcut` — plus a monitor
+  selector, moved into `modules/imi/screensaver/`.
 - `services/DnsOverTls.qml` (321) + the polkit rule. No UI beyond a quick toggle.
 - `services/AppUsage.qml` (190). Pure logic, atomic writes, trivially unit-testable
   — which our rules will want anyway.


### PR DESCRIPTION
Lands on #215's branch, before #215 merges, so the survey is not cited with claims that do not hold.

## The finding that was wrong

§3.3 item 3 said the Android quick-toggle editor "mutates the config array in place" — `toggleList[myIdx] = toggleList[sibIdx]`, `.push(...)`, `.splice(...)` with no reassignment — and treated that as a defect. §3.2 item 4, §4's Category C bullet and shortlist rank 9 all rested on it.

This repo settled it months ago:

- 031cd3d32 ("fix(sidebar): make quick toggle edits actually notify") made **exactly** the change the finding recommends — an `updateToggles()` helper that copies the list, applies the edit and assigns the result back, at all four edit sites.
- 26b625905 reverted it, having measured against a real `Config` that a QML list property **does** notify on in-place mutation: `push`, `splice`, element assignment, mutating an element's property and whole-list assignment all emit the change signal. The revert also deleted `tests/lint_config_list_mutation.py` as a lint enforcing a rule that does not exist and rejecting correct code.
- 81379796b ("fix(sidebar): choose a delegate for the toggle each row entry now holds") is the actual fix: `DelegateChooser` picks a component only at delegate creation and `ScriptModel` keeps delegates alive across updates, so an entry that changed identity in place kept the old component. The row models are plain arrays now.
- e4a0a1f3f ("test(sidebar): render the quick toggle panel through real layout edits") covers it, driving the real panel through the edits that reflow rows.

The finding is rewritten to what survives: **no validation and no cancel path** on quick-toggle layout edits, which makes their draft/commit controller a feature worth considering rather than a repair. The revert and the delegate fix are cited by SHA in the document so this cannot be raised a third time, and the text says outright that reassigning the array was tried and undone. The four edit sites' line numbers are corrected while there (`:262`/`:304`, not `:260`/`:302`).

## Two more wrong claims about our own tree

Checking the rest, as the premise of one bad finding demanded:

- **§2.4's OLED saver row read "none".** We ship `modules/imi/screensaver/`: an OLED blackout by design (`ScreensaverContent.qml:22`), already one `Overlay` surface per screen, with a black/drifting-clock mode, config, a settings row, an arming timer — **and** `show`/`hide`/`toggle` IPC verbs. The genuine deltas are three: nothing binds those verbs to a key (the only caller is `hypridle.conf`'s 240s listener), it blanks every screen rather than one, and it holds no idle inhibitor. Re-priced from "~280 lines, best ratio in the survey" to "~80–120 lines against an existing module" and re-ranked 8 → 12. §4's Category A entry, which listed their file as a near-verbatim port, would have shipped a second screensaver.
- **§2.2's Bluetooth row read "none — `BluetoothStatus.qml` has no connect/disconnect signals".** True observation, wrong conclusion: `modules/imi/sidebarRight/bluetoothDevices/` is a full connect/disconnect dialog driving `Quickshell.Bluetooth`'s own `BluetoothDevice`. We lack their popup on a connection *event*, not the ability to connect.

Two undercounts fixed too (`ScreencopyView` is in five files, not four; `hyprpicker` is spawned from three call sites, not one).

Sampled and confirmed **correct**: tiling assistant, workspace profiles, scratchpad-empty overlay, alarm-ringing popup (`TimerService.qml` is pomodoro/stopwatch only).

## The pattern, recorded

All three errors share a shape — their tree was read, ours was searched — so §2 now opens with a warning to re-verify the "Ours" column before acting on any row, and the appendix says what the method actually was instead of claiming uniform verification. Nothing is retracted on suspicion.

The other three §3.3 findings were re-checked against the tree and all hold: the missing `anti-flashbang-weak.glsl` (`HyprlandAntiFlashbangShader.qml:13`, `cycle()`'s first branch is `enableWeak()`), the translated-name deep link (`SettingsContent.qml:135`; entry range corrected to `:169-182`), and `get.sh:29-31`'s `reset --hard FETCH_HEAD`.

`tests/run_tests.sh`: 757 passed, 0 failed, 0 skipped.

Docs: not needed — this corrects a research document under `docs/`; it changes no mechanism, directory, singleton or test-suite behaviour that AGENT.md or CONTRIBUTING.md describes.
