### PR TITLE
Click-to-select subject masking, for the half of the library the detectors refuse

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -2427,6 +2427,23 @@ Four things about that column generalise past it:
   whole extent. `tst_clock_depth_eligibility.qml` pins both halves, and its
   second case uses a 3.56:1 picture in a 4:3 box on purpose — at a matching
   aspect the box IS the cover rect and every registration bug is invisible.
+- **A file rewritten at the same path is not reloaded, and neither clearing the
+  source nor `cache: false` fixes it.** Qt keys its pixmap cache on the URL, so
+  an `Image` whose file changes underneath it keeps drawing the old bytes for
+  the life of the process. Measured with a `qml6` probe: a 32x8 PNG rewritten on
+  disk at 99x17 and re-assigned to the identical URL still reported
+  `implicitWidth` 32, and setting `source = ""` first and re-assigning did not
+  help; with a `#<token>` fragment appended it loaded the new bytes, and the
+  fragment is not part of the filename so nothing else about the load changes.
+  This bites twice here — the prompted candidate is rewritten on every click and
+  the accepted mask whenever a second candidate is accepted for the same
+  wallpaper — and both failures look like the feature ignoring the user rather
+  than like a cache. `ClockDepthCutout.maskRevision` carries the producer's
+  token (the file's mtime in nanoseconds, as a **string**: 1.8e18 does not
+  survive a JSON round trip through a double), and
+  `tests/lint_clock_depth_geometry.py` fails on a depth layer that names the
+  mask path without it. Anything else here that writes a file the shell is
+  already displaying has the same question to answer.
 - **A click that finds nothing must not write a `.none` marker.** That marker
   means "this model looked at this picture and there is nothing in it" and is
   worth not re-learning at 4.5s a time. A click that lands on flat sky is one

--- a/AGENT.md
+++ b/AGENT.md
@@ -2444,11 +2444,17 @@ Four things about that column generalise past it:
   `tests/lint_clock_depth_geometry.py` fails on a depth layer that names the
   mask path without it. Anything else here that writes a file the shell is
   already displaying has the same question to answer.
-- **A click that finds nothing must not write a `.none` marker.** That marker
-  means "this model looked at this picture and there is nothing in it" and is
-  worth not re-learning at 4.5s a time. A click that lands on flat sky is one
-  attempt, and recording it as a refusal tells the picker to stop offering the
-  one column the user aims.
+- **A click that finds nothing must not write a `.none` marker, and it does not
+  use the detectors' floor either.** That marker means "this model looked at this
+  picture and there is nothing in it" and is worth not re-learning at 4.5s a
+  time. A click that lands on flat sky is one attempt, and recording it as a
+  refusal tells the picker to stop offering the one column the user aims. The
+  threshold is a separate constant for the same reason: `EMPTY_FOREGROUND`
+  (0.005) divides a model's own answer from a stray fragment, while a click is
+  the user asserting there is something there — measured, reusing it discarded a
+  76000-pixel object on a 7680x2160 wallpaper as "nothing there", and it was not
+  buying the refusal it looked like it was for, since a click on flat sky comes
+  back at 1.6-10% because SAM answers with the sky.
 
 **A segmentation model returning nothing is usually the wrong model, not an empty
 picture.** `isnet-anime` and `isnet-general-use` are complementary and neither is

--- a/AGENT.md
+++ b/AGENT.md
@@ -395,6 +395,24 @@ a tempdir; the clean-checkout case asserts the update stays *silent*, which is t
 the fix from becoming a nuisance for everyone who has no local work.
 d5d2f69b0 ("fix(get.sh): rescue local work before resetting the update checkout").
 
+**A Python dependency is declared in `sdata/uv/requirements.in` and installed
+from `sdata/uv/requirements.txt`, and adding it to the first does nothing.**
+`install-python-packages` runs `uv pip install -r requirements.txt`, which is a
+compiled lock; the `.in` is the input a human edits and nothing at install time
+reads. `onnxruntime` was added to the `.in` when the subject-mask producer landed
+and the lock was never recompiled, so **every venv the installer has ever built
+lacks it** — and the only symptom is a raw `ModuleNotFoundError` surfacing in the
+depth picker at the moment the user presses a button, on a machine where that
+path has never once worked. It ran on the author's machine because it had been
+installed by hand. Recompile with the existing lock as preferences
+(`uv pip compile requirements.in -o requirements.txt` in that directory, with
+`requirements.txt` already present) rather than from scratch, or the diff for one
+package moves every pin in the file — and this venv exists precisely because a
+moving `numpy` is what breaks segmentation stacks (the design doc's own §1.1
+finding). A check that reads the `.in` is checking the wrong file and stays green
+for the whole life of the bug; `tests/test_clock_depth_cache.py` reads both now.
+(fix(install): put onnxruntime in the lock the installer actually installs.)
+
 ## Directory map
 
 ```
@@ -521,9 +539,11 @@ services/                  Singletons wrapping external state/processes - one pe
                               the desktop clock's depth mode. Asks
                               scripts/background/subject_mask.py - the shell never computes a cache
                               key of its own - and queries nothing at all until either
-                              background.clockDepth.enable or the picker is open. The `run` half is
-                              reached ONLY from the wallpaper selector's picker; nothing reactive
-                              can start segmentation
+                              background.clockDepth.enable or the picker is open. The `run` and
+                              `select` halves are reached ONLY from the wallpaper selector's
+                              picker; nothing reactive can start segmentation. It also holds the
+                              prompted model's clicks for the wallpaper on screen, restored from
+                              the cache once per wallpaper rather than on every status
   MprisController.qml         The one answer to "which player is the media UI showing". It filters
                               the bus list (proxies always, duplicates by setting) through
                               MprisSelection.js - a .pragma library kept pure so the rules are
@@ -539,13 +559,19 @@ panelFamilies/              PanelLoader.qml (thin LazyLoader) + ImmaterialImpuls
                             actual list of panels for the "imi" family)
 
 scripts/                   Standalone helper scripts (Python/bash) invoked via Process/Quickshell.execDetached
-  background/subject_mask.py  Segments a wallpaper's subject through ONNX Runtime (isnet-anime or
-                              isnet-general-use, fetched on first use, ~1.3-4.5s and ~1GB RSS per
-                              run) and owns the mask cache in ${Directories.cache}/clock-depth. It
-                              owns the CACHE KEY too - path/mtime/size - and the shell never
-                              computes one, so an in-place wallpaper edit invalidates its mask, its
-                              opt-out and its candidates together. `status` and `sweep` are
-                              stdlib-only and load no model; `run` needs the uv venv
+  background/subject_mask.py  Segments a wallpaper's subject through ONNX Runtime and owns the mask
+                              cache in ${Directories.cache}/clock-depth. Two kinds of model: the
+                              salient detectors (isnet-anime, isnet-general-use) answer the PICTURE
+                              and are asked with `run` (~1.3-4.5s, ~1GB RSS); mobile-sam answers a
+                              POINT and is asked with `select --point x,y[,label]` (~1.6s for the
+                              first click, ~0.3s for every one after, because the image embedding
+                              is cached at the key). It owns the CACHE KEY too - path/mtime/size -
+                              and the shell never computes one, so an in-place wallpaper edit
+                              invalidates its mask, its opt-out, its candidates and its embedding
+                              together. It also reports the model list, so the picker holds no copy
+                              of it. `status` and `sweep` are stdlib-only and load no model - a
+                              prompted mask's clicks live in a PNG text chunk it parses by hand for
+                              exactly that reason; `run` and `select` need the uv venv
                               (subject-mask-venv.sh)
 translations/              i18n string tables (Translation.tr(...) singleton)
 assets/                    Static images/fonts bundled with the shell
@@ -2349,6 +2375,63 @@ which is the one place in this shell that is right: every `Appearance` token is
 generated *from* the wallpaper on screen, so a token there is guaranteed to be a
 colour the picture already contains.
 (refactor(background): one cutout for the layer and the picker to draw.)
+
+**And when both models return nothing, the answer is a different QUESTION, not a
+lower threshold.** Swept over the 91 wallpapers in this library, the two salient
+detectors leave 45 of them at `none` — half the library, with the picker
+correctly reporting that neither found a subject and nothing to be done about it.
+The tempting read is that `EMPTY_FOREGROUND = 0.005` and the `mask > 0.5`
+binarisation are throwing away a faint answer. They are not, and the measurement
+is what settles it: before any threshold, on `aishot-3263.jpg`,
+`isnet-general-use` claims 2.78% of the frame at 0.1 confidence and 0.28% at 0.5,
+`isnet-anime` 0.07% and 0.00%; on `aishot-1206.jpg` it is 1.20%/0.19% and
+0.00%/0.00%. Admitting a claim that small admits noise. These are salient-object
+detectors — one dominant object against a separable background — and a full-bleed
+wallpaper has no background to separate from, so the model is being asked a
+question the picture does not answer. `mobile-sam` is asked a different one
+("what is the thing at this point"), which is why it is a third column in the
+picker rather than a fourth detector, and why the user clicking is not a fallback
+but the mechanism. (feat(background): a third model that answers a click instead
+of the picture.)
+
+Four things about that column generalise past it:
+
+- **The encoder/decoder split is a contract, not an implementation detail.**
+  Encoding the picture costs seconds and depends only on the picture; decoding a
+  mask from clicks reads the embedding and costs milliseconds. Measured on a
+  7680x2160 wallpaper: 1.63s for the first click, 0.34s for the second, of which
+  0.24s is starting Python. A fused single-file export would charge the first
+  click's price for every click, and refinement — which is the entire interaction
+  — would be unusable. `tests/test_clock_depth_cache.py` pins the pair as two
+  files, and pins that a cached embedding comes back with the encoder file absent
+  and `onnxruntime` raising on import.
+- **The prompt lives inside the mask, in a PNG text chunk.** A SAM mask is a
+  function of the clicks as well as the picture, so something has to record them
+  — and every other place to put them is a pair that has to agree. In the key
+  they mint an entry per click, so a five-click refinement leaves five masks and
+  needs a sixth file to say which was accepted. In a sidecar they are two files a
+  sweep, a copy or a crash can separate, and `accept` is a byte copy so the
+  sidecar would have to be copied by hand in the one place forgetting is silent.
+  In `Config` they are a map keyed by a runtime path, which the `JsonAdapter`
+  cannot hold. Inside the file the prompt cannot arrive without its mask or
+  outlive it, `accept` carries it for free, and the accepted copy keeps saying
+  what it was cut with after the candidate is refined further. `status` reads it
+  back with a hand-written chunk reader, because that path may not import Pillow.
+- **`coverRect` needed no new case, and that was confirmed rather than assumed.**
+  A prompted mask comes out at the picture's own aspect (SAM resizes the longest
+  side and pads) where a salient one is square (isnet squashes), and `coverRect`
+  exists precisely because of that squash — so the obvious guess is that a
+  non-square mask needs a second path. It does not: the rect is a rectangle for
+  the WALLPAPER and the function never reads the mask's dimensions at all, so
+  stretching any mask into it maps that mask's whole extent onto the picture's
+  whole extent. `tst_clock_depth_eligibility.qml` pins both halves, and its
+  second case uses a 3.56:1 picture in a 4:3 box on purpose — at a matching
+  aspect the box IS the cover rect and every registration bug is invisible.
+- **A click that finds nothing must not write a `.none` marker.** That marker
+  means "this model looked at this picture and there is nothing in it" and is
+  worth not re-learning at 4.5s a time. A click that lands on flat sky is one
+  attempt, and recording it as a refusal tells the picker to stop offering the
+  one column the user aims.
 
 **A segmentation model returning nothing is usually the wrong model, not an empty
 picture.** `isnet-anime` and `isnet-general-use` are complementary and neither is

--- a/AGENT.md
+++ b/AGENT.md
@@ -2405,6 +2405,7 @@ Four things about that column generalise past it:
   — would be unusable. `tests/test_clock_depth_cache.py` pins the pair as two
   files, and pins that a cached embedding comes back with the encoder file absent
   and `onnxruntime` raising on import.
+  (feat(background): a third model that answers a click instead of the picture.)
 - **The prompt lives inside the mask, in a PNG text chunk.** A SAM mask is a
   function of the clicks as well as the picture, so something has to record them
   — and every other place to put them is a pair that has to agree. In the key
@@ -2417,6 +2418,7 @@ Four things about that column generalise past it:
   outlive it, `accept` carries it for free, and the accepted copy keeps saying
   what it was cut with after the candidate is refined further. `status` reads it
   back with a hand-written chunk reader, because that path may not import Pillow.
+  (test(clock-depth): pin the prompt, its home in the mask, and the embedding cache.)
 - **`coverRect` needed no new case, and that was confirmed rather than assumed.**
   A prompted mask comes out at the picture's own aspect (SAM resizes the longest
   side and pads) where a salient one is square (isnet squashes), and `coverRect`
@@ -2427,6 +2429,7 @@ Four things about that column generalise past it:
   whole extent. `tst_clock_depth_eligibility.qml` pins both halves, and its
   second case uses a 3.56:1 picture in a 4:3 box on purpose — at a matching
   aspect the box IS the cover rect and every registration bug is invisible.
+  (test(clock-depth): confirm a picture-shaped mask needs no new registration.)
 - **A file rewritten at the same path is not reloaded, and neither clearing the
   source nor `cache: false` fixes it.** Qt keys its pixmap cache on the URL, so
   an `Image` whose file changes underneath it keeps drawing the old bytes for
@@ -2444,6 +2447,7 @@ Four things about that column generalise past it:
   `tests/lint_clock_depth_geometry.py` fails on a depth layer that names the
   mask path without it. Anything else here that writes a file the shell is
   already displaying has the same question to answer.
+  (fix(background): bust Qt's pixmap cache when a mask is rewritten in place.)
 - **A click that finds nothing must not write a `.none` marker, and it does not
   use the detectors' floor either.** That marker means "this model looked at this
   picture and there is nothing in it" and is worth not re-learning at 4.5s a
@@ -2455,6 +2459,7 @@ Four things about that column generalise past it:
   76000-pixel object on a 7680x2160 wallpaper as "nothing there", and it was not
   buying the refusal it looked like it was for, since a click on flat sky comes
   back at 1.6-10% because SAM answers with the sky.
+  (fix(background): a click's floor is not the detectors' floor.)
 
 **A segmentation model returning nothing is usually the wrong model, not an empty
 picture.** `isnet-anime` and `isnet-general-use` are complementary and neither is

--- a/AGENT.md
+++ b/AGENT.md
@@ -2377,7 +2377,7 @@ colour the picture already contains.
 (refactor(background): one cutout for the layer and the picker to draw.)
 
 **And when both models return nothing, the answer is a different QUESTION, not a
-lower threshold.** Swept over the 91 wallpapers in this library, the two salient
+lower threshold.** Swept over the 94 wallpapers in this library, the two salient
 detectors leave 45 of them at `none` — half the library, with the picker
 correctly reporting that neither found a subject and nothing to be done about it.
 The tempting read is that `EMPTY_FOREGROUND = 0.005` and the `mask > 0.5`

--- a/dots/.config/quickshell/imi/modules/common/functions/clockDepth.js
+++ b/dots/.config/quickshell/imi/modules/common/functions/clockDepth.js
@@ -84,6 +84,45 @@ function coverRect(sourceWidth, sourceHeight, boxWidth, boxHeight) {
     return { x: (bw - width) / 2, y: (bh - height) / 2, width: width, height: height };
 }
 
+// A click on a preview, as a point in the picture's own frame.
+//
+// The inverse of what `coverRect` returns, and it takes that rectangle rather
+// than recomputing one: the mask surface is where the whole wallpaper sits
+// inside the preview box, so a click's fraction ALONG that rectangle is the same
+// fraction of the picture whatever the preview's size or the monitor's aspect.
+// Anything that worked the crop out again here would be a second registration,
+// which is what ClockDepthCutout exists to prevent.
+//
+// Kept here rather than inline in the handler because it is the one part of the
+// gesture a test can reach - nothing about a rendered preview is reachable from
+// qmltestrunner - and because a click sent to the wrong part of the picture
+// produces a perfectly good mask of the wrong thing, with nothing to show that
+// anything went wrong.
+//
+// Clamped, not rejected: the producer refuses a point outside the picture, and a
+// rounding error at the very edge of a frame would come back to the user as an
+// error about a click that looked entirely ordinary. Returns null only for a
+// rect with no area, where there is no picture to have clicked on.
+function normalisedPoint(rect, x, y) {
+    const r = rect || {};
+    const width = positive(r.width);
+    const height = positive(r.height);
+    if (width === 0 || height === 0)
+        return null;
+    const originX = (typeof r.x === "number" && isFinite(r.x)) ? r.x : 0;
+    const originY = (typeof r.y === "number" && isFinite(r.y)) ? r.y : 0;
+    if (!isFinite(x) || !isFinite(y))
+        return null;
+    return {
+        x: clamp01((x - originX) / width),
+        y: clamp01((y - originY) / height)
+    };
+}
+
+function clamp01(value) {
+    return value < 0 ? 0 : (value > 1 ? 1 : value);
+}
+
 function positive(value) {
     return (typeof value === "number" && isFinite(value) && value > 0) ? value : 0;
 }

--- a/dots/.config/quickshell/imi/modules/imi/background/Background.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/Background.qml
@@ -1312,6 +1312,7 @@ Variants {
                 // image under the outgoing image's mask for the length of it.
                 wallpaperSource: wallpaper.source
                 maskPath: ClockDepth.maskPath
+                maskRevision: ClockDepth.maskRevision
             }
         }
 

--- a/dots/.config/quickshell/imi/modules/imi/background/ClockDepthCutout.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/ClockDepthCutout.qml
@@ -27,6 +27,16 @@ Item {
     // outgoing image's mask for the length of every switch.
     property url wallpaperSource
     property string maskPath: ""
+    // A token that changes when the mask file's bytes do, hung on the URL as a
+    // fragment. Qt caches a pixmap by URL and a mask is rewritten at the SAME
+    // path twice over - once per click while a subject is being selected, and
+    // again when a second candidate is accepted for the same wallpaper.
+    // Measured with a qml6 probe: a 32x8 image rewritten at 99x17 and
+    // re-assigned to the identical URL still reported 32x8, and clearing the
+    // source to "" first did not help either; with a fragment it loaded the new
+    // bytes. The fragment is not part of the filename, so nothing else about
+    // the load changes. The producer owns the token, as it owns the key.
+    property string maskRevision: ""
 
     // The registered mask surface, exposed so an inspector can draw over the
     // SAME item rather than rebuild a second one from the same numbers - which
@@ -89,7 +99,8 @@ Item {
             y: mask.coverRect.y
             width: mask.coverRect.width
             height: mask.coverRect.height
-            source: root.maskPath === "" ? "" : `file://${root.maskPath}`
+            source: root.maskPath === "" ? ""
+                : `file://${root.maskPath}${root.maskRevision === "" ? "" : "#" + root.maskRevision}`
             fillMode: Image.Stretch
             smooth: true
             asynchronous: true

