### PR TITLE
Edit Mode stage 3: the desktop shrinks into a viewport

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1927,7 +1927,25 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   `TestCase` sends it to the focused item of *its own* window, so a driver parented outside any
   window cannot deliver one. What no such harness can answer is the background *layer surface's*
   keyboard focus, since weston gives it no wlr-layer-shell. 2c8ccae70 ("test(widgets): drive the
-  resize grip with real mouse events").
+  resize grip with real mouse events"). `EditModeRuntimeTest.qml` is the same shape with the
+  canvas under Edit Mode's transform, and it drives every gesture in **canvas** coordinates,
+  which `TestCase` maps through that transform on the way to the window: the same drive numbers
+  at two scales must store the same position and cover a *different* amount of screen, and both
+  halves are asserted because "the widget moved" is satisfied by a drag that reads raw scene
+  deltas and lands the scale's worth short. (test(editMode): drive the desktop at the mode's own
+  scale.)
+- **A gesture has three ends now, not two: released, cancelled, and the release that follows a
+  cancel.** `AbstractWidget.cancelDrag()` exists because Edit Mode can end mid-drag, and a
+  release *commits* — clamped and written to the store — while the drag itself is deliberately
+  unclamped until then, so committing an unfinished gesture stores an overshoot (705e9006d's
+  defect). Three things about it do not generalise from the release path: the pre-press position
+  comes back by restoring the x/y **binding** rather than by assignment, since only a commit
+  writes `targetX`/`targetY`; a group drag needs its own cancel (`WidgetCanvas.widgetDragCancelled`)
+  because `widgetDragEnded` commits every follower, a follower never getting a release of its
+  own being the whole reason it does; and the pointer is still **grabbed**, so a release is still
+  coming and `dragCancelled` has to swallow exactly that one — measured, what it would otherwise
+  write is wherever the restore animation had reached. (feat(editMode): leaving mid-drag cancels
+  the gesture instead of committing it.)
 - **"The frost is gated on the toggle" is not "the surface is gated on the toggle."**
   `appearance.transparency.enable` removed every desktop widget's blur — `PluginWidget`'s blur
   `Repeater` reads the flag — while the widgets' panel alpha kept coming from
@@ -2273,6 +2291,44 @@ of the `suppressContents` fullscreen gate, which the viewport carries for its ow
 Sizing is deliberately screen-derived rather than wallpaper-derived: a live WE project reports no
 intrinsic size, and `PreserveAspectCrop` already covers a still, so one rule serves both.
 (feat(background): revive wallpaper parallax, for stills and Wallpaper Engine.)
+
+**Edit Mode shrinks that viewport, and it does it with a TRANSFORM — never with
+x/y/width/height.** `GlobalStates.editMode` scales and insets three of the
+background surface's siblings at once (`parallaxViewport`, `widgetCanvas`, the
+clock depth layer), all from one `bgRoot.editMatrix`, so the desktop becomes an
+object on the screen over its own wallpaper blurred. The transform is what makes
+the whole thing cost nothing: `scale` leaves `x`, `y`, `width` and `height`
+alone, so every clamp range, every position in `plugin-state.json` and the
+hand-computed drag are untouched — the drag maps the pointer through the moving
+widget into the canvas frame and the transform cancels itself out, which
+`EditModeRuntimeTest.qml` drives at two scales rather than assuming. Writing the
+inset into the containers' `x`/`y` instead would fold a second meaning into the
+four properties the parallax animates, the frost samples by and every clamp
+measures against, which is b710ef731's defect in a new place. Three things the
+mode is built out of are worth not re-deriving:
+- **The inset is derived, not chosen** (`modules/common/functions/edit_mode.js`):
+  the desktop shrinks by exactly the drawer's declared width plus a margin, so
+  the drawer opens into space that already exists. It takes the drawer's WIDTH
+  and has no input for whether the drawer is open — a viewport that changed size
+  mid-edit would rescale every widget under the cursor and hand every `Behavior`
+  carrying the box a moving target.
+- **The blurred backdrop cannot be the lock's `blurLoader` with a second gate**,
+  which is what the spec asked for: that loader is a *child* of
+  `parallaxViewport`, so it takes the edit transform and shrinks along with the
+  desktop it is meant to sit behind. It is a sibling `Loader` at `z: -1` sharing
+  one `WallpaperBlurBackdrop` component with the lock's, and it works because a
+  `ShaderEffectSource` renders its source item in that item's OWN coordinates —
+  a transformed wallpaper still yields an untransformed texture.
+- **The per-widget frost is stood down for the mode, not aligned to it**
+  (`PluginWidget.frostSuspended`, the generalisation of what used to be
+  `lockCoversFrost`). Measured on a live desktop with a Wallpaper Engine scene:
+  cards that are visibly frosted at rest render as flat tinted panels under the
+  transform, because the frost's sample rect is computed from three frames the
+  transform does not move together. Suspending it is the difference between a
+  deliberate look and a broken one nothing logs — and it is why proxy
+  rectangles, the spec's fallback, are not needed.
+(feat(editMode): shrink the desktop into a viewport on the background surface,
+feat(editMode): stand the per-widget frost down for the mode.)
 
 **The clock depth layer is the counter-case to that rule, and it is why it is a
 FOURTH sibling.** `widgetCanvas` sits at `z: 2` as a sibling of

