### PR TITLE
fix(get.sh): stop the updater silently destroying local work in the suite checkout

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -305,6 +305,44 @@ Four things around that are worth not re-deriving:
   both *and* whose 3×3 neighbourhood is uniform (which kills subpixel edges), and report RMSE plus
   what code 255 became.
 
+## The suite checkout, and why the updater cannot just reset it
+
+`get.sh` keeps the whole suite in `~/.local/share/immaterial-impulse/src` (`Directories.suiteSrc`),
+clones it once and re-uses it for every update — Settings > About > **Update Dots** spawns a kitty
+running the same script. That directory is a **normal git repository the user can work in**, and
+someone hacking on their own shell does exactly that, so the update path may not simply make it
+match `$REF`: `git checkout -f` + `git reset --hard FETCH_HEAD` destroy commits made there,
+uncommitted edits, and any untracked file the incoming tree carries a path for (`-f` overwrites
+those; untracked files it does *not* name, and stashes, both survive a reset untouched).
+
+It still resets — landing on `$REF` is the updater's whole job, and aborting on a dirty tree would
+tax every user who has no local work for the sake of the one who does. What it does first is move
+whatever those two commands would eat somewhere git can name it back: the old HEAD onto
+`imi-rescue/<short-sha>` (named for the commit, so re-running does not litter the checkout with one
+ref per update), and the at-risk working-tree paths into a stash.
+
+Three non-obvious pieces:
+
+- **In a `--depth 1` checkout, ancestry cannot answer "does this HEAD belong to the remote".** Both
+  HEAD and the incoming tip are grafted, so `merge-base --is-ancestor` walks nothing and says "not
+  an ancestor" for a checkout that is merely a few commits *behind* — indistinguishable from one
+  that is ahead. The script therefore records what it installed in `refs/imi/installed` and trusts
+  a HEAD equal to that marker; the ancestry test stays as the answer for the full-clone fallback.
+  A checkout predating the marker gets rescued conservatively, once.
+- **A stash needs a git identity, and a machine being installed for the first time often has
+  none** — git then refuses to write the stash commit. `get.sh` borrows one (`git var
+  GIT_COMMITTER_IDENT` is the probe) rather than losing the work. Any other stash failure aborts
+  the update, because proceeding *is* the data loss.
+- **Printing the rescue to the terminal is not telling the user.** `setup`'s whiptail menu paints
+  over the scrollback seconds later, in a terminal the shell spawned, so the same text is appended
+  to `rescued-local-work.log` beside the checkout and — when stdin is a tty — the script waits for
+  Enter before handing off.
+
+`tests/test_get_sh_preserves_local_work.py` drives all of it against throwaway origin/DEST repos in
+a tempdir; the clean-checkout case asserts the update stays *silent*, which is the half that keeps
+the fix from becoming a nuisance for everyone who has no local work.
+d5d2f69b0 ("fix(get.sh): rescue local work before resetting the update checkout").
+
 ## Directory map
 
 ```

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -676,6 +676,15 @@ if ! python3 "$SCRIPT_DIR/test_installer_file_sync.py"; then
     exit 1
 fi
 
+# get.sh resets the update checkout onto $REF, and that checkout is a repo the
+# user can commit in. Drives throwaway origin/DEST repos inside a tempdir, so
+# it can never reach the machine's real one.
+echo "Running get.sh local-work preservation tests..."
+if ! python3 "$SCRIPT_DIR/test_get_sh_preserves_local_work.py"; then
+    echo "get.sh local-work preservation tests failed."
+    exit 1
+fi
+
 echo "Running installer legacy migration tests..."
 if ! python3 "$SCRIPT_DIR/test_installer_legacy_migration.py"; then
     echo "installer legacy migration tests failed."

--- a/dots/.config/quickshell/imi/tests/test_get_sh_preserves_local_work.py
+++ b/dots/.config/quickshell/imi/tests/test_get_sh_preserves_local_work.py
@@ -230,6 +230,30 @@ class GetShLocalWorkTests(unittest.TestCase):
         self.assertEqual((self.dest / "scratch.txt").read_text(encoding="utf-8"),
                          "my notes\n")
 
+    def test_updating_again_from_the_rescue_branch_still_works(self):
+        """Recovering means checking the rescue branch out. Then updating again.
+
+        `git branch -f` refuses to move a branch that is checked out, so a
+        rescue that re-creates its own branch unconditionally kills the update
+        of the user who has just recovered - the one person guaranteed to be
+        standing on it.
+        """
+        self.run_get_sh()
+        (self.dest / "README.md").write_text("my own work\n", encoding="utf-8")
+        local = self.commit(self.dest, "my local commit")
+        self.advance_origin()
+        self.run_get_sh()
+        branch = self.rescue_branches()[0]
+
+        git(self.dest, "checkout", "-q", branch)
+        target = self.advance_origin(content="upstream v3\n")
+
+        self.run_get_sh()
+
+        self.assertEqual(git_out(self.dest, "rev-parse", "HEAD"), target)
+        self.assertEqual(git_out(self.dest, "rev-parse", branch), local,
+                         "the recovered branch was moved or lost")
+
     def test_a_clean_checkout_updates_in_silence(self):
         self.run_get_sh()
         target = self.advance_origin()

--- a/dots/.config/quickshell/imi/tests/test_get_sh_preserves_local_work.py
+++ b/dots/.config/quickshell/imi/tests/test_get_sh_preserves_local_work.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""get.sh must land on $REF without destroying work that exists nowhere else.
+
+The updater's checkout (`~/.local/share/immaterial-impulse/src` by default) is
+a normal git repository the user can work in - and hacking on your own shell is
+exactly what someone with that checkout does. `git checkout -f` plus
+`git reset --hard FETCH_HEAD` used to run over all of it: commits made there,
+uncommitted edits, and untracked files the incoming tree overwrites.
+
+Every test drives a throwaway origin repo and a throwaway DEST in a tempdir.
+Nothing here may look at the machine's real checkout: the fixtures set IMI_REPO,
+IMI_REF and IMI_DEST, plus HOME and GIT_CONFIG_*, so a run cannot reach the
+user's data or their git config. The absent git identity is deliberate - a
+machine being set up for the first time has none, and the stash the rescue
+writes needs one.
+
+What is pinned:
+  - a local commit survives, on a named branch, and the update still lands;
+  - uncommitted changes survive in a stash and pop back cleanly;
+  - an untracked file the incoming tree would overwrite is preserved, while an
+    untracked file it does not touch is left alone in the working tree;
+  - a clean, up-to-date-ish checkout updates in silence - no rescue branch, no
+    stash, no note file (the fix must not tax the normal user);
+  - the rescue works with no git identity configured anywhere.
+"""
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve()
+while not (ROOT / "get.sh").exists():
+    ROOT = ROOT.parent
+GET_SH = ROOT / "get.sh"
+
+SETUP_STUB = """#!/usr/bin/env bash
+echo "SETUP RAN $*"
+"""
+
+# Identity for the fixtures' own commits only. get.sh runs without one.
+IDENT = ["-c", "user.name=Fixture", "-c", "user.email=fixture@example.com"]
+
+
+def git(cwd, *args, check=True):
+    return subprocess.run(
+        ["git", "-C", str(cwd), *args],
+        capture_output=True, text=True, check=check,
+        env={**os.environ, "GIT_CONFIG_GLOBAL": "/dev/null",
+             "GIT_CONFIG_SYSTEM": "/dev/null"})
+
+
+def git_out(cwd, *args):
+    return git(cwd, *args).stdout.strip()
+
+
+class GetShLocalWorkTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="imi-get-sh-"))
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        self.home = self.tmp / "home"
+        self.home.mkdir()
+        self.origin = self.tmp / "origin"
+        self.dest = self.tmp / "dest" / "src"
+
+        self.origin.mkdir()
+        git(self.origin, "init", "-q", "-b", "main")
+        (self.origin / "setup").write_text(SETUP_STUB, encoding="utf-8")
+        (self.origin / "setup").chmod(0o755)
+        (self.origin / "README.md").write_text("upstream v1\n", encoding="utf-8")
+        self.commit(self.origin, "first commit")
+
+    # ------------------------------------------------------------- fixtures
+    def commit(self, repo, message):
+        git(repo, "add", "-A")
+        git(repo, *IDENT, "commit", "-q", "-m", message)
+        return git_out(repo, "rev-parse", "HEAD")
+
+    def advance_origin(self, filename="README.md", content="upstream v2\n"):
+        (self.origin / filename).write_text(content, encoding="utf-8")
+        return self.commit(self.origin, f"upstream change to {filename}")
+
+    def run_get_sh(self, expect_success=True):
+        """Run get.sh against the throwaway origin/DEST, with no git identity."""
+        env = {
+            "PATH": os.environ["PATH"],
+            "HOME": str(self.home),
+            "IMI_REPO": f"file://{self.origin}",
+            "IMI_REF": "main",
+            "IMI_DEST": str(self.dest),
+            # No global/system git config, and none of the identity env vars:
+            # this is what a freshly installed machine looks like.
+            "GIT_CONFIG_GLOBAL": "/dev/null",
+            "GIT_CONFIG_SYSTEM": "/dev/null",
+            "GIT_TERMINAL_PROMPT": "0",
+        }
+        proc = subprocess.run(["bash", str(GET_SH)], capture_output=True,
+                              text=True, env=env, stdin=subprocess.DEVNULL)
+        if expect_success:
+            self.assertEqual(proc.returncode, 0,
+                             f"get.sh failed:\n{proc.stdout}\n{proc.stderr}")
+            self.assertIn("SETUP RAN", proc.stdout,
+                          "get.sh never reached the installer")
+        return proc
+
+    def rescue_branches(self):
+        out = git_out(self.dest, "for-each-ref", "--format=%(refname:short)",
+                      "refs/heads/imi-rescue/")
+        return [line for line in out.splitlines() if line]
+
+    def stash_entries(self):
+        out = git_out(self.dest, "stash", "list")
+        return [line for line in out.splitlines() if line]
+
+    # ---------------------------------------------------------------- tests
+    def test_a_local_commit_survives_the_update(self):
+        self.run_get_sh()
+        (self.dest / "README.md").write_text("my own work\n", encoding="utf-8")
+        local = self.commit(self.dest, "my local commit")
+        target = self.advance_origin()
+
+        self.run_get_sh()
+
+        self.assertEqual(git_out(self.dest, "rev-parse", "HEAD"), target,
+                         "the update did not land on $REF")
+        branches = self.rescue_branches()
+        self.assertEqual(len(branches), 1,
+                         f"expected one rescue branch, got {branches}")
+        self.assertEqual(git_out(self.dest, "rev-parse", branches[0]), local,
+                         "the rescue branch does not point at the local commit")
+        self.assertEqual(
+            git_out(self.dest, "show", f"{branches[0]}:README.md"),
+            "my own work",
+            "the rescued commit does not carry the local content")
+
+    def test_the_user_is_told_where_the_rescued_work_went(self):
+        self.run_get_sh()
+        (self.dest / "README.md").write_text("my own work\n", encoding="utf-8")
+        self.commit(self.dest, "my local commit")
+        (self.dest / "README.md").write_text("and an edit on top\n",
+                                             encoding="utf-8")
+        self.advance_origin()
+
+        proc = self.run_get_sh()
+
+        branch = self.rescue_branches()[0]
+        self.assertIn(branch, proc.stdout,
+                      "the rescue branch is never named on screen")
+        self.assertIn("stash pop", proc.stdout,
+                      "the way back to the stashed work is never spelled out")
+        # whiptail replaces the terminal seconds later, so the trail on disk is
+        # the half that survives.
+        note = self.dest.parent / "rescued-local-work.log"
+        self.assertTrue(note.exists(), "no rescue note was written")
+        note_text = note.read_text(encoding="utf-8")
+        self.assertIn(branch, note_text)
+        self.assertIn(str(self.dest), note_text)
+
+    def test_uncommitted_changes_survive_and_pop_back(self):
+        self.run_get_sh()
+        (self.dest / "README.md").write_text("edited, never committed\n",
+                                             encoding="utf-8")
+        # Upstream moves a different file, so the pop is a clean one. (An
+        # upstream change to the same file conflicts on pop - that is git
+        # working, and the next test pins that the content is still there.)
+        target = self.advance_origin(filename="CHANGELOG.md",
+                                     content="upstream changelog\n")
+
+        self.run_get_sh()
+
+        self.assertEqual(git_out(self.dest, "rev-parse", "HEAD"), target)
+        self.assertEqual((self.dest / "README.md").read_text(encoding="utf-8"),
+                         "upstream v1\n", "the update did not land on $REF")
+        self.assertEqual(len(self.stash_entries()), 1,
+                         "the uncommitted edit was not stashed")
+        git(self.dest, *IDENT, "stash", "pop")
+        self.assertEqual((self.dest / "README.md").read_text(encoding="utf-8"),
+                         "edited, never committed\n",
+                         "the stash did not carry the user's edit back")
+
+    def test_an_edit_to_a_file_upstream_also_changed_is_still_in_the_stash(self):
+        self.run_get_sh()
+        (self.dest / "README.md").write_text("edited, never committed\n",
+                                             encoding="utf-8")
+        target = self.advance_origin()
+
+        self.run_get_sh()
+
+        self.assertEqual(git_out(self.dest, "rev-parse", "HEAD"), target)
+        self.assertEqual((self.dest / "README.md").read_text(encoding="utf-8"),
+                         "upstream v2\n", "the update did not land on $REF")
+        self.assertEqual(
+            git_out(self.dest, "show", "refs/stash:README.md"),
+            "edited, never committed",
+            "the edit is not recoverable from the stash")
+
+    def test_the_stash_is_written_without_a_configured_git_identity(self):
+        self.run_get_sh()
+        (self.dest / "README.md").write_text("edited\n", encoding="utf-8")
+        self.advance_origin()
+
+        self.run_get_sh()
+
+        self.assertEqual(len(self.stash_entries()), 1)
+        self.assertEqual(git_out(self.dest, "log", "-1", "--format=%ae",
+                                 "refs/stash"), "imi@localhost",
+                         "the fallback identity is not what wrote the stash")
+
+    def test_a_colliding_untracked_file_is_kept_and_an_innocent_one_is_left(self):
+        self.run_get_sh()
+        (self.dest / "NEW.md").write_text("mine\n", encoding="utf-8")
+        (self.dest / "scratch.txt").write_text("my notes\n", encoding="utf-8")
+        self.advance_origin(filename="NEW.md", content="upstream's NEW\n")
+
+        self.run_get_sh()
+
+        self.assertEqual((self.dest / "NEW.md").read_text(encoding="utf-8"),
+                         "upstream's NEW\n", "the update did not land on $REF")
+        self.assertEqual(len(self.stash_entries()), 1)
+        # A stash's untracked files live on its third parent, and popping one
+        # over a file that now exists is refused - which is why the recovery
+        # the message points at is `git show`/`git checkout` from the stash,
+        # not only a pop.
+        self.assertEqual(git_out(self.dest, "show", "refs/stash^3:NEW.md"),
+                         "mine", "the overwritten untracked file was lost")
+        # Nothing threatened this one, so nothing should have moved it.
+        self.assertTrue((self.dest / "scratch.txt").exists(),
+                        "an untracked file the update never touched was stashed")
+        self.assertEqual((self.dest / "scratch.txt").read_text(encoding="utf-8"),
+                         "my notes\n")
+
+    def test_a_clean_checkout_updates_in_silence(self):
+        self.run_get_sh()
+        target = self.advance_origin()
+
+        proc = self.run_get_sh()
+
+        self.assertEqual(git_out(self.dest, "rev-parse", "HEAD"), target)
+        self.assertEqual(self.rescue_branches(), [],
+                         "a clean checkout was given a rescue branch")
+        self.assertEqual(self.stash_entries(), [],
+                         "a clean checkout was stashed")
+        self.assertNotIn("set aside", proc.stdout)
+        self.assertFalse((self.dest.parent / "rescued-local-work.log").exists(),
+                         "a clean update wrote a rescue note")
+
+    def test_a_checkout_from_before_the_marker_is_rescued_conservatively(self):
+        """A --depth 1 checkout cannot prove its HEAD came from the remote.
+
+        Without the marker ref (checkouts made by an older get.sh) both sides
+        are grafted, so `merge-base --is-ancestor` cannot answer and the script
+        saves the old HEAD rather than guessing. It costs one ref, once - the
+        marker is written on the way out, so the next update is silent.
+        """
+        self.run_get_sh()
+        before = git_out(self.dest, "rev-parse", "HEAD")
+        git(self.dest, "update-ref", "-d", "refs/imi/installed")
+        self.assertTrue(
+            (self.dest / ".git" / "shallow").exists(),
+            "fixture is not a shallow checkout - the marker case is untested")
+        target = self.advance_origin()
+
+        self.run_get_sh()
+
+        self.assertEqual(git_out(self.dest, "rev-parse", "HEAD"), target)
+        branches = self.rescue_branches()
+        self.assertEqual(len(branches), 1, "the old HEAD was not saved")
+        self.assertEqual(git_out(self.dest, "rev-parse", branches[0]), before)
+
+        # ... and the next update, with the marker back in place, is silent.
+        second = self.advance_origin(content="upstream v3\n")
+        self.run_get_sh()
+        self.assertEqual(git_out(self.dest, "rev-parse", "HEAD"), second)
+        self.assertEqual(len(self.rescue_branches()), 1,
+                         "the marker did not quiet the next update")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dots/.config/quickshell/imi/tests/test_get_sh_preserves_local_work.py
+++ b/dots/.config/quickshell/imi/tests/test_get_sh_preserves_local_work.py
@@ -159,6 +159,10 @@ class GetShLocalWorkTests(unittest.TestCase):
 
     def test_uncommitted_changes_survive_and_pop_back(self):
         self.run_get_sh()
+        # The one test that runs with an identity available, so the branch that
+        # does NOT borrow one is exercised too.
+        git(self.dest, "config", "user.name", "Local User")
+        git(self.dest, "config", "user.email", "local@example.com")
         (self.dest / "README.md").write_text("edited, never committed\n",
                                              encoding="utf-8")
         # Upstream moves a different file, so the pop is a clean one. (An

--- a/get.sh
+++ b/get.sh
@@ -19,6 +19,139 @@ REPO="${IMI_REPO:-https://github.com/XephyLon/immaterial-impulse}"
 REF="${IMI_REF:-main}"
 DEST="${IMI_DEST:-${XDG_DATA_HOME:-$HOME/.local/share}/immaterial-impulse/src}"
 
+# The commit this script last installed. It is the only way to tell "this
+# checkout is exactly what the updater put here" from "the user has committed
+# in it" in a --depth 1 checkout: both HEAD and the incoming tip are grafted,
+# so `merge-base --is-ancestor` has no history to walk and answers "no" for
+# every checkout that is merely a few commits behind.
+INSTALLED_REF="refs/imi/installed"
+
+# The installer's whiptail menu takes over the terminal within seconds of this
+# script printing anything, and the terminal is one the shell spawned, so a
+# rescue has to leave a trail on disk as well as on screen.
+RESCUE_LOG="$(dirname "$DEST")/rescued-local-work.log"
+
+dgit() { git -C "$DEST" "$@"; }
+
+announce() { printf '%s\n' "$@" | tee -a "$RESCUE_LOG"; }
+
+# git refuses to write the stash's commits without an identity, and a machine
+# being set up for the first time frequently has none configured. Borrowing an
+# identity for one stash commit beats losing the work that commit holds.
+stash_identity() {
+  if dgit var GIT_COMMITTER_IDENT >/dev/null 2>&1; then
+    return
+  fi
+  printf '%s\n' -c "user.name=Immaterial Impulse installer" -c "user.email=imi@localhost"
+}
+
+# HEAD may be moved without asking only when it is the remote's own commit:
+# either the one this script installed, or - in a full clone, where the answer
+# is computable - an ancestor of the incoming tip.
+head_came_from_remote() {
+  local head="$1" target="$2" installed
+  installed="$(dgit rev-parse --verify -q "$INSTALLED_REF" || true)"
+  if [[ -n "$installed" && "$head" == "$installed" ]]; then
+    return 0
+  fi
+  dgit merge-base --is-ancestor "$head" "$target" 2>/dev/null
+}
+
+# `checkout -f` + `reset --hard` are how this script guarantees the checkout
+# really is $REF. They are also how it used to destroy, with no warning, work
+# that exists nowhere else: commits the user made here, uncommitted edits, and
+# untracked files the incoming tree happens to overwrite. Move all three
+# somewhere git can hand back, then say where in words that outlive the
+# installer's screen. Aborting instead would punish the overwhelmingly common
+# case (a clean checkout, nothing to save) for the rare one.
+preserve_local_work() {
+  local head target short rescue_branch="" stash_message=""
+  local -a at_risk=()
+  local -a identity=()
+  local -A incoming=()
+
+  head="$(dgit rev-parse --verify -q HEAD || true)"
+  [[ -n "$head" ]] || return 0
+  target="$(dgit rev-parse FETCH_HEAD)"
+
+  if [[ "$head" != "$target" ]] && ! head_came_from_remote "$head" "$target"; then
+    short="$(dgit rev-parse --short "$head")"
+    # Named for the commit rather than for the moment, so re-running the
+    # updater against the same local work reuses the ref instead of littering
+    # the checkout with one more every time.
+    rescue_branch="imi-rescue/$short"
+    dgit branch -f "$rescue_branch" "$head" >/dev/null
+  fi
+
+  while IFS= read -r -d '' path; do
+    at_risk+=("$path")
+  done < <(dgit diff --name-only -z HEAD --)
+
+  # An untracked file is at risk only where the incoming tree carries a file of
+  # the same name: `checkout -f` overwrites exactly those and leaves every
+  # other untracked file alone. Stashing all of them would make a user's own
+  # scratch files vanish out of the checkout on an update that never threatened
+  # them.
+  while IFS= read -r -d '' path; do
+    incoming["$path"]=1
+  done < <(dgit ls-tree -r --name-only -z "$target")
+  while IFS= read -r -d '' path; do
+    if [[ -n "${incoming[$path]:-}" ]]; then
+      at_risk+=("$path")
+    fi
+  done < <(dgit ls-files --others --exclude-standard -z)
+
+  if (( ${#at_risk[@]} > 0 )); then
+    stash_message="Immaterial Impulse updater: work set aside before updating to $REF"
+    mapfile -t identity < <(stash_identity)
+    if ! dgit "${identity[@]}" stash push --include-untracked \
+         --message "$stash_message" -- "${at_risk[@]}"; then
+      echo "[ImI] Refusing to update: ${#at_risk[@]} file(s) in $DEST have changes" >&2
+      echo "[ImI] that could not be stashed, and the update would overwrite them." >&2
+      echo "[ImI] Save or commit them (or stash them by hand), then re-run." >&2
+      exit 1
+    fi
+  fi
+
+  if [[ -z "$rescue_branch" && -z "$stash_message" ]]; then
+    return 0
+  fi
+
+  announce \
+    "" \
+    "============================================================" \
+    "[ImI] $(date '+%Y-%m-%d %H:%M:%S') - local work in $DEST was set aside" \
+    "------------------------------------------------------------" \
+    "The updater makes that checkout match '$REF' exactly, which" \
+    "overwrites whatever is in it. Nothing was thrown away:"
+  if [[ -n "$rescue_branch" ]]; then
+    announce \
+      "" \
+      "  Your commits are on the branch $rescue_branch" \
+      "    git -C \"$DEST\" log $rescue_branch" \
+      "    git -C \"$DEST\" checkout $rescue_branch"
+  fi
+  if [[ -n "$stash_message" ]]; then
+    announce \
+      "" \
+      "  Your ${#at_risk[@]} changed/added file(s) are in the newest stash" \
+      "    git -C \"$DEST\" stash list" \
+      "    git -C \"$DEST\" stash pop"
+  fi
+  announce \
+    "" \
+    "This message is also saved in:" \
+    "  $RESCUE_LOG" \
+    "============================================================" \
+    ""
+
+  # The whiptail menu is about to replace everything above, so give a watching
+  # user a chance to read it. No terminal, no prompt - the update still runs.
+  if [[ -t 0 ]]; then
+    read -r -p "[ImI] Press Enter to continue with the update ... " _ || true
+  fi
+}
+
 if ! command -v git >/dev/null 2>&1; then
   echo "[ImI] git is required to fetch Immaterial Impulse. Install git and re-run." >&2
   exit 1
@@ -27,6 +160,7 @@ fi
 if [[ -d "$DEST/.git" ]]; then
   echo "[ImI] Updating existing checkout at $DEST ..."
   git -C "$DEST" fetch --depth 1 origin "$REF"
+  preserve_local_work
   git -C "$DEST" checkout -f "$REF" 2>/dev/null || git -C "$DEST" checkout -f FETCH_HEAD
   git -C "$DEST" reset --hard FETCH_HEAD
 else
@@ -35,6 +169,7 @@ else
   git clone --depth 1 --branch "$REF" "$REPO" "$DEST" 2>/dev/null \
     || git clone "$REPO" "$DEST"
 fi
+git -C "$DEST" update-ref "$INSTALLED_REF" HEAD
 
 cd "$DEST"
 echo "[ImI] Launching the installer (source: $DEST) ..."

--- a/get.sh
+++ b/get.sh
@@ -80,7 +80,13 @@ preserve_local_work() {
     # updater against the same local work reuses the ref instead of littering
     # the checkout with one more every time.
     rescue_branch="imi-rescue/$short"
-    dgit branch -f "$rescue_branch" "$head" >/dev/null
+    # Recovering means checking that branch out, and `git branch -f` refuses to
+    # move a branch that is checked out - which would abort the next update
+    # from under the user who had just recovered. The name carries the sha, so
+    # an existing one already points where this would put it.
+    if [[ "$(dgit rev-parse --verify -q "refs/heads/$rescue_branch" || true)" != "$head" ]]; then
+      dgit branch -f "$rescue_branch" "$head" >/dev/null
+    fi
   fi
 
   while IFS= read -r -d '' path; do


### PR DESCRIPTION
`~/.local/share/immaterial-impulse/src` is a normal git repository, and someone hacking on their own shell commits in it. The update path made it match `$REF` with `git checkout -f` + `git reset --hard FETCH_HEAD`, which destroyed three kinds of work that exist nowhere else — commits made there, uncommitted edits, and untracked files the incoming tree overwrites — with no warning and nothing afterwards saying where any of it went.

## What it does now

The updater still lands on `$REF` exactly, and still resets. It just moves what those two commands would eat somewhere git can hand back first, and then says where:

- **commits** → a branch `imi-rescue/<short-sha>`, named for the commit rather than the moment, so re-running the updater against the same local work reuses the ref instead of adding one every time.
- **uncommitted changes** → a stash, with a message naming the updater.
- **untracked files** → the same stash, but only the ones the incoming tree carries a path for. `checkout -f` overwrites exactly those and leaves every other untracked file alone, so stashing all of them would make a user's own scratch files vanish on an update that never threatened them.

Aborting on a dirty tree was rejected: it taxes every user with no local work for the sake of the one who has some. Stashing silently was rejected too — the whole failure here is that nothing told anyone.

## Three parts that are not guessable from reading the old script

- **In a `--depth 1` checkout, ancestry cannot answer "did this HEAD come from the remote".** Both HEAD and the incoming tip are grafted, so `merge-base --is-ancestor` has nothing to walk and answers "not an ancestor" for a checkout that is merely a few commits *behind* — indistinguishable from one that is ahead. So the script records what it installed in `refs/imi/installed` and trusts a HEAD equal to that marker; the ancestry test remains the answer for the full-clone fallback. A checkout predating the marker is rescued conservatively, once.
- **A stash needs a git identity, and a machine being installed for the first time often has none** — git then refuses to write the stash commit. The script borrows one (`git var GIT_COMMITTER_IDENT` is the probe) rather than losing the work. Any *other* stash failure aborts the update, because there proceeding is the data loss.
- **Printing to the terminal is not telling the user.** Settings > About > *Update Dots* spawns kitty running this script, and `setup`'s whiptail menu paints over the scrollback seconds later. The same text is appended to `rescued-local-work.log` beside the checkout, and when stdin is a tty the script waits for Enter before handing off.

One follow-up fix in its own commit: `git branch -f` refuses to move a branch that is checked out, so re-creating the rescue branch unconditionally killed the next update for the one person guaranteed to be standing on it — the user who had just recovered.

## Tests

`dots/.config/quickshell/imi/tests/test_get_sh_preserves_local_work.py` (wired into `run_tests.sh`) builds a throwaway origin repo and a throwaway DEST in a tempdir and runs the real `get.sh` against them with its own `IMI_REPO`/`IMI_REF`/`IMI_DEST` and `HOME`; it cannot reach any real checkout. The origin is cloned over `file://` so DEST really is shallow (asserted, not assumed — a local-path clone silently ignores `--depth`), and git identity is unset in the child environment because that is what a fresh machine looks like.

Nine cases: the local commit survives and is named on screen; uncommitted edits survive and pop back; an edit to a file upstream also changed is still reachable in the stash; a colliding untracked file is preserved while an innocent one is left in the working tree; the stash is written with no identity configured, and one case runs *with* one so both branches execute; updating again from the rescue branch works; and — the half that keeps this from becoming a nuisance — a clean checkout updates in **silence**: no rescue branch, no stash, no note file.

Proven to fail on the pre-fix code: 7 of 8 cases red against `gh/main`'s `get.sh` (the clean-checkout silence test passes on both, by design), and the rescue-branch case red against the unguarded `branch -f`.

`tests/run_tests.sh`: 757 passed, 0 failed — unchanged from the baseline, with the new Python check green ahead of it.

## Verification status

**Verified by the test harness only.** The standing project rule is that installer fixes count as verified through the real user path (Settings > Update Dots), and that path was deliberately not run here: a real update deletes `~/.config/quickshell` on a machine with a live shell and five other agents working on it. **User-path verification is outstanding.**

Docs: updated AGENT.md §The suite checkout, and why the updater cannot just reset it