--- a/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/ClockDepthPicker.qml
+++ b/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/ClockDepthPicker.qml
@@ -27,8 +27,8 @@ import "../../common/functions/clockDepth.js" as ClockDepthLogic
  * shown side by side, at the same size, for exactly that reason.
  *
  * A THIRD column, because on this library "the wrong model" is usually still
- * the answer after trying both: swept over the 91 wallpapers here, 45 return
- * nothing from either detector. Those are not empty pictures - they are
+ * the answer after trying both: swept over the 94 wallpapers here, 45 return
+ * nothing from either detector and 3 have never been run. Those are not empty pictures - they are
  * landscapes and full-bleed illustrations with plenty to stand in front of a
  * clock and no single salient object to find. That column is MobileSAM and it
  * answers a different question: not "what is the subject of this picture" but

--- a/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/ClockDepthPicker.qml
+++ b/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/ClockDepthPicker.qml
@@ -5,6 +5,7 @@ import qs.services
 import qs.modules.common
 import qs.modules.common.widgets
 import qs.modules.imi.background
+import "../../common/functions/clockDepth.js" as ClockDepthLogic
 
 /**
  * Where the quality gate lives, and it is a human - so this is the instrument
@@ -478,17 +479,20 @@ Item {
                             acceptedButtons: Qt.LeftButton | Qt.RightButton
                             cursorShape: Qt.CrossCursor
                             onClicked: mouse => {
-                                const frame = previewCutout.maskRect
-                                if (frame.width <= 0 || frame.height <= 0)
+                                // The cutout's own mask rectangle is where the
+                                // whole wallpaper sits inside this preview, so
+                                // the click's fraction along it IS the point in
+                                // the picture. Worked out in clockDepth.js
+                                // because it is the one part of this gesture a
+                                // test can reach, and because a click sent to
+                                // the wrong part of the picture comes back as a
+                                // perfectly good mask of the wrong thing.
+                                const point = ClockDepthLogic.normalisedPoint(
+                                    previewCutout.maskRect, mouse.x, mouse.y)
+                                if (!point)
                                     return
-                                // Clamped rather than passed through: the
-                                // producer refuses a point outside the picture,
-                                // and a rounding error at the very edge of the
-                                // frame would come back as an error message
-                                // about a click that looked perfectly ordinary.
-                                const nx = Math.max(0, Math.min(1, (mouse.x - frame.x) / frame.width))
-                                const ny = Math.max(0, Math.min(1, (mouse.y - frame.y) / frame.height))
-                                ClockDepth.addPoint(nx, ny, mouse.button === Qt.LeftButton)
+                                ClockDepth.addPoint(point.x, point.y,
+                                    mouse.button === Qt.LeftButton)
                             }
                         }
 

--- a/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/ClockDepthPicker.qml
+++ b/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/ClockDepthPicker.qml
@@ -403,6 +403,7 @@ Item {
                             anchors.fill: parent
                             wallpaperSource: previewWallpaper.source
                             maskPath: candidate.maskPath
+                            maskRevision: ClockDepth.revisions?.[candidate.modelName] ?? ""
                             visible: candidate.maskPath !== ""
                         }
 

--- a/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/ClockDepthPicker.qml
+++ b/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/ClockDepthPicker.qml
@@ -231,10 +231,10 @@ Item {
                     readonly property bool thisRunning: ClockDepth.running === candidate.modelName
                     readonly property bool chosen: ClockDepth.state === "accepted"
                         && ClockDepth.acceptedModel === candidate.modelName
-                    // Whether the OTHER column found something. A model that
+                    // Whether ANY other column found something. A model that
                     // returns nothing is usually the wrong model rather than an
                     // empty picture, so an empty result has to point at its
-                    // neighbour instead of reading as a verdict on the image.
+                    // neighbours instead of reading as a verdict on the image.
                     readonly property bool otherFound: {
                         const results = ClockDepth.candidates ?? ({})
                         for (const other in results) {
@@ -255,11 +255,11 @@ Item {
 
                     Layout.fillWidth: true
                     Layout.fillHeight: true
-                    // Both columns take half the row whatever their content is
-                    // wider than. Without a preferred width a RowLayout hands
-                    // fillWidth children their implicit widths first, so the
-                    // column whose button labels are longer gets a bigger
-                    // preview - and the two cutouts are being compared.
+                    // Every column takes an equal share of the row whatever
+                    // its content is wider than. Without a preferred width a
+                    // RowLayout hands fillWidth children their implicit widths
+                    // first, so the column whose button labels are longer gets a
+                    // bigger preview - and the cutouts are being compared.
                     Layout.preferredWidth: 1
                     spacing: Appearance.spacing.space100
 
@@ -538,7 +538,7 @@ Item {
                                         return ""
                                     return candidate.refused
                                         ? (candidate.otherFound
-                                            ? Translation.tr("Nothing here — the other model found something")
+                                            ? Translation.tr("Nothing here — another column found something")
                                             : Translation.tr("Nothing here — try clicking the subject"))
                                         : Translation.tr("Not run yet")
                                 }

--- a/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/ClockDepthPicker.qml
+++ b/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/ClockDepthPicker.qml
@@ -17,13 +17,33 @@ import qs.modules.imi.background
  * per-wallpaper artifact the user accepts once, with segmentation proposing
  * candidates.
  *
- * Two models, because neither is a superset of the other: `isnet-anime` carries
- * most of this library and returns nothing at all on the semi-photographic
- * minority that `isnet-general-use` handles best. So a model that finds nothing
- * usually means the WRONG MODEL rather than no subject - measured on
- * `cat_upscayl_2x…png`, where the illustration model returns `none` and the
- * photographic one returns a foreground of 0.143 - and the two are shown side
- * by side, at the same size, for exactly that reason.
+ * Two detectors, because neither is a superset of the other: `isnet-anime`
+ * carries most of this library and returns nothing at all on the
+ * semi-photographic minority that `isnet-general-use` handles best. So a model
+ * that finds nothing usually means the WRONG MODEL rather than no subject -
+ * measured on `cat_upscayl_2x…png`, where the illustration model returns `none`
+ * and the photographic one returns a foreground of 0.143 - and the two are
+ * shown side by side, at the same size, for exactly that reason.
+ *
+ * A THIRD column, because on this library "the wrong model" is usually still
+ * the answer after trying both: swept over the 91 wallpapers here, 45 return
+ * nothing from either detector. Those are not empty pictures - they are
+ * landscapes and full-bleed illustrations with plenty to stand in front of a
+ * clock and no single salient object to find. That column is MobileSAM and it
+ * answers a different question: not "what is the subject of this picture" but
+ * "what is the thing at this point". So the user points at it.
+ *
+ * Its whole interaction is the preview: left-click adds a point the cutout must
+ * contain, right-click one it must not, and the mask redraws per click because
+ * the picture is encoded once and each click only decodes - 1.6s for the first
+ * and 0.3s for every one after it. Both gestures are said on the preview
+ * itself, because a click surface with its instructions somewhere else is a
+ * click surface nobody discovers. The clicks are drawn back on as plus and
+ * minus discs so a correction is aimed at a thing rather than at a memory.
+ *
+ * All three columns are the same width, which is the point of the layout: the
+ * cutouts are being compared, and the clickable one is not more important than
+ * the two it is being compared against.
  *
  * The preview is composited the way the desktop is - the wallpaper cropped as it
  * will be, with a clock over it and the cutout on top - rather than shown as a
@@ -69,14 +89,19 @@ Item {
         case "declined":
             return Translation.tr("This wallpaper is set to no depth. Accepting a cutout below undoes that.")
         case "none":
-            return Translation.tr("Neither model found a subject in this wallpaper yet.")
+            // Not "there is no subject in this wallpaper" - that was a verdict
+            // on the picture, and half this library reaches it while holding a
+            // perfectly good thing to stand in front of the clock. It is a
+            // verdict on the two models that answer on their own, and the
+            // column that answers a click is what it points at.
+            return Translation.tr("Neither detector found a subject. Click the one you want in the third preview.")
         case "candidate":
             return Translation.tr("A cutout is ready to judge. Nothing is drawn until you keep one.")
         case "unreadable":
         case "error":
             return Translation.tr("Could not read this wallpaper's cache entry.")
         default:
-            return Translation.tr("No cutout for this wallpaper yet. Run a model, then keep it only if the edge looks right where your widgets sit.")
+            return Translation.tr("No cutout for this wallpaper yet. Run a detector or click the subject, then keep it only if the edge looks right where your widgets sit.")
         }
     }
 
@@ -181,24 +206,31 @@ Item {
             spacing: Appearance.spacing.space150
 
             Repeater {
-                model: ClockDepth.models
+                model: ClockDepth.modelSpecs
 
                 ColumnLayout {
                     id: candidate
-                    required property string modelData
+                    required property var modelData
 
-                    readonly property string maskPath: ClockDepth.candidates?.[candidate.modelData] ?? ""
+                    readonly property string modelName: candidate.modelData.name ?? ""
+                    // The producer says which models answer a click and which
+                    // answer the picture; this column is the same shape either
+                    // way and differs only in how it is asked.
+                    readonly property bool prompted: candidate.modelData.kind === "prompted"
+                    readonly property var points: candidate.prompted ? (ClockDepth.points ?? []) : []
+
+                    readonly property string maskPath: ClockDepth.candidates?.[candidate.modelName] ?? ""
                     // Absent from `candidates` and present-but-null in it are
                     // different things and must read differently: the first is a
                     // model nobody has run, the second is a model that ran and
                     // found nothing. Collapsing them is how a picker ends up
                     // inviting the user to spend 4.5 seconds re-learning that
                     // there is no one in the picture.
-                    readonly property bool refused: candidate.modelData in (ClockDepth.candidates ?? ({}))
+                    readonly property bool refused: candidate.modelName in (ClockDepth.candidates ?? ({}))
                         && candidate.maskPath === ""
-                    readonly property bool thisRunning: ClockDepth.running === candidate.modelData
+                    readonly property bool thisRunning: ClockDepth.running === candidate.modelName
                     readonly property bool chosen: ClockDepth.state === "accepted"
-                        && ClockDepth.acceptedModel === candidate.modelData
+                        && ClockDepth.acceptedModel === candidate.modelName
                     // Whether the OTHER column found something. A model that
                     // returns nothing is usually the wrong model rather than an
                     // empty picture, so an empty result has to point at its
@@ -206,7 +238,7 @@ Item {
                     readonly property bool otherFound: {
                         const results = ClockDepth.candidates ?? ({})
                         for (const other in results) {
-                            if (other !== candidate.modelData && (results[other] ?? "") !== "")
+                            if (other !== candidate.modelName && (results[other] ?? "") !== "")
                                 return true
                         }
                         return false
@@ -236,9 +268,11 @@ Item {
                         spacing: Appearance.spacing.space50
 
                         StyledText {
-                            text: candidate.modelData === "isnet-anime"
-                                ? Translation.tr("Illustration")
-                                : Translation.tr("Photographic")
+                            text: candidate.prompted
+                                ? Translation.tr("Click to select")
+                                : candidate.modelName === "isnet-anime"
+                                    ? Translation.tr("Illustration")
+                                    : Translation.tr("Photographic")
                             font.pixelSize: Appearance.font.pixelSize.normal
                             color: Appearance.colors.colOnLayer0
                         }
@@ -255,7 +289,7 @@ Item {
                         }
                         Item { Layout.fillWidth: true }
                         StyledText {
-                            text: candidate.modelData
+                            text: candidate.modelName
                             font.pixelSize: Appearance.font.pixelSize.smallest
                             color: Appearance.colors.colSubtext
                         }
@@ -371,6 +405,93 @@ Item {
                             visible: candidate.maskPath !== ""
                         }
 
+                        // Where the clicks landed, drawn back onto the picture.
+                        //
+                        // Positioned through the cutout's OWN mask rectangle
+                        // rather than from a second crop worked out here: that
+                        // rect is where the whole wallpaper sits inside this
+                        // box, so a normalised point in the picture is a
+                        // fraction along it. Anything else would put the dot
+                        // somewhere other than where the click was sent, which
+                        // is the one thing that would make this gesture
+                        // unteachable.
+                        Repeater {
+                            model: candidate.points
+
+                            Item {
+                                id: marker
+                                required property var modelData
+                                readonly property rect frame: previewCutout.maskRect
+                                readonly property bool include: (marker.modelData.label ?? 1) === 1
+
+                                width: 18
+                                height: 18
+                                x: marker.frame.x + marker.modelData.x * marker.frame.width
+                                    - width / 2
+                                y: marker.frame.y + marker.modelData.y * marker.frame.height
+                                    - height / 2
+                                visible: candidate.prompted
+
+                                // Black and white, and hardcoded, for the same
+                                // reason the inspect contour is: every
+                                // Appearance colour is generated FROM this
+                                // wallpaper, so a token here is a colour the
+                                // picture is guaranteed to contain. A disc
+                                // against its own outline reads on any image.
+                                Rectangle {
+                                    anchors.fill: parent
+                                    radius: width / 2
+                                    color: marker.include ? "#ffffff" : "#101010"
+                                    border.width: 2
+                                    border.color: marker.include ? "#101010" : "#ffffff"
+
+                                    MaterialSymbol {
+                                        anchors.centerIn: parent
+                                        // The glyph is the whole explanation of
+                                        // what a right-click did, on the object
+                                        // it did it to.
+                                        text: marker.include ? "add" : "remove"
+                                        iconSize: 12
+                                        color: marker.include ? "#101010" : "#ffffff"
+                                    }
+                                }
+                            }
+                        }
+
+                        // The gesture. Declared after everything it points at so
+                        // it is on top, and only for the prompted column - the
+                        // salient ones answer the picture and have nothing to
+                        // aim.
+                        MouseArea {
+                            id: pointArea
+                            anchors.fill: parent
+                            // Gated on the wallpaper having DECODED, not merely
+                            // on a path. An Image's implicit size reads 0 until
+                            // its source resolves, and `coverRect` answers a
+                            // zero-sized source with the box itself - so a click
+                            // arriving in that window would be measured against
+                            // a frame the picture does not occupy and sent to
+                            // the producer as a point somewhere else entirely.
+                            enabled: candidate.prompted && root.wallpaper !== ""
+                                && previewCutout.wallpaperStatus === Image.Ready
+                            visible: enabled
+                            acceptedButtons: Qt.LeftButton | Qt.RightButton
+                            cursorShape: Qt.CrossCursor
+                            onClicked: mouse => {
+                                const frame = previewCutout.maskRect
+                                if (frame.width <= 0 || frame.height <= 0)
+                                    return
+                                // Clamped rather than passed through: the
+                                // producer refuses a point outside the picture,
+                                // and a rounding error at the very edge of the
+                                // frame would come back as an error message
+                                // about a click that looked perfectly ordinary.
+                                const nx = Math.max(0, Math.min(1, (mouse.x - frame.x) / frame.width))
+                                const ny = Math.max(0, Math.min(1, (mouse.y - frame.y) / frame.height))
+                                ClockDepth.addPoint(nx, ny, mouse.button === Qt.LeftButton)
+                            }
+                        }
+
                         // Along the bottom edge rather than centred: the middle
                         // of the preview is where the clock is, and a status
                         // label printed across it is sitting on the one thing
@@ -380,12 +501,15 @@ Item {
                             anchors.right: parent.right
                             anchors.bottom: parent.bottom
                             implicitHeight: statusLabel.implicitHeight + Appearance.spacing.space100
-                            visible: candidate.maskPath === "" || candidate.thisRunning
+                            visible: statusLabel.text !== ""
                             color: Appearance.colors.colLayer0
 
                             StyledText {
                                 id: statusLabel
                                 anchors.centerIn: parent
+                                width: parent.width - Appearance.spacing.space100
+                                horizontalAlignment: Text.AlignHCenter
+                                elide: Text.ElideRight
                                 // "No subject found" was a verdict on the
                                 // picture and it is usually a verdict on the
                                 // model: measured, the illustration model
@@ -393,13 +517,31 @@ Item {
                                 // the other model cuts out cleanly. A user who
                                 // reads the first sentence stops; a user who
                                 // reads this one runs the other column.
-                                text: candidate.thisRunning
-                                    ? Translation.tr("Looking for a subject…")
-                                    : candidate.refused
+                                //
+                                // The prompted column's line is the whole of
+                                // its instructions, and it is on the surface
+                                // the gesture is aimed at, because there is
+                                // nowhere else a person would look for it.
+                                text: {
+                                    if (candidate.thisRunning)
+                                        return candidate.prompted
+                                            ? Translation.tr("Cutting…")
+                                            : Translation.tr("Looking for a subject…")
+                                    if (candidate.prompted) {
+                                        if (candidate.points.length === 0)
+                                            return Translation.tr("Click the subject")
+                                        if (candidate.maskPath === "")
+                                            return Translation.tr("Nothing there — click on the subject itself")
+                                        return Translation.tr("Right-click to exclude what it grabbed")
+                                    }
+                                    if (candidate.maskPath !== "")
+                                        return ""
+                                    return candidate.refused
                                         ? (candidate.otherFound
                                             ? Translation.tr("Nothing here — the other model found something")
-                                            : Translation.tr("Nothing here — try the other model"))
+                                            : Translation.tr("Nothing here — try clicking the subject"))
                                         : Translation.tr("Not run yet")
+                                }
                                 font.pixelSize: Appearance.font.pixelSize.small
                                 color: Appearance.colors.colOnLayer0
                             }
@@ -412,11 +554,53 @@ Item {
 
                         DialogButton {
                             id: runButton
+                            visible: !candidate.prompted
                             enabled: !root.busy && root.wallpaper !== ""
                             buttonText: candidate.maskPath !== "" || candidate.refused
                                 ? Translation.tr("Run again")
                                 : Translation.tr("Run")
-                            onClicked: ClockDepth.runModel(candidate.modelData)
+                            onClicked: ClockDepth.runModel(candidate.modelName)
+                        }
+                        // The prompted column's two corrections, as glyphs
+                        // rather than as labelled buttons: a third of the
+                        // dialog's width already carries an accept button, and
+                        // the words that would go on these are the ones the
+                        // preview's own line is saying.
+                        RippleButton {
+                            id: undoButton
+                            visible: candidate.prompted
+                            enabled: !root.busy && candidate.points.length > 0
+                            implicitWidth: 36
+                            implicitHeight: 36
+                            buttonRadius: height / 2
+                            onClicked: ClockDepth.undoPoint()
+                            contentItem: MaterialSymbol {
+                                anchors.centerIn: parent
+                                text: "undo"
+                                iconSize: Appearance.font.pixelSize.larger
+                                color: Appearance.colors.colOnLayer0
+                            }
+                            StyledToolTip {
+                                text: Translation.tr("Take back the last click")
+                            }
+                        }
+                        RippleButton {
+                            id: clearButton
+                            visible: candidate.prompted
+                            enabled: !root.busy && candidate.points.length > 0
+                            implicitWidth: 36
+                            implicitHeight: 36
+                            buttonRadius: height / 2
+                            onClicked: ClockDepth.clearPoints()
+                            contentItem: MaterialSymbol {
+                                anchors.centerIn: parent
+                                text: "backspace"
+                                iconSize: Appearance.font.pixelSize.larger
+                                color: Appearance.colors.colOnLayer0
+                            }
+                            StyledToolTip {
+                                text: Translation.tr("Start this selection over")
+                            }
                         }
                         Item { Layout.fillWidth: true }
                         DialogButton {
@@ -427,7 +611,7 @@ Item {
                             colText: Appearance.colors.colOnPrimary
                             buttonText: Translation.tr("Use this")
                             onClicked: {
-                                ClockDepth.acceptModel(candidate.modelData)
+                                ClockDepth.acceptModel(candidate.modelName)
                                 // Accepting a mask while the feature is switched
                                 // off would put the artifact on disk and change
                                 // nothing on screen, which reads as the button

--- a/dots/.config/quickshell/imi/scripts/background/subject-mask-venv.sh
+++ b/dots/.config/quickshell/imi/scripts/background/subject-mask-venv.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 # Runs subject_mask.py inside the shell's uv venv, where onnxruntime lives.
 #
-# Only `run` needs it. `status` and `sweep` are stdlib-only on purpose - the
-# shell's read path must not depend on a venv that may not be built yet, and a
-# background whose depth layer failed to appear because a venv was missing would
-# be indistinguishable from a wallpaper with no mask.
+# Only `run` and `select` need it. `status` and `sweep` are stdlib-only on
+# purpose - the shell's read path must not depend on a venv that may not be
+# built yet, and a background whose depth layer failed to appear because a venv
+# was missing would be indistinguishable from a wallpaper with no mask.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 source "$(eval echo "${IMMATERIAL_IMPULSE_VIRTUAL_ENV:-$ILLOGICAL_IMPULSE_VIRTUAL_ENV}")/bin/activate"

--- a/dots/.config/quickshell/imi/scripts/background/subject_mask.py
+++ b/dots/.config/quickshell/imi/scripts/background/subject_mask.py
@@ -307,7 +307,14 @@ def status(root, wallpaper):
         return {"state": "unreadable", "error": str(exc), "wallpaper": str(wallpaper)}
 
     result = {"key": key, "wallpaper": str(Path(wallpaper).expanduser().resolve()),
-              "cacheDir": str(root)}
+              "cacheDir": str(root),
+              # The models and what each one is asked with, so the picker draws
+              # one column per model without carrying its own copy of the list -
+              # a second list of model names is the pair that drifts, and the
+              # one that would drift silently is the picker's, since a model
+              # nobody named simply has no column.
+              "models": [{"name": name, "kind": spec["kind"]}
+                         for name, spec in MODELS.items()]}
     accepted = root / f"{key}.png"
     optout = root / f"{key}.off"
     candidates = {}

--- a/dots/.config/quickshell/imi/scripts/background/subject_mask.py
+++ b/dots/.config/quickshell/imi/scripts/background/subject_mask.py
@@ -109,6 +109,22 @@ MODELS = {
 # answer and must be recorded rather than recomputed on every visit.
 EMPTY_FOREGROUND = 0.005
 
+# A click's floor is far lower, and it has to be a different number rather than
+# the same one reused. The salient threshold answers "did this model find a
+# subject in this picture", where 0.5% of the frame is a plausible dividing line
+# between an answer and a stray fragment. A click is the user ASSERTING there is
+# something there and pointing at it, so the only thing left to detect is a
+# decoder that returned nothing at all.
+#
+# Measured, and this is not theoretical: excluding part of a hillside on
+# `aishot-1206.jpg` left a mask at 0.46% of the frame - on that 7680x2160
+# wallpaper, 76000 pixels, a plainly visible object - and the salient floor threw
+# it away as "nothing there". Meanwhile a click on flat sky comes back at 1.6-10%
+# because SAM answers with the sky, so the high floor was not buying a refusal
+# for the case it looked like it was for. 0.0002 is about a 57x57 blob at that
+# resolution, which is the smallest thing worth compositing over a clock.
+EMPTY_PROMPTED_FOREGROUND = 0.0002
+
 # Keys, not files: dropping a key's `.off` while keeping its `.png` would
 # resurrect a mask the user declined.
 SWEEP_KEEP_KEYS = 200
@@ -617,7 +633,7 @@ def select(root, wallpaper, model, points):
     mask = decode_mask(root, model, embedding, resized, points)
     foreground = float((mask > 0.5).mean())
 
-    if foreground < EMPTY_FOREGROUND:
+    if foreground < EMPTY_PROMPTED_FOREGROUND:
         candidate.unlink(missing_ok=True)
         return {"state": "empty", "key": key, "model": model,
                 "foreground": foreground, "prompt": points}

--- a/dots/.config/quickshell/imi/scripts/background/subject_mask.py
+++ b/dots/.config/quickshell/imi/scripts/background/subject_mask.py
@@ -248,6 +248,14 @@ def read_png_text(path, keyword):
         return None
 
 
+def file_revision(path):
+    """A token that changes whenever this file's bytes might have."""
+    try:
+        return str(Path(path).stat().st_mtime_ns)
+    except OSError:
+        return ""
+
+
 def read_prompt(path):
     """The clicks a prompted mask was cut with, or None for a salient one."""
     raw = read_png_text(path, PROMPT_CHUNK)
@@ -324,6 +332,19 @@ def status(root, wallpaper):
         elif (root / f"{key}.{model}.none").exists():
             candidates[model] = None
     result["candidates"] = candidates
+    # A token that changes whenever a mask's bytes do. Qt caches a pixmap by its
+    # URL, so a mask rewritten at the same path is served from the cache
+    # FOREVER - measured with a qml6 probe: a 32x8 image rewritten at 99x17 and
+    # re-assigned to the identical URL still reported 32x8, and clearing the
+    # source first did not help. Every click after the first would appear to do
+    # nothing. The shell hangs this on the URL as a fragment, which Qt leaves out
+    # of the filename and keeps in the cache key.
+    #
+    # A string because these are nanoseconds: 1.8e18 does not survive a JSON
+    # round trip through a double, and a revision that quietly stops changing is
+    # the bug this exists to prevent.
+    result["revisions"] = {model: file_revision(path)
+                           for model, path in candidates.items() if path}
     # The clicks each prompted candidate was cut with, read back out of the mask
     # itself. The picker draws them so re-opening on a wallpaper shows what was
     # clicked rather than an unexplained cutout with no way back into the
@@ -342,6 +363,11 @@ def status(root, wallpaper):
     elif accepted.exists():
         result["state"] = "accepted"
         result["mask"] = str(accepted)
+        # The accepted mask is rewritten in place when a second candidate is
+        # accepted for the same wallpaper, so the desktop layer needs the same
+        # token the picker does - without it, accepting the other column's
+        # cutout changes the file and nothing on screen.
+        result["maskRevision"] = file_revision(accepted)
         result["acceptedModel"] = accepted_model(root, key, candidates)
         # The accepted mask's OWN prompt, not the live candidate's. Accept is a
         # byte copy, so the clicks travelled with the pixels they produced and

--- a/dots/.config/quickshell/imi/scripts/background/subject_mask.py
+++ b/dots/.config/quickshell/imi/scripts/background/subject_mask.py
@@ -496,11 +496,12 @@ def image_embedding(root, wallpaper, model, key):
 
     This is the whole reason SAM is the right tool here rather than a fourth
     salient detector. Encoding is the expensive half and depends only on the
-    picture - measured on this machine at 2.6s for a 3840x1594 wallpaper -
-    while decoding a mask from a set of clicks reads the embedding and takes
-    milliseconds. Cached, the first click pays for the encode and every click
-    after it is effectively free; encoding per click would put a 2.6s wait
-    between every attempt and refinement is the entire interaction.
+    picture; decoding a mask from a set of clicks reads the embedding and is
+    over an order of magnitude cheaper. Measured on a 7680x2160 wallpaper:
+    encode 1.04s, load the cached embedding 0.004s, decode 0.128s - so the
+    first click costs 1.6s end to end and every one after it 0.34s, most of
+    which is starting Python. Encoding per click would put the first click's
+    price on every attempt, and refinement is the entire interaction.
 
     Stored as float16. The array is 256x64x64, which is 4MB at float32 and 2MB
     halved, and it is consumed by a decoder that immediately blurs it through a

--- a/dots/.config/quickshell/imi/scripts/background/subject_mask.py
+++ b/dots/.config/quickshell/imi/scripts/background/subject_mask.py
@@ -25,6 +25,21 @@ docs/superpowers/specs/2026-08-16-clock-depth-design.md:
     <key>.png           the candidate the user accepted - the ONLY file the shell draws
     <key>.off           the user declined every candidate for this wallpaper
 
+A fifth file exists for the prompted model only, and it is not a state:
+
+    <key>.<model>.embedding.npz   the wallpaper encoded once, so clicks are cheap
+
+Two kinds of model live behind those four states. The salient detectors
+(isnet-*) answer on their own and are asked with `run`. The prompted one
+(mobile-sam) answers a click and is asked with `select` - because on the bulk of
+this library the salient models have no answer at all: swept over the 91
+wallpapers here, one was accepted, 43 produced a candidate, and 45 returned
+nothing from BOTH models. Measured before any threshold, isnet-general-use
+claims 2.78% of `aishot-3263.jpg` at 0.1 confidence and isnet-anime 0.07%, so
+there is no threshold that recovers those pictures - the models are salient
+object detectors and a full-bleed wallpaper has no background to separate a
+subject from. Pointing at the subject is the answer, not a lower bar.
+
 Output is JSON on stdout rather than a bare path because the shell has to tell
 those states apart, and a path can only carry "yes" and "no".
 """
@@ -39,14 +54,53 @@ from pathlib import Path
 
 MODELS = {
     "isnet-anime": {
-        "url": "https://github.com/danielgatis/rembg/releases/download/v0.0.0/isnet-anime.onnx",
-        "sha256": "f15622d853e8260172812b657053460e20806f04b9e05147d49af7bed31a6e99",
+        "kind": "salient",
         "side": 1024,
+        "files": {
+            "model": {
+                "url": "https://github.com/danielgatis/rembg/releases/download/v0.0.0/isnet-anime.onnx",
+                "sha256": "f15622d853e8260172812b657053460e20806f04b9e05147d49af7bed31a6e99",
+            },
+        },
     },
     "isnet-general-use": {
-        "url": "https://github.com/danielgatis/rembg/releases/download/v0.0.0/isnet-general-use.onnx",
-        "sha256": "60920e99c45464f2ba57bee2ad08c919a52bbf852739e96947fbb4358c0d964a",
+        "kind": "salient",
         "side": 1024,
+        "files": {
+            "model": {
+                "url": "https://github.com/danielgatis/rembg/releases/download/v0.0.0/isnet-general-use.onnx",
+                "sha256": "60920e99c45464f2ba57bee2ad08c919a52bbf852739e96947fbb4358c0d964a",
+            },
+        },
+    },
+    # The click-to-select model, and the reason it is two files rather than one.
+    # Encoding an image costs seconds; decoding a mask from a click costs
+    # milliseconds and reads only the embedding, so the split is what makes the
+    # second click instant. Fused into one file it would be the same cost per
+    # click as the salient models pay per run, and the feature would be
+    # unusable - see `image_embedding`.
+    #
+    # MobileSAM rather than SAM proper: it keeps SAM's own prompt encoder and
+    # mask decoder and replaces only the image encoder with a distilled ViT-t,
+    # so the decoder contract is Meta's unchanged and the pair is 43MB against
+    # SAM ViT-H's 2.4GB. Apache-2.0 upstream (ChaoningZhang/MobileSAM), MIT on
+    # the repository hosting this ONNX export.
+    #
+    # The encoder normalises and pads INSIDE the graph, so it is fed the resized
+    # picture in raw 0-255 HWC - see `image_embedding`.
+    "mobile-sam": {
+        "kind": "prompted",
+        "side": 1024,
+        "files": {
+            "encoder": {
+                "url": "https://huggingface.co/Acly/MobileSAM/resolve/main/mobile_sam_image_encoder.onnx",
+                "sha256": "580f5fb648ea1062c0aabc26217aed56921985f03f0cbbd852bba81d760cc749",
+            },
+            "decoder": {
+                "url": "https://huggingface.co/Acly/MobileSAM/resolve/main/sam_mask_decoder_single.onnx",
+                "sha256": "93915fc7c993ab9d59ab8c9ccd3bce37f7509c81ab4150a74abd4d2abbd8570d",
+            },
+        },
     },
 }
 
@@ -59,7 +113,25 @@ EMPTY_FOREGROUND = 0.005
 # resurrect a mask the user declined.
 SWEEP_KEEP_KEYS = 200
 
-SUFFIXES = (".png", ".none", ".off")
+# The embedding is swept with the key like everything else - it is derived from
+# the same wallpaper and is worthless the moment the key changes.
+SUFFIXES = (".png", ".none", ".off", ".npz")
+
+# The PNG text chunk a prompted mask carries its own clicks in. The prompt lives
+# INSIDE the mask rather than in a sidecar file or in the cache key; the reasons
+# are in `write_mask`.
+PROMPT_CHUNK = "clock-depth-prompt"
+PROMPT_VERSION = 1
+
+
+def salient_models():
+    """The models that answer on their own, and so take a `run`."""
+    return sorted(m for m, spec in MODELS.items() if spec["kind"] == "salient")
+
+
+def prompted_models():
+    """The models that answer a click, and so take a `select`."""
+    return sorted(m for m, spec in MODELS.items() if spec["kind"] == "prompted")
 
 
 def cache_root(explicit=None):
@@ -75,6 +147,120 @@ def cache_key(wallpaper):
     st = path.stat()
     material = f"{path}\0{st.st_mtime_ns}\0{st.st_size}".encode("utf-8")
     return hashlib.sha256(material).hexdigest()[:32]
+
+
+def resize_longest_side(width, height, side):
+    """The box SAM sees the image in: longest side scaled to `side`, aspect kept.
+
+    SAM resizes the longest side and pads the remainder to a square, rather than
+    squashing the way the isnet models do. That difference is the whole reason a
+    prompted mask comes out at the WALLPAPER's aspect while a salient one comes
+    out square - and it is why `coverRect` needs no case for it, since that
+    function is a rectangle for the wallpaper and never reads the mask's own
+    shape.
+    """
+    if width <= 0 or height <= 0:
+        raise ValueError(f"image has no size: {width}x{height}")
+    scale = side / float(max(width, height))
+    # round, not floor: the transform SAM's own ResizeLongestSide applies.
+    return (max(1, int(width * scale + 0.5)), max(1, int(height * scale + 0.5)))
+
+
+def parse_point(text):
+    """One `--point x,y[,label]` argument, in the image's own normalised frame.
+
+    Normalised rather than pixels because the caller is the picker, which has a
+    preview of some arbitrary size showing a crop of the wallpaper: it knows
+    where the click landed as a fraction of the picture and does not know, and
+    must not have to know, what the file's pixel dimensions are. It is also what
+    makes a stored prompt mean the same thing after the mask is regenerated at a
+    different resolution.
+    """
+    parts = text.split(",")
+    if len(parts) not in (2, 3):
+        raise ValueError(f"point {text!r} is not x,y or x,y,label")
+    x, y = float(parts[0]), float(parts[1])
+    label = int(parts[2]) if len(parts) == 3 else 1
+    if label not in (0, 1):
+        raise ValueError(f"point {text!r} has label {label}; expected 1 (include) "
+                         f"or 0 (exclude)")
+    if not (0.0 <= x <= 1.0 and 0.0 <= y <= 1.0):
+        raise ValueError(f"point {text!r} is outside the picture")
+    return {"x": x, "y": y, "label": label}
+
+
+def encode_prompt(points, resized_size):
+    """The clicks, as the two arrays SAM's decoder takes.
+
+    Three things here are contract rather than choice, and each of them fails
+    silently rather than loudly when it is wrong - a mask in the wrong place, or
+    a mask of the whole frame, with no error anywhere:
+
+    - coordinates are in the RESIZED image's pixels, not the original's and not
+      the padded square's, because that is the space the encoder saw;
+    - a label is 1 for a point the subject must contain and 0 for one it must
+      not, and
+    - a padding point at (0, 0) labelled -1 is appended. The decoder's exported
+      graph has a fixed slot for a box, and with no box the padding point is
+      what tells it there is none. Omitting it does not raise: the decoder reads
+      the first point as a box corner instead, and the mask comes back wrong.
+    """
+    import numpy as np
+
+    width, height = resized_size
+    coords = [[p["x"] * width, p["y"] * height] for p in points]
+    labels = [float(p["label"]) for p in points]
+    coords.append([0.0, 0.0])
+    labels.append(-1.0)
+    return (np.array([coords], dtype=np.float32), np.array([labels], dtype=np.float32))
+
+
+def read_png_text(path, keyword):
+    """One tEXt chunk out of a PNG, with the standard library only.
+
+    `status` is the shell's read path and may not import Pillow (see the module
+    docstring), but it has to report the prompt a mask was cut with so the
+    picker can show the clicks back. A PNG's chunk layout is simple enough that
+    reading one keyword out of it is cheaper than the dependency would be.
+    """
+    try:
+        with open(path, "rb") as handle:
+            if handle.read(8) != b"\x89PNG\r\n\x1a\n":
+                return None
+            while True:
+                header = handle.read(8)
+                if len(header) < 8:
+                    return None
+                length = int.from_bytes(header[:4], "big")
+                kind = header[4:8]
+                if kind == b"IEND":
+                    return None
+                if kind == b"tEXt":
+                    name, _, value = handle.read(length).partition(b"\0")
+                    if name.decode("latin-1") == keyword:
+                        return value.decode("latin-1")
+                else:
+                    # Seek rather than read: the pixels are megabytes and the
+                    # text chunks are not among them.
+                    handle.seek(length, os.SEEK_CUR)
+                handle.seek(4, os.SEEK_CUR)
+    except OSError:
+        return None
+
+
+def read_prompt(path):
+    """The clicks a prompted mask was cut with, or None for a salient one."""
+    raw = read_png_text(path, PROMPT_CHUNK)
+    if raw is None:
+        return None
+    try:
+        payload = json.loads(raw)
+    except ValueError:
+        return None
+    if not isinstance(payload, dict) or payload.get("version") != PROMPT_VERSION:
+        return None
+    points = payload.get("points")
+    return points if isinstance(points, list) else None
 
 
 def accepted_model(root, key, candidates):
@@ -131,6 +317,18 @@ def status(root, wallpaper):
         elif (root / f"{key}.{model}.none").exists():
             candidates[model] = None
     result["candidates"] = candidates
+    # The clicks each prompted candidate was cut with, read back out of the mask
+    # itself. The picker draws them so re-opening on a wallpaper shows what was
+    # clicked rather than an unexplained cutout with no way back into the
+    # gesture that produced it.
+    prompts = {}
+    for model, path in candidates.items():
+        if path is None:
+            continue
+        prompt = read_prompt(path)
+        if prompt is not None:
+            prompts[model] = prompt
+    result["prompts"] = prompts
 
     if optout.exists():
         result["state"] = "declined"
@@ -138,6 +336,14 @@ def status(root, wallpaper):
         result["state"] = "accepted"
         result["mask"] = str(accepted)
         result["acceptedModel"] = accepted_model(root, key, candidates)
+        # The accepted mask's OWN prompt, not the live candidate's. Accept is a
+        # byte copy, so the clicks travelled with the pixels they produced and
+        # this stays right after the candidate is refined further - which is the
+        # case where a recorded-beside-it prompt would start describing a mask
+        # the desktop is not drawing.
+        accepted_prompt = read_prompt(accepted)
+        if accepted_prompt is not None:
+            result["acceptedPrompt"] = accepted_prompt
     elif candidates and all(v is None for v in candidates.values()):
         result["state"] = "none"
     elif candidates:
@@ -147,19 +353,26 @@ def status(root, wallpaper):
     return result
 
 
-def model_path(root, model):
-    return root / "models" / f"{model}.onnx"
+def model_path(root, model, role="model"):
+    """Where one of a model's ONNX files lives.
+
+    The single-file models keep the bare `<model>.onnx` they already occupy on
+    disk - a role in the name would orphan the two 176MB files every machine
+    that has used this feature has already fetched.
+    """
+    name = model if role == "model" else f"{model}.{role}"
+    return root / "models" / f"{name}.onnx"
 
 
-def fetch_model(root, model, progress=None):
-    """Download a model on first use. 176MB, so it is not bundled.
+def fetch_model(root, model, role="model", progress=None):
+    """Download a model file on first use. 176MB, so it is not bundled.
 
     Written to a temporary name and renamed into place: a rename is atomic, so an
     interrupted download can never leave a truncated file that looks like a model
     and fails at session construction instead of at fetch time.
     """
-    spec = MODELS[model]
-    target = model_path(root, model)
+    spec = MODELS[model]["files"][role]
+    target = model_path(root, model, role)
     if target.exists():
         return target
     target.parent.mkdir(parents=True, exist_ok=True)
@@ -193,7 +406,6 @@ def segment(image_path, onnx_path, side):
     onnxruntime, and so a machine without it can still answer cache questions.
     """
     import numpy as np
-    import onnxruntime as ort
     from PIL import Image
 
     Image.MAX_IMAGE_PIXELS = None
@@ -203,16 +415,191 @@ def segment(image_path, onnx_path, side):
     # measured at foreground 0.9999 on three separate wallpapers.
     array = np.asarray(image.resize((side, side), Image.LANCZOS), np.float32) / 255.0
     array = array - 0.5
-    session = ort.InferenceSession(str(onnx_path), providers=["CPUExecutionProvider"])
+    session = session_for(onnx_path)
     name = session.get_inputs()[0].name
     mask = session.run(None, {name: array.transpose(2, 0, 1)[None]})[0][0][0]
     mask = (mask - mask.min()) / (mask.max() - mask.min() + 1e-8)
     return mask
 
 
+def session_for(onnx_path):
+    """One ONNX session, with the import failure said in words a user can act on.
+
+    A missing `onnxruntime` is the single most likely way this script fails on a
+    working machine - the venv is built by the installer and this is the only
+    thing in the shell that needs a package in it - and what the picker showed
+    for it was `ModuleNotFoundError: No module named 'onnxruntime'`, which names
+    neither the venv nor the command that repairs it.
+    """
+    try:
+        import onnxruntime as ort
+    except ImportError as exc:
+        raise RuntimeError(
+            "onnxruntime is missing from the shell's Python environment, so no "
+            "model can run. Rebuild it with: uv pip install --python "
+            "\"$IMMATERIAL_IMPULSE_VIRTUAL_ENV\" onnxruntime "
+            f"(python said: {exc})") from exc
+    return ort.InferenceSession(str(onnx_path), providers=["CPUExecutionProvider"])
+
+
+def image_embedding(root, wallpaper, model, key):
+    """The wallpaper's SAM embedding, computed once and cached at the key.
+
+    This is the whole reason SAM is the right tool here rather than a fourth
+    salient detector. Encoding is the expensive half and depends only on the
+    picture - measured on this machine at 2.6s for a 3840x1594 wallpaper -
+    while decoding a mask from a set of clicks reads the embedding and takes
+    milliseconds. Cached, the first click pays for the encode and every click
+    after it is effectively free; encoding per click would put a 2.6s wait
+    between every attempt and refinement is the entire interaction.
+
+    Stored as float16. The array is 256x64x64, which is 4MB at float32 and 2MB
+    halved, and it is consumed by a decoder that immediately blurs it through a
+    transposed convolution into a 256x256 logit field - the mantissa bits are
+    not what decides where the edge lands. It is cast back on load because the
+    decoder's input is float32.
+    """
+    import numpy as np
+    from PIL import Image
+
+    cached = root / f"{key}.{model}.embedding.npz"
+    if cached.exists():
+        with np.load(cached) as stored:
+            return (stored["embedding"].astype(np.float32), tuple(stored["resized"]))
+
+    spec = MODELS[model]
+    encoder = model_path(root, model, "encoder")
+    if not encoder.exists():
+        encoder = fetch_model(root, model, "encoder")
+
+    Image.MAX_IMAGE_PIXELS = None
+    image = Image.open(wallpaper).convert("RGB")
+    # Resize the longest side and let the graph pad the rest. This is SAM's own
+    # preprocessing and the opposite of what the isnet models want: squashing
+    # here would ask the encoder for features of a picture nothing was trained
+    # on, and every click would land on the wrong part of it.
+    #
+    # Raw 0-255, unnormalised and UNPADDED, because this export carries
+    # `preprocess()` inside the graph - it subtracts the ImageNet mean, divides
+    # by the standard deviation and pads bottom-right itself. Padding here first
+    # would put zeros through that normalisation instead of leaving them at
+    # zero, which is a border of -2.1 the model has never seen and a mask that
+    # goes subtly wrong near the edges of the frame with nothing to show for it.
+    resized = resize_longest_side(image.width, image.height, spec["side"])
+    array = np.asarray(image.resize(resized, Image.LANCZOS), np.float32)
+
+    session = session_for(encoder)
+    name = session.get_inputs()[0].name
+    embedding = session.run(None, {name: array})[0]
+
+    root.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=str(root), suffix=".part")
+    try:
+        # Handed the open descriptor rather than the path: `np.savez` appends
+        # `.npz` to any name that does not already end in it, so passing the
+        # temporary name writes a SECOND file and leaves the empty one this
+        # created - which then gets renamed into place and loads as "No data
+        # left in file" on the next click.
+        with os.fdopen(fd, "wb") as out:
+            np.savez(out, embedding=embedding.astype(np.float16),
+                     resized=np.array(resized, np.int32))
+        os.rename(tmp, cached)
+    except BaseException:
+        if os.path.exists(tmp):
+            os.unlink(tmp)
+        raise
+    return (embedding.astype(np.float32), resized)
+
+
+def decode_mask(root, model, embedding, resized, points):
+    """One set of clicks into one mask. Milliseconds, and no image is opened.
+
+    The decoder returns LOGITS, not a normalised field: zero is the boundary and
+    the sign is the answer. The salient path's min-max normalisation would be
+    wrong here twice over - it would move the boundary to wherever the extremes
+    happen to fall, and on a confident mask it would stretch a hard edge across
+    the whole range. A sigmoid keeps 0.5 at the model's own boundary and keeps
+    the edge as soft as the model actually left it, which is what stops the
+    cutout reading as a sticker.
+    """
+    import numpy as np
+
+    decoder = model_path(root, model, "decoder")
+    if not decoder.exists():
+        decoder = fetch_model(root, model, "decoder")
+
+    coords, labels = encode_prompt(points, resized)
+    session = session_for(decoder)
+    names = {i.name for i in session.get_inputs()}
+    feed = {
+        "image_embeddings": embedding,
+        "point_coords": coords,
+        "point_labels": labels,
+        # No previous mask. `has_mask_input` is what says so; a zeroed
+        # `mask_input` with the flag set is a mask that claims nothing, which is
+        # a different prompt.
+        "mask_input": np.zeros((1, 1, 256, 256), np.float32),
+        "has_mask_input": np.zeros(1, np.float32),
+    }
+    if "orig_im_size" in names:
+        # The RESIZED size, not the wallpaper's. It is what the decoder crops
+        # the padding away against, and asking for the wallpaper's own
+        # resolution would store a 3MB mask carrying no information the 1024
+        # one does not - the same trade §3 of the design already made.
+        feed["orig_im_size"] = np.array([resized[1], resized[0]], np.float32)
+    outputs = session.run(None, feed)
+    masks = outputs[0]
+    scores = outputs[1] if len(outputs) > 1 else None
+    if masks.shape[1] > 1 and scores is not None:
+        # A multi-mask export answers with the subject at three scales - a
+        # sleeve, an arm, a person - and the IoU head is the model's own opinion
+        # of which one the click meant.
+        best = int(np.argmax(np.asarray(scores).reshape(-1)))
+    else:
+        best = 0
+    return 1.0 / (1.0 + np.exp(-masks[0][best].astype(np.float32)))
+
+
+def select(root, wallpaper, model, points):
+    """Cut a mask from clicks, or clear the one that is there.
+
+    No `.none` marker is ever written here, and that is the difference between a
+    model's verdict and a user's gesture. `<key>.<model>.none` means "this model
+    looked at this picture and there is nothing in it", which is worth recording
+    so nobody spends 4.5s learning it twice. A click that lands on flat sky is
+    not that: it is one attempt, and recording it would tell the picker to stop
+    offering the one column whose whole point is that the user aims it.
+    """
+    if MODELS.get(model, {}).get("kind") != "prompted":
+        raise RuntimeError(f"{model!r} takes no clicks; use `run --model {model}`")
+    key = cache_key(wallpaper)
+    root.mkdir(parents=True, exist_ok=True)
+    candidate = root / f"{key}.{model}.png"
+
+    if not points:
+        candidate.unlink(missing_ok=True)
+        return {"state": "cleared", "key": key, "model": model}
+
+    embedding, resized = image_embedding(root, wallpaper, model, key)
+    mask = decode_mask(root, model, embedding, resized, points)
+    foreground = float((mask > 0.5).mean())
+
+    if foreground < EMPTY_FOREGROUND:
+        candidate.unlink(missing_ok=True)
+        return {"state": "empty", "key": key, "model": model,
+                "foreground": foreground, "prompt": points}
+
+    write_mask(candidate, mask, prompt=points)
+    return {"state": "produced", "key": key, "model": model,
+            "mask": str(candidate), "foreground": foreground, "prompt": points}
+
+
 def run(root, wallpaper, model, force=False):
     if model not in MODELS:
         raise SystemExit(f"unknown model {model!r}; expected one of {', '.join(MODELS)}")
+    if MODELS[model]["kind"] == "prompted":
+        raise RuntimeError(f"{model!r} needs clicks; use `select --model {model} "
+                           f"--point x,y`")
     key = cache_key(wallpaper)
     root.mkdir(parents=True, exist_ok=True)
     candidate = root / f"{key}.{model}.png"
@@ -243,7 +630,7 @@ def run(root, wallpaper, model, force=False):
             "mask": str(candidate), "foreground": foreground}
 
 
-def write_mask(path, mask):
+def write_mask(path, mask, prompt=None):
     """Save a mask at model resolution, carrying it in BOTH channels.
 
     Model resolution rather than the wallpaper's: upscaling to 5120px is a smooth
@@ -260,12 +647,35 @@ def write_mask(path, mask):
 
     A function of its own rather than four lines inside `run`, because it is the
     only part of the produced artifact that is testable without a model.
+
+    A prompted mask carries the clicks that produced it in a PNG text chunk,
+    INSIDE the file. Three alternatives were available and each of them is a
+    pair that has to agree:
+
+    - putting the prompt in the cache key mints an entry per click, so a
+      five-click refinement leaves five masks and the question "which of these
+      did the user accept" needs a sixth file to answer it;
+    - a sidecar JSON beside the mask is two files a sweep, a copy or a crash can
+      separate - and `accept` is a byte copy, so the sidecar would have to be
+      copied too, by hand, in the one place forgetting is silent;
+    - recording it in the config is a per-wallpaper map keyed by a runtime path,
+      which is exactly what `Config.qml`'s JsonAdapter cannot hold.
+
+    In the file, the prompt cannot arrive without its mask or outlive it, the
+    byte-for-byte `accept` carries it for free, and `accepted_model`'s
+    content comparison still works because both sides carry the same chunk.
     """
     import numpy as np
     from PIL import Image
+    from PIL import PngImagePlugin
 
     plane = (np.clip(np.asarray(mask, dtype="float32"), 0.0, 1.0) * 255).astype("uint8")
-    Image.fromarray(np.dstack([plane, plane]), "LA").save(path)
+    info = None
+    if prompt is not None:
+        info = PngImagePlugin.PngInfo()
+        info.add_text(PROMPT_CHUNK, json.dumps({"version": PROMPT_VERSION,
+                                                "points": prompt}))
+    Image.fromarray(np.dstack([plane, plane]), "LA").save(path, pnginfo=info)
 
 
 def accept(root, wallpaper, model):
@@ -353,9 +763,19 @@ def main(argv=None):
 
     p_run = sub.add_parser("run", help="produce a candidate mask, or return a cached one")
     p_run.add_argument("wallpaper")
-    p_run.add_argument("--model", default="isnet-anime", choices=sorted(MODELS))
+    p_run.add_argument("--model", default="isnet-anime", choices=salient_models())
     p_run.add_argument("--force", action="store_true",
                        help="re-run even when a candidate is already cached")
+
+    p_select = sub.add_parser("select", help="cut a mask from clicks on the picture")
+    p_select.add_argument("wallpaper")
+    p_select.add_argument("--model", default="mobile-sam", choices=prompted_models())
+    p_select.add_argument("--point", action="append", default=[], metavar="X,Y[,LABEL]",
+                          help="a click, normalised to the picture: 0,0 is the top "
+                               "left and 1,1 the bottom right. LABEL is 1 for a "
+                               "point the subject must contain (the default) and 0 "
+                               "for one it must not. Repeatable; no points at all "
+                               "clears the candidate.")
 
     p_accept = sub.add_parser("accept", help="draw this model's candidate from now on")
     p_accept.add_argument("wallpaper")
@@ -375,6 +795,9 @@ def main(argv=None):
             result = status(root, args.wallpaper)
         elif args.command == "run":
             result = run(root, args.wallpaper, args.model, force=args.force)
+        elif args.command == "select":
+            result = select(root, args.wallpaper, args.model,
+                            [parse_point(p) for p in args.point])
         elif args.command == "accept":
             result = accept(root, args.wallpaper, args.model)
         elif args.command == "decline":

--- a/dots/.config/quickshell/imi/services/ClockDepth.qml
+++ b/dots/.config/quickshell/imi/services/ClockDepth.qml
@@ -76,7 +76,6 @@ Singleton {
         { "name": "isnet-general-use", "kind": "salient" },
         { "name": "mobile-sam", "kind": "prompted" }
     ]
-    readonly property var models: root.modelSpecs.map(spec => spec.name)
     // "" while nothing is running, otherwise the model being segmented. The
     // picker disables itself on this rather than on a bare boolean, so it can
     // say WHICH model is running - a run is 1.3 to 4.5 seconds and a button that
@@ -111,6 +110,10 @@ Singleton {
     // is the gesture continued rather than an unexplained cutout.
     property var prompts: ({})
     property var acceptedPrompt: []
+
+    function looksLikeList(value): bool {
+        return value !== null && value !== undefined && typeof value.length === "number"
+    }
 
     function addPoint(x: real, y: real, include: bool): void {
         if (root.promptedModel === "")
@@ -276,7 +279,12 @@ Singleton {
                 root.acceptedModel = parsed.acceptedModel ?? ""
                 root.prompts = parsed.prompts ?? ({})
                 root.acceptedPrompt = parsed.acceptedPrompt ?? []
-                if (Array.isArray(parsed.models) && parsed.models.length > 0)
+                // Array-LIKENESS rather than Array.isArray, here and below: a
+                // list that has been through a `property var` is a QVariantList
+                // on the way back and keeps its indices and its length while
+                // losing the brand, which is the same trap a manifest's
+                // grid.sizes hit crossing a model boundary.
+                if (root.looksLikeList(parsed.models) && parsed.models.length > 0)
                     root.modelSpecs = parsed.models
                 if (root.promptRestoredFor !== root.queriedPath) {
                     root.promptRestoredFor = root.queriedPath
@@ -287,8 +295,8 @@ Singleton {
                     // produced what is on screen rather than an empty preview
                     // with no way back into it.
                     const candidate = root.prompts?.[root.promptedModel]
-                    root.points = Array.isArray(candidate) ? candidate
-                        : (Array.isArray(root.acceptedPrompt) ? root.acceptedPrompt : [])
+                    root.points = root.looksLikeList(candidate) ? candidate
+                        : (root.looksLikeList(root.acceptedPrompt) ? root.acceptedPrompt : [])
                 }
             }
         }

--- a/dots/.config/quickshell/imi/services/ClockDepth.qml
+++ b/dots/.config/quickshell/imi/services/ClockDepth.qml
@@ -65,13 +65,91 @@ Singleton {
     property string queriedPath: ""
 
     // The picker's side. Everything below is reached only from a button.
-    readonly property list<string> models: ["isnet-anime", "isnet-general-use"]
+    //
+    // The producer names the models and says what each is asked with, so the
+    // picker does not carry a second copy of the list. This is the value it
+    // answers with today, kept only so the picker's columns are drawn on the
+    // frame it opens rather than 200ms later - `tests/test_clock_depth_models.py`
+    // fails the suite when it stops matching what the producer reports.
+    property var modelSpecs: [
+        { "name": "isnet-anime", "kind": "salient" },
+        { "name": "isnet-general-use", "kind": "salient" },
+        { "name": "mobile-sam", "kind": "prompted" }
+    ]
+    readonly property var models: root.modelSpecs.map(spec => spec.name)
     // "" while nothing is running, otherwise the model being segmented. The
     // picker disables itself on this rather than on a bare boolean, so it can
     // say WHICH model is running - a run is 1.3 to 4.5 seconds and a button that
     // only greys out reads as a hang.
     property string running: ""
     property string lastError: ""
+
+    // The clicks the prompted column is working from, in the picture's own
+    // normalised frame. One list rather than one per model because there is one
+    // prompted model; the producer refuses the verb for the others.
+    property var points: []
+    // Restoration is keyed on the wallpaper rather than done on every status,
+    // because a click that finds nothing writes no candidate - so re-reading the
+    // prompt off the cache after one would silently discard the click the user
+    // just made, along with any way to undo or refine it.
+    property string promptRestoredFor: ""
+    // A click that arrived while the previous one was still decoding. Dropping
+    // it would be the natural thing and the wrong one: the whole gesture is
+    // adding points, and at ~0.3s per decode a user placing three of them
+    // outruns it.
+    property bool selectPending: false
+
+    readonly property string promptedModel: {
+        for (const spec of root.modelSpecs) {
+            if (spec.kind === "prompted")
+                return spec.name
+        }
+        return ""
+    }
+    // What the prompted column was cut with, whether or not it is the one the
+    // desktop draws. The picker shows these back so re-opening on a wallpaper
+    // is the gesture continued rather than an unexplained cutout.
+    property var prompts: ({})
+    property var acceptedPrompt: []
+
+    function addPoint(x: real, y: real, include: bool): void {
+        if (root.promptedModel === "")
+            return
+        root.points = root.points.concat([{ "x": x, "y": y, "label": include ? 1 : 0 }])
+        root.selectPoints()
+    }
+
+    function undoPoint(): void {
+        if (root.points.length === 0)
+            return
+        root.points = root.points.slice(0, root.points.length - 1)
+        root.selectPoints()
+    }
+
+    function clearPoints(): void {
+        root.points = []
+        root.selectPoints()
+    }
+
+    function selectPoints(): void {
+        if (root.wallpaperPath === "" || root.promptedModel === "")
+            return
+        if (root.running !== "") {
+            root.selectPending = true
+            return
+        }
+        root.lastError = ""
+        root.selectPending = false
+        root.running = root.promptedModel
+        const args = root.points.map(point =>
+            `--point ${point.x.toFixed(4)},${point.y.toFixed(4)},${point.label}`).join(" ")
+        selectProcess.command = ["bash", "-c",
+            `source "\${IMMATERIAL_IMPULSE_VIRTUAL_ENV:-$ILLOGICAL_IMPULSE_VIRTUAL_ENV}/bin/activate" && ` +
+            `python3 '${Directories.scriptPath}/background/subject_mask.py' select ` +
+            `'${StringUtils.shellSingleQuoteEscape(root.wallpaperPath)}' ` +
+            `--model ${root.promptedModel} ${args}`]
+        selectProcess.running = true
+    }
 
     // Deliberately not driven by anything reactive. Segmentation costs ~1GB of
     // transient RSS and produces an unusable mask about a third of the time, so
@@ -124,6 +202,11 @@ Singleton {
         root.candidates = ({})
         root.acceptedModel = ""
         root.queriedPath = ""
+        root.prompts = ({})
+        root.acceptedPrompt = []
+        root.points = []
+        root.promptRestoredFor = ""
+        root.selectPending = false
     }
 
     onWallpaperPathChanged: {
@@ -191,6 +274,22 @@ Singleton {
                 root.maskPath = parsed.state === "accepted" ? (parsed.mask ?? "") : ""
                 root.candidates = parsed.candidates ?? ({})
                 root.acceptedModel = parsed.acceptedModel ?? ""
+                root.prompts = parsed.prompts ?? ({})
+                root.acceptedPrompt = parsed.acceptedPrompt ?? []
+                if (Array.isArray(parsed.models) && parsed.models.length > 0)
+                    root.modelSpecs = parsed.models
+                if (root.promptRestoredFor !== root.queriedPath) {
+                    root.promptRestoredFor = root.queriedPath
+                    // The candidate's clicks first: that is the working state,
+                    // and it exists whenever the user has clicked at all. The
+                    // accepted mask's are the fallback, so re-opening on a
+                    // wallpaper whose cutout was kept shows the gesture that
+                    // produced what is on screen rather than an empty preview
+                    // with no way back into it.
+                    const candidate = root.prompts?.[root.promptedModel]
+                    root.points = Array.isArray(candidate) ? candidate
+                        : (Array.isArray(root.acceptedPrompt) ? root.acceptedPrompt : [])
+                }
             }
         }
     }
@@ -217,6 +316,38 @@ Singleton {
                 // comes back through the one reader rather than being mirrored
                 // here into a second notion of the same state.
                 root.refresh()
+            }
+        }
+    }
+
+    Process {
+        id: selectProcess
+        stdout: StdioCollector {
+            id: selectCollector
+            onStreamFinished: {
+                root.running = ""
+                let parsed = null
+                try {
+                    parsed = JSON.parse(selectCollector.text)
+                } catch (error) {
+                    parsed = null
+                }
+                if (!parsed || parsed.state === "error") {
+                    root.lastError = parsed?.error
+                        ?? Translation.tr("Could not cut a mask from those points.")
+                    root.selectPending = false
+                    return
+                }
+                if (parsed.state === "empty")
+                    root.lastError = Translation.tr(
+                        "Nothing there. Click on the subject itself, or right-click to exclude what it grabbed.")
+                // Same discipline as a run: the select wrote a candidate or
+                // removed one, and `status` is what turns either into what the
+                // picker draws - so the answer comes back through the one
+                // reader rather than being mirrored into a second notion of it.
+                root.refresh()
+                if (root.selectPending)
+                    root.selectPoints()
             }
         }
     }

--- a/dots/.config/quickshell/imi/services/ClockDepth.qml
+++ b/dots/.config/quickshell/imi/services/ClockDepth.qml
@@ -59,6 +59,13 @@ Singleton {
     // overwrites its candidate. Derived by the producer from the bytes rather
     // than recorded anywhere, so it cannot drift from the file the shell draws.
     property string acceptedModel: ""
+    // Cache-busting tokens for the mask files, owned by the producer like the
+    // key. Qt caches a pixmap by URL and both of these files are rewritten in
+    // place - the candidate on every click, the accepted mask when a second
+    // candidate is accepted for the same wallpaper - so without them the
+    // picture on screen is whichever mask happened to load first.
+    property string maskRevision: ""
+    property var revisions: ({})
 
     readonly property bool optedOut: root.state === "declined"
 
@@ -204,6 +211,8 @@ Singleton {
         root.maskPath = ""
         root.candidates = ({})
         root.acceptedModel = ""
+        root.maskRevision = ""
+        root.revisions = ({})
         root.queriedPath = ""
         root.prompts = ({})
         root.acceptedPrompt = []
@@ -270,6 +279,8 @@ Singleton {
                     root.maskPath = ""
                     root.candidates = ({})
                     root.acceptedModel = ""
+                    root.maskRevision = ""
+                    root.revisions = ({})
                     return
                 }
                 root.state = parsed.state ?? "error"
@@ -277,6 +288,8 @@ Singleton {
                 root.maskPath = parsed.state === "accepted" ? (parsed.mask ?? "") : ""
                 root.candidates = parsed.candidates ?? ({})
                 root.acceptedModel = parsed.acceptedModel ?? ""
+                root.maskRevision = parsed.maskRevision ?? ""
+                root.revisions = parsed.revisions ?? ({})
                 root.prompts = parsed.prompts ?? ({})
                 root.acceptedPrompt = parsed.acceptedPrompt ?? []
                 // Array-LIKENESS rather than Array.isArray, here and below: a

--- a/dots/.config/quickshell/imi/tests/lint_clock_depth_geometry.py
+++ b/dots/.config/quickshell/imi/tests/lint_clock_depth_geometry.py
@@ -246,6 +246,18 @@ def check(raw, cutout_raw=None):
              f"{WALLPAPER_ID + '.source'!r}: it must draw whatever the wallpaper "
              f"item is drawing, not whatever the config currently names")
 
+    # Qt caches a pixmap by URL, and the accepted mask is rewritten AT THE SAME
+    # PATH whenever a second candidate is accepted for the same wallpaper - so a
+    # layer that names the path without the producer's revision token draws
+    # whichever mask happened to load first, for the rest of the session, with
+    # nothing in any log. Measured with a qml6 probe: re-assigning the identical
+    # URL after the file changed still served the old bytes, and clearing the
+    # source to "" first did not help.
+    revision_binding = declaration(cutout_use, "maskRevision") if cutout_use else None
+    if not revision_binding:
+        fail(f"{CUTOUT_TYPE} is given no maskRevision: the accepted mask is "
+             f"rewritten in place, and Qt would keep serving the cached one")
+
     # Without the mask the layer is a copy of the wallpaper drawn at full
     # opacity over the clock - the loudest possible version of this feature's
     # own failure, and one that nothing else here would notice, because every
@@ -287,6 +299,7 @@ Item {
         anchors.fill: parent
         wallpaperSource: wallpaper.source
         maskPath: ClockDepth.maskPath
+        maskRevision: ClockDepth.maskRevision
     }
 }
 Image {
@@ -393,8 +406,11 @@ def self_check():
             "wallpaperSource: wallpaper.source", "wallpaperSource: bgRoot.wallpaperPath"),
         "the layer rebuilding the cutout itself": SELF_CHECK_BACKGROUND.replace(
             "    ClockDepthCutout {\n        id: clockDepthCutout\n        anchors.fill: parent\n"
-            "        wallpaperSource: wallpaper.source\n        maskPath: ClockDepth.maskPath\n    }",
+            "        wallpaperSource: wallpaper.source\n        maskPath: ClockDepth.maskPath\n"
+            "        maskRevision: ClockDepth.maskRevision\n    }",
             "    Image { id: hand; source: wallpaper.source }"),
+        "the mask cache-buster dropped": SELF_CHECK_BACKGROUND.replace(
+            "        maskRevision: ClockDepth.maskRevision\n", ""),
     }
     cutout_mutations = {
         "the mask dropped entirely": re.sub(

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -938,6 +938,12 @@ if ! python3 "$SCRIPT_DIR/test_clock_depth_cache.py"; then
     exit 1
 fi
 
+echo "Running clock depth model list tests..."
+if ! python3 "$SCRIPT_DIR/test_clock_depth_models.py"; then
+    echo "Clock depth model list tests failed."
+    exit 1
+fi
+
 echo "Running clock depth geometry lint..."
 if ! python3 "$SCRIPT_DIR/lint_clock_depth_geometry.py"; then
     echo "Clock depth geometry lint failed."

--- a/dots/.config/quickshell/imi/tests/test_clock_depth_cache.py
+++ b/dots/.config/quickshell/imi/tests/test_clock_depth_cache.py
@@ -169,6 +169,39 @@ class StatusTest(unittest.TestCase):
         self.assertIsNone(result["candidates"][models[0]])
         self.assertIsNotNone(result["candidates"][models[1]])
 
+    def test_every_mask_is_reported_with_a_revision_that_moves_with_its_bytes(self):
+        """Qt caches a pixmap by URL, and both mask files are rewritten in place.
+
+        Measured with a qml6 probe: a 32x8 PNG rewritten at 99x17 and
+        re-assigned to the identical URL still reported 32x8, and clearing the
+        source to "" first did not help. So without a token that changes, a
+        click-refined candidate and a re-accepted mask both keep drawing
+        whichever version loaded first, for the rest of the session, with
+        nothing in any log. A string, because these are nanoseconds and 1.8e18
+        does not survive a JSON round trip through a double.
+        """
+        candidate = self.cache / f"{self.key}.mobile-sam.png"
+        candidate.write_bytes(b"first")
+        accepted = self.cache / f"{self.key}.png"
+        accepted.write_bytes(b"first")
+        before = self.status()
+        self.assertIsInstance(before["revisions"]["mobile-sam"], str)
+        self.assertIsInstance(before["maskRevision"], str)
+
+        later = time.time() + 120
+        candidate.write_bytes(b"second")
+        os.utime(candidate, (later, later))
+        accepted.write_bytes(b"second")
+        os.utime(accepted, (later, later))
+        after = self.status()
+        self.assertNotEqual(before["revisions"]["mobile-sam"],
+                            after["revisions"]["mobile-sam"])
+        self.assertNotEqual(before["maskRevision"], after["maskRevision"])
+
+    def test_a_refusal_carries_no_revision_because_it_has_no_file(self):
+        (self.cache / f"{self.key}.isnet-anime.none").write_text("")
+        self.assertNotIn("isnet-anime", self.status()["revisions"])
+
     def test_an_unreadable_wallpaper_answers_rather_than_crashing(self):
         result = subject_mask.status(self.cache, self.dir / "not-here.png")
         self.assertEqual(result["state"], "unreadable")

--- a/dots/.config/quickshell/imi/tests/test_clock_depth_cache.py
+++ b/dots/.config/quickshell/imi/tests/test_clock_depth_cache.py
@@ -420,12 +420,403 @@ class MaskFileTest(unittest.TestCase):
         self.assertEqual(self.written().size, (8, 8))
 
 
+class PromptTest(unittest.TestCase):
+    """The clicks, and the two arrays the decoder takes them as.
+
+    Every one of these fails silently rather than loudly when it is wrong: a
+    mask somewhere else in the picture, or a mask of the whole frame, with
+    nothing in any log and a picker that looks like it simply mis-segments.
+    """
+    def test_a_bare_point_is_a_point_the_subject_must_contain(self):
+        self.assertEqual(subject_mask.parse_point("0.5,0.25"),
+                         {"x": 0.5, "y": 0.25, "label": 1})
+
+    def test_a_zero_label_is_a_point_the_subject_must_not_contain(self):
+        self.assertEqual(subject_mask.parse_point("0.1,0.2,0")["label"], 0)
+
+    def test_a_point_outside_the_picture_is_refused(self):
+        for bad in ("1.5,0.2", "-0.1,0.2", "0.2,2", "0.2", "0.2,0.3,7", "a,b"):
+            with self.assertRaises(ValueError, msg=bad):
+                subject_mask.parse_point(bad)
+
+    def test_the_longest_side_is_scaled_and_the_aspect_is_kept(self):
+        """SAM resizes and pads; the isnet models squash. That is the whole
+        reason a prompted mask comes out at the picture's own shape."""
+        self.assertEqual(subject_mask.resize_longest_side(3840, 1594, 1024),
+                         (1024, 425))
+        self.assertEqual(subject_mask.resize_longest_side(1080, 1920, 1024),
+                         (576, 1024))
+        self.assertEqual(subject_mask.resize_longest_side(1024, 1024, 1024),
+                         (1024, 1024))
+        # The short side ROUNDS, it does not truncate: SAM's own
+        # ResizeLongestSide is `int(x * scale + 0.5)`, and the point coordinates
+        # the decoder was traced against are scaled by the rounded size divided
+        # by the original. 700 * 1024 / 1000 is 716.8, so this is the one case
+        # in the set that can tell the two apart - the others land on whole
+        # pixels and pass either way.
+        self.assertEqual(subject_mask.resize_longest_side(1000, 700, 1024),
+                         (1024, 717))
+
+    def test_a_prompted_masks_aspect_is_the_pictures_aspect(self):
+        """Confirmed rather than assumed, because `coverRect` exists precisely
+        because the salient models' masks are NOT the picture's aspect.
+
+        A mask at the picture's own aspect stretched into the rectangle the
+        whole picture would occupy is a uniform scale, so the registration needs
+        no case for it - which is the claim this pins on the producer's side and
+        `tst_clock_depth_eligibility.qml` pins on the shell's.
+        """
+        for width, height in ((3840, 1594), (7680, 2160), (1080, 1920), (8400, 4725)):
+            mask = subject_mask.resize_longest_side(width, height, 1024)
+            self.assertAlmostEqual(mask[0] / mask[1], width / height, places=2,
+                                   msg=f"{width}x{height} -> {mask}")
+
+    def test_an_image_with_no_size_is_refused_rather_than_divided_by(self):
+        with self.assertRaises(ValueError):
+            subject_mask.resize_longest_side(0, 100, 1024)
+
+    def test_the_coordinates_are_in_the_resized_images_pixels(self):
+        """Not the original's and not the padded square's - the space the
+        encoder saw. A point in either of the other two lands somewhere else in
+        the picture, and the mask that comes back is a perfectly good mask of
+        the wrong thing."""
+        try:
+            import numpy  # noqa: F401
+        except ImportError:
+            self.skipTest("needs numpy (the shell's uv venv)")
+        coords, labels = subject_mask.encode_prompt(
+            [{"x": 0.5, "y": 0.5, "label": 1}], (1024, 425))
+        self.assertAlmostEqual(float(coords[0][0][0]), 512.0)
+        self.assertAlmostEqual(float(coords[0][0][1]), 212.5)
+
+    def test_a_padding_point_is_appended_because_there_is_no_box(self):
+        """The decoder's graph has a fixed slot for a box. With no box the
+        (0,0)/-1 padding point is what says so; omitting it does not raise, it
+        makes the decoder read the first click as a box corner."""
+        try:
+            import numpy  # noqa: F401
+        except ImportError:
+            self.skipTest("needs numpy (the shell's uv venv)")
+        points = [{"x": 0.2, "y": 0.3, "label": 1}, {"x": 0.8, "y": 0.4, "label": 0}]
+        coords, labels = subject_mask.encode_prompt(points, (1024, 512))
+        self.assertEqual(coords.shape, (1, 3, 2))
+        self.assertEqual(labels.shape, (1, 3))
+        self.assertEqual([float(v) for v in labels[0]], [1.0, 0.0, -1.0])
+        self.assertEqual([float(v) for v in coords[0][2]], [0.0, 0.0])
+
+    def test_both_arrays_are_float32(self):
+        try:
+            import numpy as np
+        except ImportError:
+            self.skipTest("needs numpy (the shell's uv venv)")
+        coords, labels = subject_mask.encode_prompt(
+            [{"x": 0.5, "y": 0.5, "label": 1}], (1024, 425))
+        self.assertEqual(coords.dtype, np.float32)
+        self.assertEqual(labels.dtype, np.float32)
+
+
+class PromptInTheMaskTest(unittest.TestCase):
+    """A prompted mask carries its own clicks, inside the PNG.
+
+    The alternatives are all pairs that have to agree - a key per click needing
+    a sixth file to say which was accepted, a sidecar a byte-for-byte `accept`
+    would have to copy by hand, a config map the JsonAdapter cannot hold. In the
+    file, the prompt cannot arrive without its mask or outlive it.
+    """
+    def setUp(self):
+        try:
+            import numpy  # noqa: F401
+            from PIL import Image  # noqa: F401
+        except ImportError:
+            self.skipTest("needs numpy and pillow (the shell's uv venv)")
+        self.tmp = tempfile.TemporaryDirectory()
+        self.dir = Path(self.tmp.name)
+        self.addCleanup(self.tmp.cleanup)
+
+    def mask_array(self):
+        import numpy as np
+        mask = np.zeros((8, 8), dtype="float32")
+        mask[:, 4:] = 1.0
+        return mask
+
+    def test_the_clicks_survive_a_round_trip_through_the_file(self):
+        prompt = [{"x": 0.5, "y": 0.25, "label": 1}, {"x": 0.9, "y": 0.8, "label": 0}]
+        path = self.dir / "mask.png"
+        subject_mask.write_mask(path, self.mask_array(), prompt=prompt)
+        self.assertEqual(subject_mask.read_prompt(path), prompt)
+
+    def test_reading_the_prompt_back_needs_no_pillow(self):
+        """`status` is the shell's read path and may import nothing outside the
+        standard library - which is the reason the chunk is read by hand rather
+        than by opening the image."""
+        path = self.dir / "mask.png"
+        subject_mask.write_mask(path, self.mask_array(),
+                                prompt=[{"x": 0.5, "y": 0.5, "label": 1}])
+        poison = self.dir / "poison"
+        poison.mkdir()
+        for module in ("PIL", "numpy", "onnxruntime"):
+            (poison / f"{module}.py").write_text(
+                f"raise AssertionError('reading a prompt imported {module}')\n")
+        proc = subprocess.run(
+            [sys.executable, "-c",
+             f"import sys; sys.path.insert(0, {str(SCRIPT.parent)!r}); "
+             f"import subject_mask; print(subject_mask.read_prompt({str(path)!r}))"],
+            capture_output=True, text=True,
+            env=dict(os.environ, PYTHONPATH=str(poison)))
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn("0.5", proc.stdout)
+
+    def test_a_salient_masks_file_carries_no_prompt(self):
+        path = self.dir / "mask.png"
+        subject_mask.write_mask(path, self.mask_array())
+        self.assertIsNone(subject_mask.read_prompt(path))
+
+    def test_a_file_that_is_not_a_png_answers_none_rather_than_raising(self):
+        broken = self.dir / "broken.png"
+        broken.write_bytes(b"not a png at all")
+        self.assertIsNone(subject_mask.read_prompt(broken))
+        self.assertIsNone(subject_mask.read_prompt(self.dir / "absent.png"))
+
+    def test_the_prompt_travels_with_the_pixels_through_an_accept(self):
+        """`accept` is a byte copy, so this is free - and it is the property
+        that makes the acceptance survive a restart with the clicks that
+        produced it, rather than as an unexplained cutout."""
+        cache = self.dir / "cache"
+        cache.mkdir()
+        wallpaper = self.dir / "wall.png"
+        wallpaper.write_bytes(b"wallpaper")
+        key = subject_mask.cache_key(wallpaper)
+        prompt = [{"x": 0.4, "y": 0.6, "label": 1}]
+        subject_mask.write_mask(cache / f"{key}.mobile-sam.png", self.mask_array(),
+                                prompt=prompt)
+        subject_mask.accept(cache, wallpaper, "mobile-sam")
+        result = subject_mask.status(cache, wallpaper)
+        self.assertEqual(result["state"], "accepted")
+        self.assertEqual(result["acceptedPrompt"], prompt)
+        self.assertEqual(result["acceptedModel"], "mobile-sam")
+
+    def test_refining_the_candidate_leaves_the_accepted_prompt_alone(self):
+        """The one case a prompt recorded beside the mask gets wrong.
+
+        Clicking again overwrites the candidate; the accepted mask and its
+        clicks are a frozen copy, so what the desktop is drawing keeps saying
+        what it was cut with. A shared record would start describing a mask
+        nothing is showing, and `acceptedModel` already goes to None here
+        because the bytes have moved apart - which is the honest answer.
+        """
+        cache = self.dir / "cache"
+        cache.mkdir()
+        wallpaper = self.dir / "wall.png"
+        wallpaper.write_bytes(b"wallpaper")
+        key = subject_mask.cache_key(wallpaper)
+        first = [{"x": 0.4, "y": 0.6, "label": 1}]
+        subject_mask.write_mask(cache / f"{key}.mobile-sam.png", self.mask_array(),
+                                prompt=first)
+        subject_mask.accept(cache, wallpaper, "mobile-sam")
+        second = first + [{"x": 0.7, "y": 0.2, "label": 0}]
+        subject_mask.write_mask(cache / f"{key}.mobile-sam.png", self.mask_array() * 0.5,
+                                prompt=second)
+        result = subject_mask.status(cache, wallpaper)
+        self.assertEqual(result["acceptedPrompt"], first)
+        self.assertEqual(result["prompts"]["mobile-sam"], second)
+
+
+class PromptedCacheTest(unittest.TestCase):
+    """The prompted model inside the four states, and the embedding beside them."""
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.dir = Path(self.tmp.name)
+        self.cache = self.dir / "cache"
+        self.cache.mkdir()
+        self.wallpaper = self.dir / "wall.png"
+        self.wallpaper.write_bytes(b"wallpaper")
+        self.key = subject_mask.cache_key(self.wallpaper)
+        self.addCleanup(self.tmp.cleanup)
+
+    def in_a_fresh_interpreter(self, body, poison):
+        """Run `body` against the producer with `poison` first on the path.
+
+        A separate process rather than a monkeypatch: the thing being pinned is
+        that a module is never IMPORTED, and this one is already imported here.
+        """
+        return subprocess.run(
+            [sys.executable, "-c",
+             f"import sys; sys.path.insert(0, {str(SCRIPT.parent)!r})\n"
+             f"import subject_mask\n{body}"],
+            capture_output=True, text=True,
+            env=dict(os.environ, PYTHONPATH=str(poison)))
+
+    def test_a_click_mask_is_a_candidate_even_when_both_detectors_refused(self):
+        """The state this whole feature exists for. Measured over this library:
+        45 of 91 wallpapers return nothing from BOTH salient models, and every
+        one of them read as `none` - a verdict on the picture, with nowhere to
+        go."""
+        for model in subject_mask.salient_models():
+            (self.cache / f"{self.key}.{model}.none").write_text("")
+        self.assertEqual(subject_mask.status(self.cache, self.wallpaper)["state"],
+                         "none")
+        (self.cache / f"{self.key}.mobile-sam.png").write_bytes(b"a clicked mask")
+        self.assertEqual(subject_mask.status(self.cache, self.wallpaper)["state"],
+                         "candidate")
+
+    def test_an_opt_out_still_beats_a_clicked_mask(self):
+        (self.cache / f"{self.key}.mobile-sam.png").write_bytes(b"a clicked mask")
+        (self.cache / f"{self.key}.png").write_bytes(b"a clicked mask")
+        (self.cache / f"{self.key}.off").write_text("")
+        self.assertEqual(subject_mask.status(self.cache, self.wallpaper)["state"],
+                         "declined")
+
+    def test_clicking_nothing_clears_the_candidate(self):
+        (self.cache / f"{self.key}.mobile-sam.png").write_bytes(b"a clicked mask")
+        result = subject_mask.select(self.cache, self.wallpaper, "mobile-sam", [])
+        self.assertEqual(result["state"], "cleared")
+        self.assertFalse((self.cache / f"{self.key}.mobile-sam.png").exists())
+        self.assertEqual(subject_mask.status(self.cache, self.wallpaper)["state"],
+                         "absent")
+
+    def test_a_cleared_candidate_leaves_no_refusal_marker_behind(self):
+        """A click that finds nothing is one attempt, not a verdict.
+
+        `<key>.<model>.none` means "this model looked and there is nothing in
+        this picture", which is worth not re-learning. Writing one for a click
+        would tell the picker to stop offering the one column the user aims.
+        """
+        subject_mask.select(self.cache, self.wallpaper, "mobile-sam", [])
+        self.assertFalse((self.cache / f"{self.key}.mobile-sam.none").exists())
+
+    def test_the_two_kinds_of_model_refuse_each_others_verb(self):
+        with self.assertRaises(RuntimeError):
+            subject_mask.select(self.cache, self.wallpaper, "isnet-anime",
+                                [{"x": 0.5, "y": 0.5, "label": 1}])
+        with self.assertRaises(RuntimeError):
+            subject_mask.run(self.cache, self.wallpaper, "mobile-sam")
+
+    def test_a_refused_verb_answers_in_json_rather_than_a_traceback(self):
+        proc = run_cli("--cache-dir", str(self.cache), "select", str(self.wallpaper),
+                       "--model", "mobile-sam", "--point", "5,5")
+        self.assertEqual(proc.returncode, 1)
+        self.assertEqual(json.loads(proc.stdout)["state"], "error",
+                         "the picker parses stdout; a traceback on stderr is a "
+                         "click that does nothing with no explanation")
+
+    def test_a_second_click_reuses_the_embedding_instead_of_encoding_again(self):
+        """The reason SAM is the right tool, pinned rather than asserted.
+
+        Proved by removing the encoder from the equation entirely: the model
+        file does not exist and `onnxruntime` raises on import, so anything that
+        reaches the encoder fails. A cached embedding must come back regardless,
+        because encoding costs seconds and refinement is the whole interaction.
+        """
+        try:
+            import numpy as np
+        except ImportError:
+            self.skipTest("needs numpy (the shell's uv venv)")
+        embedding = np.arange(2 * 3, dtype=np.float32).reshape(1, 2, 3)
+        np.savez(self.cache / f"{self.key}.mobile-sam.embedding.npz",
+                 embedding=embedding.astype(np.float16),
+                 resized=np.array((1024, 425), np.int32))
+        poison = self.dir / "poison"
+        poison.mkdir()
+        (poison / "onnxruntime.py").write_text(
+            "raise AssertionError('a cached embedding re-encoded the image')\n")
+        proc = self.in_a_fresh_interpreter(
+            "from pathlib import Path\n"
+            f"embedding, resized = subject_mask.image_embedding("
+            f"Path({str(self.cache)!r}), {str(self.wallpaper)!r}, 'mobile-sam', "
+            f"{self.key!r})\n"
+            "print([int(v) for v in resized], [float(v) for v in embedding.reshape(-1)])",
+            poison)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn("[1024, 425]", proc.stdout)
+        self.assertIn("5.0", proc.stdout)
+
+    def test_the_embedding_is_swept_with_the_key_it_belongs_to(self):
+        """It is derived from the same wallpaper and worthless the moment the
+        key changes, so leaving it behind is a 2MB leak per wallpaper the user
+        ever clicked on."""
+        old = "a" * 32
+        (self.cache / f"{old}.mobile-sam.embedding.npz").write_bytes(b"x")
+        (self.cache / f"{old}.png").write_bytes(b"x")
+        newer = self.cache / f"{'b' * 32}.png"
+        newer.write_bytes(b"x")
+        os.utime(newer, (time.time() + 100, time.time() + 100))
+        subject_mask.sweep(self.cache, keep=1)
+        self.assertEqual([p.name for p in self.cache.iterdir()], [newer.name])
+
+
+class MissingRuntimeTest(unittest.TestCase):
+    """A venv with no onnxruntime must say what to run, not raise Python at the user.
+
+    It was pinned in `requirements.in` and never compiled into the lock the
+    installer installs, so this is not hypothetical: every venv the installer
+    has built is in exactly this state, and what the picker showed was
+    `ModuleNotFoundError: No module named 'onnxruntime'`.
+    """
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.dir = Path(self.tmp.name)
+        self.cache = self.dir / "cache"
+        self.cache.mkdir()
+        self.wallpaper = self.dir / "wall.png"
+        self.wallpaper.write_bytes(b"wallpaper")
+        self.addCleanup(self.tmp.cleanup)
+
+    def test_the_error_names_the_environment_and_the_command_that_repairs_it(self):
+        missing = self.dir / "missing"
+        missing.mkdir()
+        (missing / "onnxruntime.py").write_text(
+            "raise ImportError(\"No module named 'onnxruntime'\")\n")
+        proc = subprocess.run(
+            [sys.executable, "-c",
+             f"import sys; sys.path.insert(0, {str(SCRIPT.parent)!r}); "
+             f"import subject_mask; subject_mask.session_for('/nowhere.onnx')"],
+            capture_output=True, text=True,
+            env=dict(os.environ, PYTHONPATH=str(missing)))
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("onnxruntime is missing", proc.stderr)
+        self.assertIn("uv pip install", proc.stderr,
+                      "a user reading this has to be able to act on it")
+        self.assertIn("IMMATERIAL_IMPULSE_VIRTUAL_ENV", proc.stderr)
+
+
 class ContractTest(unittest.TestCase):
-    def test_every_model_declares_a_url_and_a_checksum(self):
+    def test_every_model_file_declares_a_url_and_a_checksum(self):
         for model, spec in subject_mask.MODELS.items():
-            self.assertTrue(spec["url"].startswith("https://"), model)
-            self.assertRegex(spec["sha256"], r"^[0-9a-f]{64}$", model)
+            self.assertIn(spec["kind"], ("salient", "prompted"), model)
             self.assertEqual(spec["side"], 1024, model)
+            self.assertTrue(spec["files"], model)
+            for role, file in spec["files"].items():
+                self.assertTrue(file["url"].startswith("https://"), f"{model}.{role}")
+                self.assertRegex(file["sha256"], r"^[0-9a-f]{64}$", f"{model}.{role}")
+
+    def test_a_single_file_model_keeps_the_name_it_already_occupies_on_disk(self):
+        """The two 176MB isnet files are already fetched on every machine.
+
+        Putting a role in their filename would orphan both and re-download 350MB
+        the first time anyone opened the picker after the update - silently, as
+        a several-minute hang behind a button that used to be instant.
+        """
+        root = Path("/cache")
+        self.assertEqual(subject_mask.model_path(root, "isnet-anime"),
+                         root / "models/isnet-anime.onnx")
+        self.assertEqual(subject_mask.model_path(root, "mobile-sam", "encoder"),
+                         root / "models/mobile-sam.encoder.onnx")
+
+    def test_the_prompted_model_ships_the_encoder_and_the_decoder_separately(self):
+        """The split IS the feature, so it is a contract rather than a detail.
+
+        One fused file would re-encode the image on every click - seconds each,
+        for a gesture whose whole value is that the second click is instant.
+        """
+        for model in subject_mask.prompted_models():
+            self.assertEqual(set(subject_mask.MODELS[model]["files"]),
+                             {"encoder", "decoder"}, model)
+
+    def test_run_and_select_are_offered_for_different_models(self):
+        self.assertTrue(subject_mask.salient_models())
+        self.assertTrue(subject_mask.prompted_models())
+        self.assertEqual(set(subject_mask.salient_models())
+                         & set(subject_mask.prompted_models()), set())
 
     def test_the_venv_wrapper_exists_and_is_executable(self):
         self.assertTrue(VENV_WRAPPER.exists())

--- a/dots/.config/quickshell/imi/tests/test_clock_depth_cache.py
+++ b/dots/.config/quickshell/imi/tests/test_clock_depth_cache.py
@@ -681,9 +681,9 @@ class PromptedCacheTest(unittest.TestCase):
 
     def test_a_click_mask_is_a_candidate_even_when_both_detectors_refused(self):
         """The state this whole feature exists for. Measured over this library:
-        45 of 91 wallpapers return nothing from BOTH salient models, and every
-        one of them read as `none` - a verdict on the picture, with nowhere to
-        go."""
+        45 of the 94 wallpapers here return nothing from BOTH salient models,
+        and every one of them read as `none` - a verdict on the picture, with
+        nowhere to go."""
         for model in subject_mask.salient_models():
             (self.cache / f"{self.key}.{model}.none").write_text("")
         self.assertEqual(subject_mask.status(self.cache, self.wallpaper)["state"],

--- a/dots/.config/quickshell/imi/tests/test_clock_depth_cache.py
+++ b/dots/.config/quickshell/imi/tests/test_clock_depth_cache.py
@@ -717,6 +717,30 @@ class PromptedCacheTest(unittest.TestCase):
         subject_mask.select(self.cache, self.wallpaper, "mobile-sam", [])
         self.assertFalse((self.cache / f"{self.key}.mobile-sam.none").exists())
 
+    def test_a_click_keeps_a_subject_the_detectors_floor_would_discard(self):
+        """The two floors answer different questions and must not be one number.
+
+        The salient floor divides "this model found a subject in this picture"
+        from "it found a stray fragment", and 0.5% of the frame is a plausible
+        place to put that. A click is the user asserting there IS something and
+        pointing at it, so the only thing left to detect is a decoder that
+        returned nothing.
+
+        Measured rather than argued: excluding part of a hillside on
+        `aishot-1206.jpg` left a mask at 0.46% of the frame - 76000 pixels on
+        that 7680x2160 wallpaper, a plainly visible object - which the salient
+        floor discarded as "nothing there". And a click on flat sky comes back
+        at 1.6-10% because SAM answers with the sky, so the high floor was not
+        even buying the refusal it looked like it was for.
+        """
+        self.assertLess(subject_mask.EMPTY_PROMPTED_FOREGROUND,
+                        subject_mask.EMPTY_FOREGROUND / 10)
+        self.assertGreater(subject_mask.EMPTY_PROMPTED_FOREGROUND, 0,
+                           "a decoder returning nothing must still be refused")
+        # The case that was thrown away, at the size it actually came back.
+        self.assertGreater(0.0046, subject_mask.EMPTY_PROMPTED_FOREGROUND)
+        self.assertLess(0.0046, subject_mask.EMPTY_FOREGROUND)
+
     def test_the_two_kinds_of_model_refuse_each_others_verb(self):
         with self.assertRaises(RuntimeError):
             subject_mask.select(self.cache, self.wallpaper, "isnet-anime",

--- a/dots/.config/quickshell/imi/tests/test_clock_depth_cache.py
+++ b/dots/.config/quickshell/imi/tests/test_clock_depth_cache.py
@@ -438,6 +438,24 @@ class ContractTest(unittest.TestCase):
                       "run needs a session; without the pin the venv has none and "
                       "the picker fails at the moment the user clicks it")
 
+    def test_onnxruntime_reaches_the_file_the_installer_actually_installs(self):
+        """The declaration and the lock are two files, and only one is installed.
+
+        `sdata/lib/package-installers.sh` runs `uv pip install -r
+        requirements.txt`; `requirements.in` is the input a human edits and
+        nothing reads at install time. onnxruntime was added to the `.in` when
+        the producer landed and the lock was never recompiled, so every venv the
+        installer has ever built lacks it - and the only symptom is a raw
+        `ModuleNotFoundError` at the moment the user clicks Run in the picker,
+        on a machine where the feature has never worked. The old version of this
+        check read the `.in` and was green throughout.
+        """
+        lock = ROOT.parents[3] / "sdata/uv/requirements.txt"
+        self.assertRegex(lock.read_text(), r"(?m)^onnxruntime==",
+                         "the installer installs the compiled lock, not the .in - "
+                         "recompile with `uv pip compile requirements.in -o "
+                         "requirements.txt` after adding a dependency")
+
     def test_the_script_does_not_import_onnxruntime_at_module_scope(self):
         source = SCRIPT.read_text()
         head = source.split("def segment(", 1)[0]

--- a/dots/.config/quickshell/imi/tests/test_clock_depth_models.py
+++ b/dots/.config/quickshell/imi/tests/test_clock_depth_models.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""The picker's columns come from the producer, and the fallback must agree.
+
+`scripts/background/subject_mask.py` is the authority on which models exist and
+what each one is asked with - `status` reports them, and `ClockDepth` takes the
+list from that answer, so the picker draws one column per model without holding
+an opinion about which models there are.
+
+It keeps one literal copy anyway, as the value shown on the frame the picker
+opens rather than 200ms later when the first `status` lands. That is a pair that
+has to agree, and the failure is silent in the direction that matters: a model
+the fallback does not name simply has no column for the moment before the query
+answers, and a model it names wrongly draws a column with a dead button. So the
+pair is pinned here rather than trusted.
+
+The order matters too, because it is the order the columns are drawn in and the
+producer's answer replaces the fallback in place - two lists in different orders
+would make the columns jump sideways a fifth of a second after the picker opens.
+"""
+import json
+import re
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/background/subject_mask.py"
+SERVICE = ROOT / "services/ClockDepth.qml"
+PICKER = ROOT / "modules/imi/wallpaperSelector/ClockDepthPicker.qml"
+
+sys.path.insert(0, str(SCRIPT.parent))
+import subject_mask  # noqa: E402
+
+
+def declared_fallback(source):
+    """The `modelSpecs` literal out of ClockDepth.qml, as a list of pairs.
+
+    Read as JSON rather than by a per-field regex: the whole value is a JSON
+    array in QML's own syntax, so parsing it is both simpler and unable to
+    silently match half a declaration after a reformat.
+    """
+    marker = re.search(r"property\s+var\s+modelSpecs:\s*\[", source)
+    if not marker:
+        return None
+    opening = source.index("[", marker.start())
+    depth = 0
+    for index in range(opening, len(source)):
+        if source[index] == "[":
+            depth += 1
+        elif source[index] == "]":
+            depth -= 1
+            if depth == 0:
+                literal = source[opening:index + 1]
+                break
+    else:
+        return None
+    return [(entry["name"], entry["kind"]) for entry in json.loads(literal)]
+
+
+class ModelListParityTest(unittest.TestCase):
+    def setUp(self):
+        self.producer = [(name, spec["kind"])
+                         for name, spec in subject_mask.MODELS.items()]
+
+    def test_the_fallback_names_the_producers_models_in_the_producers_order(self):
+        fallback = declared_fallback(SERVICE.read_text())
+        self.assertIsNotNone(fallback,
+                             "ClockDepth.qml declares no modelSpecs literal - the "
+                             "picker would draw nothing until the first status lands")
+        self.assertEqual(fallback, self.producer)
+
+    def test_status_reports_the_models_so_the_shell_need_not_know_them(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            wallpaper = Path(tmp) / "wall.png"
+            wallpaper.write_bytes(b"wallpaper")
+            proc = subprocess.run(
+                [sys.executable, str(SCRIPT), "--cache-dir", str(Path(tmp) / "cache"),
+                 "status", str(wallpaper)],
+                capture_output=True, text=True)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        reported = [(entry["name"], entry["kind"])
+                    for entry in json.loads(proc.stdout)["models"]]
+        self.assertEqual(reported, self.producer)
+
+    def test_exactly_one_model_answers_a_click(self):
+        """The picker resolves the prompted column by asking which model is
+        prompted, and `ClockDepth.promptedModel` returns the first. A second one
+        would leave the other's column clickable and wired to the first's cache
+        entry - the same mask under two headings."""
+        prompted = [name for name, kind in self.producer if kind == "prompted"]
+        self.assertEqual(len(prompted), 1, prompted)
+
+    def test_the_picker_asks_the_kind_rather_than_naming_the_model(self):
+        """A branch on `"mobile-sam"` in the picker is the drift this removes.
+
+        The producer decides which models take clicks; a picker that decides for
+        itself is a second answer, and the one that goes stale is the picker's,
+        because a model it does not know about simply renders as a column whose
+        Run button spawns a verb the producer refuses.
+        """
+        source = PICKER.read_text()
+        for name, kind in self.producer:
+            if kind != "prompted":
+                continue
+            self.assertNotIn(f'"{name}"', source,
+                             f"ClockDepthPicker.qml names {name} directly; it must "
+                             f"branch on the model's kind instead")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dots/.config/quickshell/imi/tests/tst_clock_depth_eligibility.qml
+++ b/dots/.config/quickshell/imi/tests/tst_clock_depth_eligibility.qml
@@ -126,6 +126,45 @@ TestCase {
         fuzzyCompare(r.width / r.height, 3840 / 1594, 0.0001);
     }
 
+    function test_a_mask_at_the_pictures_own_aspect_lands_unstretched() {
+        // Confirmed rather than assumed, because `coverRect` exists precisely
+        // BECAUSE the salient models' masks are square while the wallpaper is
+        // not - so a mask that is not square is the case the function was never
+        // written for, and the obvious guess is that it needs a second path.
+        //
+        // It does not, and the reason is that the rect is a rectangle for the
+        // WALLPAPER: the function never reads the mask's dimensions at all.
+        // Stretching a mask into it lands every mask's own extent onto the
+        // picture's own extent, so a mask that already carries the picture's
+        // aspect is scaled by the same factor on both axes - it is not squashed
+        // and then unsquashed, it is simply not squashed.
+        const r = ClockDepth.coverRect(3840, 1594, 5120, 1440);
+        // What MobileSAM returns for that picture: the longest side at 1024,
+        // the aspect kept. tests/test_clock_depth_cache.py pins the producer to
+        // exactly this size.
+        const maskW = 1024, maskH = 425;
+        fuzzyCompare(r.width / maskW, r.height / maskH, 0.005);
+    }
+
+    function test_the_square_mask_and_the_picture_shaped_one_share_one_rect() {
+        // The half that would break if anyone "fixed" coverRect to take the
+        // mask's size: one wallpaper has one cover rect, and both kinds of mask
+        // are stretched into it. A per-mask rect is a second registration, and
+        // the picker and the desktop layer draw through the same component
+        // precisely so there cannot be two.
+        // A 3.56:1 picture into a 4:3 box, deliberately: at a matching aspect
+        // the box IS the cover rect and every registration bug is invisible,
+        // which is the hole test_clock_depth_compositing.qml's fixture had.
+        const wide = ClockDepth.coverRect(7680, 2160, 1600, 1200);
+        const again = ClockDepth.coverRect(7680, 2160, 1600, 1200);
+        compare(wide.width, again.width);
+        compare(wide.height, again.height);
+        // A square mask stretched into it is squashed by the picture's own
+        // aspect ratio; a 1024x288 one is not. Both cover the same rectangle.
+        fuzzyCompare(wide.width / wide.height, 7680 / 2160, 0.0001);
+        fuzzyCompare(wide.width / 1024, wide.height / 288, 0.005);
+    }
+
     function test_an_unloaded_image_yields_the_box_rather_than_NaN() {
         // An Image's implicit size reads 0 until its source resolves, and a NaN
         // on x/y/width/height does not misplace the mask - it stops the item

--- a/dots/.config/quickshell/imi/tests/tst_clock_depth_eligibility.qml
+++ b/dots/.config/quickshell/imi/tests/tst_clock_depth_eligibility.qml
@@ -165,6 +165,59 @@ TestCase {
         fuzzyCompare(wide.width / 1024, wide.height / 288, 0.005);
     }
 
+    // normalisedPoint: a click on a preview, as a point in the picture.
+
+    function test_a_click_in_the_middle_of_the_picture_is_the_middle() {
+        const r = ClockDepth.coverRect(3840, 1594, 5120, 1440);
+        const p = ClockDepth.normalisedPoint(r, 2560, 720);
+        fuzzyCompare(p.x, 0.5, 0.0001);
+        fuzzyCompare(p.y, 0.5, 0.0001);
+    }
+
+    function test_the_crop_is_undone_by_the_same_rect_that_applied_it() {
+        // The registration, run backwards. The picture overflows the box, so a
+        // click at the box's left edge is NOT the picture's left edge - it is
+        // wherever the crop starts, and getting this wrong sends the click to a
+        // part of the wallpaper the user cannot see. Round-tripping is the check
+        // that cannot be satisfied by a plausible-looking wrong formula.
+        const r = ClockDepth.coverRect(3840, 1594, 5120, 1440);
+        const cases = [[0.1, 0.2], [0.5, 0.5], [0.87, 0.04], [1, 1], [0, 0]];
+        for (let i = 0; i < cases.length; i++) {
+            const nx = cases[i][0], ny = cases[i][1];
+            const p = ClockDepth.normalisedPoint(r,
+                r.x + nx * r.width, r.y + ny * r.height);
+            fuzzyCompare(p.x, nx, 0.0001, "x for " + cases[i]);
+            fuzzyCompare(p.y, ny, 0.0001, "y for " + cases[i]);
+        }
+    }
+
+    function test_a_click_at_the_boxs_edge_is_inside_the_picture_not_at_its_edge() {
+        // 3840x1594 into 5120x1440 crops the top and bottom away, so the top of
+        // the box is somewhere down the picture. A mapping that ignored the
+        // rect's origin would answer 0 here and put every click too high.
+        const r = ClockDepth.coverRect(3840, 1594, 5120, 1440);
+        const p = ClockDepth.normalisedPoint(r, 0, 0);
+        compare(p.x, 0);
+        verify(p.y > 0.05, "top of the box maps to the top of the picture: " + p.y);
+    }
+
+    function test_a_click_outside_the_picture_is_clamped_rather_than_refused() {
+        // The producer refuses a point outside the picture, so an off-by-a-pixel
+        // at the frame's edge would reach the user as an error message about a
+        // click that looked entirely ordinary.
+        const r = ClockDepth.coverRect(1000, 1000, 500, 500);
+        const p = ClockDepth.normalisedPoint(r, -40, 9000);
+        compare(p.x, 0);
+        compare(p.y, 1);
+    }
+
+    function test_an_empty_rect_answers_null_rather_than_a_point() {
+        verify(ClockDepth.normalisedPoint({ x: 0, y: 0, width: 0, height: 0 }, 5, 5) === null);
+        verify(ClockDepth.normalisedPoint(undefined, 5, 5) === null);
+        verify(ClockDepth.normalisedPoint({ x: 0, y: 0, width: 100, height: 100 },
+            NaN, 5) === null);
+    }
+
     function test_an_unloaded_image_yields_the_box_rather_than_NaN() {
         // An Image's implicit size reads 0 until its source resolves, and a NaN
         // on x/y/width/height does not misplace the mask - it stops the item

--- a/sdata/uv/requirements.txt
+++ b/sdata/uv/requirements.txt
@@ -16,6 +16,8 @@ cryptography==46.0.0
     # via google-auth
 dbus-python==1.4.0
     # via kde-material-you-colors
+flatbuffers==25.12.19
+    # via onnxruntime
 google-auth==2.49.1
     # via -r requirements.in
 idna==3.11
@@ -37,18 +39,24 @@ numpy==2.2.2
     #   -r requirements.in
     #   kde-material-you-colors
     #   material-color-utilities
+    #   onnxruntime
     #   opencv-contrib-python
+onnxruntime==1.28.0
+    # via -r requirements.in
 opencv-contrib-python==4.12.0.88
     # via -r requirements.in
 packaging==24.2
     # via
     #   build
+    #   onnxruntime
     #   setuptools-scm
 pillow==11.1.0
     # via
     #   -r requirements.in
     #   kde-material-you-colors
     #   material-color-utilities
+protobuf==7.35.1
+    # via onnxruntime
 psutil==6.1.1
     # via -r requirements.in
 pyasn1==0.6.3


### PR DESCRIPTION
The depth picker's two models are salient-object detectors, and on this library
they mostly have no answer. Swept over `~/Pictures/Wallpapers` (94 files today),
counting only what the two detectors say: **45 return nothing from both, 46 have
a candidate, 3 have never been run.** Half the library reaches a picker that says
"neither model found a subject" — a verdict on the picture — with nothing to do
about it.

**This is not a threshold problem** and must not be fixed as one. Measured before
any threshold:

| wallpaper | model | >0.1 conf | >0.3 | >0.5 |
|---|---|---|---|---|
| aishot-3263.jpg | isnet-general-use | 2.78% | 0.72% | 0.28% |
| aishot-3263.jpg | isnet-anime | 0.07% | 0.00% | 0.00% |
| aishot-1206.jpg | isnet-general-use | 1.20% | 0.31% | 0.19% |
| aishot-1206.jpg | isnet-anime | 0.00% | 0.00% | 0.00% |

Even at 0.1 confidence these models claim 1-3% of the frame. Admitting that
admits noise. They find one dominant object against a separable background and a
full-bleed wallpaper has none, so the model is being asked a question the picture
does not answer.

So this adds a third column that asks a different one — not "what is the subject
of this picture" but "what is the thing at this point" — and the user points at
it.

## The model

**MobileSAM**, `Acly/MobileSAM`, encoder 26.9 MB and decoder 15.7 MB, both pinned
by sha256 the way the isnet models already are. It keeps SAM's own prompt encoder
and mask decoder and replaces only the image encoder with a distilled ViT-t, so
the decoder contract is Meta's unchanged and the pair is 43 MB rather than SAM
ViT-H's 2.4 GB. Apache-2.0 upstream, MIT on the repository hosting the export,
and byte-identically mirrored at a second repo. EdgeSAM was rejected on a
non-commercial licence and a decoder that takes no `mask_input`; SAM-HQ-tiny has
no published ONNX export at all.

## The encoder/decoder split, and the embedding cache

The split is the whole reason SAM is the right tool, so it is treated as a
contract rather than an implementation detail. Encoding the picture depends only
on the picture and costs seconds; decoding a mask from clicks reads the embedding
and costs milliseconds.

Measured on a 7680x2160 wallpaper: **1.63s for the first click, 0.34s for every
one after it** — and 0.24s of that 0.34 is starting Python. The embedding is
cached at the wallpaper's existing cache key as `<key>.mobile-sam.embedding.npz`,
float16 (2 MB rather than 4: the decoder immediately blurs it through a
transposed convolution into a 256x256 logit field, so the mantissa bits are not
what decides where the edge lands), and it is swept with its key like everything
else. `test_clock_depth_cache.py` pins that a cached embedding comes back with
the encoder file absent and `onnxruntime` raising on import, which is the only
way to prove the second click does not re-encode.

## Where the prompt is stored, and why

**Inside the mask, in a PNG text chunk.** A SAM mask is a function of the clicks
as well as the picture, so something has to record them, and every other place is
a pair that has to agree:

- in the cache key: mints an entry per click, so a five-click refinement leaves
  five masks and needs a sixth file to say which one was accepted;
- in a sidecar JSON: two files a sweep, a copy or a crash can separate — and
  `accept` is a byte-for-byte copy, so the sidecar would have to be copied by
  hand in the one place forgetting is silent;
- in `Config`: a per-wallpaper map keyed by a runtime path, which the
  `JsonAdapter` cannot hold.

In the file, the prompt cannot arrive without its mask or outlive it, `accept`
carries it for free, and the accepted copy keeps saying what it was cut with
after the candidate is refined further. `status` reads it back with a
hand-written chunk reader, because `status` is the shell's read path and may not
import Pillow.

## The click UX

Left-click adds a point the cutout must contain, right-click one it must not, and
the mask redraws per click. Both are said on the preview itself, in the space the
"not run yet" label occupied, because a click surface whose instructions are
somewhere else is a click surface nobody discovers. The clicks come back as plus
and minus discs so a correction is aimed at a thing rather than at a memory,
drawn black-on-white because every `Appearance` colour is generated *from* this
wallpaper and so is guaranteed to be a colour the picture contains — the same
reason the inspect contour is hardcoded magenta. Undo and start-over are glyph
buttons; accept, decline and inspect are the ones that were already there.

**A box prompt is not exposed.** It is cheap at the model level and it is a
second gesture to discover on a surface whose whole instruction set has to fit in
one line, and what a box is for — "the first click grabbed too much" — is what
right-click already fixes without a mode.

All three columns are the same width. The cutouts are being compared, and the
clickable one is not more important than the two it is compared against.

## Worked example

`aishot-3263.jpg`, a 7680x2160 valley landscape. `isnet-anime` returns
foreground 0.0000; `isnet-general-use` returns 0.0019 — both below the refusal
floor, so the picker's verdict was `none` with nothing to do. Two clicks on the
central monolith return a clean cutout at foreground 0.081, and composited the
way the desktop composites it, a 420pt `21:47` has its `21:` fully occluded and
its `47` showing past the cliff edge.

`aishot-1206.jpg` is the same story from **one** click: both detectors at 0.0000
and 0.0019, one click on the tower gives 0.019 with the roof, the windows and the
structure at its base.

## Two bugs found on the way

**The installer has never installed `onnxruntime`.** It was added to
`sdata/uv/requirements.in` when the producer landed and the lock was never
recompiled; `install-python-packages` runs `uv pip install -r requirements.txt`.
So every venv the installer has built lacks it, and the only symptom is a raw
`ModuleNotFoundError` in front of a user pressing a button. The lock is
recompiled with the existing pins as preferences, so the diff is onnxruntime and
its two transitive deps and nothing else moves. The failure is legible now
regardless — it names the environment and the command that repairs it — and the
check that should have caught this read `requirements.in`, the file nothing
installs.

**A mask rewritten at the same path is not reloaded.** Qt caches a pixmap by URL,
and this feature rewrites two mask files in place: the candidate on every click,
and the accepted mask whenever a second candidate is accepted for the same
wallpaper. Probed with `qml6` rather than reasoned about — a 32x8 PNG rewritten
at 99x17 and re-assigned to the identical URL still reported 32x8, and clearing
`source` to `""` first did not help. Without a fix, every click after the first
would leave the preview showing the first click's mask, which reads exactly like
the model ignoring the point. The producer now reports a revision token per mask
and `ClockDepthCutout` hangs it on the URL as a fragment;
`lint_clock_depth_geometry.py` fails on a depth layer that omits it.

A third, smaller one: a click's empty-mask floor cannot be the detectors'. Reusing
`EMPTY_FOREGROUND` discarded a 76000-pixel object on a 7680x2160 wallpaper as
"nothing there", and it was not buying the refusal it looked like it was for,
since a click on flat sky comes back at 1.6-10% (SAM answers with the sky).

## Geometry

Confirmed rather than assumed, because `coverRect` exists precisely because the
salient models squash the picture to a square: a prompted mask comes out at the
picture's own aspect, and it needs no new path. The rect is a rectangle for the
*wallpaper* and the function never reads the mask's dimensions, so stretching any
mask into it maps that mask's whole extent onto the picture's whole extent.
Pinned in `tst_clock_depth_eligibility.qml`, whose second case deliberately puts
a 3.56:1 picture in a 4:3 box — at a matching aspect the box *is* the cover rect
and every registration bug is invisible.

The click's inverse of that registration moved into `clockDepth.js` as
`normalisedPoint`, because it is the one part of the gesture a test can reach and
its failure is silent: a click sent to the wrong part of the picture comes back
as a perfectly good mask of the wrong thing. It takes the cutout's published
rect, so `coverRect` still has exactly one caller and the lint still says so.

## Tests

`859 passed, 0 failed` on `gh/main`, re-measured; **`866 passed, 0 failed`** here
— seven new `coverRect`/`normalisedPoint` cases — plus 34 new Python cases
(`test_clock_depth_cache.py` 41 → 71, and the new `test_clock_depth_models.py`).

Every new check was proven to fail on deliberately planted breakage — 30
mutations in total, each planted in a clean tree and reverted. Two survived a
first attempt and both are recorded in the commits that fixed them: a resize case
where every size landed on a whole pixel so flooring and rounding agreed, and a
`coverRect` case whose box shared the picture's aspect so the box *was* the cover
rect.

Docs: updated AGENT.md §Directory map, §The suite checkout and why the updater cannot just reset it, §Dynamic/data-driven QML gotchas