--- a/dots/.config/quickshell/imi/EditModeRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/EditModeRuntimeTest.qml
@@ -1,0 +1,353 @@
+import QtQuick
+import QtTest
+import Quickshell
+import qs
+import qs.modules.common
+import qs.modules.common.plugins
+import qs.modules.common.widgets.widgetCanvas
+import "modules/common/functions/edit_mode.js" as EditMode
+
+/**
+ * Drives Edit Mode's desktop with real mouse events, on a real widget canvas
+ * carrying the real transform.
+ *
+ * The question the viewport turns on is whether a gesture still lands where the
+ * pointer put it once the canvas is drawn at a scale. Nothing static can answer
+ * it: the drag is computed by mapping the pointer through the moving widget
+ * into the canvas frame, so the transform is supposed to cancel itself out, and
+ * "supposed to" is what d2ebb5aeb ("fix(widgetCanvas): compute the drag by hand
+ * - MouseArea.drag cannot track it") already measured as half a gesture lost
+ * once.
+ *
+ * Every gesture below is driven in CANVAS coordinates, which QtTest maps
+ * through the transform on the way to the window. So the same drive numbers at
+ * two different scales must produce the same stored position and a different
+ * screen travel - and a drag that read raw scene deltas would move by the
+ * scale's worth less while passing every check that only looks at "did it
+ * move".
+ *
+ * What this cannot see: it is a FloatingWindow, not a layer surface, so nothing
+ * about the background surface - its keyboard focus, the blur backdrop's
+ * compositor behaviour, the namespace - is visible here. Weston implements no
+ * wlr-layer-shell.
+ *
+ * Run it against a throwaway config:
+ *   XDG_CONFIG_HOME=$(mktemp -d) XDG_STATE_HOME=$(mktemp -d) qs -p EditModeRuntimeTest.qml
+ */
+ShellRoot {
+    id: harness
+
+    property int failures: 0
+    property int checksRun: 0
+    readonly property string testScreen: "EDIT-MODE-TEST"
+
+    readonly property int screenWidth: 1200
+    readonly property int screenHeight: 700
+
+    function check(label, ok) {
+        harness.checksRun++;
+        console.log(`[EditMode] ${label}: ${ok ? "ok" : "FAIL"}`);
+        if (!ok)
+            harness.failures++;
+    }
+
+    // The same derivation the background surface applies, from the same module
+    // and the same tokens: a harness that scaled by a number of its own would
+    // score a transform the shell never draws.
+    readonly property var viewport: EditMode.viewportGeometry({
+        screenWidth: harness.screenWidth,
+        screenHeight: harness.screenHeight,
+        drawerWidth: Appearance.sizes.editModeDrawerWidth,
+        margin: Appearance.sizes.editModeMargin
+    })
+    readonly property var applied: EditMode.atProgress(harness.viewport,
+                                                       GlobalStates.editMode ? 1 : 0)
+
+    function manifestFor(id, grid) {
+        return {
+            id: id,
+            name: id,
+            grid: grid,
+            desktopWidget: { type: "Item" }
+        };
+    }
+
+    readonly property var resizableManifest: harness.manifestFor("edit-resize-probe", {
+        cols: 3, rows: 2,
+        sizes: [{ cols: 3, rows: 2 }, { cols: 2, rows: 2 }, { cols: 2, rows: 1 }]
+    })
+    readonly property var fixedManifest: harness.manifestFor("edit-move-probe", { cols: 2, rows: 1 })
+
+    FloatingWindow {
+        visible: true
+        implicitWidth: harness.screenWidth
+        implicitHeight: harness.screenHeight
+        color: "black"
+
+        TestCase {
+            id: driver
+            when: false
+            name: "EditModeDriver"
+        }
+
+        WidgetCanvas {
+            id: canvas
+            width: harness.screenWidth
+            height: harness.screenHeight
+            editMode: GlobalStates.editMode
+            selectionEnabled: true
+            // No animation here: the entry curve is the shell's business and a
+            // gesture driven mid-flight would score a scale nothing settled at.
+            transform: Matrix4x4 {
+                matrix: Qt.matrix4x4(
+                    harness.applied.scale, 0, 0, harness.applied.x,
+                    0, harness.applied.scale, 0, harness.applied.y,
+                    0, 0, 1, 0,
+                    0, 0, 0, 1)
+            }
+
+            PluginWidget {
+                id: resizableWidget
+                manifest: harness.resizableManifest
+                screenName: harness.testScreen
+                screenWidth: harness.screenWidth
+                screenHeight: harness.screenHeight
+                scaledScreenWidth: harness.screenWidth
+                scaledScreenHeight: harness.screenHeight
+                wallpaperScale: 1
+            }
+
+            PluginWidget {
+                id: movableWidget
+                manifest: harness.fixedManifest
+                screenName: harness.testScreen
+                screenWidth: harness.screenWidth
+                screenHeight: harness.screenHeight
+                scaledScreenWidth: harness.screenWidth
+                scaledScreenHeight: harness.screenHeight
+                wallpaperScale: 1
+            }
+        }
+    }
+
+    function placeWidgets() {
+        PluginState.setPosition("edit-resize-probe", harness.testScreen,
+                                { x: 36, y: 36, placementStrategy: "free" });
+        PluginState.setPosition("edit-move-probe", harness.testScreen,
+                                { x: 36, y: 396, placementStrategy: "free" });
+    }
+
+    // ---- gestures, driven in canvas coordinates --------------------------
+
+    function dragBy(widget, dx, dy) {
+        const x = widget.x + widget.width / 2;
+        const y = widget.y + widget.height / 2;
+        driver.mousePress(canvas, x, y, Qt.LeftButton);
+        driver.mouseMove(canvas, x + dx / 2, y + dy / 2, 20, Qt.LeftButton);
+        driver.mouseMove(canvas, x + dx, y + dy, 20, Qt.LeftButton);
+        driver.mouseRelease(canvas, x + dx, y + dy, Qt.LeftButton);
+    }
+
+    // The grip is 16x16 anchored to the widget's bottom-right with the host's
+    // own spacing token, so a token change moves the gesture with it.
+    function gripCenter(widget) {
+        const inset = Appearance.spacing.space100 + 8;
+        return { x: widget.x + widget.width - inset, y: widget.y + widget.height - inset };
+    }
+
+    function dragGripBy(widget, dx, dy) {
+        const point = harness.gripCenter(widget);
+        driver.mousePress(canvas, point.x, point.y, Qt.LeftButton);
+        driver.mouseMove(canvas, point.x + dx / 2, point.y + dy / 2, 20, Qt.LeftButton);
+        driver.mouseMove(canvas, point.x + dx, point.y + dy, 20, Qt.LeftButton);
+        driver.mouseRelease(canvas, point.x + dx, point.y + dy, Qt.LeftButton);
+    }
+
+    function storedPosition(id) { return PluginState.position(id, harness.testScreen); }
+    function storedSize(id) { return PluginState.option(id, "__gridSize", ""); }
+
+    function screenRectOf(widget) { return widget.mapToItem(null, 0, 0); }
+
+    property var travelUnscaled: null
+    property var travelScaled: null
+    property var before: null
+
+    readonly property var steps: [
+        // ---- the same gesture, unscaled and scaled ------------------------
+        //
+        // Scored first and against each other: everything else about the mode
+        // is a property, and this is the only thing the viewport can break.
+        () => {
+            harness.check("the mode is off to begin with", !GlobalStates.editMode
+                          && Math.abs(harness.applied.scale - 1) < 1e-9);
+            harness.before = harness.screenRectOf(movableWidget);
+        },
+        () => harness.dragBy(movableWidget, 120, 60),
+        () => {
+            const after = harness.screenRectOf(movableWidget);
+            harness.travelUnscaled = { x: after.x - harness.before.x, y: after.y - harness.before.y };
+            const stored = harness.storedPosition("edit-move-probe");
+            harness.check("unscaled: the widget lands 120x60 further on, snapped to the lattice",
+                          Math.round(stored.x) === 156 && Math.round(stored.y) === 456);
+        },
+
+        () => { GlobalStates.editMode = true; harness.placeWidgets(); },
+        () => {
+            harness.check("the viewport shrinks the canvas without resizing it",
+                          harness.applied.scale < 1
+                          && canvas.width === harness.screenWidth
+                          && canvas.height === harness.screenHeight);
+            harness.check("the widget's own box is untouched by the transform",
+                          Math.round(movableWidget.width)
+                              === Math.round(Appearance.sizes.widgetGridSpanX(2))
+                          && Math.round(movableWidget.x) === 36);
+            harness.before = harness.screenRectOf(movableWidget);
+        },
+        () => harness.dragBy(movableWidget, 120, 60),
+        () => {
+            const after = harness.screenRectOf(movableWidget);
+            harness.travelScaled = { x: after.x - harness.before.x, y: after.y - harness.before.y };
+            const stored = harness.storedPosition("edit-move-probe");
+            // The point of the whole stage: the pointer travelled the same
+            // distance ACROSS THE DESKTOP and the widget went with it, so the
+            // stored position is identical to the unscaled run.
+            harness.check("scaled: the same gesture stores the same position",
+                          Math.round(stored.x) === 156 && Math.round(stored.y) === 456);
+            // ...while covering less of the screen, which is what proves the
+            // transform was actually applied rather than the check being
+            // trivially true.
+            harness.check("scaled: the same gesture covers less screen",
+                          Math.abs(harness.travelScaled.x)
+                              < Math.abs(harness.travelUnscaled.x) - 1
+                          && Math.abs(harness.travelScaled.y)
+                              < Math.abs(harness.travelUnscaled.y) - 1);
+        },
+
+        // ---- the affordances the mode forces on ---------------------------
+        () => {
+            Config.options.background.showGrid = false;
+            harness.check("the grid is up for the whole mode, not for the drag",
+                          canvas.gridVisible && !canvas.showGrid);
+            harness.check("the frost stands down for the mode",
+                          resizableWidget.frostSuspended);
+        },
+        () => {
+            Config.options.background.showGrid = true;
+            GlobalStates.editMode = false;
+            harness.check("and the grid goes back to being the drag's",
+                          !canvas.gridVisible);
+            harness.check("and the frost comes back", !resizableWidget.frostSuspended);
+            GlobalStates.editMode = true;
+        },
+
+        // ---- the global lock, suppressed rather than written --------------
+        () => {
+            GlobalStates.editMode = false;
+            Config.options.background.widgetsLocked = true;
+            harness.placeWidgets();
+        },
+        () => harness.dragBy(movableWidget, 120, 0),
+        () => harness.check("locked and not editing: the drag is refused",
+                            Math.round(harness.storedPosition("edit-move-probe").x) === 36),
+        () => { GlobalStates.editMode = true; },
+        () => harness.dragBy(movableWidget, 120, 0),
+        () => {
+            harness.check("locked and editing: the drag moves the widget",
+                          Math.round(harness.storedPosition("edit-move-probe").x) === 156);
+            harness.check("...and the stored lock is untouched",
+                          Config.options.background.widgetsLocked === true);
+        },
+        () => {
+            PluginState.setOption("edit-move-probe", "positionLocked", true);
+            harness.placeWidgets();
+        },
+        () => harness.dragBy(movableWidget, 120, 0),
+        () => {
+            harness.check("a widget the user pinned still refuses",
+                          Math.round(harness.storedPosition("edit-move-probe").x) === 36);
+            PluginState.setOption("edit-move-probe", "positionLocked", false);
+            Config.options.background.widgetsLocked = false;
+        },
+
+        // ---- the grip, shown by the mode and driven at scale ---------------
+        //
+        // No hover first: in the mode the grip is already out, so the press
+        // reaches it. That is both the affordance check and the one that scores
+        // the grip's delta in the right frame - it is read in the widget's
+        // parent frame, and a scene-space delta here would resize by the
+        // scale's worth less than the pointer travelled.
+        () => { harness.placeWidgets(); },
+        () => harness.dragGripBy(resizableWidget, -150, 0),
+        () => {
+            harness.check("the grip is out for the mode and resizes at scale",
+                          harness.storedSize("edit-resize-probe") === "2x2");
+            harness.check("...and the widget did not walk",
+                          Math.round(harness.storedPosition("edit-resize-probe").x) === 36
+                          && Math.round(harness.storedPosition("edit-resize-probe").y) === 36);
+        },
+
+        // ---- leaving mid-drag cancels, it does not commit ------------------
+        () => { harness.placeWidgets(); },
+        () => {
+            const x = movableWidget.x + movableWidget.width / 2;
+            const y = movableWidget.y + movableWidget.height / 2;
+            driver.mousePress(canvas, x, y, Qt.LeftButton);
+            driver.mouseMove(canvas, x + 240, y, 20, Qt.LeftButton);
+            harness.check("the drag is in flight", movableWidget.dragging
+                          && Math.round(movableWidget.x) > 200);
+            GlobalStates.editMode = false;
+            // The release still arrives, because the pointer was never let go
+            // of - and it must commit nothing.
+            driver.mouseRelease(canvas, x + 240, y, Qt.LeftButton);
+        },
+        // Scored a tick later: the widget travels back on its position
+        // Behavior, so the frame the cancel happened on is one this check must
+        // not read.
+        () => {
+            harness.check("leaving the mode puts the widget back",
+                          !movableWidget.dragging && Math.round(movableWidget.x) === 36);
+            harness.check("...and stores the position the press found",
+                          Math.round(harness.storedPosition("edit-move-probe").x) === 36);
+        }
+    ]
+
+    property int stepIndex: 0
+
+    Timer {
+        id: setup
+        interval: 250
+        repeat: true
+        running: true
+        onTriggered: {
+            if (!PluginState.ready || !Config.ready)
+                return;
+            Config.options.background.widgetsLocked = false;
+            Config.options.background.showSnapLines = false;
+            if (Math.round(resizableWidget.x) === 36 && Math.round(movableWidget.y) === 396) {
+                setup.running = false;
+                runner.running = true;
+                return;
+            }
+            harness.placeWidgets();
+        }
+    }
+
+    // One step per tick, and the tick outlasts the 500ms position/size
+    // animations: every check reads a settled value, and a frame sampled
+    // mid-Behavior is a working animation reading as a failed gesture.
+    Timer {
+        id: runner
+        interval: 700
+        repeat: true
+        running: false
+        onTriggered: {
+            if (harness.stepIndex >= harness.steps.length) {
+                runner.running = false;
+                console.log(`[EditMode] checks: ${harness.checksRun} failures: ${harness.failures}`);
+                Qt.exit(harness.failures === 0 ? 0 : 1);
+                return;
+            }
+            harness.steps[harness.stepIndex++]();
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/EditModeRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/EditModeRuntimeTest.qml
@@ -272,12 +272,18 @@ ShellRoot {
         // ---- the grip, shown by the mode and driven at scale ---------------
         //
         // No hover first: in the mode the grip is already out, so the press
-        // reaches it. That is both the affordance check and the one that scores
-        // the grip's delta in the right frame - it is read in the widget's
-        // parent frame, and a scene-space delta here would resize by the
-        // scale's worth less than the pointer travelled.
+        // reaches it. That is the affordance half.
+        //
+        // The 160px pull is the frame half, and it is chosen to be
+        // discriminating rather than merely large. Shrinking needs the target
+        // to come inside the smaller span's edge, which is 144px away
+        // (3x2 -> 2x2), so 160 canvas pixels give one span - while the same
+        // gesture measured in SCENE pixels is 160 x the mode's scale, which
+        // falls short of 144 and gives none. Measured: a 150px pull committed
+        // 2x2 under BOTH frames, so the first version of this check was
+        // vacuous exactly the way a probe taken at a wall is.
         () => { harness.placeWidgets(); },
-        () => harness.dragGripBy(resizableWidget, -150, 0),
+        () => harness.dragGripBy(resizableWidget, -160, 0),
         () => {
             harness.check("the grip is out for the mode and resizes at scale",
                           harness.storedSize("edit-resize-probe") === "2x2");

--- a/dots/.config/quickshell/imi/GlobalStates.qml
+++ b/dots/.config/quickshell/imi/GlobalStates.qml
@@ -57,10 +57,34 @@ Singleton {
     // lingering one can paint over a newly opened neighbour; each popup watches
     // this so the previous one closes at once instead of overlapping the new one.
     property var activeBarPopup: null
+    // Edit Mode: the desktop shrinks into a viewport and every affordance it
+    // normally hides comes out (docs/superpowers/specs/2026-08-16-edit-mode-design.md).
+    //
+    // Here and not in `Config.options` deliberately: a persisted edit mode is a
+    // shell that comes back from a restart with the desktop shrunk, and every
+    // change the mode makes is written through to its own store as it happens,
+    // so the mode itself has nothing to remember. It is also what makes a
+    // hot-reload mid-edit correct with no code - the mode is gone, the edits
+    // are on disk.
+    //
+    // Global rather than per monitor: the bar and dock layouts it will edit are
+    // themselves global, and a per-monitor mode would have to explain why
+    // moving a bar chip on one screen changed another.
+    property bool editMode: false
+
     property bool dropShelfOpen: false
     property real dropShelfX: 0
     property real dropShelfY: 0
     property bool dropShelfAnchorBelow: false // Shelf hangs below the anchor point (bar reveal) instead of above it
+
+    // Anything that takes the screen away ends the mode, because the desktop it
+    // shrinks is no longer the thing on screen. The lock is the one that
+    // matters: the background surface is promoted to Overlay and repurposed as
+    // the lock backdrop while locked, so a shrunk desktop would be the lock
+    // screen's wallpaper.
+    onScreenLockedChanged: if (root.screenLocked) root.editMode = false
+    onOverviewOpenChanged: if (root.overviewOpen) root.editMode = false
+    onSessionOpenChanged: if (root.sessionOpen) root.editMode = false
 
     onSidebarRightOpenChanged: {
         if (GlobalStates.sidebarRightOpen) {

--- a/dots/.config/quickshell/imi/modules/common/Appearance.qml
+++ b/dots/.config/quickshell/imi/modules/common/Appearance.qml
@@ -700,6 +700,16 @@ Singleton {
         property real searchWidth: 360
         property real sidebarWidth: 460
         property real sidebarWidthExtended: 750
+        // Edit Mode's viewport is inset by exactly what the drawer will need,
+        // so the drawer opens into space that already exists rather than
+        // covering the desktop or resizing it (spec §1.2). The drawer itself
+        // does not exist until stage 5; this is the one number both it and the
+        // inset read, so it plugs in here rather than restating a width the
+        // desktop has already been shrunk by.
+        property real editModeDrawerWidth: 380
+        // The gap outside the shrunk desktop on its three free sides, and
+        // between it and the drawer's slot on the fourth.
+        property real editModeMargin: root.spacing.space300
         property real baseVerticalBarWidth: 46
         property real verticalBarWidth: Config.options.bar.cornerStyle === 1 ? 
             (baseVerticalBarWidth + root.sizes.hyprlandGapsOut * 2) : baseVerticalBarWidth

--- a/dots/.config/quickshell/imi/modules/common/functions/edit_mode.js
+++ b/dots/.config/quickshell/imi/modules/common/functions/edit_mode.js
@@ -1,0 +1,100 @@
+.pragma library
+
+// Edit Mode's two pieces of arithmetic, kept here because they are the only
+// parts of the mode a test can reach: everything else about it is a layer
+// surface, a transform and a pointer, and `qmltestrunner` can construct none of
+// those.
+//
+// See docs/superpowers/specs/2026-08-16-edit-mode-design.md §8.2 (the ladder)
+// and §1.2 (the inset).
+
+// The tab the mode opens on. A string rather than a boolean because the
+// Lockscreen tab joins it later (spec §1.4) and the ladder already has to say
+// which tab it returns to.
+var DESKTOP_TAB = "desktop";
+
+// Escape is overloaded on the desktop before Edit Mode exists: WidgetCanvas
+// clears a marquee selection with it and PluginWidget cancels a grip resize
+// with it. So the mode may not simply take the key - it resolves in order and
+// the first match wins, which is what keeps both of those working while the
+// mode is on.
+//
+// A pure function of three inputs, so the precedence is checkable without a
+// canvas, a widget or a compositor. The caller does the work each answer names.
+function resolveEscape(state) {
+    const s = state || {};
+    if (s.gestureInFlight)
+        return "cancelGesture";
+    if ((s.selectionCount || 0) > 0)
+        return "clearSelection";
+    if ((s.tab || DESKTOP_TAB) !== DESKTOP_TAB)
+        return "desktopTab";
+    return "exit";
+}
+
+// A desktop scaled below this is not an editor any more, it is a thumbnail.
+// Only reachable on a screen too narrow to host the drawer at all, where the
+// alternative answers are a zero or a negative scale.
+var MIN_SCALE = 0.2;
+
+// The viewport's inset is DERIVED, not chosen: the desktop shrinks by exactly
+// what the drawer will need, so the drawer opens into space that already
+// exists rather than covering the desktop or resizing it (spec §1.2, §1.3).
+//
+// `drawerWidth` is passed whether or not the drawer is open, and this function
+// has no input for the open state on purpose. A desktop that was full width
+// with the drawer closed would be RESIZED by opening it, and a viewport that
+// changes size mid-edit rescales every widget under the cursor: a drag in
+// flight finds its target a different size than when it was grabbed, and every
+// Behavior carrying the box is handed a moving target, which per b710ef731
+// ("fix(plugins): stop the position Behavior swallowing the parallax
+// cancellation") means it restarts every frame and never ticks. Opening the
+// drawer translates the desktop instead, which is stage 5's `x` offset on top
+// of the `x` this returns.
+//
+// `margin` is one token: the desktop is inset by it on the left, on the top and
+// on the bottom, and the space reserved on the right is the drawer's own width
+// plus one more of it - the gap between the desktop and the drawer. What the
+// drawer does inside that slot is stage 5's business; the desktop's geometry
+// does not depend on it.
+function viewportGeometry(input) {
+    const screenWidth = (input && input.screenWidth) || 0;
+    const screenHeight = (input && input.screenHeight) || 0;
+    const drawerWidth = (input && input.drawerWidth) || 0;
+    const margin = (input && input.margin) || 0;
+    if (screenWidth <= 0 || screenHeight <= 0)
+        return { scale: 1, x: 0, y: 0, width: screenWidth, height: screenHeight };
+
+    // Two margins horizontally (outside the desktop, and between the desktop
+    // and the drawer) and two vertically, so the desktop is inset by the same
+    // amount on every side it does not share with the drawer.
+    const roomX = screenWidth - drawerWidth - margin * 2;
+    const roomY = screenHeight - margin * 2;
+    const scale = Math.max(MIN_SCALE,
+        Math.min(1, roomX / screenWidth, roomY / screenHeight));
+
+    return {
+        scale: scale,
+        // The left margin is fixed; whatever slack the other axis leaves
+        // accumulates on the right, which is the side the drawer is on.
+        x: margin,
+        y: (screenHeight - screenHeight * scale) / 2,
+        width: screenWidth * scale,
+        height: screenHeight * scale
+    };
+}
+
+// The entry and exit animation, expressed as one scalar the shell can put a
+// single `Behavior` on. Interpolating the geometry rather than animating three
+// properties separately is what keeps the desktop's corner travelling in a
+// straight line, and it means the transform's inputs move together or not at
+// all - there is no frame in which the scale has arrived and the offset has
+// not.
+function atProgress(geometry, progress) {
+    const t = Math.max(0, Math.min(1, progress || 0));
+    return {
+        scale: 1 + (geometry.scale - 1) * t,
+        x: geometry.x * t,
+        y: geometry.y * t
+    };
+}

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
@@ -718,7 +718,12 @@ AbstractBackgroundWidget {
             bottom: parent.bottom
             margins: Appearance.spacing.space100
         }
-        opacity: (rootWidget.containsMouse || resizeArea.containsMouse || rootWidget.resizingGrid)
+        // Hover-revealed normally; up for the whole of Edit Mode, which is the
+        // mode's point - a widget whose only sign that it can be resized is a
+        // corner that appears when the pointer is already on it is not a
+        // discoverable one.
+        opacity: (GlobalStates.editMode || rootWidget.containsMouse
+                || resizeArea.containsMouse || rootWidget.resizingGrid)
             ? 0.5 : 0
         visible: opacity > 0 && rootWidget.gridResizable && !rootWidget.interactionLocked
 

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
@@ -603,16 +603,28 @@ AbstractBackgroundWidget {
     // In-shell frost: sample + blur the wallpaper region behind each blur region.
     // The sample tracks rootWidget.x/y live so it stays aligned while dragging.
     //
-    // While the screen is locked AND the lock blurs the wallpaper
-    // (Background.qml's blurLoader shows a blurred + zoomed wallpaper), skip our
-    // own blur surface - the widget's translucent panel then shows that lock
-    // background through it, keeping the frost consistent with the lock screen.
-    // If the lock does NOT blur the wallpaper, keep blurring per widget so a
+    // Two states stand the per-widget frost down, and naming the condition
+    // rather than either cause is what let the second one join without a second
+    // gate.
+    //
+    // The lock, while it blurs the wallpaper (Background.qml's blurLoader shows
+    // a blurred + zoomed wallpaper): the widget's translucent panel then shows
+    // that lock background through it, so the frost stays consistent with the
+    // lock screen. If the lock does NOT blur, keep blurring per widget so a
     // blur-enabled widget stays frosted against the sharp wallpaper.
-    readonly property bool lockCoversFrost: GlobalStates.screenLocked
-        && Config.options.lock.blur.enable
+    //
+    // Edit Mode, unconditionally: the whole desktop is drawn under a scale
+    // transform there, and a frost is a ShaderEffectSource sampling the
+    // wallpaper at a rect computed from three frames that the transform does
+    // not move together. Measured on a live desktop with a Wallpaper Engine
+    // scene, cards that are visibly frosted at rest render as flat tinted
+    // panels under the transform - so this is not a frost the mode is choosing
+    // to give up, it is one it would only appear to have.
+    readonly property bool frostSuspended: (GlobalStates.screenLocked
+            && Config.options.lock.blur.enable)
+        || GlobalStates.editMode
     Repeater {
-        model: rootWidget.frostBlur && rootWidget.blurEnabled && !rootWidget.lockCoversFrost
+        model: rootWidget.frostBlur && rootWidget.blurEnabled && !rootWidget.frostSuspended
             && rootWidget.hasBlurSurface
             && (Config.options.appearance.transparency.enable || rootWidget.keepTranslucent)
             ? (pluginNode.hasCustomBlurRegions

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
@@ -754,19 +754,25 @@ AbstractBackgroundWidget {
             // being untrue again.
             preventStealing: true
 
-            // The pointer is tracked in scene coordinates against its position
-            // at the press, because the grip is anchored to a widget that
-            // resizes underneath it: a delta read from this moving item would
-            // fold the resize back into the gesture.
-            property real pressSceneX: 0
-            property real pressSceneY: 0
+            // The pointer is tracked in the widget's PARENT frame against its
+            // position at the press. Two things decide that frame. It must not
+            // be this item or the widget, which resize underneath the gesture -
+            // a delta read from a moving item folds the resize back into it.
+            // And it must not be the scene either, once Edit Mode draws the
+            // canvas under a scale transform: a scene delta is in screen
+            // pixels, so the same gesture would resize by 1/scale as much as
+            // the pointer travelled over the widget. The parent is static in
+            // both senses, and it is the frame AbstractWidget's drag already
+            // computes in.
+            property real pressFrameX: 0
+            property real pressFrameY: 0
             property real pressWidth: 0
             property real pressHeight: 0
 
             onPressed: mouse => {
-                const scenePoint = resizeArea.mapToItem(null, mouse.x, mouse.y);
-                resizeArea.pressSceneX = scenePoint.x;
-                resizeArea.pressSceneY = scenePoint.y;
+                const pressPoint = resizeArea.mapToItem(rootWidget.parent, mouse.x, mouse.y);
+                resizeArea.pressFrameX = pressPoint.x;
+                resizeArea.pressFrameY = pressPoint.y;
                 // The span being animated to, not the frame's width: pressing
                 // the grip again while the last resize is still travelling
                 // would otherwise measure the gesture from a size the widget
@@ -779,10 +785,10 @@ AbstractBackgroundWidget {
             }
             onPositionChanged: mouse => {
                 if (!rootWidget.resizingGrid) return;
-                const scenePoint = resizeArea.mapToItem(null, mouse.x, mouse.y);
+                const point = resizeArea.mapToItem(rootWidget.parent, mouse.x, mouse.y);
                 rootWidget.previewGridResize(
-                    resizeArea.pressWidth + scenePoint.x - resizeArea.pressSceneX,
-                    resizeArea.pressHeight + scenePoint.y - resizeArea.pressSceneY);
+                    resizeArea.pressWidth + point.x - resizeArea.pressFrameX,
+                    resizeArea.pressHeight + point.y - resizeArea.pressFrameY);
             }
             // A release after Escape commits nothing: the cancel already
             // cleared the preview, and endGridResize has nothing to store.

--- a/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/AbstractWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/AbstractWidget.qml
@@ -94,6 +94,7 @@ MouseArea {
     // canvas captures cannot bake a first-step jump into the cluster.
     onPressed: (mouse) => {
         if (mouse.button !== Qt.LeftButton || !root.draggable) return
+        root.dragCancelled = false
         const p = root.mapToItem(root.parent, mouse.x, mouse.y)
         root.dragPressParentX = p.x
         root.dragPressParentY = p.y
@@ -132,6 +133,35 @@ MouseArea {
         root.dragActive = false
         const canvas = findCanvas(root.parent)
         if (canvas && canvas.widgetDragEnded) canvas.widgetDragEnded(root)
+    }
+
+    // Put the widget back where the press found it and commit nothing. Called
+    // when something ends the gesture that is not the user finishing it - Edit
+    // Mode being left mid-drag, and Escape while dragging.
+    //
+    // Restoring the BINDING is what returns the position: only a commit writes
+    // targetX/targetY, so re-binding x/y through them is the pre-press place.
+    // A widget with no such binding (the overlay's) is put back by hand.
+    property bool dragCancelling: false
+    // The pointer is still GRABBED when a gesture is cancelled - the mode ended,
+    // the user did not let go - so a release is still coming, and a release
+    // commits. It has to commit nothing: what it would write is wherever the
+    // restore animation happened to be at that moment, which is a position the
+    // widget is not at and the user never chose.
+    property bool dragCancelled: false
+    function cancelDrag() {
+        if (!root.dragActive) return
+        root.dragCancelling = true
+        root.dragCancelled = true
+        root.dragActive = false
+        const canvas = findCanvas(root.parent)
+        if (canvas && canvas.widgetDragCancelled) canvas.widgetDragCancelled(root)
+        if (root.restoreXYBinding) root.restoreXYBinding()
+        else {
+            root.x = root.dragStartX
+            root.y = root.dragStartY
+        }
+        root.dragCancelling = false
     }
 
     function center() {
@@ -232,7 +262,9 @@ MouseArea {
             if (Math.abs(widgetCenterY - canvas.height / 2) < root.gridSize / 2)
                 horizontalLines.push(canvas.height / 2)
 
-            if (Config.options.background.showSnapLines)
+            // A cancelled drag flashes nothing: the lines say "this is where it
+            // landed", and it did not land anywhere.
+            if (Config.options.background.showSnapLines && !root.dragCancelling)
                 canvas.flashLines(verticalLines, horizontalLines)
         }
 

--- a/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/WidgetCanvas.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/WidgetCanvas.qml
@@ -4,7 +4,12 @@ import qs.modules.common
 
 MouseArea {
     id: root
-    property int gridSize: 24
+    // The drawn lattice is the one the drag snaps to (AbstractWidget's 12px),
+    // with every second line emphasised so the 24px rhythm this used to draw is
+    // still readable. Drawing 24 while snapping 12 was honest enough while the
+    // grid was only up during a drag; with it up for the whole of Edit Mode, a
+    // widget landing between two lines reads as broken snapping.
+    property int gridSize: 12
     property bool showGrid: false
     readonly property bool isWidgetCanvas: true
     readonly property bool gridVisible: showGrid && Config.options.background.showGrid
@@ -221,6 +226,11 @@ MouseArea {
         root.centerYActive = yActive
     }
 
+    // Every second line at full strength, the ones between it fainter: the fine
+    // lattice is what the drag actually lands on, and the emphasis is what
+    // keeps a screen's worth of 12px lines readable rather than grey.
+    readonly property real fineGridOpacity: 0.4
+
     Repeater {
         model: root.gridVisible ? Math.ceil(root.width / root.gridSize) : 0
         delegate: Rectangle {
@@ -228,6 +238,7 @@ MouseArea {
             x: index * root.gridSize
             width: 1
             height: root.height
+            opacity: index % 2 === 0 ? 1 : root.fineGridOpacity
             color: Appearance.colors.colLayer0Border
         }
     }
@@ -239,6 +250,7 @@ MouseArea {
             y: index * root.gridSize
             width: root.width
             height: 1
+            opacity: index % 2 === 0 ? 1 : root.fineGridOpacity
             color: Appearance.colors.colLayer0Border
         }
     }

--- a/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/WidgetCanvas.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/WidgetCanvas.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import qs
 import qs.modules.common
+import "../../functions/edit_mode.js" as EditMode
 
 MouseArea {
     id: root
@@ -50,13 +51,35 @@ MouseArea {
     property real marqueeAnchorX: 0
     property real marqueeAnchorY: 0
 
-    // Escape is the keyboard way out of a selection. The desktop's layer
-    // surface only takes keys while it is OnDemand, so a live selection also
-    // registers as a keyboard-focus requester alongside the widgets above.
+    // Escape is the keyboard way out of a selection, and Edit Mode may not take
+    // it from that or from a grip resize (PluginWidget handles its own, which
+    // gets the key first because the grip has focus during the gesture). The
+    // ladder resolves in order and the first match wins; the module owns the
+    // precedence so it is checkable without a canvas.
+    //
+    // The desktop's layer surface only takes keys while it is OnDemand, so a
+    // live selection - and the mode - register as keyboard-focus requesters
+    // alongside the widgets above. Whether the compositor then delivers the key
+    // to a Bottom-layer surface is not established, which is why the mode has a
+    // pointer way out as well and no feature depends on this alone.
     focus: root.selectionEnabled
-    Keys.onEscapePressed: root.clearSelection()
+    Keys.onEscapePressed: {
+        const action = EditMode.resolveEscape({
+            gestureInFlight: root.draggingWidget() !== null,
+            selectionCount: root.selectedWidgets.length,
+            tab: EditMode.DESKTOP_TAB
+        })
+        if (action === "cancelGesture") root.cancelActiveDrag()
+        else if (action === "clearSelection") root.clearSelection()
+        else if (root.editMode) GlobalStates.editMode = false
+    }
+    readonly property bool keyboardFocusHeld: root.selectedWidgets.length > 0 || root.editMode
+    onKeyboardFocusHeldChanged: {
+        root.setKeyboardFocusRequest(root, root.keyboardFocusHeld)
+        if (root.keyboardFocusHeld) root.forceActiveFocus()
+    }
     onSelectedWidgetsChanged: {
-        root.setKeyboardFocusRequest(root, root.selectedWidgets.length > 0)
+        root.setKeyboardFocusRequest(root, root.keyboardFocusHeld)
         if (root.selectedWidgets.length > 0) root.forceActiveFocus()
     }
 

--- a/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/WidgetCanvas.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/WidgetCanvas.qml
@@ -12,7 +12,15 @@ MouseArea {
     property int gridSize: 12
     property bool showGrid: false
     readonly property bool isWidgetCanvas: true
-    readonly property bool gridVisible: showGrid && Config.options.background.showGrid
+    // Handed in by the surface that owns this canvas - the desktop's, and only
+    // the desktop's. The overlay reuses this component and has its own store
+    // and its own dismissal, so it must not follow the mode.
+    property bool editMode: false
+    // Edit Mode's whole purpose is that the affordances stop hiding, so the
+    // grid is up for the mode rather than for the gesture. It overrides the
+    // config switch, whose meaning is "draw the grid while I drag".
+    readonly property bool gridVisible: root.editMode
+        || (showGrid && Config.options.background.showGrid)
 
     // Desktop widgets sit on the background layer surface, which only accepts
     // keyboard input while GlobalStates.desktopWidgetKeyboardFocus flips it to
@@ -59,7 +67,11 @@ MouseArea {
     // - a zero-size band over nothing draggable - is the click-away deselect.
     onPressed: (mouse) => {
         if (!root.selectionEnabled || mouse.button !== Qt.LeftButton) return
-        if (Config.options.background.widgetsLocked) return
+        // The mode subtracts the global lock rather than writing it: the stored
+        // preference is untouched and the desktop is locked again on the way
+        // out. AbstractBackgroundWidget's `interactionLocked` does the same for
+        // the widgets themselves.
+        if (!root.editMode && Config.options.background.widgetsLocked) return
         root.marqueeAnchorX = mouse.x
         root.marqueeAnchorY = mouse.y
         root.marqueeActive = true
@@ -133,7 +145,9 @@ MouseArea {
     Connections {
         target: Config.options.background
         function onWidgetsLockedChanged() {
-            if (Config.options.background.widgetsLocked) root.clearSelection()
+            // Not while editing: the mode suppresses that lock, so the widgets
+            // are still live and a cleared selection would be a lie about them.
+            if (Config.options.background.widgetsLocked && !root.editMode) root.clearSelection()
         }
     }
 

--- a/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/WidgetCanvas.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/WidgetCanvas.qml
@@ -218,6 +218,48 @@ MouseArea {
         }
     }
 
+    // The cancel half of the drag, which nothing needed until the mode could
+    // end in the middle of one. A release COMMITS - clamped and written to the
+    // store - and the drag is deliberately unclamped until then, so committing
+    // a gesture the user never finished stores an overshoot: exactly the defect
+    // 705e9006d ("fix(plugins): stop a widget's stored position disagreeing
+    // with where it is drawn") fixed, where a real store held a widget at
+    // x: -852 on a 5120px screen.
+    function widgetDragCancelled(widget) {
+        const group = root.groupDrag
+        if (group && group.leader === widget) root.groupDrag = null
+        widget.groupDragMinX = -Infinity
+        widget.groupDragMaxX = Infinity
+        widget.groupDragMinY = -Infinity
+        widget.groupDragMaxY = Infinity
+        if (!group || group.leader !== widget) return
+        for (const entry of group.followers) {
+            entry.widget.groupDragging = false
+            // Put the follower back and rebind, rather than committing it the
+            // way widgetDragEnded does: a follower never gets a release event,
+            // so this is the only path that can undo its imperative move.
+            entry.widget.x = entry.startX
+            entry.widget.y = entry.startY
+            if (entry.widget.restoreXYBinding) entry.widget.restoreXYBinding()
+        }
+    }
+
+    function draggingWidget() {
+        for (const widget of root.widgetsUnder(root, []))
+            if (widget.dragging) return widget
+        return null
+    }
+
+    function cancelActiveDrag() {
+        const widget = root.draggingWidget()
+        if (widget && widget.cancelDrag) widget.cancelDrag()
+    }
+
+    // Leaving the mode mid-drag cancels the gesture. It cannot commit: a widget
+    // is only clamped on release, and the mode ending is not the user letting
+    // go of anything.
+    onEditModeChanged: if (!root.editMode) root.cancelActiveDrag()
+
     Connections {
         target: root.groupDrag ? root.groupDrag.leader : null
         function onXChanged() { root.syncGroupFollowers() }

--- a/dots/.config/quickshell/imi/modules/imi/background/Background.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/Background.qml
@@ -8,6 +8,7 @@ import qs.modules.common.widgets.widgetCanvas
 import qs.modules.common.functions as CF
 import "../../common/functions/parallax.js" as ParallaxMath
 import "../../common/functions/clockDepth.js" as ClockDepthLogic
+import "../../common/functions/edit_mode.js" as EditMode
 import QtQuick
 import QtQuick.Layouts
 import Qt5Compat.GraphicalEffects
@@ -520,6 +521,42 @@ Variants {
                 ? weLoader.item
                 : (bgRoot.wallpaperAnimation === "" ? wallpaper : transitionEffect))
 
+        // ---- Edit Mode's viewport ----------------------------------------
+        //
+        // The desktop stops being the whole screen and becomes an object on it:
+        // the wallpaper viewport, the widget canvas and the clock-depth layer
+        // all take one transform, so what the user is arranging keeps its
+        // proportions and its coordinates. Derived, never chosen - see
+        // edit_mode.js for why the drawer's width is the input.
+        readonly property var editViewport: EditMode.viewportGeometry({
+            screenWidth: bgRoot.width,
+            screenHeight: bgRoot.height,
+            drawerWidth: Appearance.sizes.editModeDrawerWidth,
+            margin: Appearance.sizes.editModeMargin
+        })
+        // One animated scalar for the whole entry, so the scale and the offset
+        // cannot arrive on different frames. It moves once per mode change, not
+        // per frame, which is what makes a Behavior legitimate here at all.
+        property real editProgress: GlobalStates.editMode ? 1 : 0
+        Behavior on editProgress {
+            NumberAnimation {
+                duration: 400
+                easing.type: Easing.BezierSpline
+                easing.bezierCurve: Appearance.animationCurves.expressiveDefaultSpatial
+            }
+        }
+        readonly property var editTransform: EditMode.atProgress(bgRoot.editViewport, bgRoot.editProgress)
+        // A scale about the top-left followed by a translation, written as one
+        // matrix rather than as a [Scale, Translate] pair: the order a transform
+        // list composes in is exactly the kind of thing that is wrong by a
+        // factor of the scale and still looks plausible. Row-major, so a point
+        // maps to (s*x + tx, s*y + ty).
+        readonly property matrix4x4 editMatrix: Qt.matrix4x4(
+            bgRoot.editTransform.scale, 0, 0, bgRoot.editTransform.x,
+            0, bgRoot.editTransform.scale, 0, bgRoot.editTransform.y,
+            0, 0, 1, 0,
+            0, 0, 0, 1)
+
         property bool shouldBlur: (GlobalStates.screenLocked && Config.options.lock.blur.enable)
         property color dominantColor: Appearance.colors.colPrimary
         property bool dominantColorIsDark: dominantColor.hslLightness < 0.5
@@ -679,6 +716,15 @@ Variants {
             // Everything the background draws hangs off here, so this is what
             // `hideWhenFullscreen` switches off - see suppressContents above.
             visible: !bgRoot.suppressContents
+
+            // Edit Mode shrinks the wallpaper and the widgets on it by the same
+            // transform, so the desktop reads as one object. A transform and
+            // not x/y/width: those four are what the parallax animates, what
+            // every widget's clamp measures against and what the frost samples
+            // by, and folding a second meaning into them is the mistake
+            // b710ef731 ("fix(plugins): stop the position Behavior swallowing
+            // the parallax cancellation") cost a store full of walked positions.
+            transform: Matrix4x4 { matrix: bgRoot.editMatrix }
 
             // Slower than a workspace switch on purpose: the wallpaper trails
             // the workspace animation rather than racing it, which is what reads
@@ -1163,6 +1209,17 @@ Variants {
             // The desktop is the canvas the marquee exists for: rubber-band
             // several widgets, then drag any of them to move the cluster.
             selectionEnabled: true
+            // The one desktop canvas is the one that edits. The overlay reuses
+            // this component and must never enter the mode, so the flag is
+            // handed in here rather than read from GlobalStates inside it.
+            editMode: GlobalStates.editMode
+            // The same transform the wallpaper takes. `scale` is a render-time
+            // transform and touches none of x, y, width or height, so every
+            // stored position still means the same point, every clamp range is
+            // unchanged, and the hand-computed drag stays exact - it maps the
+            // pointer through the moving item into this frame, and the current
+            // transform cancels itself out (AbstractWidget).
+            transform: Matrix4x4 { matrix: bgRoot.editMatrix }
 
             transitions: Transition {
                 PropertyAnimation {
@@ -1273,6 +1330,11 @@ Variants {
             height: parallaxViewport.height
             // Above widgetCanvas (z 2), which is the whole point.
             z: 3
+            // A fourth thing that reconstructs the viewport, so a fourth copy
+            // of the edit transform: this layer paints the wallpaper's own
+            // pixels back over the widgets, and a subject drawn at full size
+            // over a shrunk desktop is a picture of a different wallpaper.
+            transform: Matrix4x4 { matrix: bgRoot.editMatrix }
             // Its own copy of the fullscreen gate. The viewport carries one for
             // its children and widgetCanvas carries a second because it moved
             // out; a fourth sibling needs a fourth, or the subject floats over
@@ -1316,6 +1378,35 @@ Variants {
                 wallpaperSource: wallpaper.source
                 maskPath: ClockDepth.maskPath
                 maskRevision: ClockDepth.maskRevision
+            }
+        }
+
+        // Edit Mode's backdrop: the wallpaper, blurred, behind the shrunk
+        // desktop. That blur plus the shrink IS the mode signal - there is no
+        // scrim - so it is not optional and is not gated on the lock's own blur
+        // preference; only its radius is borrowed from there, since it is the
+        // same picture and a second setting for it would be a second thing to
+        // disagree.
+        //
+        // A SIBLING of the viewport rather than a second gate on the lock's
+        // blurLoader, which is what the spec asked for and which cannot work:
+        // that loader is a CHILD of parallaxViewport, so it takes the edit
+        // transform with everything else in there and shrinks along with the
+        // desktop it is supposed to sit behind. Sourcing the wallpaper item is
+        // unaffected - a ShaderEffectSource renders its source item in that
+        // item's own coordinates, not the scene's.
+        Loader {
+            id: editBackdrop
+            active: bgRoot.editProgress > 0 && !bgRoot.suppressContents
+            anchors.fill: parent
+            // Below every wallpaper layer and the widgets (all z 0..3), above
+            // the desktop's right-click area at z -2.
+            z: -1
+            opacity: bgRoot.editProgress
+            sourceComponent: WallpaperBlurBackdrop {
+                source: bgRoot.liveWallpaperLayer
+                radius: Config.options.lock.blur.radius
+                samples: Config.options.lock.blur.size
             }
         }
 

--- a/dots/.config/quickshell/imi/modules/imi/background/Background.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/Background.qml
@@ -509,6 +509,17 @@ Variants {
             return enabled && sensitiveWallpaper && sensitiveNetwork;
         }
 
+        // Whichever layer is painting the wallpaper right now, as an item. Both
+        // things that blur the wallpaper - the lock backdrop and Edit Mode's -
+        // read this rather than each resolving the same four-way choice, since
+        // two copies of it would disagree the first time a fifth layer arrived.
+        readonly property Item liveWallpaperLayer: (bgRoot.weShown
+                && (bgRoot.lockWallShown || lockPeelTimer.running))
+            ? lockPeel
+            : (bgRoot.weShown
+                ? weLoader.item
+                : (bgRoot.wallpaperAnimation === "" ? wallpaper : transitionEffect))
+
         property bool shouldBlur: (GlobalStates.screenLocked && Config.options.lock.blur.enable)
         property color dominantColor: Appearance.colors.colPrimary
         property bool dominantColorIsDark: dominantColor.hslLightness < 0.5
@@ -926,22 +937,14 @@ Variants {
                         easing.bezierCurve: Appearance.animationCurves.expressiveDefaultSpatial
                     }
                 }
-                sourceComponent: GaussianBlur {
-                    // Blur the lock peel (WE<->lock-image) when a lock wallpaper is
+                sourceComponent: WallpaperBlurBackdrop {
+                    // The lock peel (WE<->lock-image) when a lock wallpaper is
                     // in play; the live WE surface when it is the wallpaper;
                     // otherwise the static image / transition.
-                    source: (bgRoot.weShown && (bgRoot.lockWallShown || lockPeelTimer.running))
-                        ? lockPeel
-                        : (bgRoot.weShown
-                            ? weLoader.item
-                            : (bgRoot.wallpaperAnimation === "" ? wallpaper : transitionEffect))
+                    source: bgRoot.liveWallpaperLayer
                     radius: GlobalStates.screenLocked ? Config.options.lock.blur.radius : 0
-                    samples: Config.options.lock.blur.size 
-                    Rectangle {
-                        opacity: GlobalStates.screenLocked ? 1 : 0
-                        anchors.fill: parent
-                        color: CF.ColorUtils.transparentize(Appearance.colors.colLayer0, 0.7)
-                    }
+                    samples: Config.options.lock.blur.size
+                    tintOpacity: GlobalStates.screenLocked ? 1 : 0
                 }
             }
 

--- a/dots/.config/quickshell/imi/modules/imi/background/WallpaperBlurBackdrop.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/WallpaperBlurBackdrop.qml
@@ -1,0 +1,31 @@
+import QtQuick
+import Qt5Compat.GraphicalEffects
+import qs.modules.common
+import qs.modules.common.functions as CF
+
+/**
+ * The wallpaper, blurred, with a tint over it.
+ *
+ * Two surfaces want exactly this picture and for the same reason - the lock
+ * screen, and Edit Mode's backdrop behind the shrunk desktop - so it is one
+ * component rather than two GaussianBlurs that would drift a radius or a tint
+ * apart. Only one of them is ever live: locking ends Edit Mode
+ * (GlobalStates.onScreenLockedChanged).
+ *
+ * `source` is an item, not a path: a ShaderEffectSource renders its source
+ * item in that item's OWN coordinate system, so this keeps working while the
+ * wallpaper it samples is drawn inside a transformed viewport - which is the
+ * whole reason Edit Mode's backdrop can stay full-screen while the desktop it
+ * covers shrinks.
+ */
+GaussianBlur {
+    id: root
+
+    property real tintOpacity: 1
+
+    Rectangle {
+        anchors.fill: parent
+        opacity: root.tintOpacity
+        color: CF.ColorUtils.transparentize(Appearance.colors.colLayer0, 0.7)
+    }
+}

--- a/dots/.config/quickshell/imi/modules/imi/background/widgets/AbstractBackgroundWidget.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/widgets/AbstractBackgroundWidget.qml
@@ -49,10 +49,17 @@ AbstractWidget {
     // Dragging is pointer input, so a click-through widget is necessarily
     // locked as well; the reverse does not hold, and a locked-but-clickable
     // widget (pinned media controls, say) stays a useful state.
+    //
+    // Edit Mode subtracts the GLOBAL term and only that one. The per-widget pin
+    // survives, which is the same invariant read the other way round: an editor
+    // that unpinned everything would be unlocking exactly what the user pinned
+    // on purpose. And it subtracts rather than writing `widgetsLocked = false`,
+    // which would destroy a stored preference and leave the desktop unlocked
+    // after the mode ended.
     property bool positionLocked: false
     property bool clickThrough: false
     readonly property bool interactionLocked: clickThrough || positionLocked
-        || Config.options.background.widgetsLocked
+        || (Config.options.background.widgetsLocked && !GlobalStates.editMode)
 
     // Two gates, because one property name means two different things here and
     // neither covers the other.

--- a/dots/.config/quickshell/imi/modules/imi/background/widgets/AbstractBackgroundWidget.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/widgets/AbstractBackgroundWidget.qml
@@ -117,7 +117,15 @@ AbstractWidget {
     function clampX(v) { return Math.max(0, Math.min(v, scaledScreenWidth - clampWidth)); }
     function clampY(v) { return Math.max(0, Math.min(v, scaledScreenHeight - clampHeight)); }
 
-    onReleased: root.commitPosition()
+    // A cancelled gesture swallows exactly its own release: see dragCancelled
+    // in AbstractWidget for why the release still arrives at all.
+    onReleased: {
+        if (root.dragCancelled) {
+            root.dragCancelled = false;
+            return;
+        }
+        root.commitPosition();
+    }
 
     // The one write-back path for a finished move. A real release runs it via
     // the handler above; a group drag runs it on every follower through

--- a/dots/.config/quickshell/imi/modules/imi/desktopMenu/DesktopMenu.qml
+++ b/dots/.config/quickshell/imi/modules/imi/desktopMenu/DesktopMenu.qml
@@ -310,6 +310,42 @@ Scope {
                             }
                         }
 
+                        // Edit layout. A verb, so no submenu and no chevron:
+                        // unlike Wallpaper & style and Widgets, this row has no
+                        // quick-settings half and no Settings page behind it.
+                        //
+                        // The same row is also the way out, which is not what
+                        // the toolbar's Done will be - it stands in for it until
+                        // stage 4 draws one. Escape is the other exit and it
+                        // depends on the compositor delivering keys to a
+                        // Bottom-layer surface, which is not established here;
+                        // a mode whose only way out is unproven is not one to
+                        // ship.
+                        RippleButton {
+                            implicitHeight: 40
+                            colBackground: "transparent"
+                            colBackgroundHover: Appearance.colors.colLayer2
+                            contentItem: RowLayout {
+                                anchors { fill: parent; leftMargin: Appearance.spacing.space150; rightMargin: Appearance.spacing.space150 }
+                                spacing: Appearance.spacing.space150
+                                MaterialSymbol {
+                                    text: GlobalStates.editMode ? "done" : "edit"
+                                    iconSize: Appearance.font.pixelSize.larger
+                                    color: Appearance.colors.colOnLayer1
+                                }
+                                StyledText {
+                                    Layout.fillWidth: true
+                                    text: GlobalStates.editMode ? "Done editing" : "Edit layout"
+                                    font.pixelSize: Appearance.font.pixelSize.normal
+                                    color: Appearance.colors.colOnLayer1
+                                }
+                            }
+                            onClicked: {
+                                GlobalStates.desktopMenuOpen = false
+                                GlobalStates.editMode = !GlobalStates.editMode
+                            }
+                        }
+
                         RippleButton {
                             implicitHeight: 40
                             colBackground: "transparent"

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -307,6 +307,12 @@ if ! python3 "$SCRIPT_DIR/test_widget_resize_grip_runtime.py"; then
     exit 1
 fi
 
+echo "Running edit mode contract tests..."
+if ! python3 "$SCRIPT_DIR/test_edit_mode_contract.py"; then
+    echo "Edit mode contract tests failed."
+    exit 1
+fi
+
 # Whether a drag still lands where the pointer put it once the desktop is drawn
 # at a scale. Nothing static can see that: the drag is hand-computed and the
 # transform is only SUPPOSED to cancel itself out. Brings its own weston.

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -307,6 +307,15 @@ if ! python3 "$SCRIPT_DIR/test_widget_resize_grip_runtime.py"; then
     exit 1
 fi
 
+# Whether a drag still lands where the pointer put it once the desktop is drawn
+# at a scale. Nothing static can see that: the drag is hand-computed and the
+# transform is only SUPPOSED to cancel itself out. Brings its own weston.
+echo "Running edit mode runtime tests..."
+if ! python3 "$SCRIPT_DIR/test_edit_mode_runtime.py"; then
+    echo "Edit mode runtime tests failed."
+    exit 1
+fi
+
 echo "Running dock position contract tests..."
 if ! python3 "$SCRIPT_DIR/test_dock_position_contract.py"; then
     echo "Dock position contract tests failed."

--- a/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
@@ -70,7 +70,9 @@ def test_nothing_computes_the_mode_from_anything_but_the_one_flag():
                         text.find("\n", match.start())]
             allowed = (
                 "GlobalStates.editMode" in line
-                or re.search(r"property bool editMode", line)
+                # A declaration, and only with a neutral default: a property
+                # DERIVED from something else is the second source.
+                or re.search(r"property bool editMode: false\s*$", line)
                 or "root.editMode" in line
                 or "rootWidget.editMode" in line
                 or line.lstrip().startswith("//")

--- a/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""What Edit Mode may do to the desktop, and what it may not.
+
+Stage 3 of docs/superpowers/specs/2026-08-16-edit-mode-design.md, so this
+covers the viewport and the desktop only; the chrome surface's half of §11.2
+lands with the chrome.
+
+Five of these guard failures that are silent on screen:
+
+- a second notion of "am I editing" (§11.2's one-predicate rule, the analogue of
+  the dock's one-derivation lint) - four copies of a mode check is how three of
+  them go stale;
+- the mode written into the shrink instead of transformed into it: `scale` is a
+  render-time transform precisely because x/y/width/height are what the
+  parallax animates, what every clamp measures and what the frost samples, and
+  folding a second meaning into them is what b710ef731 punished;
+- something inside the viewport compensating for the viewport, which reads as
+  correct at scale 1 and is wrong everywhere else;
+- the mode WRITING the global widget lock rather than subtracting it, which
+  destroys a stored preference and leaves the desktop unlocked afterwards;
+- and the mid-drag exit committing rather than cancelling, which stores an
+  unclamped overshoot - the defect 705e9006d fixed, where a real store held a
+  widget at x: -852 on a 5120px screen.
+"""
+
+import re
+from pathlib import Path
+
+from contract_runner import run
+
+ROOT = Path(__file__).resolve().parent.parent
+MODULE = ROOT / "modules/common/functions/edit_mode.js"
+GLOBAL_STATES = ROOT / "GlobalStates.qml"
+CONFIG = ROOT / "modules/common/Config.qml"
+BACKGROUND = ROOT / "modules/imi/background/Background.qml"
+CANVAS = ROOT / "modules/common/widgets/widgetCanvas/WidgetCanvas.qml"
+WIDGET = ROOT / "modules/common/widgets/widgetCanvas/AbstractWidget.qml"
+BACKGROUND_WIDGET = ROOT / "modules/imi/background/widgets/AbstractBackgroundWidget.qml"
+PLUGIN_WIDGET = ROOT / "modules/common/plugins/PluginWidget.qml"
+
+# Everything that takes part in the mode. Listed rather than globbed so a new
+# participant is a deliberate addition to this list, which is where someone
+# reads what the rules are.
+PARTICIPANTS = [BACKGROUND, CANVAS, WIDGET, BACKGROUND_WIDGET, PLUGIN_WIDGET]
+
+
+def read(path: Path) -> str:
+    assert path.exists(), f"{path} is missing - this check has nothing to say"
+    return path.read_text()
+
+
+def test_the_mode_is_ephemeral_state_and_not_a_setting():
+    states = read(GLOBAL_STATES)
+    assert re.search(r"property bool editMode:\s*false", states), \
+        "GlobalStates must declare the mode"
+    assert "editMode" not in read(CONFIG), \
+        ("a persisted edit mode is a shell that comes back from a restart with "
+         "the desktop shrunk and every affordance out")
+
+
+def test_nothing_computes_the_mode_from_anything_but_the_one_flag():
+    # A file may read GlobalStates.editMode, or take it as a property the owning
+    # surface hands in (WidgetCanvas, which the overlay reuses and which must
+    # never follow the mode). What it may not do is derive it from a second
+    # source, because then there are two answers to one question.
+    for path in PARTICIPANTS:
+        text = read(path)
+        for match in re.finditer(r"(?<![.\w])editMode\b", text):
+            line = text[text.rfind("\n", 0, match.start()) + 1:
+                        text.find("\n", match.start())]
+            allowed = (
+                "GlobalStates.editMode" in line
+                or re.search(r"property bool editMode", line)
+                or "root.editMode" in line
+                or "rootWidget.editMode" in line
+                or line.lstrip().startswith("//")
+            )
+            assert allowed, f"{path.name}: a second source for the mode: {line.strip()}"
+
+
+def test_the_viewport_is_a_transform_and_not_a_resize():
+    text = read(BACKGROUND)
+    # The three siblings that draw the desktop all take the SAME matrix, so
+    # there is one arithmetic and they cannot drift a pixel apart.
+    applied = re.findall(r"transform:\s*Matrix4x4\s*\{\s*matrix:\s*bgRoot\.editMatrix\s*\}", text)
+    assert len(applied) == 3, \
+        (f"expected the wallpaper viewport, the widget canvas and the clock depth "
+         f"layer to carry the edit transform, found {len(applied)}")
+    # Nothing may write the geometry the mode is supposed to leave alone.
+    for prop in ("width", "height", "x", "y"):
+        assert not re.search(rf"^\s*{prop}:[^\n]*editViewport", text, re.M), \
+            f"the mode writes {prop} instead of transforming it"
+
+
+def test_nothing_inside_the_viewport_compensates_for_the_viewport():
+    # Recovering a screen coordinate by dividing by the scale is the tempting
+    # way to write anything that has to reach outside the desktop, and it is
+    # exactly the coupling the transform exists to avoid. The scale is
+    # Background's alone; nothing else may even name it.
+    for path in PARTICIPANTS:
+        if path == BACKGROUND:
+            continue
+        text = read(path)
+        assert "editMatrix" not in text and "editViewport" not in text, \
+            f"{path.name} reaches for the viewport's own transform"
+    background = read(BACKGROUND)
+    matrix = re.search(r"readonly property matrix4x4 editMatrix: Qt\.matrix4x4\((.*?)\)\n",
+                       background, re.S)
+    assert matrix, "the transform is no longer written as one matrix"
+    for match in re.finditer(r"editTransform\.(scale|x|y)", background):
+        assert matrix.start() < match.start() < matrix.end(), \
+            ("the viewport's own transform is used outside the matrix it "
+             f"builds, at offset {match.start()}")
+
+
+def test_the_escape_ladder_is_the_module_and_not_open_coded():
+    text = read(CANVAS)
+    assert 'import "../../functions/edit_mode.js" as EditMode' in text
+    handler = re.search(r"Keys\.onEscapePressed:\s*\{(.*?)\n    \}", text, re.S)
+    assert handler, "the canvas no longer answers Escape"
+    body = handler.group(1)
+    assert "EditMode.resolveEscape" in body, \
+        "the ladder's precedence belongs to the module, where a test can reach it"
+    # The four answers the module gives, and no branch invented beside them.
+    for answer in ("cancelGesture", "clearSelection"):
+        assert answer in body, f"the handler ignores the module's {answer}"
+
+
+def test_the_global_lock_is_suppressed_and_never_written():
+    # A write would destroy a stored preference and leave the desktop unlocked
+    # once the mode ended. Only the two places that mean "the user asked for the
+    # lock to change" may write it.
+    writers = {
+        # The desktop menu's submenu switch, and a right-click on a widget:
+        # the two gestures that mean "change the lock".
+        "modules/common/widgets/WidgetsSubmenu.qml",
+        "modules/common/widgets/widgetCanvas/AbstractWidget.qml",
+    }
+    seen = set()
+    for path in ROOT.rglob("*.qml"):
+        if "/tests/" in str(path) or path.name.endswith("RuntimeTest.qml"):
+            continue
+        for line in path.read_text().splitlines():
+            if line.lstrip().startswith("//"):
+                continue
+            if not re.search(r"Config\.options\.background\.widgetsLocked\s*=(?!=)", line):
+                continue
+            relative = str(path.relative_to(ROOT))
+            seen.add(relative)
+            assert relative in writers, f"{relative} writes the global widget lock"
+    assert seen == writers, f"a sanctioned writer disappeared: {writers - seen}"
+    # ...and the suppression is a subtraction on the resolved lock.
+    assert re.search(r"widgetsLocked\s*&&\s*!GlobalStates\.editMode",
+                     read(BACKGROUND_WIDGET)), \
+        "the mode must subtract the global term from interactionLocked"
+
+
+def test_leaving_the_mode_mid_drag_cancels_the_gesture():
+    canvas = read(CANVAS)
+    assert re.search(r"onEditModeChanged:[^\n]*cancelActiveDrag", canvas), \
+        "the mode ending must reach the drag"
+    cancel = re.search(r"function widgetDragCancelled\(widget\)\s*\{(.*?)\n    \}", canvas, re.S)
+    assert cancel, "the canvas has no cancel path for a group drag"
+    assert "commitPosition" not in cancel.group(1), \
+        ("a cancel that commits stores an unclamped overshoot: the drag is "
+         "deliberately unclamped until the release that commits it")
+    widget = read(WIDGET)
+    assert re.search(r"function cancelDrag\(\)", widget)
+    assert "restoreXYBinding" in widget, \
+        "the pre-press position comes back through the binding, not by hand"
+    # The release that follows a cancel is still coming, and must commit
+    # nothing - what it would write is wherever the restore animation reached.
+    assert re.search(r"dragCancelled\s*\)\s*\{", read(BACKGROUND_WIDGET)), \
+        "the release after a cancel is not swallowed"
+
+
+def test_the_frost_names_its_condition_rather_than_one_of_its_causes():
+    text = read(PLUGIN_WIDGET)
+    assert "lockCoversFrost" not in text, \
+        "the gate has two producers now and may not be named for one of them"
+    gate = re.search(r"readonly property bool frostSuspended:(.*?)\n    Repeater", text, re.S)
+    assert gate, "PluginWidget no longer resolves whether its frost is suspended"
+    assert "GlobalStates.editMode" in gate.group(1)
+    assert "GlobalStates.screenLocked" in gate.group(1)
+    assert "!rootWidget.frostSuspended" in text, "the blur Repeater ignores the gate"
+
+
+def test_the_inset_is_derived_from_one_declared_drawer_width():
+    module = read(MODULE)
+    assert "function viewportGeometry" in module
+    # Stage 5's drawer plugs into this number; a second one written into the
+    # drawer would be two fields that must agree.
+    appearance = read(ROOT / "modules/common/Appearance.qml")
+    assert re.search(r"property real editModeDrawerWidth:\s*\d", appearance)
+    assert "Appearance.sizes.editModeDrawerWidth" in read(BACKGROUND), \
+        "the viewport must derive its inset from the drawer's declared width"
+    assert not re.search(r"drawerOpen|drawerVisible", module), \
+        ("the inset may not depend on the drawer being open - opening it "
+         "translates the desktop, it never resizes it")
+
+
+if __name__ == "__main__":
+    raise SystemExit(run(globals()))

--- a/dots/.config/quickshell/imi/tests/test_edit_mode_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_edit_mode_runtime.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Drives Edit Mode's desktop with real mouse events, at the mode's own scale.
+
+`EditModeRuntimeTest.qml` builds a real `WidgetCanvas` with real
+`PluginWidget`s on it, applies the same transform the background surface
+applies - from the same module and the same tokens - and drags widgets around
+inside it. This module is the driver: it stands up a headless weston, points
+throwaway XDG dirs at it, and fails the suite on any check the harness reports.
+
+`tst_edit_mode.qml` covers the arithmetic and `test_edit_mode_contract.py`
+covers what the source says. Neither can answer the question the viewport turns
+on: whether a gesture still lands where the pointer put it once the canvas is
+drawn at a scale. The drag is hand-computed by mapping the pointer through the
+moving widget into the canvas frame, so the transform is meant to cancel itself
+out - and the last time that was assumed rather than measured, half a gesture
+was being swallowed (d2ebb5aeb).
+
+Headless weston rather than the caller's session because the harness opens a
+window. It implements no wlr-layer-shell, so nothing about the background
+*surface* is visible from here - the blur backdrop, the keyboard focus the
+Escape ladder needs and the compositor's alpha map are all outside what any
+harness can say.
+
+Skips when weston or qs is missing, as in CI.
+"""
+
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HARNESS = ROOT / "EditModeRuntimeTest.qml"
+SOCKET = "wayland-imi-edit-mode"
+
+
+# The harness prints how many checks it ran. A literal rather than anything read
+# back out of that output: a harness whose step list shrinks must redden here
+# instead of reporting `failures: 0` for a shorter run.
+EXPECTED_CHECKS = 19
+
+
+def _stop(proc):
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+
+
+def _runtime_available():
+    return shutil.which("qs") is not None and shutil.which("weston") is not None
+
+
+@unittest.skipUnless(_runtime_available(), "needs qs and weston on PATH")
+class EditModeRuntimeTest(unittest.TestCase):
+    def setUp(self):
+        self.home = Path(tempfile.mkdtemp(prefix="imi-edit-mode-"))
+        self.addCleanup(shutil.rmtree, self.home, ignore_errors=True)
+
+    def test_the_desktop_edits_the_same_way_at_the_mode_s_scale(self):
+        env = dict(os.environ)
+        env.setdefault("XDG_RUNTIME_DIR", f"/run/user/{os.getuid()}")
+        env["WAYLAND_DISPLAY"] = SOCKET
+        env.pop("DISPLAY", None)
+
+        weston = subprocess.Popen(
+            ["weston", "--backend=headless", "--renderer=pixman",
+             f"--socket={SOCKET}", "--width=1400", "--height=900"],
+            env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        self.addCleanup(_stop, weston)
+
+        socket_path = Path(env["XDG_RUNTIME_DIR"]) / SOCKET
+        deadline = time.monotonic() + 15
+        while not socket_path.exists() and time.monotonic() < deadline:
+            time.sleep(0.2)
+        self.assertTrue(socket_path.exists(), "headless weston never came up")
+
+        # This box's headless EGL has no driver, so force software rendering.
+        env["LIBGL_ALWAYS_SOFTWARE"] = "1"
+        env["QT_QUICK_BACKEND"] = "software"
+        env["XDG_CONFIG_HOME"] = str(self.home / "config")
+        env["XDG_STATE_HOME"] = str(self.home / "state")
+
+        proc = subprocess.run(["qs", "-p", str(HARNESS)], cwd=str(ROOT), env=env,
+                              capture_output=True, text=True, timeout=240)
+        output = proc.stdout + proc.stderr
+        failed = [line for line in output.splitlines() if "FAIL" in line]
+        self.assertEqual(failed, [], f"harness reported failures:\n{output}")
+        self.assertIn(f"[EditMode] checks: {EXPECTED_CHECKS} failures: 0", output,
+                      f"harness did not finish cleanly:\n{output}")
+
+        # A transform bound through the geometry it transforms shows up here
+        # rather than as a failed check - the desktop would still shrink, it
+        # would just never settle.
+        self.assertNotIn("Binding loop", output,
+                         f"the desktop tree grew a binding loop:\n{output}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dots/.config/quickshell/imi/tests/test_widget_grip_lock.py
+++ b/dots/.config/quickshell/imi/tests/test_widget_grip_lock.py
@@ -112,7 +112,8 @@ class TheHostHandsDownTheResolvedLock(unittest.TestCase):
         squashed = re.sub(r"\s+", " ", uncommented(BASE))
         self.assertIn(
             "readonly property bool interactionLocked: clickThrough "
-            "|| positionLocked || Config.options.background.widgetsLocked",
+            "|| positionLocked || (Config.options.background.widgetsLocked "
+            "&& !GlobalStates.editMode)",
             squashed)
 
 
@@ -209,13 +210,25 @@ class TheHostsOwnResizeGrip(unittest.TestCase):
         """
         self.assertIn("preventStealing: true", self._grip())
 
-    def test_the_drag_is_measured_in_scene_coordinates(self):
-        """The grip is anchored to a widget that resizes underneath it while
-        the drag is live, so a delta read from the grip's own frame folds the
-        resize back into the gesture (AGENT.md: a drag cannot be tracked
-        through the item it moves).
+    def test_the_drag_is_measured_in_a_frame_that_neither_moves_nor_scales(self):
+        """Two requirements, and only one frame satisfies both.
+
+        The grip is anchored to a widget that resizes underneath it while the
+        drag is live, so a delta read from the grip's own frame - or the
+        widget's - folds the resize back into the gesture (AGENT.md: a drag
+        cannot be tracked through the item it moves). That is why this was
+        measured in scene coordinates.
+
+        The scene stopped being enough when Edit Mode began drawing the canvas
+        under a scale transform: a scene delta is in screen pixels while the
+        span it sizes is in canvas pixels, so the resize would lag the pointer
+        by the scale. The widget's PARENT is static in both senses and is the
+        frame AbstractWidget's drag already computes in.
         """
-        self.assertIn("resizeArea.mapToItem(null,", self._grip())
+        grip = self._grip()
+        self.assertIn("resizeArea.mapToItem(rootWidget.parent,", grip)
+        self.assertNotIn("mapToItem(null,", grip)
+        self.assertNotIn("mapToItem(resizeArea,", grip)
 
     def test_escape_cancels_the_resize(self):
         grip = self._grip()

--- a/dots/.config/quickshell/imi/tests/test_widget_group_selection.py
+++ b/dots/.config/quickshell/imi/tests/test_widget_group_selection.py
@@ -162,8 +162,18 @@ class GroupDragIsRigid(unittest.TestCase):
         path, or the reverse. The base class releases through commitPosition
         and PluginWidget overrides that one function.
         """
-        self.assertIn("onReleased: root.commitPosition()", uncommented(BASE))
-        self.assertIn("function commitPosition()", uncommented(BASE))
+        base = uncommented(BASE)
+        release = re.search(r"(?m)^    onReleased: \{(.*?)^    \}", base, re.S)
+        assert release, "the base class no longer releases"
+        body = release.group(1)
+        self.assertIn("root.commitPosition();", body)
+        # The only thing the handler may do besides committing is decline to,
+        # for the release that follows a cancelled gesture. A write-back
+        # spelled out here would be the second copy this check exists to stop.
+        for writeback in ("configEntry.x", "setPosition", "targetX ="):
+            self.assertNotIn(writeback, body,
+                             "the release path must write back through commitPosition alone")
+        self.assertIn("function commitPosition()", base)
         host = uncommented(HOST)
         self.assertIn("function commitPosition()", host)
         # Anchored to the host's own scope. A nested MouseArea - the grid

--- a/dots/.config/quickshell/imi/tests/test_widget_interaction_modes.py
+++ b/dots/.config/quickshell/imi/tests/test_widget_interaction_modes.py
@@ -93,11 +93,17 @@ class TheHostOwnsTheMechanism(unittest.TestCase):
         deliberately pinned.
         """
         expr = binding(BASE, "interactionLocked")
-        self.assertNotIn("&&", expr, "the locks must OR, never AND")
         self.assertEqual(expr.count("||"), 2, "all three locks must be joined")
         for term in ("clickThrough", "positionLocked",
                      "Config.options.background.widgetsLocked"):
             self.assertIn(term, expr)
+        # Exactly one `&&` is allowed and only inside the global term: Edit
+        # Mode subtracts that lock for the length of the mode, and subtracts
+        # only that one, so a widget the user pinned stays pinned. Any other
+        # `&&` is two locks AND-ed, which is the inversion this check is for.
+        remainder = expr.replace(
+            "Config.options.background.widgetsLocked && !GlobalStates.editMode", "")
+        self.assertNotIn("&&", remainder, "the locks must OR, never AND")
 
     def test_draggable_reads_the_combined_lock(self):
         """Leaving `draggable` on the raw global toggle is the silent failure

--- a/dots/.config/quickshell/imi/tests/tst_edit_mode.qml
+++ b/dots/.config/quickshell/imi/tests/tst_edit_mode.qml
@@ -62,17 +62,18 @@ TestCase {
         fuzzyCompare(wide.x, 24, 1e-9);
     }
 
-    function test_a_tall_screen_is_bound_by_its_height_instead() {
-        // The vertical margins bind first here, so the horizontal slack grows -
-        // and it grows on the drawer's side, which is where the extra room is
-        // wanted. A geometry that took only the horizontal ratio would put the
-        // desktop's top and bottom edges off the screen.
-        const tall = EditMode.viewportGeometry({
-            screenWidth: 1080, screenHeight: 1920, drawerWidth: 100, margin: 40
+    function test_a_short_screen_is_bound_by_its_height_instead() {
+        // On a wide, short panel the vertical margins bind first, so the
+        // horizontal slack grows - and it grows on the drawer's side, which is
+        // where extra room is wanted. A geometry that took only the horizontal
+        // ratio would put the desktop's top and bottom edges off the screen.
+        const short = EditMode.viewportGeometry({
+            screenWidth: 1280, screenHeight: 400, drawerWidth: 120, margin: 40
         });
-        fuzzyCompare(tall.scale, (1920 - 80) / 1920, 1e-9);
-        verify(tall.height <= 1920 - 80 + 0.5);
-        verify(tall.width <= 1080 - 100 - 80 + 0.5);
+        fuzzyCompare(short.scale, (400 - 80) / 400, 1e-9);
+        verify(short.scale < (1280 - 120 - 80) / 1280);
+        verify(short.height <= 400 - 80 + 0.5);
+        verify(short.width <= 1280 - 120 - 80 + 0.5);
     }
 
     function test_the_inset_does_not_depend_on_the_drawer_being_open() {

--- a/dots/.config/quickshell/imi/tests/tst_edit_mode.qml
+++ b/dots/.config/quickshell/imi/tests/tst_edit_mode.qml
@@ -1,0 +1,132 @@
+import QtTest
+import "../modules/common/functions/edit_mode.js" as EditMode
+
+// Edit Mode's two testable decisions: which of four things Escape does, and how
+// far the desktop shrinks. Everything else about the mode is a transform on a
+// layer surface, which `qmltestrunner` cannot construct at all - so these two
+// are where a regression can be caught cheaply, and the runtime harness
+// (EditModeRuntimeTest.qml) is where the rest is.
+TestCase {
+    name: "EditModeTest"
+
+    function test_escape_cancels_a_gesture_before_anything_else() {
+        // A drag, a grip resize or a reorder in flight owns the key: the mode
+        // stays on and the gesture is put back. Asserted with a selection and a
+        // non-default tab also present, because precedence is the whole point
+        // of the ladder and each branch alone would pass a `||` chain.
+        compare(EditMode.resolveEscape({
+            gestureInFlight: true, selectionCount: 3, tab: "lockscreen"
+        }), "cancelGesture");
+    }
+
+    function test_escape_clears_a_selection_before_changing_tab() {
+        compare(EditMode.resolveEscape({
+            gestureInFlight: false, selectionCount: 2, tab: "lockscreen"
+        }), "clearSelection");
+    }
+
+    function test_escape_returns_to_the_desktop_tab_before_leaving() {
+        compare(EditMode.resolveEscape({
+            gestureInFlight: false, selectionCount: 0, tab: "lockscreen"
+        }), "desktopTab");
+    }
+
+    function test_escape_leaves_the_mode_only_when_nothing_else_answers() {
+        compare(EditMode.resolveEscape({
+            gestureInFlight: false, selectionCount: 0, tab: EditMode.DESKTOP_TAB
+        }), "exit");
+        // An absent tab is the desktop one. The caller does not have a tab bar
+        // until stage 4 and must not have to invent a string to get an exit.
+        compare(EditMode.resolveEscape({ gestureInFlight: false, selectionCount: 0 }), "exit");
+        compare(EditMode.resolveEscape({}), "exit");
+    }
+
+    readonly property var wide: EditMode.viewportGeometry({
+        screenWidth: 5120, screenHeight: 1440, drawerWidth: 400, margin: 24
+    })
+
+    function test_the_desktop_shrinks_by_exactly_what_the_drawer_will_need() {
+        // 5120 - 400 - 2*24 = 4672 of room, so the scale is the ratio of that
+        // to the screen and the drawn width is that room exactly. Asserted as
+        // the width rather than only as the scale: the scale is the mechanism,
+        // the width is the promise.
+        fuzzyCompare(wide.width, 4672, 0.5);
+        fuzzyCompare(wide.scale, 4672 / 5120, 1e-9);
+        // The space left over on the right is the drawer plus its gap.
+        fuzzyCompare(5120 - (wide.x + wide.width), 400 + 24, 0.5);
+    }
+
+    function test_the_desktop_keeps_its_aspect_and_is_centred_vertically() {
+        fuzzyCompare(wide.height / wide.width, 1440 / 5120, 1e-9);
+        fuzzyCompare(wide.y, (1440 - wide.height) / 2, 0.5);
+        fuzzyCompare(wide.x, 24, 1e-9);
+    }
+
+    function test_a_tall_screen_is_bound_by_its_height_instead() {
+        // The vertical margins bind first here, so the horizontal slack grows -
+        // and it grows on the drawer's side, which is where the extra room is
+        // wanted. A geometry that took only the horizontal ratio would put the
+        // desktop's top and bottom edges off the screen.
+        const tall = EditMode.viewportGeometry({
+            screenWidth: 1080, screenHeight: 1920, drawerWidth: 100, margin: 40
+        });
+        fuzzyCompare(tall.scale, (1920 - 80) / 1920, 1e-9);
+        verify(tall.height <= 1920 - 80 + 0.5);
+        verify(tall.width <= 1080 - 100 - 80 + 0.5);
+    }
+
+    function test_the_inset_does_not_depend_on_the_drawer_being_open() {
+        // There is no open-state input, and there must not be one: opening the
+        // drawer translates the desktop, it never resizes it. The check that
+        // can see a regression is that the geometry is a function of the
+        // drawer's WIDTH alone - so a caller that started passing 0 while the
+        // drawer was shut would have to change this number.
+        const closed = EditMode.viewportGeometry({
+            screenWidth: 5120, screenHeight: 1440, drawerWidth: 400, margin: 24
+        });
+        compare(closed.width, wide.width);
+        compare(closed.x, wide.x);
+        verify(EditMode.viewportGeometry({
+            screenWidth: 5120, screenHeight: 1440, drawerWidth: 0, margin: 24
+        }).width !== wide.width);
+    }
+
+    function test_a_screen_too_narrow_for_the_drawer_still_answers_a_usable_scale() {
+        // Reachable on a 1024px-wide panel beside a 400px drawer with big
+        // margins. The arithmetic's honest answer is a negative scale, which
+        // renders as a desktop turned inside out rather than as an error.
+        const cramped = EditMode.viewportGeometry({
+            screenWidth: 300, screenHeight: 200, drawerWidth: 400, margin: 24
+        });
+        compare(cramped.scale, EditMode.MIN_SCALE);
+        verify(cramped.width > 0);
+        // Nothing to divide by either, when a screen has not reported a size.
+        const nothing = EditMode.viewportGeometry({
+            screenWidth: 0, screenHeight: 0, drawerWidth: 400, margin: 24
+        });
+        compare(nothing.scale, 1);
+    }
+
+    function test_the_transform_interpolates_from_identity() {
+        // The entry animation is one scalar, so there is no frame in which the
+        // scale has arrived and the offset has not.
+        const start = EditMode.atProgress(wide, 0);
+        compare(start.scale, 1);
+        compare(start.x, 0);
+        compare(start.y, 0);
+
+        const end = EditMode.atProgress(wide, 1);
+        compare(end.scale, wide.scale);
+        compare(end.x, wide.x);
+        compare(end.y, wide.y);
+
+        const half = EditMode.atProgress(wide, 0.5);
+        fuzzyCompare(half.scale, 1 + (wide.scale - 1) / 2, 1e-9);
+        fuzzyCompare(half.x, wide.x / 2, 1e-9);
+
+        // A progress outside [0, 1] is what an interruptible Behavior can hand
+        // in on an overshooting curve; it clamps rather than magnifying.
+        compare(EditMode.atProgress(wide, 1.4).scale, wide.scale);
+        compare(EditMode.atProgress(wide, -0.3).scale, 1);
+    }
+}

--- a/dots/.config/quickshell/imi/tests/tst_edit_mode.qml
+++ b/dots/.config/quickshell/imi/tests/tst_edit_mode.qml
@@ -67,13 +67,13 @@ TestCase {
         // horizontal slack grows - and it grows on the drawer's side, which is
         // where extra room is wanted. A geometry that took only the horizontal
         // ratio would put the desktop's top and bottom edges off the screen.
-        const short = EditMode.viewportGeometry({
+        const panel = EditMode.viewportGeometry({
             screenWidth: 1280, screenHeight: 400, drawerWidth: 120, margin: 40
         });
-        fuzzyCompare(short.scale, (400 - 80) / 400, 1e-9);
-        verify(short.scale < (1280 - 120 - 80) / 1280);
-        verify(short.height <= 400 - 80 + 0.5);
-        verify(short.width <= 1280 - 120 - 80 + 0.5);
+        fuzzyCompare(panel.scale, (400 - 80) / 400, 1e-9);
+        verify(panel.scale < (1280 - 120 - 80) / 1280);
+        verify(panel.height <= 400 - 80 + 0.5);
+        verify(panel.width <= 1280 - 120 - 80 + 0.5);
     }
 
     function test_the_inset_does_not_depend_on_the_drawer_being_open() {


### PR DESCRIPTION
Stage 3 of `docs/superpowers/specs/2026-08-16-edit-mode-design.md` §12 — the first stage a user would call "Edit Mode". Right-click → **Edit layout** shrinks the desktop into a viewport over its own wallpaper blurred, and gives you the editor that was always there with its affordances shown instead of hidden.

In scope and shipped: `GlobalStates.editMode`; the desktop-menu row; the shrink and inset on the background surface; the blurred backdrop; the frost gate generalised; the exit ladder (`edit_mode.js` + `tst_edit_mode.qml`); the desktop's affordances forced on (grid, grips, global-lock suppression); the mid-drag cancel. Not in scope and not built: the toolbar, Done and the tab bar (stage 4), the drawer (5), the per-widget menu and Size stepper (6), the bar and dock (8), the Lockscreen tab (9), edge snap and undo (10).

## The probes that gated this stage (§11.4), measured on the author's machine

Run on a live session before any of this was written; not re-run here.

**Probe 3 — chrome vs bar/dock.** `hyprctl layers`: `level 1: quickshell:background`; `level 2: quickshell:dock, quickshell:bar`; `level 3: quickshell:screenCorners ×4, quickshell:barPopup`. The background surface is **below** the bar and the dock, so chrome drawn on it renders underneath them. §2.3's answer: the viewport stays on the background surface and the chrome needs its own surface at level 2 or above.

**Probe 2 — frost under scale, static wallpaper.** Scaling `widgetCanvas` to 0.73 renders every widget correctly and the frost survives cleanly. `Item.scale` on the live tree is viable; §2.2's recommendation stands and proxies are off the table.

**Probe 1 — the same with a live Wallpaper Engine scene.** The frost does **not** survive: cards that are visibly frosted unscaled render as flat tinted panels under the transform, confirming the claim at `Background.qml:1186-1189`. Reported as a visual reading rather than a number — the cards change size and position between captures, so equivalent regions could not be sampled, and that is not dressed up as a measurement.

**Probe 4 — keyboard focus.** Partial. A `Bottom`-layer surface with `WlrLayershell.keyboardFocus: OnDemand` does grant QML active focus (`qs -p` probe: `itemActiveFocus=true`). Whether the compositor delivers keys was not established. It gates undo at stage 10 — and it is why the mode here has a pointer way out and nothing depends on a key arriving.

## The surface split

The viewport is the **background surface**, in place. Nothing is reparented, because the canvas is already there — and moving it to a new surface would cost the live-wallpaper frost outright, since a `ShaderEffectSource` reaches items in its own scene graph only and `weSurfaceItem` lives in this window. Probe 3 says chrome will need a second surface at level 2+; this stage draws no chrome, so it mints no namespace and adds nothing to `rules.lua`'s generated-threshold loop. Stage 4 does that exercise in full, with `BarPopupOverlay.qml:53-69`'s reasoning about why it is its own namespace rather than `quickshell:popup`.

Three siblings of that surface draw the desktop — `parallaxViewport`, `widgetCanvas` and the clock-depth layer — and all three take **one** `bgRoot.editMatrix`, so there is a single piece of arithmetic and they cannot drift apart. A transform, never `x`/`y`/`width`/`height`: those four are what the parallax animates, what every clamp measures against, what every stored position means and what the frost samples by, and folding a second meaning into them is b710ef731's defect in a new place. `scale` leaves all of them alone, so the store, the clamp range and the hand-computed drag are untouched.

**One deviation from the spec, with a reason.** §1.1 says the blurred backdrop is "a second gate on that same `Loader`". It cannot be: that `Loader` is a *child* of `parallaxViewport`, so it takes the edit transform with everything else in there and shrinks along with the desktop it is meant to sit behind. It is a sibling `Loader` at `z: -1` instead, sharing one extracted `WallpaperBlurBackdrop` component with the lock's so there is still one declaration of that picture. It works because a `ShaderEffectSource` renders its source item in that item's own coordinates — a transformed wallpaper yields an untransformed texture.

**The frost stands down for the mode** rather than being aligned to it (§2.4), which is probe 1's consequence: `lockCoversFrost` becomes `frostSuspended`, named for the condition instead of one of its two causes.

## The grid

**The premise was wrong, checked in the source rather than accepted:** the grid is *not* a sibling of the canvas. `WidgetCanvas.qml`'s two grid `Repeater`s, the centre lines, the marquee and the flash lines are all declared as children of the canvas root, so the transform carries all five and the lattice keeps corresponding to widget positions. Nothing had to move, and nothing had to be scaled in step. The runtime harness scores this the only way that means anything — it drives every gesture in canvas coordinates, which `TestCase` maps through the transform, so a lattice that had come loose would show up as a drag landing somewhere else.

What did need answering is §11.4 Q3's actual question, the 24-drawn-vs-12-snapped mismatch. With the grid up for the whole mode rather than for the length of a drag, a widget settling between two lines reads as broken snapping. The drawn lattice is 12px now, with every second line at full strength so the old 24px rhythm stays legible — its own commit, since it changes what an ordinary drag looks like.

## The exit ladder

`edit_mode.js`'s `resolveEscape({gestureInFlight, selectionCount, tab})` resolves in order, first match wins: cancel the gesture → clear the selection → return to the Desktop tab → leave the mode. Pure, so the precedence is checkable without a canvas; the stage-4 tab branch is already answered so it does not have to be invented later, and an absent `tab` is the desktop one.

Escape does not take the key from the two things that already had it — the marquee's clear and the grip's resize cancel (which gets it first, since the grip holds focus during the gesture). But Escape is an *addition* here, not the way out: probe 4 leaves key delivery to a `Bottom` surface open, so the desktop-menu row toggles, reading **Edit layout** / **Done editing**. That is stage 4's Done arriving early rather than shipping a mode whose only exit is unproven. The mode also ends on anything that takes the screen away — the lock, the overview, the session screen — the lock mattering most, since the background surface is promoted to `Overlay` and repurposed as the lock backdrop while locked.

Leaving mid-drag **cancels**; it cannot commit. The drag is unclamped until release by design, so committing an unfinished gesture stores an overshoot — 705e9006d's defect, where a real store held `visualizer` at `x: -852` on a 5120px screen. Three ends, not two: the widget's own cancel restores through the x/y *binding* (only a commit writes `targetX`/`targetY`, so re-binding is the pre-press position), the group half is separate because `widgetDragEnded` commits every follower, and the release that still arrives — the pointer was never let go of — is swallowed, since measured, what it would otherwise write is wherever the restore animation had reached.

## Tests

Baseline on `gh/main` (`d51c7e1c8`), re-measured in a clean worktree: **866 passed, 0 failed**, whole suite green. This branch: **878 passed, 0 failed**, whole suite green — Python tier included.

- `tests/tst_edit_mode.qml` — the ladder's four branches and their precedence; the inset's arithmetic, including that it has no drawer-open input and that a screen too narrow for the drawer still answers a usable scale.
- `tests/test_edit_mode_contract.py` — nine source contracts: the mode is `GlobalStates` and not `Config`; nothing derives it from a second source; the viewport is a transform and not a resize; nothing inside it compensates for it; the ladder is the module rather than open-coded; the global lock is subtracted and never written; the mid-drag exit cancels; the frost gate names its condition; the inset derives from one declared drawer width.
- `tests/test_edit_mode_runtime.py` + `EditModeRuntimeTest.qml` — nineteen checks under headless weston, driving real mouse events on real `PluginWidget`s. Every gesture is driven in canvas coordinates, so the same numbers at two scales must store the same position and cover a *different* amount of screen; both halves are asserted, because "the widget moved" is satisfied by a drag that reads raw scene deltas and lands the scale's worth short.

Every new check was proven to fail on planted breakage, in a clean tree: dropping the ladder's first branch, dropping the inset's `min()` and its progress clamp, ignoring the drawer's width, a mode key in `Config`, a derived `editMode`, the transform removed, a division by the viewport scale, the ladder open-coded, the lock written on entry, the group cancel committing, the frost gate renamed back or forgetting Edit Mode, the drawer width inlined, the grid not forced, the lock not suppressed, the cancel not reached, the release after a cancel committing, and the grip's delta read in scene coordinates again.

Two of those found real gaps rather than confirming anything: the contract's one-predicate check waved `property bool editMode: Config.options.background.showGrid` through, and the harness's grip gesture (150px) committed the same span under **both** frames — the sibling harness's "probed at a wall, the check is vacuous" lesson, met again. Both are fixed in their own commits, with the miss recorded in the message.

Three existing checks pinned spellings this branch changes, and each was tightened rather than loosened, then re-proven against the mutation it exists for: `interactionLocked` may carry exactly one `&&` and only the mode's subtraction; the grip's frame must be static in two senses (not moving, not scaling) rather than literally the scene; and the release handler must write back through `commitPosition` alone rather than being one particular line.

Also fixed along the way: **the resize grip measured its delta in scene coordinates**, which is correct at scale 1 and lags the pointer by the scale under the viewport.

## Verification, and its limits

Every touched file compiles (`Qt.createComponent` probe on `Background.qml`, `WallpaperBlurBackdrop.qml`, `AbstractBackgroundWidget.qml`, `WidgetCanvas.qml`, `AbstractWidget.qml`, `PluginWidget.qml`, `DesktopMenu.qml`, `GlobalStates.qml`). This has **not** been loaded as a live shell: the author is at the machine using `gh/main`, and a second full instance would put a second bar, dock and desktop on their screen. The first live load is a `Configuration Loaded` + `grep ERROR:` check away, and it is the one thing no harness here can stand in for — weston implements no wlr-layer-shell, so the backdrop's compositor behaviour and the surface's keyboard focus are both outside what any of this can say.

Docs: updated AGENT.md §Layer-shell / desktop-widget notes — the edit-mode viewport as a transform, why the backdrop cannot be a second gate on the lock's blur Loader, why the frost stands down, the cancel path's three ends, and the runtime harness's canvas-coordinate trick.
