### PR TITLE
fix(sessionScreen): one source for the session button's press, and a lint that can see the radius channel

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1501,13 +1501,33 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   file from `lint_disabled_opacity.py` on purpose, since that one keys on a dim expression and was
   blind to this for the whole life of the widget. It resolves which types apply the model rather than
   naming them, reads a declaration whole (block-bodied values included), and self-checks against an
-  in-memory fixture so the machinery is proven independently of what the tree contains. Note what the
-  sweep that came with it found and did **not** fix: `modules/imi/sessionScreen/SessionActionButton.qml`
-  keys `buttonRadius` on `button.down`, which is the same doubling in the *radius* channel
-  (`RippleButton` already tightens by `pressRadiusScale` through `pressProgress`), tangled with a
-  `focus` shape the model has no state for.
+  in-memory fixture so the machinery is proven independently of what the tree contains.
   f62673b7f ("fix(discordVoice): let the button own the hover and press motion"),
   1d5d196fd ("test(lint): fail on a hover/press scale inside a control that already scales").
+- **A radius composites too — through the control rather than through the scene graph — and the
+  lint above knew only the transform, so it wrote the next case up as a note instead of failing on
+  it.** That first version named `modules/imi/sessionScreen/SessionActionButton.qml` in its own
+  sweep, right here in this file and in `docs/widget-standards-audit-2026-08-16.md`, as a neighbour
+  it was not fixing: the button keyed `buttonRadius` on `button.down` while `RippleButton` was
+  already tightening. It reasoned that a `pressProgress`-driven radius "composites with nothing",
+  which is true of the scene graph and false of the control —
+  `RippleButton.buttonEffectiveRadius` is *computed from* `buttonRadius`, so a caller keying that
+  on `down` has its own value multiplied by `pressRadiusScale` on the way to the corner. The two
+  sources pulled opposite ways, so this did not read as too much squish: measured on the real
+  component, a press took the corner **30 → 51** — the button's own jump to `size / 2`, then the
+  model's 0.85 landing on the circle — where every other control tightens. It is 30 → 25.5 now.
+  Three things generalise. The `focus` half stayed, because that is the session grid's keyboard
+  cursor and the model has no state for it; a control may still own a shape the model does not
+  name. `tests/lint_interaction_motion_double.py` is per **channel** now — a file is a control in
+  the channels it actually applies the model in, so `MediaTransportButton` (which scales and does
+  not tighten) is not held to the radius rule — and the radius detector reads a *whole*
+  declaration, because both `RippleButton`s spell `buttonEffectiveRadius` across two lines with
+  `pressProgress` on the continuation, and a line-scoped version finds no radius control at all and
+  reports a clean tree. And the rule reaches only controls that apply the model:
+  `common/widgets/GroupButton.qml` drives its own `down`-keyed radius and bounce and has never
+  adopted it, so it is a non-adoption rather than a doubling and the lint leaves it alone.
+  fix(sessionScreen): let RippleButton own the session button's press,
+  test(lint): fail on a hover/press radius inside a control that already tightens.
 - **A one-tree widget's geometry reads the SETTLED span's box, never the animating one.** Three
   trees were written with `spanW: root.implicitWidth`, and `implicitWidth` carries a Behavior: every
   rect became a per-frame target, so the Behaviors that carry the travel never converged, and any

--- a/docs/widget-standards-audit-2026-08-16.md
+++ b/docs/widget-standards-audit-2026-08-16.md
@@ -263,6 +263,19 @@ doubles the model's press tightening in the radius channel and is tangled with a
 model has no state for; and the design system's own `RippleButton.qml:208` hand-rolls a state layer
 beside the model it drives (already recorded in §6).
 
