### PR TITLE
Pick the wallpaper's subject on the desktop, not on a thumbnail

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -461,12 +461,18 @@ modules/imi/                 The "imi" (Immaterial Impulse) panel family - one d
                               the sidebars
   background/                 Desktop background + the canvas the draggable desktop widgets sit on.
                               ClockDepthCutout.qml is the wallpaper's subject cut out by its mask -
-                              the ONE place the mask's registration is computed, drawn both by the
-                              depth layer and by the picker that judges it (see the clock-depth
-                              notes below).
+                              the ONE place the mask's registration is computed, drawn by the depth
+                              layer, by the picker that shows per-wallpaper state, and by the
+                              desktop selector that authors it (see the clock-depth notes below).
                               The widgets themselves are all bundled plugins now (see
                               modules/common/plugins/bundled/); background/widgets/ holds only
                               AbstractBackgroundWidget.qml, which is the plugin host's base class.
+  clockDepthSelect/           Picking that subject ON the desktop: a transparent, screen-sized
+                              Overlay surface per output that draws the candidate cutout into the
+                              box Background publishes, over the live widgets, and turns a click
+                              into a MobileSAM prompt. It redraws neither the wallpaper nor the
+                              widgets - both are already on screen, which is what makes the pixels
+                              clicked the pixels the depth layer will mask
   overview/                   Workspace/window overview (like GNOME Activities)
   notificationPopup/          Desktop notification popups
   settings/                   The in-shell settings UI (pages/ = one file per settings category)
@@ -539,11 +545,14 @@ services/                  Singletons wrapping external state/processes - one pe
                               the desktop clock's depth mode. Asks
                               scripts/background/subject_mask.py - the shell never computes a cache
                               key of its own - and queries nothing at all until either
-                              background.clockDepth.enable or the picker is open. The `run` and
-                              `select` halves are reached ONLY from the wallpaper selector's
-                              picker; nothing reactive can start segmentation. It also holds the
-                              prompted model's clicks for the wallpaper on screen, restored from
-                              the cache once per wallpaper rather than on every status
+                              background.clockDepth.enable, the picker, or the desktop selector is
+                              open. `run` is reached ONLY from the wallpaper selector's picker and
+                              `select` ONLY from the desktop selector; nothing reactive can start
+                              segmentation. It also holds the prompted model's clicks for the
+                              wallpaper on screen, restored from the cache once per wallpaper
+                              rather than on every status, and `selectable` - whether the desktop
+                              is currently showing the still image it is asking about, which is
+                              the precondition both of those surfaces gate the gesture on
   MprisController.qml         The one answer to "which player is the media UI showing". It filters
                               the bus list (proxies always, duplicates by setting) through
                               MprisSelection.js - a .pragma library kept pure so the rules are
@@ -2516,6 +2525,74 @@ Four things about that column generalise past it:
   buying the refusal it looked like it was for, since a click on flat sky comes
   back at 1.6-10% because SAM answers with the sky.
   (fix(background): a click's floor is not the detectors' floor.)
+
+**And the click belongs on the desktop, because a mask judged at screen size
+cannot be authored on a thumbnail.** The gesture shipped on a ~300px preview
+inside the depth picker, which is a structural mismatch rather than a matter of
+taste: the mask is scored against real widgets at 5120x1440 and was being aimed
+at a postage stamp, so a click landing on a character's shoulder in the preview
+is several hundred pixels off in the thing being judged - and nothing reports it,
+because a mis-aimed click comes back as a perfectly good mask of the wrong thing.
+`modules/imi/clockDepthSelect/` is a transparent, screen-sized `Overlay` surface
+per output; the picker keeps the two detector columns, this wallpaper's verdict
+and the way in. Four things about it generalise.
+
+- **Nothing on that surface redraws anything, and that is the whole design.**
+  The wallpaper is already on screen at exactly the size and crop the mask has
+  to line up with, and the widgets are already under it, so the pixels clicked
+  are the pixels the depth layer will mask by construction rather than by
+  arithmetic, and the cutout drawn over the widgets IS the occlusion being
+  judged. A second copy of either is a second chance to be misaligned, in a
+  feature that already spent an evening on a misalignment that turned out not to
+  exist (see the two-captures entry above). `test_clock_depth_select_contract.py`
+  fails the suite on an `Image` appearing in that file at all.
+- **A layer surface cannot read another window's items, so the geometry is
+  PUBLISHED rather than re-derived.** The wallpaper viewport is oversized and
+  offset by the parallax pan, and `ParallaxMath.offsets` is right there and
+  pure - reconstructing it on the selector's side would look like reuse and be a
+  second derivation of the one number `ClockDepthCutout` exists to have only one
+  of. `Background.qml` publishes the depth layer's own live box per screen into
+  `GlobalStates.clockDepthViewports` (including the wallpaper ITEM's source, not
+  the config path, for the reason the layer reads the item), the surface draws
+  its cutout into that box, and the click is measured against the rectangle that
+  same cutout publishes. The binding is null while the mode is disarmed, so it is
+  a comparison rather than a fresh object per frame of every pan for the rest of
+  the session. Note which coordinate space that leaves: a click arrives in SCREEN
+  coordinates and the registration is expressed inside the box, so
+  `clockDepth.js`'s `promptFromScreen` composes the translation - and the
+  translation is exactly the term that is zero with parallax off, i.e. correct on
+  the first screen anyone tries it on and wrong on every workspace but the middle
+  one.
+- **Two flags meaning "somebody is picking" is one flag too many.** `ClockDepth`
+  drops every cached answer the moment nothing is `watching`, and the picker's
+  claim (`picking`) dies with the picker as the wallpaper selector closes. Giving
+  the new mode a second write of that same bool means whichever surface goes away
+  last clears it, on an ordering nothing controls - and clearing it forgets the
+  candidate the user walked out to judge. `watching` reads
+  `GlobalStates.clockDepthSelectOpen` directly instead, and the entry point arms
+  BEFORE either surface closes.
+- **The predicate for "can this be picked on" is deliberately not a subset of
+  `eligible`.** Two of that function's refusals - no mask, and the per-wallpaper
+  opt-out - are precisely the states picking exists to change, so inheriting them
+  would make the feature unreachable from the half of the library it was built
+  for. `selectable` refuses the other thing they have in common: a desktop whose
+  pixels are not the still image the producer is being asked about (a preview the
+  wallpaper selector reverts on close, a live Wallpaper Engine project, centred
+  mode, the lock screen). `eligible` gains one refusal of its own, `selecting`,
+  because the accepted mask drawn under a candidate is a second silhouette and
+  wherever the two disagree the difference reads as the candidate having claimed
+  something it did not.
+
+  Two smaller ones. The surface takes `OnDemand` keyboard focus, never
+  `Exclusive` - there is one per output and an Exclusive grab is session-wide,
+  the trap `Screensaver.qml` records. And its namespace needs `blur = false` plus
+  a region over its toolbar rather than falling through to the catch-all
+  `ignore_alpha = 0.05`, under which a screen-sized surface of transparent pixels
+  asks the compositor to blur the entire screen.
+  3869f90e9 ("feat(clockDepthSelect): pick the wallpaper's subject on the desktop itself"),
+  e3f0f7e00 ("feat(background): stand the depth layer down while a pick is live, and hand over its box"),
+  3e30a844b ("feat(clockDepth): answer where a desktop click lands, and when one is allowed"),
+  5ad1db2be ("refactor(wallpapers): make the depth picker the way in, not the place to author").
 
 **A segmentation model returning nothing is usually the wrong model, not an empty
 picture.** `isnet-anime` and `isnet-general-use` are complementary and neither is

--- a/dots/.config/hypr/hyprland/rules.lua
+++ b/dots/.config/hypr/hyprland/rules.lua
@@ -144,6 +144,16 @@ hl.layer_rule({ match = { namespace = "quickshell:.*" }, ignore_alpha = 0.05})
 hl.layer_rule({ match = { namespace = "quickshell:bar" }, animation = "slide"})
 hl.layer_rule({ match = { namespace = "quickshell:actionCenter" }, no_anim = true})
 hl.layer_rule({ match = { namespace = "quickshell:cheatsheet" }, animation = "slide bottom"})
+-- The subject selector: a full-screen surface that is transparent everywhere
+-- except one toolbar, because the wallpaper and the widgets it is judging are
+-- the real ones underneath it. Under the catch-all above that is the worst
+-- possible case - a screen-sized surface asking the compositor to blur the
+-- entire screen behind it - so its blur is scoped to the toolbar's own rect
+-- through a region, the same way the bar's and the sidebars' are. It also opens
+-- and closes on a button, so a map animation on something this size reads as
+-- the desktop lurching.
+hl.layer_rule({ match = { namespace = "quickshell:clockDepthSelect" }, no_anim = true})
+hl.layer_rule({ match = { namespace = "quickshell:clockDepthSelect" }, blur = false})
 -- Bare `slide`, like the bar above: the compositor slides toward whichever
 -- edge the surface is anchored to, so the dock's exit and entry follow its
 -- configured edge. Naming the edge here pinned it to the bottom, and a top

