### PR TITLE
Undo and redo the subject-picking gesture from the keyboard

### DIFF
--- a/dots/.config/quickshell/imi/modules/imi/clockDepthSelect/ClockDepthSelectSurface.qml
+++ b/dots/.config/quickshell/imi/modules/imi/clockDepthSelect/ClockDepthSelectSurface.qml
@@ -96,6 +96,24 @@ PanelWindow {
             if (event.key === Qt.Key_Escape) {
                 root.cancelled()
                 event.accepted = true
+                return
+            }
+            // Handled here rather than as a `Shortcut`: a Shortcut is scoped to
+            // its window and this surface is one per output, so the same chord
+            // would be declared on every screen and Qt would call the match
+            // ambiguous. Keys go to whichever surface holds focus, which is the
+            // screen the user is picking on.
+            if (event.modifiers & Qt.ControlModifier) {
+                if (event.key === Qt.Key_Z) {
+                    if (event.modifiers & Qt.ShiftModifier)
+                        ClockDepth.redoPoint()
+                    else
+                        ClockDepth.undoPoint()
+                    event.accepted = true
+                } else if (event.key === Qt.Key_Y) {
+                    ClockDepth.redoPoint()
+                    event.accepted = true
+                }
             }
         }
 
@@ -310,11 +328,21 @@ PanelWindow {
                     }
                 }
 