+**Update — the first of those two is fixed, and the lint that named it now fails on it.** Recording
+a neighbour in prose beside a check that cannot see it is how this survived: the lint knew only the
+`scale` channel, on the reasoning that a `pressProgress`-driven radius "composites with nothing",
+which is true of the scene graph and false of the control — `RippleButton.buttonEffectiveRadius` is
+computed *from* `buttonRadius`, so the button's own jump to `size / 2` on `down` was then
+multiplied by `pressRadiusScale`. Measured on the real component, a press took the corner **30 →
+51** where every other control tightens; it is 30 → 25.5 now, and the `focus` shape (this grid's
+keyboard cursor, which the model has no state for) stayed. The lint is per *channel* now and reddens
+on the pre-fix line. The design-system state layer at `RippleButton.qml:208` is still open: it is
+the tint/opacity channel rather than a geometry one, and it lives in the vendored population §6
+covers. fix(sessionScreen): let RippleButton own the session button's press,
+test(lint): fail on a hover/press radius inside a control that already tightens.
+
 ### G5 — custom-image's resize animates a target that moves every frame (standard 4, *unverified at runtime*)
 
 `bundled/custom-image/Widget.qml:92-101`:

--- a/dots/.config/quickshell/imi/modules/imi/sessionScreen/SessionActionButton.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sessionScreen/SessionActionButton.qml
@@ -11,7 +11,15 @@ RippleButton {
     property bool keyboardDown: false
     property real size: 120
 
-    buttonRadius: (button.focus || button.down) ? size / 2 : Appearance.rounding.verylarge
+    // Focus only. `focus` is this grid's keyboard cursor and the shared model
+    // has no state for it, so the button still owns that shape - but the press
+    // belongs to RippleButton, which tightens `buttonRadius` by
+    // `pressRadiusScale` through the model's animated `pressProgress`. Naming
+    // `down` here too drove the same channel from two places and they pulled
+    // opposite ways: measured, a press took the corner 30 -> 51 (the button's
+    // own jump to a circle, then the model's 0.85 on top of it) where every
+    // other control in the shell tightens.
+    buttonRadius: button.focus ? size / 2 : Appearance.rounding.verylarge
     colBackground: button.keyboardDown ? Appearance.colors.colSecondaryContainerActive : 
         button.focus ? Appearance.colors.colPrimary : 
         Appearance.colors.colSecondaryContainer

--- a/dots/.config/quickshell/imi/tests/lint_interaction_motion_double.py
+++ b/dots/.config/quickshell/imi/tests/lint_interaction_motion_double.py
@@ -19,11 +19,33 @@
 # beside a green suite for the whole life of the widget. A detector that knows
 # one idiom stops detecting the moment the idiom changes.
 #
-# The rule: inside a control that applies the interaction model's `scale`, no
-# descendant (and not the control itself) may write a scale-family property from
-# a raw hover/press flag. The sanctioned channels are the driver's own outputs -
-# `scale`, `hoverProgress`, `pressProgress` - which carry the right tier because
-# `InteractionMotion.qml` writes the tier onto the animation BEFORE the target.
+# ...which is exactly how the FIRST version of this file missed the case its own
+# commit message named. It knew one channel - `scale` - because the failure that
+# motivated it was a transform, and it said so: "a file that merely declares one
+# may be using only `pressProgress` for a radius, which composites with
+# nothing." That sentence is about a transform's arithmetic and it left the
+# radius channel with no rule at all, so `sessionScreen/SessionActionButton.qml`
+# was written up in AGENT.md as found-and-not-fixed and the suite stayed green
+# over it. A radius composites too, just through the control rather than through
+# the scene graph: `RippleButton.buttonEffectiveRadius` is COMPUTED FROM
+# `buttonRadius`, so a caller keying `buttonRadius` on `down` has its own value
+# multiplied by `pressRadiusScale` on the way to the corner. Measured on the
+# real component, a press took that button's corner from 30 to 51 - the button's
+# jump to a circle, then the model's 0.85 landing on the circle - where every
+# other control in the shell tightens.
+#
+# So the check is per CHANNEL now, and a channel is (the properties that express
+# it, what applying the model in it looks like). A control is a control in the
+# channels it actually applies the model in: `MediaTransportButton` scales and
+# does not tighten, so a radius written inside it doubles nothing, and flagging
+# it would be a rule nobody can act on.
+#
+# The rule: inside a control that applies the interaction model in a channel, no
+# descendant (and not the control itself) may write that channel from a raw
+# hover/press flag. The sanctioned channels are the driver's own outputs -
+# `scale`, `radiusScale`, `hoverProgress`, `pressProgress` - which carry the
+# right tier because `InteractionMotion.qml` writes the tier onto the animation
+# BEFORE the target.
 #
 # Exits non-zero listing offenders. Wired into run_tests.sh / CI.
 
@@ -34,9 +56,17 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 MODULES = ROOT / "modules"
 
-# The scale-family properties. A transform is a transform however it is spelled:
-# `scale` on an Item, or `xScale`/`yScale` inside a `Scale {}`.
-SCALE_PROP = re.compile(r"^\s*(scale|xScale|yScale)\s*:(.*)$")
+# A property is written either as a plain binding (`scale: ...`) or as a
+# declaration that something else then reads (`property real squish: ...`).
+# Matching only the first leaves an indirection one rename wide open; matching
+# both adds no hit to the current tree, so this closes a hole rather than moving
+# the goalposts.
+DECL_PREFIX = r"(?:readonly\s+)?(?:property\s+\w+\s+)?"
+
+
+def prop_matcher(names):
+    return re.compile(rf"^\s*{DECL_PREFIX}(?:{'|'.join(names)})\s*:(.*)$")
+
 
 # The raw interaction flags a control exposes. Deliberately NOT `hoverProgress`
 # or `pressProgress`: those are the model's own animated channels and reading
@@ -47,13 +77,35 @@ STATE_FLAG = re.compile(
 )
 
 # A file declares itself an interaction-model control by driving an
-# `InteractionMotion` and applying its `scale`. Both halves are required: a file
-# that merely declares one may be using only `pressProgress` for a radius, which
-# composites with nothing.
+# `InteractionMotion` and applying one of its outputs. Both halves are required:
+# a file that merely declares one is a driver nobody has wired up yet, and
+# nothing inside it is doubling anything.
 DRIVES_MOTION = re.compile(r"\bInteractionMotion\s*\{")
-APPLIES_MOTION_SCALE = re.compile(
-    r"^\s*(?:scale|xScale|yScale)\s*:.*\.\s*scale\b"
+
+# The scale-family properties. A transform is a transform however it is spelled:
+# `scale` on an Item, or `xScale`/`yScale` inside a `Scale {}`.
+SCALE_NAMES = ("scale", "xScale", "yScale")
+
+# The radius-family properties, plus the two per-corner vocabularies the two
+# `RippleButton`s expose (`cornerTopLeft...` on the mainline one,
+# `topLeftRadius...` on the design system's, which `SegmentedWrapper` drives).
+#
+# `buttonRadiusPressed` and `buttonEffectiveRadius` are deliberately absent from
+# the OFFENDING set: the first is the model's own escape hatch - the value it
+# interpolates TO, so naming it replaces the tightening instead of stacking on
+# it - and the second is the applied result.
+RADIUS_NAMES = (
+    "radius", "buttonRadius",
+    "topLeftRadius", "topRightRadius", "bottomLeftRadius", "bottomRightRadius",
+    "cornerTopLeft", "cornerTopRight", "cornerBottomLeft", "cornerBottomRight",
 )
+RADIUS_APPLIER_NAMES = RADIUS_NAMES + ("buttonEffectiveRadius",)
+
+# What "this file applies the model in this channel" looks like. Scale is read
+# straight off the driver; a radius is a lerp along `pressProgress` (or a
+# multiply by `radiusScale`), because a corner has no origin to scale about.
+APPLIES_SCALE = re.compile(r"\.\s*scale\b")
+APPLIES_RADIUS = re.compile(r"\.\s*(?:pressProgress|radiusScale)\b")
 
 TYPE_BEFORE_BRACE = re.compile(r"([A-Z]\w*)\s*$")
 
@@ -123,7 +175,10 @@ def declaration_value(lines, index, first_fragment):
     A source-text check over a QML property has to answer whether the value is a
     line or a block - the settled-span check was vacuous for the largest tree it
     named because it read only the line, and `readonly property real spanW: {`
-    says nothing at all.
+    says nothing at all. The radius channel needs it for a second reason: both
+    `RippleButton`s declare `buttonEffectiveRadius` across two lines, with
+    `pressProgress` on the continuation, so a line-scoped detector would not
+    recognise either control.
     """
     value = strip_noise(first_fragment)
     depth = value.count("{") - value.count("}")
@@ -145,18 +200,53 @@ def declaration_value(lines, index, first_fragment):
     return value
 
 
-def motion_controls(sources):
-    """Type names (file stems) whose declaration applies the model's scale."""
-    return {
-        path
-        for path, lines in sources.items()
-        if any(DRIVES_MOTION.search(line) for line in lines)
-        and any(APPLIES_MOTION_SCALE.match(line) for line in lines)
-    }
+class Channel:
+    """One visual channel the model drives, and how to recognise both sides."""
+
+    def __init__(self, name, offending, applier, applies, doubling):
+        self.name = name
+        self.offending = prop_matcher(offending)
+        self.applier = prop_matcher(applier)
+        self.applies = applies
+        self.doubling = doubling
 
 
-def scan(sources, controls):
-    """(violations, files that opened a motion-control block)."""
+CHANNELS = [
+    Channel(
+        "scale", SCALE_NAMES, SCALE_NAMES, APPLIES_SCALE,
+        "a transform composites down the scene graph, so a hover/press scale "
+        "written inside a control that already applies `interactionMotion.scale` "
+        "MULTIPLIES with the model instead of replacing it",
+    ),
+    Channel(
+        "radius", RADIUS_NAMES, RADIUS_APPLIER_NAMES, APPLIES_RADIUS,
+        "the control's pressed radius is COMPUTED FROM `buttonRadius`, so a "
+        "hover/press radius written inside one is multiplied by "
+        "`pressRadiusScale` on its way to the corner - two sources on one "
+        "channel, which is how a session button ended up GROWING its corner on "
+        "press while the rest of the shell tightens",
+    ),
+]
+
+
+def motion_controls(sources, channel):
+    """Files whose declaration applies the model in this channel."""
+    found = set()
+    for path, lines in sources.items():
+        if not any(DRIVES_MOTION.search(line) for line in lines):
+            continue
+        for index, line in enumerate(lines):
+            match = channel.applier.match(line)
+            if not match:
+                continue
+            if channel.applies.search(declaration_value(lines, index, match.group(1))):
+                found.add(path)
+                break
+    return found
+
+
+def scan(sources, channel, controls):
+    """(violations, files that opened a motion-control block for this channel)."""
     violations = []
     hosts = set()
     for path, lines in sources.items():
@@ -164,15 +254,15 @@ def scan(sources, controls):
         own_type = path.stem
         for number, line in enumerate(lines, 1):
             enclosing = set(stacks[number - 1])
-            if path.stem in controls:
+            if own_type in controls:
                 enclosing.add(own_type)
             inside = enclosing & controls
             if inside:
                 hosts.add(path)
-            match = SCALE_PROP.match(line)
+            match = channel.offending.match(line)
             if not match or not inside:
                 continue
-            value = declaration_value(lines, number - 1, match.group(2))
+            value = declaration_value(lines, number - 1, match.group(1))
             if STATE_FLAG.search(value):
                 violations.append((path, number, sorted(inside)[0],
                                    " ".join(value.split())[:90]))
@@ -180,9 +270,12 @@ def scan(sources, controls):
 
 
 # The check matches source text over a tree it does not control, so both halves
-# of it are proven against a fixture that cannot drift: a doubled scale written
-# as a plain ternary, one written as a block, and the two spellings that must
-# NOT redden - the driver's own output, and a scale outside any control.
+# of it are proven against a fixture that cannot drift: per channel, a doubling
+# written as a plain ternary, one written as a block, one hidden behind a
+# property declaration - and the spellings that must NOT redden, namely the
+# driver's own outputs and anything outside a control. The radius fixture also
+# carries the two-line `buttonEffectiveRadius` shape, because a line-scoped
+# detector would silently find no radius control at all and report a clean tree.
 SELF_CHECK = {
     "Control.qml": """
 Button {
@@ -217,24 +310,114 @@ Item {
     }
 }
 """,
+    "Tightening.qml": """
+Button {
+    property InteractionMotion interactionMotion: InteractionMotion {
+        down: root.down
+    }
+    property real buttonRadius: 8
+    property real buttonRadiusPressed: buttonRadius * Appearance.interaction.pressRadiusScale
+    property real buttonEffectiveRadius: root.buttonRadius
+        + (root.buttonRadiusPressed - root.buttonRadius) * interactionMotion.pressProgress
+    background: Rectangle {
+        radius: root.buttonEffectiveRadius
+    }
+}
+""",
+    # Rooted ON the control, which is the shape that was missed: a
+    # `RippleButton` subclass re-stating the press in its own radius.
+    "TighteningCallSite.qml": """
+Tightening {
+    buttonRadius: (button.focus || button.down) ? size / 2 : Appearance.rounding.verylarge
+    QtObject {
+        property real radius: button.hovered ? 4 : 12
+    }
+    Rectangle {
+        radius: {
+            if (button.down)
+                return 4;
+            return 12;
+        }
+    }
+    Rectangle {
+        radius: root.someShape ? 4 : 12
+    }
+}
+""",
+    "TighteningLoose.qml": """
+Item {
+    Loose {
+        radius: hoverArea.containsMouse ? 4 : 12
+    }
+}
+""",
 }
 
 
 def self_check():
     sources = {Path(name): text.splitlines()
                for name, text in SELF_CHECK.items()}
-    controls = {path.stem for path in motion_controls(sources)}
-    if controls != {"Control"}:
-        return (f"the interaction-model control detector resolved {controls or 'nothing'} "
-                "on a fixture declaring exactly one")
-    violations, hosts = scan(sources, controls)
-    found = {(path.name, number) for path, number, _, _ in violations}
-    if found != {("CallSite.qml", 5), ("CallSite.qml", 8)}:
-        return (f"the scan resolved {sorted(found)} on a fixture holding a "
-                "ternary doubling at 5 and a block doubling at 8")
-    if Path("CallSite.qml") not in hosts:
-        return "the block parser did not see the control instantiated at the call site"
+    expected = {
+        "scale": ({"Control"}, {("CallSite.qml", 5), ("CallSite.qml", 8)},
+                  "CallSite.qml", None),
+        "radius": ({"Tightening"},
+                   {("TighteningCallSite.qml", 3), ("TighteningCallSite.qml", 5), ("TighteningCallSite.qml", 8)},
+                   "TighteningCallSite.qml", "TighteningLoose.qml"),
+    }
+    for channel in CHANNELS:
+        want_controls, want_hits, want_host, want_clean = expected[channel.name]
+        controls = {path.stem for path in motion_controls(sources, channel)}
+        if controls != want_controls:
+            return (f"the {channel.name}-channel control detector resolved "
+                    f"{controls or 'nothing'} on a fixture declaring "
+                    f"{want_controls}")
+        violations, hosts = scan(sources, channel, controls)
+        found = {(path.name, number) for path, number, _, _ in violations}
+        if found != want_hits:
+            return (f"the {channel.name} scan resolved {sorted(found)} on a "
+                    f"fixture holding doublings at {sorted(want_hits)}")
+        if Path(want_host) not in hosts:
+            return (f"the block parser did not see the {channel.name} control "
+                    f"instantiated at {want_host}")
+        if want_clean and Path(want_clean) in hosts:
+            return (f"the {channel.name} scan placed {want_clean} inside a "
+                    "control it never instantiates, so its rule reaches "
+                    "further than the model does")
     return None
+
+
+# Pin what each detector is supposed to have found, by FILE rather than by type
+# name: the plugin design system ships its own `RippleButton`, so a name-level
+# guard stays satisfied by the copy while the mainline one loses its transform -
+# the state in which flagging inner scales is exactly wrong.
+EXPECTED_CONTROLS = {
+    "scale": {
+        "common/widgets/RippleButton.qml",
+        "common/plugins/designsystem/widgets/RippleButton.qml",
+        "common/plugins/bundled/nandoroid-media/MediaTransportButton.qml",
+    },
+    # `MediaTransportButton` is absent on purpose: it scales and does not
+    # tighten, so it is not a radius-channel control and a radius inside it
+    # doubles nothing.
+    "radius": {
+        "common/widgets/RippleButton.qml",
+        "common/plugins/designsystem/widgets/RippleButton.qml",
+    },
+}
+
+# ...and pin that the nesting analysis resolves against the real tree, not only
+# against the fixture. One file whose ROOT is a control, one that instantiates
+# them as children - the two shapes the stack has to get right.
+EXPECTED_HOSTS = {
+    "scale": {
+        "common/widgets/ConfigSwitch.qml",
+        "common/plugins/bundled/discordVoice/Widget.qml",
+    },
+    "radius": {
+        "common/widgets/ConfigSwitch.qml",
+        "imi/sessionScreen/SessionActionButton.qml",
+    },
+}
 
 
 def main():
@@ -248,61 +431,51 @@ def main():
     sources = {path: path.read_text(encoding="utf-8").splitlines()
                for path in files}
 
-    control_files = motion_controls(sources)
-    controls = {path.stem for path in control_files}
+    failed = False
+    summary = []
+    for channel in CHANNELS:
+        control_files = motion_controls(sources, channel)
+        controls = {path.stem for path in control_files}
 
-    # Pin what the detector is supposed to have found, by FILE rather than by
-    # type name: the plugin design system ships its own `RippleButton`, so a
-    # name-level guard stays satisfied by the copy while the mainline one loses
-    # its transform - the state in which flagging inner scales is exactly wrong.
-    expected_controls = {
-        "common/widgets/RippleButton.qml",
-        "common/plugins/designsystem/widgets/RippleButton.qml",
-        "common/plugins/bundled/nandoroid-media/MediaTransportButton.qml",
-    }
-    found_controls = {str(path.relative_to(MODULES)) for path in control_files}
-    missing = expected_controls - found_controls
-    if missing:
-        print("Interaction-motion lint FAILED: the scan found no applied "
-              f"`interactionMotion.scale` in {sorted(missing)} - either those "
-              "controls stopped driving the model, or the detector's shape "
-              "assumption broke and every call site below is now unguarded.",
-              file=sys.stderr)
-        return 1
+        found_controls = {str(path.relative_to(MODULES)) for path in control_files}
+        missing = EXPECTED_CONTROLS[channel.name] - found_controls
+        if missing:
+            print(f"Interaction-motion lint FAILED: the {channel.name}-channel "
+                  f"scan found no applied interaction model in {sorted(missing)} "
+                  "- either those controls stopped driving the model, or the "
+                  "detector's shape assumption broke and every call site below "
+                  "is now unguarded.", file=sys.stderr)
+            return 1
 
-    violations, hosts = scan(sources, controls)
+        violations, hosts = scan(sources, channel, controls)
 
-    # ...and pin that the nesting analysis resolves against the real tree, not
-    # only against the fixture. One file whose ROOT is a control, one that
-    # instantiates them as children - the two shapes the stack has to get right.
-    expected_hosts = {
-        "common/widgets/ConfigSwitch.qml",
-        "common/plugins/bundled/discordVoice/Widget.qml",
-    }
-    found_hosts = {str(path.relative_to(MODULES)) for path in hosts}
-    missing_hosts = expected_hosts - found_hosts
-    if missing_hosts:
-        print("Interaction-motion lint FAILED: the brace-depth scan no longer "
-              f"places anything inside a control in {sorted(missing_hosts)}, so "
-              "it would report a clean tree whatever those files contain.",
-              file=sys.stderr)
-        return 1
+        found_hosts = {str(path.relative_to(MODULES)) for path in hosts}
+        missing_hosts = EXPECTED_HOSTS[channel.name] - found_hosts
+        if missing_hosts:
+            print("Interaction-motion lint FAILED: the brace-depth scan no "
+                  f"longer places anything inside a {channel.name}-channel "
+                  f"control in {sorted(missing_hosts)}, so it would report a "
+                  "clean tree whatever those files contain.", file=sys.stderr)
+            return 1
 
-    if violations:
-        print("Interaction-motion lint FAILED: a transform composites, so a "
-              "hover/press scale written inside a control that already applies "
-              "`interactionMotion.scale` MULTIPLIES with the model instead of "
-              "replacing it - and carries one hand-picked duration where the "
-              "model has five tiers. Delete it; the control already scales the "
-              "whole subtree:", file=sys.stderr)
-        for path, number, control, value in violations:
-            rel = path.relative_to(MODULES)
-            print(f"  {rel}:{number}: inside {control}: {value}", file=sys.stderr)
+        if violations:
+            failed = True
+            print(f"Interaction-motion lint FAILED in the {channel.name} "
+                  f"channel: {channel.doubling} - and carries one hand-picked "
+                  "duration where the model has five tiers. Delete it; the "
+                  "control already drives the whole subtree:", file=sys.stderr)
+            for path, number, control, value in violations:
+                rel = path.relative_to(MODULES)
+                print(f"  {rel}:{number}: inside {control}: {value}",
+                      file=sys.stderr)
+        summary.append(f"{len(control_files)} {channel.name} controls in "
+                       f"{len(hosts)} files")
+
+    if failed:
         return 1
 
     print(f"Interaction-motion lint passed ({len(files)} QML files, "
-          f"{len(controls)} interaction-model controls, "
-          f"{len(hosts)} files hosting one)")
+          + ", ".join(summary) + ")")
     return 0
 
 


### PR DESCRIPTION
`SessionActionButton` keyed `buttonRadius` on `button.focus || button.down`, so a press drove
the corner radius from the button *and* from the shared interaction model at the same time.
`RippleButton` already tightens: `buttonEffectiveRadius` lerps `buttonRadius` towards
`buttonRadius * Appearance.interaction.pressRadiusScale` along the model's animated
`pressProgress`, on the tier `interaction_motion.js` picks for that transition.

The two pulled opposite ways, so this did not read as "a bit too much squish" — it inverted the
gesture. Measured on the real component with the model's inputs driven directly (a throwaway
`qs -p` probe reading `buttonEffectiveRadius`, which is what the background's four corner radii
are bound to — not a screenshot, and not a synthetic pointer):

