### PR TITLE
Replace the double-ffplay sound hack with an XDG sound-theme engine

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -305,6 +305,58 @@ Four things around that are worth not re-deriving:
   both *and* whose 3×3 neighbourhood is uniform (which kills subpixel edges), and report RMSE plus
   what code 255 became.
 
+**A sound event is one `pw-play` on a path the shell resolved, and neither half of that sentence
+was true before.** `Audio.playSystemSound()` built
+`/usr/share/sounds/<theme>/stereo/<event>.oga` and the same with `.ogg`, spawned an `ffplay` at
+each, and let the wrong one fail silently. Measured against the six themes on this machine, that
+guess is wrong in four distinguishable ways at once, and none of them reaches a log: no theme ships
+both extensions for the same event, so the second spawn is *always* wasted (~50 ms, ~38 ms CPU,
+53 MiB peak, 165 shared objects mapped, to print `No such file or directory`); `oxygen` and
+`harmony2` are `.ogg`-only while the other four are `.oga`, so which of the two is the wasted one is
+a property of the theme; `Pop` declares `Directories=stereo/alert stereo/action stereo/notification`
+and keeps every file under those, so a hardcoded `stereo/` reached 0 of its 25 sounds and that theme
+was **entirely silent**; and with no `Inherits=` walk, `oxygen` — which ships neither `complete` nor
+`suspend-error` — lost the battery-charged chime and the suspend-failure alert even with
+`freedesktop` installed beside it. `~/.local/share/sounds` was never searched at all.
+
+Three things about the replacement generalise past sound.
+
+- **Playback stays a process spawn even though QtMultimedia works here.** Probed with `qml6`: it
+  decodes and plays a `.oga` fine. It also takes a bare QtQuick process from 65 MiB / 133 mapped
+  shared objects to **113 MiB / 238** and keeps it there for the life of the shell whether or not a
+  sound is ever played, writes a three-line ffmpeg `Input #0, ogg, from '<path>'` decode banner to
+  stderr on *every* play, and floods five multi-kilobyte `spaVisitChoice: parse error` lines from
+  PipeWire when the first player is constructed — all of it into the `log.log` this document tells
+  you to tail. A spawn is 6.3 ms of CPU, freed on exit, and is a command list a test can read. Prefer
+  the mechanism you can observe.
+- **`pw-play`, not `ffplay`, and the reason is dependency declaration rather than taste.** `pw-play`
+  ships in `pipewire-audio`, a hard dependency of the `pipewire-pulse` that `sdata/deps-info.md`
+  lists; `ffplay` comes from `ffmpeg`, which this repo installs only inside the Wallpaper Engine
+  build's dependency list and names nowhere as a shell dependency. It is also 7.4x cheaper (15
+  mapped libraries against 165). Before adding a `Process` command here, check `sdata/deps-info.md`
+  for the binary rather than for whether your machine happens to have it.
+- **The engine is three pieces so that the decisions are testable.** `scripts/sounds/
+  scan-sound-themes.py` reports what is on disk and judges nothing — it does not even filter by
+  extension, because "that file is not a sound" is a judgement and `ocean` ships
+  `power-unplug.oga.license` beside its sounds to catch anyone making it loosely.
+  `services/sound_theme.js` makes every decision and touches no disk. `services/SoundTheme.qml`
+  owns only the process lifetimes. That split is what lets `tests/tst_sound_theme.qml` cover the
+  `Inherits=` walk (breadth-first with a visited set, so a cycle terminates and a diamond is visited
+  once), the implicit fallback to the default theme, the per-theme subdirectory list, and the
+  `.disabled` marker — which stops the walk rather than falling through, since inheriting past it
+  plays a *wrong* sound rather than a missing one.
+
+`SoundTheme` is also a live instance of the "a singleton is constructed on first use" trap under
+[Runtime model](#runtime-model--read-this-before-assuming-anything-about-building-or-compiling): the
+only thing that reaches it is a `play()` call, so the theme scan has not *started* when the first
+sound is asked for. Measured with a `qs -p` probe — a `play()` from `Component.onCompleted` reports
+`ready=false pending=1`, and a moment later `ready=true pending=0` with one `pw-play` carrying the
+resolved path. It holds up to four events and flushes them from the scan's `onExited` rather than
+from a successful parse, so a scan that fails outright still clears the queue.
+8b31496c3 ("feat(sounds): a testable XDG sound-theme resolver"),
+cbd8e707e ("feat(sounds): scan the sound-theme roots into one catalogue"),
+a3a8f65cf ("fix(sounds): play one resolved file instead of two guessed ones").
+
 ## The suite checkout, and why the updater cannot just reset it
 
 `get.sh` keeps the whole suite in `~/.local/share/immaterial-impulse/src` (`Directories.suiteSrc`),
@@ -400,7 +452,15 @@ modules/imi/                 The "imi" (Immaterial Impulse) panel family - one d
   sessionScreen/, onScreenKeyboard/, wallpaperSelector/, verticalBar/, desktopMenu/
 
 services/                  Singletons wrapping external state/processes - one per concern:
-  Audio.qml                  PipeWire default sink/source wrapper (Quickshell.Services.Pipewire)
+  Audio.qml                  PipeWire default sink/source wrapper (Quickshell.Services.Pipewire).
+                              Devices and volume only - it does not play sounds
+  SoundTheme.qml             The shell's sound events, as an XDG sound-theme engine. Three pieces
+                              on purpose: scripts/sounds/scan-sound-themes.py reports what is on
+                              disk and decides nothing, services/sound_theme.js decides everything
+                              and touches no disk (event name -> file, the Inherits= walk, the
+                              subdirectory and extension rules, the .disabled marker), and this
+                              singleton owns the process lifetimes. Playback is a spawned
+                              `pw-play` - see "External binaries the shell drives"
   ResourceUsage.qml           Polls /proc/meminfo, /proc/stat, df, nvidia-smi on a timer
   HyprlandData.qml            Polls `hyprctl clients/monitors/layers/workspaces -j` on Hyprland IPC
                               events - the source of truth for "what does hyprctl currently see",

--- a/dots/.config/quickshell/imi/modules/common/Directories.qml
+++ b/dots/.config/quickshell/imi/modules/common/Directories.qml
@@ -82,6 +82,7 @@ Singleton {
     property string iconThemeApplyScriptPath: FileUtils.trimFileProtocol(`${Directories.scriptPath}/icons/apply-icon-theme.sh`)
     property string cursorThemeScanScriptPath: FileUtils.trimFileProtocol(`${Directories.scriptPath}/cursor/scan-cursor-themes.py`)
     property string cursorThemeApplyScriptPath: FileUtils.trimFileProtocol(`${Directories.scriptPath}/cursor/apply-cursor-theme.sh`)
+    property string soundThemeScanScriptPath: FileUtils.trimFileProtocol(`${Directories.scriptPath}/sounds/scan-sound-themes.py`)
     property string recordScriptPath: FileUtils.trimFileProtocol(`${Directories.scriptPath}/videos/record.sh`)
     property string userAvatarPathAccountsService: FileUtils.trimFileProtocol(`/var/lib/AccountsService/icons/${SystemInfo.username}`)
     property string userAvatarPathRicersAndWeirdSystems: FileUtils.trimFileProtocol(`${Directories.home}.face`)

--- a/dots/.config/quickshell/imi/modules/imi/settings/pages/GeneralConfig.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/pages/GeneralConfig.qml
@@ -313,6 +313,34 @@ ContentPage {
                     checked: Config.options.sounds.pomodoro
                     onToggleRequested: Config.options.sounds.pomodoro = !Config.options.sounds.pomodoro
                 }
+                ConfigComboBox {
+                    id: soundThemeCombo
+                    Layout.fillWidth: true
+                    buttonIcon: "graphic_eq"
+                    text: Translation.tr("Sound theme")
+                    description: Translation.tr("Where the shell's alert sounds come from. An event a theme does not ship falls back to the default theme.")
+                    fieldWidth: 240
+                    // A theme name the config holds that is no longer installed
+                    // still resolves (through the default theme), so it stays in
+                    // the list rather than being silently replaced by whatever
+                    // the picker would otherwise land on - ConfigComboBox lands
+                    // on index 0 for a value its model does not carry.
+                    model: {
+                        const installed = SoundTheme.themes.map(theme => ({
+                            displayName: theme.displayName,
+                            value: theme.id
+                        }));
+                        const stored = Config.options.sounds.theme;
+                        if (installed.some(theme => theme.value === stored))
+                            return installed;
+                        return [{ displayName: stored, value: stored }, ...installed];
+                    }
+                    textRole: "displayName"
+                    currentValue: Config.options.sounds.theme
+                    onSelected: newValue => {
+                        Config.options.sounds.theme = newValue;
+                    }
+                }
             }
         }
 