+                // Gated on the history rather than on the points, so "Start
+                // over" stays undoable - after it there are no points left, and
+                // a button reading `points.length` would disable itself exactly
+                // when the user most wants it back.
                 DialogButton {
                     id: undoButton
-                    enabled: !root.busy && root.points.length > 0
+                    enabled: !root.busy && ClockDepth.pointHistory.length > 0
                     buttonText: Translation.tr("Undo")
                     onClicked: ClockDepth.undoPoint()
+                }
+                DialogButton {
+                    id: redoButton
+                    enabled: !root.busy && ClockDepth.pointFuture.length > 0
+                    buttonText: Translation.tr("Redo")
+                    onClicked: ClockDepth.redoPoint()
                 }
                 DialogButton {
                     id: clearButton

--- a/dots/.config/quickshell/imi/services/ClockDepth.qml
+++ b/dots/.config/quickshell/imi/services/ClockDepth.qml
@@ -144,23 +144,60 @@ Singleton {
         return value !== null && value !== undefined && typeof value.length === "number"
     }
 
-    function addPoint(x: real, y: real, include: bool): void {
-        if (root.promptedModel === "")
-            return
-        root.points = root.points.concat([{ "x": x, "y": y, "label": include ? 1 : 0 }])
+    // History keeps whole point lists rather than a stack of "remove the last
+    // click", so that start-over is one undo away like every other step. A
+    // pop-the-last-point stack cannot express it: clearing four points would
+    // cost four undos or be silently unrecoverable, and both read as the
+    // history having lost the gesture.
+    property var pointHistory: []
+    property var pointFuture: []
+
+    // Every deliberate edit goes through here, so no path can move the points
+    // without the history seeing it.
+    function commitPoints(next): void {
+        root.pointHistory = root.pointHistory.concat([root.points])
+        root.pointFuture = []
+        root.points = next
         root.selectPoints()
     }
 
-    function undoPoint(): void {
-        if (root.points.length === 0)
+    // Adopting a prompt off disk is where a gesture starts, not a step in one,
+    // so it resets the history instead of becoming undoable into someone
+    // else's clicks.
+    function adoptPoints(next): void {
+        root.pointHistory = []
+        root.pointFuture = []
+        root.points = next
+    }
+
+    function addPoint(x: real, y: real, include: bool): void {
+        if (root.promptedModel === "")
             return
-        root.points = root.points.slice(0, root.points.length - 1)
+        root.commitPoints(root.points.concat([{ "x": x, "y": y, "label": include ? 1 : 0 }]))
+    }
+
+    function undoPoint(): void {
+        if (root.pointHistory.length === 0)
+            return
+        root.pointFuture = root.pointFuture.concat([root.points])
+        root.points = root.pointHistory[root.pointHistory.length - 1]
+        root.pointHistory = root.pointHistory.slice(0, root.pointHistory.length - 1)
+        root.selectPoints()
+    }
+
+    function redoPoint(): void {
+        if (root.pointFuture.length === 0)
+            return
+        root.pointHistory = root.pointHistory.concat([root.points])
+        root.points = root.pointFuture[root.pointFuture.length - 1]
+        root.pointFuture = root.pointFuture.slice(0, root.pointFuture.length - 1)
         root.selectPoints()
     }
 
     function clearPoints(): void {
-        root.points = []
-        root.selectPoints()
+        if (root.points.length === 0)
+            return
+        root.commitPoints([])
     }
 
     function selectPoints(): void {
@@ -238,7 +275,7 @@ Singleton {
         root.queriedPath = ""
         root.prompts = ({})
         root.acceptedPrompt = []
-        root.points = []
+        root.adoptPoints([])
         root.promptRestoredFor = ""
         root.selectPending = false
     }
@@ -330,8 +367,8 @@ Singleton {
                     // produced what is on screen rather than an empty preview
                     // with no way back into it.
                     const candidate = root.prompts?.[root.promptedModel]
-                    root.points = root.looksLikeList(candidate) ? candidate
-                        : (root.looksLikeList(root.acceptedPrompt) ? root.acceptedPrompt : [])
+                    root.adoptPoints(root.looksLikeList(candidate) ? candidate
+                        : (root.looksLikeList(root.acceptedPrompt) ? root.acceptedPrompt : []))
                 }
             }
         }

--- a/dots/.config/quickshell/imi/tests/test_clock_depth_select_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_clock_depth_select_contract.py
@@ -495,3 +495,56 @@ class ThePickerIsTheWayInNotThePlaceToAuthor(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TheClickHistoryIsWholeStates(unittest.TestCase):
+    """Undo and redo over the selection gesture.
+
+    The history keeps whole point lists rather than a stack of "remove the last
+    click", because start-over has to be one undo away like every other step. A
+    pop-the-last-point stack cannot express it: clearing four points would cost
+    four undos, or be unrecoverable, and both read as the history having lost
+    the gesture.
+    """
+
+    def setUp(self):
+        self.service = text(SERVICE)
+        self.surface = text(SURFACE)
+
+    def test_every_edit_goes_through_one_commit(self):
+        # If an edit writes root.points directly it is invisible to undo, and
+        # the failure is silent - the button simply skips a step.
+        for name in ("addPoint", "clearPoints"):
+            body = re.search(r"function %s\(.*?\n    \}" % name, self.service, re.DOTALL)
+            self.assertIsNotNone(body, "%s is gone" % name)
+            self.assertIn("commitPoints", body.group(0),
+                          "%s edits the points without the history seeing it" % name)
+
+    def test_adopting_a_stored_prompt_is_not_an_undoable_step(self):
+        # Reading a prompt off disk is where a gesture starts. If it were a
+        # step, undo would walk back into a previous session's clicks.
+        body = re.search(r"function adoptPoints\(.*?\n    \}", self.service, re.DOTALL)
+        self.assertIsNotNone(body, "adoptPoints is gone")
+        self.assertIn("root.pointHistory = []", body.group(0))
+        self.assertIn("root.pointFuture = []", body.group(0))
+
+    def test_a_new_click_forgets_the_redo_branch(self):
+        body = re.search(r"function commitPoints\(.*?\n    \}", self.service, re.DOTALL)
+        self.assertIsNotNone(body, "commitPoints is gone")
+        self.assertIn("root.pointFuture = []", body.group(0))
+
+    def test_both_chords_reach_the_service(self):
+        keys = re.search(r"Keys\.onPressed:.*?\n        \}", self.surface, re.DOTALL)
+        self.assertIsNotNone(keys, "the surface handles no keys")
+        block = keys.group(0)
+        self.assertIn("Qt.ControlModifier", block)
+        self.assertIn("Qt.ShiftModifier", block)
+        self.assertIn("ClockDepth.undoPoint()", block)
+        self.assertIn("ClockDepth.redoPoint()", block)
+
+    def test_undo_is_offered_while_there_is_history_not_while_there_are_points(self):
+        # After "Start over" there are no points and undo must still be live.
+        undo = re.search(r"id: undoButton.*?\n                \}", self.surface, re.DOTALL)
+        self.assertIsNotNone(undo, "the undo button is gone")
+        self.assertIn("ClockDepth.pointHistory.length > 0", undo.group(0))
+        self.assertNotIn("root.points.length", undo.group(0))


### PR DESCRIPTION
Picking a subject is several clicks, each a guess that can grab too much, and the only way back was a button. `Ctrl+Z` steps back, `Ctrl+Shift+Z` (and `Ctrl+Y`) steps forward, with a Redo button beside Undo.

## Whole states, not a stack of clicks

The history keeps whole point lists rather than "remove the last click". That is what lets **Start over be one undo away** like every other step — a pop-the-last-point stack would charge four undos to recover four cleared points, or lose them outright, and both read as the history having dropped the gesture.

Two consequences worth stating:

- Every deliberate edit goes through `commitPoints`, so no path can move the points without the history seeing it. A direct `root.points = …` is invisible to undo and fails silently, by skipping a step.
- Adopting a stored prompt off disk resets the history instead of becoming a step in it, or undo walks back into a previous session's clicks.

## Keys, not a Shortcut

`Keys.onPressed` rather than a `Shortcut`, because this surface is **one per output**: the same chord declared on every screen makes Qt call the match ambiguous. Keys reach whichever surface holds focus, which is the screen being picked on.

## The Undo button's gate

On `pointHistory.length`, not `points.length` — after Start over there are no points left, and that is exactly when undo is wanted. Start over stays gated on the points, since there is nothing to clear when there are none.

## Verification

Full suite **892 passed, 0 failed**. Five new contract checks, each proven to fail on a planted mutation in a clean tree:

| plant | caught |
|---|---|
| `addPoint` writes `root.points` directly | yes |
| `commitPoints` keeps the redo branch | yes |
| the Shift branch removed, so no redo chord | yes |
| Undo gated on `points.length` again | yes |

Not driven on a live shell — the surface is reachable only by the compile sweep, so the chords want a real deploy to confirm the compositor delivers them.

Docs: not needed — no documented behaviour changed; the gesture's keys are described in the PR and the surface's own comments.