| state | before | after |
| --- | --- | --- |
| rest | 30.00 | 30.00 |
| hover | 30.00 | 30.00 |
| hover+press | **51.00** | **25.50** |
| focus | 60.00 | 60.00 |
| focus+press | 51.00 | 51.00 |

A pressed session button *grew* its corner by 21px — its own jump to `size / 2`, then the model's
0.85 landing on the circle — while every other control in the shell tightens. Exactly one state
changed; hover and both resting shapes measure identically before and after. The `focus` half
stayed: that is the session grid's keyboard cursor, not an interaction state, and the model has
rest/hovered/pressed/disabled and nothing for it — so the button keeps owning that shape and the
`Behavior on buttonRadius` that carries it between buttons under the arrow keys.

## Why the existing lint missed it

`tests/lint_interaction_motion_double.py` knew exactly one channel, `scale`, because the failure
that motivated it was a transform. Its header said so: *"a file that merely declares one may be
using only `pressProgress` for a radius, which composites with nothing."* That is true of the
scene graph and false of the control — `buttonEffectiveRadius` is computed **from** `buttonRadius`,
so a caller keying that on `down` is multiplied by `pressRadiusScale` on the way to the corner.

The sweep that shipped with that lint *found* this button, and wrote it up in `AGENT.md` and in
`docs/widget-standards-audit-2026-08-16.md` as a neighbour it was not fixing. A note is not a
check, and the suite stayed green over it for the whole time.