--- a/dots/.config/quickshell/imi/scripts/sounds/scan-sound-themes.py
+++ b/dots/.config/quickshell/imi/scripts/sounds/scan-sound-themes.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Report what is in the XDG sound-theme roots, as JSON. Decides nothing.
+
+Usage: scan-sound-themes.py [ROOT ...]
+Defaults to the standard sound roots when no ROOT is given.
+
+Output: {"roots": [...], "entries": [{theme, dir, index, files}, ...]} with the
+entries in root precedence order, so the same theme installed in two roots
+appears twice with the higher-precedence copy first.
+
+Every choice about the data - which subdirectory, which extension, when to walk
+an Inherits= chain, what a sidecar file is - belongs to services/sound_theme.js,
+which a test can reach. This script only says what exists. Deliberately no
+filtering by extension for the same reason: "that file is not a sound" is a
+judgement, and it is one the resolver already makes by building exact
+<event><extension> names.
+"""
+import json
+import os
+import sys
+
+# A sound theme is a few dozen small files. These bounds exist so a root that is
+# not what we think it is - a symlink into $HOME, a mount point - cannot turn a
+# startup scan into a filesystem crawl.
+MAX_FILES_PER_THEME = 4000
+MAX_DEPTH = 4
+MAX_INDEX_BYTES = 64 * 1024
+
+
+def default_roots():
+    home = os.path.expanduser("~")
+    data_home = os.environ.get("XDG_DATA_HOME") or os.path.join(home, ".local", "share")
+    data_dirs = os.environ.get("XDG_DATA_DIRS") or "/usr/local/share:/usr/share"
+    roots = [os.path.join(data_home, "sounds"), os.path.join(home, ".sounds")]
+    roots += [os.path.join(d, "sounds") for d in data_dirs.split(":") if d]
+    roots.append("/usr/share/sounds")
+    seen = set()
+    ordered = []
+    for root in roots:
+        if root not in seen:
+            seen.add(root)
+            ordered.append(root)
+    return ordered
+
+
+def read_index(theme_dir):
+    path = os.path.join(theme_dir, "index.theme")
+    try:
+        with open(path, "rb") as handle:
+            return handle.read(MAX_INDEX_BYTES).decode("utf-8", "replace")
+    except OSError:
+        return ""
+
+
+def list_files(theme_dir):
+    files = []
+    base_depth = theme_dir.rstrip("/").count("/")
+    for current, subdirs, names in os.walk(theme_dir, followlinks=False):
+        if current.rstrip("/").count("/") - base_depth >= MAX_DEPTH:
+            subdirs[:] = []
+        for name in names:
+            files.append(os.path.relpath(os.path.join(current, name), theme_dir))
+            if len(files) >= MAX_FILES_PER_THEME:
+                return sorted(files)
+    return sorted(files)
+
+
+def scan(roots):
+    entries = []
+    for root in roots:
+        if not os.path.isdir(root):
+            continue
+        try:
+            names = sorted(os.listdir(root))
+        except OSError:
+            continue
+        for name in names:
+            theme_dir = os.path.join(root, name)
+            if not os.path.isdir(theme_dir):
+                continue
+            entries.append({
+                "theme": name,
+                "dir": theme_dir,
+                "index": read_index(theme_dir),
+                "files": list_files(theme_dir),
+            })
+    return entries
+
+
+def main():
+    roots = sys.argv[1:] or default_roots()
+    json.dump({"roots": roots, "entries": scan(roots)}, sys.stdout)
+    sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/dots/.config/quickshell/imi/services/Audio.qml
+++ b/dots/.config/quickshell/imi/services/Audio.qml
@@ -16,7 +16,6 @@ Singleton {
     property PwNode sink: Pipewire.defaultAudioSink
     property PwNode source: Pipewire.defaultAudioSource
     readonly property real hardMaxValue: 2.00 // People keep joking about setting volume to 5172% so...
-    property string audioTheme: Config.options.sounds.theme
     property real value: sink?.audio.volume ?? 0
     
     function friendlyDeviceName(node) {
@@ -114,26 +113,4 @@ Singleton {
         }
     }
 
-    function playSystemSound(soundName) {
-        const ogaPath = `/usr/share/sounds/${root.audioTheme}/stereo/${soundName}.oga`;
-        const oggPath = `/usr/share/sounds/${root.audioTheme}/stereo/${soundName}.ogg`;
-
-        // Try playing .oga first
-        let command = [
-            "ffplay",
-            "-nodisp",
-            "-autoexit",
-            ogaPath
-        ];
-        Quickshell.execDetached(command);
-
-        // Also try playing .ogg (ffplay will just fail silently if file doesn't exist)
-        command = [
-            "ffplay",
-            "-nodisp",
-            "-autoexit",
-            oggPath
-        ];
-        Quickshell.execDetached(command);
-    }
 }

--- a/dots/.config/quickshell/imi/services/Battery.qml
+++ b/dots/.config/quickshell/imi/services/Battery.qml
@@ -100,7 +100,7 @@ Singleton {
             "--hint=int:transient:1",
         ])
 
-        if (root.soundEnabled) Audio.playSystemSound("dialog-warning");
+        if (root.soundEnabled) SoundTheme.play("dialog-warning");
     }
 
     onIsCriticalAndNotChargingChanged: {
@@ -114,7 +114,7 @@ Singleton {
             "--hint=int:transient:1",
         ]);
 
-        if (root.soundEnabled) Audio.playSystemSound("suspend-error");
+        if (root.soundEnabled) SoundTheme.play("suspend-error");
     }
 
     onIsSuspendingAndNotChargingChanged: {
@@ -133,15 +133,15 @@ Singleton {
             "--hint=int:transient:1",
         ]);
 
-        if (root.soundEnabled) Audio.playSystemSound("complete");
+        if (root.soundEnabled) SoundTheme.play("complete");
     }
 
     onIsPluggedInChanged: {
         if (!root.available || !root.soundEnabled) return;
         if (isPluggedIn) {
-            Audio.playSystemSound("power-plug")
+            SoundTheme.play("power-plug")
         } else {
-            Audio.playSystemSound("power-unplug")
+            SoundTheme.play("power-unplug")
         }
     }
 }

--- a/dots/.config/quickshell/imi/services/SoundTheme.qml
+++ b/dots/.config/quickshell/imi/services/SoundTheme.qml
@@ -1,0 +1,91 @@
+pragma Singleton
+
+import qs.modules.common
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import "sound_theme.js" as SoundThemeLogic
+
+/**
+ * The shell's sound events: an event name in, one XDG-resolved file played out.
+ *
+ * The split is deliberate and is the whole reason this is testable at all.
+ * `scripts/sounds/scan-sound-themes.py` reports what is on disk and decides
+ * nothing; `sound_theme.js` decides everything and touches no disk; this
+ * singleton owns the process lifetimes that neither of them can.
+ *
+ * Playback is a spawned `pw-play`, not an in-process QtMultimedia player, and
+ * that was measured rather than assumed. Importing QtMultimedia and playing one
+ * 223ms chime takes a bare QtQuick process from 65 MiB / 133 mapped shared
+ * objects to 113 MiB / 238 - permanently, for the life of the shell, whether or
+ * not the user ever enables a sound - and its ffmpeg backend prints a three-line
+ * decode banner to stderr per play, straight into the `log.log` that every
+ * debugging session here greps. A spawn costs 6ms of CPU, is freed on exit, and
+ * is a command list a test can read.
+ */
+Singleton {
+    id: root
+
+    property var catalogue: SoundThemeLogic.buildCatalogue(null)
+    property bool ready: false
+
+    readonly property var themes: SoundThemeLogic.selectableThemes(root.catalogue)
+    readonly property string activeTheme: Config.options.sounds.theme
+
+    // A singleton is constructed on first use, and the only thing that reaches
+    // this one is a `play()` call - so the scan has not even started when the
+    // first sound is asked for, and dropping it would silently lose whichever
+    // event happens to come first after a login. Held rather than dropped, and
+    // bounded rather than unbounded: the scan answers in ~20ms, so anything
+    // still arriving after four events has a problem a queue cannot fix.
+    property var pendingEvents: []
+    readonly property int maxPendingEvents: 4
+
+    function play(eventName) {
+        if (!SoundThemeLogic.isPlayableEventName(eventName))
+            return;
+        if (!root.ready) {
+            if (root.pendingEvents.length < root.maxPendingEvents)
+                root.pendingEvents = root.pendingEvents.concat([eventName]);
+            return;
+        }
+        const path = SoundThemeLogic.resolveEvent(root.catalogue, root.activeTheme, eventName);
+        if (path.length === 0)
+            return;
+        Quickshell.execDetached(["pw-play", path]);
+    }
+
+    function rescan() {
+        if (!scanProcess.running)
+            scanProcess.running = true;
+    }
+
+    Process {
+        id: scanProcess
+        running: true
+        command: ["python3", Directories.soundThemeScanScriptPath]
+        stdout: StdioCollector {
+            onStreamFinished: {
+                try {
+                    root.catalogue = SoundThemeLogic.buildCatalogue(JSON.parse(text));
+                } catch (error) {
+                    // No themes this session means silence, not a broken shell:
+                    // resolveEvent answers "" for every event against an empty
+                    // catalogue and play() drops it.
+                    console.warn("[SoundTheme] could not parse the theme scan:", error);
+                    root.catalogue = SoundThemeLogic.buildCatalogue(null);
+                }
+            }
+        }
+        // Flushed on exit rather than on a successful parse, so a scan that
+        // fails outright still clears the queue instead of holding events for
+        // the rest of the session.
+        onExited: {
+            root.ready = true;
+            const held = root.pendingEvents;
+            root.pendingEvents = [];
+            for (let i = 0; i < held.length; i++)
+                root.play(held[i]);
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/services/TimerService.qml
+++ b/dots/.config/quickshell/imi/services/TimerService.qml
@@ -65,7 +65,7 @@ Singleton {
 
             Quickshell.execDetached(["notify-send", "Pomodoro", notificationMessage, "-a", "Shell"]);
             if (Config.options.sounds.pomodoro) {
-                Audio.playSystemSound("alarm-clock-elapsed")
+                SoundTheme.play("alarm-clock-elapsed")
             }
 
             if (!pomodoroBreak) {

--- a/dots/.config/quickshell/imi/services/sound_theme.js
+++ b/dots/.config/quickshell/imi/services/sound_theme.js
@@ -1,0 +1,221 @@
+.pragma library
+
+// Pure XDG sound-theme resolution: event name -> file on disk.
+//
+// Everything that decides *which* file a sound event plays lives here, so the
+// rules are reachable from a test. The filesystem half is a dumb collector
+// (scripts/sounds/scan-sound-themes.py) that reports what exists; this module
+// makes every choice about it - which theme, which subdirectory, which
+// extension, and when to walk up an Inherits= chain.
+//
+// Spec: https://specifications.freedesktop.org/sound-theme-spec/
+
+// The theme every lookup falls back to. The spec calls it the default theme and
+// it is what the freedesktop package installs; a theme naming no Inherits= still
+// gets it, and so does a theme name that resolves to nothing at all.
+var DEFAULT_THEME = "freedesktop";
+
+// Extension precedence. `.disabled` is the spec's "this event is deliberately
+// silent" marker and must stop the walk rather than fall through to a parent -
+// otherwise a theme author's silence is overridden by an inherited sound, which
+// is a *wrong* sound rather than a missing one. `.oga` is not in the spec but is
+// what the freedesktop, ocean, Smooth and Pop themes actually ship.
+var EXTENSIONS = [".disabled", ".oga", ".ogg", ".wav"];
+
+// Used when a theme declares no Directories=. The empty entry is the theme root,
+// which is where a directory of loose files (no index.theme at all) keeps them.
+var FALLBACK_DIRECTORIES = ["stereo", ""];
+
+// A key list is comma-separated per the spec, but every installed theme on this
+// machine writes Directories= space-separated (Pop:
+// "stereo/alert stereo/action stereo/notification"). Accept both.
+function splitList(value) {
+    return String(value === undefined || value === null ? "" : value)
+        .replace(/,/g, " ")
+        .split(/\s+/)
+        .filter(function (part) {
+            return part.length > 0;
+        });
+}
+
+// Reads only the [Sound Theme] group. Localized keys (Name[de]=) are ignored on
+// purpose: nothing here should pick a theme's identity out of the user's locale,
+// and `valid` is what tells a directory of loose .wav files (/usr/share/sounds/alsa)
+// apart from a real theme.
+function parseIndexTheme(text) {
+    var result = {
+        valid: false,
+        name: "",
+        directories: [],
+        inherits: []
+    };
+    var lines = String(text === undefined || text === null ? "" : text).split(/\r\n|\r|\n/);
+    var inSection = false;
+    for (var i = 0; i < lines.length; i++) {
+        var line = lines[i].trim();
+        if (line.length === 0 || line.charAt(0) === "#")
+            continue;
+        if (line.charAt(0) === "[") {
+            inSection = (line === "[Sound Theme]");
+            if (inSection)
+                result.valid = true;
+            continue;
+        }
+        if (!inSection)
+            continue;
+        var eq = line.indexOf("=");
+        if (eq < 0)
+            continue;
+        var key = line.slice(0, eq).trim();
+        var value = line.slice(eq + 1).trim();
+        if (key === "Name")
+            result.name = value;
+        else if (key === "Directories")
+            result.directories = splitList(value);
+        else if (key === "Inherits")
+            result.inherits = splitList(value);
+    }
+    return result;
+}
+
+// Folds the scanner's flat entry list into one record per theme name.
+//
+// `scan.entries` arrives in search-root precedence order (XDG_DATA_HOME first,
+// /usr/share/sounds last), and a theme present in two roots keeps both entries in
+// that order - so a theme dropped into ~/.local/share/sounds shadows the system
+// copy file by file rather than only when it is complete.
+function buildCatalogue(scan) {
+    var catalogue = {
+        themes: {},
+        names: []
+    };
+    var entries = (scan && scan.entries) || [];
+    for (var i = 0; i < entries.length; i++) {
+        var raw = entries[i];
+        var name = String((raw && raw.theme) || "");
+        if (name.length === 0)
+            continue;
+        var theme = catalogue.themes[name];
+        if (!theme) {
+            theme = {
+                name: name,
+                displayName: "",
+                valid: false,
+                inherits: [],
+                entries: []
+            };
+            catalogue.themes[name] = theme;
+            catalogue.names.push(name);
+        }
+        var meta = parseIndexTheme(raw.index);
+        // The highest-precedence copy carrying an index.theme owns the theme's
+        // identity and its parents; a system copy does not get to re-parent a
+        // theme the user has overridden.
+        if (!theme.valid && meta.valid) {
+            theme.valid = true;
+            theme.displayName = meta.name;
+            theme.inherits = meta.inherits;
+        }
+        var files = {};
+        var list = (raw && raw.files) || [];
+        for (var f = 0; f < list.length; f++)
+            files[String(list[f])] = true;
+        theme.entries.push({
+            dir: String((raw && raw.dir) || ""),
+            directories: meta.directories.length > 0 ? meta.directories : FALLBACK_DIRECTORIES.slice(),
+            files: files
+        });
+    }
+    return catalogue;
+}
+
+// Breadth-first over Inherits=, which is what makes a diamond ("both parents
+// inherit freedesktop") visit each theme once and a cycle terminate at all.
+// DEFAULT_THEME is appended last rather than inserted, so an explicit Inherits=
+// ordering still decides everything above it.
+function themeChain(catalogue, themeName) {
+    var chain = [];
+    var seen = {};
+    var queue = [String(themeName === undefined || themeName === null ? "" : themeName).trim()];
+    while (queue.length > 0) {
+        var name = queue.shift();
+        if (name.length === 0 || seen[name] === true)
+            continue;
+        seen[name] = true;
+        chain.push(name);
+        var theme = catalogue && catalogue.themes ? catalogue.themes[name] : null;
+        if (!theme)
+            continue;
+        for (var i = 0; i < theme.inherits.length; i++)
+            queue.push(theme.inherits[i]);
+    }
+    if (seen[DEFAULT_THEME] !== true)
+        chain.push(DEFAULT_THEME);
+    return chain;
+}
+
+// An event id is a name, never a path. `..` in an event name would otherwise
+// reach out of the theme directory entirely, and the caller hands whatever it is
+// given straight to a player process.
+function isPlayableEventName(eventName) {
+    var event = String(eventName === undefined || eventName === null ? "" : eventName);
+    if (event.length === 0)
+        return false;
+    if (event.indexOf("/") >= 0 || event.indexOf("\\") >= 0)
+        return false;
+    return event !== "." && event !== "..";
+}
+
+// The whole point: one absolute path, or "" for "play nothing".
+//
+// "" covers both "no theme in the chain has this event" and "a theme in the
+// chain silenced it with a .disabled marker" - the caller cannot act differently
+// on those two, and conflating them is what keeps the marker meaningful.
+function resolveEvent(catalogue, themeName, eventName) {
+    if (!isPlayableEventName(eventName))
+        return "";
+    var event = String(eventName);
+    var chain = themeChain(catalogue, themeName);
+    for (var c = 0; c < chain.length; c++) {
+        var theme = catalogue && catalogue.themes ? catalogue.themes[chain[c]] : null;
+        if (!theme)
+            continue;
+        for (var e = 0; e < theme.entries.length; e++) {
+            var entry = theme.entries[e];
+            for (var d = 0; d < entry.directories.length; d++) {
+                var dir = entry.directories[d];
+                var prefix = dir.length > 0 ? dir + "/" : "";
+                for (var x = 0; x < EXTENSIONS.length; x++) {
+                    var relative = prefix + event + EXTENSIONS[x];
+                    if (entry.files[relative] !== true)
+                        continue;
+                    if (EXTENSIONS[x] === ".disabled")
+                        return "";
+                    return entry.dir + "/" + relative;
+                }
+            }
+        }
+    }
+    return "";
+}
+
+// What the settings picker offers. A directory of loose sound files with no
+// index.theme (/usr/share/sounds/alsa is the one on a stock Arch install) is
+// reachable by name but is not a sound theme and is not offered as one.
+function selectableThemes(catalogue) {
+    var offered = [];
+    var names = (catalogue && catalogue.names) || [];
+    for (var i = 0; i < names.length; i++) {
+        var theme = catalogue.themes[names[i]];
+        if (!theme || !theme.valid)
+            continue;
+        offered.push({
+            id: theme.name,
+            displayName: theme.displayName.length > 0 ? theme.displayName : theme.name
+        });
+    }
+    offered.sort(function (a, b) {
+        return a.displayName.toLowerCase() < b.displayName.toLowerCase() ? -1 : (a.displayName.toLowerCase() > b.displayName.toLowerCase() ? 1 : 0);
+    });
+    return offered;
+}

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -567,6 +567,12 @@ if ! python3 "$SCRIPT_DIR/test_cursor_theme_apply.py"; then
     exit 1
 fi
 
+echo "Running sound theme scanner tests..."
+if ! python3 "$SCRIPT_DIR/test_sound_theme_scan.py"; then
+    echo "Sound theme scanner tests failed."
+    exit 1
+fi
+
 echo "Running default config tests..."
 if ! python3 "$SCRIPT_DIR/test_default_config.py"; then
     echo "Default config tests failed."

--- a/dots/.config/quickshell/imi/tests/test_sound_theme_scan.py
+++ b/dots/.config/quickshell/imi/tests/test_sound_theme_scan.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""scripts/sounds/scan-sound-themes.py reports what is on disk, and nothing else.
+
+The resolver (services/sound_theme.js, tests/tst_sound_theme.qml) makes every
+decision about a sound theme, so what has to hold here is narrow but load-bearing:
+the roots come out in precedence order, a theme is reported once per root it
+appears in, subdirectories are walked, paths are relative to the theme directory,
+and nothing is filtered out on the scanner's own judgement.
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SCANNER = os.path.join(REPO_ROOT, "scripts", "sounds", "scan-sound-themes.py")
+
+
+def run(*roots, env=None):
+    result = subprocess.run(
+        [sys.executable, SCANNER, *roots],
+        capture_output=True, text=True, check=True,
+        env={**os.environ, **(env or {})},
+    )
+    return json.loads(result.stdout)
+
+
+def write(path, content=""):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(content)
+
+
+class SoundThemeScanTest(unittest.TestCase):
+    def test_a_theme_is_reported_with_its_index_and_its_files(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = os.path.join(tmp, "sounds")
+            write(os.path.join(root, "demo", "index.theme"),
+                  "[Sound Theme]\nName=Demo\nDirectories=stereo\n")
+            write(os.path.join(root, "demo", "stereo", "power-plug.oga"))
+            scan = run(root)
+            self.assertEqual(scan["roots"], [root])
+            self.assertEqual(len(scan["entries"]), 1)
+            entry = scan["entries"][0]
+            self.assertEqual(entry["theme"], "demo")
+            self.assertEqual(entry["dir"], os.path.join(root, "demo"))
+            self.assertIn("Name=Demo", entry["index"])
+            self.assertEqual(sorted(entry["files"]),
+                             ["index.theme", os.path.join("stereo", "power-plug.oga")])
+
+    def test_nested_context_directories_are_walked(self):
+        # The Pop theme keeps every file under stereo/{alert,action,notification}
+        # and nothing directly in stereo/. A non-recursive listing reports it as
+        # an empty theme, which is exactly the silence this work removed.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = os.path.join(tmp, "sounds")
+            write(os.path.join(root, "Pop", "index.theme"),
+                  "[Sound Theme]\nDirectories=stereo/alert stereo/notification\n")
+            write(os.path.join(root, "Pop", "stereo", "alert", "alarm-clock-elapsed.oga"))
+            write(os.path.join(root, "Pop", "stereo", "notification", "power-plug.oga"))
+            files = run(root)["entries"][0]["files"]
+            self.assertIn(os.path.join("stereo", "alert", "alarm-clock-elapsed.oga"), files)
+            self.assertIn(os.path.join("stereo", "notification", "power-plug.oga"), files)
+
+    def test_the_same_theme_in_two_roots_is_reported_once_per_root_in_order(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            user = os.path.join(tmp, "user", "sounds")
+            system = os.path.join(tmp, "system", "sounds")
+            write(os.path.join(user, "ocean", "stereo", "power-plug.oga"))
+            write(os.path.join(system, "ocean", "stereo", "power-unplug.oga"))
+            entries = run(user, system)["entries"]
+            self.assertEqual([e["dir"] for e in entries],
+                             [os.path.join(user, "ocean"), os.path.join(system, "ocean")])
+
+    def test_sidecars_and_unknown_extensions_are_reported_rather_than_judged(self):
+        # ocean ships power-unplug.oga.license beside its sounds. Filtering it
+        # here would move a decision out of the tested resolver; the resolver
+        # ignores it by building exact <event><extension> names instead.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = os.path.join(tmp, "sounds")
+            write(os.path.join(root, "ocean", "stereo", "power-unplug.oga.license"))
+            self.assertEqual(run(root)["entries"][0]["files"],
+                             [os.path.join("stereo", "power-unplug.oga.license")])
+
+    def test_a_missing_root_and_a_plain_file_are_both_skipped(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = os.path.join(tmp, "sounds")
+            write(os.path.join(root, "loose.oga"))
+            scan = run(os.path.join(tmp, "nope"), root)
+            self.assertEqual(scan["entries"], [])
+            self.assertEqual(len(scan["roots"]), 2)
+
+    def test_the_default_roots_follow_xdg_and_put_the_user_first(self):
+        env = {"XDG_DATA_HOME": "/x/data", "XDG_DATA_DIRS": "/a/share:/b/share", "HOME": "/x"}
+        roots = run(env=env)["roots"]
+        self.assertEqual(roots[0], "/x/data/sounds")
+        self.assertIn("/a/share/sounds", roots)
+        self.assertIn("/b/share/sounds", roots)
+        self.assertEqual(roots[-1], "/usr/share/sounds")
+        self.assertEqual(len(roots), len(set(roots)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dots/.config/quickshell/imi/tests/tst_sound_theme.qml
+++ b/dots/.config/quickshell/imi/tests/tst_sound_theme.qml
@@ -1,0 +1,309 @@
+import QtQuick
+import QtTest
+import "../services/sound_theme.js" as SoundTheme
+
+// The fixtures below are modelled on what is actually installed on a stock Arch
+// machine, measured before this engine was written:
+//   freedesktop  35 .oga, flat in stereo/
+//   oxygen       63 .ogg, flat in stereo/, and no `complete` or `suspend-error`
+//   Pop          25 .oga, none of them in stereo/ - all under
+//                stereo/{alert,action,notification} per its Directories=
+//   ocean        45 .oga plus 32 .oga.license sidecars beside them
+// Each of those four shapes broke the double-ffplay implementation differently.
+TestCase {
+    name: "SoundThemeTest"
+
+    readonly property string freedesktopIndex: "[Sound Theme]\nName=Default\nDirectories=stereo\n"
+
+    readonly property string popIndex: "# a comment\n" +
+        "[Sound Theme]\n" +
+        "Name=Pop\n" +
+        "Comment=The Pop Sound Theme\n" +
+        "Directories=stereo/alert stereo/action stereo/notification\n" +
+        "\n" +
+        "[stereo/alert]\n" +
+        "Context=Alert\n" +
+        "OutputProfile=stereo\n"
+
+    function makeCatalogue() {
+        return SoundTheme.buildCatalogue({
+            roots: ["/home/u/.local/share/sounds", "/usr/share/sounds"],
+            entries: [
+                {
+                    theme: "freedesktop",
+                    dir: "/usr/share/sounds/freedesktop",
+                    index: freedesktopIndex,
+                    files: [
+                        "index.theme",
+                        "stereo/power-plug.oga",
+                        "stereo/power-unplug.oga",
+                        "stereo/complete.oga",
+                        "stereo/suspend-error.oga",
+                        "stereo/dialog-warning.oga",
+                        "stereo/alarm-clock-elapsed.oga"
+                    ]
+                },
+                {
+                    theme: "oxygen",
+                    dir: "/usr/share/sounds/oxygen",
+                    index: "[Sound Theme]\nName=Oxygen\nName[de]=Sauerstoff\nDirectories=stereo\n",
+                    files: [
+                        "index.theme",
+                        "stereo/power-plug.ogg",
+                        "stereo/power-unplug.ogg",
+                        "stereo/dialog-warning.ogg",
+                        "stereo/alarm-clock-elapsed.ogg"
+                    ]
+                },
+                {
+                    theme: "Pop",
+                    dir: "/usr/share/sounds/Pop",
+                    index: popIndex,
+                    files: [
+                        "index.theme",
+                        "stereo/notification/power-plug.oga",
+                        "stereo/notification/complete.oga",
+                        "stereo/alert/alarm-clock-elapsed.oga"
+                    ]
+                },
+                {
+                    theme: "ocean",
+                    dir: "/usr/share/sounds/ocean",
+                    index: "[Sound Theme]\nName=Ocean\nDirectories=stereo\n",
+                    files: [
+                        "index.theme",
+                        "index.theme.license",
+                        "stereo/power-unplug.oga.license",
+                        "stereo/power-plug.oga"
+                    ]
+                },
+                {
+                    theme: "alsa",
+                    dir: "/usr/share/sounds/alsa",
+                    index: "",
+                    files: ["Front_Center.wav"]
+                }
+            ]
+        });
+    }
+
+    function test_parseIndexThemeReadsOnlyTheSoundThemeGroup() {
+        const parsed = SoundTheme.parseIndexTheme(popIndex);
+        verify(parsed.valid);
+        compare(parsed.name, "Pop");
+        compare(parsed.directories.join("|"), "stereo/alert|stereo/action|stereo/notification");
+        // Context/OutputProfile live in a per-directory group and must not leak
+        // into the theme's own keys.
+        compare(parsed.inherits.length, 0);
+    }
+
+    function test_parseIndexThemeAcceptsCommasAndWhitespace() {
+        compare(SoundTheme.parseIndexTheme("[Sound Theme]\nInherits=ocean,freedesktop\n").inherits.join("|"),
+            "ocean|freedesktop");
+        compare(SoundTheme.parseIndexTheme("[Sound Theme]\nInherits= ocean ,  freedesktop \n").inherits.join("|"),
+            "ocean|freedesktop");
+    }
+
+    function test_aDirectoryOfLooseFilesIsNotAThemeIndex() {
+        const parsed = SoundTheme.parseIndexTheme("");
+        verify(!parsed.valid);
+        compare(parsed.directories.length, 0);
+    }
+
+    function test_resolvesAnOgaThemeWithoutGuessingTheExtension() {
+        compare(SoundTheme.resolveEvent(makeCatalogue(), "freedesktop", "power-plug"),
+            "/usr/share/sounds/freedesktop/stereo/power-plug.oga");
+    }
+
+    function test_resolvesAnOggOnlyThemeThroughTheSameCall() {
+        compare(SoundTheme.resolveEvent(makeCatalogue(), "oxygen", "power-plug"),
+            "/usr/share/sounds/oxygen/stereo/power-plug.ogg");
+    }
+
+    function test_aThemeWithContextSubdirectoriesIsSearchedInThemAll() {
+        const catalogue = makeCatalogue();
+        // Pop keeps nothing directly in stereo/. A hardcoded stereo/ path finds
+        // 0 of its 25 sounds, which is silence with no error - the state the
+        // shell shipped in for this theme.
+        compare(SoundTheme.resolveEvent(catalogue, "Pop", "power-plug"),
+            "/usr/share/sounds/Pop/stereo/notification/power-plug.oga");
+        compare(SoundTheme.resolveEvent(catalogue, "Pop", "alarm-clock-elapsed"),
+            "/usr/share/sounds/Pop/stereo/alert/alarm-clock-elapsed.oga");
+    }
+
+    function test_aSidecarFileIsNotASound() {
+        // ocean ships power-unplug.oga.license and no power-unplug.oga, so
+        // anything matching on "the event name followed by something" hands a
+        // text file to the player.
+        compare(SoundTheme.resolveEvent(makeCatalogue(), "ocean", "power-unplug"),
+            "/usr/share/sounds/freedesktop/stereo/power-unplug.oga");
+    }
+
+    function test_anEventTheThemeLacksFallsBackToTheDefaultTheme() {
+        const catalogue = makeCatalogue();
+        // oxygen declares no Inherits= and ships neither of these. The spec's
+        // implicit fallback is what keeps the battery-charged chime audible.
+        compare(SoundTheme.resolveEvent(catalogue, "oxygen", "complete"),
+            "/usr/share/sounds/freedesktop/stereo/complete.oga");
+        compare(SoundTheme.resolveEvent(catalogue, "oxygen", "suspend-error"),
+            "/usr/share/sounds/freedesktop/stereo/suspend-error.oga");
+    }
+
+    function test_aThemeThatIsNotInstalledStillResolvesThroughTheDefault() {
+        compare(SoundTheme.resolveEvent(makeCatalogue(), "no-such-theme", "complete"),
+            "/usr/share/sounds/freedesktop/stereo/complete.oga");
+        compare(SoundTheme.resolveEvent(makeCatalogue(), "", "complete"),
+            "/usr/share/sounds/freedesktop/stereo/complete.oga");
+    }
+
+    function test_anEventNoThemeHasResolvesToNothing() {
+        compare(SoundTheme.resolveEvent(makeCatalogue(), "freedesktop", "device-added"), "");
+    }
+
+    function test_theInheritsChainIsWalkedInOrder() {
+        const catalogue = SoundTheme.buildCatalogue({
+            entries: [
+                {
+                    theme: "child",
+                    dir: "/usr/share/sounds/child",
+                    index: "[Sound Theme]\nName=Child\nDirectories=stereo\nInherits=middle,other\n",
+                    files: ["stereo/own.oga"]
+                },
+                {
+                    theme: "middle",
+                    dir: "/usr/share/sounds/middle",
+                    index: "[Sound Theme]\nName=Middle\nDirectories=stereo\n",
+                    files: ["stereo/shared.oga"]
+                },
+                {
+                    theme: "other",
+                    dir: "/usr/share/sounds/other",
+                    index: "[Sound Theme]\nName=Other\nDirectories=stereo\n",
+                    files: ["stereo/shared.oga", "stereo/only-here.oga"]
+                },
+                {
+                    theme: "freedesktop",
+                    dir: "/usr/share/sounds/freedesktop",
+                    index: freedesktopIndex,
+                    files: ["stereo/shared.oga", "stereo/last-resort.oga"]
+                }
+            ]
+        });
+        compare(SoundTheme.themeChain(catalogue, "child").join("|"), "child|middle|other|freedesktop");
+        compare(SoundTheme.resolveEvent(catalogue, "child", "own"), "/usr/share/sounds/child/stereo/own.oga");
+        // First parent named wins over the second, and both win over the default.
+        compare(SoundTheme.resolveEvent(catalogue, "child", "shared"), "/usr/share/sounds/middle/stereo/shared.oga");
+        compare(SoundTheme.resolveEvent(catalogue, "child", "only-here"), "/usr/share/sounds/other/stereo/only-here.oga");
+        compare(SoundTheme.resolveEvent(catalogue, "child", "last-resort"),
+            "/usr/share/sounds/freedesktop/stereo/last-resort.oga");
+    }
+
+    function test_anInheritsCycleTerminates() {
+        const catalogue = SoundTheme.buildCatalogue({
+            entries: [
+                {
+                    theme: "a",
+                    dir: "/s/a",
+                    index: "[Sound Theme]\nDirectories=stereo\nInherits=b\n",
+                    files: []
+                },
+                {
+                    theme: "b",
+                    dir: "/s/b",
+                    index: "[Sound Theme]\nDirectories=stereo\nInherits=a\n",
+                    files: ["stereo/ping.oga"]
+                }
+            ]
+        });
+        compare(SoundTheme.themeChain(catalogue, "a").join("|"), "a|b|freedesktop");
+        compare(SoundTheme.resolveEvent(catalogue, "a", "ping"), "/s/b/stereo/ping.oga");
+    }
+
+    function test_aDiamondVisitsEachThemeOnce() {
+        const catalogue = SoundTheme.buildCatalogue({
+            entries: [
+                { theme: "top", dir: "/s/top", index: "[Sound Theme]\nDirectories=stereo\nInherits=left,right\n", files: [] },
+                { theme: "left", dir: "/s/left", index: "[Sound Theme]\nDirectories=stereo\nInherits=base\n", files: [] },
+                { theme: "right", dir: "/s/right", index: "[Sound Theme]\nDirectories=stereo\nInherits=base\n", files: [] },
+                { theme: "base", dir: "/s/base", index: "[Sound Theme]\nDirectories=stereo\n", files: ["stereo/ping.oga"] }
+            ]
+        });
+        compare(SoundTheme.themeChain(catalogue, "top").join("|"), "top|left|right|base|freedesktop");
+    }
+
+    function test_aDisabledMarkerSilencesTheEventInsteadOfInheritingOne() {
+        const catalogue = SoundTheme.buildCatalogue({
+            entries: [
+                {
+                    theme: "quiet",
+                    dir: "/s/quiet",
+                    index: "[Sound Theme]\nDirectories=stereo\nInherits=freedesktop\n",
+                    files: ["stereo/power-plug.disabled"]
+                },
+                {
+                    theme: "freedesktop",
+                    dir: "/usr/share/sounds/freedesktop",
+                    index: freedesktopIndex,
+                    files: ["stereo/power-plug.oga"]
+                }
+            ]
+        });
+        compare(SoundTheme.resolveEvent(catalogue, "quiet", "power-plug"), "");
+        compare(SoundTheme.resolveEvent(catalogue, "freedesktop", "power-plug"),
+            "/usr/share/sounds/freedesktop/stereo/power-plug.oga");
+    }
+
+    function test_aUserInstalledCopyShadowsTheSystemOneFileByFile() {
+        const catalogue = SoundTheme.buildCatalogue({
+            entries: [
+                {
+                    theme: "ocean",
+                    dir: "/home/u/.local/share/sounds/ocean",
+                    index: "[Sound Theme]\nName=Ocean\nDirectories=stereo\n",
+                    files: ["stereo/power-plug.oga"]
+                },
+                {
+                    theme: "ocean",
+                    dir: "/usr/share/sounds/ocean",
+                    index: "[Sound Theme]\nName=Ocean\nDirectories=stereo\n",
+                    files: ["stereo/power-plug.oga", "stereo/power-unplug.oga"]
+                }
+            ]
+        });
+        compare(SoundTheme.resolveEvent(catalogue, "ocean", "power-plug"),
+            "/home/u/.local/share/sounds/ocean/stereo/power-plug.oga");
+        // The user's incomplete copy must not hide the rest of the system theme.
+        compare(SoundTheme.resolveEvent(catalogue, "ocean", "power-unplug"),
+            "/usr/share/sounds/ocean/stereo/power-unplug.oga");
+    }
+
+    function test_aThemeWithNoIndexIsSearchedAtItsRootAndUnderStereo() {
+        const catalogue = makeCatalogue();
+        compare(SoundTheme.resolveEvent(catalogue, "alsa", "Front_Center"),
+            "/usr/share/sounds/alsa/Front_Center.wav");
+    }
+
+    function test_anEventNameIsAnIdentifierNotAPath() {
+        const catalogue = makeCatalogue();
+        verify(!SoundTheme.isPlayableEventName("../../../etc/passwd"));
+        verify(!SoundTheme.isPlayableEventName(""));
+        verify(!SoundTheme.isPlayableEventName(".."));
+        verify(SoundTheme.isPlayableEventName("power-plug"));
+        compare(SoundTheme.resolveEvent(catalogue, "freedesktop", "../stereo/power-plug"), "");
+    }
+
+    function test_thePickerOffersRealThemesSortedByTheirName() {
+        const offered = SoundTheme.selectableThemes(makeCatalogue());
+        compare(offered.map(theme => theme.id).join("|"), "freedesktop|ocean|oxygen|Pop");
+        compare(offered[0].displayName, "Default");
+        // alsa has no index.theme: reachable by name, but not a theme to offer.
+        compare(offered.filter(theme => theme.id === "alsa").length, 0);
+    }
+
+    function test_anEmptyScanResolvesToNothingRatherThanThrowing() {
+        const catalogue = SoundTheme.buildCatalogue(null);
+        compare(SoundTheme.resolveEvent(catalogue, "freedesktop", "power-plug"), "");
+        compare(SoundTheme.selectableThemes(catalogue).length, 0);
+        compare(SoundTheme.themeChain(catalogue, "anything").join("|"), "anything|freedesktop");
+    }
+}


### PR DESCRIPTION
`services/Audio.qml`'s `playSystemSound()` built two paths by hand and spawned an `ffplay` at each, letting whichever was wrong fail silently. This replaces it with a real XDG sound-theme engine: scan the roots, follow `Inherits=`, resolve an event to a file once, play it once.

## The before-state, measured

Six sound themes are installed on this machine. Against them, the guess is wrong in four distinguishable ways at once, and none of them reaches a log:

| theme | layout | what the user got |
|---|---|---|
| freedesktop | 35 `.oga`, flat in `stereo/` | one sound, one doomed process |
| ocean | 45 `.oga` + 32 `.oga.license` sidecars | one sound where the `.oga` exists |
| oxygen | 63 `.ogg`, flat | one sound, one doomed process |
| harmony2 | 50 `.ogg`, flat | one sound, one doomed process |
| Smooth | 59 `.oga`, flat | one sound, one doomed process |
| **Pop** | 25 `.oga`, **none of them in `stereo/`** | **silence, two doomed processes** |

- **Never two sounds.** No installed theme ships both extensions for the same event, so the second spawn is unconditionally wasted — and which of the two is wasted is a property of the *theme*, not the event.
- **The wasted process costs ~50 ms wall, ~38 ms CPU, ~53 MiB peak RSS and 165 mapped shared objects** to print `No such file or directory`. It is `execDetached`, so the cost lands on the system rather than on the shell's main thread.
- **`Pop` was entirely silent.** It declares `Directories=stereo/alert stereo/action stereo/notification` and keeps every file under those; the hardcoded `stereo/` reached 0 of its 25 sounds.
- **No `Inherits=` walk, no implicit default-theme fallback.** `oxygen` ships neither `complete` nor `suspend-error`, so the battery-charged chime and the suspend-failure alert were silent with `freedesktop` installed right beside them.
- **`~/.local/share/sounds` was never searched**, so a user-installed theme was unreachable.

**Call sites: six, found by grep, all still working.** `Battery.qml` raises `dialog-warning`, `suspend-error`, `complete`, `power-plug`, `power-unplug`; `TimerService.qml` raises `alarm-clock-elapsed`. Nothing else in the tree plays a sound.

## Design decisions

**Playback stays a process spawn.** QtMultimedia is available and works — probed with `qml6`, it decodes and plays a `.oga` fine — so this is a choice. Measured, importing it and playing one 223 ms chime takes a bare QtQuick process from **65 MiB / 133 mapped shared objects to 113 MiB / 238**, permanently, whether or not a sound is ever played; its ffmpeg backend writes a three-line `Input #0, ogg, from '<path>'` banner to stderr on *every* play, and constructing the first player emits five multi-kilobyte `spaVisitChoice: parse error` lines from PipeWire — all into the `log.log` AGENT.md tells the next agent to grep. A spawn is 6.3 ms of CPU, freed on exit, and is a command list a test can read. An in-process path we cannot test is worse than one we can.

**`pw-play` rather than `ffplay`.** 7.4× cheaper (6.3 ms CPU vs 46.7, 15 mapped libraries vs 165) and, more importantly, *declared*: `pw-play` ships in `pipewire-audio`, a hard dependency of the `pipewire-pulse` that `sdata/deps-info.md` lists, while `ffplay` comes from `ffmpeg`, which this repo installs only inside the Wallpaper Engine build's dependency list and names nowhere as a shell dependency. Verified decoding all three extensions the installed themes use.

**Three pieces, so the decisions are testable.** `scripts/sounds/scan-sound-themes.py` reports what is on disk and judges nothing — it does not even filter by extension, because "that file is not a sound" is a judgement and `ocean` ships `power-unplug.oga.license` to catch anyone making it loosely. `services/sound_theme.js` decides everything and touches no disk. `services/SoundTheme.qml` owns only the process lifetimes.

## Deliberately left out

- **Theme install from a tarball** — a separate feature from playing a sound correctly, and one whose whole content is archive extraction into a data directory.
- **A player pool** — it amortises `MediaPlayer` construction; with a process per sound there is nothing to pool.
- **Per-event overrides** — an event→path map is dynamic-keyed state, which AGENT.md forbids in a `JsonAdapter` outright, so it would need its own store for a feature nobody has asked for.
- **Rate limits and startup grace windows** — they exist in the surveyed fork because it plays a sound per *notification*, where a burst is real. Ours has six call sites, every one edge-triggered on a physically rate-limited state change. A limiter now would be plumbing with no burst source to test it against. It earns its place the day a notification sound does.

What *is* kept is a bounded pending queue, and it is not speculative: `SoundTheme` is a live instance of AGENT.md's "a singleton is constructed on first use" trap — the only thing that reaches it is a `play()` call, so the scan has not *started* when the first sound is asked for.

## The research document was right this time

`docs/p3drovfx-research-2026-08-16.md` §2.5's "Ours: nothing" and its description of the defect both hold up under a fresh grep. `playSystemSound` really is at `Audio.qml:117`, really does spawn twice, and nothing else in the tree resolves a sound theme. If anything the row *understated* it: it says one of the two fails silently, and the measured picture is that for `Pop` **both** do.

## Verification

- `tests/run_tests.sh`: **788 passed, 0 failed** (baseline on `gh/main` is 767; +21 QML cases), plus 6 new Python cases in the scanner check and `DesignSystemCompile checked=172 failures=0`, which compiles the modified settings page.
- Every new QML assertion proven to fail on planted broken code, in a clean tree: hardcoding `stereo/` → 2 red; dropping the default-theme fallback → 7 red; removing the `.disabled` stop → 1 red; prefix-matching filenames instead of exact → 1 red; searching only the first root's copy of a theme → 1 red; letting an event name be a path → 1 red. Removing the `Inherits=` visited set does **not** redden — it hangs, which is itself the evidence that the guard is what makes the walk terminate.
- End to end in a real `qs -p` probe: all six events resolve to real files for `freedesktop`, `oxygen`, `Pop` and an uninstalled theme name; the cold-start queue reports `ready=false pending=1` then `ready=true pending=0`; and exactly one `/usr/bin/pw-play /usr/share/sounds/freedesktop/stereo/power-plug.oga` was observed in `/proc`. No `ERROR:` or `WARN scene:` lines.
- **Not verified:** that the resulting audio sounds right to a human, and the live `~/.config/quickshell/imi` shell was deliberately not touched (two other agents share this machine). `SoundTheme` is a new `pragma Singleton`, so the running shell needs a **full restart** — `pkill -x quickshell; sleep 1; setsid -f qs -c imi` — not a hot reload, before it exists there.

Docs: updated AGENT.md §Directory map, §External binaries the shell drives