### PR TITLE
Finish the OLED screensaver: a key, one monitor at a time, and a keep-awake

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1006,6 +1006,32 @@ Two non-obvious behaviors have bitten this codebase before and are worth knowing
   `GlobalStates.settingsHeldForRegionSelector` so Settings can remain visible in screenshots without
   racing surface creation. Because clearing the grab also empties its dismissable list, Settings
   must re-register itself when selection ends even though its own `visible` property never changed.
+- **`WlrKeyboardFocus.Exclusive` is a session-wide grab, so a per-monitor surface must not take
+  it.** A fullscreen overlay covering every screen can hold the keyboard — that is what makes the
+  idle screensaver wake on any key without leaking the keystroke into whatever was focused. The
+  same surface on *one* monitor cannot: the grab is not scoped to that output, so it swallows what
+  the user types on the screen they moved to, and a saver that dismisses on a keypress therefore
+  dismisses itself on their first letter. `modules/imi/screensaver/Screensaver.qml` picks
+  `Exclusive` for the all-screens idle path and `None` for a deliberately blanked monitor. The
+  pointer half of the same rule: getting back to work means moving the pointer *off* that monitor,
+  which is motion across the surface being escaped, so a deliberate blank ignores motion and takes
+  a click. afb1c7ea5 ("feat(screensaver): blank one named monitor, not every screen").
+- **An idle inhibitor belongs to the *deliberate* half of a feature, never to the idle half.** The
+  screensaver has two ways in — hypridle's 240s listener (`ipc call screensaver show`) and a
+  keybind — and only the second holds `services/Idle.qml`'s inhibitor. Holding it on the idle path
+  would mean a user who walks away is blanked at 240s and then never reaches lock (300s), DPMS off
+  (600s) or suspend (900s): the ladder hypridle exists for, disabled by the thing that fires first
+  in it. That is why the two paths are separate state (`GlobalStates.screensaverActive` vs
+  `screensaverScreens`) rather than one flag with a mode. Two things generalise. The hold is a
+  third bit ORed into the one existing `IdleInhibitor` rather than a second one — that window's own
+  comment records a 0x0 surface mapping unreliably enough that Hyprland's ext-idle-notify ignored
+  the inhibitor, and a second copy would re-learn it while giving "is the system awake" two answers
+  to disagree about. And it is **derived** from the blanked-screen list rather than stored as a
+  flag someone sets and clears, so it has no release path to forget: every way the saver comes down
+  empties the list, and emptying the list *is* the release. If the shell dies while a screen is
+  blanked, nothing leaks — a `zwp_idle_inhibitor` is destroyed with the `wl_surface` it was created
+  on, and a client's surfaces die with its Wayland connection. 83544dedb ("feat(idle): a
+  deliberately blanked monitor holds the keep-awake").
 
 ## State propagation is reactive, or it is a bug waiting
 

--- a/docs/p3drovfx-research-2026-08-16.md
+++ b/docs/p3drovfx-research-2026-08-16.md
@@ -496,6 +496,15 @@ them:
 - `modules/common/PanelSchedule.qml` (42) + the `PanelLoader` ticket gate. Pure
   scheduling; touches nothing visual.
 - ~~`modules/ii/oledSaver/OledSaver.qml` (178)~~ — **not a port at all; see §2.4.**