## The widening

The check is per **channel** now — a channel being (the properties that express it, what applying
the model in it looks like) — and a file is a control in the channels it actually applies the
model in, so `MediaTransportButton` (which scales and does not tighten) is not held to the radius
rule. Two details that are load-bearing:

- the radius detector reads a **whole declaration**, because both `RippleButton`s spell
  `buttonEffectiveRadius` across two lines with `pressProgress` on the continuation; a
  line-scoped version finds no radius control at all and reports a clean tree;
- `buttonRadiusPressed` is deliberately not an offence — it is the value the model interpolates
  *to*, so naming it replaces the tightening rather than stacking on it.

The property matchers also now admit a `property real x:` declaration, not only a plain binding.
Verified to add no hit to the current tree: it closes an indirection hole rather than moving the
goalposts.

## Proof it fails

Not on a fixture alone — on the real defect. With the pre-fix line planted back in a clean tree:

```
$ python3 tests/lint_interaction_motion_double.py          # this PR
Interaction-motion lint FAILED in the radius channel: ...
  imi/sessionScreen/SessionActionButton.qml:22: inside RippleButton:
    (button.focus || button.down) ? size / 2 : Appearance.rounding.verylarge
exit=1

$ python3 <main's copy of the same file>                    # the version that missed it
Interaction-motion lint passed (634 QML files, 2 interaction-model controls, 97 files hosting one)
exit=0
```