--- a/dots/.config/quickshell/imi/DesignSystemCompile.qml
+++ b/dots/.config/quickshell/imi/DesignSystemCompile.qml
@@ -62,6 +62,11 @@ ShellRoot {
                 // someone clicks its toolbar button - which on a shell where
                 // nobody has is never.
                 Quickshell.shellPath("modules/imi/wallpaperSelector/ClockDepthPicker.qml"),
+                // Same shape one step on: the desktop subject selector's
+                // surface is behind a Loader that stays inactive until somebody
+                // arms the mode from that picker, so an ordinary run never
+                // compiles it.
+                Quickshell.shellPath("modules/imi/clockDepthSelect/ClockDepthSelectSurface.qml"),
                 // The cheatsheet only compiles when the user presses Super+/,
                 // and the keybind editor only when a row's pencil is clicked.
                 Quickshell.shellPath("modules/imi/cheatsheet/CheatsheetKeybinds.qml"),

--- a/dots/.config/quickshell/imi/GlobalStates.qml
+++ b/dots/.config/quickshell/imi/GlobalStates.qml
@@ -31,6 +31,18 @@ Singleton {
     property bool overviewOpen: false
     property bool regionSelectorOpen: false
     property bool settingsHeldForRegionSelector: false
+    // Picking the wallpaper's subject on the desktop itself, at full size, over
+    // the real widgets - rather than on a 300px thumbnail in the wallpaper
+    // selector, where a click landing on a shoulder is several hundred pixels
+    // off by the time the mask is judged at screen size.
+    property bool clockDepthSelectOpen: false
+    // Per screen name: where the wallpaper's whole box sits in that screen's
+    // coordinates, plus the source the wallpaper item is actually drawing.
+    // Published by Background.qml while the selector above is armed, because the
+    // selection surface is a different window and cannot read that item. It
+    // draws its cutout into this box and measures its clicks against the same
+    // rectangle, so the pixels it judges are the pixels the depth layer masks.
+    property var clockDepthViewports: ({})
     // True while a copy snip's crop/clipboard pipeline runs; cancel paths
     // must not dismiss (and thereby kill) the in-flight process.
     property bool snipCopyInFlight: false

--- a/dots/.config/quickshell/imi/GlobalStates.qml
+++ b/dots/.config/quickshell/imi/GlobalStates.qml
@@ -98,6 +98,17 @@ Singleton {
     onOverviewOpenChanged: if (root.overviewOpen) root.editMode = false
     onSessionOpenChanged: if (root.sessionOpen) root.editMode = false
 
+    // Edit Mode and subject picking are both full-screen modes over the same
+    // desktop, and each shrinks or covers what the other needs at full size:
+    // picking must click the wallpaper at the size it is masked at, which a
+    // shrunk desktop is not, and Edit Mode's affordances would sit under the
+    // picker's surface. They land from separate branches, so the exclusion is
+    // stated once here rather than as a gate inside either mode - a mode that
+    // gated on the other's key would read `undefined` on the base that does not
+    // declare it yet and take its fallback forever.
+    onEditModeChanged: if (root.editMode) root.clockDepthSelectOpen = false
+    onClockDepthSelectOpenChanged: if (root.clockDepthSelectOpen) root.editMode = false
+
     onSidebarRightOpenChanged: {
         if (GlobalStates.sidebarRightOpen) {
             Notifications.timeoutAll();

--- a/dots/.config/quickshell/imi/modules/common/functions/clockDepth.js
+++ b/dots/.config/quickshell/imi/modules/common/functions/clockDepth.js
@@ -27,6 +27,12 @@ function eligible(state) {
     // The per-wallpaper opt-out. Checked before the mask, so a declined mask
     // left on disk beside its marker cannot come back.
     if (s.optedOut) return false;
+    // The desktop selector is drawing the CANDIDATE at full size over these
+    // same widgets. The accepted mask underneath it would be a second
+    // silhouette arguing with the one being judged, and where the two disagree
+    // the difference reads as the candidate having claimed something it did
+    // not - which is a verdict given against the wrong picture.
+    if (s.selecting) return false;
     if (!s.maskPath) return false;
     // A live Wallpaper Engine project is a moving surface with no file to
     // segment, and a mask of the frozen greeter still would be a stale

--- a/dots/.config/quickshell/imi/modules/common/functions/clockDepth.js
+++ b/dots/.config/quickshell/imi/modules/common/functions/clockDepth.js
@@ -119,8 +119,59 @@ function normalisedPoint(rect, x, y) {
     };
 }
 
+// A click on the DESKTOP, as a point in the picture's own frame.
+//
+// The selection surface is a separate, screen-sized layer surface sitting over
+// the wallpaper, so a click arrives in screen coordinates while the
+// registration - `normalisedPoint` and the rectangle it consumes - is expressed
+// inside the box the cutout is drawn in. That box is the wallpaper viewport,
+// which is oversized and negatively offset whenever parallax is on.
+//
+// Composed here rather than at the call site for the same reason
+// `normalisedPoint` exists at all: the offset is the part that is silently
+// zero for whoever writes it. A viewport at rest with parallax switched off
+// sits at exactly (0, 0), so a translation that has been left out entirely is
+// correct on the first screen anyone tries it on and wrong by up to the whole
+// zoom overflow on every workspace but the middle one - and the wrong answer
+// is still a perfectly good mask, of the wrong thing.
+function promptFromScreen(box, pictureRect, screenX, screenY) {
+    const b = box || {};
+    if (!isFinite(screenX) || !isFinite(screenY))
+        return null;
+    return normalisedPoint(pictureRect, screenX - origin(b.x), screenY - origin(b.y));
+}
+
+// May a subject be picked on the desktop right now?
+//
+// A narrower question than `eligible`, and deliberately not a subset of it:
+// two of that predicate's refusals - no mask, and the per-wallpaper opt-out -
+// are exactly the states selecting exists to change, so gating the gesture on
+// them would make the feature unreachable from the half of the library it was
+// built for. What both refuse is the same underlying thing: a desktop whose
+// pixels are not the still image the producer is being asked about.
+function selectable(state) {
+    const s = state || {};
+    if (!s.wallpaperPath) return false;
+    // The wallpaper selector reverts a preview the moment it closes, and the
+    // gesture is entered by closing it - so the picture under the click would
+    // not be the picture the clicks get stored against.
+    if (s.previewing) return false;
+    // A live Wallpaper Engine project owns the screen; the still this service
+    // names is not what is being drawn, so a cutout of it is a sticker.
+    if (s.weActive) return false;
+    // Centred mode draws the wallpaper at its own size in its own shape, which
+    // is not the geometry the cutout is registered against.
+    if (s.centeredWallpaper) return false;
+    if (s.screenLocked) return false;
+    return true;
+}
+
 function clamp01(value) {
     return value < 0 ? 0 : (value > 1 ? 1 : value);
+}
+
+function origin(value) {
+    return (typeof value === "number" && isFinite(value)) ? value : 0;
 }
 
 function positive(value) {

--- a/dots/.config/quickshell/imi/modules/imi/background/Background.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/Background.qml
@@ -250,6 +250,23 @@ Variants {
             ? ParallaxMath.offsets(bgRoot.parallaxState)
             : ({ x: 0, y: 0 })
 
+        // Hands the depth layer's live box to the subject selector, which is a
+        // layer surface of its own and therefore in another window. Keyed by
+        // screen name and written per screen rather than as one rect, because
+        // the same wallpaper is cropped differently on every output and a
+        // cutout drawn into the wrong screen's box is a silhouette in the wrong
+        // place. Removing the entry on disarm rather than leaving a stale one
+        // behind keeps the map's contents equal to "the screens currently
+        // publishing", which is what the surface tests to know it can draw.
+        function publishDepthViewport(viewport): void {
+            const published = Object.assign({}, GlobalStates.clockDepthViewports)
+            if (viewport === null)
+                delete published[bgRoot.screen.name]
+            else
+                published[bgRoot.screen.name] = viewport
+            GlobalStates.clockDepthViewports = published
+        }
+
         property string effectiveWallpaperPath: {
             if (GlobalStates.screenLocked && Config.options.background.lockWall !== "")
                 return Config.options.background.lockWall
@@ -1350,6 +1367,10 @@ Variants {
                 enable: ClockDepth.enabled,
                 maskPath: ClockDepth.maskPath,
                 optedOut: ClockDepth.optedOut,
+                // The selection surface draws the candidate over these same
+                // widgets while it is up; two cutouts arguing is not a thing
+                // anyone can give a verdict on.
+                selecting: GlobalStates.clockDepthSelectOpen,
                 weActive: bgRoot.weActive,
                 wallpaperIsVideo: bgRoot.wallpaperIsVideo,
                 centeredWallpaper: bgRoot.centeredWallpaperEnabled,
@@ -1363,6 +1384,27 @@ Variants {
                     easing.bezierCurve: Appearance.animation.elementMove.bezierCurve
                 }
             }
+
+            // What the selection surface has to be handed to draw the same
+            // cutout on the same pixels. It is a separate layer surface in a
+            // separate window, so it can read neither this item nor the
+            // wallpaper item - and reconstructing the pan from parallax.js on
+            // the other side would be a second derivation of the one number
+            // this whole component exists to have only one of.
+            //
+            // Null while the mode is disarmed, so the binding is a comparison
+            // rather than a fresh object on every frame of every pan for the
+            // rest of the session.
+            readonly property var publishedViewport: GlobalStates.clockDepthSelectOpen
+                ? ({
+                    x: clockDepthLayer.x,
+                    y: clockDepthLayer.y,
+                    width: clockDepthLayer.width,
+                    height: clockDepthLayer.height,
+                    source: String(wallpaper.source)
+                })
+                : null
+            onPublishedViewportChanged: bgRoot.publishDepthViewport(clockDepthLayer.publishedViewport)
 
             // The registration lives in the component, not here, because the
             // wallpaper selector's picker draws the same cutout to ask whether

--- a/dots/.config/quickshell/imi/modules/imi/clockDepthSelect/ClockDepthSelect.qml
+++ b/dots/.config/quickshell/imi/modules/imi/clockDepthSelect/ClockDepthSelect.qml
@@ -1,0 +1,105 @@
+pragma ComponentBehavior: Bound
+import qs
+import qs.services
+import qs.modules.common
+import QtQuick
+import Quickshell
+
+/**
+ * Picking the wallpaper's subject on the desktop, at full size, over the real
+ * widgets.
+ *
+ * The gesture used to live on a ~300px thumbnail inside the wallpaper
+ * selector's depth picker, and the reason that was wrong is structural rather
+ * than aesthetic: the mask is JUDGED at screen size against the widgets it has
+ * to occlude, and it was AUTHORED against a postage stamp. A click landing on a
+ * character's shoulder in the preview is several hundred pixels off at
+ * 5120x1440, and nothing about the result says so - a mis-aimed click comes
+ * back as a perfectly good mask of the wrong thing.
+ *
+ * So the surface is the desktop. Nothing here redraws the wallpaper: it is
+ * already on screen at exactly the size and crop the click has to be measured
+ * against, and the selection surface is transparent over it, so the pixels the
+ * user clicks are by construction the pixels the depth layer will mask. The
+ * widgets stay live underneath for the same reason - they are what the cutout
+ * has to occlude, and a composited copy of them would be a second thing that
+ * can drift from the first.
+ *
+ * The picker keeps the two salient detectors, this wallpaper's verdict, and the
+ * way in. It is where you SEE the state; this is where you author it.
+ */
+Scope {
+    id: root
+
+    // The wallpaper this session is cutting, captured when the mode arms. The
+    // clicks are stored against that picture's cache key, so if the picture
+    // changes underneath the surface every one of them belongs to a different
+    // file and the cutout on screen is registered against something that is no
+    // longer there.
+    property string armedWallpaper: ""
+
+    function cancel(): void {
+        GlobalStates.clockDepthSelectOpen = false
+    }
+
+    function accept(): void {
+        if (ClockDepth.promptedModel === "")
+            return
+        ClockDepth.acceptModel(ClockDepth.promptedModel)
+        // Accepting a cutout while the feature is switched off would put the
+        // artifact on disk and change nothing on screen, which reads as the
+        // button not working. The acceptance IS the intent - same reasoning as
+        // the picker's own accept, which the two detector columns still use.
+        Config.options.background.clockDepth.enable = true
+        root.cancel()
+    }
+
+    function decline(): void {
+        ClockDepth.declineWallpaper()
+        root.cancel()
+    }
+
+    Connections {
+        target: GlobalStates
+        function onClockDepthSelectOpenChanged() {
+            root.armedWallpaper = GlobalStates.clockDepthSelectOpen
+                ? ClockDepth.wallpaperPath : ""
+        }
+    }
+
+    Connections {
+        target: ClockDepth
+        // Two ways the ground moves under an armed selection, and both leave
+        // the surface drawing a cutout of a picture the desktop is not showing:
+        // the wallpaper is switched, or the desktop stops being a still image
+        // at all (a Wallpaper Engine project starts, the screen locks, centred
+        // mode goes on). Disarming is the whole response - the candidate stays
+        // on disk under its own key, so re-entering on that wallpaper picks the
+        // gesture back up rather than starting over.
+        function onWallpaperPathChanged() {
+            if (GlobalStates.clockDepthSelectOpen
+                && ClockDepth.wallpaperPath !== root.armedWallpaper)
+                root.cancel()
+        }
+        function onSelectableChanged() {
+            if (GlobalStates.clockDepthSelectOpen && !ClockDepth.selectable)
+                root.cancel()
+        }
+    }
+
+    Variants {
+        model: Quickshell.screens
+        delegate: Loader {
+            id: surfaceLoader
+            required property var modelData
+            active: GlobalStates.clockDepthSelectOpen
+
+            sourceComponent: ClockDepthSelectSurface {
+                screen: surfaceLoader.modelData
+                onCancelled: root.cancel()
+                onAccepted: root.accept()
+                onDeclined: root.decline()
+            }
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/modules/imi/clockDepthSelect/ClockDepthSelectSurface.qml
+++ b/dots/.config/quickshell/imi/modules/imi/clockDepthSelect/ClockDepthSelectSurface.qml
@@ -1,0 +1,344 @@
+pragma ComponentBehavior: Bound
+import qs
+import qs.services
+import qs.modules.common
+import qs.modules.common.widgets
+import qs.modules.imi.background
+import QtQuick
+import QtQuick.Layouts
+import Qt5Compat.GraphicalEffects
+import Quickshell
+import Quickshell.Wayland
+import "../../common/functions/clockDepth.js" as ClockDepthLogic
+
+/**
+ * One screen's worth of the subject selector: a transparent layer surface over
+ * the desktop, its chrome, and the cutout it is authoring.
+ *
+ * TRANSPARENT is the whole design. The wallpaper is already on screen at
+ * exactly the size and crop the mask has to line up with, and the desktop
+ * widgets are already drawn under it - so a click here lands on the pixels the
+ * depth layer will mask, by construction rather than by arithmetic, and the
+ * cutout drawn over them is the real occlusion rather than a picture of one.
+ * Redrawing either would be a second copy, and a second copy is a second chance
+ * to be misaligned in a feature that has already spent an evening chasing a
+ * misalignment that turned out not to exist.
+ *
+ * The one thing this surface cannot see is where the wallpaper's box sits: the
+ * background is a different window, its viewport is oversized and offset by the
+ * parallax pan, and reconstructing that pan here would be a second derivation
+ * of the number ClockDepthCutout exists to have only one of. It is published
+ * per screen instead (GlobalStates.clockDepthViewports, written by
+ * Background.qml while this mode is armed), and everything geometric follows
+ * from it: the cutout is drawn into that box and the click is measured against
+ * the rectangle that same cutout publishes.
+ */
+PanelWindow {
+    id: root
+
+    signal cancelled()
+    signal accepted()
+    signal declined()
+
+    color: "transparent"
+    WlrLayershell.namespace: "quickshell:clockDepthSelect"
+    WlrLayershell.layer: WlrLayer.Overlay
+    // OnDemand, not Exclusive: this surface exists once per output, and an
+    // Exclusive grab is session-wide rather than scoped to the screen it was
+    // taken on - it would swallow what the user types on any other monitor.
+    // Same choice, for the same reason, as the region selector.
+    WlrLayershell.keyboardFocus: WlrKeyboardFocus.OnDemand
+    exclusionMode: ExclusionMode.Ignore
+    anchors {
+        left: true
+        right: true
+        top: true
+        bottom: true
+    }
+
+    // Where the wallpaper's whole box sits on THIS screen, published by the
+    // background. Null until it arrives, and null again the moment the mode
+    // disarms - so nothing here draws against a guessed geometry.
+    readonly property var viewport: GlobalStates.clockDepthViewports?.[root.screen.name] ?? null
+    readonly property string modelName: ClockDepth.promptedModel
+    // The CANDIDATE, not ClockDepth.maskPath: that one is only ever the
+    // accepted mask, and the whole point of this surface is judging something
+    // before it is accepted.
+    readonly property string maskPath: ClockDepth.candidates?.[root.modelName] ?? ""
+    readonly property string maskRevision: ClockDepth.revisions?.[root.modelName] ?? ""
+    readonly property var points: ClockDepth.points ?? []
+    readonly property bool busy: ClockDepth.running !== ""
+
+    // Off by default, exactly as it is in the picker. At full size the veil
+    // dims the widgets as well - which is right for reading the mask's edge and
+    // wrong for judging whether the cutout occludes the clock, and those are
+    // two different questions asked at two different moments.
+    property bool inspect: false
+    // Gated on the mask having DECODED rather than on a path: the veil is the
+    // INVERSE of the mask surface, so a mask that has not loaded is a
+    // transparent surface whose inverse blacks out the entire desktop - a
+    // failure that reads as the model having claimed nothing.
+    readonly property bool inspecting: root.inspect && root.maskPath !== ""
+        && cutout.maskStatus === Image.Ready
+
+    WindowBlurRegion {
+        targetWindow: root
+        regionItem: chromeCard
+        regionRadius: Appearance.rounding.normal
+    }
+
+    Item {
+        id: content
+        anchors.fill: parent
+        focus: true
+
+        Keys.onPressed: event => {
+            if (event.key === Qt.Key_Escape) {
+                root.cancelled()
+                event.accepted = true
+            }
+        }
+
+        // Everything registered to the picture lives in here, at the wallpaper
+        // box's own geometry, so each child can anchor to it and no child needs
+        // its own copy of the offset. The box always covers the screen (the
+        // parallax viewport is the screen scaled up), so a veil filling it
+        // reaches every pixel a veil filling the screen would.
+        Item {
+            id: pictureFrame
+            visible: root.viewport !== null
+            x: root.viewport?.x ?? 0
+            y: root.viewport?.y ?? 0
+            width: root.viewport?.width ?? root.width
+            height: root.viewport?.height ?? root.height
+
+            // INSPECT: everything the model did NOT claim, dimmed. Masked by
+            // the inverse of the SAME registered surface the cutout is masked
+            // by, so the lit region and the drawn region cannot be a pixel
+            // apart.
+            Rectangle {
+                id: veilSource
+                anchors.fill: parent
+                color: "black"
+                visible: false
+            }
+            Loader {
+                anchors.fill: parent
+                active: root.inspecting
+                visible: active
+                sourceComponent: OpacityMask {
+                    source: veilSource
+                    maskSource: cutout.maskSurface
+                    invert: true
+                    opacity: 0.66
+                }
+            }
+
+            // INSPECT: the silhouette traced. The veil says WHAT was claimed;
+            // this says where the boundary runs and how hard it is. Drawn under
+            // the cutout so only its outer half shows.
+            Loader {
+                anchors.fill: parent
+                active: root.inspecting
+                visible: active
+                sourceComponent: Glow {
+                    source: cutout.maskSurface
+                    // Hardcoded, and this is the one place in the shell that is
+                    // right: every Appearance colour is generated FROM this
+                    // wallpaper, so a token here is guaranteed to be a colour
+                    // the picture already contains.
+                    color: "#ff00c8"
+                    radius: 8
+                    samples: 17
+                    spread: 0.45
+                    // Without it the blur clamps at the item's edge and a
+                    // subject touching the bottom of the frame smears into a
+                    // band across it, which reads as a defect in the mask being
+                    // judged rather than in the instrument judging it.
+                    transparentBorder: true
+                }
+            }
+
+            // The subject, cut out exactly the way the desktop cuts it out -
+            // the same component, on the same box, so this cannot show a
+            // registration the desktop does not use. It is the real occlusion:
+            // the widgets underneath are the live ones.
+            ClockDepthCutout {
+                id: cutout
+                anchors.fill: parent
+                wallpaperSource: root.viewport?.source ?? ""
+                maskPath: root.maskPath
+                maskRevision: root.maskRevision
+            }
+
+            // Where the clicks landed, drawn back onto the picture through the
+            // cutout's OWN mask rectangle. Anything else would put the disc
+            // somewhere other than where the click was sent, which is the one
+            // thing that would make this gesture unteachable.
+            Repeater {
+                model: root.points
+
+                Item {
+                    id: marker
+                    required property var modelData
+                    readonly property rect frame: cutout.maskRect
+                    readonly property bool include: (marker.modelData.label ?? 1) === 1
+
+                    width: 22
+                    height: 22
+                    x: marker.frame.x + marker.modelData.x * marker.frame.width - width / 2
+                    y: marker.frame.y + marker.modelData.y * marker.frame.height - height / 2
+
+                    // Black and white, and hardcoded, for the same reason the
+                    // contour is: a disc against its own outline reads on any
+                    // image, and every generated token is a colour this picture
+                    // is guaranteed to contain.
+                    Rectangle {
+                        anchors.fill: parent
+                        radius: width / 2
+                        color: marker.include ? "#ffffff" : "#101010"
+                        border.width: 2
+                        border.color: marker.include ? "#101010" : "#ffffff"
+
+                        MaterialSymbol {
+                            anchors.centerIn: parent
+                            text: marker.include ? "add" : "remove"
+                            iconSize: 14
+                            color: marker.include ? "#101010" : "#ffffff"
+                        }
+                    }
+                }
+            }
+        }
+
+        // The gesture. Screen-sized rather than box-sized because the box
+        // overflows the screen and a click can only ever arrive inside it
+        // anyway; the conversion takes the box as its origin.
+        MouseArea {
+            id: pointArea
+            anchors.fill: parent
+            // Gated on the wallpaper having DECODED, not merely on a path: an
+            // Image's implicit size reads 0 until its source resolves, and
+            // `coverRect` answers a zero-sized source with the box itself - so
+            // a click arriving in that window would be measured against a frame
+            // the picture does not occupy and sent to the producer as a point
+            // somewhere else entirely.
+            enabled: root.viewport !== null && cutout.wallpaperStatus === Image.Ready
+            acceptedButtons: Qt.LeftButton | Qt.RightButton
+            cursorShape: Qt.CrossCursor
+            onClicked: mouse => {
+                const point = ClockDepthLogic.promptFromScreen(
+                    Qt.rect(pictureFrame.x, pictureFrame.y,
+                        pictureFrame.width, pictureFrame.height),
+                    cutout.maskRect, mouse.x, mouse.y)
+                if (!point)
+                    return
+                ClockDepth.addPoint(point.x, point.y, mouse.button === Qt.LeftButton)
+            }
+        }
+
+        Rectangle {
+            id: chromeCard
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.bottom: parent.bottom
+            anchors.bottomMargin: Appearance.spacing.space300
+            implicitWidth: chromeRow.implicitWidth + Appearance.spacing.space300
+            implicitHeight: chromeRow.implicitHeight + Appearance.spacing.space200
+            radius: Appearance.rounding.normal
+            color: Appearance.colors.colLayer0
+
+            // The chrome is a set of controls, so it keeps its own clicks
+            // instead of letting them fall through to the point gesture behind
+            // it - pressing "Use this" must not also plant a point under it.
+            MouseArea {
+                anchors.fill: parent
+                acceptedButtons: Qt.AllButtons
+                onClicked: {}
+            }
+
+            RowLayout {
+                id: chromeRow
+                anchors.centerIn: parent
+                spacing: Appearance.spacing.space150
+
+                MaterialSymbol {
+                    text: "layers"
+                    iconSize: Appearance.font.pixelSize.huge
+                    color: Appearance.colors.colOnLayer0
+                }
+
+                ColumnLayout {
+                    spacing: 0
+
+                    StyledText {
+                        // Which picture is being cut, said outright. The mode is
+                        // entered from a surface that has just closed, and the
+                        // clicks are stored against this file's cache key.
+                        text: Translation.tr("Depth for %1")
+                            .arg(ClockDepth.wallpaperPath.split("/").pop())
+                        font.pixelSize: Appearance.font.pixelSize.normal
+                        color: Appearance.colors.colOnLayer0
+                    }
+                    StyledText {
+                        // The whole instruction set, on the surface the gesture
+                        // is aimed at, because there is nowhere else a person
+                        // would look for it.
+                        text: {
+                            if (ClockDepth.lastError !== "")
+                                return ClockDepth.lastError
+                            if (root.busy)
+                                return Translation.tr("Cutting…")
+                            if (root.points.length === 0)
+                                return Translation.tr("Left-click the thing that should stand in front of your widgets.")
+                            if (root.maskPath === "")
+                                return Translation.tr("Nothing there — click on the subject itself.")
+                            return Translation.tr("Right-click anything it grabbed that it should not have.")
+                        }
+                        font.pixelSize: Appearance.font.pixelSize.smaller
+                        color: ClockDepth.lastError !== ""
+                            ? Appearance.m3colors.m3error
+                            : Appearance.colors.colSubtext
+                    }
+                }
+
+                DialogButton {
+                    id: undoButton
+                    enabled: !root.busy && root.points.length > 0
+                    buttonText: Translation.tr("Undo")
+                    onClicked: ClockDepth.undoPoint()
+                }
+                DialogButton {
+                    id: clearButton
+                    enabled: !root.busy && root.points.length > 0
+                    buttonText: Translation.tr("Start over")
+                    onClicked: ClockDepth.clearPoints()
+                }
+                DialogButton {
+                    id: inspectButton
+                    toggled: root.inspect
+                    buttonText: Translation.tr("Inspect")
+                    onClicked: root.inspect = !root.inspect
+                }
+                DialogButton {
+                    id: declineButton
+                    buttonText: Translation.tr("No depth for this wallpaper")
+                    onClicked: root.declined()
+                }
+                DialogButton {
+                    id: acceptButton
+                    enabled: !root.busy && root.maskPath !== ""
+                    colBackground: Appearance.colors.colPrimary
+                    colBackgroundHover: Appearance.colors.colPrimaryHover
+                    colText: Appearance.colors.colOnPrimary
+                    buttonText: Translation.tr("Use this")
+                    onClicked: root.accepted()
+                }
+                DialogButton {
+                    id: cancelButton
+                    buttonText: Translation.tr("Cancel (Esc)")
+                    onClicked: root.cancelled()
+                }
+            }
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/modules/imi/clockDepthSelect/ClockDepthSelectSurface.qml
+++ b/dots/.config/quickshell/imi/modules/imi/clockDepthSelect/ClockDepthSelectSurface.qml
@@ -269,17 +269,26 @@ PanelWindow {
 
                 ColumnLayout {
                     spacing: 0
+                    // Bounded, and both lines elide: a wallpaper's file name is
+                    // arbitrary and the instruction is a sentence, so without a
+                    // ceiling the toolbar grows past the screen it is centred
+                    // on and its buttons leave with it.
+                    Layout.maximumWidth: 420
 
                     StyledText {
                         // Which picture is being cut, said outright. The mode is
                         // entered from a surface that has just closed, and the
                         // clicks are stored against this file's cache key.
+                        Layout.fillWidth: true
+                        elide: Text.ElideMiddle
                         text: Translation.tr("Depth for %1")
                             .arg(ClockDepth.wallpaperPath.split("/").pop())
                         font.pixelSize: Appearance.font.pixelSize.normal
                         color: Appearance.colors.colOnLayer0
                     }
                     StyledText {
+                        Layout.fillWidth: true
+                        elide: Text.ElideRight
                         // The whole instruction set, on the surface the gesture
                         // is aimed at, because there is nowhere else a person
                         // would look for it.
@@ -316,6 +325,15 @@ PanelWindow {
                 DialogButton {
                     id: inspectButton
                     toggled: root.inspect
+                    // RippleButton fills a toggled button with colPrimary and
+                    // DialogButton writes its label in colPrimary, so a toggle
+                    // left to the defaults reads its own text off its own
+                    // background. Set through colEnabled rather than colText,
+                    // which is the alias that would take the disabled dim with
+                    // it.
+                    colEnabled: root.inspect
+                        ? Appearance.colors.colOnPrimary
+                        : Appearance.colors.colPrimary
                     buttonText: Translation.tr("Inspect")
                     onClicked: root.inspect = !root.inspect
                 }

--- a/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/ClockDepthPicker.qml
+++ b/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/ClockDepthPicker.qml
@@ -5,7 +5,6 @@ import qs.services
 import qs.modules.common
 import qs.modules.common.widgets
 import qs.modules.imi.background
-import "../../common/functions/clockDepth.js" as ClockDepthLogic
 
 /**
  * Where the quality gate lives, and it is a human - so this is the instrument
@@ -34,13 +33,16 @@ import "../../common/functions/clockDepth.js" as ClockDepthLogic
  * answers a different question: not "what is the subject of this picture" but
  * "what is the thing at this point". So the user points at it.
  *
- * Its whole interaction is the preview: left-click adds a point the cutout must
- * contain, right-click one it must not, and the mask redraws per click because
- * the picture is encoded once and each click only decodes - 1.6s for the first
- * and 0.3s for every one after it. Both gestures are said on the preview
- * itself, because a click surface with its instructions somewhere else is a
- * click surface nobody discovers. The clicks are drawn back on as plus and
- * minus discs so a correction is aimed at a thing rather than at a memory.
+ * That column is NOT clicked here. The gesture used to live on this preview and
+ * it was the wrong surface for it: the mask is judged at screen size against
+ * real widgets and was being authored against a ~300px thumbnail, where a click
+ * landing on a character's shoulder is several hundred pixels off by the time
+ * anyone sees the result - and a mis-aimed click comes back as a perfectly good
+ * mask of the wrong thing. Selecting happens on the desktop itself
+ * (modules/imi/clockDepthSelect), on the wallpaper as it is actually drawn, and
+ * this column is the way in and the record of what came back: the clicks are
+ * drawn on as plus and minus discs, and the cutout they produced sits under
+ * them.
  *
  * All three columns are the same width, which is the point of the layout: the
  * cutouts are being compared, and the clickable one is not more important than
@@ -95,7 +97,7 @@ Item {
             // perfectly good thing to stand in front of the clock. It is a
             // verdict on the two models that answer on their own, and the
             // column that answers a click is what it points at.
-            return Translation.tr("Neither detector found a subject. Click the one you want in the third preview.")
+            return Translation.tr("Neither detector found a subject. Pick the one you want on the desktop itself.")
         case "candidate":
             return Translation.tr("A cutout is ready to judge. Nothing is drawn until you keep one.")
         case "unreadable":
@@ -107,6 +109,10 @@ Item {
     }
 
     signal closeRequested()
+    // The way into the desktop selector. Raised rather than acted on, because
+    // getting there means closing this dialog AND the wallpaper selector around
+    // it, and neither is this component's to close.
+    signal selectOnDesktopRequested()
 
     Rectangle {
         anchors.fill: parent
@@ -460,43 +466,6 @@ Item {
                             }
                         }
 
-                        // The gesture. Declared after everything it points at so
-                        // it is on top, and only for the prompted column - the
-                        // salient ones answer the picture and have nothing to
-                        // aim.
-                        MouseArea {
-                            id: pointArea
-                            anchors.fill: parent
-                            // Gated on the wallpaper having DECODED, not merely
-                            // on a path. An Image's implicit size reads 0 until
-                            // its source resolves, and `coverRect` answers a
-                            // zero-sized source with the box itself - so a click
-                            // arriving in that window would be measured against
-                            // a frame the picture does not occupy and sent to
-                            // the producer as a point somewhere else entirely.
-                            enabled: candidate.prompted && root.wallpaper !== ""
-                                && previewCutout.wallpaperStatus === Image.Ready
-                            visible: enabled
-                            acceptedButtons: Qt.LeftButton | Qt.RightButton
-                            cursorShape: Qt.CrossCursor
-                            onClicked: mouse => {
-                                // The cutout's own mask rectangle is where the
-                                // whole wallpaper sits inside this preview, so
-                                // the click's fraction along it IS the point in
-                                // the picture. Worked out in clockDepth.js
-                                // because it is the one part of this gesture a
-                                // test can reach, and because a click sent to
-                                // the wrong part of the picture comes back as a
-                                // perfectly good mask of the wrong thing.
-                                const point = ClockDepthLogic.normalisedPoint(
-                                    previewCutout.maskRect, mouse.x, mouse.y)
-                                if (!point)
-                                    return
-                                ClockDepth.addPoint(point.x, point.y,
-                                    mouse.button === Qt.LeftButton)
-                            }
-                        }
-
                         // Along the bottom edge rather than centred: the middle
                         // of the preview is where the clock is, and a status
                         // label printed across it is sitting on the one thing
@@ -533,18 +502,20 @@ Item {
                                             ? Translation.tr("Cutting…")
                                             : Translation.tr("Looking for a subject…")
                                     if (candidate.prompted) {
+                                        if (!ClockDepth.selectable)
+                                            return Translation.tr("Apply this wallpaper to pick on the desktop")
                                         if (candidate.points.length === 0)
-                                            return Translation.tr("Click the subject")
+                                            return Translation.tr("Pick the subject on the desktop")
                                         if (candidate.maskPath === "")
-                                            return Translation.tr("Nothing there — click on the subject itself")
-                                        return Translation.tr("Right-click to exclude what it grabbed")
+                                            return Translation.tr("Nothing found there yet")
+                                        return Translation.tr("Refine it on the desktop")
                                     }
                                     if (candidate.maskPath !== "")
                                         return ""
                                     return candidate.refused
                                         ? (candidate.otherFound
                                             ? Translation.tr("Nothing here — another column found something")
-                                            : Translation.tr("Nothing here — try clicking the subject"))
+                                            : Translation.tr("Nothing here — try picking it on the desktop"))
                                         : Translation.tr("Not run yet")
                                 }
                                 font.pixelSize: Appearance.font.pixelSize.small
@@ -566,50 +537,32 @@ Item {
                                 : Translation.tr("Run")
                             onClicked: ClockDepth.runModel(candidate.modelName)
                         }
-                        // The prompted column's two corrections, as glyphs
-                        // rather than as labelled buttons: a third of the
-                        // dialog's width already carries an accept button, and
-                        // the words that would go on these are the ones the
-                        // preview's own line is saying.
-                        RippleButton {
-                            id: undoButton
-                            visible: candidate.prompted
-                            enabled: !root.busy && candidate.points.length > 0
-                            implicitWidth: 36
-                            implicitHeight: 36
-                            buttonRadius: height / 2
-                            onClicked: ClockDepth.undoPoint()
-                            contentItem: MaterialSymbol {
-                                anchors.centerIn: parent
-                                text: "undo"
-                                iconSize: Appearance.font.pixelSize.larger
-                                color: Appearance.colors.colOnLayer0
-                            }
-                            StyledToolTip {
-                                text: Translation.tr("Take back the last click")
-                            }
-                        }
-                        RippleButton {
-                            id: clearButton
-                            visible: candidate.prompted
-                            enabled: !root.busy && candidate.points.length > 0
-                            implicitWidth: 36
-                            implicitHeight: 36
-                            buttonRadius: height / 2
-                            onClicked: ClockDepth.clearPoints()
-                            contentItem: MaterialSymbol {
-                                anchors.centerIn: parent
-                                text: "backspace"
-                                iconSize: Appearance.font.pixelSize.larger
-                                color: Appearance.colors.colOnLayer0
-                            }
-                            StyledToolTip {
-                                text: Translation.tr("Start this selection over")
-                            }
-                        }
                         Item { Layout.fillWidth: true }
+                        // The prompted column's one action, and it leaves this
+                        // dialog: the clicking, the undo, the start-over and
+                        // the verdict all live on the desktop now, where the
+                        // cutout is the size it will be judged at and the
+                        // widgets it has to hide behind are the real ones.
+                        // Refusing when the desktop is showing something else -
+                        // a preview this dialog's own grid is about to revert,
+                        // a live Wallpaper Engine project - is the difference
+                        // between selecting on the wallpaper and selecting on
+                        // whatever happens to be there afterwards.
+                        DialogButton {
+                            id: selectOnDesktopButton
+                            visible: candidate.prompted
+                            enabled: !root.busy && ClockDepth.selectable
+                            colBackground: Appearance.colors.colPrimary
+                            colBackgroundHover: Appearance.colors.colPrimaryHover
+                            colText: Appearance.colors.colOnPrimary
+                            buttonText: candidate.points.length > 0
+                                ? Translation.tr("Refine on desktop")
+                                : Translation.tr("Pick on desktop")
+                            onClicked: root.selectOnDesktopRequested()
+                        }
                         DialogButton {
                             id: acceptButton
+                            visible: !candidate.prompted
                             enabled: !root.busy && candidate.maskPath !== ""
                             colBackground: Appearance.colors.colPrimary
                             colBackgroundHover: Appearance.colors.colPrimaryHover

--- a/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/WallpaperSelectorContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/WallpaperSelectorContent.qml
@@ -514,6 +514,17 @@ MouseArea {
                             Component.onCompleted: ClockDepth.picking = true
                             Component.onDestruction: ClockDepth.picking = false
                             onCloseRequested: root.depthPickerOpen = false
+                            // The mode is armed BEFORE either surface closes.
+                            // ClockDepth keeps its cache answers only while
+                            // something is watching, and destroying the picker
+                            // drops its claim - so arming afterwards would let
+                            // the service forget the candidate in between and
+                            // re-query for it from an empty state.
+                            onSelectOnDesktopRequested: {
+                                GlobalStates.clockDepthSelectOpen = true;
+                                root.depthPickerOpen = false;
+                                GlobalStates.wallpaperSelectorOpen = false;
+                            }
                         }
                     }
 

--- a/dots/.config/quickshell/imi/panelFamilies/ImmaterialImpulseFamily.qml
+++ b/dots/.config/quickshell/imi/panelFamilies/ImmaterialImpulseFamily.qml
@@ -5,6 +5,7 @@ import qs.modules.common
 import qs.modules.imi.background
 import qs.modules.imi.cheatsheet
 import qs.modules.imi.bar
+import qs.modules.imi.clockDepthSelect
 import qs.modules.imi.dock
 import qs.modules.imi.lock
 import qs.modules.imi.mediaControls
@@ -36,6 +37,7 @@ Scope {
     PanelLoader { component: BarPopupOverlay {} }
     PanelLoader { component: Background {} }
     PanelLoader { component: Cheatsheet {} }
+    PanelLoader { component: ClockDepthSelect {} }
     PanelLoader { extraCondition: Config.options.dock.enable; component: Dock {} }
     PanelLoader { component: Lock {} }
     PanelLoader { component: MediaControls {} }

--- a/dots/.config/quickshell/imi/services/ClockDepth.qml
+++ b/dots/.config/quickshell/imi/services/ClockDepth.qml
@@ -1,12 +1,14 @@
 pragma Singleton
 pragma ComponentBehavior: Bound
 
+import qs
 import qs.services
 import qs.modules.common
 import qs.modules.common.functions
 import Quickshell
 import Quickshell.Io
 import QtQuick
+import "../modules/common/functions/clockDepth.js" as ClockDepthLogic
 
 /**
  * What the subject-mask cache holds for the wallpaper that is on screen.
@@ -34,7 +36,14 @@ Singleton {
     // on a machine that has never enabled depth would show nothing and be unable
     // to accept anything - which is the one order every new user arrives in.
     property bool picking: false
+    // The desktop selector counts as picking for every purpose here, and it is
+    // read off the flag rather than given a `picking` write of its own: the
+    // picker is destroyed as the wallpaper selector closes and the mode arms,
+    // so one bool with two writers would be cleared by the surface that is
+    // going away, on an ordering nothing here controls - and clearing it
+    // forgets the candidate the user is about to judge.
     readonly property bool watching: root.enabled || root.picking
+        || GlobalStates.clockDepthSelectOpen
 
     // The wallpaper on screen, not the one in the config: the selector previews
     // by path while the user arrows through the grid, and a mask belonging to
@@ -68,6 +77,19 @@ Singleton {
     property var revisions: ({})
 
     readonly property bool optedOut: root.state === "declined"
+
+    // Whether the desktop is currently showing the still image this service is
+    // asking about, which is the precondition for picking a subject on it.
+    // Assembled here because two windows read it - the picker's way in, and the
+    // selection mode's own guard against the ground moving under it - and two
+    // copies of a predicate are two answers waiting to disagree.
+    readonly property bool selectable: ClockDepthLogic.selectable({
+        wallpaperPath: root.wallpaperPath,
+        previewing: Wallpapers.previewPath !== "",
+        weActive: (Config.options.wallpaperSelector.wallpaperEngine.activePath ?? "") !== "",
+        centeredWallpaper: Config.options.background.centeredWallpaper ?? false,
+        screenLocked: GlobalStates.screenLocked
+    })
 
     property string queriedPath: ""
 

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -965,6 +965,12 @@ if ! python3 "$SCRIPT_DIR/lint_clock_depth_geometry.py"; then
     exit 1
 fi
 
+echo "Running clock depth desktop selector contract tests..."
+if ! python3 "$SCRIPT_DIR/test_clock_depth_select_contract.py"; then
+    echo "Clock depth desktop selector contract tests failed."
+    exit 1
+fi
+
 echo "Running clock depth compositing tests..."
 if ! python3 "$SCRIPT_DIR/test_clock_depth_compositing.py"; then
     echo "Clock depth compositing tests failed."

--- a/dots/.config/quickshell/imi/tests/test_clock_depth_select_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_clock_depth_select_contract.py
@@ -1,0 +1,480 @@
+#!/usr/bin/env python3
+"""The desktop subject selector's surface, its arming, and its verdicts.
+
+Picking the wallpaper's subject moved off a ~300px thumbnail in the wallpaper
+selector and onto the desktop, at full size, over the real widgets. Almost
+nothing about that is reachable from a unit test - qmltestrunner cannot
+construct a layer surface, weston implements no wlr-layer-shell, and the one
+thing the mode is for is a human looking at pixels - so the parts that ARE
+source text are pinned here.
+
+What each group is guarding, and why the failure would otherwise be silent:
+
+  - THE SURFACE. Its whole design is that it redraws nothing: the wallpaper is
+    already on screen at the size and crop the click has to be measured
+    against, and the widgets are already under it. An `Image` appearing in that
+    file is a second copy of the picture, which is a second chance to be
+    misaligned - and a misalignment here reads as the model having picked the
+    wrong thing.
+  - THE CONVERSION. A click arrives in screen coordinates and has to reach the
+    producer as a point in the picture. It goes screen -> the box the
+    background published -> the rectangle ClockDepthCutout publishes ->
+    `normalisedPoint`, and every step of that already exists. A second
+    derivation - recomputing the crop here, or reading `coverRect` - would be a
+    registration nothing else uses, which is the exact failure ClockDepthCutout
+    was extracted to make impossible.
+  - THE ARMING. Entering, escaping, accepting, declining, and the ground moving
+    underneath (the wallpaper switching, the desktop ceasing to show a still).
+    Every one of these leaves either a surface over a desktop it no longer
+    describes, or a verdict recorded against the wrong picture.
+  - THE PICKER. It is the way IN and the record of state now, not the place a
+    mask is authored. The gesture coming back to it is a regression, not a
+    convenience.
+"""
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+RULES = ROOT.parents[1] / "hypr/hyprland/rules.lua"
+
+SURFACE = ROOT / "modules/imi/clockDepthSelect/ClockDepthSelectSurface.qml"
+MODE = ROOT / "modules/imi/clockDepthSelect/ClockDepthSelect.qml"
+GLOBAL_STATES = ROOT / "GlobalStates.qml"
+BACKGROUND = ROOT / "modules/imi/background/Background.qml"
+SERVICE = ROOT / "services/ClockDepth.qml"
+PICKER = ROOT / "modules/imi/wallpaperSelector/ClockDepthPicker.qml"
+SELECTOR = ROOT / "modules/imi/wallpaperSelector/WallpaperSelectorContent.qml"
+FAMILY = ROOT / "panelFamilies/ImmaterialImpulseFamily.qml"
+
+NAMESPACE = "quickshell:clockDepthSelect"
+
+
+def strip_comments(source):
+    """Drop comments, keeping newlines so line-anchored patterns still work.
+
+    Needed in both directions here. Every rule below is explained in a comment
+    beside the code that honours it, so a check reading raw text would find its
+    own prose and pass on a file that had deleted the code - and a brace inside
+    a comment would derail the block reader. String state is tracked because
+    `file://` inside a template literal is not the start of a comment.
+    """
+    out = []
+    index, length = 0, len(source)
+    quote = None
+    while index < length:
+        char = source[index]
+        if quote:
+            out.append(char)
+            if char == "\\" and index + 1 < length:
+                out.append(source[index + 1])
+                index += 2
+                continue
+            if char == quote:
+                quote = None
+            index += 1
+            continue
+        if char in "'\"`":
+            quote = char
+            out.append(char)
+            index += 1
+            continue
+        if char == "/" and index + 1 < length and source[index + 1] == "/":
+            while index < length and source[index] != "\n":
+                index += 1
+            continue
+        if char == "/" and index + 1 < length and source[index + 1] == "*":
+            end = source.find("*/", index + 2)
+            end = length if end < 0 else end + 2
+            out.append("\n" * source.count("\n", index, end))
+            index = end
+            continue
+        out.append(char)
+        index += 1
+    return "".join(out)
+
+
+def body_after(source, marker):
+    """The brace-matched block that opens at the first `marker` in `source`.
+
+    Brace-matched rather than line-scoped because every one of these bodies is
+    written across several lines, and a line-scoped reader finds an opening
+    brace, reports a clean file, and stops looking.
+    """
+    found = re.search(marker, source)
+    if not found:
+        return None
+    opening = source.find("{", found.end() - 1)
+    if opening < 0:
+        return None
+    depth = 0
+    for index in range(opening, len(source)):
+        char = source[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source[opening + 1:index]
+    return None
+
+
+def block_for(source, object_id):
+    """The whole declaration of the object carrying `id: <object_id>`."""
+    marker = re.search(rf"^\s*id:\s*{re.escape(object_id)}\s*$", source, re.MULTILINE)
+    if not marker:
+        return None
+    opening = source.rfind("{", 0, marker.start())
+    if opening < 0:
+        return None
+    depth = 0
+    for index in range(opening, len(source)):
+        char = source[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source[opening + 1:index]
+    return None
+
+
+def text(path):
+    return strip_comments(path.read_text())
+
+
+class TheSurfaceRedrawsNothing(unittest.TestCase):
+    """The transparent-over-the-real-thing property, in source terms."""
+
+    def setUp(self):
+        self.surface = text(SURFACE)
+
+    def test_the_surface_declares_no_image_of_its_own(self):
+        # The wallpaper is on screen already. An Image here would be a second
+        # copy of it, drawn from a second decode at a geometry this file worked
+        # out for itself - and this feature has already spent an evening on a
+        # misalignment that turned out not to exist.
+        self.assertNotRegex(
+            self.surface, r"(?<![\w.])Image\s*\{",
+            "the selection surface must not draw a picture of its own - the "
+            "wallpaper under it is the one the mask has to line up with")
+
+    def test_the_surface_is_transparent_and_takes_the_whole_screen(self):
+        self.assertIn('color: "transparent"', self.surface)
+        for edge in ("left", "right", "top", "bottom"):
+            self.assertRegex(self.surface, rf"{edge}:\s*true")
+
+    def test_the_cutout_is_the_shared_component_with_its_revision(self):
+        cutout = block_for(self.surface, "cutout")
+        self.assertIsNotNone(cutout, "the surface draws no ClockDepthCutout")
+        self.assertIn("ClockDepthCutout", self.surface)
+        # Qt caches a pixmap by URL and the candidate is rewritten at the same
+        # path on every click, so without the producer's token the preview
+        # freezes on the first click's mask - which reads exactly like the
+        # model ignoring every point after the first.
+        self.assertRegex(cutout, r"maskRevision:\s*root\.maskRevision")
+
+    def test_the_cutout_draws_the_candidate_not_the_accepted_mask(self):
+        # ClockDepth.maskPath is only ever the ACCEPTED mask. A surface whose
+        # whole job is judging something before it is accepted would show the
+        # previous verdict and never change.
+        self.assertRegex(
+            self.surface,
+            r"maskPath:\s*ClockDepth\.candidates\?\.\[root\.modelName\]")
+        self.assertNotRegex(self.surface, r"maskPath:\s*ClockDepth\.maskPath")
+
+
+class TheClickReachesThePicture(unittest.TestCase):
+    def setUp(self):
+        self.surface = text(SURFACE)
+
+    def test_the_cutout_sits_in_the_box_the_background_published(self):
+        frame = block_for(self.surface, "pictureFrame")
+        self.assertIsNotNone(frame, "nothing carries the published viewport")
+        for axis in ("x", "y", "width", "height"):
+            self.assertRegex(
+                frame, rf"{axis}:\s*root\.viewport\?\.{axis}",
+                f"the picture frame's {axis} is not the published viewport's - "
+                "the surface would be drawing against a geometry it guessed")
+        self.assertRegex(
+            self.surface,
+            r"viewport:\s*GlobalStates\.clockDepthViewports\?\.\[root\.screen\.name\]",
+            "the viewport must be read per screen: one wallpaper is cropped "
+            "differently on every output")
+
+    def test_the_conversion_is_the_one_that_already_exists(self):
+        area = block_for(self.surface, "pointArea")
+        self.assertIsNotNone(area, "the surface has no click area")
+        self.assertIn("ClockDepthLogic.promptFromScreen", area)
+        # Through the rectangle the cutout PUBLISHES, so the click is measured
+        # against the same registration the mask is drawn with.
+        self.assertIn("cutout.maskRect", area)
+
+    def test_the_surface_derives_no_registration_of_its_own(self):
+        # lint_clock_depth_geometry.py already fails the suite on a second
+        # caller of coverRect; this is the same rule stated where the temptation
+        # is - the surface knows the box and the picture's size and could work
+        # the crop out again in three lines.
+        self.assertNotIn("coverRect", self.surface)
+        self.assertNotIn("PreserveAspectCrop", self.surface)
+
+    def test_the_click_area_waits_for_the_wallpaper_to_decode(self):
+        # An Image's implicit size reads 0 until its source resolves, and
+        # coverRect answers a zero-sized source with the box itself - so a click
+        # arriving in that window is measured against a frame the picture does
+        # not occupy and sent to the producer as a point somewhere else.
+        area = block_for(self.surface, "pointArea")
+        self.assertRegex(area, r"enabled:[^\n]*cutout\.wallpaperStatus === Image\.Ready")
+        self.assertRegex(area, r"enabled:[^\n]*root\.viewport !== null")
+
+    def test_left_includes_and_right_excludes(self):
+        area = block_for(self.surface, "pointArea")
+        self.assertRegex(area, r"acceptedButtons:\s*Qt\.LeftButton \| Qt\.RightButton")
+        self.assertRegex(
+            area, r"ClockDepth\.addPoint\([^)]*mouse\.button === Qt\.LeftButton")
+
+
+class TheSurfaceIsALayerSurfaceThisShellCanLiveWith(unittest.TestCase):
+    def setUp(self):
+        self.surface = text(SURFACE)
+        self.rules = RULES.read_text()
+
+    def test_it_mints_its_own_namespace(self):
+        self.assertIn(f'WlrLayershell.namespace: "{NAMESPACE}"', self.surface)
+        # Reusing quickshell:popup is the documented wrong answer: it carries
+        # ignore_alpha = 1 from an old tooltip fix, which is right for an opaque
+        # card and wrong for a screen-sized transparent one.
+        self.assertNotIn('WlrLayershell.namespace: "quickshell:popup"', self.surface)
+
+    def test_it_sits_above_everything_it_is_drawn_over(self):
+        self.assertIn("WlrLayershell.layer: WlrLayer.Overlay", self.surface)
+        self.assertIn("exclusionMode: ExclusionMode.Ignore", self.surface)
+
+    def test_its_keyboard_grab_is_not_session_wide(self):
+        # One surface per output. An Exclusive grab is not scoped to the output
+        # it was taken on, so it swallows what the user types on every other
+        # screen - the trap Screensaver.qml records for a per-monitor blank.
+        self.assertIn("WlrKeyboardFocus.OnDemand", self.surface)
+        self.assertNotIn("WlrKeyboardFocus.Exclusive", self.surface)
+
+    def test_the_layer_rules_exist_for_the_namespace(self):
+        # Without them a screen-sized surface whose pixels are mostly
+        # transparent falls through to the catch-all `ignore_alpha = 0.05` and
+        # asks the compositor to blur the entire screen behind it, and gets a
+        # map animation on something the size of the desktop.
+        self.assertRegex(
+            self.rules, rf'namespace = "{re.escape(NAMESPACE)}" \}}, no_anim = true')
+        self.assertRegex(
+            self.rules, rf'namespace = "{re.escape(NAMESPACE)}" \}}, blur = false')
+
+    def test_the_toolbar_publishes_the_blur_region_that_rule_requires(self):
+        # blur = false without a region is a panel with no blur at all rather
+        # than one with a crisp shadow. lint_blur_region_pairing.py fails on the
+        # pairing; this says which item the region is for.
+        region = body_after(self.surface, r"WindowBlurRegion\s*\{")
+        self.assertIsNotNone(region, "no WindowBlurRegion for the toolbar")
+        self.assertIn("regionItem: chromeCard", region)
+
+    def test_the_toolbar_keeps_its_own_clicks(self):
+        # The click gesture covers the whole screen. Without a scrim under the
+        # toolbar, pressing "Use this" also plants a point underneath it.
+        chrome = block_for(self.surface, "chromeCard")
+        self.assertIsNotNone(chrome, "the toolbar has no id to check")
+        self.assertRegex(chrome, r"MouseArea\s*\{")
+        self.assertRegex(chrome, r"acceptedButtons:\s*Qt\.AllButtons")
+
+
+class TheVerdictsLiveHereNow(unittest.TestCase):
+    def setUp(self):
+        self.surface = text(SURFACE)
+        self.mode = text(MODE)
+
+    def test_escape_cancels_without_a_verdict(self):
+        keys = body_after(self.surface, r"Keys\.onPressed:\s*event =>")
+        self.assertIsNotNone(keys, "the surface handles no keys")
+        self.assertIn("Qt.Key_Escape", keys)
+        self.assertIn("root.cancelled()", keys)
+        for verdict in ("acceptModel", "declineWallpaper", "accepted()", "declined()"):
+            self.assertNotIn(
+                verdict, keys,
+                "Escape must leave without a verdict: the candidate stays on "
+                "disk under its own key, so re-entering picks the gesture up")
+
+    def test_accept_and_decline_are_both_reachable_from_the_surface(self):
+        self.assertIn("root.accepted()", self.surface)
+        self.assertIn("root.declined()", self.surface)
+        self.assertIn("root.cancelled()", self.surface)
+
+    def test_accepting_records_the_mask_and_turns_the_feature_on(self):
+        accept = body_after(self.mode, r"function accept\(\)")
+        self.assertIsNotNone(accept, "the mode has no accept()")
+        self.assertIn("ClockDepth.acceptModel(ClockDepth.promptedModel)", accept)
+        # Accepting while the global switch is off writes the artifact and
+        # changes nothing on screen, which reads as the button not working.
+        self.assertIn("Config.options.background.clockDepth.enable = true", accept)
+        self.assertIn("root.cancel()", accept)
+
+    def test_declining_records_the_refusal_and_leaves(self):
+        decline = body_after(self.mode, r"function decline\(\)")
+        self.assertIsNotNone(decline, "the mode has no decline()")
+        self.assertIn("ClockDepth.declineWallpaper()", decline)
+        self.assertIn("root.cancel()", decline)
+
+    def test_cancelling_gives_no_verdict_at_all(self):
+        cancel = body_after(self.mode, r"function cancel\(\)")
+        self.assertIsNotNone(cancel, "the mode has no cancel()")
+        self.assertIn("GlobalStates.clockDepthSelectOpen = false", cancel)
+        for verdict in ("acceptModel", "declineWallpaper"):
+            self.assertNotIn(verdict, cancel)
+
+
+class TheModeDisarmsWhenTheGroundMoves(unittest.TestCase):
+    def setUp(self):
+        self.mode = text(MODE)
+
+    def test_the_surfaces_are_gated_on_the_one_flag(self):
+        self.assertRegex(self.mode, r"active:\s*GlobalStates\.clockDepthSelectOpen")
+        self.assertRegex(self.mode, r"model:\s*Quickshell\.screens")
+
+    def test_arming_captures_the_wallpaper_it_armed_on(self):
+        armed = body_after(self.mode, r"function onClockDepthSelectOpenChanged\(\)")
+        self.assertIsNotNone(armed, "nothing watches the arming flag")
+        self.assertIn("ClockDepth.wallpaperPath", armed)
+        self.assertIn("root.armedWallpaper", armed)
+
+    def test_a_wallpaper_change_underneath_disarms(self):
+        # The clicks are stored against the picture's cache key. If the picture
+        # changes, every one of them belongs to a different file and the cutout
+        # on screen is registered against something no longer there - and
+        # nothing about that is visible, because a cutout of the wrong picture
+        # is still a cutout.
+        changed = body_after(self.mode, r"function onWallpaperPathChanged\(\)")
+        self.assertIsNotNone(changed, "nothing watches the wallpaper")
+        self.assertIn("root.armedWallpaper", changed)
+        self.assertIn("root.cancel()", changed)
+
+    def test_a_desktop_that_stops_showing_a_still_disarms(self):
+        changed = body_after(self.mode, r"function onSelectableChanged\(\)")
+        self.assertIsNotNone(changed, "nothing watches whether picking is possible")
+        self.assertIn("ClockDepth.selectable", changed)
+        self.assertIn("root.cancel()", changed)
+
+    def test_the_mode_is_loaded_by_the_panel_family(self):
+        # A module nothing loads is a module that is never wrong.
+        family = text(FAMILY)
+        self.assertIn("import qs.modules.imi.clockDepthSelect", family)
+        self.assertRegex(family, r"PanelLoader \{ component: ClockDepthSelect \{\} \}")
+
+
+class TheDesktopHandsOverItsGeometry(unittest.TestCase):
+    def setUp(self):
+        self.background = text(BACKGROUND)
+        self.states = text(GLOBAL_STATES)
+        self.service = text(SERVICE)
+
+    def test_the_flag_and_the_map_are_declared(self):
+        self.assertIn("property bool clockDepthSelectOpen: false", self.states)
+        self.assertIn("property var clockDepthViewports: ({})", self.states)
+
+    def test_the_depth_layer_stands_down_while_a_selection_is_live(self):
+        # The surface draws the candidate over the same widgets at the same
+        # geometry. Left on, the accepted mask underneath would be a second
+        # silhouette, and where the two disagree the difference reads as the
+        # candidate having claimed something it did not.
+        self.assertRegex(
+            self.background, r"selecting:\s*GlobalStates\.clockDepthSelectOpen")
+
+    def test_the_published_box_is_the_depth_layers_own(self):
+        layer = block_for(self.background, "clockDepthLayer")
+        self.assertIsNotNone(layer, "the depth layer is gone")
+        published = re.search(
+            r"publishedViewport:(.*?)onPublishedViewportChanged", layer, re.DOTALL)
+        self.assertIsNotNone(published, "the layer publishes no viewport")
+        value = published.group(1)
+        for axis in ("x", "y", "width", "height"):
+            self.assertRegex(
+                value, rf"{axis}:\s*clockDepthLayer\.{axis}",
+                f"the published {axis} is not the depth layer's own - the "
+                "surface would draw its cutout somewhere the desktop does not")
+        # The wallpaper ITEM's source, not the config path: a switch assigns
+        # that source imperatively so it can snapshot the outgoing frame.
+        self.assertRegex(value, r"source:\s*String\(wallpaper\.source\)")
+        # Null while disarmed, so the binding is a comparison rather than a
+        # fresh object on every frame of every pan for the rest of the session.
+        self.assertRegex(value, r"GlobalStates\.clockDepthSelectOpen\s*\?")
+
+    def test_the_publisher_is_keyed_per_screen_and_clears_on_disarm(self):
+        publish = body_after(self.background, r"function publishDepthViewport\(viewport\)")
+        self.assertIsNotNone(publish, "the background publishes nothing")
+        self.assertIn("bgRoot.screen.name", publish)
+        self.assertIn("delete published[bgRoot.screen.name]", publish)
+
+    def test_the_service_keeps_watching_while_the_mode_is_armed(self):
+        # ClockDepth forgets every cached answer the moment nothing is
+        # watching, and the picker's claim dies with the picker as the wallpaper
+        # selector closes. Read off the flag rather than given a second writer
+        # of `picking`: one bool with two writers is cleared by whichever
+        # surface goes away last, on an ordering nothing controls.
+        watching = re.search(
+            r"property bool watching:(.*?)\n\n", self.service, re.DOTALL)
+        self.assertIsNotNone(watching, "the service declares no watching")
+        self.assertIn("GlobalStates.clockDepthSelectOpen", watching.group(1))
+
+
+class ThePickerIsTheWayInNotThePlaceToAuthor(unittest.TestCase):
+    def setUp(self):
+        self.picker = text(PICKER)
+        self.selector = text(SELECTOR)
+
+    def test_the_picker_no_longer_takes_the_clicks(self):
+        # The whole point of the change. A ~300px preview is where a click on a
+        # character's shoulder becomes several hundred pixels of error at
+        # 5120x1440, and nothing about the resulting mask says so.
+        for authoring in ("ClockDepth.addPoint", "ClockDepth.undoPoint",
+                          "ClockDepth.clearPoints", "normalisedPoint"):
+            self.assertNotIn(
+                authoring, self.picker,
+                f"{authoring} is back in the picker: the mask must be authored "
+                "on the desktop, at the size it is judged at")
+
+    def test_the_prompted_column_offers_the_way_in(self):
+        self.assertIn("signal selectOnDesktopRequested()", self.picker)
+        button = block_for(self.picker, "selectOnDesktopButton")
+        self.assertIsNotNone(button, "the prompted column has no way onto the desktop")
+        self.assertIn("visible: candidate.prompted", button)
+        self.assertIn("root.selectOnDesktopRequested()", button)
+        # Refusing while the desktop shows something else - a preview this
+        # dialog's own grid reverts on close, a live Wallpaper Engine project -
+        # is the difference between picking on the wallpaper and picking on
+        # whatever is there afterwards.
+        self.assertIn("ClockDepth.selectable", button)
+
+    def test_the_prompted_column_no_longer_accepts_from_a_thumbnail(self):
+        accept = block_for(self.picker, "acceptButton")
+        self.assertIsNotNone(accept, "the picker has no accept button at all")
+        self.assertIn("visible: !candidate.prompted", accept)
+
+    def test_the_two_detectors_keep_their_run_and_their_accept(self):
+        # Nothing about the salient columns changed, and a sweep that took them
+        # out with the gesture would be a regression this file should name.
+        run = block_for(self.picker, "runButton")
+        self.assertIsNotNone(run, "the detectors lost their Run button")
+        self.assertIn("ClockDepth.runModel(candidate.modelName)", run)
+        self.assertIn("ClockDepth.acceptModel(candidate.modelName)", self.picker)
+        self.assertIn("ClockDepth.declineWallpaper()", self.picker)
+
+    def test_entering_arms_before_either_surface_closes(self):
+        handler = body_after(self.selector, r"onSelectOnDesktopRequested:")
+        self.assertIsNotNone(handler, "the selector does not answer the picker")
+        armed = handler.index("GlobalStates.clockDepthSelectOpen = true")
+        closed = handler.index("GlobalStates.wallpaperSelectorOpen = false")
+        self.assertLess(
+            armed, closed,
+            "arm first: ClockDepth keeps its cache answers only while "
+            "something is watching, and destroying the picker drops its claim - "
+            "so arming afterwards lets the service forget the candidate the "
+            "user is about to judge")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dots/.config/quickshell/imi/tests/test_clock_depth_select_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_clock_depth_select_contract.py
@@ -376,6 +376,23 @@ class TheDesktopHandsOverItsGeometry(unittest.TestCase):
         self.assertIn("property bool clockDepthSelectOpen: false", self.states)
         self.assertIn("property var clockDepthViewports: ({})", self.states)
 
+    def test_the_two_full_screen_modes_exclude_each_other(self):
+        # Edit Mode shrinks the desktop; picking must click the wallpaper at the
+        # size it is masked at. Either arriving while the other is up leaves a
+        # mode half-armed - a picker surface over a shrunk desktop maps every
+        # click through geometry that is no longer on screen.
+        #
+        # Stated once in GlobalStates rather than as a gate inside either mode,
+        # because the two landed from separate branches and a gate reading the
+        # other's key resolves to `undefined` on a base that has not declared it
+        # yet, and then takes its fallback forever.
+        self.assertRegex(
+            self.states,
+            r"onEditModeChanged:\s*if\s*\(root\.editMode\)\s*root\.clockDepthSelectOpen = false")
+        self.assertRegex(
+            self.states,
+            r"onClockDepthSelectOpenChanged:\s*if\s*\(root\.clockDepthSelectOpen\)\s*root\.editMode = false")
+
     def test_the_depth_layer_stands_down_while_a_selection_is_live(self):
         # The surface draws the candidate over the same widgets at the same
         # geometry. Left on, the accepted mask underneath would be a second

--- a/dots/.config/quickshell/imi/tests/tst_clock_depth_eligibility.qml
+++ b/dots/.config/quickshell/imi/tests/tst_clock_depth_eligibility.qml
@@ -19,6 +19,7 @@ TestCase {
             enable: true,
             maskPath: "/cache/clock-depth/abc.png",
             optedOut: false,
+            selecting: false,
             weActive: false,
             wallpaperIsVideo: false,
             centeredWallpaper: false,
@@ -50,6 +51,25 @@ TestCase {
         // The decline marker and the mask are files beside each other, and a
         // mask left there must not outvote the user's last word.
         compare(showing({ optedOut: true }), false);
+    }
+
+    function test_an_armed_desktop_selection_refuses() {
+        // The selection surface draws the CANDIDATE over the same widgets at
+        // the same geometry. Left on, the accepted mask underneath it would be
+        // a second silhouette, and wherever the two disagree the difference
+        // reads as the candidate having claimed something it did not - a
+        // verdict given against a composite of two masks.
+        compare(showing({ selecting: true }), false);
+    }
+
+    function test_an_armed_selection_refuses_even_with_everything_else_perfect() {
+        // Deliberately separate from the case above: `selecting` is checked
+        // BEFORE the mask, so a state with no mask would refuse anyway and the
+        // check above would pass with the clause deleted if the fixture drifted.
+        compare(ClockDepth.eligible({
+            enable: true, maskPath: "/cache/clock-depth/abc.png",
+            optedOut: false, selecting: true
+        }), false);
     }
 
     function test_a_live_wallpaper_engine_project_refuses() {

--- a/dots/.config/quickshell/imi/tests/tst_clock_depth_eligibility.qml
+++ b/dots/.config/quickshell/imi/tests/tst_clock_depth_eligibility.qml
@@ -218,6 +218,147 @@ TestCase {
             NaN, 5) === null);
     }
 
+    // promptFromScreen: a click on the DESKTOP, as a point in the picture.
+    //
+    // The desktop selector is a screen-sized layer surface of its own, so its
+    // clicks arrive in screen coordinates while the registration is expressed
+    // inside the wallpaper viewport's box - which is bigger than the screen and
+    // negatively offset by the parallax pan. The translation between the two is
+    // the only new arithmetic the mode adds, and it is exactly the part that is
+    // zero on a machine with parallax switched off.
+
+    // The desktop this repository is developed on: 5120x1440 at the default
+    // 1.1 workspace zoom, so the viewport is 5632x1584 and the pan slides it
+    // between 0 and -512 / -144. The wallpaper is 3840x1594, whose aspect
+    // matches neither the screen's nor the viewport's - at a matching aspect
+    // the box IS the cover rect and every registration bug is invisible.
+    readonly property var panned: ({ x: -412, y: -101, width: 5632, height: 1584 })
+    readonly property var atRest: ({ x: -256, y: -72, width: 5632, height: 1584 })
+
+    function pictureRectFor(box) {
+        return ClockDepth.coverRect(3840, 1594, box.width, box.height);
+    }
+
+    function screenPointFor(box, nx, ny) {
+        // Where a given point in the picture is drawn, in screen coordinates:
+        // the box's own origin, plus where the picture sits inside the box,
+        // plus the fraction along it. The forward direction of what
+        // promptFromScreen undoes, spelled out here rather than reusing the
+        // function under test.
+        const r = pictureRectFor(box);
+        return { x: box.x + r.x + nx * r.width, y: box.y + r.y + ny * r.height };
+    }
+
+    function test_a_desktop_click_round_trips_through_the_pan_and_the_crop() {
+        const cases = [[0.1, 0.2], [0.5, 0.5], [0.87, 0.04], [0.33, 0.91]];
+        for (let i = 0; i < cases.length; i++) {
+            const nx = cases[i][0], ny = cases[i][1];
+            const hit = screenPointFor(panned, nx, ny);
+            const p = ClockDepth.promptFromScreen(panned, pictureRectFor(panned),
+                hit.x, hit.y);
+            fuzzyCompare(p.x, nx, 0.0001, "x for " + cases[i]);
+            fuzzyCompare(p.y, ny, 0.0001, "y for " + cases[i]);
+        }
+    }
+
+    function test_the_same_click_means_different_points_at_different_pans() {
+        // The check a dropped translation cannot pass. The pan is the whole
+        // reason the origin is there, and a version that ignored it would give
+        // one answer for both - which is right on precisely the workspace where
+        // the viewport happens to sit at the origin, and wrong everywhere else.
+        const rest = ClockDepth.promptFromScreen(atRest, pictureRectFor(atRest), 2560, 720);
+        const moved = ClockDepth.promptFromScreen(panned, pictureRectFor(panned), 2560, 720);
+        verify(Math.abs(rest.x - moved.x) > 0.02,
+            "the pan did not move the point: " + rest.x + " vs " + moved.x);
+        verify(Math.abs(rest.y - moved.y) > 0.005,
+            "the pan did not move the point vertically: " + rest.y + " vs " + moved.y);
+    }
+
+    function test_the_pictures_own_aspect_survives_the_screens() {
+        // The registration this whole rect exists for, checked from the click
+        // side: 3840x1594 into 5632x1584 crops top and bottom, so a click at
+        // the top of the SCREEN is well down the picture, and one at the left
+        // edge is not at the picture's left edge either once the pan has slid
+        // it. A mapping that measured against the screen instead of the picture
+        // would answer 0 for both.
+        const p = ClockDepth.promptFromScreen(atRest, pictureRectFor(atRest), 0, 0);
+        verify(p.y > 0.05, "top of the screen maps to the top of the picture: " + p.y);
+        verify(p.x > 0.02, "left of the screen maps to the left of the picture: " + p.x);
+        verify(p.x < 0.2, "left of the screen is nowhere near the middle: " + p.x);
+    }
+
+    function test_a_box_with_no_origin_is_read_as_the_screens_own() {
+        // Parallax off: the viewport is the screen, sitting at (0, 0), and the
+        // published box carries no offsets. That is the case where a missing
+        // translation is invisible, so it is checked rather than assumed.
+        const box = { width: 5120, height: 1440 };
+        const r = ClockDepth.coverRect(3840, 1594, 5120, 1440);
+        const p = ClockDepth.promptFromScreen(box, r, r.x + 0.4 * r.width,
+            r.y + 0.6 * r.height);
+        fuzzyCompare(p.x, 0.4, 0.0001);
+        fuzzyCompare(p.y, 0.6, 0.0001);
+    }
+
+    function test_a_missing_box_or_a_non_finite_click_answers_null_not_a_guess() {
+        // The surface only enables its click area once the box has arrived and
+        // the wallpaper has decoded, but a refusal is what the arithmetic owes
+        // regardless: a guessed point comes back as a good mask of the wrong
+        // thing, which is the one failure nothing on screen reports.
+        const r = ClockDepth.coverRect(3840, 1594, 5632, 1584);
+        verify(ClockDepth.promptFromScreen(panned, r, NaN, 10) === null);
+        verify(ClockDepth.promptFromScreen(panned, undefined, 10, 10) === null);
+        verify(ClockDepth.promptFromScreen(undefined, r, 10, 10) !== null);
+    }
+
+    // selectable: whether the desktop is showing the picture being asked about.
+
+    function picking(overrides) {
+        const state = {
+            wallpaperPath: "/home/user/Pictures/Wallpapers/aishot-3263.jpg",
+            previewing: false,
+            weActive: false,
+            centeredWallpaper: false,
+            screenLocked: false
+        };
+        for (const key in overrides)
+            state[key] = overrides[key];
+        return ClockDepth.selectable(state);
+    }
+
+    function test_a_still_wallpaper_on_screen_can_be_picked_on() {
+        compare(picking({}), true);
+    }
+
+    function test_no_mask_and_a_standing_refusal_do_not_stop_a_pick() {
+        // The half that must NOT be inherited from `eligible`. Selecting exists
+        // for the wallpapers that have no mask and for the ones whose owner
+        // said no once - gating it on those would make the feature unreachable
+        // from exactly the half of the library it was built for.
+        compare(picking({ maskPath: "", optedOut: true }), true);
+    }
+
+    function test_a_preview_the_selector_is_about_to_revert_refuses() {
+        compare(picking({ previewing: true }), false);
+    }
+
+    function test_a_live_wallpaper_engine_project_cannot_be_picked_on() {
+        compare(picking({ weActive: true }), false);
+    }
+
+    function test_centred_mode_cannot_be_picked_on() {
+        compare(picking({ centeredWallpaper: true }), false);
+    }
+
+    function test_a_locked_screen_cannot_be_picked_on() {
+        compare(picking({ screenLocked: true }), false);
+    }
+
+    function test_no_wallpaper_at_all_cannot_be_picked_on() {
+        compare(picking({ wallpaperPath: "" }), false);
+        compare(ClockDepth.selectable({}), false);
+        compare(ClockDepth.selectable(undefined), false);
+    }
+
     function test_an_unloaded_image_yields_the_box_rather_than_NaN() {
         // An Image's implicit size reads 0 until its source resolves, and a NaN
         // on x/y/width/height does not misplace the mask - it stops the item


### PR DESCRIPTION
> "Terrible UX on the manual selection part. Have it be part of the desktop
> itself when selecting. A thumbnail is too small to get the correct subject."

#235's producer, embedding cache, prompt-in-PNG storage and mask pipeline are
untouched. What moves is *where the clicking happens*, and the reason it had to
move is structural rather than aesthetic: the mask is **judged** at screen size
against real widgets and was being **authored** against a ~300px preview. A
click landing on a character's shoulder in that preview is several hundred
pixels off at 5120x1440 — and nothing reports it, because a mis-aimed click
comes back as a perfectly good mask of the wrong thing.

## The surface

`modules/imi/clockDepthSelect/` — one **transparent, screen-sized `Overlay`
layer surface per output**, on the region selector's precedent (own namespace,
`ExclusionMode.Ignore`, `no_anim`, `OnDemand` keyboard focus).

**Nothing on it redraws anything, and that is the whole design.** The wallpaper
is already on screen at exactly the size and crop the mask has to line up with,
so the pixels the user clicks are the pixels the depth layer will mask *by
construction* rather than by arithmetic. The widgets are already under it, live,
so the cutout drawn over them **is** the occlusion being judged rather than a
picture of one. Either copy would be a second chance to be misaligned, in a
feature that has already burned an evening on a misalignment that turned out not
to exist. `test_clock_depth_select_contract.py` fails the suite on an `Image`
appearing in that file at all.

**The widgets stay live underneath — they are not composited.** The compositor
already stacks them the way the desktop does: the real widget canvas on the
background surface, this surface above it, the candidate cutout drawn on this
surface. That is the same z-order `clockDepthLayer` (z 3) has over
`widgetCanvas` (z 2), reproduced for free by being a higher layer rather than
re-derived. The desktop's own depth layer stands down while the mode is armed —
a new `selecting` refusal in `eligible()` — because the accepted mask under the
candidate is a second silhouette, and wherever the two disagree the difference
reads as the candidate having claimed something it did not.

## How a screen click reaches the prompt

Through what already exists, with exactly one new composition:

1. `Background.qml` publishes **the depth layer's own live box** per screen into
   `GlobalStates.clockDepthViewports` — x/y/width/height plus the source the
   wallpaper *item* is drawing (not the config path; a switch assigns that
   source imperatively so it can snapshot the outgoing frame).
2. The surface draws a `ClockDepthCutout` into that box. Same component, same
   geometry inputs, so its registration cannot differ from the desktop's.
3. A click is `clockDepth.js`'s new `promptFromScreen(box, cutout.maskRect, x, y)`
   → `normalisedPoint` → `ClockDepth.addPoint`.

`coverRect` still has exactly one caller and `lint_clock_depth_geometry.py`
still says so; the surface mentions neither it nor a fill mode.

**Why publish rather than re-derive.** A layer surface cannot read another
window's items. The wallpaper viewport is oversized and offset by the parallax
pan, and `ParallaxMath.offsets` is pure and right there — which is the tempting
wrong answer, because reconstructing it on this side would be a second
derivation of the one number `ClockDepthCutout` exists to have only one of. The
publishing binding is `null` while the mode is disarmed, so it is a comparison
rather than a fresh object per frame of every pan for the rest of the session,
and a disarmed screen's entry is deleted rather than left stale.

**The new arithmetic is one translation, and it is the term that is silently
zero.** A click arrives in screen coordinates; the registration is expressed
inside the box. With parallax off the viewport sits at exactly (0, 0), so a
translation left out entirely is correct on the first screen anyone tries it on
and wrong by up to the whole zoom overflow on every workspace but the middle
one. Tested against a 3840x1594 wallpaper in a 5632x1584 viewport on a 5120x1440
screen — three aspects, none equal, because at a matching aspect the box *is*
the cover rect and every registration bug is invisible.

## Live preview, and inspect at full size

Every click redraws the cutout in place over the real desktop: `addPoint` →
`select` → `status` → the candidate's path and revision → the cutout. Undo and
start over are there; **accept and decline live here now**, since this is where
the user is looking at the thing they are judging. Escape leaves without a
verdict — the candidate stays on disk under its own key, so re-entering picks
the gesture back up rather than starting over.

The picker's inspect treatment is **reused as-is, still off by default**, and at
full size that default is a real decision rather than a copied one: the veil
dims the live widgets along with everything else the model did not claim, which
is right for reading where the mask's edge runs and wrong for judging whether
the cutout hides the clock. Two questions, two moments, so it stays a toggle.

## Entry, and what the picker is now

The depth picker keeps the two salient detectors (Run / Run again / Use this),
this wallpaper's verdict line, the prompted column's preview and its plus/minus
discs — per-wallpaper **state**. It loses the authoring: the click surface,
undo, start over, and accepting a prompted mask from a thumbnail. Its prompted
column's one action is **Pick on desktop** / **Refine on desktop**, which arms
the mode and closes both surfaces.

The button refuses when the desktop is showing something else —
`ClockDepth.selectable`, a new pure predicate. It is deliberately **not** a
subset of `eligible`: two of that predicate's refusals (no mask, the
per-wallpaper opt-out) are precisely the states picking exists to change, so
inheriting them would make the feature unreachable from the half of the library
it was built for. What it does refuse is a desktop whose pixels are not the
still being asked about — a grid preview the selector reverts on close, a live
Wallpaper Engine project, centred mode, the lock screen.

**Arming happens before either surface closes.** `ClockDepth` drops every cached
answer the moment nothing is `watching`, and the picker's `picking` claim dies
with the picker — so arming afterwards would let the service forget the very
candidate the user walked out to judge. `watching` reads the flag directly
rather than taking a second writer of `picking`: one bool with two writers is
cleared by whichever surface goes away last, on an ordering nothing controls.

## Compositor rules

A new namespace, minted properly rather than reusing `quickshell:popup` —
`BarPopupOverlay.qml:53-69` records that it carries `ignore_alpha = 1` from an
old tooltip fix, which is right for an opaque card and wrong for a screen-sized
transparent one. It takes `blur = false` plus a `WindowBlurRegion` over its
toolbar, because a new namespace otherwise falls through to the catch-all
`ignore_alpha = 0.05`, under which a screen-sized surface of transparent pixels
asks the compositor to blur the entire screen. `lint_blur_region_pairing.py`
holds the two halves together.

`OnDemand` keyboard focus, never `Exclusive`: there is one surface per output
and an Exclusive grab is session-wide rather than scoped to the output it was
taken on — the trap `Screensaver.qml` already records.

## Tests

`866 passed, 0 failed` on `gh/main`, re-measured; **`880 passed, 0 failed`**
here — 14 new QML cases (the screen→prompt composition including the
differing-aspect and differing-pan cases, the `selecting` refusal, and
`selectable`) — plus **35 new Python contract checks**
(`test_clock_depth_select_contract.py`). `DesignSystemCompile` goes 175 → 176:
the surface joins the explicit list, since it sits behind a Loader that is
inactive until somebody arms the mode.

**31 mutations planted in a clean tree, all 31 caught** — every new check proven
to fail on deliberately broken code, including the ones that are only
interesting when they are wrong: a click that ignores the box's origin, a
published box that is a guess rather than the layer's own, a stale entry left
behind on disarm, Escape recording a verdict, the service dropping its watch
while the mode is armed, and the gesture coming back to the thumbnail.

Not covered by any harness, and stated rather than skipped: the surface's actual
mapping, its keyboard focus and the compositor's blur handling need a live load
to see — `qmltestrunner` cannot construct a layer surface and weston implements
no wlr-layer-shell. What was verified without one: both new QML files compile
under `qs -p` (as do `Background.qml`, `WallpaperSelectorContent.qml` and the
mode's Scope, checked temporarily through the same sweep), and a disposable
`qs -p` probe confirmed `ClockDepth.watching` follows the new flag in both
directions with no import cycle.

## Coordination

Edit Mode stage 3 is in flight on `feat/edit-mode-viewport` and touches the same
three shared files. This branch's footprint in them is deliberately small and
additive: two properties in `GlobalStates.qml` (placed beside the region
selector's, away from the end of the file where `editMode` will land), two
`layer_rule` lines in `rules.lua` (not in the generated-threshold `ipairs` list),
and one refusal plus one publisher in `Background.qml`. Nothing existing was
restructured.

The two modes cannot be entered from each other's surfaces, so neither can arm
the other half-way today. `GlobalStates.editMode` does not exist on this base and
is deliberately not referenced — a gate on an undeclared key reads as `undefined`
and takes its fallback forever, silently. Whichever of the two lands second
should add the cross-check, in both directions, against
`GlobalStates.clockDepthSelectOpen`.

Docs: updated AGENT.md §Directory map, §State propagation is reactive (the clock-depth cluster)