+  **Landed.** All three deltas are closed against our own module, with nothing
+  taken from theirs: a `GlobalShortcut` bound to `CTRL+SUPER+L`, a per-monitor
+  state list beside the all-screens idle flag, and an idle inhibitor held only
+  by the deliberate path. The one thing the survey did not predict is that the
+  inhibitor must *not* be held by the idle path, which their single-mode saver
+  has no way to express. afb1c7ea5 ("feat(screensaver): blank one named
+  monitor, not every screen"), a6c57a0b2 ("feat(screensaver): give the
+  on-demand blank a key that reaches it"), 83544dedb ("feat(idle): a
+  deliberately blanked monitor holds the keep-awake").
   We already have the module, and it is the same shape: one `GlobalStates`
   property, a `Variants` blackout window, an `IpcHandler`. Dropping their file in
   would ship a second screensaver. What is worth taking is the two pieces ours
@@ -614,7 +623,7 @@ Ordered by value to the user per unit of work. Sizes are new-code estimates for
 | 9 | **EasyEffects state verification** | Fixes a toggle of ours that lies when the launch fails | Tiny, ~70-line diff |
 | 10 | **Local plugin registration + reload IPC verb** | The friction that keeps third-party widgets from existing; does not weaken our installer's security model | Small-medium, ~200 lines |
 | 11 | **Idle: timed keep-awake sessions** | Composes with our `autoOnExternalMonitor`; the absolute-epoch-deadline detail is worth copying verbatim | Small, ~180 net-new + chips UI |
-| 12 | **OLED saver: finish the one we have** (§2.4) | Not a new module — bind a key to the `show`/`hide`/`toggle` verbs `modules/imi/screensaver/` already exposes, let it target one monitor instead of all of them, and give it an idle inhibitor so a deliberate blank does not fall through hypridle's lock/DPMS/suspend ladder. Ranked here, not at 8: that rank priced it as a new module on a survey row that wrongly read "none" | Small, ~80–120 lines against an existing module |
+| 12 | ~~**OLED saver: finish the one we have**~~ (§2.4) — **done**, see below | Not a new module — bind a key to the `show`/`hide`/`toggle` verbs `modules/imi/screensaver/` already exposes, let it target one monitor instead of all of them, and give it an idle inhibitor so a deliberate blank does not fall through hypridle's lock/DPMS/suspend ladder. Ranked here, not at 8: that rank priced it as a new module on a survey row that wrongly read "none" | Small, ~80–120 lines against an existing module |
 | 13 | **`CommandsService` + a cheatsheet page** | A genuinely new feature with no equivalent anywhere in ours | Medium, ~550 lines |
 | 14 | **In-UI update log via `systemd-run`** | Solves the shell-kills-its-own-updater problem properly and removes hardcoded `kitty`/`fish`. Pair with an update-available indicator, which is *easier* for us since we keep a real checkout | Medium, ~330 lines |
 | 15 | **Scratchpad-empty overlay** | Cheapest self-contained module in their tree | Small, ~170 lines |

--- a/dots/.config/hypr/hypridle.conf
+++ b/dots/.config/hypr/hypridle.conf
@@ -12,6 +12,10 @@ general {
 # OLED screensaver (quickshell). Keep timeout in sync with Config.options.screensaver.timeout.
 # Must fire BEFORE the lock listener below (240 < 300) or lock supersedes it.
 # show() no-ops unless screensaver.enable is true, so this listener is safe to leave in place.
+# This is the idle path, and it holds no idle inhibitor on purpose: the ladder
+# below is exactly what should happen once nobody is here. Blanking a monitor on
+# demand (CTRL+SUPER+L, or `ipc call screensaver toggleMonitor <name>`) does hold
+# one, so none of these listeners fire while a screen is deliberately dark.
 listener {
     timeout = 240 # 4mins (before lock at 5mins)
     on-timeout = qs -c imi ipc call screensaver show

--- a/dots/.config/hypr/hyprland/keybinds.lua
+++ b/dots/.config/hypr/hyprland/keybinds.lua
@@ -356,6 +356,8 @@ hl.bind("SUPER + ALT + Equal",
 
 --##! Session
 hl.bind("SUPER + L", hl.dsp.exec_cmd("loginctl lock-session"), { description = "Session: Lock" })
+hl.bind("CTRL + SUPER + L", hl.dsp.global("quickshell:screensaverToggleMonitor"),
+    { description = "Session: Blank the focused monitor (OLED screensaver)" })
 hl.bind("SUPER + SHIFT + L", hl.dsp.exec_cmd("systemctl suspend || loginctl suspend"),
     { locked = true, description = "Session: Sleep" }) -- Sleep
 -- hl.bind("switch:on:Lid Switch", hl.dsp.exec_cmd("systemctl suspend || loginctl suspend"), {locked = true} ) -- # [hidden] Suspend when laptop lid is closed, uncomment if for whatever reason it's not the default behavior

--- a/dots/.config/quickshell/imi/GlobalStates.qml
+++ b/dots/.config/quickshell/imi/GlobalStates.qml
@@ -15,7 +15,14 @@ Singleton {
     property bool sidebarRightOpen: false
     property bool mediaControlsOpen: false
     property bool sysTrayOverflowOpen: false
+    // The idle path: hypridle's listener blanks every screen, and the ladder
+    // behind it (lock, DPMS, suspend) is meant to keep running underneath.
     property bool screensaverActive: false
+    // The deliberate path: monitor names the user blacked out on purpose. Kept
+    // apart from the flag above because only this one holds an idle inhibitor
+    // (services/Idle.qml) - blanking a panel to work on another must not walk
+    // the session into a lock, and going idle still must.
+    property var screensaverScreens: []
     property bool osdBrightnessOpen: false
     property bool settingsOpen: false
     property bool osdVolumeOpen: false

--- a/dots/.config/quickshell/imi/modules/imi/screensaver/Screensaver.qml
+++ b/dots/.config/quickshell/imi/modules/imi/screensaver/Screensaver.qml
@@ -4,12 +4,56 @@ import QtQuick
 import Quickshell
 import Quickshell.Io
 import Quickshell.Wayland
+import "screensaver_screens.js" as ScreensaverScreens
 
 Scope {
     id: root
 
-    property bool active: GlobalStates.screensaverActive
+    // Two ways in, and they are not the same thing.
+    //
+    // `screensaverActive` is the idle path: hypridle's 240s listener calls
+    // show(), every screen goes black, and the lock/DPMS/suspend ladder behind
+    // it (300/600/900s) must keep running - nobody is here.
+    //
+    // `screensaverScreens` is the deliberate path: the user named a monitor,
+    // so that monitor blacks out, the others are untouched, and an idle
+    // inhibitor is held (services/Idle.qml) so blanking a panel on purpose
+    // cannot walk the session into a lock or a suspend.
+    property bool idleActive: GlobalStates.screensaverActive
+    readonly property var deliberateScreens: GlobalStates.screensaverScreens
     readonly property string mode: Config.options.screensaver?.mode ?? "black"
+
+    function showOn(name: string): void {
+        GlobalStates.screensaverScreens = ScreensaverScreens.withScreen(root.deliberateScreens, name);
+    }
+
+    function hideOn(name: string): void {
+        GlobalStates.screensaverScreens = ScreensaverScreens.withoutScreen(root.deliberateScreens, name);
+    }
+
+    function toggleOn(name: string): void {
+        GlobalStates.screensaverScreens = ScreensaverScreens.toggledScreen(root.deliberateScreens, name);
+    }
+
+    function toggleAll(): void {
+        const next = ScreensaverScreens.toggledAll(root.deliberateScreens, Quickshell.screens.map(screen => screen.name), root.idleActive);
+        GlobalStates.screensaverActive = false;
+        GlobalStates.screensaverScreens = next;
+    }
+
+    Connections {
+        target: Quickshell
+
+        // An unplugged monitor's overlay goes away with its delegate, but its
+        // name would stay in the list - and the inhibitor derived from the list
+        // would be held for the rest of the session with nothing on screen to
+        // explain it.
+        function onScreensChanged(): void {
+            const live = ScreensaverScreens.pruned(root.deliberateScreens, Quickshell.screens.map(screen => screen.name));
+            if (live.length !== root.deliberateScreens.length)
+                GlobalStates.screensaverScreens = live;
+        }
+    }
 
     Variants { // One overlay surface per screen
         model: Quickshell.screens
@@ -17,17 +61,25 @@ Scope {
         delegate: Loader {
             id: screenLoader
             required property ShellScreen modelData
-            active: root.active
+            readonly property bool deliberate: ScreensaverScreens.isBlanked(root.deliberateScreens, modelData.name)
+            active: root.idleActive || screenLoader.deliberate
 
             sourceComponent: PanelWindow {
                 id: saverWindow
                 screen: screenLoader.modelData
                 visible: true
 
+                readonly property bool deliberate: screenLoader.deliberate
+
                 exclusionMode: ExclusionMode.Ignore
                 WlrLayershell.namespace: "quickshell:screensaver"
                 WlrLayershell.layer: WlrLayer.Overlay
-                WlrLayershell.keyboardFocus: WlrKeyboardFocus.Exclusive
+                // The idle saver takes the keyboard so any key wakes it and no
+                // keystroke leaks into whatever was focused. A deliberately
+                // blanked monitor must not: the whole point is that the user
+                // keeps typing on another screen, and an exclusive grab here
+                // would swallow that and dismiss itself on the first letter.
+                WlrLayershell.keyboardFocus: saverWindow.deliberate ? WlrKeyboardFocus.None : WlrKeyboardFocus.Exclusive
                 color: "transparent"
 
                 anchors {
@@ -49,9 +101,17 @@ Scope {
                     onTriggered: saverWindow.armed = true
                 }
 
-                function dismiss() {
+                function dismiss(pointerMotion: bool): void {
                     if (!saverWindow.armed)
                         return;
+                    // Motion alone does not take down a deliberate blank. The
+                    // user chose it and then has to move the pointer off that
+                    // monitor to get back to work, which is motion across this
+                    // very surface; a click or the keybind is the way out.
+                    if (pointerMotion && saverWindow.deliberate)
+                        return;
+                    if (saverWindow.deliberate)
+                        root.hideOn(screenLoader.modelData.name);
                     GlobalStates.screensaverActive = false;
                 }
 
@@ -61,19 +121,19 @@ Scope {
                     focus: true
 
                     // Any input (once armed) dismisses; unloading resets the drift.
-                    Keys.onPressed: saverWindow.dismiss()
+                    Keys.onPressed: saverWindow.dismiss(false)
 
                     ScreensaverContent {
                         anchors.fill: parent
                         mode: root.mode
-                        active: root.active
+                        active: root.idleActive || saverWindow.deliberate
                     }
 
                     MouseArea {
                         anchors.fill: parent
                         hoverEnabled: true
-                        onPositionChanged: saverWindow.dismiss()
-                        onPressed: saverWindow.dismiss()
+                        onPositionChanged: saverWindow.dismiss(true)
+                        onPressed: saverWindow.dismiss(false)
                     }
                 }
             }
@@ -83,6 +143,8 @@ Scope {
     IpcHandler {
         target: "screensaver"
 
+        // The idle path. hypridle drives exactly these two and neither touches
+        // the deliberate list, so neither takes an inhibitor.
         function show(): void {
             if (!(Config.options.screensaver?.enable ?? false))
                 return;
@@ -91,13 +153,24 @@ Scope {
 
         function hide(): void {
             GlobalStates.screensaverActive = false;
+            GlobalStates.screensaverScreens = [];
         }
 
+        // The deliberate path.
         function toggle(): void {
-            if (GlobalStates.screensaverActive)
-                GlobalStates.screensaverActive = false;
-            else if (Config.options.screensaver?.enable ?? false)
-                GlobalStates.screensaverActive = true;
+            root.toggleAll();
+        }
+
+        function showMonitor(name: string): void {
+            root.showOn(name);
+        }
+
+        function hideMonitor(name: string): void {
+            root.hideOn(name);
+        }
+
+        function toggleMonitor(name: string): void {
+            root.toggleOn(name);
         }
     }
 }

--- a/dots/.config/quickshell/imi/modules/imi/screensaver/Screensaver.qml
+++ b/dots/.config/quickshell/imi/modules/imi/screensaver/Screensaver.qml
@@ -2,6 +2,7 @@ import qs
 import qs.modules.common
 import QtQuick
 import Quickshell
+import Quickshell.Hyprland
 import Quickshell.Io
 import Quickshell.Wayland
 import "screensaver_screens.js" as ScreensaverScreens
@@ -138,6 +139,15 @@ Scope {
                 }
             }
         }
+    }
+
+    // Deliberate, so it is not gated on screensaver.enable: that switch arms
+    // the idle trigger in hypridle.conf, and swallowing a key the user just
+    // pressed would be a silent no-op with nothing to explain it.
+    GlobalShortcut {
+        name: "screensaverToggleMonitor"
+        description: "Blanks the focused monitor (OLED screensaver)"
+        onPressed: root.toggleOn(Hyprland.focusedMonitor?.name ?? "")
     }
 
     IpcHandler {

--- a/dots/.config/quickshell/imi/modules/imi/screensaver/screensaver_screens.js
+++ b/dots/.config/quickshell/imi/modules/imi/screensaver/screensaver_screens.js
@@ -1,0 +1,48 @@
+.pragma library
+
+// The set of monitors the screensaver's on-demand path is deliberately holding
+// black. It lives here rather than inline in Screensaver.qml because a Scope
+// built out of Quickshell types cannot be constructed by qmltestrunner, while
+// every way this state can go wrong is plain set arithmetic: a name added
+// twice, a monitor unplugged while it is blanked, a "blank everything" that
+// only half applies.
+
+function isBlanked(screens, name) {
+    return !!name && screens.indexOf(name) !== -1;
+}
+
+function withScreen(screens, name) {
+    if (!name || isBlanked(screens, name))
+        return screens.slice();
+    return screens.concat([name]);
+}
+
+function withoutScreen(screens, name) {
+    return screens.filter(function (each) {
+        return each !== name;
+    });
+}
+
+function toggledScreen(screens, name) {
+    if (!name)
+        return screens.slice();
+    return isBlanked(screens, name) ? withoutScreen(screens, name) : withScreen(screens, name);
+}
+
+// "Blank every screen" is the same list with every name in it, so the
+// all-screens verb needs no second flag that could disagree with this one.
+// It still has to see the idle flag: an idle-raised saver is on screen while
+// this list is empty, and a toggle that ignored it would answer "everything is
+// already black" with "black everything" instead of taking it down.
+function toggledAll(screens, allNames, idleActive) {
+    return (idleActive || screens.length > 0) ? [] : allNames.slice();
+}
+
+// A monitor unplugged while blanked takes its overlay with it, but its name
+// would sit in this list forever - and the idle inhibitor derived from the
+// list would be held forever with it.
+function pruned(screens, liveNames) {
+    return screens.filter(function (each) {
+        return liveNames.indexOf(each) !== -1;
+    });
+}

--- a/dots/.config/quickshell/imi/modules/imi/settings/pages/LockIdleConfig.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/pages/LockIdleConfig.qml
@@ -175,6 +175,7 @@ ContentPage {
                 ConfigSwitch {
                     buttonIcon: "bedtime"
                     text: Translation.tr("Enable OLED screensaver")
+                    description: Translation.tr("Blanks every screen once the session goes idle. Blanking the focused monitor by keybind works either way, and keeps the system awake while that screen is dark")
                     checked: Config.options.screensaver.enable
                     onToggleRequested: Config.options.screensaver.enable = !Config.options.screensaver.enable
                 }

--- a/dots/.config/quickshell/imi/services/Idle.qml
+++ b/dots/.config/quickshell/imi/services/Idle.qml
@@ -1,4 +1,5 @@
 pragma Singleton
+import qs
 import qs.modules.common
 import qs.services
 import QtQuick
@@ -9,7 +10,7 @@ import "../modules/common/functions/monitorDetection.js" as MonitorDetection
 /**
  * Keep-awake (idle inhibitor) state.
  *
- * Two inputs are ORed into the actual Wayland inhibitor:
+ * Three inputs are ORed into the actual Wayland inhibitor:
  * - `inhibit`: the manual "Keep system awake" toggle (persisted per Hyprland
  *   instance via Persistent.states.idle.inhibit).
  * - auto keep-awake (ported from end-4/dots-hyprland PR #2109): while
@@ -19,6 +20,9 @@ import "../modules/common/functions/monitorDetection.js" as MonitorDetection
  *   switching it off while a monitor is connected is honored (no forced
  *   re-toggle); the automatic part is stopped by unplugging the monitor or
  *   disabling the config option.
+ * - `screensaverHold`: a monitor the user deliberately blanked. Each input owns
+ *   its own bit and none of them writes another's, so a deliberate blank cannot
+ *   flip the manual toggle back on the way out.
  */
 Singleton {
     id: root
@@ -30,7 +34,21 @@ Singleton {
     readonly property bool autoOnExternalMonitor: Config.options.idleInhibitor.autoOnExternalMonitor
     readonly property bool hasExternalMonitor: MonitorDetection.hasExternal(Quickshell.screens.map(s => s.name))
     readonly property bool autoInhibitActive: root.autoOnExternalMonitor && root.hasExternalMonitor
-    readonly property bool effectiveInhibit: root.inhibit || root.autoInhibitActive
+
+    // A monitor blanked on purpose keeps hypridle's ladder (lock 300s, DPMS off
+    // 600s, suspend 900s) from running out from under a user who is working on
+    // another screen. An *idle*-raised screensaver deliberately holds nothing:
+    // there the ladder is the point.
+    //
+    // Derived from the screen list rather than stored as a flag the screensaver
+    // sets and clears, because a stored bit has a release path to get wrong and
+    // this has none. If the shell dies while a monitor is blanked the inhibitor
+    // goes with it either way - a zwp_idle_inhibitor is destroyed with the
+    // wl_surface it was created on, and the client's surfaces die with the
+    // connection, so the compositor drops the inhibit without anyone asking.
+    readonly property bool screensaverHold: GlobalStates.screensaverScreens.length > 0
+
+    readonly property bool effectiveInhibit: root.inhibit || root.autoInhibitActive || root.screensaverHold
 
     onAutoInhibitActiveChanged: {
         // Only announce when the automatic part actually changes the effective

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -895,6 +895,12 @@ if ! python3 "$SCRIPT_DIR/test_dropshelf_summon.py"; then
     exit 1
 fi
 
+echo "Running screensaver on-demand tests..."
+if ! python3 "$SCRIPT_DIR/test_screensaver_on_demand.py"; then
+    echo "Screensaver on-demand tests failed."
+    exit 1
+fi
+
 echo "Running event-loop safety tests..."
 if ! python3 "$SCRIPT_DIR/test_event_loop_safety_contract.py"; then
     echo "Event-loop safety tests failed."

--- a/dots/.config/quickshell/imi/tests/test_screensaver_on_demand.py
+++ b/dots/.config/quickshell/imi/tests/test_screensaver_on_demand.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""The screensaver's on-demand path: a key that reaches it, one monitor at a
+time, and an idle inhibitor while a screen is deliberately dark.
+
+Every one of these fails silently. An IPC verb nothing binds is a feature the
+user cannot reach; a per-monitor blank that regresses the idle path leaves the
+lock ladder wired to nothing; and an inhibitor acquired without a release path
+keeps the machine awake for the rest of the session with nothing on screen to
+explain it. None of it is reachable from qmltestrunner - the module is a Scope
+of Quickshell types - so the wiring is pinned as a source contract and the set
+arithmetic behind it lives in screensaver_screens.js (tst_screensaver_screens).
+"""
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HYPR = ROOT.parents[1] / "hypr"
+
+SAVER = ROOT / "modules/imi/screensaver/Screensaver.qml"
+IDLE = ROOT / "services/Idle.qml"
+STATES = ROOT / "GlobalStates.qml"
+KEYBINDS = HYPR / "hyprland/keybinds.lua"
+HYPRIDLE = HYPR / "hypridle.conf"
+
+SHORTCUT = "screensaverToggleMonitor"
+
+
+def qml_function_body(src, name):
+    """The body of `function <name>(...)` - brace matched, so a check about one
+    verb cannot accidentally read its neighbour's body."""
+    match = re.search(r"function\s+%s\s*\([^)]*\)\s*(?::\s*\w+\s*)?\{" % re.escape(name), src)
+    assert match, f"no function {name}"
+    depth, start = 0, match.end() - 1
+    for i in range(start, len(src)):
+        if src[i] == "{":
+            depth += 1
+        elif src[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start + 1:i]
+    raise AssertionError(f"unterminated body for {name}")
+
+
+def lua_bind_chunks(src):
+    """(chord, chunk) for every `hl.bind("<chord>", ...)` in the file. `chunk`
+    runs to the next bind, so a flag or dispatcher belonging to one bind is
+    never read as another's."""
+    chunks = []
+    parts = src.split("hl.bind(")[1:]
+    for part in parts:
+        chord = re.match(r'\s*"([^"]*)"', part)
+        if chord:
+            chunks.append((chord.group(1), part))
+    return chunks
+
+
+class TheVerbsExist(unittest.TestCase):
+    def setUp(self):
+        self.saver = SAVER.read_text()
+
+    def test_the_ipc_handler_still_answers_to_screensaver(self):
+        self.assertIn('target: "screensaver"', self.saver)
+
+    def test_the_idle_verbs_are_unchanged(self):
+        for verb in ("function show(): void", "function hide(): void"):
+            self.assertIn(verb, self.saver)
+
+    def test_a_monitor_can_be_named(self):
+        for verb in ("function showMonitor(name: string): void",
+                     "function hideMonitor(name: string): void",
+                     "function toggleMonitor(name: string): void"):
+            self.assertIn(verb, self.saver,
+                          "the per-monitor path has no IPC verb, so nothing "
+                          "but the keybind can reach one screen")
+
+    def test_the_per_monitor_verbs_write_the_screen_list(self):
+        for verb, call in (("showMonitor", "root.showOn(name)"),
+                           ("hideMonitor", "root.hideOn(name)"),
+                           ("toggleMonitor", "root.toggleOn(name)")):
+            self.assertIn(call, qml_function_body(self.saver, verb))
+
+
+class TheKeybindExists(unittest.TestCase):
+    def setUp(self):
+        self.saver = SAVER.read_text()
+        self.keybinds = KEYBINDS.read_text()
+
+    def test_the_module_declares_a_global_shortcut(self):
+        self.assertIn(f'name: "{SHORTCUT}"', self.saver,
+                      "the IPC verbs shipped with nothing bound to them - the "
+                      "gap this closes; a GlobalShortcut is how every other "
+                      "module here is reachable from a key")
+
+    def test_the_companion_config_binds_it(self):
+        self.assertIn(f"quickshell:{SHORTCUT}", self.keybinds,
+                      "a GlobalShortcut with no hl.bind() is as unreachable as "
+                      "the IPC verbs were")
+
+    def test_it_ships_bound_with_a_description(self):
+        # Bound, not left for the user to discover: an unbound default is the
+        # gap. Described, so it appears in the cheatsheet and in the keyboard
+        # shortcuts editor, which is where a collision gets resolved.
+        chords = [c for c, chunk in lua_bind_chunks(self.keybinds)
+                  if f"quickshell:{SHORTCUT}" in chunk]
+        self.assertEqual(len(chords), 1, f"expected one bind, got {chords}")
+        chunk = next(chunk for c, chunk in lua_bind_chunks(self.keybinds)
+                     if f"quickshell:{SHORTCUT}" in chunk)
+        self.assertIn("description =", chunk)
+
+    def test_the_chord_it_takes_is_not_already_taken(self):
+        # "Check what is already taken" as a check rather than as a note. The
+        # loop-generated binds are covered by the sibling test below.
+        chords = [c for c, _ in lua_bind_chunks(self.keybinds)]
+        ours = next(c for c, chunk in lua_bind_chunks(self.keybinds)
+                    if f"quickshell:{SHORTCUT}" in chunk)
+        self.assertEqual(chords.count(ours), 1,
+                         f"{ours} is bound {chords.count(ours)} times")
+
+    def test_no_generated_bind_can_produce_that_chord(self):
+        # Several binds are built by concatenation in a loop
+        # (`"SUPER + " .. arrowkey[i]`), so a literal scan cannot see them. What
+        # they append comes from table literals in the same file, and every one
+        # of those is a direction, a keypad code or a digit - never a bare
+        # letter. If that stops holding, this chord needs re-checking by hand.
+        tables = re.findall(r"\{\s*(\"[^\"]*\"(?:\s*,\s*\"[^\"]*\")*)\s*\}",
+                            self.keybinds)
+        suffixes = {s.strip().strip('"') for table in tables
+                    for s in table.split(",")}
+        ours = next(c for c, chunk in lua_bind_chunks(self.keybinds)
+                    if f"quickshell:{SHORTCUT}" in chunk)
+        key = ours.rsplit("+", 1)[-1].strip()
+        self.assertNotIn(key, suffixes,
+                         f"a generated bind appends {key!r}, so {ours} may "
+                         "already be taken")
+
+    def test_the_key_blanks_the_focused_monitor(self):
+        # Focused, not "under the cursor": every other per-monitor surface here
+        # (the OSDs, the desktop menu, the screen translator, the session
+        # screen) resolves Hyprland.focusedMonitor, and a screensaver that
+        # picked a different monitor than the rest of the shell would be its
+        # own rule to remember.
+        shortcut = self.saver[self.saver.index(f'name: "{SHORTCUT}"'):]
+        shortcut = shortcut[:shortcut.index("IpcHandler")]
+        self.assertIn("Hyprland.focusedMonitor?.name", shortcut)
+        self.assertIn("root.toggleOn(", shortcut)
+
+    def test_the_key_is_not_gated_on_the_idle_switch(self):
+        # screensaver.enable arms hypridle's listener. Gating a key the user
+        # just pressed on it would be a silent no-op with nothing to explain it,
+        # so the gate belongs in show() and nowhere else.
+        self.assertIn("Config.options.screensaver?.enable",
+                      qml_function_body(self.saver, "show"))
+        self.assertEqual(self.saver.count("screensaver?.enable"), 1)
+
+
+class TheInhibitorIsAcquiredAndReleased(unittest.TestCase):
+    def setUp(self):
+        self.idle = IDLE.read_text()
+        self.saver = SAVER.read_text()
+        self.states = STATES.read_text()
+
+    def test_the_state_the_hold_derives_from_exists(self):
+        self.assertIn("property var screensaverScreens: []", self.states)
+
+    def test_the_hold_is_ored_into_the_one_inhibitor(self):
+        # One inhibitor, not a second IdleInhibitor of our own: Idle.qml's
+        # window carries a comment about a 0x0 surface mapping unreliably, and
+        # a second copy would have to re-learn that.
+        self.assertIn("root.inhibit || root.autoInhibitActive || root.screensaverHold",
+                      self.idle)
+        self.assertEqual(self.idle.count("IdleInhibitor {"), 1)
+
+    def test_the_hold_is_derived_and_so_has_no_release_path_to_forget(self):
+        self.assertIn(
+            "readonly property bool screensaverHold: GlobalStates.screensaverScreens.length > 0",
+            self.idle)
+        # A writer anywhere would make it a stored flag with a release path.
+        for tree in ("modules", "services", "panelFamilies"):
+            for path in (ROOT / tree).rglob("*.qml"):
+                if path.is_file():
+                    self.assertNotIn("screensaverHold =", path.read_text(), str(path))
+
+    def test_it_does_not_fight_the_external_monitor_keep_awake(self):
+        # Each input owns exactly one bit. toggleInhibit must keep writing only
+        # the manual one, or a deliberate blank could flip the user's toggle.
+        toggle = qml_function_body(self.idle, "toggleInhibit")
+        self.assertNotIn("screensaverHold", toggle)
+        self.assertNotIn("autoInhibitActive", toggle)
+        self.assertIn("root.inhibit", toggle)
+        self.assertIn("root.autoOnExternalMonitor && root.hasExternalMonitor", self.idle)
+
+    def test_an_idle_raised_saver_holds_nothing(self):
+        # The whole reason the two paths are separate state: a saver raised
+        # because nobody is here must let the lock/DPMS/suspend ladder run.
+        self.assertNotIn("screensaverActive", self.idle)
+
+    def test_dismissing_a_deliberate_blank_releases_it(self):
+        dismiss = qml_function_body(self.saver, "dismiss")
+        self.assertIn("root.hideOn(screenLoader.modelData.name)", dismiss)
+
+    def test_the_idle_resume_verb_releases_it_too(self):
+        self.assertIn("GlobalStates.screensaverScreens = []",
+                      qml_function_body(self.saver, "hide"))
+
+    def test_an_unplugged_monitor_releases_it(self):
+        # The delegate goes with the screen; the name would not, and the hold
+        # is derived from the name.
+        prune = qml_function_body(self.saver, "onScreensChanged")
+        self.assertIn("ScreensaverScreens.pruned", prune)
+        self.assertIn("GlobalStates.screensaverScreens = live", prune)
+
+
+class ThePerMonitorPathDoesNotRegressTheIdlePath(unittest.TestCase):
+    def setUp(self):
+        self.saver = SAVER.read_text()
+        self.hypridle = HYPRIDLE.read_text()
+
+    def test_there_is_still_one_surface_per_screen(self):
+        self.assertIn("model: Quickshell.screens", self.saver)
+
+    def test_the_idle_flag_still_raises_every_one_of_them(self):
+        self.assertIn("active: root.idleActive || screenLoader.deliberate", self.saver)
+
+    def test_show_still_blanks_everything_and_names_no_monitor(self):
+        show = qml_function_body(self.saver, "show")
+        self.assertIn("GlobalStates.screensaverActive = true", show)
+        self.assertNotIn("screensaverScreens", show,
+                         "the idle verb must not enter the deliberate list, or "
+                         "going idle would hold the inhibitor that stops the "
+                         "session ever reaching the lock")
+
+    def test_hypridle_still_drives_those_two_verbs(self):
+        self.assertIn("ipc call screensaver show", self.hypridle)
+        self.assertIn("ipc call screensaver hide", self.hypridle)
+
+    def test_the_screensaver_still_fires_before_the_lock(self):
+        timeouts = [int(t) for t in re.findall(r"timeout\s*=\s*(\d+)", self.hypridle)]
+        self.assertEqual(timeouts[0], 240)
+        self.assertLess(timeouts[0], timeouts[1])
+
+    def test_only_the_idle_saver_takes_the_keyboard(self):
+        # A deliberately blanked monitor with an exclusive keyboard grab would
+        # swallow what the user types on the screen they moved to - and dismiss
+        # itself on the first letter, which is the opposite of the feature.
+        self.assertIn(
+            "WlrLayershell.keyboardFocus: saverWindow.deliberate "
+            "? WlrKeyboardFocus.None : WlrKeyboardFocus.Exclusive",
+            self.saver)
+
+    def test_pointer_drift_does_not_take_down_a_deliberate_blank(self):
+        # Getting back to work means moving the pointer off that monitor, which
+        # is motion across this very surface.
+        dismiss = qml_function_body(self.saver, "dismiss")
+        self.assertIn("if (pointerMotion && saverWindow.deliberate)", dismiss)
+        self.assertIn("onPositionChanged: saverWindow.dismiss(true)", self.saver)
+        self.assertIn("onPressed: saverWindow.dismiss(false)", self.saver)
+
+    def test_the_backdrop_is_still_black_on_both_paths(self):
+        content = (ROOT / "modules/imi/screensaver/ScreensaverContent.qml").read_text()
+        self.assertIn('color: "black"', content)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dots/.config/quickshell/imi/tests/tst_screensaver_screens.qml
+++ b/dots/.config/quickshell/imi/tests/tst_screensaver_screens.qml
@@ -1,0 +1,84 @@
+import QtTest
+import "../modules/imi/screensaver/screensaver_screens.js" as Saver
+
+// The set of monitors the screensaver is deliberately holding black. Everything
+// that reads it - which overlay maps, and whether services/Idle.qml holds an
+// idle inhibitor - is a question about this list, so the list is where the
+// arithmetic is checked.
+TestCase {
+    name: "ScreensaverScreensTest"
+
+    function test_a_named_monitor_goes_in_and_comes_back_out() {
+        const one = Saver.withScreen([], "DP-1");
+        compare(one, ["DP-1"]);
+        verify(Saver.isBlanked(one, "DP-1"));
+        verify(!Saver.isBlanked(one, "DP-2"));
+        compare(Saver.withoutScreen(one, "DP-1"), []);
+    }
+
+    function test_the_other_monitors_are_left_alone() {
+        // The whole point of the deliberate path: one panel dark, the rest not.
+        const one = Saver.withScreen(["DP-1", "HDMI-A-1"], "DP-2");
+        compare(one.length, 3);
+        const back = Saver.withoutScreen(one, "DP-2");
+        compare(back, ["DP-1", "HDMI-A-1"]);
+    }
+
+    function test_showing_a_monitor_twice_does_not_double_it() {
+        // Two presses of `showMonitor` must not need two `hideMonitor`s, or the
+        // inhibitor stays held after the screen has already come back.
+        const twice = Saver.withScreen(Saver.withScreen([], "DP-1"), "DP-1");
+        compare(twice, ["DP-1"]);
+        compare(Saver.withoutScreen(twice, "DP-1"), []);
+    }
+
+    function test_an_empty_name_is_not_a_monitor() {
+        // Hyprland.focusedMonitor is null for a moment after a hotplug, and the
+        // keybind resolves that to "". Blanking a screen called "" would hold
+        // the inhibitor against a surface that can never be dismissed.
+        compare(Saver.withScreen([], ""), []);
+        compare(Saver.toggledScreen([], ""), []);
+        verify(!Saver.isBlanked([""], ""));
+    }
+
+    function test_toggle_answers_the_state_it_is_given() {
+        compare(Saver.toggledScreen([], "DP-1"), ["DP-1"]);
+        compare(Saver.toggledScreen(["DP-1"], "DP-1"), []);
+        compare(Saver.toggledScreen(["DP-2"], "DP-1"), ["DP-2", "DP-1"]);
+    }
+
+    function test_toggle_all_blanks_everything_or_takes_it_all_down() {
+        const all = ["DP-1", "DP-2"];
+        compare(Saver.toggledAll([], all, false), all);
+        compare(Saver.toggledAll(["DP-1"], all, false), []);
+    }
+
+    function test_toggle_all_takes_down_an_idle_raised_saver() {
+        // An idle-raised saver is on screen while this list is empty. A toggle
+        // that only looked at the list would answer a black screen by blanking
+        // every screen again, and the user's key would read as doing nothing.
+        compare(Saver.toggledAll([], ["DP-1", "DP-2"], true), []);
+    }
+
+    function test_an_unplugged_monitor_stops_holding_the_inhibitor() {
+        const blanked = ["DP-1", "DP-2"];
+        compare(Saver.pruned(blanked, ["DP-1"]), ["DP-1"]);
+        compare(Saver.pruned(blanked, []), []);
+        // A monitor still present is not pruned, or every hotplug would clear
+        // a deliberate blank on an unrelated screen.
+        compare(Saver.pruned(blanked, ["DP-1", "DP-2", "HDMI-A-1"]), blanked);
+    }
+
+    function test_none_of_it_mutates_the_list_it_was_given() {
+        // These feed a GlobalStates property write. Mutating in place would
+        // change the value without raising its changed signal, so the overlays
+        // and the inhibitor would both keep reading the old set.
+        const original = ["DP-1"];
+        Saver.withScreen(original, "DP-2");
+        Saver.withoutScreen(original, "DP-1");
+        Saver.toggledScreen(original, "DP-1");
+        Saver.toggledAll(original, ["DP-1", "DP-2"], false);
+        Saver.pruned(original, []);
+        compare(original, ["DP-1"]);
+    }
+}


### PR DESCRIPTION
The screensaver module has shipped for a while as a true-black OLED blackout with two modes, an arming timer, config, a settings row, and `show`/`hide`/`toggle` IPC verbs. Three things were missing, and each made a different part of it unusable.

## 1. Nothing bound the IPC verbs

There was no `GlobalShortcut` in the module and no `screensaver` binding anywhere in `dots/.config/hypr/`. The only caller was `hypridle.conf`'s 240s listener, so the on-demand path existed and could not be reached.

It is declared the way every other module here declares one — a named `GlobalShortcut`, bound from `keybinds.lua` with `hl.dsp.global(...)` — rather than an `exec_cmd` firing `qs ipc call`, which spawns a process per press.

**It ships bound, on `CTRL+SUPER+L`.** An unbound default leaves the feature exactly as reachable as it is today, which is the gap. The chord was checked against every `hl.bind` in the shipped config rather than assumed free: `SUPER+L` is Lock and `SUPER+SHIFT+L` is Sleep, so the session group is where it belongs and `CTRL+SUPER+L` is the free neighbour. A user whose own `custom/keybinds.lua` claims it has the keyboard-shortcuts editor, which exists for exactly this collision. The check is mechanized rather than promised: `test_screensaver_on_demand.py` asserts the chord appears exactly once across every bind in the file, and — because several binds are generated by concatenation in a loop, which a literal scan cannot see — a sibling check reads every table literal in the file and fails if any of them appends a bare letter.

**Focused monitor, not under the cursor.** Every other per-monitor surface in this shell resolves `Hyprland.focusedMonitor` (the OSDs, the desktop menu, the screen translator, the session screen, brightness). A saver that picked differently would be one more rule to remember for no gain. A named monitor stays reachable from `ipc call screensaver toggleMonitor <name>`.

**Not gated on `screensaver.enable`.** That switch arms the idle listener; a key the user just pressed is an explicit request, and a silent no-op with nothing on screen to explain it is worse than either answer. The settings row now says which half it controls, so the switch stops reading as off while the feature works.

## 2. Every screen blanked together

The `Variants` over `Quickshell.screens` was already one surface per screen — what changed is the state driving it. `GlobalStates.screensaverScreens` is the list of monitors deliberately blanked; a screen's overlay maps when the idle flag is set **or** its name is in that list. The two are kept apart rather than collapsed into one list with everything in it, because only the deliberate path holds an inhibitor (below).

Two consequences that are not obvious from the state change, and are the reason this is more than a filter:

- **A deliberately blanked monitor must not take `WlrKeyboardFocus.Exclusive`.** That grab is session-wide, not per-output. It is right for the idle saver — any key wakes it, no keystroke leaks into whatever was focused — and exactly wrong here: it swallows what the user types on the screen they moved to, and a saver that dismisses on a keypress therefore dismisses itself on their first letter. `Exclusive` for the idle path, `None` for a deliberate blank.
- **Pointer motion does not dismiss a deliberate blank.** Getting back to work means moving the pointer *off* that monitor, which is motion across the surface being escaped. A click, the keybind, or `hide` takes it down.

The set arithmetic lives in `screensaver_screens.js` because a `Scope` of Quickshell types cannot be constructed by `qmltestrunner`, and every way this state goes wrong is a set operation: a name added twice (two shows needing two hides, so the inhibitor outlives the screen), a monitor unplugged while blanked (its delegate goes, its name does not), and a toggle-all that cannot see an idle-raised saver and answers a black screen by blacking it again.

## 3. No idle inhibitor

Blanking a screen on purpose walked straight into hypridle's ladder: lock at 300s, DPMS off at 600s, suspend at 900s, while the user sat there working on the other monitor.

- **Third bit ORed into the existing inhibitor**, not a second `IdleInhibitor`. `services/Idle.qml`'s inhibitor window carries a comment recording that a 0x0 surface mapped unreliably enough for Hyprland's ext-idle-notify to ignore the inhibitor and hibernate anyway; a second copy would re-learn that, and "is the system awake" would have two answers for the quick toggle to disagree with.
- **It does not fight `autoOnExternalMonitor`.** Each of the three inputs owns exactly one bit and writes no other — `toggleInhibit` still touches only the manual one — so a blank cannot flip the user's keep-awake toggle on the way out, and unplugging a monitor still stops only the automatic part.
- **Derived, not stored.** A stored flag has a release path to get wrong; a derivation from the blanked-screen list has none, because every way the saver comes down empties the list and emptying the list *is* the release. The paths are pinned by test: a click on a deliberate blank, the keybind, `hide` (hypridle's `on-resume`), and a monitor being unplugged.
- **If the shell dies while a screen is blanked, nothing leaks.** A `zwp_idle_inhibitor` is destroyed with the `wl_surface` it was created on, and a client's surfaces die with its Wayland connection, so the compositor drops the inhibit without anyone asking. That is the argument for an inhibitor over a `systemd-inhibit` child or a state file hypridle would have to be told to re-read.
- **An idle-raised saver still holds nothing**, which is the whole reason the two paths are separate state. At 240s with nobody there, the ladder underneath is exactly what should happen — holding the inhibitor on the idle path would mean the first rung of hypridle's ladder disables the rest of it, and walking away would never reach lock or suspend.

The accepted trade-off, stated plainly: a monitor left deliberately blanked keeps the session awake and unlocked indefinitely. That is the same semantics as the existing "Keep system awake" quick toggle, and deliberate is the whole distinction being drawn.

## Tests

- `tst_screensaver_screens.qml` — 11 checks driving the set arithmetic for real: dedup, an empty monitor name (what `Hyprland.focusedMonitor?.name ?? ""` yields for a moment after a hotplug, and a blanked screen called `""` could never be dismissed), the unplug prune, the idle-aware toggle-all, and that none of the operations mutates the array it was handed — these feed a property write whose changed signal is the only thing the overlays and the inhibitor observe.
- `test_screensaver_on_demand.py` — 27 checks in four groups matching the four things that were wrong: the verbs exist, the binding exists, the inhibitor is acquired and released on every path, and the per-monitor work has not regressed the all-screens idle path (`show()` must not enter the deliberate list, the delegates still follow the idle flag, hypridle still drives the two verbs, 240 still precedes 300).

Both were proven to fail on planted breakage — 12 mutations against the Python contract (shortcut renamed, chord unbound, chord collided with `SUPER+L`, hold dropped from the OR, hold made a stored flag, `hide()` stops releasing, the idle verb enters the deliberate list, the delegates stop following the idle flag, exclusive focus on a deliberate blank, prune removed, per-monitor verbs removed, the key gated on `enable`) and 4 against the JS module (dedup removed, prune neutered, toggle-all blinded to the idle flag, an in-place mutation). Each reddened exactly the intended check; the tree was clean for every plant.

**Suite: 778 passed, 0 failed** (`gh/main` baseline is 767; +11 QML checks). Every Python contract check green.

## Verified vs inferred

- **Verified:** the suite; a `qs -p` compile probe over `Screensaver.qml`, `ScreensaverContent.qml`, `GlobalStates.qml`, `Idle.qml` and `LockIdleConfig.qml` (`checked=5 failures=0`); a second live probe confirming `Quickshell` really emits `screensChanged` and that the `.js` module resolves and answers correctly at runtime; the mutation runs above.
- **Inferred, not driven:** the `CTRL+SUPER+L` bind itself. A keybind file is not live-tested by editing the running compositor's config, and blanking a screen or exercising the ladder on this machine was off the table. What is checked is that the chord is free across the shipped config and that the shortcut name on both sides matches; that the compositor delivers it is the same assumption every other `hl.dsp.global` bind here rests on. The keyboard-focus split and the inhibitor's effect on hypridle's ladder are likewise reasoned from the protocols and pinned by contract, not observed on screen.

Docs: updated AGENT.md §Layer-shell (wlr-layer-shell) gotchas — two new entries: an exclusive keyboard grab is session-wide so a per-monitor surface must not take it, and an idle inhibitor belongs to a feature's deliberate half and never its idle half. Also marked the OLED-saver row landed in docs/p3drovfx-research-2026-08-16.md.