The self-check fixture grew the radius half to match the scale half and then some: a ternary
doubling, a block-bodied one, one hidden behind a property declaration, the two-line
`buttonEffectiveRadius` shape the detector must recognise, and two spellings that must **not**
redden — a radius keyed on something that is not an interaction flag, and one in a file that
instantiates no control at all. Both negatives earned their place by reddening a draft.

## What else the widened lint caught

Nothing. Swept over all 634 QML files it finds one radius doubling (this one) and no second
scale doubling. Two `down`-keyed radius ternaries sit outside its reach on purpose —
`common/widgets/GroupButton.qml` and its caller `imi/sidebarLeft/ApiCommandButton.qml` — because
`GroupButton` has never adopted the model at all: it drives its own radius and its own bounce, so
nothing there is doubling the model. That is a non-adoption, which is a different job, and
teaching this lint to flag it would make it fire on a control with no model to double. (Noted
rather than fixed: the call site's `down` branch is in fact dead, since `GroupButton` picks its
own `buttonRadiusPressed` while down. Out of scope here.)

Also left open and said to be open in the audit: the design system's own `RippleButton.qml:208`
hand-rolls a state layer beside the model it drives. That is the tint/opacity channel rather than
a geometry one, and it lives in the vendored population §6 of that audit already covers.

## Verification

- `tests/run_tests.sh`: **757 passed, 0 failed** — parity with main's baseline.
- The file compiles and runs under a real `qs` process (the measurement probe above instantiated
  it and read its properties back). Nothing was deployed to `~/.config/quickshell/imi`; the probe
  was a disposable `qs -p` inside this worktree, so the live shell was never touched.
- Two nested-weston harnesses (`test_widget_resize_grip_runtime.py`,
  `test_clight_integration_runtime.py`) flaked on intermediate runs with
  `Failed to create wl_display` / `The Wayland connection broke` while other sessions on this
  machine were running their own headless compositors; both pass in isolation and the final full
  run is clean.

Docs: updated AGENT.md §Dynamic/data-driven QML gotchas (the interaction-model entry) and
docs/widget-standards-audit-2026-08-16.md §G4