### PR TITLE
fix(verticalBar): render plugin bar widgets instead of an empty stub

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1772,6 +1772,25 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   transform, press scale included, cancels out — and set the target to pressStart + delta, as
   `widgetCanvas/AbstractWidget.qml` now does. d2ebb5aeb ("fix(widgetCanvas): compute the drag by
   hand - MouseArea.drag cannot track it").
+- **The two bars load the same widget files out of `modules/imi/bar/`, and each used to decide
+  which file for itself.** `Config.options.bar.layouts.*` is shared and Settings > Bar offers a
+  plugin's bar widget whatever the orientation, but only `BarContent.qml` ever learned the
+  `plugin:` branch 2a3801a62 ("feat(plugins): support installable QML packages") added.
+  `VerticalBarContent.qml`'s fallback capitalises a widget name into a file name, so
+  `plugin:docker_plugin` resolved to `Plugin:docker_plugin.qml` - measured with a `qml6` probe, the
+  `Loader` reaches `Loader.Error` with a null `item`, and the only evidence is one
+  `No such file or directory` line per widget. That is neither a `WARN scene:` nor an `ERROR:`, so
+  the configuration still loads and the bar simply draws the empty `BarGroup` stub around nothing.
+  `modules/imi/bar/bar_widget_source.js` is the one mapping now; it answers with a **file name**
+  and the caller prepends its own directory, because the two bars reach that directory by different
+  relative paths and a `.pragma library` has no engine context to assume for `Qt.resolvedUrl`.
+  `tests/test_bar_widget_parity.py` fails on either bar deciding for itself and on the two
+  `getWidgetUrl` bodies differing by anything except that directory literal;
+  `tests/tst_bar_widget_source.qml` pins the mapping. The orientation API a plugin gets is one
+  duck-typed `property bool vertical` on the entry point's root, which the host writes - and a
+  widget that declares none is rendered anyway rather than omitted, since omitting it is the same
+  silent disappearance this fixed. a47462fcc ("fix(verticalBar): render plugin bar widgets instead
+  of an empty stub"), 06d31aabc ("test(bar): pin the two bars to one widget-url resolution").
 - **A `Process`'s `onExited` handler that ignores its `exitCode` argument will happily act on stale
   data.** `TempScreenshotProcess` writes to a deterministic path (`image-${screen.name}`), so a failed
   `grim` run used to leave the *previous* successful capture sitting there untouched - the region

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -250,10 +250,16 @@ bug in anything that qualifies:
   for `ERROR:` - not just `WARN` - before calling the change verified. See AGENT.md's "Where to look
   when something goes wrong" for the cascade format and the `pgrep -af 'qs -c imi'` caveat.
   `DesignSystemCompile.qml` (run by `run_tests.sh`, skipped without `WAYLAND_DISPLAY`) narrows this
-  for the design system, the bundled packages, every settings page and the desktop-widget host
-  (`PluginWidget.qml`, which only compiles once a plugin is enabled on some monitor) - it compiles
-  them, so a bad property on a page nobody opened is caught. Everything else still needs the live
-  load. 494580b65 ("feat(plugins): resolve a placed widget's span from its stored choice").
+  for the design system, the bundled packages, every settings page, the desktop-widget host
+  (`PluginWidget.qml`, which only compiles once a plugin is enabled on some monitor) and both bars
+  - it compiles them, so a bad property on a page nobody opened is caught. Everything else still
+  needs the live load. 494580b65 ("feat(plugins): resolve a placed widget's span from its stored
+  choice"). The vertical bar joined that list for the same reason the dock is on it: it is opt-in,
+  so anything wrong with it stays green until someone switches it on - which is how the two bars
+  came to resolve widget files differently in the first place. Note the limit the sweep has, which
+  is easy to over-read: it proves a file *compiles*, and a missing `.js` import resolves at binding
+  time rather than compile time, so it passes one. ("fix(verticalBar): render plugin bar widgets
+  instead of an empty stub").
   **It sweeps a bundled package through its `Widget.qml` only**, on the reasoning that a sibling
   file is a type resolved through the package's `qmldir` and so is reached from the entry point
   anyway. A file the entry point loads *by URL* is not that - it is a standalone component that

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -110,6 +110,14 @@ Component paths must be relative, remain inside the package, and must not contai
 entry points are `barWidget`, `desktopWidget`, `controlCenterWidget`, `launcherProvider`, `panel`,
 and `settingsUi`. Bar entries use the stable `plugin:<id>` layout identifier.
 
+`barWidget` is drawn by both bars — the horizontal one and the vertical one share
+`Config.options.bar.layouts.*`, so a widget placed on one is placed on the other. The whole
+orientation API is one duck-typed property: declare `property bool vertical: false` on the entry
+point's root and the host writes it (`true` in the vertical bar), as `docker`'s `DockerWidget.qml`
+and `discordVoice`'s `BarWidget.qml` do. There is nothing to opt out of — a widget that declares no
+`vertical` is still rendered in a vertical bar, laid out as it was written, because a widget the
+user placed and then cannot find is exactly the failure this replaced.
+
 `desktopWidget` additionally takes three optional booleans — `blur`, `locked` and `clickThrough`.
 None of them is a setting: each **seeds the default** of the matching per-plugin option in
 `plugin-state.json` (`blurEnabled`, `positionLocked`, `clickThrough`), so a widget can ship an

--- a/dots/.config/quickshell/imi/DesignSystemCompile.qml
+++ b/dots/.config/quickshell/imi/DesignSystemCompile.qml
@@ -77,6 +77,18 @@ ShellRoot {
                 Quickshell.shellPath("modules/imi/bar/SysTray.qml"),
                 Quickshell.shellPath("modules/imi/bar/DockerPlugin.qml"),
                 Quickshell.shellPath("modules/imi/bar/DiscordVoicePlugin.qml"),
+                // The generic package bar host, which compiles only once some
+                // installed plugin's widget is in the user's bar layout.
+                Quickshell.shellPath("modules/imi/bar/PluginBarWidget.qml"),
+                // Both bars. The vertical one is the dock's case exactly -
+                // bar.vertical defaults false, so a bad property or a missing
+                // import in it passes every test and is found by whoever turns
+                // it on. The two bars drifting apart unobserved is the whole
+                // defect a47462fcc ("fix(verticalBar): render plugin bar
+                // widgets instead of an empty stub") came out of.
+                Quickshell.shellPath("modules/imi/bar/BarContent.qml"),
+                Quickshell.shellPath("modules/imi/verticalBar/VerticalBar.qml"),
+                Quickshell.shellPath("modules/imi/verticalBar/VerticalBarContent.qml"),
                 Quickshell.shellPath("modules/common/plugins/bundled/docker/DockerPopup.qml"),
                 Quickshell.shellPath("modules/common/plugins/bundled/docker/DockerWidget.qml"),
                 Quickshell.shellPath("modules/common/plugins/bundled/discordVoice/DiscordVoicePopup.qml"),

--- a/dots/.config/quickshell/imi/modules/imi/bar/BarContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/BarContent.qml
@@ -9,6 +9,7 @@ import qs.modules.common
 import qs.modules.common.plugins
 import qs.modules.common.widgets
 import qs.modules.common.functions
+import "bar_widget_source.js" as BarWidgetSource
 
 Item {
     id: root
@@ -48,12 +49,7 @@ Item {
             if (name === "sysTray" && !trayHasItems) return false;
             if (root.suppressDockerForMemoryTest
                     && (name === "dockerPlugin" || name === "plugin:docker_plugin")) return false;
-            // A plugin's bar widget tracks its enabled state: disabling (or
-            // uninstalling) a plugin drops its id from plugins.enabled, so its
-            // bar entry disappears with it. The layout token still holds the id
-            // (plugin:<id>), so re-enabling restores the widget in place.
-            if (name.startsWith("plugin:") && !Config.options.plugins.enabled.includes(name.substring(7)))
-                return false;
+            if (BarWidgetSource.isDisabledPlugin(name, Config.options.plugins.enabled)) return false;
             return true;
         });
     }
@@ -63,16 +59,8 @@ Item {
     readonly property var effectiveRightLayout:  filterLayout(Config.options.bar.layouts.rightLayout)
 
     function getWidgetUrl(name) {
-        if (!name) return "";
-        // Bundled native plugins use a direct component just like WeatherBar.
-        // The generic package Loader remains available for installed plugins,
-        // but must not sit in Docker's bar geometry path: forcing that Loader
-        // to fill its implicit-size host caused multi-gigabyte relayout loops.
-        if (name === "plugin:docker_plugin") return Qt.resolvedUrl("./DockerPlugin.qml");
-        if (name === "plugin:discord_voice") return Qt.resolvedUrl("./DiscordVoicePlugin.qml");
-        if (name.startsWith("plugin:")) return Qt.resolvedUrl("./PluginBarWidget.qml");
-        let formattedName = name.charAt(0).toUpperCase() + name.slice(1);
-        return Qt.resolvedUrl("./" + formattedName + ".qml");
+        const fileName = BarWidgetSource.fileNameFor(name);
+        return fileName ? Qt.resolvedUrl("./" + fileName) : "";
     }
 
     function getMirroredForIndex(layout, idx) {

--- a/dots/.config/quickshell/imi/modules/imi/bar/bar_widget_source.js
+++ b/dots/.config/quickshell/imi/modules/imi/bar/bar_widget_source.js
@@ -1,0 +1,79 @@
+.pragma library
+
+// Which file draws a bar widget, for both bars.
+//
+// The horizontal bar and the vertical bar each carried their own copy of this
+// mapping, and only the horizontal one ever grew the `plugin:` branch that
+// 2a3801a62 ("feat(plugins): support installable QML packages") added. The two
+// bars share `Config.options.bar.layouts.*` and Settings > Bar offers plugin
+// widgets whatever the orientation, so a layout holding `plugin:docker_plugin`
+// hit the vertical bar's fallback, which capitalises a widget name into a file
+// name: it resolved `Plugin:docker_plugin.qml`, the Loader went to
+// Loader.Error, and the bar drew the empty BarGroup stub around it. The only
+// evidence was one `No such file or directory` line per widget - not a
+// `WARN scene:` and not an `ERROR:`, so the config still loaded.
+//
+// The mapping lives here, once, because two names for one thing let whichever
+// one is not on screen rot silently.
+
+const PLUGIN_PREFIX = "plugin:";
+
+// Bundled plugins whose bar entry point is a native component in
+// modules/imi/bar/ rather than the generic package host. Docker is off the
+// generic path deliberately: PluginBarWidget's own Loader inside Docker's
+// implicit-size chain caused multi-gigabyte relayout loops
+// (7fb128afe ("fix(plugins): prevent Docker host memory runaway")).
+const NATIVE_BAR_COMPONENTS = {
+    "docker_plugin": "DockerPlugin.qml",
+    "discord_voice": "DiscordVoicePlugin.qml"
+};
+
+const PACKAGE_BAR_COMPONENT = "PluginBarWidget.qml";
+
+function pluginIdOf(name) {
+    if (!name || !name.startsWith(PLUGIN_PREFIX))
+        return "";
+    return name.substring(PLUGIN_PREFIX.length);
+}
+
+// An installed plugin picks its own id, so the lookup goes through
+// hasOwnProperty: a plugin calling itself `constructor` would otherwise resolve
+// to something off Object's prototype and be loaded as a file name.
+function nativeComponentFor(pluginId) {
+    return Object.prototype.hasOwnProperty.call(NATIVE_BAR_COMPONENTS, pluginId)
+        ? NATIVE_BAR_COMPONENTS[pluginId]
+        : "";
+}
+
+// The file name alone. `Qt.resolvedUrl` needs an engine context a shared
+// library has no business assuming, and the two bars reach modules/imi/bar/ by
+// different relative paths, so the directory belongs to the caller and the
+// mapping stays reachable from a test without one.
+function fileNameFor(name) {
+    if (!name)
+        return "";
+    const pluginId = pluginIdOf(name);
+    if (pluginId)
+        return nativeComponentFor(pluginId) || PACKAGE_BAR_COMPONENT;
+    return name.charAt(0).toUpperCase() + name.slice(1) + ".qml";
+}
+
+// A plugin's bar widget tracks its enabled state: disabling (or uninstalling) a
+// plugin drops its id from plugins.enabled, so its bar entry disappears with
+// it. The layout token still holds the id, so re-enabling restores the widget
+// in place.
+//
+// `plugins.enabled` is a `list<string>`, which reaches JS as a sequence
+// wrapper rather than an Array - Config.qml's own migration walks it by index
+// for the same reason - so this reads its length rather than calling a method
+// only a real Array is obliged to have.
+function isDisabledPlugin(name, enabledPluginIds) {
+    const pluginId = pluginIdOf(name);
+    if (!pluginId)
+        return false;
+    for (let i = 0; i < enabledPluginIds.length; i++) {
+        if (enabledPluginIds[i] === pluginId)
+            return false;
+    }
+    return true;
+}

--- a/dots/.config/quickshell/imi/modules/imi/verticalBar/VerticalBarContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/verticalBar/VerticalBarContent.qml
@@ -10,6 +10,7 @@ import qs.modules.common
 import qs.modules.common.widgets
 import qs.modules.common.functions
 import qs.modules.imi.bar as Bar
+import "../bar/bar_widget_source.js" as BarWidgetSource
 
 Item {
     id: root
@@ -21,8 +22,11 @@ Item {
     readonly property bool trayHasItems: SystemTray.items.values.length > 0
 
     function filterLayout(layout) {
-        if (trayHasItems) return layout
-        return layout.filter(name => name !== "sysTray")
+        return layout.filter(name => {
+            if (name === "sysTray" && !trayHasItems) return false
+            if (BarWidgetSource.isDisabledPlugin(name, Config.options.plugins.enabled)) return false
+            return true
+        })
     }
 
     readonly property var effectiveLeftLayout:   filterLayout(Config.options.bar.layouts.leftLayout)
@@ -60,9 +64,8 @@ Item {
     }
 
     function getWidgetUrl(name) {
-        if (!name) return "";
-        let formattedName = name.charAt(0).toUpperCase() + name.slice(1);
-        return Qt.resolvedUrl("../bar/" + formattedName + ".qml");
+        const fileName = BarWidgetSource.fileNameFor(name);
+        return fileName ? Qt.resolvedUrl("../bar/" + fileName) : "";
     }
 
     function getMirroredForIndex(layout, idx) {
@@ -192,6 +195,7 @@ Item {
                                 Layout.fillWidth: true
                                 source: root.getWidgetUrl(modelData)
                                 onLoaded: {
+                                    if (item && item.hasOwnProperty("pluginId")) item.pluginId = BarWidgetSource.pluginIdOf(modelData)
                                     if (item && "vertical" in item) item.vertical = true
                                     if (item && item.hasOwnProperty("mirrored"))
                                         item.mirrored = root.getMirroredForIndex(root.effectiveLeftLayout, index)
@@ -219,6 +223,7 @@ Item {
                             Layout.fillWidth: true
                             source: root.getWidgetUrl(modelData)
                             onLoaded: {
+                                if (item && item.hasOwnProperty("pluginId")) item.pluginId = BarWidgetSource.pluginIdOf(modelData)
                                 if (item && "vertical" in item) item.vertical = true
                                 if (item && item.hasOwnProperty("mirrored"))
                                     item.mirrored = root.getMirroredForIndex(root.effectiveLeftLayout, index)
@@ -268,6 +273,7 @@ Item {
                                 Layout.fillWidth: true
                                 source: root.getWidgetUrl(modelData)
                                 onLoaded: {
+                                    if (item && item.hasOwnProperty("pluginId")) item.pluginId = BarWidgetSource.pluginIdOf(modelData)
                                     if (item && "vertical" in item) item.vertical = true
                                     if (item && item.hasOwnProperty("mirrored"))
                                         item.mirrored = root.getMirroredForIndex(root.effectiveMiddleLayout, index)
@@ -295,6 +301,7 @@ Item {
                             Layout.fillWidth: true
                             source: root.getWidgetUrl(modelData)
                             onLoaded: {
+                                if (item && item.hasOwnProperty("pluginId")) item.pluginId = BarWidgetSource.pluginIdOf(modelData)
                                 if (item && "vertical" in item) item.vertical = true
                                 if (item && item.hasOwnProperty("mirrored"))
                                     item.mirrored = root.getMirroredForIndex(root.effectiveMiddleLayout, index)
@@ -345,6 +352,7 @@ Item {
                                 Layout.fillWidth: true
                                 source: root.getWidgetUrl(modelData)
                                 onLoaded: {
+                                    if (item && item.hasOwnProperty("pluginId")) item.pluginId = BarWidgetSource.pluginIdOf(modelData)
                                     if (item && "vertical" in item) item.vertical = true
                                     if (item && item.hasOwnProperty("mirrored"))
                                         item.mirrored = root.getMirroredForIndex(root.effectiveRightLayout, index)
@@ -372,6 +380,7 @@ Item {
                             Layout.fillWidth: true
                             source: root.getWidgetUrl(modelData)
                             onLoaded: {
+                                if (item && item.hasOwnProperty("pluginId")) item.pluginId = BarWidgetSource.pluginIdOf(modelData)
                                 if (item && "vertical" in item) item.vertical = true
                                 if (item && item.hasOwnProperty("mirrored"))
                                     item.mirrored = root.getMirroredForIndex(root.effectiveRightLayout, index)

--- a/dots/.config/quickshell/imi/tests/lint_plugin_processes.py
+++ b/dots/.config/quickshell/imi/tests/lint_plugin_processes.py
@@ -103,16 +103,22 @@ if re.search(
         bar_content):
     failures.append(
         "modules/imi/bar/BarContent.qml: Docker native adapter must remain visible for testing")
-if not re.search(
-        r'name\s*===\s*["\']plugin:docker_plugin["\'].*DockerPlugin\.qml',
-        bar_content, re.DOTALL):
-    failures.append(
-        "modules/imi/bar/BarContent.qml: bundled Docker must use its direct native bar component")
 if re.search(
         r'Layout\.preferredWidth\s*:\s*modelData\s*===\s*["\']plugin:docker_plugin["\']',
         bar_content):
     failures.append(
         "modules/imi/bar/BarContent.qml: Docker must use the same content-driven sizing as native widgets")
+
+# Which file draws a bar widget moved out of BarContent.qml and into the module
+# both bars ask, so the pin follows it - and now covers the vertical bar too,
+# which used to be able to point Docker at the generic host without this
+# noticing. a47462fcc ("fix(verticalBar): render plugin bar widgets instead of
+# an empty stub").
+bar_source = (ROOT / "modules/imi/bar/bar_widget_source.js").read_text(encoding="utf-8")
+if not re.search(
+        r'["\']docker_plugin["\']\s*:\s*["\']DockerPlugin\.qml["\']', bar_source):
+    failures.append(
+        "modules/imi/bar/bar_widget_source.js: bundled Docker must use its direct native bar component")
 
 docker_adapter = (ROOT / "modules/imi/bar/DockerPlugin.qml").read_text(encoding="utf-8")
 docker_adapter_code = re.sub(r"//.*", "", docker_adapter)

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -336,6 +336,15 @@ if ! python3 "$SCRIPT_DIR/test_bar_hover_region.py"; then
     exit 1
 fi
 
+# The two bars draw the same layout out of the same directory, and each used to
+# resolve a widget to a file on its own. Only the horizontal one ever learned
+# `plugin:`, so every plugin bar widget was an empty stub on a vertical bar.
+echo "Running bar widget parity tests..."
+if ! python3 "$SCRIPT_DIR/test_bar_widget_parity.py"; then
+    echo "Bar widget parity tests failed."
+    exit 1
+fi
+
 echo "Running cheatsheet width budget tests..."
 if ! python3 "$SCRIPT_DIR/test_cheatsheet_width_budget.py"; then
     echo "Cheatsheet width budget tests failed."

--- a/dots/.config/quickshell/imi/tests/test_bar_widget_parity.py
+++ b/dots/.config/quickshell/imi/tests/test_bar_widget_parity.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""The two bars resolve a widget to a file the same way, or the suite reddens.
+
+The horizontal bar and the vertical bar draw the same `Config.options.bar.
+layouts.*` out of the same `modules/imi/bar/` directory, and each used to carry
+its own `getWidgetUrl`. Only the horizontal one ever learned the `plugin:`
+branch 2a3801a62 ("feat(plugins): support installable QML packages") added, so
+a layout holding `plugin:docker_plugin` reached the vertical bar's fallback -
+which capitalises a widget name into a file name, and produced
+`Plugin:docker_plugin.qml`. Measured with a `qml6` probe: `Loader.status` 3
+(`Loader.Error`), `item` null, and one `No such file or directory` line per
+widget - not a `WARN scene:` and not an `ERROR:`, so the configuration still
+loaded and the bar simply drew the empty BarGroup stub around nothing.
+
+The defect class is not the missing branch, it is that a capability could be
+added to one bar and not the other at all. So the resolution is one module,
+`modules/imi/bar/bar_widget_source.js` (behaviour pinned by
+`tst_bar_widget_source.qml`), and these checks are what stop a second copy
+growing back:
+
+  - each bar's `getWidgetUrl` must ASK the module, not decide anything itself;
+  - the two bodies must be identical once the directory literal - the one
+    thing that legitimately differs, since the two bars sit at different depths
+    - is normalised away. Any divergence in the kinds they support is a
+    divergence in that text;
+  - the same for the layout filter, which carried the second copy of "is this a
+    plugin, and is it still enabled";
+  - and every file name the module can name must exist, which is the check that
+    would have caught the original bug from the other end.
+
+Nothing here reads raw file text: `_qml_source` blanks comments and matches
+braces, for the reason recorded in `test_background_fullscreen_suppression.py`
+- a text pattern over QML decays into one that matches nothing after a reformat,
+and a comment mentioning the word being grepped for defeats it outright.
+"""
+import re
+import unittest
+from pathlib import Path
+
+from test_background_fullscreen_suppression import _qml_source
+
+ROOT = Path(__file__).resolve().parents[1]
+BAR_DIR = ROOT / "modules/imi/bar"
+HORIZONTAL = BAR_DIR / "BarContent.qml"
+VERTICAL = ROOT / "modules/imi/verticalBar/VerticalBarContent.qml"
+MODULE = BAR_DIR / "bar_widget_source.js"
+
+MODULE_NAMESPACE = "BarWidgetSource"
+
+# A relative directory literal: `"./"`, `"../bar/"`. The only part of the two
+# resolutions that is allowed to differ.
+_DIR_LITERAL = re.compile(r'"[^"\n]*/"')
+
+# `"DockerPlugin.qml"` on the right of a `:` or an `=` in the shared module.
+_COMPONENT_LITERAL = re.compile(r'"([A-Za-z][\w.-]*\.qml)"')
+
+# A call to the shared enabled rule, whatever it is handed.
+_SHARED_ENABLED_CALL = re.compile(
+    re.escape(MODULE_NAMESPACE) + r"\.isDisabledPlugin\([^()]*\)")
+
+# What a bar must not spell for itself any more - each is one half of a copy
+# that had already drifted once.
+_OWN_DECISION = (
+    ("plugin:", "the plugin layout-token prefix"),
+    ("charAt(0).toUpperCase()", "the widget-name capitalisation"),
+    (".substring(7)", "the hardcoded plugin-prefix length"),
+)
+
+
+def _normalised(body):
+    """A function body with its directory literal and layout collapsed."""
+    return " ".join(_DIR_LITERAL.sub('"<dir>"', body).split())
+
+
+class BarWidgetResolutionParityTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.bars = {}
+        for label, path in (("horizontal", HORIZONTAL), ("vertical", VERTICAL)):
+            qml = _qml_source(path)
+            assert qml.unclosed == 0, (
+                f"unbalanced braces in {path} - the pins below would silently "
+                f"stop covering anything.")
+            cls.bars[label] = (path, qml)
+
+    def _function_body(self, label, name):
+        path, qml = self.bars[label]
+        body = qml.function_body(name)
+        self.assertIsNotNone(
+            body, f"{path} declares no `function {name}` - the pins below "
+                  f"cover nothing without it.")
+        return body
+
+    def test_both_bars_import_the_shared_resolver(self):
+        for label, (path, qml) in self.bars.items():
+            imports = re.findall(
+                r'^\s*import\s+"([^"]+)"\s+as\s+(\w+)\s*$', qml.text, re.M)
+            resolved = {
+                (path.parent / target).resolve(): alias
+                for target, alias in imports
+            }
+            self.assertIn(
+                MODULE.resolve(), resolved,
+                f"the {label} bar does not import {MODULE.name}; it is "
+                f"resolving widget files on its own again.")
+            self.assertEqual(
+                resolved[MODULE.resolve()], MODULE_NAMESPACE,
+                f"the {label} bar imports {MODULE.name} under a different "
+                f"namespace, so the pins below cannot see the call sites.")
+
+    def test_neither_bar_decides_a_widget_kind_for_itself(self):
+        for label in self.bars:
+            body = self._function_body(label, "getWidgetUrl")
+            self.assertIn(
+                f"{MODULE_NAMESPACE}.fileNameFor", body,
+                f"the {label} bar's getWidgetUrl does not ask "
+                f"{MODULE.name} which file draws the widget.")
+            for token, what in _OWN_DECISION:
+                self.assertNotIn(
+                    token, body,
+                    f"the {label} bar's getWidgetUrl spells {what} itself - "
+                    f"that is the second copy this module replaced, and the "
+                    f"copy the other bar will not get.")
+
+    def test_the_two_bars_resolve_a_widget_identically(self):
+        horizontal = _normalised(self._function_body("horizontal", "getWidgetUrl"))
+        vertical = _normalised(self._function_body("vertical", "getWidgetUrl"))
+        self.assertEqual(
+            horizontal, vertical,
+            "the two bars' widget-url resolution has diverged. Everything "
+            "except the directory each bar reaches modules/imi/bar/ by must "
+            "be the same text, or one bar supports a kind of widget the other "
+            "does not.\n"
+            f"  horizontal: {horizontal}\n"
+            f"  vertical:   {vertical}")
+
+    def test_both_bars_drop_a_disabled_plugin_through_the_shared_rule(self):
+        # Scoped to the enabled decision rather than to every mention of the
+        # prefix: the horizontal bar's `suppressDockerForMemoryTest` hook names
+        # one specific layout token on purpose, which is a fact about Docker
+        # and not a rule about what a plugin id is.
+        for label in self.bars:
+            body = self._function_body(label, "filterLayout")
+            self.assertIn(
+                f"{MODULE_NAMESPACE}.isDisabledPlugin", body,
+                f"the {label} bar's filterLayout does not ask {MODULE.name} "
+                f"whether a layout entry is a disabled plugin - a plugin the "
+                f"user switched off would keep its bar slot.")
+            residue = _SHARED_ENABLED_CALL.sub("", body)
+            self.assertNotIn(
+                "plugins.enabled", residue,
+                f"the {label} bar's filterLayout reads plugins.enabled outside "
+                f"{MODULE_NAMESPACE}.isDisabledPlugin - that is the second copy "
+                f"of the rule, and the copy the other bar will not get.")
+            self.assertNotIn(
+                ".substring(", residue,
+                f"the {label} bar's filterLayout takes a plugin id apart "
+                f"itself; ask {MODULE_NAMESPACE}.pluginIdOf.")
+
+    def test_every_component_the_resolver_can_name_exists(self):
+        # The original bug was a resolution to a file that is not there, which
+        # a Loader reports as one easily-missed log line. Read the names the
+        # module can produce back off disk.
+        source = MODULE.read_text()
+        named = sorted(set(_COMPONENT_LITERAL.findall(source)))
+        self.assertGreaterEqual(
+            len(named), 3,
+            f"{MODULE.name} names {named}, which is fewer components than the "
+            f"two native plugin widgets plus the package host - the pin below "
+            f"has stopped covering the mapping.")
+        for component in named:
+            self.assertTrue(
+                (BAR_DIR / component).is_file(),
+                f"{MODULE.name} can resolve a bar widget to {component}, which "
+                f"does not exist in {BAR_DIR.relative_to(ROOT)} - both bars "
+                f"would draw an empty group and log one 'No such file or "
+                f"directory' line per widget.")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dots/.config/quickshell/imi/tests/test_discord_voice_plugin.py
+++ b/dots/.config/quickshell/imi/tests/test_discord_voice_plugin.py
@@ -366,8 +366,20 @@ class DiscordVoicePluginSafetyTests(unittest.TestCase):
         self.assertIn("onStarted: root.flushPendingMessages()", service)
 
     def test_native_bar_route_is_click_only_and_closes_on_focus_loss(self):
-        host = (ROOT / "modules/imi/bar/BarContent.qml").read_text()
-        self.assertIn('name === "plugin:discord_voice"', host)
+        # Which file draws a bar widget is one mapping both bars ask now, so
+        # the native route is pinned there - and holds for the vertical bar
+        # too, which could not draw this widget at all before. a47462fcc
+        # ("fix(verticalBar): render plugin bar widgets instead of an empty
+        # stub").
+        mapping = (ROOT / "modules/imi/bar/bar_widget_source.js").read_text()
+        self.assertRegex(
+            mapping, r'["\']discord_voice["\']\s*:\s*["\']DiscordVoicePlugin\.qml["\']')
+        for bar_file in ("modules/imi/bar/BarContent.qml",
+                         "modules/imi/verticalBar/VerticalBarContent.qml"):
+            self.assertIn(
+                "BarWidgetSource.fileNameFor", (ROOT / bar_file).read_text(),
+                f"{bar_file} resolves widget files itself again, so the "
+                f"mapping pinned above is not the one it uses")
         adapter = (ROOT / "modules/imi/bar/DiscordVoicePlugin.qml").read_text()
         self.assertIn("hoverEnabled: false", adapter)
         self.assertIn("cursorShape: Qt.PointingHandCursor", adapter)

--- a/dots/.config/quickshell/imi/tests/test_docker_memory_safety.py
+++ b/dots/.config/quickshell/imi/tests/test_docker_memory_safety.py
@@ -108,10 +108,20 @@ class DockerMemorySafetyTests(unittest.TestCase):
         self.assertNotIn("enableDockerForMemoryTest", bar)
         self.assertNotRegex(
             bar, r'name\s*===\s*["\']plugin:docker_plugin["\']\s*\)\s*return\s+false')
+        # Which file draws a bar widget is one mapping both bars ask now, so
+        # the pin follows it there - and covers the vertical bar for free,
+        # where before Docker could have been pointed at the generic package
+        # host there without this noticing. a47462fcc ("fix(verticalBar):
+        # render plugin bar widgets instead of an empty stub").
+        mapping = self.text("modules/imi/bar/bar_widget_source.js")
         self.assertRegex(
-            bar,
-            r'if \(name === "plugin:docker_plugin"\)[\s\S]*?return Qt\.resolvedUrl\("\./DockerPlugin\.qml"\)',
-        )
+            mapping, r'["\']docker_plugin["\']\s*:\s*["\']DockerPlugin\.qml["\']')
+        for bar_file in ("modules/imi/bar/BarContent.qml",
+                         "modules/imi/verticalBar/VerticalBarContent.qml"):
+            self.assertIn(
+                "BarWidgetSource.fileNameFor", self.text(bar_file),
+                f"{bar_file} resolves widget files itself again, so the "
+                f"mapping pinned above is not the one it uses")
 
     def test_runtime_harness_exercises_repeated_popup_lifecycle(self):
         harness = self.text("DockerRuntimeTest.qml")

--- a/dots/.config/quickshell/imi/tests/tst_bar_widget_source.qml
+++ b/dots/.config/quickshell/imi/tests/tst_bar_widget_source.qml
@@ -1,0 +1,75 @@
+import QtTest
+import "../modules/imi/bar/bar_widget_source.js" as BarWidgetSource
+
+// Which file draws a bar widget. Both bars ask this module, so the kinds it
+// knows about are the kinds BOTH bars support - which is the whole point: the
+// vertical bar used to carry its own copy that had never learned `plugin:`,
+// and capitalised the id into `Plugin:docker_plugin.qml`.
+TestCase {
+    name: "BarWidgetSourceTest"
+
+    function test_a_plain_widget_name_is_capitalised_into_its_file() {
+        compare(BarWidgetSource.fileNameFor("media"), "Media.qml");
+        compare(BarWidgetSource.fileNameFor("clockWidget"), "ClockWidget.qml");
+        compare(BarWidgetSource.fileNameFor("sysTray"), "SysTray.qml");
+    }
+
+    function test_an_absent_widget_name_resolves_to_nothing() {
+        compare(BarWidgetSource.fileNameFor(""), "");
+        compare(BarWidgetSource.fileNameFor(undefined), "");
+        compare(BarWidgetSource.fileNameFor(null), "");
+    }
+
+    function test_a_plugin_id_never_reaches_the_capitalising_fallback() {
+        // The defect verbatim: `plugin:docker_plugin` came out of the vertical
+        // bar as `Plugin:docker_plugin.qml`. A colon cannot appear in any file
+        // this shell ships, so it is the shape to refuse, not one id.
+        const names = ["plugin:docker_plugin", "plugin:discord_voice",
+                       "plugin:some_installed_package", "plugin:x"];
+        for (const name of names) {
+            const fileName = BarWidgetSource.fileNameFor(name);
+            verify(fileName.indexOf(":") === -1,
+                   `${name} resolved to ${fileName}, which is a capitalised id rather than a file`);
+            verify(fileName.indexOf("plugin:") === -1,
+                   `${name} resolved to ${fileName}`);
+        }
+    }
+
+    function test_the_two_bundled_bar_plugins_take_their_native_components() {
+        compare(BarWidgetSource.fileNameFor("plugin:docker_plugin"), "DockerPlugin.qml");
+        compare(BarWidgetSource.fileNameFor("plugin:discord_voice"), "DiscordVoicePlugin.qml");
+    }
+
+    function test_every_other_plugin_takes_the_generic_package_host() {
+        compare(BarWidgetSource.fileNameFor("plugin:some_installed_package"), "PluginBarWidget.qml");
+        compare(BarWidgetSource.fileNameFor("plugin:nandoroid_media"), "PluginBarWidget.qml");
+    }
+
+    // An installed plugin picks its own id, so the native-component lookup is
+    // an attacker-chosen key into an object literal. Without the hasOwnProperty
+    // guard these resolve to something off Object's prototype.
+    function test_an_id_naming_a_prototype_member_still_takes_the_package_host() {
+        compare(BarWidgetSource.fileNameFor("plugin:constructor"), "PluginBarWidget.qml");
+        compare(BarWidgetSource.fileNameFor("plugin:toString"), "PluginBarWidget.qml");
+        compare(BarWidgetSource.fileNameFor("plugin:__proto__"), "PluginBarWidget.qml");
+    }
+
+    function test_a_plugin_id_is_the_layout_token_minus_its_prefix() {
+        compare(BarWidgetSource.pluginIdOf("plugin:docker_plugin"), "docker_plugin");
+        compare(BarWidgetSource.pluginIdOf("media"), "");
+        compare(BarWidgetSource.pluginIdOf(""), "");
+        compare(BarWidgetSource.pluginIdOf(undefined), "");
+        // Not a prefix match anywhere but the front.
+        compare(BarWidgetSource.pluginIdOf("myplugin:thing"), "");
+    }
+
+    function test_only_a_plugin_the_user_disabled_is_dropped_from_a_layout() {
+        const enabled = ["docker_plugin", "notes"];
+        verify(!BarWidgetSource.isDisabledPlugin("plugin:docker_plugin", enabled));
+        verify(BarWidgetSource.isDisabledPlugin("plugin:discord_voice", enabled));
+        // A built-in widget is not a plugin and is never dropped by this rule,
+        // whatever the enabled list happens to hold.
+        verify(!BarWidgetSource.isDisabledPlugin("media", enabled));
+        verify(!BarWidgetSource.isDisabledPlugin("media", []));
+    }
+}


### PR DESCRIPTION
## What was broken

A vertical bar could not draw a plugin's bar widget at all.

`VerticalBarContent.qml`'s `getWidgetUrl` had no `plugin:` branch — only
`BarContent.qml` ever grew the one 2a3801a62 ("feat(plugins): support installable QML
packages") added. So a layout token fell through to the fallback that capitalises a
widget name into a file name, and `plugin:docker_plugin` resolved to
`../bar/Plugin:docker_plugin.qml`.

Measured with a `qml6` probe rather than assumed. The colon does not make Qt reject the
path — it is simply part of a file name that does not exist. The `Loader` reaches
`Loader.Error` with a null `item`, and the whole of the evidence is one line per widget:

```
file:///.../modules/imi/bar/Plugin:docker_plugin.qml: No such file or directory
```

That is neither a `WARN scene:` nor an `ERROR:`, so the configuration still loads. What
the user sees is the `BarGroup` around the failed Loader: an 8px `colLayer1` nub in the
strip, or an empty M3 pill under cornerStyle 3. The two bars share one
`Config.options.bar.layouts.*` and Settings → Bar offers plugin widgets whatever the
orientation, so it is reachable by putting Docker on the bar and switching the bar to
vertical — the widget silently stops existing.

The vertical bar's `getWidgetUrl` never had that branch; this is an omission, not a
removal to argue with (`git log -S` on the file returns four commits, none about
plugins).

## What changed

The missing branch is the symptom. The defect class is that a capability could be added
to one bar and not the other at all, silently, for as long as nobody ran the shell with
the other bar on screen — so the resolution is now **one mapping both bars ask**,
`modules/imi/bar/bar_widget_source.js`. It answers with a file *name*: the two bars reach
`modules/imi/bar/` by different relative paths, and a `.pragma library` has no engine
context it may assume for `Qt.resolvedUrl`, so the directory belongs to the caller and
the mapping stays reachable from a test without one.

The enabled-plugin filter moved with it — it was the second copy of "is this a plugin,
and which one", hardcoded `substring(7)` included. Without it on the vertical side, this
PR would have shipped the mirror-image bug: a bar entry for a plugin the user had
switched off.

**Orientation.** Nothing new was invented. `PluginBarWidget` already declares `vertical`
and forwards it into the package root, and the vertical bar already writes `vertical` on
every widget it loads, so a bar widget declaring `property bool vertical` (both bundled
ones do) lays itself out for a column. A widget that declares none is **rendered anyway,
not omitted**: a manifest has no way to say "horizontal only", the presence of a
duck-typed property is too weak a proxy to hide a widget on, and a widget the user placed
and then cannot find is the failure being fixed here rather than a reasonable response to
it. `PLUGINS.md` now says so, so the next reader does not take the absence of a rule for
an oversight.

Hardening picked up on the way: an installed plugin picks its own id, so the native
component lookup goes through `hasOwnProperty` — a plugin calling itself `constructor`
would otherwise resolve to something off `Object`'s prototype and be handed to a Loader.

## Tests

`tst_bar_widget_source.qml` pins the mapping — every kind of layout token, including the
one that produced the bug (a plugin id must never reach the capitalising fallback,
checked by refusing a colon in the result rather than by naming one id).

`test_bar_widget_parity.py` is the check for the defect class: each bar's `getWidgetUrl`
must ask the module rather than decide anything itself, and the two bodies must be
identical once the directory literal — the one thing that legitimately differs — is
normalised away. Same for the layout filter, scoped to the enabled decision so the
horizontal bar's deliberate `suppressDockerForMemoryTest` hook stays legal. It also reads
every component the module can name back off disk, which is the original bug from the
other end: a resolution to a file that is not there. It reads the QML through
`_qml_source` rather than as text.

`DesignSystemCompile.qml` now sweeps both bars and `PluginBarWidget.qml`. The vertical
bar is the dock's case exactly — `bar.vertical` defaults false, so anything wrong with it
passes every check until someone switches it on, which is how the two bars came to
diverge unobserved in the first place.

Every check was proven against planted code, in a clean tree:

| planted | reddens |
| --- | --- |
| the `plugin:` branch deleted from the mapping | `tst_bar_widget_source.qml`, 4 failures, reproducing `Plugin:docker_plugin.qml` verbatim |
| the vertical bar's pre-fix `getWidgetUrl` restored | parity, 2 failures |
| the horizontal bar's `plugin:` branch deleted | parity, 2 failures |
| the mapping naming a file that is not there | parity, 1 failure |
| the vertical bar's disabled-plugin filter removed | parity, 1 failure |
| the vertical bar's shared import removed | parity, 1 failure |
| Docker/Discord pointed at the generic host | `lint_plugin_processes.py`, `test_docker_memory_safety.py`, `test_discord_voice_plugin.py` |
| a bad root type in `VerticalBarContent.qml` | compile sweep, `checked=172 failures=2` |

Three existing pins ("this bundled plugin uses its direct native bar component") read the
`plugin:<id>` branch out of BarContent.qml and so pointed at a file that no longer
decides it. They follow the mapping, and each is wider for the move: both widgets stay
off the generic package Loader — which for Docker is what caused the multi-gigabyte
relayout loop 7fb128afe fixed — for *both* bars now. Each also asserts that both bars
actually ask the mapping, so a pin cannot go on passing against a file neither reads.

## Verification

`tests/run_tests.sh`: **767 passed, 0 failed** (baseline on `main` is 757; the 10 are
`BarWidgetSourceTest`), `DesignSystemCompile checked=172 failures=0`, exit 0.

Not deployed to the live shell — one shell is shared with several concurrent agents and
switching the bar to vertical is a settings change. What is unverified by that choice is
the rendered result on screen; what is verified is that both bars compile, that the
resolution is correct and identical, and that the failure mode reproduced and then
stopped reproducing under a probe.

One limit worth stating rather than leaving to be over-read: the compile sweep proves a
file *compiles*, and a missing `.js` import resolves when a binding runs rather than at
compile time — measured, deleting the import passes it. The parity test's import check is
what covers that half.

Docs: updated AGENT.md §Dynamic/data-driven QML gotchas, CONTRIBUTING.md §New features and bugfixes need tests, docs/PLUGINS.md §Manifest entry points