### PR TITLE
Clock depth: the no-op oracle, and an instrument for the accept/decline verdict

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -442,6 +442,10 @@ modules/imi/                 The "imi" (Immaterial Impulse) panel family - one d
   screenCorners/              Decorative fake screen-rounding + corner hover/click zones that open
                               the sidebars
   background/                 Desktop background + the canvas the draggable desktop widgets sit on.
+                              ClockDepthCutout.qml is the wallpaper's subject cut out by its mask -
+                              the ONE place the mask's registration is computed, drawn both by the
+                              depth layer and by the picker that judges it (see the clock-depth
+                              notes below).
                               The widgets themselves are all bundled plugins now (see
                               modules/common/plugins/bundled/); background/widgets/ holds only
                               AbstractBackgroundWidget.qml, which is the plugin host's base class.
@@ -2224,6 +2228,74 @@ in `modules/common/functions/clockDepth.js` beside the eligibility predicate for
 the same reason `ParallaxMath.sampleOrigin` is: nothing about the rendered layer
 is reachable from `qmltestrunner`, so the arithmetic has to be.
 (feat(background): draw the wallpaper's subject over the desktop widgets.)
+
+**Two captures separated in wall-clock time on a desktop somebody is using are
+not an A/B test, and the thing that changes between them becomes your signal.**
+The clock depth layer was reported as making the wallpaper's quality "drop
+completely", measured with two `grim -o DP-1` shots taken minutes apart with the
+feature toggled between them, and scored at 97.8% of pixels differing with a mean
+absolute difference of 48.5/255 over the whole frame. That was read as the masked
+copy landing off by a scale factor, and a whole geometry hypothesis was built on
+it. **The user had changed the wallpaper between the two captures.** The diff was
+two different pictures. Nothing about the numbers looked wrong — they were
+enormous, consistent, and reproduced the reported symptom exactly, which is what
+made them convincing. Before diffing two frames of a live desktop, ask what else
+could have moved; if the answer is "anything", the measurement belongs in one
+process with the inputs pinned.
+
+The repair generalises past this feature: **find the invariant that turns the
+question into an oracle.** The depth layer paints the wallpaper's own pixels back
+over the wallpaper, so where no widget sits it draws a picture over itself —
+which means with an empty widget canvas, depth on and depth off must be the same
+frame *whatever the mask contains*. `tests/test_clock_depth_noop.py` runs exactly
+that: one `qs` process, one wallpaper nothing can swap, only the depth flag moving
+between the two grabs. On the current code it is bit-identical on its synthetic
+fixture and differs by at most one least-significant bit on 0.18% of pixels
+against the real 3840x1594 wallpaper — the source making a round trip through the
+effect's intermediate buffer — so the alignment question is settled rather than
+argued. Its fixture's wallpaper aspect is deliberately nothing like its
+viewport's, because at a matching aspect `PreserveAspectCrop` is the identity and
+every crop bug is invisible; the sibling compositing probe's 2:1-into-2:1 fixture
+has that hole, which is why "the fixture actually crops" is a check there rather
+than a comment. Note the half the oracle cannot see: a mask registered to the
+wrong pixels still passes, because masking the wallpaper with the wrong shape
+still draws the wallpaper over the wallpaper.
+(test(background): score the depth layer's no-op invariant in pixels.)
+
+**A visualizer that computes its own geometry is a visualizer that can lie about
+the thing it exists to judge.** The wallpaper selector's depth picker is where
+the accept/decline verdict is given, and it drew its preview from its own copy of
+the layer's stack — the same `coverRect` call, the same clipping surface, the
+same `OpacityMask`. Two hand-written copies of a registration is the shape this
+repo keeps paying for, except worse in this direction: a picker whose crop drifts
+from the layer's certifies a mask against a geometry the desktop never draws, and
+the drift is invisible precisely because both look plausible. They are one
+`modules/imi/background/ClockDepthCutout.qml` now, and the rule the lint enforces
+is the deliverable rather than the component — `coverRect` may be called from
+that file and from its own unit test and nowhere else, so a second caller
+reddens the suite instead of becoming a second opinion.
+
+Three things about building the inspection view on top of it. The veil that dims
+what the model did *not* claim is `OpacityMask { invert: true }` over the **same**
+surface the cutout is masked by, so the lit region and the drawn region cannot be
+a pixel apart. The contour is a `Glow` with `transparentBorder: true`, because
+without it the blur clamps at the item's edge and a subject touching the bottom of
+the frame smears into a band across it — which reads as a defect in the mask being
+judged rather than in the instrument judging it. And its colour is hardcoded,
+which is the one place in this shell that is right: every `Appearance` token is
+generated *from* the wallpaper on screen, so a token there is guaranteed to be a
+colour the picture already contains.
+(refactor(background): one cutout for the layer and the picker to draw.)
+
+**A segmentation model returning nothing is usually the wrong model, not an empty
+picture.** `isnet-anime` and `isnet-general-use` are complementary and neither is
+a superset — measured, `isnet-anime` returns `none` on `cat_upscayl_2x…png` where
+`isnet-general-use` returns a foreground of 0.143, and the pair swap on other
+wallpapers. So a UI that reports one model's refusal as "no subject found" states
+a verdict on the image that the evidence does not support, and a user who reads it
+stops. Both models are offered side by side, at the same size, and a refusal
+points at the other column.
+(feat(wallpapers): give the depth picker an inspect mode.)
 
 **A sample rect and the item it samples must be in the same coordinate space —
 and "it samples the real thing" is not evidence that they are.** The desktop

--- a/docs/superpowers/specs/2026-08-16-clock-depth-design.md
+++ b/docs/superpowers/specs/2026-08-16-clock-depth-design.md
@@ -422,3 +422,98 @@ its whole design depends on having looked at stage 1's real output.
 **Stage 4 — lock screen.** `lockWall` and `lock.centerClock`, if wanted.
 
 Start with **Stage 1: the subject-mask producer and its cache.**
+
+---
+
+## 8. Wallpaper Engine — designed, not landed
+
+§4 refused a live Wallpaper Engine project on the reasoning that it is "a moving
+surface with no file to segment". The first half is true and the second is not:
+the shell already photographs every WE project it renders. This section is what
+that opens, what it costs, and where it stops being honest — written now because
+WE support is wanted, and stated as a design rather than shipped because none of
+it is reachable from a headless harness.
+
+### 8.1 There is already a static input, and it registers for free
+
+`Background.captureGreeterStill` (`Background.qml:381-404`) grabs `weLoader.item`
+into `${Directories.wallpaperEngineStills}/${activeProject}.png`, 600 ms after the
+surface reports its first frame, once per project load, on the first screen only.
+
+Two measured properties of those files decide most of the design. There are 16 on
+this machine, at 5120x1440 and 5478x1540 — **the viewport's own size**, because
+the WE layer is `anchors.fill: parent` inside `parallaxViewport`. So a still's
+aspect *is* the viewport's aspect, `coverRect` degenerates to the identity, and a
+mask cut from a still registers 1:1 onto the layer with no new geometry at all.
+The zoom is baked in, but only as a scale factor on both axes, which `coverRect`
+already absorbs.
+
+`web` projects never arrive here: `weActive` (`:274`) excludes them and they fall
+back to the static wallpaper, which this feature already supports.
+
+### 8.2 The cache key cannot be the still's stat triple
+
+`cache_key` hashes path, mtime and size. The still is re-grabbed on **every load
+of the project**, so its mtime moves every session — measured, four of the 16
+stills on this machine were rewritten today. Keying on the file would therefore
+mint a new key per session, which does not merely re-run a 1.3 s job: the
+acceptance lives at the key (`<key>.png`), so **the user's verdict would be lost
+on every restart**, silently, and the feature would read as "it forgets".
+
+So the producer needs a caller-supplied identity — `--identity we:<projectId>` —
+hashed in place of the stat triple, with the still passed as the image to
+segment. Roughly fifteen lines and a handful of cases in
+`test_clock_depth_cache.py`. The trade it makes is the mirror image of §3's: an
+identity keyed on the project id does **not** notice the user editing the
+project, so a changed scene keeps its old mask until the picker is re-run. That
+is the right way round — a stale mask over an edited *file* is §3's worst
+failure because nothing prompts the user, whereas changing a WE project is
+something the user did on purpose and can re-judge from the picker.
+
+### 8.3 Mask the live surface, never the still
+
+The obvious implementation — draw the still, masked — is wrong. It would put a
+frozen frame over a moving scene, so every animated pixel inside the silhouette
+would be visibly stale.
+
+The layer should mask the **live** surface instead:
+`ShaderEffectSource { sourceItem: weLoader.item }`, which this file already
+builds as `weLiveSource` (`:753`) for the WE transition, sized to the same
+viewport. Then the pixels are live and only the *silhouette* is static.
+`ClockDepthCutout` grows a `liveSource` alternative to `wallpaperSource` and
+hands whichever is set to the `OpacityMask`; the lint's "shares the wallpaper's
+image request" rule stays scoped to the still-image path, since there is no
+second decode to share on the live one.
+
+### 8.4 Where it stops being honest, and what the UI must say
+
+A static mask over a live scene is correct exactly while the subject does not
+move within the frame. A character standing in a parallaxing scene is the case
+that works, and it is the common case in this library. A scene whose subject
+walks, turns or is occluded by its own animation will drift out of its silhouette
+— the clock will be covered by nothing, or uncovered by something.
+
+There is no way to detect that automatically (the same finding as §1.2, one level
+up: judging whether a mask holds across a scene's motion is exactly as
+unautomatable as judging whether it is a good mask). So it belongs in the picker
+next to the verdict, in the same place the mask's own quality is judged, and the
+inspect mode added since §6 is what makes it judgeable: dim what the model did
+not claim, then let the scene run for a few seconds and watch whether the
+subject leaves its own outline.
+
+### 8.5 Two availability edges
+
+A project that has not rendered in a session with the shell up has **no still**,
+so the picker must say "show this wallpaper first" rather than fail. And the
+still belongs to the first screen only, which is fine — one mask serves every
+monitor, per §2 — but it means a project that has only ever been shown while the
+first screen was suppressed has none either.
+
+### 8.6 Why this is a separate landing
+
+None of §8 can be verified where the rest of this feature is verified. Weston
+runs no Wallpaper Engine renderer and the WE module is a separate build, so the
+probes cannot reach any of it; it has to be judged on the real desktop, by
+looking at a moving scene. That is a different kind of change from the ones this
+PR carries, all of which are pinned headlessly — and the instrument §8.4 depends
+on is the inspect mode this PR adds, so the order is the right way round.

--- a/dots/.config/quickshell/imi/ClockDepthNoOpProbe.qml
+++ b/dots/.config/quickshell/imi/ClockDepthNoOpProbe.qml
@@ -1,0 +1,209 @@
+import QtQuick
+import Quickshell
+import qs.modules.imi.background
+import "modules/common/functions/clockDepth.js" as ClockDepthLogic
+
+/*
+ * The one invariant this feature cannot violate: with nothing underneath it,
+ * turning depth ON must change nothing at all.
+ *
+ * The depth layer paints the wallpaper's own pixels back over the wallpaper.
+ * Where no widget sits, that is drawing a picture over itself - so with the
+ * widget canvas empty, depth on and depth off must be the same frame, whatever
+ * the mask says. Any difference is the copy landing somewhere other than the
+ * region it copies: a different crop, a different scale, a different offset.
+ *
+ * That oracle exists because the alternative is judging it by eye, and by eye a
+ * near-miss double exposure does not read as a geometry bug. It reads as the
+ * wallpaper's quality dropping - which is exactly how it was reported, and
+ * exactly how a review then measured it wrong: two `grim` captures minutes
+ * apart on a desktop somebody was using, with the wallpaper changed in between.
+ * A single process, a pinned wallpaper and nothing but the depth flag moving
+ * between the two frames is the control that was missing.
+ *
+ * The fixture deliberately CROPS. A wallpaper whose aspect matches its viewport
+ * makes PreserveAspectCrop the identity and every crop bug invisible, which is
+ * what the sibling compositing probe's 2:1-into-2:1 fixture does - so the
+ * "the fixture crops" check below is load-bearing rather than decorative.
+ *
+ *   ./tests/run_clock_depth_noop_probe.sh
+ */
+ShellRoot {
+    id: harness
+
+    property int checksRun: 0
+    property int failures: 0
+    function check(label, ok, detail) {
+        harness.checksRun++;
+        console.log(`[ClockDepthNoOp] ${label}: ${ok ? "ok" : "FAIL"}${detail ? " " + detail : ""}`);
+        if (!ok) harness.failures++;
+    }
+
+    readonly property string wallpaperFile: Quickshell.env("CLOCK_DEPTH_WALLPAPER") || ""
+    readonly property string fullMaskFile: Quickshell.env("CLOCK_DEPTH_FULL_MASK") || ""
+    readonly property string partMaskFile: Quickshell.env("CLOCK_DEPTH_PART_MASK") || ""
+    readonly property string shotDir: Quickshell.env("CLOCK_DEPTH_SHOT_DIR") || ""
+
+    // The only thing that moves between a pair of shots. Not the mask path:
+    // swapping that would change two things at once and the diff could no
+    // longer be attributed to the flag.
+    property bool depthOn: false
+    property string activeMask: harness.fullMaskFile
+
+    FloatingWindow {
+        id: window
+        implicitWidth: 800
+        implicitHeight: 225
+        color: "black"
+
+        Item {
+            id: field
+            anchors.fill: parent
+            // The grab takes THIS item, so it carries its own ground: grabbing
+            // over the window's colour yields a transparent PNG whose pixels
+            // read as black to any analyser.
+            Rectangle { anchors.fill: parent; color: "black" }
+
+            // Oversized and offset, as the parallax viewport is at every
+            // workspace but the middle one. At rest the layer and the viewport
+            // are trivially level; the offset is where a copy that reconstructs
+            // the position by hand can be wrong.
+            Item {
+                id: parallaxViewport
+                width: 880
+                height: 247
+                x: -40
+                y: -11
+
+                Image {
+                    id: wallpaper
+                    anchors.fill: parent
+                    fillMode: Image.PreserveAspectCrop
+                    cache: true
+                    smooth: true
+                    asynchronous: false
+                    source: harness.wallpaperFile === "" ? "" : `file://${harness.wallpaperFile}`
+                }
+            }
+
+            // Deliberately empty. The widget canvas is what the depth layer
+            // exists to draw over, and with anything on it the two frames
+            // differ for the right reason and the invariant says nothing.
+            Item {
+                id: widgetCanvas
+                anchors.fill: parent
+                z: 2
+            }
+
+            Item {
+                id: clockDepthLayer
+                x: parallaxViewport.x
+                y: parallaxViewport.y
+                width: parallaxViewport.width
+                height: parallaxViewport.height
+                z: 3
+                visible: clockDepthLayer.opacity > 0
+                enabled: false
+                opacity: ClockDepthLogic.eligible({
+                    enable: harness.depthOn,
+                    maskPath: harness.activeMask,
+                    optedOut: false,
+                    weActive: false,
+                    wallpaperIsVideo: false,
+                    centeredWallpaper: false,
+                    screenLocked: false,
+                    transitionInFlight: false
+                }) ? 1 : 0
+
+                ClockDepthCutout {
+                    id: clockDepthCutout
+                    anchors.fill: parent
+                    wallpaperSource: wallpaper.source
+                    maskPath: harness.activeMask
+                }
+            }
+        }
+    }
+
+    function shoot(name, next) {
+        field.grabToImage(result => {
+            result.saveToFile(`${harness.shotDir}/${name}.png`);
+            next();
+        });
+    }
+
+    Timer {
+        id: settle
+        interval: 400
+        property var next: null
+        onTriggered: if (settle.next) settle.next()
+    }
+    function after(step) {
+        settle.next = step;
+        settle.restart();
+    }
+
+    Timer {
+        running: true
+        interval: 1000
+        onTriggered: {
+            harness.check("all three fixtures are on disk",
+                harness.wallpaperFile !== "" && harness.fullMaskFile !== ""
+                    && harness.partMaskFile !== "" && harness.shotDir !== "");
+            harness.check("the wallpaper decoded",
+                wallpaper.status === Image.Ready, `status=${wallpaper.status}`);
+            harness.check("the mask decoded",
+                clockDepthCutout.maskStatus === Image.Ready,
+                `status=${clockDepthCutout.maskStatus}`);
+            harness.check("the layer is exactly where the viewport is",
+                clockDepthLayer.x === parallaxViewport.x
+                    && clockDepthLayer.y === parallaxViewport.y
+                    && clockDepthLayer.width === parallaxViewport.width
+                    && clockDepthLayer.height === parallaxViewport.height);
+            // Without this the whole probe can pass vacuously: at a matching
+            // aspect PreserveAspectCrop crops nothing, so a layer that got the
+            // scale wrong would still produce an identical frame.
+            harness.check("the fixture actually crops",
+                clockDepthCutout.maskRect.height > parallaxViewport.height + 1,
+                `cover=${clockDepthCutout.maskRect.height.toFixed(1)} `
+                    + `box=${parallaxViewport.height}`);
+            harness.check("nothing is showing while depth is off",
+                clockDepthLayer.opacity === 0 && !clockDepthLayer.visible,
+                `opacity=${clockDepthLayer.opacity}`);
+            harness.shoot("off_full", () => {
+                harness.depthOn = true;
+                harness.after(harness.fullOn);
+            });
+        }
+    }
+
+    function fullOn(): void {
+        harness.check("the layer is fully opaque with an opaque mask and depth on",
+            clockDepthLayer.opacity === 1 && clockDepthLayer.visible,
+            `opacity=${clockDepthLayer.opacity}`);
+        harness.shoot("on_full", () => {
+            harness.depthOn = false;
+            harness.activeMask = harness.partMaskFile;
+            harness.after(harness.partOff);
+        });
+    }
+
+    function partOff(): void {
+        harness.check("the second mask decoded",
+            clockDepthCutout.maskStatus === Image.Ready,
+            `status=${clockDepthCutout.maskStatus}`);
+        harness.shoot("off_part", () => {
+            harness.depthOn = true;
+            harness.after(harness.partOn);
+        });
+    }
+
+    function partOn(): void {
+        harness.shoot("on_part", () => harness.finish());
+    }
+
+    function finish(): void {
+        console.log(`[ClockDepthNoOp] checks: ${harness.checksRun} failures: ${harness.failures}`);
+        Qt.quit();
+    }
+}

--- a/dots/.config/quickshell/imi/ClockDepthProbe.qml
+++ b/dots/.config/quickshell/imi/ClockDepthProbe.qml
@@ -1,6 +1,6 @@
 import QtQuick
 import Quickshell
-import Qt5Compat.GraphicalEffects
+import qs.modules.imi.background
 import "modules/common/functions/clockDepth.js" as ClockDepthLogic
 
 /*
@@ -121,43 +121,16 @@ ShellRoot {
                     transitionInFlight: false
                 }) ? 1 : 0
 
-                Image {
-                    id: clockDepthWallpaper
+                // The shipping component, not a copy of it. The LAYER is
+                // re-declared here because Background.qml's lives inside a
+                // wlr-layer-shell PanelWindow and weston implements none; the
+                // registration inside it is the real one, so a probe that
+                // rebuilt it would be scoring its own arithmetic.
+                ClockDepthCutout {
+                    id: clockDepthCutout
                     anchors.fill: parent
-                    source: wallpaper.source
-                    fillMode: Image.PreserveAspectCrop
-                    cache: true
-                    smooth: true
-                    asynchronous: false
-                    visible: false
-                }
-
-                Item {
-                    id: clockDepthMaskSurface
-                    anchors.fill: parent
-                    visible: false
-                    clip: true
-
-                    Image {
-                        id: clockDepthMask
-                        readonly property var coverRect: ClockDepthLogic.coverRect(
-                            clockDepthWallpaper.implicitWidth, clockDepthWallpaper.implicitHeight,
-                            clockDepthMaskSurface.width, clockDepthMaskSurface.height)
-                        x: clockDepthMask.coverRect.x
-                        y: clockDepthMask.coverRect.y
-                        width: clockDepthMask.coverRect.width
-                        height: clockDepthMask.coverRect.height
-                        source: harness.activeMask === "" ? "" : `file://${harness.activeMask}`
-                        fillMode: Image.Stretch
-                        smooth: true
-                        asynchronous: false
-                    }
-                }
-
-                OpacityMask {
-                    anchors.fill: parent
-                    source: clockDepthWallpaper
-                    maskSource: clockDepthMaskSurface
+                    wallpaperSource: wallpaper.source
+                    maskPath: harness.activeMask
                 }
             }
         }
@@ -209,8 +182,8 @@ ShellRoot {
         interval: 300
         onTriggered: {
             harness.check("a mask file that has gone still leaves the layer eligible",
-                clockDepthLayer.opacity === 1 && clockDepthMask.status === Image.Error,
-                `opacity=${clockDepthLayer.opacity} maskStatus=${clockDepthMask.status}`);
+                clockDepthLayer.opacity === 1 && clockDepthCutout.maskStatus === Image.Error,
+                `opacity=${clockDepthLayer.opacity} maskStatus=${clockDepthCutout.maskStatus}`);
             if (harness.brokenShot !== "")
                 field.grabToImage(result => {
                     result.saveToFile(harness.brokenShot);
@@ -261,7 +234,7 @@ ShellRoot {
             harness.check("the wallpaper decoded",
                 wallpaper.status === Image.Ready, `status=${wallpaper.status}`);
             harness.check("the mask decoded",
-                clockDepthMask.status === Image.Ready, `status=${clockDepthMask.status}`);
+                clockDepthCutout.maskStatus === Image.Ready, `status=${clockDepthCutout.maskStatus}`);
             harness.check("the layer sits above the widget canvas",
                 clockDepthLayer.z > widgetCanvas.z,
                 `layer.z=${clockDepthLayer.z} canvas.z=${widgetCanvas.z}`);
@@ -275,15 +248,17 @@ ShellRoot {
             // wallpaper would be drawn unmasked over the widgets) and carries
             // the wallpaper's aspect rather than the box's, which is the whole
             // of the un-squash.
-            const wallpaperAspect = clockDepthWallpaper.implicitWidth / clockDepthWallpaper.implicitHeight;
+            const maskRect = clockDepthCutout.maskRect;
+            const sourceSize = clockDepthCutout.wallpaperSourceSize;
+            const wallpaperAspect = sourceSize.width / sourceSize.height;
             harness.check("the mask covers the box on both axes",
-                clockDepthMask.width >= parallaxViewport.width - 0.001
-                    && clockDepthMask.height >= parallaxViewport.height - 0.001,
-                `mask=${clockDepthMask.width.toFixed(1)}x${clockDepthMask.height.toFixed(1)} `
+                maskRect.width >= parallaxViewport.width - 0.001
+                    && maskRect.height >= parallaxViewport.height - 0.001,
+                `mask=${maskRect.width.toFixed(1)}x${maskRect.height.toFixed(1)} `
                     + `box=${parallaxViewport.width}x${parallaxViewport.height}`);
             harness.check("the mask is un-squashed to the wallpaper's aspect",
-                Math.abs(clockDepthMask.width / clockDepthMask.height - wallpaperAspect) < 0.001,
-                `mask=${(clockDepthMask.width / clockDepthMask.height).toFixed(3)} `
+                Math.abs(maskRect.width / maskRect.height - wallpaperAspect) < 0.001,
+                `mask=${(maskRect.width / maskRect.height).toFixed(3)} `
                     + `wallpaper=${wallpaperAspect.toFixed(3)}`);
             harness.check("the layer starts level with the viewport",
                 clockDepthLayer.x === parallaxViewport.x && clockDepthLayer.y === parallaxViewport.y);

--- a/dots/.config/quickshell/imi/modules/imi/background/Background.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/Background.qml
@@ -1299,77 +1299,19 @@ Variants {
                 }
             }
 
-            Image {
-                id: clockDepthWallpaper
+            // The registration lives in the component, not here, because the
+            // wallpaper selector's picker draws the same cutout to ask whether
+            // it is any good - and a picker that computed its own crop could
+            // certify a mask against a geometry the desktop never uses.
+            ClockDepthCutout {
+                id: clockDepthCutout
                 anchors.fill: parent
-                // Every one of these matches the `wallpaper` item inside the
-                // viewport on purpose. Same source, same size, same fill mode
-                // means the per-screen crop matches with no geometry of its own
-                // - and it means Qt's image cache serves both from ONE decode:
-                // a fill mode's aspect flags are part of the request, so a
-                // Stretch copy of the same file would decode all over again.
-                //
-                // The wallpaper item's own source is assigned imperatively, so
-                // a switch can snapshot the old frame before reloading; reading
-                // bgRoot.wallpaperPath here instead would put the incoming
+                // The wallpaper ITEM, not bgRoot.wallpaperPath: a switch
+                // assigns that source imperatively so it can snapshot the
+                // outgoing frame, and reading the path would put the incoming
                 // image under the outgoing image's mask for the length of it.
-                source: wallpaper.source
-                fillMode: Image.PreserveAspectCrop
-                cache: true
-                smooth: true
-                asynchronous: true
-                // Drawn by the OpacityMask below, not by itself.
-                visible: false
-            }
-
-            Item {
-                id: clockDepthMaskSurface
-                anchors.fill: parent
-                visible: false
-                // The mask is drawn oversized and offset (see coverRect), and
-                // this is what crops it back to the wallpaper's box - the same
-                // crop PreserveAspectCrop applies to the image it masks.
-                clip: true
-
-                Image {
-                    id: clockDepthMask
-                    // The mask is the model's own output: the whole picture
-                    // squashed to a square. So it is NOT the wallpaper's aspect,
-                    // and filling it into the same box would stretch it
-                    // differently from the image it masks - by 3.5x on this
-                    // monitor. Stretched into the rectangle the whole wallpaper
-                    // would occupy if nothing clipped it, undoing the squash and
-                    // re-applying the crop are the same operation.
-                    //
-                    // What masks is this file's ALPHA - Qt's OpacityMask reads
-                    // nothing else, so the producer writes the mask into the
-                    // alpha channel as well as the luminance. A plain grayscale
-                    // mask is opaque everywhere and lets the whole wallpaper
-                    // through, which draws the picture flat over the clock
-                    // rather than the subject behind it.
-                    readonly property var coverRect: ClockDepthLogic.coverRect(
-                        clockDepthWallpaper.implicitWidth, clockDepthWallpaper.implicitHeight,
-                        clockDepthMaskSurface.width, clockDepthMaskSurface.height)
-                    x: clockDepthMask.coverRect.x
-                    y: clockDepthMask.coverRect.y
-                    width: clockDepthMask.coverRect.width
-                    height: clockDepthMask.coverRect.height
-                    source: ClockDepth.maskPath === "" ? "" : `file://${ClockDepth.maskPath}`
-                    fillMode: Image.Stretch
-                    smooth: true
-                    asynchronous: true
-                }
-            }
-
-            // The one thing that paints. A missing or corrupt mask leaves this
-            // with an Image.Error maskSource, which shows nothing rather than
-            // showing everything - the right failure direction, and the reason
-            // the layer degrades to today's flat clock instead of to a
-            // wallpaper pasted over it.
-            OpacityMask {
-                anchors.fill: parent
-                source: clockDepthWallpaper
-                maskSource: clockDepthMaskSurface
+                wallpaperSource: wallpaper.source
+                maskPath: ClockDepth.maskPath
             }
         }
 

--- a/dots/.config/quickshell/imi/modules/imi/background/ClockDepthCutout.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/ClockDepthCutout.qml
@@ -1,0 +1,108 @@
+import QtQuick
+import Qt5Compat.GraphicalEffects
+import "../../common/functions/clockDepth.js" as ClockDepthLogic
+
+/**
+ * The wallpaper's subject, cut out of the wallpaper by its mask.
+ *
+ * One component because there are two call sites that must never be able to
+ * disagree: Background.qml draws this over the desktop widgets, and the
+ * wallpaper selector's picker draws it to ask the user whether the cutout is
+ * any good. Those were two hand-written copies of the same stack - the same
+ * `coverRect` call, the same clipping mask surface, the same OpacityMask -
+ * which is a visualizer that can drift from the thing it exists to judge, and
+ * a visualizer that disagrees with the layer is worse than none: it certifies
+ * a mask against a registration the desktop never uses.
+ *
+ * Everything geometric about the registration is here and nowhere else;
+ * `tests/lint_clock_depth_geometry.py` fails the suite on a second caller of
+ * `coverRect`.
+ */
+Item {
+    id: root
+
+    // The wallpaper ITEM's own source, never a config path. A switch assigns
+    // the wallpaper item's source imperatively so it can snapshot the outgoing
+    // frame first, so reading the path would put the incoming image under the
+    // outgoing image's mask for the length of every switch.
+    property url wallpaperSource
+    property string maskPath: ""
+
+    // The registered mask surface, exposed so an inspector can draw over the
+    // SAME item rather than rebuild a second one from the same numbers - which
+    // is the drift this component exists to make impossible.
+    readonly property alias maskSurface: maskSurface
+    readonly property alias maskStatus: mask.status
+    readonly property alias wallpaperStatus: cutoutWallpaper.status
+    // The un-squashed mask rectangle, in this item's coordinates. Usually
+    // larger than the item and offset negatively, because most of the point is
+    // that the picture is bigger than the box that crops it.
+    readonly property rect maskRect: Qt.rect(mask.x, mask.y, mask.width, mask.height)
+    readonly property size wallpaperSourceSize: Qt.size(cutoutWallpaper.implicitWidth,
+        cutoutWallpaper.implicitHeight)
+
+    Image {
+        id: cutoutWallpaper
+        anchors.fill: parent
+        // Every one of these matches the `wallpaper` item inside the viewport
+        // on purpose. Same source, same size, same fill mode means the
+        // per-screen crop matches with no geometry of its own - and it means
+        // Qt's image cache serves both from ONE decode, since a fill mode's
+        // aspect flags are part of the request and a Stretch copy of the same
+        // file would decode all over again.
+        source: root.wallpaperSource
+        fillMode: Image.PreserveAspectCrop
+        cache: true
+        smooth: true
+        asynchronous: true
+        // Drawn by the OpacityMask below, not by itself.
+        visible: false
+    }
+
+    Item {
+        id: maskSurface
+        anchors.fill: parent
+        visible: false
+        // The mask is drawn oversized and offset (see coverRect), and this is
+        // what crops it back to the wallpaper's box - the same crop
+        // PreserveAspectCrop applies to the image it masks.
+        clip: true
+
+        Image {
+            id: mask
+            // The mask is the model's own output: the whole picture squashed to
+            // a square. So it is NOT the wallpaper's aspect, and filling it
+            // into the same box would stretch it differently from the image it
+            // masks - by 3.5x on this monitor. Stretched into the rectangle the
+            // whole wallpaper would occupy if nothing clipped it, undoing the
+            // squash and re-applying the crop are the same operation.
+            //
+            // What masks is this file's ALPHA - Qt's OpacityMask reads nothing
+            // else, so the producer writes the mask into the alpha channel as
+            // well as the luminance. A plain grayscale mask is opaque
+            // everywhere and lets the whole wallpaper through, which draws the
+            // picture flat over the clock rather than the subject behind it.
+            readonly property var coverRect: ClockDepthLogic.coverRect(
+                cutoutWallpaper.implicitWidth, cutoutWallpaper.implicitHeight,
+                maskSurface.width, maskSurface.height)
+            x: mask.coverRect.x
+            y: mask.coverRect.y
+            width: mask.coverRect.width
+            height: mask.coverRect.height
+            source: root.maskPath === "" ? "" : `file://${root.maskPath}`
+            fillMode: Image.Stretch
+            smooth: true
+            asynchronous: true
+        }
+    }
+
+    // The one thing that paints. A missing or corrupt mask leaves this with an
+    // Image.Error maskSource, which shows nothing rather than showing
+    // everything - the right failure direction, and the reason the layer
+    // degrades to today's flat clock instead of to a wallpaper pasted over it.
+    OpacityMask {
+        anchors.fill: parent
+        source: cutoutWallpaper
+        maskSource: maskSurface
+    }
+}

--- a/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/ClockDepthPicker.qml
+++ b/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/ClockDepthPicker.qml
@@ -4,10 +4,11 @@ import Qt5Compat.GraphicalEffects
 import qs.services
 import qs.modules.common
 import qs.modules.common.widgets
-import "../../common/functions/clockDepth.js" as ClockDepthLogic
+import qs.modules.imi.background
 
 /**
- * Where the quality gate lives, and it is a human.
+ * Where the quality gate lives, and it is a human - so this is the instrument
+ * it makes its decision with.
  *
  * There is no automatic check for whether a mask is good. Scoring the whole
  * library numerically ranked rectangular slabs of background ABOVE clean
@@ -18,15 +19,29 @@ import "../../common/functions/clockDepth.js" as ClockDepthLogic
  *
  * Two models, because neither is a superset of the other: `isnet-anime` carries
  * most of this library and returns nothing at all on the semi-photographic
- * minority that `isnet-general-use` handles best. Both are offered; either, or
- * neither, can be chosen.
+ * minority that `isnet-general-use` handles best. So a model that finds nothing
+ * usually means the WRONG MODEL rather than no subject - measured on
+ * `cat_upscayl_2x…png`, where the illustration model returns `none` and the
+ * photographic one returns a foreground of 0.143 - and the two are shown side
+ * by side, at the same size, for exactly that reason.
  *
  * The preview is composited the way the desktop is - the wallpaper cropped as it
- * will be, dimmed, with a clock over it, and the cutout on top - rather than
- * shown as a bare mask. A bare cutout hides the failure that matters: the depth
- * layer paints the wallpaper's own pixels back over themselves, so a wrong mask
- * costs nothing where no widget sits, and the only question is whether it is
- * right where the clock is.
+ * will be, with a clock over it and the cutout on top - rather than shown as a
+ * bare mask. A bare cutout hides the failure that matters: the depth layer
+ * paints the wallpaper's own pixels back over themselves, so a wrong mask costs
+ * nothing where no widget sits, and the only question is whether it is right
+ * where the clock is.
+ *
+ * INSPECT is the other half, and it is the half that was missing: at full
+ * brightness a soft edge, a halo and a rectangular slab of background are all
+ * invisible against the image they were cut from - that is §1.2's own finding,
+ * which is why the feasibility survey judged every candidate as a cutout over a
+ * flat field rather than over its wallpaper. Switching it on dims everything
+ * the model did NOT claim and traces the silhouette, so the three questions a
+ * verdict actually rests on - where is the edge, how soft is it, what did it
+ * grab that it should not have - are answerable by looking. It draws over the
+ * SAME registered mask surface the desktop layer masks with (see
+ * ClockDepthCutout), so it cannot show a registration the desktop does not use.
  */
 Item {
     id: root
@@ -35,6 +50,35 @@ Item {
 
     readonly property string wallpaper: ClockDepth.wallpaperPath
     readonly property bool busy: ClockDepth.running !== ""
+    // Off by default and gated all the way down: with it off the picker draws
+    // exactly what the desktop will draw, and the inspection layers - a second
+    // pass over the mask surface and a glow - are not instantiated at all.
+    property bool inspect: false
+
+    // What this wallpaper's verdict currently is, said first. Both wrong
+    // conclusions this feature produced on the way in - the user's "toggling it
+    // on does nothing" and the review's "the layer is misaligned" - were the
+    // same missing sentence: the wallpaper on screen simply had no accepted
+    // cutout, and nothing anywhere said so.
+    readonly property string verdictLine: {
+        if (root.wallpaper === "")
+            return Translation.tr("No wallpaper to work from.")
+        switch (ClockDepth.state) {
+        case "accepted":
+            return Translation.tr("This wallpaper has a cutout, and the widgets are drawn behind it.")
+        case "declined":
+            return Translation.tr("This wallpaper is set to no depth. Accepting a cutout below undoes that.")
+        case "none":
+            return Translation.tr("Neither model found a subject in this wallpaper yet.")
+        case "candidate":
+            return Translation.tr("A cutout is ready to judge. Nothing is drawn until you keep one.")
+        case "unreadable":
+        case "error":
+            return Translation.tr("Could not read this wallpaper's cache entry.")
+        default:
+            return Translation.tr("No cutout for this wallpaper yet. Run a model, then keep it only if the edge looks right where your widgets sit.")
+        }
+    }
 
     signal closeRequested()
 
@@ -77,14 +121,29 @@ Item {
                 }
                 StyledText {
                     Layout.fillWidth: true
+                    // The first thing a person opening this needs is whether
+                    // this wallpaper has a cutout at all - which is the
+                    // question nobody could answer while the feature looked
+                    // like it was doing nothing, when in fact it was correctly
+                    // doing nothing for a wallpaper that has no mask.
                     text: ClockDepth.lastError !== ""
                         ? ClockDepth.lastError
-                        : Translation.tr("Run a model, then keep the cutout only if the subject's edge looks right where your widgets sit.")
+                        : root.verdictLine
                     font.pixelSize: Appearance.font.pixelSize.smaller
                     color: ClockDepth.lastError !== ""
                         ? Appearance.m3colors.m3error
                         : Appearance.colors.colSubtext
                     wrapMode: Text.WordWrap
+                }
+            }
+            IconToolbarButton {
+                id: inspectButton
+                implicitHeight: 36
+                onClicked: root.inspect = !root.inspect
+                toggled: root.inspect
+                text: "chrome_reader_mode"
+                StyledToolTip {
+                    text: Translation.tr("Dim everything the model did not pick, and trace its edge")
                 }
             }
             RippleButton {
@@ -123,6 +182,24 @@ Item {
                     readonly property bool refused: candidate.modelData in (ClockDepth.candidates ?? ({}))
                         && candidate.maskPath === ""
                     readonly property bool thisRunning: ClockDepth.running === candidate.modelData
+                    readonly property bool chosen: ClockDepth.state === "accepted"
+                        && ClockDepth.acceptedModel === candidate.modelData
+                    // Whether the OTHER column found something. A model that
+                    // returns nothing is usually the wrong model rather than an
+                    // empty picture, so an empty result has to point at its
+                    // neighbour instead of reading as a verdict on the image.
+                    readonly property bool otherFound: ClockDepth.models.some(other =>
+                        other !== candidate.modelData
+                        && (ClockDepth.candidates?.[other] ?? "") !== "")
+                    // Gated on the mask having DECODED, not merely on a path:
+                    // the veil masks by the inverse of the mask surface, so an
+                    // Image.Error or a not-yet-loaded mask is a transparent
+                    // surface whose inverse covers the entire preview in black
+                    // - a failure that reads as "the model claimed nothing"
+                    // rather than as "there is nothing to inspect".
+                    readonly property bool inspecting: root.inspect
+                        && candidate.maskPath !== ""
+                        && previewCutout.maskStatus === Image.Ready
 
                     Layout.fillWidth: true
                     Layout.fillHeight: true
@@ -135,12 +212,34 @@ Item {
                     Layout.preferredWidth: 1
                     spacing: Appearance.spacing.space100
 
-                    StyledText {
-                        text: candidate.modelData === "isnet-anime"
-                            ? Translation.tr("Illustration")
-                            : Translation.tr("Photographic")
-                        font.pixelSize: Appearance.font.pixelSize.normal
-                        color: Appearance.colors.colOnLayer0
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: Appearance.spacing.space50
+
+                        StyledText {
+                            text: candidate.modelData === "isnet-anime"
+                                ? Translation.tr("Illustration")
+                                : Translation.tr("Photographic")
+                            font.pixelSize: Appearance.font.pixelSize.normal
+                            color: Appearance.colors.colOnLayer0
+                        }
+                        // Which of the two the desktop is actually drawing.
+                        // Without it the picker shows two cutouts and no
+                        // indication of which one was ever accepted, so the
+                        // question "what is on my screen right now" is
+                        // unanswerable from the one surface built to answer it.
+                        MaterialSymbol {
+                            visible: candidate.chosen
+                            text: "check_circle"
+                            iconSize: Appearance.font.pixelSize.normal
+                            color: Appearance.colors.colPrimary
+                        }
+                        Item { Layout.fillWidth: true }
+                        StyledText {
+                            text: candidate.modelData
+                            font.pixelSize: Appearance.font.pixelSize.smallest
+                            color: Appearance.colors.colSubtext
+                        }
                     }
 
                     Item {
@@ -156,6 +255,12 @@ Item {
                             color: Appearance.colors.colLayer1
                         }
 
+                        // The picture as the desktop crops it. Drawn at full
+                        // brightness, because with inspect off this preview's
+                        // only job is to be honest about what the wallpaper
+                        // will look like with the cutout on it - the diagnosis
+                        // is the other mode's job, and a preview that is
+                        // permanently half a diagnosis is neither.
                         Image {
                             id: previewWallpaper
                             anchors.fill: parent
@@ -164,22 +269,35 @@ Item {
                             cache: true
                             smooth: true
                             asynchronous: true
-                            visible: false
                         }
 
-                        // Everything that is NOT the subject, dimmed. This is
-                        // the whole reason the preview is not the plain
-                        // wallpaper: a soft edge is invisible against the image
-                        // it was cut from, and a rectangular slab of background
-                        // is only obvious once the rest is darker than it.
-                        Image {
+                        // INSPECT: everything the model did NOT claim, dimmed.
+                        // A soft edge, a halo and a rectangular slab of
+                        // background are all invisible against the image they
+                        // were cut from - which is why the feasibility survey
+                        // judged every candidate over a flat field - so the
+                        // veil is what turns "it looks like the wallpaper" into
+                        // a readable answer about what was picked.
+                        //
+                        // Masked by the INVERSE of the same registered surface
+                        // the cutout is masked by, so the lit region and the
+                        // drawn region cannot be off by a pixel from each other.
+                        Rectangle {
+                            id: veilSource
                             anchors.fill: parent
-                            source: previewWallpaper.source
-                            fillMode: Image.PreserveAspectCrop
-                            cache: true
-                            smooth: true
-                            asynchronous: true
-                            opacity: 0.35
+                            color: "black"
+                            visible: false
+                        }
+                        Loader {
+                            anchors.fill: parent
+                            active: candidate.inspecting
+                            visible: active
+                            sourceComponent: OpacityMask {
+                                source: veilSource
+                                maskSource: previewCutout.maskSurface
+                                invert: true
+                                opacity: 0.66
+                            }
                         }
 
                         StyledText {
@@ -191,32 +309,46 @@ Item {
                             color: Appearance.colors.colOnLayer0
                         }
 
-                        Item {
-                            id: previewMaskSurface
+                        // INSPECT: the silhouette itself, traced. The veil says
+                        // WHAT was claimed; this says WHERE the boundary runs
+                        // and how hard it is - a mask that follows hair tufts
+                        // draws a tight bright line, a mushy one draws a wide
+                        // faint band, and a rectangular slab draws a rectangle.
+                        // Drawn under the cutout so only its outer half shows,
+                        // which keeps the subject's own pixels unpainted.
+                        Loader {
                             anchors.fill: parent
-                            visible: false
-                            clip: true
-
-                            Image {
-                                id: previewMask
-                                readonly property var coverRect: ClockDepthLogic.coverRect(
-                                    previewWallpaper.implicitWidth, previewWallpaper.implicitHeight,
-                                    previewMaskSurface.width, previewMaskSurface.height)
-                                x: previewMask.coverRect.x
-                                y: previewMask.coverRect.y
-                                width: previewMask.coverRect.width
-                                height: previewMask.coverRect.height
-                                source: candidate.maskPath === "" ? "" : `file://${candidate.maskPath}`
-                                fillMode: Image.Stretch
-                                smooth: true
-                                asynchronous: true
+                            active: candidate.inspecting
+                            visible: active
+                            sourceComponent: Glow {
+                                source: previewCutout.maskSurface
+                                // The one hardcoded colour in this file, and it
+                                // has to be: every Appearance token is
+                                // generated FROM this wallpaper, so a token
+                                // here is guaranteed to be a colour the picture
+                                // already contains. The feasibility survey
+                                // judged its masks over flat magenta for the
+                                // same reason.
+                                color: "#ff00c8"
+                                radius: 8
+                                samples: 17
+                                spread: 0.45
+                                // Otherwise the blur clamps at the item's edges
+                                // and a subject touching the bottom of the
+                                // frame smears into a band across it, which
+                                // reads as a mask claiming the whole edge.
+                                transparentBorder: true
                             }
                         }
 
-                        OpacityMask {
+                        // The subject, cut out exactly the way the desktop cuts
+                        // it out. Same component, so the preview cannot show a
+                        // registration the desktop does not use.
+                        ClockDepthCutout {
+                            id: previewCutout
                             anchors.fill: parent
-                            source: previewWallpaper
-                            maskSource: previewMaskSurface
+                            wallpaperSource: previewWallpaper.source
+                            maskPath: candidate.maskPath
                             visible: candidate.maskPath !== ""
                         }
 
@@ -235,10 +367,19 @@ Item {
                             StyledText {
                                 id: statusLabel
                                 anchors.centerIn: parent
+                                // "No subject found" was a verdict on the
+                                // picture and it is usually a verdict on the
+                                // model: measured, the illustration model
+                                // returns nothing on photographic wallpapers
+                                // the other model cuts out cleanly. A user who
+                                // reads the first sentence stops; a user who
+                                // reads this one runs the other column.
                                 text: candidate.thisRunning
                                     ? Translation.tr("Looking for a subject…")
                                     : candidate.refused
-                                        ? Translation.tr("No subject found")
+                                        ? (candidate.otherFound
+                                            ? Translation.tr("Nothing here — the other model found something")
+                                            : Translation.tr("Nothing here — try the other model"))
                                         : Translation.tr("Not run yet")
                                 font.pixelSize: Appearance.font.pixelSize.small
                                 color: Appearance.colors.colOnLayer0
@@ -287,11 +428,13 @@ Item {
 
             StyledText {
                 Layout.fillWidth: true
-                text: ClockDepth.state === "accepted"
-                    ? Translation.tr("This wallpaper is using a cutout.")
-                    : ClockDepth.state === "declined"
-                        ? Translation.tr("This wallpaper is set to no depth.")
-                        : ""
+                // The global switch, not this wallpaper's verdict - that is the
+                // header's job now. Worth its own line because accepting a
+                // cutout turns the switch on, so the two are easy to conflate
+                // and only one of them is per-wallpaper.
+                text: ClockDepth.enabled
+                    ? Translation.tr("Depth is on. Wallpapers with no accepted cutout are unaffected.")
+                    : Translation.tr("Depth is off. Keeping a cutout turns it on.")
                 font.pixelSize: Appearance.font.pixelSize.smaller
                 color: Appearance.colors.colSubtext
             }

--- a/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/ClockDepthPicker.qml
+++ b/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/ClockDepthPicker.qml
@@ -136,12 +136,27 @@ Item {
                     wrapMode: Text.WordWrap
                 }
             }
-            IconToolbarButton {
+            // A RippleButton rather than the IconToolbarButton this started as:
+            // ToolbarButton carries `Layout.fillHeight: true` for the toolbars
+            // it was written for, and IconToolbarButton derives its width from
+            // its height - so in a header row it stretches to the row and comes
+            // out as a circle a third of the dialog wide, which is also what
+            // made the row that tall. It is the close button's twin now.
+            RippleButton {
                 id: inspectButton
+                implicitWidth: 36
                 implicitHeight: 36
-                onClicked: root.inspect = !root.inspect
+                buttonRadius: height / 2
                 toggled: root.inspect
-                text: "chrome_reader_mode"
+                onClicked: root.inspect = !root.inspect
+                contentItem: MaterialSymbol {
+                    anchors.centerIn: parent
+                    text: "chrome_reader_mode"
+                    iconSize: Appearance.font.pixelSize.larger
+                    color: inspectButton.toggled
+                        ? Appearance.colors.colOnPrimary
+                        : Appearance.colors.colOnLayer0
+                }
                 StyledToolTip {
                     text: Translation.tr("Dim everything the model did not pick, and trace its edge")
                 }
@@ -188,9 +203,14 @@ Item {
                     // returns nothing is usually the wrong model rather than an
                     // empty picture, so an empty result has to point at its
                     // neighbour instead of reading as a verdict on the image.
-                    readonly property bool otherFound: ClockDepth.models.some(other =>
-                        other !== candidate.modelData
-                        && (ClockDepth.candidates?.[other] ?? "") !== "")
+                    readonly property bool otherFound: {
+                        const results = ClockDepth.candidates ?? ({})
+                        for (const other in results) {
+                            if (other !== candidate.modelData && (results[other] ?? "") !== "")
+                                return true
+                        }
+                        return false
+                    }
                     // Gated on the mask having DECODED, not merely on a path:
                     // the veil masks by the inverse of the mask surface, so an
                     // Image.Error or a not-yet-loaded mask is a transparent
@@ -203,7 +223,6 @@ Item {
 
                     Layout.fillWidth: true
                     Layout.fillHeight: true
-                    Layout.alignment: Qt.AlignTop
                     // Both columns take half the row whatever their content is
                     // wider than. Without a preferred width a RowLayout hands
                     // fillWidth children their implicit widths first, so the
@@ -418,6 +437,13 @@ Item {
                             }
                         }
                     }
+
+                    // The preview's height is locked to the screen's aspect, so
+                    // a tall dialog has height nothing wants. It falls here
+                    // rather than being shared out above the label, which would
+                    // float the two cutouts in the middle of the dialog away
+                    // from the buttons that act on them.
+                    Item { Layout.fillHeight: true }
                 }
             }
         }

--- a/dots/.config/quickshell/imi/scripts/background/subject_mask.py
+++ b/dots/.config/quickshell/imi/scripts/background/subject_mask.py
@@ -77,6 +77,42 @@ def cache_key(wallpaper):
     return hashlib.sha256(material).hexdigest()[:32]
 
 
+def accepted_model(root, key, candidates):
+    """Which candidate the accepted mask is a copy of, or None.
+
+    Derived from the bytes rather than recorded in a fifth file. `accept` is a
+    byte-for-byte copy, so the answer is already on disk, and a recorded one
+    would be a second thing that has to agree with the first with nothing
+    reporting it when it stops - the `activeStill` shape, and this cache is full
+    of pairs that are deliberately derived for exactly that reason.
+
+    None is a real answer and not only an error: re-running a model overwrites
+    its candidate, so an accepted mask can stop matching either of them, and
+    "the cutout you accepted is not either of these" is what the picker should
+    then say rather than crediting whichever it happens to resemble.
+    """
+    accepted = root / f"{key}.png"
+    blob = None
+    try:
+        size = accepted.stat().st_size
+        for model, path in candidates.items():
+            if path is None:
+                continue
+            candidate = Path(path)
+            # Size first: two 1024x1024 masks from different models are
+            # routinely both ~300 KB but never the same 300 KB, so this skips
+            # the read on the mismatching one without deciding anything by it.
+            if candidate.stat().st_size != size:
+                continue
+            if blob is None:
+                blob = accepted.read_bytes()
+            if candidate.read_bytes() == blob:
+                return model
+    except OSError:
+        return None
+    return None
+
+
 def status(root, wallpaper):
     """What the shell asks. Reads directory entries; loads nothing."""
     try:
@@ -101,6 +137,7 @@ def status(root, wallpaper):
     elif accepted.exists():
         result["state"] = "accepted"
         result["mask"] = str(accepted)
+        result["acceptedModel"] = accepted_model(root, key, candidates)
     elif candidates and all(v is None for v in candidates.values()):
         result["state"] = "none"
     elif candidates:

--- a/dots/.config/quickshell/imi/services/ClockDepth.qml
+++ b/dots/.config/quickshell/imi/services/ClockDepth.qml
@@ -54,6 +54,11 @@ Singleton {
     // model name -> candidate mask path, or null where that model looked and
     // found nothing. The picker reads this; the depth layer does not.
     property var candidates: ({})
+    // Which model's candidate the accepted mask is a copy of; "" when nothing
+    // is accepted, and also when it matches neither, because re-running a model
+    // overwrites its candidate. Derived by the producer from the bytes rather
+    // than recorded anywhere, so it cannot drift from the file the shell draws.
+    property string acceptedModel: ""
 
     readonly property bool optedOut: root.state === "declined"
 
@@ -117,6 +122,7 @@ Singleton {
         root.key = ""
         root.maskPath = ""
         root.candidates = ({})
+        root.acceptedModel = ""
         root.queriedPath = ""
     }
 
@@ -177,12 +183,14 @@ Singleton {
                     root.state = "error"
                     root.maskPath = ""
                     root.candidates = ({})
+                    root.acceptedModel = ""
                     return
                 }
                 root.state = parsed.state ?? "error"
                 root.key = parsed.key ?? ""
                 root.maskPath = parsed.state === "accepted" ? (parsed.mask ?? "") : ""
                 root.candidates = parsed.candidates ?? ({})
+                root.acceptedModel = parsed.acceptedModel ?? ""
             }
         }
     }

--- a/dots/.config/quickshell/imi/tests/lint_clock_depth_geometry.py
+++ b/dots/.config/quickshell/imi/tests/lint_clock_depth_geometry.py
@@ -27,12 +27,22 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 BACKGROUND = ROOT / "modules/imi/background/Background.qml"
+CUTOUT = ROOT / "modules/imi/background/ClockDepthCutout.qml"
 
 LAYER_ID = "clockDepthLayer"
 CANVAS_ID = "widgetCanvas"
-DEPTH_IMAGE_ID = "clockDepthWallpaper"
-MASK_SURFACE_ID = "clockDepthMaskSurface"
+CUTOUT_TYPE = "ClockDepthCutout"
+DEPTH_IMAGE_ID = "cutoutWallpaper"
+MASK_SURFACE_ID = "maskSurface"
 WALLPAPER_ID = "wallpaper"
+
+# The registration - un-squashing the model's square mask and re-applying the
+# wallpaper's crop - is computed in exactly one file. Two call sites draw this
+# cutout: the desktop layer, and the picker that asks the user whether it is any
+# good. A picker that derived its own crop would certify a mask against a
+# geometry the desktop never uses, which is a visualizer that lies about the one
+# thing it exists to judge.
+REGISTRATION_FUNCTION = "coverRect"
 
 INPUT_TYPES = ("MouseArea", "MultiPointTouchArea", "Flickable", "HoverHandler",
                "TapHandler", "DragHandler", "PointHandler", "WheelHandler",
@@ -118,6 +128,30 @@ def block_for(source, object_id):
     return None
 
 
+def type_block(source, type_name):
+    """The whole declaration of the first `<TypeName> { ... }` in `source`.
+
+    Brace-matched for the same reason `block_for` is, and deliberately not
+    anchored on indentation: a check whose pattern bakes in the column its
+    target currently sits at stops matching after any reformat, and passes
+    vacuously rather than reporting that it has stopped looking.
+    """
+    marker = re.search(rf"(?<![\w.]){re.escape(type_name)}\s*\{{", source)
+    if not marker:
+        return None
+    opening = source.index("{", marker.start())
+    depth = 0
+    for index in range(opening, len(source)):
+        char = source[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source[opening + 1:index]
+    return None
+
+
 def declaration(block, name):
     """One property's whole value, block-bodied values included."""
     marker = re.search(rf"^(\s*)(?:readonly\s+)?(?:property\s+\S+\s+)?{re.escape(name)}:\s*",
@@ -138,8 +172,9 @@ def declaration(block, name):
     return rest.strip()
 
 
-def check(raw):
+def check(raw, cutout_raw=None):
     source = strip_comments(raw)
+    cutout = strip_comments(cutout_raw if cutout_raw is not None else raw)
     layer = block_for(source, LAYER_ID)
     if layer is None:
         fail(f"no object carries `id: {LAYER_ID}` - the depth layer is gone")
@@ -183,7 +218,12 @@ def check(raw):
         fail(f"could not read both z values ({LAYER_ID}={layer_z!r}, "
              f"{CANVAS_ID}={canvas_z!r})")
 
-    depth_image = block_for(source, DEPTH_IMAGE_ID)
+    if not re.search(rf"^\s*{CUTOUT_TYPE}\s*\{{", layer, re.MULTILINE):
+        fail(f"{LAYER_ID} does not draw a {CUTOUT_TYPE}: the registration must "
+             f"come from the component the picker also draws, or the two can "
+             f"disagree about where the mask lands")
+
+    depth_image = block_for(cutout, DEPTH_IMAGE_ID)
     wallpaper = block_for(source, WALLPAPER_ID)
     if depth_image is None or wallpaper is None:
         fail(f"could not find both {DEPTH_IMAGE_ID} and {WALLPAPER_ID}")
@@ -199,9 +239,10 @@ def check(raw):
     # it can snapshot the outgoing frame first. Reading the path instead would
     # put the incoming image under the outgoing image's mask for the length of
     # every switch, so the depth image follows the ITEM.
-    source_binding = declaration(depth_image, "source")
+    cutout_use = type_block(layer, CUTOUT_TYPE)
+    source_binding = declaration(cutout_use, "wallpaperSource") if cutout_use else None
     if source_binding != f"{WALLPAPER_ID}.source":
-        fail(f"{DEPTH_IMAGE_ID}.source is {source_binding!r}, expected "
+        fail(f"{CUTOUT_TYPE}.wallpaperSource is {source_binding!r}, expected "
              f"{WALLPAPER_ID + '.source'!r}: it must draw whatever the wallpaper "
              f"item is drawing, not whatever the config currently names")
 
@@ -209,9 +250,9 @@ def check(raw):
     # opacity over the clock - the loudest possible version of this feature's
     # own failure, and one that nothing else here would notice, because every
     # geometry check above still passes on it.
-    mask = re.search(r"OpacityMask\s*\{(.*?)\}", layer, re.DOTALL)
+    mask = re.search(r"OpacityMask\s*\{(.*?)\}", cutout, re.DOTALL)
     if not mask:
-        fail(f"{LAYER_ID} contains no OpacityMask: the layer would paint the "
+        fail(f"{CUTOUT_TYPE} contains no OpacityMask: the layer would paint the "
              f"whole wallpaper over the clock, not the subject")
     else:
         body = mask.group(1)
@@ -219,7 +260,7 @@ def check(raw):
             fail(f"the OpacityMask does not mask {DEPTH_IMAGE_ID}")
         if declaration(body, "maskSource") != MASK_SURFACE_ID:
             fail(f"the OpacityMask's maskSource is not {MASK_SURFACE_ID}")
-    surface = block_for(layer, MASK_SURFACE_ID)
+    surface = block_for(cutout, MASK_SURFACE_ID)
     if surface is None:
         fail(f"no object carries `id: {MASK_SURFACE_ID}`")
     elif declaration(surface, "clip") != "true":
@@ -227,7 +268,7 @@ def check(raw):
              f"offset, and uncropped it masks the wrong pixels")
 
 
-SELF_CHECK_GOOD = """
+SELF_CHECK_BACKGROUND = """
 Item {
     id: widgetCanvas
     z: 2
@@ -241,26 +282,11 @@ Item {
     z: 3
     visible: !bgRoot.suppressContents && clockDepthLayer.opacity > 0
     enabled: false
-    Image {
-        id: clockDepthWallpaper
-        source: wallpaper.source
-        fillMode: Image.PreserveAspectCrop
-        cache: true
-        smooth: true
-        asynchronous: true
-        visible: false
-    }
-    Item {
-        id: clockDepthMaskSurface
+    ClockDepthCutout {
+        id: clockDepthCutout
         anchors.fill: parent
-        visible: false
-        clip: true
-        Image { id: clockDepthMask; fillMode: Image.Stretch }
-    }
-    OpacityMask {
-        anchors.fill: parent
-        source: clockDepthWallpaper
-        maskSource: clockDepthMaskSurface
+        wallpaperSource: wallpaper.source
+        maskPath: ClockDepth.maskPath
     }
 }
 Image {
@@ -272,6 +298,70 @@ Image {
 }
 """
 
+SELF_CHECK_CUTOUT = """
+Item {
+    id: root
+    Image {
+        id: cutoutWallpaper
+        anchors.fill: parent
+        source: root.wallpaperSource
+        fillMode: Image.PreserveAspectCrop
+        cache: true
+        smooth: true
+        asynchronous: true
+        visible: false
+    }
+    Item {
+        id: maskSurface
+        anchors.fill: parent
+        visible: false
+        clip: true
+        Image { id: mask; fillMode: Image.Stretch }
+    }
+    OpacityMask {
+        anchors.fill: parent
+        source: cutoutWallpaper
+        maskSource: maskSurface
+    }
+}
+"""
+
+
+def registration_callers():
+    """Every file that computes the mask's placement for itself.
+
+    The rule is one caller, and it is the whole reason the cutout became a
+    component: the desktop layer and the picker that judges its output must be
+    unable to disagree about where the mask lands, because a picker registered
+    differently from the layer certifies a mask against a geometry nothing ever
+    draws. A second caller is not a duplicate to tidy up later - it is a
+    visualizer that can start lying without anything reporting it.
+    """
+    callers = []
+    for path in sorted(ROOT.rglob("*.qml")) + sorted(ROOT.rglob("*.js")):
+        if path.name == "clockDepth.js":
+            continue
+        try:
+            text = strip_comments(path.read_text())
+        except (OSError, UnicodeDecodeError):
+            continue
+        if re.search(rf"\.{REGISTRATION_FUNCTION}\s*\(", text):
+            callers.append(path.relative_to(ROOT).as_posix())
+    return callers
+
+
+def check_one_registration():
+    callers = registration_callers()
+    # The eligibility unit test is the function's own test, which is the one
+    # place calling it is not a second registration - it asserts the arithmetic
+    # rather than drawing anything with it.
+    expected = sorted([CUTOUT.relative_to(ROOT).as_posix(),
+                       "tests/tst_clock_depth_eligibility.qml"])
+    if sorted(callers) != expected:
+        fail(f"{REGISTRATION_FUNCTION} is called from {callers}, expected only "
+             f"{expected}: the mask's placement is computed in one file so the "
+             f"picker cannot show a registration the desktop does not use")
+
 
 def self_check():
     """Prove the machinery independently of what the tree happens to contain.
@@ -281,49 +371,64 @@ def self_check():
     """
     global failures
     saved, failures = failures, []
-    check(SELF_CHECK_GOOD)
+    check(SELF_CHECK_BACKGROUND, SELF_CHECK_CUTOUT)
     clean = failures
-    mutations = {
-        "pan bound to the target": SELF_CHECK_GOOD.replace(
+    background_mutations = {
+        "pan bound to the target": SELF_CHECK_BACKGROUND.replace(
             "x: parallaxViewport.x", "x: bgRoot.parallaxOffsets.x"),
-        "fullscreen gate dropped": SELF_CHECK_GOOD.replace(
+        "fullscreen gate dropped": SELF_CHECK_BACKGROUND.replace(
             "visible: !bgRoot.suppressContents && clockDepthLayer.opacity > 0",
             "visible: clockDepthLayer.opacity > 0"),
-        "input gate dropped": SELF_CHECK_GOOD.replace("    enabled: false\n", ""),
-        "a MouseArea in the layer": SELF_CHECK_GOOD.replace(
-            "    Image {\n        id: clockDepthWallpaper",
-            "    MouseArea { anchors.fill: parent }\n    Image {\n        id: clockDepthWallpaper"),
-        "drawn below the clock": SELF_CHECK_GOOD.replace("    z: 3", "    z: 1"),
-        "fill mode diverged": SELF_CHECK_GOOD.replace(
+        "input gate dropped": SELF_CHECK_BACKGROUND.replace("    enabled: false\n", ""),
+        "a MouseArea in the layer": SELF_CHECK_BACKGROUND.replace(
+            "    ClockDepthCutout {",
+            "    MouseArea { anchors.fill: parent }\n    ClockDepthCutout {"),
+        "drawn below the clock": SELF_CHECK_BACKGROUND.replace("    z: 3", "    z: 1"),
+        "fill mode diverged": SELF_CHECK_BACKGROUND.replace(
             "    id: wallpaper\n    fillMode: Image.PreserveAspectCrop",
             "    id: wallpaper\n    fillMode: Image.Stretch"),
-        "the layer removed": SELF_CHECK_GOOD.replace("id: clockDepthLayer", "id: somethingElse"),
-        "the depth image chasing the config path": SELF_CHECK_GOOD.replace(
-            "source: wallpaper.source", "source: bgRoot.wallpaperPath"),
+        "the layer removed": SELF_CHECK_BACKGROUND.replace(
+            "id: clockDepthLayer", "id: somethingElse"),
+        "the cutout chasing the config path": SELF_CHECK_BACKGROUND.replace(
+            "wallpaperSource: wallpaper.source", "wallpaperSource: bgRoot.wallpaperPath"),
+        "the layer rebuilding the cutout itself": SELF_CHECK_BACKGROUND.replace(
+            "    ClockDepthCutout {\n        id: clockDepthCutout\n        anchors.fill: parent\n"
+            "        wallpaperSource: wallpaper.source\n        maskPath: ClockDepth.maskPath\n    }",
+            "    Image { id: hand; source: wallpaper.source }"),
+    }
+    cutout_mutations = {
         "the mask dropped entirely": re.sub(
-            r"OpacityMask \{.*?\n    \}\n", "", SELF_CHECK_GOOD, flags=re.DOTALL),
-        "the mask surface no longer clips": SELF_CHECK_GOOD.replace(
+            r"OpacityMask \{.*?\n    \}\n", "", SELF_CHECK_CUTOUT, flags=re.DOTALL),
+        "the mask surface no longer clips": SELF_CHECK_CUTOUT.replace(
             "        clip: true\n", ""),
-        "the OpacityMask masking something else": SELF_CHECK_GOOD.replace(
-            "        maskSource: clockDepthMaskSurface", "        maskSource: somethingElse"),
+        "the OpacityMask masking something else": SELF_CHECK_CUTOUT.replace(
+            "        maskSource: maskSurface", "        maskSource: somethingElse"),
+        "the cutout image no longer shares the wallpaper's request":
+            SELF_CHECK_CUTOUT.replace(
+                "        fillMode: Image.PreserveAspectCrop", "        fillMode: Image.Stretch"),
     }
     # The comment stripper is the half that decides whether any of the above
     # ever matches again once someone documents a refusal in the same words the
     # check greps for - which is exactly what the layer's own comments do.
-    documented = SELF_CHECK_GOOD.replace(
+    documented = SELF_CHECK_BACKGROUND.replace(
         "    x: parallaxViewport.x",
         "    // deliberately NOT bgRoot.parallaxOffsets, see #157 { unbalanced\n"
         "    x: parallaxViewport.x")
     problems = []
     if clean:
         problems.append(f"the reference tree does not pass: {clean}")
-    for name, mutated in mutations.items():
+    for name, mutated in background_mutations.items():
         failures = []
-        check(mutated)
+        check(mutated, SELF_CHECK_CUTOUT)
+        if not failures:
+            problems.append(f"the check does not notice: {name}")
+    for name, mutated in cutout_mutations.items():
+        failures = []
+        check(SELF_CHECK_BACKGROUND, mutated)
         if not failures:
             problems.append(f"the check does not notice: {name}")
     failures = []
-    check(documented)
+    check(documented, SELF_CHECK_CUTOUT)
     if failures:
         problems.append(f"a comment naming the trap fails the check: {failures}")
     failures = saved
@@ -337,13 +442,15 @@ def main():
             print(f"clock depth geometry lint SELF-CHECK: {problem}", file=sys.stderr)
         return 1
 
-    check(BACKGROUND.read_text())
+    check(BACKGROUND.read_text(), CUTOUT.read_text())
+    check_one_registration()
     if failures:
         for message in failures:
             print(f"clock depth geometry lint: {message}", file=sys.stderr)
         return 1
     print("Clock depth geometry lint passed: the layer follows the viewport, "
-          "gates on fullscreen, takes no input and shares the wallpaper's request")
+          "gates on fullscreen, takes no input, shares the wallpaper's request "
+          "and registers the mask in one place")
     return 0
 
 

--- a/dots/.config/quickshell/imi/tests/run_clock_depth_noop_probe.sh
+++ b/dots/.config/quickshell/imi/tests/run_clock_depth_noop_probe.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Headless weston + qs, the runtime-harness pattern. One process, one wallpaper
+# that nothing can change under it, and only the depth flag moving between the
+# frames it grabs - which is the control a pair of live `grim` captures does not
+# have.
+set -u
+SOCKET="wl-imi-clock-depth-noop"
+TMP=$(mktemp -d)
+export XDG_RUNTIME_DIR="$TMP/runtime"; mkdir -p "$XDG_RUNTIME_DIR"; chmod 700 "$XDG_RUNTIME_DIR"
+export XDG_CONFIG_HOME="$TMP/config" XDG_CACHE_HOME="$TMP/cache" XDG_STATE_HOME="$TMP/state" XDG_DATA_HOME="$TMP/data"
+mkdir -p "$XDG_CONFIG_HOME" "$XDG_CACHE_HOME" "$XDG_STATE_HOME" "$XDG_DATA_HOME"
+weston --backend=headless-backend.so --socket="$SOCKET" --width=1280 --height=800 &>"$TMP/weston.log" &
+WPID=$!
+sleep 2
+DBUS_SESSION_BUS_ADDRESS="unix:path=/nonexistent" WAYLAND_DISPLAY="$SOCKET" \
+    CLOCK_DEPTH_WALLPAPER="${CLOCK_DEPTH_WALLPAPER:-}" \
+    CLOCK_DEPTH_FULL_MASK="${CLOCK_DEPTH_FULL_MASK:-}" \
+    CLOCK_DEPTH_PART_MASK="${CLOCK_DEPTH_PART_MASK:-}" \
+    CLOCK_DEPTH_SHOT_DIR="${CLOCK_DEPTH_SHOT_DIR:-}" \
+    timeout 60 qs -p "$(dirname "$0")/../ClockDepthNoOpProbe.qml" 2>&1 | grep "ClockDepthNoOp"
+kill $WPID 2>/dev/null
+rm -rf "$TMP"

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -931,6 +931,12 @@ if ! python3 "$SCRIPT_DIR/test_clock_depth_compositing.py"; then
     exit 1
 fi
 
+echo "Running clock depth no-op tests..."
+if ! python3 "$SCRIPT_DIR/test_clock_depth_noop.py"; then
+    echo "Clock depth no-op tests failed."
+    exit 1
+fi
+
 echo "Running greeter sync tests..."
 if ! python3 "$SCRIPT_DIR/test_greeter_sync.py"; then
     echo "Greeter sync tests failed."

--- a/dots/.config/quickshell/imi/tests/test_clock_depth_cache.py
+++ b/dots/.config/quickshell/imi/tests/test_clock_depth_cache.py
@@ -106,6 +106,46 @@ class StatusTest(unittest.TestCase):
         self.assertEqual(result["state"], "accepted")
         self.assertEqual(result["mask"], str(accepted))
 
+    def test_the_accepted_mask_names_the_model_it_came_from(self):
+        """Which of the two models the desktop is actually drawing.
+
+        Derived from the bytes rather than recorded, so it cannot drift from the
+        file the shell draws - and the picker needs it, because two candidates
+        shown side by side with no mark on either leaves "what is on my screen"
+        unanswerable from the one surface built to answer it.
+        """
+        (self.cache / f"{self.key}.isnet-general-use.png").write_bytes(b"photographic")
+        (self.cache / f"{self.key}.isnet-anime.png").write_bytes(b"illustration")
+        (self.cache / f"{self.key}.png").write_bytes(b"illustration")
+        self.assertEqual(self.status()["acceptedModel"], "isnet-anime")
+
+    def test_a_mask_matching_neither_candidate_names_no_model(self):
+        """Re-running a model overwrites its candidate, so this is reachable.
+
+        None is the honest answer there: crediting whichever candidate it most
+        resembles would put a check mark on a cutout the desktop is not drawing.
+        """
+        (self.cache / f"{self.key}.isnet-anime.png").write_bytes(b"illustration")
+        (self.cache / f"{self.key}.png").write_bytes(b"something else entirely")
+        self.assertIsNone(self.status()["acceptedModel"])
+
+    def test_two_candidates_of_the_same_size_are_told_apart_by_content(self):
+        """Size is a shortcut past a read, never the decision.
+
+        Two 1024x1024 masks are routinely both about 300 KB, so deciding on the
+        size alone would credit whichever model happened to be listed first.
+        """
+        (self.cache / f"{self.key}.isnet-anime.png").write_bytes(b"aaaaaaaa")
+        (self.cache / f"{self.key}.isnet-general-use.png").write_bytes(b"bbbbbbbb")
+        (self.cache / f"{self.key}.png").write_bytes(b"bbbbbbbb")
+        self.assertEqual(self.status()["acceptedModel"], "isnet-general-use")
+
+    def test_nothing_accepted_reports_no_model(self):
+        (self.cache / f"{self.key}.isnet-anime.png").write_bytes(b"illustration")
+        result = self.status()
+        self.assertEqual(result["state"], "candidate")
+        self.assertNotIn("acceptedModel", result)
+
     def test_a_declined_wallpaper_beats_an_accepted_mask(self):
         (self.cache / f"{self.key}.png").write_bytes(b"mask")
         (self.cache / f"{self.key}.off").write_text("")

--- a/dots/.config/quickshell/imi/tests/test_clock_depth_noop.py
+++ b/dots/.config/quickshell/imi/tests/test_clock_depth_noop.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Depth on and depth off are the same frame when nothing sits under the layer.
+
+The depth layer draws the wallpaper's own pixels back over the wallpaper, so
+where no widget sits it is a picture drawn over itself. Turning the feature on
+must therefore be a pixel-for-pixel no-op on an empty desktop, whatever the mask
+contains - and any difference is the copy landing somewhere other than the region
+it copies: a different crop, a different scale, or a different offset.
+
+Why this test rather than looking: a copy that misses by a fraction of a percent
+does not read as a geometry bug on screen. It reads as the wallpaper going soft,
+which is how it was reported and how it was then mis-measured - two `grim`
+captures minutes apart on a live desktop, with the wallpaper changed between
+them, diffed as if they were an A/B. The whole value here is the control: one
+process, one wallpaper nothing can swap, and only the depth flag moving.
+
+The mask is synthetic and no model runs. Note what this deliberately does NOT
+check: a mask registered to the wrong pixels still passes, because masking the
+wallpaper with the wrong shape still draws the wallpaper over the wallpaper.
+Mask registration is scored by test_clock_depth_compositing.py, which puts a
+widget underneath and reads the occlusion boundary.
+"""
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PROBE = ROOT / "tests/run_clock_depth_noop_probe.sh"
+
+EXPECTED_CHECKS = 8
+
+# The wallpaper's aspect (2.409) is deliberately nothing like the viewport's
+# (880/247 = 3.563), so PreserveAspectCrop really crops and a copy drawn at the
+# wrong scale lands somewhere visible. The probe asserts the crop happened.
+WALLPAPER_SIZE = (1600, 664)
+
+# What the invariant allows. Measured on this stack: a full-frame opaque mask
+# over a 3840x1594 photograph differs by at most one least-significant bit on 0.18% of
+# pixels, which is the source image making a round trip through the effect's
+# intermediate buffer. A copy off by a single pixel on this fixture moves whole
+# channel values, not bits.
+MAX_CHANNEL_DIFF = 2
+MAX_MEAN_DIFF = 0.05
+
+PAIRS = (("off_full", "on_full"), ("off_part", "on_part"))
+
+
+def _runtime_available():
+    if any(shutil.which(tool) is None for tool in ("qs", "weston", "magick")):
+        return False
+    try:
+        import numpy  # noqa: F401
+        from PIL import Image  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def write_fixtures(directory):
+    """A high-frequency wallpaper and two masks that mask by ALPHA.
+
+    Detail matters here in a way it does not for a compositing fixture: a flat
+    field is identical to itself however badly it is offset, so the picture has
+    to carry enough detail that a wrong crop cannot coincide with the right one.
+    """
+    wallpaper = directory / "wallpaper.png"
+    subprocess.run(["magick", "-size", "{}x{}".format(*WALLPAPER_SIZE),
+                    "-seed", "7", "plasma:fractal", str(wallpaper)],
+                   check=True, timeout=60)
+
+    from PIL import Image
+    import numpy as np
+
+    def mask(path, array):
+        plane = Image.fromarray(array)
+        # The same plane in both channels: Qt's OpacityMask reads the ALPHA and
+        # nothing else, and keeping the luminance makes the file inspectable.
+        Image.merge("LA", [plane, plane]).save(path)
+
+    full = np.full((1024, 1024), 255, np.uint8)
+    part = np.zeros((1024, 1024), np.uint8)
+    part[180:900, 260:840] = 255
+    mask(directory / "mask-full.png", full)
+    mask(directory / "mask-part.png", part)
+    return wallpaper, directory / "mask-full.png", directory / "mask-part.png"
+
+
+def difference(left, right):
+    from PIL import Image
+    import numpy as np
+    a = np.asarray(Image.open(left).convert("RGB")).astype(int)
+    b = np.asarray(Image.open(right).convert("RGB")).astype(int)
+    if a.shape != b.shape:
+        raise AssertionError(f"{left.name} is {a.shape} and {right.name} is {b.shape}")
+    delta = np.abs(a - b)
+    return int(delta.max()), float(delta.mean()), float((delta.max(axis=2) > 6).mean())
+
+
+@unittest.skipUnless(_runtime_available(), "needs qs, weston, magick, numpy and pillow")
+class ClockDepthNoOpTest(unittest.TestCase):
+    def test_turning_depth_on_over_an_empty_desktop_changes_nothing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            wallpaper, full, part = write_fixtures(tmp)
+            env = dict(os.environ,
+                       CLOCK_DEPTH_WALLPAPER=str(wallpaper),
+                       CLOCK_DEPTH_FULL_MASK=str(full),
+                       CLOCK_DEPTH_PART_MASK=str(part),
+                       CLOCK_DEPTH_SHOT_DIR=str(tmp))
+            result = subprocess.run([str(PROBE)], capture_output=True, text=True,
+                                    timeout=180, env=env)
+            output = result.stdout + result.stderr
+            self.assertIn(f"[ClockDepthNoOp] checks: {EXPECTED_CHECKS} failures: 0", output,
+                          f"harness did not finish cleanly:\n{output}")
+
+            for off, on in PAIRS:
+                off_shot, on_shot = tmp / f"{off}.png", tmp / f"{on}.png"
+                self.assertTrue(off_shot.exists() and on_shot.exists(),
+                                f"missing {off}/{on} screenshots:\n{output}")
+                worst, mean, differing = difference(off_shot, on_shot)
+                self.assertLessEqual(
+                    worst, MAX_CHANNEL_DIFF,
+                    f"drawing the subject back over its own wallpaper is not a no-op "
+                    f"({off} vs {on}): worst channel difference {worst}, mean {mean:.3f}, "
+                    f"{differing:.1%} of pixels differ by more than 6. The copy is not "
+                    f"landing on the region it copies.")
+                self.assertLessEqual(
+                    mean, MAX_MEAN_DIFF,
+                    f"{off} vs {on}: mean absolute difference {mean:.3f} over the frame")
+
+            # And the mask must not leak into the frame the layer is not drawing:
+            # a masked copy is either invisible or a no-op, never a third thing.
+            worst, mean, _ = difference(tmp / "off_full.png", tmp / "off_part.png")
+            self.assertLessEqual(worst, MAX_CHANNEL_DIFF,
+                                 "the mask changed the frame while depth was off "
+                                 f"(worst channel difference {worst})")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Continues #232. The alignment bug this branch was opened to fix **does not exist** — that is the first result, and it is measured rather than argued. What the episode actually exposed was that nobody could see what the model had decided was the subject, which is what this PR builds.

## The alignment report was a bad measurement, and here is the good one

Depth on vs depth off was reported as differing across 97.8% of the screen with a mean absolute difference of 48.5/255, from two `grim -o DP-1` captures taken minutes apart with the feature toggled between them. The wallpaper had been changed between the two shots. The diff was two different pictures.

`tests/test_clock_depth_noop.py` is the measurement that has the control the captures lacked: one `qs` process, one wallpaper nothing can swap, and **only the depth flag** moving between the two grabs, on an empty widget canvas — where drawing the wallpaper back over itself must be a no-op whatever the mask contains.

| | worst channel difference | mean | pixels differing by >6 |
|---|---|---|---|
| synthetic fixture (in the suite) | **0** | 0.000 | 0.0% |
| real 3840x1594 wallpaper + real accepted `isnet-anime` mask | **1** | 0.001 | 0.0% |

The single least-significant bit is the source making a round trip through the effect's intermediate buffer. **The subject copy lands exactly on the region it copies.** No fix was needed and none was made.

Two things the fixture does deliberately: its wallpaper's aspect (2.409) is nothing like its viewport's (3.563), because at a matching aspect `PreserveAspectCrop` is the identity and every crop bug is invisible — the sibling compositing probe's 2:1-into-2:1 fixture has exactly that hole, so *the fixture actually crops* is a check rather than a comment; and the viewport is offset, since at rest the layer and the viewport are trivially level.

Proven able to fail, on a clean tree, one plant at a time:

| planted | result |
|---|---|
| cutout image `fillMode: Image.Stretch` | worst 124, mean 18.3, 96.4% of pixels |
| cutout offset 2px sideways | worst 32, mean 5.5, 72.4% |
| cutout given a `sourceSize` | worst 22, mean 3.4, 35.4% |
| layer stops following the viewport's x | harness check reddens |

What it deliberately cannot see, stated because a test's blind spot is the dangerous half: a mask registered to the wrong *pixels* still passes, because masking the wallpaper with the wrong shape still draws the wallpaper over the wallpaper. That half stays with `test_clock_depth_compositing.py`, which puts a widget underneath and reads the occlusion boundary.

## The visualizer

Built where the verdict is given, and built so it cannot disagree with the layer.

**One registration, mechanized.** The layer and the picker each carried their own copy of the same stack — the same `coverRect` call, the same clipping surface, the same `OpacityMask`. A picker whose crop drifts from the layer's certifies a mask against a geometry the desktop never draws, and both copies look plausible while they disagree. They are one `ClockDepthCutout` now, and the deliverable is the rule rather than the component: `coverRect` may be called from that file and from its own unit test and nowhere else. `ClockDepthProbe` drives the component too, so the compositing contract that is scored is the one that ships.

**What Inspect answers.** Off by default, `Loader`-gated, so it costs nothing until asked for. At rest the preview is now *honest* — the wallpaper at full brightness with the cutout on it, i.e. what the desktop will look like — instead of the permanent 35% dim it had, which was neither a preview nor a diagnosis. Switched on it dims everything the model did **not** claim (an `OpacityMask { invert: true }` over the *same* registered surface the cutout is masked by, so the lit region and the drawn region cannot be a pixel apart) and traces the silhouette. §1.2 of the spec is the argument for needing both: a soft edge, a halo and a rectangular slab of background are all invisible against the image they were cut from, which is why the feasibility survey judged every candidate over a flat field.

Rendered against the real `arknights-endfield` mask it shows the clean cutouts around hair and weapons, the clock's digits being clipped by a shoulder — and **a slab of background the model grabbed in the top-left corner**, which the plain preview hides completely. That is the class of failure the whole accept/decline step exists to catch, and it is now visible at a glance.

Header first: *does this wallpaper have a cutout at all* — accepted, declined, candidate waiting, both models refusing, or nothing run. That one sentence is what was missing from every part of this episode, including the "toggling it on does nothing" report, which was correct behaviour for a wallpaper with no accepted mask.

Two contour details that are not free choices. Its colour is the one hardcoded value in the file, because every `Appearance` token is generated *from* the wallpaper on screen and is therefore guaranteed to be a colour the picture already contains. And the `Glow` sets `transparentBorder`, or the blur clamps at the item's edge and a subject touching the bottom of the frame smears into a band across it — which reads as a defect in the mask rather than in the instrument.

**Which model, and the model trap.** `status` now reports `acceptedModel`, derived from the bytes (`accept` is a byte-for-byte copy) rather than recorded in a new file, so it cannot drift from the file the shell draws; the picker marks that column. And "No subject found" was a verdict on the picture when it is usually a verdict on the model — measured, `isnet-anime` returns `none` on `cat_upscayl_2x…png` where `isnet-general-use` returns a foreground of 0.143 — so a refusal now points at the other column.

Three layout faults found by rendering the picker and looking at it, none visible in the source: the inspect toggle was an `IconToolbarButton`, which inherits `Layout.fillHeight: true` and derives its width from its height, so it stretched into a circle a third of the dialog wide and took the header's height with it; and the candidate columns asked to fill the row's height *and* to be top-aligned, which floated the previews away from the buttons that act on them.

## Wallpaper Engine

Designed in §8 of the spec, not landed, and the reason is stated there: none of it is reachable from a headless harness, so it has to be judged on a real desktop against a moving scene — and the instrument for judging it is the inspect mode this PR adds, so the order is the right way round.

What the design settles rather than leaving open: there **is** a static input (the shell already photographs every project into `wallpaperengine-stills`, and measured, those 16 files are the viewport's own size, so a mask cut from one registers 1:1 with no new geometry); the cache key **cannot** be the still's stat triple, because the still is re-grabbed on every project load and the acceptance lives at the key, so the user's verdict would be lost on every restart; the layer must mask the **live** surface rather than the still, or every animated pixel inside the silhouette is stale; and a static mask over a moving scene is correct only while the subject holds still within the frame, which is undetectable for the same reason mask quality is, so it belongs beside the verdict in the picker rather than being pretended away. `web` projects never arrive there — `weActive` already excludes them.

## Verification

- Full suite, CI-style (`QT_QPA_PLATFORM=offscreen`): **exit 0**, `843 passed, 0 failed`, which is this branch's stated baseline unchanged.
- Every Python stage, lint and weston probe green, including the new no-op test and the reworked geometry lint.
- `DesignSystemCompile checked=173 failures=0`.
- The picker was instantiated against the real cache under headless weston: `state accepted`, `acceptedModel isnet-anime`, no `WARN scene`, no `ERROR`.
- Planted breakage proven for the no-op test (4 mutations) and for the geometry lint's new one-registration rule; the lint's own self-check gained four more mutations for the two-file shape.
- **Not deployed.** The live shell was not touched and its config flag was not moved.

Docs: updated AGENT.md §Directory map, §Dynamic/data-driven QML gotchas (the A/B measurement trap, the no-op oracle, the one-registration rule, and the wrong-model-not-no-subject point); added §8 to docs/superpowers/specs/2026-08-16-clock-depth-design.md
