### PR TITLE
Edit Mode looks like a card lifted off the wallpaper, not a cropped screenshot

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -2315,19 +2315,54 @@ inset into the containers' `x`/`y` instead would fold a second meaning into the
 four properties the parallax animates, the frost samples by and every clamp
 measures against, which is b710ef731's defect in a new place. Three things the
 mode is built out of are worth not re-deriving:
-- **The inset is derived, not chosen** (`modules/common/functions/edit_mode.js`):
-  the desktop shrinks by exactly the drawer's declared width plus a margin, so
-  the drawer opens into space that already exists. It takes the drawer's WIDTH
-  and has no input for whether the drawer is open — a viewport that changed size
+- **The SIZE is derived and the POSITION is dead centre, and keeping those two
+  apart is the whole of it** (`modules/common/functions/edit_mode.js`). The
+  desktop shrinks by at least the drawer's declared width plus a margin, so the
+  drawer opens into space that already exists; it takes the drawer's WIDTH and
+  has no input for whether the drawer is open — a viewport that changed size
   mid-edit would rescale every widget under the cursor and hand every `Behavior`
-  carrying the box a moving target.
+  carrying the box a moving target. But the reservation is spent when the drawer
+  arrives, not held back from the start: a geometry that put it into the resting
+  `x` made the entry a slide as well as a shrink, symmetric on no frame
+  including the last, and no choice of pre-drawer inset repairs that because the
+  asymmetry is in the shape of the animation. A centred geometry's offset is
+  linear in `(1 - scale)`, so `atProgress` multiplying it by the same `t` as the
+  scale is exactly the centring offset of the intermediate scale — the margins
+  are equal in pairs on every frame, which `tst_edit_mode.qml` asserts as
+  arithmetic and `test_edit_mode_chrome.py` measures off the drawn desktop at
+  half progress. **And the scale has a ceiling** (`MAX_SCALE`): the derivation
+  is right while the drawer is a meaningful fraction of the width and stops
+  being one as the screen widens — 380px of drawer on 5120px left the desktop at
+  92%, which is the mode's whole signal spent on a border. A ceiling cannot
+  break the derivation, because shrinking further only makes the drawer's slot
+  larger.
 - **The blurred backdrop cannot be the lock's `blurLoader` with a second gate**,
   which is what the spec asked for: that loader is a *child* of
   `parallaxViewport`, so it takes the edit transform and shrinks along with the
-  desktop it is meant to sit behind. It is a sibling `Loader` at `z: -1` sharing
-  one `WallpaperBlurBackdrop` component with the lock's, and it works because a
+  desktop it is meant to sit behind. It is a sibling `Loader` sharing one
+  `WallpaperBlurBackdrop` component with the lock's, and it works because a
   `ShaderEffectSource` renders its source item in that item's OWN coordinates —
   a transformed wallpaper still yields an untransformed texture.
+- **That backdrop is drawn ABOVE the desktop, cut out to a rounded rect, and
+  that is the only cheap way to round the desktop's corner**
+  (`modules/imi/background/EditModeCard.qml`). QML has no rounded clip and the
+  desktop is three separately transformed siblings, so no property on any of
+  them rounds a corner, and wrapping all three in one masked layer pushes the
+  wallpaper through an effect for every frame of the shrink — the cost the
+  transform was chosen to avoid. Covering the corner with what is behind it is
+  identical to drawing the backdrop behind everywhere except the four corners,
+  and it gives the drop shadow somewhere honest to live: inside the same cut,
+  over the backdrop, so only the half outside the card survives and its interior
+  never darkens the desktop it is lifting. Two things measured rather than
+  argued while building it. The shadow stays `StyledRectangularShadow` at the
+  magnitude the component defines — raising `blur` from 9 to 40 on a 4403px card
+  spreads the same darkness over four times the distance and the two renders are
+  indistinguishable, because the edge contrast comes from `colShadow`'s alpha
+  and most of a `RectangularShadow` sits under its target, which the cut
+  removes. And the chrome stands down through **two** gates, the Loader's
+  `active` and its `opacity`: either alone hides it, so a frame comparison
+  passes on a tree with one of them deleted, which is why
+  `test_edit_mode_contract.py` names both.
 - **The per-widget frost is stood down for the mode, not aligned to it**
   (`PluginWidget.frostSuspended`, the generalisation of what used to be
   `lockCoversFrost`). Measured on a live desktop with a Wallpaper Engine scene:
@@ -2335,9 +2370,23 @@ mode is built out of are worth not re-deriving:
   transform, because the frost's sample rect is computed from three frames the
   transform does not move together. Suspending it is the difference between a
   deliberate look and a broken one nothing logs — and it is why proxy
-  rectangles, the spec's fallback, are not needed.
+  rectangles, the spec's fallback, are not needed. It is also the one thing the
+  mode changes in a single frame rather than easing, deliberately: a frost is a
+  sample rect that stops being valid the instant the transform starts, so fading
+  it out fades out a picture that is wrong for the whole fade.
+- **The lattice is a substrate, and it says so** (`WidgetCanvas.qml`'s `lattice`
+  item at `z: -1`). The desktop widgets arrive as EXTERNAL children of the
+  canvas — `Background.qml`'s `Repeater` over the plugin manifests — so nothing
+  in `WidgetCanvas.qml` decides whether they are drawn over the grid; the order
+  is a consequence of when each `Repeater`'s model filled. A widget whose panel
+  is translucent, which every desktop widget is and which this mode makes more
+  so by standing the frost down, then has a crisp full-strength line running
+  across it, and a line is a foreground cue whatever is really in front.
 (feat(editMode): shrink the desktop into a viewport on the background surface,
-feat(editMode): stand the per-widget frost down for the mode.)
+feat(editMode): stand the per-widget frost down for the mode,
+feat(editMode): draw the shrunk desktop as a card, not as a cropped screenshot,
+feat(editMode): shrink the desktop about dead centre, and move it only for the drawer,
+feat(widgetCanvas): the lattice is a substrate, and it dissolves at the edges.)
 
 **The clock depth layer is the counter-case to that rule, and it is why it is a
 FOURTH sibling.** `widgetCanvas` sits at `z: 2` as a sibling of
@@ -2756,6 +2805,23 @@ freezes the shell (this is exactly what a bulk token migration did to `ConfigRow
 (run by `tests/run_tests.sh` and CI) guards against reintroducing it.
 
 **Strict UI Guidelines:** See [`docs/M3_GUIDELINES.md`](docs/M3_GUIDELINES.md) for the definitive rules on tokens, rounding, layering, and expressive motion that all new components must follow.
+
+**Take a motion tier whole, because half of one is silently a generic curve.**
+`NumberAnimation { duration: Appearance.animation.elementMoveFaster.duration }` reads as compliant —
+it names a token, it has no literal — and leaves `easing.type` at Qt's default, which is
+`Easing.Linear`: exactly the generic curve `docs/M3_GUIDELINES.md` §2 forbids. Every resize grip in
+the shell faded in linearly that way beside neighbours easing on `expressiveEffects`, and nothing
+about the source shows it. Use the tier's own component
+(`animation: Appearance.animation.elementMoveFaster.numberAnimation.createObject(this)`), which
+carries the duration, the type and the curve together. Two neighbouring shapes of the same mistake:
+a duration written as a literal that happens to match a *different* tier's number (Edit Mode's entry
+was `duration: 400` beside `expressiveDefaultSpatial`, which is 500ms's curve at 400ms's clock — a
+third timing nothing else in the shell moves at), and an element given no transition at all beside
+ones that have them, which is what "not M3E-compliant" usually turns out to mean when someone says
+it about a screen rather than about a line. Note `elementMoveEnter`/`elementMoveExit` both carry
+`alwaysRunToEnd`, so they are wrong for anything the user can reverse mid-flight — a mode toggled
+twice inside its own duration finishes arriving before it starts leaving.
+(fix(editMode): take the motion tiers whole instead of half of one each.)
 
 **The sidebar's bottom widget group has a fixed height, and that is load-bearing.**
 `BottomWidgetGroup.qml`'s `expandedHeight` is a constant (352) rather than a binding on its

--- a/dots/.config/quickshell/imi/EditModeLookProbe.qml
+++ b/dots/.config/quickshell/imi/EditModeLookProbe.qml
@@ -193,8 +193,8 @@ ShellRoot {
 
     // Everything the pixel half needs to know where to look, so it holds no
     // copy of the geometry it is scoring.
-    function reportGeometry(): void {
-        console.log(`[EditModeLook] geometry: screen=${harness.screenWidth},${harness.screenHeight}`
+    function reportGeometry(tag): void {
+        console.log(`[EditModeLook] ${tag}: screen=${harness.screenWidth},${harness.screenHeight}`
             + ` card=${harness.card.x},${harness.card.y},${harness.card.width},${harness.card.height}`
             + ` radius=${harness.cardRadius} scale=${harness.applied.scale}`
             + ` marker=${cornerMarker.x},${cornerMarker.y},${cornerMarker.width},${cornerMarker.height}`
@@ -247,17 +247,42 @@ ShellRoot {
             harness.applied.scale <= EditMode.MAX_SCALE + 1e-9
                 && harness.applied.scale > EditMode.MIN_SCALE,
             `scale=${harness.applied.scale.toFixed(3)}`);
-        // Every side, because a shrink that only opened one edge is a crop.
-        harness.check("...on every side, with the drawer's slot still to the right",
-            harness.card.x >= harness.margin - 0.5
-                && harness.card.y >= harness.margin - 0.5
-                && harness.card.y + harness.card.height <= harness.screenHeight - harness.margin + 0.5
-                && harness.screenWidth - (harness.card.x + harness.card.width)
-                    >= harness.drawerWidth + harness.margin - 0.5,
+        // Dead centre, with room on each side for the drawer to translate the
+        // desktop into later. A shrink that opened one edge is a crop, and one
+        // that opened three is the desktop being shoved aside.
+        const freeX = harness.screenWidth - (harness.card.x + harness.card.width);
+        const freeY = harness.screenHeight - (harness.card.y + harness.card.height);
+        harness.check("...about dead centre, with room for the drawer on each side",
+            Math.abs(harness.card.x - freeX) < 0.5
+                && Math.abs(harness.card.y - freeY) < 0.5
+                && harness.card.x >= harness.drawerWidth / 2 + harness.margin - 0.5
+                && harness.card.y >= harness.margin - 0.5,
             `card=${harness.card.x.toFixed(1)},${harness.card.y.toFixed(1)}`
                 + ` ${harness.card.width.toFixed(1)}x${harness.card.height.toFixed(1)}`);
-        harness.reportGeometry();
+        harness.reportGeometry("geometry");
         harness.shoot("editing", () => {
+            harness.editProgress = 0.5;
+            harness.after(harness.midway);
+        });
+    }
+
+    function midway(): void {
+        // The correction the centring is for is about the ENTRY, not about
+        // where the desktop ends up: a geometry that reserved the drawer's
+        // width on one side was symmetric nowhere, and the frames nobody looks
+        // at are the ones in between. Held at half progress and photographed,
+        // so the pixel half can measure where the desktop is actually drawn
+        // rather than read the number back out of the same function.
+        const freeX = harness.screenWidth - (harness.card.x + harness.card.width);
+        const freeY = harness.screenHeight - (harness.card.y + harness.card.height);
+        harness.check("half way in, the desktop is still dead centre",
+            Math.abs(harness.card.x - freeX) < 0.5 && Math.abs(harness.card.y - freeY) < 0.5
+                && harness.applied.scale > harness.viewport.scale
+                && harness.applied.scale < 1,
+            `card=${harness.card.x.toFixed(1)},${harness.card.y.toFixed(1)}`
+                + ` scale=${harness.applied.scale.toFixed(3)}`);
+        harness.reportGeometry("midGeometry");
+        harness.shoot("midway", () => {
             harness.editProgress = 0;
             harness.after(harness.left);
         });

--- a/dots/.config/quickshell/imi/EditModeLookProbe.qml
+++ b/dots/.config/quickshell/imi/EditModeLookProbe.qml
@@ -1,0 +1,279 @@
+import QtQuick
+import Quickshell
+import qs.modules.common
+import qs.modules.common.widgets.widgetCanvas
+import qs.modules.imi.background
+import "modules/common/functions/edit_mode.js" as EditMode
+
+/*
+ * What Edit Mode's desktop looks like, in pixels.
+ *
+ * The mode is a transform on three siblings of a wlr-layer-shell PanelWindow,
+ * and weston implements no layer shell - so the four-sibling arrangement is
+ * re-declared here the way ClockDepthProbe re-declares the depth layer's, with
+ * the real `EditModeCard`, the real `WidgetCanvas` and the real `edit_mode.js`
+ * doing the work. What is re-declared is the arrangement; nothing about the
+ * chrome or the lattice is copied, because a copy is a second thing to be wrong
+ * and the point here is to score what ships.
+ *
+ * This half asserts the geometry and saves three frames. The pixels are scored
+ * by tests/test_edit_mode_chrome.py: `ItemGrabResult.image` is a QImage and a
+ * QImage is not scriptable from QML, so analysis belongs outside - the same
+ * split test_card_shadow.py already runs on.
+ *
+ * The three frames answer the three questions no source check can:
+ *
+ * - the chrome stands down COMPLETELY on exit. `rest` and `after` must be the
+ *   same picture, which is the only check that catches a radius, a shadow or a
+ *   matrix left applied to the live desktop. A property assertion cannot: an
+ *   inactive Loader and a zeroed radius are what a still-transformed viewport
+ *   reports too.
+ * - the desktop's corner is CUT. There is no rounded clip in QML, so the corner
+ *   is made by covering it with the backdrop, and "did the cover land on the
+ *   corner" is a question about one pixel. `cornerMarker` is pinned to the
+ *   canvas's own top-left corner so the answer does not depend on the picture.
+ * - the lattice is a SUBSTRATE. The desktop widgets arrive as external children
+ *   of the canvas, so nothing in WidgetCanvas.qml decides whether they are drawn
+ *   over the grid; an opaque widget must hide the lines under it completely.
+ *
+ * The wallpaper is whatever EDIT_MODE_WALLPAPER names, so the same probe serves
+ * the synthetic fixture the suite runs and a real photograph a human looks at.
+ * No check reads the wallpaper's own pixels.
+ *
+ *   EDIT_MODE_WALLPAPER=... EDIT_MODE_SHOT_DIR=... ./tests/run_edit_mode_look_probe.sh
+ */
+ShellRoot {
+    id: harness
+
+    property int checksRun: 0
+    property int failures: 0
+    function check(label, ok, detail) {
+        harness.checksRun++;
+        console.log(`[EditModeLook] ${label}: ${ok ? "ok" : "FAIL"}${detail ? " " + detail : ""}`);
+        if (!ok) harness.failures++;
+    }
+
+    readonly property string wallpaperFile: Quickshell.env("EDIT_MODE_WALLPAPER") || ""
+    readonly property string shotDir: Quickshell.env("EDIT_MODE_SHOT_DIR") || ""
+    readonly property int screenWidth: parseInt(Quickshell.env("EDIT_MODE_WIDTH") || "1600")
+    readonly property int screenHeight: parseInt(Quickshell.env("EDIT_MODE_HEIGHT") || "900")
+
+    readonly property real drawerWidth: Appearance.sizes.editModeDrawerWidth
+    readonly property real margin: Appearance.sizes.editModeMargin
+
+    // The one thing that moves. Driven directly rather than through a Behavior:
+    // every frame here is a settled one, and a curve sampled mid-flight is a
+    // working animation reading as a wrong geometry.
+    property real editProgress: 0
+
+    readonly property var viewport: EditMode.viewportGeometry({
+        screenWidth: harness.screenWidth,
+        screenHeight: harness.screenHeight,
+        drawerWidth: harness.drawerWidth,
+        margin: harness.margin
+    })
+    readonly property var applied: EditMode.atProgress(harness.viewport, harness.editProgress)
+    readonly property rect card: EditMode.cardRect(harness.viewport, harness.editProgress,
+        harness.screenWidth, harness.screenHeight)
+    readonly property real cardRadius: Appearance.rounding.verylarge * harness.editProgress
+
+    // Opaque and unmistakable: the two pixel questions are "is this the marker"
+    // rather than "is this a colour the wallpaper might also be".
+    readonly property color cornerMarkerColor: "#ff00ff"
+    readonly property color opaquePanelColor: "#00ff88"
+
+    FloatingWindow {
+        id: window
+        implicitWidth: harness.screenWidth
+        implicitHeight: harness.screenHeight
+        color: "black"
+
+        Item {
+            id: field
+            anchors.fill: parent
+            // The grab takes THIS item, so it carries its own ground: grabbing
+            // over the window's colour yields a transparent PNG whose "white"
+            // reads as black to any analyser.
+            Rectangle { anchors.fill: parent; color: "black"; z: -3 }
+
+            Item {
+                id: parallaxViewport
+                anchors.fill: parent
+                transform: Matrix4x4 { matrix: harness.matrix }
+
+                Image {
+                    id: wallpaper
+                    anchors.fill: parent
+                    fillMode: Image.PreserveAspectCrop
+                    cache: true
+                    smooth: true
+                    asynchronous: false
+                    source: harness.wallpaperFile === "" ? "" : `file://${harness.wallpaperFile}`
+                }
+            }
+
+            WidgetCanvas {
+                id: widgetCanvas
+                anchors.fill: parent
+                z: 2
+                editMode: harness.editProgress > 0.99
+                selectionEnabled: true
+                transform: Matrix4x4 { matrix: harness.matrix }
+
+                // Pinned to the canvas's own top-left corner, which is the
+                // card's top-left corner at every scale. Without a cut it
+                // reaches the card's corner pixel; with one, the backdrop does.
+                Rectangle {
+                    id: cornerMarker
+                    x: 0
+                    y: 0
+                    width: 220
+                    height: 220
+                    color: harness.cornerMarkerColor
+                }
+
+                // Opaque on purpose: a translucent panel cannot say whether the
+                // lattice is under it or over it, because either way the line
+                // shows through.
+                Rectangle {
+                    id: opaquePanel
+                    x: 520
+                    y: 300
+                    width: 260
+                    height: 180
+                    radius: Appearance.rounding.normal
+                    color: harness.opaquePanelColor
+                }
+
+                // What a desktop widget actually looks like: a translucent card
+                // on the wallpaper. Here to be looked at, not to be measured.
+                Repeater {
+                    model: [
+                        { wx: 130, wy: 420, ww: 300, wh: 200 },
+                        { wx: 860, wy: 140, ww: 340, wh: 240 },
+                        { wx: 900, wy: 520, ww: 240, wh: 150 }
+                    ]
+                    delegate: Rectangle {
+                        required property var modelData
+                        x: modelData.wx
+                        y: modelData.wy
+                        width: modelData.ww
+                        height: modelData.wh
+                        radius: Appearance.rounding.normal
+                        color: Qt.alpha(Appearance.colors.colLayer1, 0.35)
+                        border.width: Appearance.borderWidth.standard
+                        border.color: Appearance.colors.colLayer0Border
+                    }
+                }
+            }
+
+            Loader {
+                id: editChrome
+                active: harness.editProgress > 0
+                anchors.fill: parent
+                z: 4
+                enabled: false
+                opacity: harness.editProgress
+                sourceComponent: EditModeCard {
+                    wallpaperLayer: wallpaper
+                    blurRadius: Config.options.lock.blur.radius
+                    blurSamples: Config.options.lock.blur.size
+                    card: harness.card
+                    cardRadius: harness.cardRadius
+                }
+            }
+        }
+    }
+
+    readonly property matrix4x4 matrix: Qt.matrix4x4(
+        harness.applied.scale, 0, 0, harness.applied.x,
+        0, harness.applied.scale, 0, harness.applied.y,
+        0, 0, 1, 0,
+        0, 0, 0, 1)
+
+    // Everything the pixel half needs to know where to look, so it holds no
+    // copy of the geometry it is scoring.
+    function reportGeometry(): void {
+        console.log(`[EditModeLook] geometry: screen=${harness.screenWidth},${harness.screenHeight}`
+            + ` card=${harness.card.x},${harness.card.y},${harness.card.width},${harness.card.height}`
+            + ` radius=${harness.cardRadius} scale=${harness.applied.scale}`
+            + ` marker=${cornerMarker.x},${cornerMarker.y},${cornerMarker.width},${cornerMarker.height}`
+            + ` panel=${opaquePanel.x},${opaquePanel.y},${opaquePanel.width},${opaquePanel.height}`
+            + ` markerColor=${harness.cornerMarkerColor} panelColor=${harness.opaquePanelColor}`);
+    }
+
+    function shoot(name, next) {
+        field.grabToImage(result => {
+            result.saveToFile(`${harness.shotDir}/${name}.png`);
+            next();
+        });
+    }
+
+    Timer {
+        id: settle
+        interval: 500
+        property var next: null
+        onTriggered: if (settle.next) settle.next()
+    }
+    function after(step) {
+        settle.next = step;
+        settle.restart();
+    }
+
+    Timer {
+        running: true
+        interval: 1200
+        onTriggered: {
+            harness.check("the fixture is on disk, decoded, and there is somewhere to shoot",
+                harness.wallpaperFile !== "" && harness.shotDir !== ""
+                    && wallpaper.status === Image.Ready,
+                `status=${wallpaper.status}`);
+            harness.check("at rest the card is the whole screen, square",
+                harness.card.x === 0 && harness.card.y === 0
+                    && harness.card.width === harness.screenWidth
+                    && harness.card.height === harness.screenHeight
+                    && harness.cardRadius === 0);
+            harness.check("at rest there is no chrome to stand down",
+                !editChrome.active);
+            harness.shoot("rest", () => {
+                harness.editProgress = 1;
+                harness.after(harness.editing);
+            });
+        }
+    }
+
+    function editing(): void {
+        harness.check("the mode shrinks the desktop enough to read as an object",
+            harness.applied.scale <= EditMode.MAX_SCALE + 1e-9
+                && harness.applied.scale > EditMode.MIN_SCALE,
+            `scale=${harness.applied.scale.toFixed(3)}`);
+        // Every side, because a shrink that only opened one edge is a crop.
+        harness.check("...on every side, with the drawer's slot still to the right",
+            harness.card.x >= harness.margin - 0.5
+                && harness.card.y >= harness.margin - 0.5
+                && harness.card.y + harness.card.height <= harness.screenHeight - harness.margin + 0.5
+                && harness.screenWidth - (harness.card.x + harness.card.width)
+                    >= harness.drawerWidth + harness.margin - 0.5,
+            `card=${harness.card.x.toFixed(1)},${harness.card.y.toFixed(1)}`
+                + ` ${harness.card.width.toFixed(1)}x${harness.card.height.toFixed(1)}`);
+        harness.reportGeometry();
+        harness.shoot("editing", () => {
+            harness.editProgress = 0;
+            harness.after(harness.left);
+        });
+    }
+
+    function left(): void {
+        harness.check("leaving puts the card back to the whole screen, square, unchromed",
+            harness.card.x === 0 && harness.card.y === 0
+                && harness.card.width === harness.screenWidth
+                && harness.cardRadius === 0
+                && !editChrome.active);
+        harness.shoot("after", () => harness.finish());
+    }
+
+    function finish(): void {
+        console.log(`[EditModeLook] checks: ${harness.checksRun} failures: ${harness.failures}`);
+        Qt.exit(harness.failures === 0 ? 0 : 1);
+    }
+}

--- a/dots/.config/quickshell/imi/modules/common/functions/edit_mode.js
+++ b/dots/.config/quickshell/imi/modules/common/functions/edit_mode.js
@@ -55,9 +55,28 @@ var MIN_SCALE = 0.2;
 // screen where it is the tighter constraint it still decides.
 var MAX_SCALE = 0.86;
 
-// The viewport's inset is DERIVED, not chosen: the desktop shrinks by at least
-// what the drawer will need, so the drawer opens into space that already
-// exists rather than covering the desktop or resizing it (spec §1.2, §1.3).
+// The SIZE is derived, not chosen: the desktop shrinks by at least what the
+// drawer will need, so the drawer opens into space that already exists rather
+// than covering the desktop or resizing it (spec §1.2, §1.3).
+//
+// The POSITION is dead centre, and the two are deliberately separate. Entering
+// the mode is a concentric shrink - the desktop gets smaller where it is, and
+// nothing slides - because reserving the drawer's width inside the resting
+// geometry makes the entry asymmetric from its first frame: the desktop drifts
+// toward one edge on the way in, which reads as being shoved aside rather than
+// lifted off the wallpaper, and it does it whether or not a drawer exists yet.
+// The drawer's width is still what decides how far the desktop moves when the
+// drawer OPENS; that is a translation applied at that point, in stage 5, on top
+// of the `x` this returns.
+//
+// The arithmetic that lets those two coexist: a centred desktop has
+// `(screenWidth - width) / 2` free on each side, and the scale below holds
+// `width <= screenWidth - drawerWidth - 2 * margin`, so each side has at least
+// `drawerWidth / 2 + margin`. Opening a drawer of `drawerWidth + margin` on the
+// right therefore needs the desktop to travel at most `drawerWidth / 2` left,
+// which leaves exactly `margin` on its other side. The reservation is real; it
+// is just spent when the drawer arrives instead of being held back from the
+// start.
 //
 // `drawerWidth` is passed whether or not the drawer is open, and this function
 // has no input for the open state on purpose. A desktop that was full width
@@ -66,15 +85,10 @@ var MAX_SCALE = 0.86;
 // flight finds its target a different size than when it was grabbed, and every
 // Behavior carrying the box is handed a moving target, which per b710ef731
 // ("fix(plugins): stop the position Behavior swallowing the parallax
-// cancellation") means it restarts every frame and never ticks. Opening the
-// drawer translates the desktop instead, which is stage 5's `x` offset on top
-// of the `x` this returns.
+// cancellation") means it restarts every frame and never ticks.
 //
-// `margin` is one token: the desktop is inset by it on the left, on the top and
-// on the bottom, and the space reserved on the right is the drawer's own width
-// plus one more of it - the gap between the desktop and the drawer. What the
-// drawer does inside that slot is stage 5's business; the desktop's geometry
-// does not depend on it.
+// `margin` is one token: the gap between the desktop and the screen's edge, and
+// the gap between the desktop and the drawer's slot once there is a drawer.
 function viewportGeometry(input) {
     const screenWidth = (input && input.screenWidth) || 0;
     const screenHeight = (input && input.screenHeight) || 0;
@@ -91,26 +105,18 @@ function viewportGeometry(input) {
     const scale = Math.max(MIN_SCALE,
         Math.min(MAX_SCALE, roomX / screenWidth, roomY / screenHeight));
     const width = screenWidth * scale;
-
-    // Whatever is left over once the desktop, its own margin and the drawer's
-    // slot are accounted for. It is zero on a screen where the drawer decides
-    // the scale, and it is most of a drawer's width again on a wide one, where
-    // the ceiling does - so before this the desktop hugged the left edge of a
-    // 5120px screen with 693px of empty blur on its right, which reads as the
-    // desktop having been shoved aside rather than lifted off the wallpaper.
-    const surplus = Math.max(0, (screenWidth - margin - width) - (drawerWidth + margin));
+    const height = screenHeight * scale;
 
     return {
         scale: scale,
-        // The left margin, plus half of anything spare. Half rather than all,
-        // because the other half stays on the drawer's side: the slot to the
-        // right is `drawerWidth + margin + surplus / 2`, which is still at
-        // least what the drawer asked for, so the derivation stage 5 plugs into
-        // holds whichever of the two constraints decided the scale.
-        x: margin + surplus / 2,
-        y: (screenHeight - screenHeight * scale) / 2,
+        // Centred on both axes, which is what makes `atProgress` a concentric
+        // shrink rather than a slide: the offset is linear in the scale, so
+        // `x * t` is exactly the centring offset of the intermediate scale and
+        // the four margins stay equal in pairs on every frame of the entry.
+        x: (screenWidth - width) / 2,
+        y: (screenHeight - height) / 2,
         width: width,
-        height: screenHeight * scale
+        height: height
     };
 }
 
@@ -120,6 +126,13 @@ function viewportGeometry(input) {
 // straight line, and it means the transform's inputs move together or not at
 // all - there is no frame in which the scale has arrived and the offset has
 // not.
+//
+// The offset is scaled by the SAME t as the scale, and that is what makes the
+// shrink concentric rather than merely centred at the end: a centred geometry's
+// `x` is `screenWidth * (1 - scale) / 2`, which is linear in `(1 - scale)`, so
+// `x * t` is the exact centring offset for the intermediate scale
+// `1 + (scale - 1) * t`. The desktop's four margins are therefore equal in
+// pairs at every point of the animation and not only at rest.
 function atProgress(geometry, progress) {
     const t = Math.max(0, Math.min(1, progress || 0));
     return {

--- a/dots/.config/quickshell/imi/modules/common/functions/edit_mode.js
+++ b/dots/.config/quickshell/imi/modules/common/functions/edit_mode.js
@@ -90,14 +90,26 @@ function viewportGeometry(input) {
     const roomY = screenHeight - margin * 2;
     const scale = Math.max(MIN_SCALE,
         Math.min(MAX_SCALE, roomX / screenWidth, roomY / screenHeight));
+    const width = screenWidth * scale;
+
+    // Whatever is left over once the desktop, its own margin and the drawer's
+    // slot are accounted for. It is zero on a screen where the drawer decides
+    // the scale, and it is most of a drawer's width again on a wide one, where
+    // the ceiling does - so before this the desktop hugged the left edge of a
+    // 5120px screen with 693px of empty blur on its right, which reads as the
+    // desktop having been shoved aside rather than lifted off the wallpaper.
+    const surplus = Math.max(0, (screenWidth - margin - width) - (drawerWidth + margin));
 
     return {
         scale: scale,
-        // The left margin is fixed; whatever slack the other axis leaves
-        // accumulates on the right, which is the side the drawer is on.
-        x: margin,
+        // The left margin, plus half of anything spare. Half rather than all,
+        // because the other half stays on the drawer's side: the slot to the
+        // right is `drawerWidth + margin + surplus / 2`, which is still at
+        // least what the drawer asked for, so the derivation stage 5 plugs into
+        // holds whichever of the two constraints decided the scale.
+        x: margin + surplus / 2,
         y: (screenHeight - screenHeight * scale) / 2,
-        width: screenWidth * scale,
+        width: width,
         height: screenHeight * scale
     };
 }

--- a/dots/.config/quickshell/imi/modules/common/functions/edit_mode.js
+++ b/dots/.config/quickshell/imi/modules/common/functions/edit_mode.js
@@ -37,7 +37,25 @@ function resolveEscape(state) {
 // alternative answers are a zero or a negative scale.
 var MIN_SCALE = 0.2;
 
-// The viewport's inset is DERIVED, not chosen: the desktop shrinks by exactly
+// ...and a desktop scaled ABOVE this is not an object on the screen either: it
+// is the screen with four thin strips of blur around it.
+//
+// The drawer-derived inset below is the right answer while the drawer is a
+// meaningful fraction of the width, and it stops being one as the screen
+// widens - 380px of drawer plus two 24px margins on a 5120px monitor leaves the
+// desktop at 92%, which spends the whole mode signal on a border. The shrink IS
+// the signal (spec §1.1: there is no scrim), so it has to be legible at every
+// screen size and not only at the one where the arithmetic happens to bite.
+//
+// A ceiling rather than a second inset, because a ceiling cannot break the
+// derivation stage 5 plugs into: the space reserved on the right of the desktop
+// is `screenWidth - margin - width`, which the drawer term already holds at or
+// above `drawerWidth + margin`, and lowering the scale further can only make it
+// larger. So the drawer still opens into space that already exists, and on a
+// screen where it is the tighter constraint it still decides.
+var MAX_SCALE = 0.86;
+
+// The viewport's inset is DERIVED, not chosen: the desktop shrinks by at least
 // what the drawer will need, so the drawer opens into space that already
 // exists rather than covering the desktop or resizing it (spec §1.2, §1.3).
 //
@@ -71,7 +89,7 @@ function viewportGeometry(input) {
     const roomX = screenWidth - drawerWidth - margin * 2;
     const roomY = screenHeight - margin * 2;
     const scale = Math.max(MIN_SCALE,
-        Math.min(1, roomX / screenWidth, roomY / screenHeight));
+        Math.min(MAX_SCALE, roomX / screenWidth, roomY / screenHeight));
 
     return {
         scale: scale,
@@ -96,5 +114,27 @@ function atProgress(geometry, progress) {
         scale: 1 + (geometry.scale - 1) * t,
         x: geometry.x * t,
         y: geometry.y * t
+    };
+}
+
+// Where the desktop is ON SCREEN at a given progress - the rectangle the mode's
+// chrome frames.
+//
+// It comes from the same `atProgress` the transform is built out of rather than
+// from the transform's own terms, so the card's corner, its border and its
+// shadow cannot end up a pixel off the desktop they belong to. That is the same
+// rule ClockDepthCutout is one component for: two hand-written copies of a
+// registration drift, and the drift is invisible because both look plausible.
+//
+// At progress 0 this is the whole screen at 0,0, which is what makes "the
+// chrome stands down completely on exit" a property of the arithmetic rather
+// than of a `visible` binding someone has to remember.
+function cardRect(geometry, progress, screenWidth, screenHeight) {
+    const applied = atProgress(geometry, progress);
+    return {
+        x: applied.x,
+        y: applied.y,
+        width: screenWidth * applied.scale,
+        height: screenHeight * applied.scale
     };
 }

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
@@ -739,8 +739,15 @@ AbstractBackgroundWidget {
             ? 0.5 : 0
         visible: opacity > 0 && rootWidget.gridResizable && !rootWidget.interactionLocked
 
+        // The whole tier, not just its duration. Taking the number and leaving
+        // the curve hands the animation Qt's default, which is Easing.Linear -
+        // a generic curve, which docs/M3_GUIDELINES.md §2 forbids outright - so
+        // every grip in this shell has faded linearly beside neighbours easing
+        // on expressiveEffects. Entering Edit Mode reveals every resizable
+        // widget's grip at once, which is where one linear fade stops being one
+        // control's private detail.
         Behavior on opacity {
-            NumberAnimation { duration: Appearance.animation.elementMoveFaster.duration }
+            animation: Appearance.animation.elementMoveFaster.numberAnimation.createObject(this)
         }
 
         Keys.onEscapePressed: event => {

--- a/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/WidgetCanvas.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/WidgetCanvas.qml
@@ -310,67 +310,128 @@ MouseArea {
     // keeps a screen's worth of 12px lines readable rather than grey.
     readonly property real fineGridOpacity: 0.4
 
-    Repeater {
-        model: root.gridVisible ? Math.ceil(root.width / root.gridSize) : 0
-        delegate: Rectangle {
-            required property int index
-            x: index * root.gridSize
-            width: 1
+    // The lattice dissolves toward the canvas edges rather than being sliced off
+    // at them. Two halves, and both are needed: a gradient ALONG each line so it
+    // fades at its own two ends, and a per-line opacity ACROSS the lattice so
+    // the lines nearest an edge are the faintest. Either one alone leaves the
+    // other axis running full strength into the boundary, which is what read as
+    // the grid ending abruptly - a texture pasted onto the desktop rather than
+    // something the surface has.
+    readonly property real gridFadeFraction: 0.07
+    function edgeFade(position, extent) {
+        const band = extent * root.gridFadeFraction
+        if (band <= 0) return 1
+        const distance = Math.min(position, extent - position)
+        return distance >= band ? 1 : Math.max(0, distance / band)
+    }
+
+    // One gradient object shared by every line on that axis rather than one
+    // declared inside each delegate: a screen's worth of 12px lines is several
+    // hundred delegates, and four GradientStops apiece is a few thousand objects
+    // built at the moment the mode is entered.
+    //
+    // The far ends are the line's own colour at zero alpha, not "transparent" -
+    // a stop interpolating toward #00000000 walks the colour through black on
+    // the way, which draws a dark smudge at exactly the edge this exists to
+    // make quiet.
+    readonly property color gridLineColor: Appearance.colors.colLayer0Border
+    readonly property color gridLineFadeColor: Qt.rgba(root.gridLineColor.r,
+        root.gridLineColor.g, root.gridLineColor.b, 0)
+    readonly property Gradient gridFadeAlongY: Gradient {
+        GradientStop { position: 0; color: root.gridLineFadeColor }
+        GradientStop { position: root.gridFadeFraction; color: root.gridLineColor }
+        GradientStop { position: 1 - root.gridFadeFraction; color: root.gridLineColor }
+        GradientStop { position: 1; color: root.gridLineFadeColor }
+    }
+    readonly property Gradient gridFadeAlongX: Gradient {
+        orientation: Gradient.Horizontal
+        GradientStop { position: 0; color: root.gridLineFadeColor }
+        GradientStop { position: root.gridFadeFraction; color: root.gridLineColor }
+        GradientStop { position: 1 - root.gridFadeFraction; color: root.gridLineColor }
+        GradientStop { position: 1; color: root.gridLineFadeColor }
+    }
+
+    // The lattice is a SUBSTRATE: widgets sit on it. That order is declared here
+    // rather than left to the order the children happen to be built in, because
+    // nothing in this file decides it - the desktop widgets arrive as EXTERNAL
+    // children of this canvas (Background.qml's Repeater over the plugin
+    // manifests), so which of the two ends up on top is a consequence of when a
+    // Repeater's model filled rather than of anything anybody chose. A widget
+    // whose panel is translucent - which every desktop widget is, and which the
+    // mode makes more so by standing the frost down - then has a crisp full
+    // strength line running across it, and reads as being under the grid.
+    Item {
+        id: lattice
+        anchors.fill: parent
+        z: -1
+        // Cannot take input, ever. The canvas's own press is what anchors the
+        // marquee and what a widget's drag is measured against.
+        enabled: false
+
+        Repeater {
+            model: root.gridVisible ? Math.ceil(root.width / root.gridSize) : 0
+            delegate: Rectangle {
+                required property int index
+                x: index * root.gridSize
+                width: 1
+                height: root.height
+                opacity: (index % 2 === 0 ? 1 : root.fineGridOpacity)
+                    * root.edgeFade(x, root.width)
+                gradient: root.gridFadeAlongY
+            }
+        }
+
+        Repeater {
+            model: root.gridVisible ? Math.ceil(root.height / root.gridSize) : 0
+            delegate: Rectangle {
+                required property int index
+                y: index * root.gridSize
+                width: root.width
+                height: 1
+                opacity: (index % 2 === 0 ? 1 : root.fineGridOpacity)
+                    * root.edgeFade(y, root.height)
+                gradient: root.gridFadeAlongX
+            }
+        }
+
+        Rectangle {
+            id: centerLineV
+            visible: root.gridVisible
+            x: root.width / 2 - width / 2
+            width: root.centerXActive ? 2 : 1
             height: root.height
-            opacity: index % 2 === 0 ? 1 : root.fineGridOpacity
-            color: Appearance.colors.colLayer0Border
-        }
-    }
+            color: root.centerXActive ? Appearance.colors.colPrimary : Appearance.colors.colLayer0Border
+            opacity: root.centerXActive ? 1 : 0.6
 
-    Repeater {
-        model: root.gridVisible ? Math.ceil(root.height / root.gridSize) : 0
-        delegate: Rectangle {
-            required property int index
-            y: index * root.gridSize
+            Behavior on color {
+                animation: Appearance.animation.elementMoveFast.colorAnimation.createObject(this)
+            }
+            Behavior on width {
+                animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
+            }
+            Behavior on opacity {
+                animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
+            }
+        }
+
+        Rectangle {
+            id: centerLineH
+            visible: root.gridVisible
+            y: root.height / 2 - height / 2
             width: root.width
-            height: 1
-            opacity: index % 2 === 0 ? 1 : root.fineGridOpacity
-            color: Appearance.colors.colLayer0Border
-        }
-    }
+            height: root.centerYActive ? 2 : 1
+            color: root.centerYActive ? Appearance.colors.colPrimary : Appearance.colors.colLayer0Border
+            opacity: root.centerYActive ? 1 : 0.6
 
-    Rectangle {
-        id: centerLineV
-        visible: root.gridVisible
-        x: root.width / 2 - width / 2
-        width: root.centerXActive ? 2 : 1
-        height: root.height
-        color: root.centerXActive ? Appearance.colors.colPrimary : Appearance.colors.colLayer0Border
-        opacity: root.centerXActive ? 1 : 0.6
-
-        Behavior on color {
-            animation: Appearance.animation.elementMoveFast.colorAnimation.createObject(this)
-        }
-        Behavior on width {
-            animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
-        }
-        Behavior on opacity {
-            animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
-        }
-    }
-
-    Rectangle {
-        id: centerLineH
-        visible: root.gridVisible
-        y: root.height / 2 - height / 2
-        width: root.width
-        height: root.centerYActive ? 2 : 1
-        color: root.centerYActive ? Appearance.colors.colPrimary : Appearance.colors.colLayer0Border
-        opacity: root.centerYActive ? 1 : 0.6
-
-        Behavior on color {
-            animation: Appearance.animation.elementMoveFast.colorAnimation.createObject(this)
-        }
-        Behavior on height {
-            animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
-        }
-        Behavior on opacity {
-            animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
+            Behavior on color {
+                animation: Appearance.animation.elementMoveFast.colorAnimation.createObject(this)
+            }
+            Behavior on height {
+                animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
+            }
+            Behavior on opacity {
+                animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
+            }
         }
     }
 

--- a/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/WidgetCanvas.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/WidgetCanvas.qml
@@ -22,6 +22,16 @@ MouseArea {
     // config switch, whose meaning is "draw the grid while I drag".
     readonly property bool gridVisible: root.editMode
         || (showGrid && Config.options.background.showGrid)
+    // ...and it arrives and leaves rather than appearing. The lattice used to be
+    // a Repeater model going straight from 0 to a screen's worth of lines, so it
+    // popped on while the desktop eased into the mode beside it - the reading of
+    // "not M3E-compliant" that costs nothing to fix. An effects tier because
+    // this is an opacity, which is what elementMoveFast is for and what the
+    // centre lines in this same file already animate on.
+    property real gridStrength: root.gridVisible ? 1 : 0
+    Behavior on gridStrength {
+        animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
+    }
 
     // Desktop widgets sit on the background layer surface, which only accepts
     // keyboard input while GlobalStates.desktopWidgetKeyboardFocus flips it to
@@ -364,12 +374,15 @@ MouseArea {
         id: lattice
         anchors.fill: parent
         z: -1
+        // The delegates outlive the flag so the fade-out has something to fade.
+        opacity: root.gridStrength
+        visible: root.gridStrength > 0
         // Cannot take input, ever. The canvas's own press is what anchors the
         // marquee and what a widget's drag is measured against.
         enabled: false
 
         Repeater {
-            model: root.gridVisible ? Math.ceil(root.width / root.gridSize) : 0
+            model: root.gridStrength > 0 ? Math.ceil(root.width / root.gridSize) : 0
             delegate: Rectangle {
                 required property int index
                 x: index * root.gridSize
@@ -382,7 +395,7 @@ MouseArea {
         }
 
         Repeater {
-            model: root.gridVisible ? Math.ceil(root.height / root.gridSize) : 0
+            model: root.gridStrength > 0 ? Math.ceil(root.height / root.gridSize) : 0
             delegate: Rectangle {
                 required property int index
                 y: index * root.gridSize
@@ -396,7 +409,6 @@ MouseArea {
 
         Rectangle {
             id: centerLineV
-            visible: root.gridVisible
             x: root.width / 2 - width / 2
             width: root.centerXActive ? 2 : 1
             height: root.height
@@ -416,7 +428,6 @@ MouseArea {
 
         Rectangle {
             id: centerLineH
-            visible: root.gridVisible
             y: root.height / 2 - height / 2
             width: root.width
             height: root.centerYActive ? 2 : 1

--- a/dots/.config/quickshell/imi/modules/imi/background/Background.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/Background.qml
@@ -573,6 +573,11 @@ Variants {
         // list composes in is exactly the kind of thing that is wrong by a
         // factor of the scale and still looks plausible. Row-major, so a point
         // maps to (s*x + tx, s*y + ty).
+        //
+        // What it DRAWS is a scale about the CENTRE, and that is the geometry's
+        // doing rather than this matrix's: the offset edit_mode.js hands in is
+        // the centring offset for the scale beside it, on every frame. A centred
+        // scale is a different matrix, not a different structure.
         readonly property matrix4x4 editMatrix: Qt.matrix4x4(
             bgRoot.editTransform.scale, 0, 0, bgRoot.editTransform.x,
             0, bgRoot.editTransform.scale, 0, bgRoot.editTransform.y,

--- a/dots/.config/quickshell/imi/modules/imi/background/Background.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/Background.qml
@@ -573,6 +573,20 @@ Variants {
             0, bgRoot.editTransform.scale, 0, bgRoot.editTransform.y,
             0, 0, 1, 0,
             0, 0, 0, 1)
+        // Where that transform puts the desktop, for the chrome drawn around
+        // it. Out of the module rather than off the matrix's own terms: the
+        // corner, the outline and the shadow have to sit on the desktop's edge
+        // exactly, and a second derivation of a registration is the drift
+        // ClockDepthCutout exists as one component to prevent.
+        readonly property rect editCard: EditMode.cardRect(bgRoot.editViewport,
+            bgRoot.editProgress, bgRoot.width, bgRoot.height)
+        // The corner grows with the shrink, so a desktop at rest has no radius
+        // applied to it at all rather than one that happens to be hidden. The
+        // ladder's own name for the tier, per docs/M3_GUIDELINES.md - a whole
+        // desktop is the "major distinct UI block" that tier is for, and the
+        // `extraLarge` alias exists for the vendored design system's call sites
+        // rather than for mainline ones.
+        readonly property real editCardRadius: Appearance.rounding.verylarge * bgRoot.editProgress
 
         property bool shouldBlur: (GlobalStates.screenLocked && Config.options.lock.blur.enable)
         property color dominantColor: Appearance.colors.colPrimary
@@ -1423,12 +1437,12 @@ Variants {
             }
         }
 
-        // Edit Mode's backdrop: the wallpaper, blurred, behind the shrunk
-        // desktop. That blur plus the shrink IS the mode signal - there is no
-        // scrim - so it is not optional and is not gated on the lock's own blur
-        // preference; only its radius is borrowed from there, since it is the
-        // same picture and a second setting for it would be a second thing to
-        // disagree.
+        // Edit Mode's chrome: the wallpaper blurred around the shrunk desktop,
+        // the desktop's corner, its outline and its shadow. That blur plus the
+        // shrink IS the mode signal - there is no scrim - so it is not optional
+        // and is not gated on the lock's own blur preference; only its radius is
+        // borrowed from there, since it is the same picture and a second setting
+        // for it would be a second thing to disagree.
         //
         // A SIBLING of the viewport rather than a second gate on the lock's
         // blurLoader, which is what the spec asked for and which cannot work:
@@ -1437,18 +1451,26 @@ Variants {
         // desktop it is supposed to sit behind. Sourcing the wallpaper item is
         // unaffected - a ShaderEffectSource renders its source item in that
         // item's own coordinates, not the scene's.
+        //
+        // ABOVE the desktop rather than behind it, which is what rounds the
+        // corner: see EditModeCard for why covering the corner with the picture
+        // behind it is the only cheap way to round three separately transformed
+        // siblings. Above the clock depth layer at z 3, and non-interactive,
+        // because desktopRightClickArea at z -2 works only while everything
+        // over it lets clicks through.
         Loader {
-            id: editBackdrop
+            id: editChrome
             active: bgRoot.editProgress > 0 && !bgRoot.suppressContents
             anchors.fill: parent
-            // Below every wallpaper layer and the widgets (all z 0..3), above
-            // the desktop's right-click area at z -2.
-            z: -1
+            z: 4
+            enabled: false
             opacity: bgRoot.editProgress
-            sourceComponent: WallpaperBlurBackdrop {
-                source: bgRoot.liveWallpaperLayer
-                radius: Config.options.lock.blur.radius
-                samples: Config.options.lock.blur.size
+            sourceComponent: EditModeCard {
+                wallpaperLayer: bgRoot.liveWallpaperLayer
+                blurRadius: Config.options.lock.blur.radius
+                blurSamples: Config.options.lock.blur.size
+                card: bgRoot.editCard
+                cardRadius: bgRoot.editCardRadius
             }
         }
 

--- a/dots/.config/quickshell/imi/modules/imi/background/Background.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/Background.qml
@@ -555,12 +555,17 @@ Variants {
         // cannot arrive on different frames. It moves once per mode change, not
         // per frame, which is what makes a Behavior legitimate here at all.
         property real editProgress: GlobalStates.editMode ? 1 : 0
+        // The shell's default spatial move, taken whole rather than spelled out
+        // - the duration used to be a literal 400 beside the spatial curve,
+        // which is neither of the two tiers docs/M3_GUIDELINES.md offers (500ms
+        // expressiveDefaultSpatial for a spatial move, 400ms emphasizedDecel for
+        // an entrance) and so is a third timing nothing else in the shell moves
+        // at. `elementMove` and not `elementMoveEnter`/`Exit`, because those two
+        // carry `alwaysRunToEnd` and this toggle has to be able to reverse
+        // mid-flight: a mode entered and left again inside 400ms would otherwise
+        // finish arriving before it started leaving.
         Behavior on editProgress {
-            NumberAnimation {
-                duration: 400
-                easing.type: Easing.BezierSpline
-                easing.bezierCurve: Appearance.animationCurves.expressiveDefaultSpatial
-            }
+            animation: Appearance.animation.elementMove.numberAnimation.createObject(this)
         }
         readonly property var editTransform: EditMode.atProgress(bgRoot.editViewport, bgRoot.editProgress)
         // A scale about the top-left followed by a translation, written as one

--- a/dots/.config/quickshell/imi/modules/imi/background/EditModeCard.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/EditModeCard.qml
@@ -1,0 +1,141 @@
+import QtQuick
+import Qt5Compat.GraphicalEffects
+import qs.modules.common
+import qs.modules.common.widgets
+
+/**
+ * Edit Mode's desktop, drawn as a card lifted off its own wallpaper.
+ *
+ * The mode shrinks the desktop with a transform and nothing else, which leaves
+ * a hard rectangular edge with no corner, no border and no shadow - a cropped
+ * screenshot rather than a surface being edited. This is the chrome around it:
+ * the blurred backdrop, the corner, the drop shadow and the outline, as one
+ * component so the four cannot end up a pixel apart from each other or from the
+ * desktop. Everything geometric comes from `card`, which is
+ * `edit_mode.js`'s `cardRect` - the same arithmetic the transform is built out
+ * of - for the reason ClockDepthCutout is one component: a second copy of a
+ * registration drifts, and the drift is invisible because both copies look
+ * plausible.
+ *
+ * ---- why the backdrop is drawn ON TOP of the desktop -----------------------
+ *
+ * The desktop is three sibling items, each carrying the edit transform, and QML
+ * has no rounded clip: there is no property on any of them that rounds a
+ * corner, and wrapping all three in one masked layer means re-rendering the
+ * wallpaper through an effect for every frame of the shrink.
+ *
+ * So the corner is made by covering it with what is behind it, which is this
+ * same blurred picture. The backdrop draws above the desktop and is cut out to
+ * the card's rounded rect, which is visually identical to drawing it behind
+ * everywhere except the four corners - and at the corners it is the difference
+ * between a rounded card and a square one. It also puts the shadow where a
+ * shadow belongs: inside the same cut-out, over the backdrop, so only the half
+ * of it outside the card survives and its interior never darkens the desktop it
+ * is supposed to lift.
+ *
+ * What it costs is one full-screen layer and one mask, re-rendered while the
+ * card's geometry moves - the 400ms of an entry or an exit, and never at rest.
+ * The blur itself is not re-run for the chrome's sake: it is the same
+ * WallpaperBlurBackdrop that was already being drawn, and it already re-renders
+ * on a live Wallpaper Engine wallpaper whatever this does.
+ */
+Item {
+    id: root
+
+    // The wallpaper layer to blur - an item, never a path, so a
+    // ShaderEffectSource renders it in its OWN coordinates and the backdrop
+    // stays full-screen while the thing it samples is transformed.
+    property Item wallpaperLayer: null
+    property real blurRadius: 0
+    property int blurSamples: 0
+    // The desktop's rectangle on screen, and the corner it is drawn with. Both
+    // interpolate from "the whole screen, square" so that at rest there is
+    // nothing inset, nothing rounded and nothing to stand down.
+    property rect card: Qt.rect(0, 0, root.width, root.height)
+    property real cardRadius: 0
+
+    // Everything that lives OUTSIDE the card, composited once and then cut to
+    // shape. The mask is inverted, so what survives is the complement of the
+    // card: the backdrop, and the outer half of the shadow drawn over it.
+    Item {
+        id: surround
+        anchors.fill: parent
+
+        layer.enabled: true
+        layer.effect: OpacityMask {
+            maskSource: cardShapeMask
+            invert: true
+        }
+
+        WallpaperBlurBackdrop {
+            anchors.fill: parent
+            source: root.wallpaperLayer
+            radius: root.blurRadius
+            samples: root.blurSamples
+        }
+
+        // Not drawn - it is the shape the shadow is taken from. A Rectangle
+        // rather than an Item because StyledRectangularShadow reads its target's
+        // radius, which is how the shadow's corner follows the card's.
+        Rectangle {
+            id: cardShape
+            x: root.card.x
+            y: root.card.y
+            width: root.card.width
+            height: root.card.height
+            radius: root.cardRadius
+            color: "transparent"
+            visible: false
+        }
+
+        // The shell's one shadow for a floating surface, at the magnitude the
+        // component defines. Measured against a 4403px card on a 5120px screen
+        // before leaving it alone: raising `blur` from the component's 9 to 40
+        // spreads the same total darkness over four times the distance and the
+        // two renders are indistinguishable - the edge contrast is set by
+        // `colShadow`'s alpha, not by the reach, and most of a RectangularShadow
+        // sits UNDER its target, which the cut removes. A bigger number here
+        // would have bought a different spelling and no depth.
+        StyledRectangularShadow {
+            target: cardShape
+        }
+    }
+
+    // The cut. Its colour is an alpha channel rather than a colour - OpacityMask
+    // reads nothing but alpha (AGENT.md's note on masking by alpha), so any
+    // opaque value does, and a design token here would say something it does not
+    // mean. `antialiasing` is what makes the corner smooth: the mask's own edge
+    // is the card's edge.
+    Item {
+        id: cardShapeMask
+        anchors.fill: parent
+        visible: false
+
+        Rectangle {
+            x: root.card.x
+            y: root.card.y
+            width: root.card.width
+            height: root.card.height
+            radius: root.cardRadius
+            color: "white"
+            antialiasing: true
+        }
+    }
+
+    // The 1px outline every floating surface in this shell carries beside its
+    // shadow (docs/M3_GUIDELINES.md §1). Drawn over the seam between the
+    // desktop and the cut rather than inside the mask, where the half of it
+    // outside the card would be removed along with everything else there.
+    Rectangle {
+        id: cardEdge
+        x: root.card.x
+        y: root.card.y
+        width: root.card.width
+        height: root.card.height
+        radius: root.cardRadius
+        color: "transparent"
+        antialiasing: true
+        border.width: Appearance.borderWidth.standard
+        border.color: Appearance.colors.colLayer0Border
+    }
+}

--- a/dots/.config/quickshell/imi/tests/run_edit_mode_look_probe.sh
+++ b/dots/.config/quickshell/imi/tests/run_edit_mode_look_probe.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Headless weston + qs, the runtime-harness pattern. The chrome is masks, a
+# gaussian blur and a shadow, so this needs the GL renderer weston's headless
+# backend gives it by default - the software scene graph the QtTest harnesses
+# run under draws none of it.
+#
+# EDIT_MODE_WALLPAPER points it at whatever picture is wanted: the suite passes
+# a synthetic fixture, a human passes a real photograph and looks at the PNGs.
+# No check reads the wallpaper's own pixels.
+set -u
+SOCKET="wl-imi-edit-mode-look"
+TMP=$(mktemp -d)
+export XDG_RUNTIME_DIR="$TMP/runtime"; mkdir -p "$XDG_RUNTIME_DIR"; chmod 700 "$XDG_RUNTIME_DIR"
+export XDG_CONFIG_HOME="$TMP/config" XDG_CACHE_HOME="$TMP/cache" XDG_STATE_HOME="$TMP/state" XDG_DATA_HOME="$TMP/data"
+mkdir -p "$XDG_CONFIG_HOME" "$XDG_CACHE_HOME" "$XDG_STATE_HOME" "$XDG_DATA_HOME"
+WIDTH="${EDIT_MODE_WIDTH:-1600}"
+HEIGHT="${EDIT_MODE_HEIGHT:-900}"
+weston --backend=headless-backend.so --socket="$SOCKET" \
+    --width="$WIDTH" --height="$HEIGHT" &>"$TMP/weston.log" &
+WPID=$!
+sleep 2
+DBUS_SESSION_BUS_ADDRESS="unix:path=/nonexistent" WAYLAND_DISPLAY="$SOCKET" \
+    EDIT_MODE_WALLPAPER="${EDIT_MODE_WALLPAPER:-}" \
+    EDIT_MODE_SHOT_DIR="${EDIT_MODE_SHOT_DIR:-}" \
+    EDIT_MODE_WIDTH="$WIDTH" EDIT_MODE_HEIGHT="$HEIGHT" \
+    timeout 60 qs -p "$(dirname "$0")/../EditModeLookProbe.qml" 2>&1 | grep "EditModeLook"
+kill $WPID 2>/dev/null
+rm -rf "$TMP"

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -322,6 +322,16 @@ if ! python3 "$SCRIPT_DIR/test_edit_mode_runtime.py"; then
     exit 1
 fi
 
+# What the mode LOOKS like: the card's corner, the lattice sitting under the
+# widgets, and the chrome being gone once the mode is left. Every one of those
+# reads as correct in the source and is only answerable in pixels. Brings its
+# own weston.
+echo "Running edit mode chrome tests..."
+if ! python3 "$SCRIPT_DIR/test_edit_mode_chrome.py"; then
+    echo "Edit mode chrome tests failed."
+    exit 1
+fi
+
 echo "Running dock position contract tests..."
 if ! python3 "$SCRIPT_DIR/test_dock_position_contract.py"; then
     echo "Dock position contract tests failed."

--- a/dots/.config/quickshell/imi/tests/test_edit_mode_chrome.py
+++ b/dots/.config/quickshell/imi/tests/test_edit_mode_chrome.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Edit Mode's desktop, scored in pixels: the corner, the substrate, the exit.
+
+`EditModeLookProbe.qml` re-declares the mode's four-sibling arrangement under a
+headless weston and saves three frames - before the mode, during it, and after
+leaving it. This module scores them. The split is forced rather than chosen:
+`ItemGrabResult.image` is a QImage and a QImage is not scriptable from QML, so
+the analysis lives outside, the same way `test_card_shadow.py` runs.
+
+Three things are checked here and nowhere else, because each of them is a
+question about pixels that reads as correct in every source file:
+
+- **the chrome stands down completely on exit.** The frame taken before the mode
+  was ever entered and the frame taken after leaving it must be the same
+  picture. A property assertion cannot say this: an inactive Loader and a zeroed
+  radius are exactly what a still-transformed viewport also reports, and a
+  radius or a shadow left applied to the live desktop is the failure that
+  matters most - it is on screen for the rest of the session.
+- **the desktop's corner is cut.** QML has no rounded clip, so the corner is
+  made by covering it with the blurred backdrop, and whether the cover landed on
+  the corner is a question about one pixel. The probe pins an opaque marker to
+  the canvas's own top-left corner, so the answer does not depend on the
+  wallpaper: at rest the card's corner pixel IS the marker, in the mode it is
+  not, and a marker's width further down the same edge it is again.
+- **the lattice is a substrate.** The desktop widgets arrive as external
+  children of the canvas, so nothing in `WidgetCanvas.qml` decides whether they
+  are drawn over the grid - the order is a consequence of when each Repeater's
+  model filled. An opaque widget must hide every line under it.
+
+The fixture is a flat colour so that "is this pixel a grid line" is answerable
+at all; the check that the lattice is drawn in the first place is what stops the
+substrate check from passing on a frame with no grid in it.
+
+Skips when weston or qs is missing, as in CI.
+"""
+
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+RUNNER = Path(__file__).resolve().parent / "run_edit_mode_look_probe.sh"
+
+SCREEN = (1600, 900)
+# Flat, and nothing like the marker or the panel. A photograph would make "is
+# this pixel a grid line" unanswerable, which is the one thing the vacuity check
+# needs to be able to ask.
+WALLPAPER_RGB = (58, 96, 140)
+
+# The harness states how many checks it ran; this is the literal it must state.
+# Read back out of its own output it would agree with itself by construction,
+# and `failures: 0` is also what a harness that ran nothing prints.
+EXPECTED_CHECKS = 6
+
+GEOMETRY = re.compile(
+    r"geometry: screen=([\d.]+),([\d.]+) card=([\d.]+),([\d.]+),([\d.]+),([\d.]+) "
+    r"radius=([\d.]+) scale=([\d.]+) marker=([\d.]+),([\d.]+),([\d.]+),([\d.]+) "
+    r"panel=([\d.]+),([\d.]+),([\d.]+),([\d.]+) markerColor=(\S+) panelColor=(\S+)")
+
+
+def _available():
+    return shutil.which("qs") is not None and shutil.which("weston") is not None
+
+
+def _hex_to_rgb(value):
+    value = value.lstrip("#")
+    if len(value) == 8:  # #aarrggbb
+        value = value[2:]
+    return tuple(int(value[i:i + 2], 16) for i in (0, 2, 4))
+
+
+@unittest.skipUnless(_available(), "needs qs and weston on PATH")
+class EditModeChromeTest(unittest.TestCase):
+    def setUp(self):
+        try:
+            from PIL import Image
+        except ImportError:
+            self.skipTest("needs Pillow to read the frames back")
+        self.Image = Image
+        self.tmp = Path(tempfile.mkdtemp(prefix="imi-edit-mode-look-"))
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+
+        wallpaper = self.tmp / "wallpaper.png"
+        Image.new("RGB", (800, 450), WALLPAPER_RGB).save(wallpaper)
+
+        env = dict(os.environ)
+        env["EDIT_MODE_WALLPAPER"] = str(wallpaper)
+        env["EDIT_MODE_SHOT_DIR"] = str(self.tmp)
+        env["EDIT_MODE_WIDTH"] = str(SCREEN[0])
+        env["EDIT_MODE_HEIGHT"] = str(SCREEN[1])
+        result = subprocess.run(["bash", str(RUNNER)], cwd=str(ROOT), env=env,
+                                capture_output=True, text=True, timeout=240)
+        self.output = result.stdout + result.stderr
+
+        self.assertNotIn("FAIL", self.output, f"the harness reported failures:\n{self.output}")
+        self.assertIn(f"[EditModeLook] checks: {EXPECTED_CHECKS} failures: 0", self.output,
+                      f"the harness did not finish cleanly:\n{self.output}")
+
+        match = GEOMETRY.search(self.output)
+        self.assertIsNotNone(match, f"the harness reported no geometry:\n{self.output}")
+        values = match.groups()
+        self.card = tuple(float(v) for v in values[2:6])
+        self.radius = float(values[6])
+        self.scale = float(values[7])
+        self.marker = tuple(float(v) for v in values[8:12])
+        self.panel = tuple(float(v) for v in values[12:16])
+        self.marker_rgb = _hex_to_rgb(values[16])
+        self.panel_rgb = _hex_to_rgb(values[17])
+
+        self.frames = {}
+        for name in ("rest", "editing", "after"):
+            path = self.tmp / f"{name}.png"
+            self.assertTrue(path.exists(), f"the harness saved no {name} frame")
+            self.frames[name] = Image.open(path).convert("RGB")
+
+    # ---- helpers ---------------------------------------------------------
+
+    def on_card(self, x, y):
+        """A point in canvas coordinates, in the frame the card is drawn at."""
+        return (round(self.card[0] + x * self.scale), round(self.card[1] + y * self.scale))
+
+    # ---- the exit --------------------------------------------------------
+
+    def test_the_desktop_after_the_mode_is_the_desktop_before_it(self):
+        rest, after = self.frames["rest"], self.frames["after"]
+        self.assertEqual(rest.size, after.size)
+        worst = 0
+        differing = 0
+        for y in range(0, rest.height, 3):
+            for x in range(0, rest.width, 3):
+                a, b = rest.getpixel((x, y)), after.getpixel((x, y))
+                delta = max(abs(p - q) for p, q in zip(a, b))
+                if delta:
+                    differing += 1
+                    worst = max(worst, delta)
+        self.assertEqual(
+            (differing, worst), (0, 0),
+            "the mode left something applied to the live desktop: "
+            f"{differing} sampled pixels differ, worst by {worst}/255")
+
+    # ---- the corner ------------------------------------------------------
+
+    def test_the_cards_corner_is_cut_out_of_the_desktop(self):
+        inset = 3
+        corner = (round(self.card[0]) + inset, round(self.card[1]) + inset)
+        # Far enough down the same edge to be past the arc, and still well
+        # inside the marker, which is 220 canvas pixels tall.
+        below = (round(self.card[0]) + inset, round(self.card[1] + self.radius * 2))
+
+        self.assertEqual(self.frames["editing"].getpixel(below), self.marker_rgb,
+                         "the desktop does not reach the card's edge at all")
+        self.assertNotEqual(self.frames["editing"].getpixel(corner), self.marker_rgb,
+                            "the card's corner is square: the desktop reaches it")
+
+    def test_the_corner_is_only_cut_while_the_mode_is_on(self):
+        # The other half of the check above, and what stops it passing on a
+        # desktop that simply is not where the geometry says it is: at rest the
+        # card is the whole screen and its corner is the marker's own pixel.
+        self.assertEqual(self.frames["rest"].getpixel((3, 3)), self.marker_rgb)
+        self.assertEqual(self.frames["after"].getpixel((3, 3)), self.marker_rgb)
+
+    # ---- the substrate ---------------------------------------------------
+
+    def test_the_lattice_is_drawn_under_the_widgets_and_not_over_them(self):
+        frame = self.frames["editing"]
+        px, py, pw, ph = self.panel
+
+        showing = []
+        for i in range(1, 40):
+            point = self.on_card(px + pw * i / 40, py + ph / 2)
+            if frame.getpixel(point) != self.panel_rgb:
+                showing.append(point)
+        self.assertEqual(showing, [],
+                         "the lattice is drawn over an opaque widget")
+
+    def test_and_the_lattice_is_there_to_be_hidden(self):
+        # Without this the check above passes on a frame with no grid in it.
+        # Sampled on a run of bare wallpaper below the panel: on the flat
+        # fixture, anything that is not the wallpaper's own colour is a line.
+        frame = self.frames["editing"]
+        px, py, pw, ph = self.panel
+        lines = 0
+        for i in range(1, 120):
+            point = self.on_card(px + pw * i / 120, py + ph + 60)
+            if frame.getpixel(point) != WALLPAPER_RGB:
+                lines += 1
+        self.assertGreater(lines, 0, "no lattice was drawn, so hiding it proves nothing")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dots/.config/quickshell/imi/tests/test_edit_mode_chrome.py
+++ b/dots/.config/quickshell/imi/tests/test_edit_mode_chrome.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
-"""Edit Mode's desktop, scored in pixels: the corner, the substrate, the exit.
+"""Edit Mode's desktop, scored in pixels: the shrink, the corner, the substrate.
 
 `EditModeLookProbe.qml` re-declares the mode's four-sibling arrangement under a
-headless weston and saves three frames - before the mode, during it, and after
-leaving it. This module scores them. The split is forced rather than chosen:
-`ItemGrabResult.image` is a QImage and a QImage is not scriptable from QML, so
-the analysis lives outside, the same way `test_card_shadow.py` runs.
+headless weston and saves four frames - before the mode, settled in it, held
+half way in, and after leaving it. This module scores them. The split is forced
+rather than chosen: `ItemGrabResult.image` is a QImage and a QImage is not
+scriptable from QML, so the analysis lives outside, the same way
+`test_card_shadow.py` runs.
 
-Three things are checked here and nowhere else, because each of them is a
+Four things are checked here and nowhere else, because each of them is a
 question about pixels that reads as correct in every source file:
 
 - **the chrome stands down completely on exit.** The frame taken before the mode
@@ -26,6 +27,11 @@ question about pixels that reads as correct in every source file:
   children of the canvas, so nothing in `WidgetCanvas.qml` decides whether they
   are drawn over the grid - the order is a consequence of when each Repeater's
   model filled. An opaque widget must hide every line under it.
+- **the shrink is concentric, on the frames nobody looks at.** A viewport that
+  reserved the drawer's width inside its resting geometry scaled about the
+  top-left and slid, and it settled somewhere plausible - which is what let it
+  ship. The desktop's position is measured off the drawn marker at half
+  progress, not read back out of the function that placed it.
 
 The fixture is a flat colour so that "is this pixel a grid line" is answerable
 at all; the check that the lattice is drawn in the first place is what stops the
@@ -54,10 +60,10 @@ WALLPAPER_RGB = (58, 96, 140)
 # The harness states how many checks it ran; this is the literal it must state.
 # Read back out of its own output it would agree with itself by construction,
 # and `failures: 0` is also what a harness that ran nothing prints.
-EXPECTED_CHECKS = 6
+EXPECTED_CHECKS = 7
 
 GEOMETRY = re.compile(
-    r"geometry: screen=([\d.]+),([\d.]+) card=([\d.]+),([\d.]+),([\d.]+),([\d.]+) "
+    r"(geometry|midGeometry): screen=([\d.]+),([\d.]+) card=([\d.]+),([\d.]+),([\d.]+),([\d.]+) "
     r"radius=([\d.]+) scale=([\d.]+) marker=([\d.]+),([\d.]+),([\d.]+),([\d.]+) "
     r"panel=([\d.]+),([\d.]+),([\d.]+),([\d.]+) markerColor=(\S+) panelColor=(\S+)")
 
@@ -100,19 +106,34 @@ class EditModeChromeTest(unittest.TestCase):
         self.assertIn(f"[EditModeLook] checks: {EXPECTED_CHECKS} failures: 0", self.output,
                       f"the harness did not finish cleanly:\n{self.output}")
 
-        match = GEOMETRY.search(self.output)
-        self.assertIsNotNone(match, f"the harness reported no geometry:\n{self.output}")
-        values = match.groups()
-        self.card = tuple(float(v) for v in values[2:6])
-        self.radius = float(values[6])
-        self.scale = float(values[7])
-        self.marker = tuple(float(v) for v in values[8:12])
-        self.panel = tuple(float(v) for v in values[12:16])
-        self.marker_rgb = _hex_to_rgb(values[16])
-        self.panel_rgb = _hex_to_rgb(values[17])
+        self.reported = {}
+        for match in GEOMETRY.finditer(self.output):
+            values = match.groups()
+            self.reported[values[0]] = {
+                "screen": tuple(float(v) for v in values[1:3]),
+                "card": tuple(float(v) for v in values[3:7]),
+                "radius": float(values[7]),
+                "scale": float(values[8]),
+                "marker": tuple(float(v) for v in values[9:13]),
+                "panel": tuple(float(v) for v in values[13:17]),
+                "markerColor": _hex_to_rgb(values[17]),
+                "panelColor": _hex_to_rgb(values[18]),
+            }
+        for tag in ("geometry", "midGeometry"):
+            self.assertIn(tag, self.reported,
+                          f"the harness reported no {tag}:\n{self.output}")
+        settled = self.reported["geometry"]
+        self.screen = settled["screen"]
+        self.card = settled["card"]
+        self.radius = settled["radius"]
+        self.scale = settled["scale"]
+        self.marker = settled["marker"]
+        self.panel = settled["panel"]
+        self.marker_rgb = settled["markerColor"]
+        self.panel_rgb = settled["panelColor"]
 
         self.frames = {}
-        for name in ("rest", "editing", "after"):
+        for name in ("rest", "editing", "midway", "after"):
             path = self.tmp / f"{name}.png"
             self.assertTrue(path.exists(), f"the harness saved no {name} frame")
             self.frames[name] = Image.open(path).convert("RGB")
@@ -141,6 +162,76 @@ class EditModeChromeTest(unittest.TestCase):
             (differing, worst), (0, 0),
             "the mode left something applied to the live desktop: "
             f"{differing} sampled pixels differ, worst by {worst}/255")
+
+    def test_the_transform_returns_the_desktop_to_its_own_coordinates(self):
+        # The other half of standing down, and the half the frame comparison
+        # above cannot see: both frames are taken at progress 0, so a transform
+        # whose identity is not the identity is wrong in both of them equally.
+        # The marker is 220 canvas pixels square at the canvas's origin, so at
+        # rest its edge is at exactly 220 - and a scale of 0.98 or an offset of
+        # a few pixels left over moves it.
+        edge = round(self.marker[2])
+        for name in ("rest", "after"):
+            frame = self.frames[name]
+            self.assertEqual(frame.getpixel((edge - 2, edge - 2)), self.marker_rgb,
+                             f"{name}: the desktop is not drawn at its own scale")
+            self.assertNotEqual(frame.getpixel((edge + 2, edge + 2)), self.marker_rgb,
+                                f"{name}: the desktop is not drawn at its own scale")
+
+    # ---- the shrink is concentric ----------------------------------------
+
+    def test_the_desktop_shrinks_about_dead_centre_mid_animation(self):
+        # The correction this exists for is about the frames nobody looks at.
+        # A viewport that reserved the drawer's width on one side scaled about
+        # the top-left and slid, so at half progress the desktop sat hard
+        # against one edge - and it settled somewhere plausible, which is what
+        # made it survive. Measured off the drawn marker rather than read back
+        # out of the same function that positions it.
+        mid = self.reported["midGeometry"]
+        frame = self.frames["midway"]
+        screen_w, screen_h = mid["screen"]
+        marker_rgb = mid["markerColor"]
+
+        # Past the rounded corner on both axes, so the arc cannot decide where
+        # the marker is judged to start.
+        probe_y = round(mid["card"][1] + mid["radius"] * 2)
+        probe_x = round(mid["card"][0] + mid["radius"] * 2)
+
+        row = [x for x in range(round(screen_w)) if frame.getpixel((x, probe_y)) == marker_rgb]
+        column = [y for y in range(round(screen_h)) if frame.getpixel((probe_x, y)) == marker_rgb]
+        self.assertTrue(row and column, "the desktop is not drawn mid-animation at all")
+
+        # The marker is a known square at the canvas's origin, so its drawn
+        # width is the scale the desktop is really being painted at. Measured to
+        # a pixel over 220, so it is worth a couple of percent and no more -
+        # enough to say "this is the transform that was reported" and not enough
+        # to locate the desktop's far edge, which is what the reported scale is
+        # for below.
+        drawn_scale = (row[-1] - row[0] + 1) / mid["marker"][2]
+        self.assertAlmostEqual(drawn_scale, mid["scale"], delta=0.02)
+        # ...and it is genuinely mid-flight, or this is the settled check again.
+        self.assertGreater(drawn_scale, self.scale + 0.01)
+        self.assertLess(drawn_scale, 0.99)
+
+        # The origin comes from the marker's CENTRE rather than from its leading
+        # edge: a scaled edge is antialiased, so the first pixel that is exactly
+        # the marker's colour sits a pixel or two inside it, and that bias lands
+        # entirely on one side of the symmetry being measured. A centre cancels
+        # it.
+        left = (row[0] + row[-1] + 1) / 2 - mid["marker"][2] / 2 * mid["scale"]
+        top = (column[0] + column[-1] + 1) / 2 - mid["marker"][3] / 2 * mid["scale"]
+        right = left + screen_w * mid["scale"]
+        bottom = top + screen_h * mid["scale"]
+        self.assertAlmostEqual(left, mid["card"][0], delta=2)
+        self.assertAlmostEqual(top, mid["card"][1], delta=2)
+        # Three pixels: an edge measured off a scaled, antialiased marker is
+        # good to about one, and the symmetry doubles that. The failure this
+        # guards is a scale about the top-left, which puts the error at the
+        # width of a whole margin - 60px here - not at three.
+        self.assertAlmostEqual(left, screen_w - right, delta=3,
+                               msg="the desktop is not centred horizontally mid-animation")
+        self.assertAlmostEqual(top, screen_h - bottom, delta=3,
+                               msg="the desktop is not centred vertically mid-animation")
 
     # ---- the corner ------------------------------------------------------
 

--- a/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
@@ -187,6 +187,43 @@ def test_the_frost_names_its_condition_rather_than_one_of_its_causes():
     assert "!rootWidget.frostSuspended" in text, "the blur Repeater ignores the gate"
 
 
+def test_the_chrome_stands_down_through_two_gates_and_not_one():
+    # Both are load-bearing and the pixel probe cannot see it: with the Loader
+    # gated and the opacity not, the chrome is gone anyway, and vice versa - so
+    # a frame comparison passes on a tree with one of them left. Which is
+    # exactly why the second one gets deleted as redundant one day.
+    text = read(BACKGROUND)
+    chrome = re.search(r"Loader \{\s*id: editChrome(.*?)\n        \}", text, re.S)
+    assert chrome, "the mode's chrome loader is gone"
+    body = chrome.group(1)
+    assert re.search(r"active:\s*bgRoot\.editProgress > 0", body), \
+        "the chrome must not exist while the mode is off"
+    assert re.search(r"opacity:\s*bgRoot\.editProgress", body), \
+        "the chrome must be transparent while the mode is off"
+    # ...and its geometry is the module's answer, not a second one.
+    assert "card: bgRoot.editCard" in body and "cardRadius: bgRoot.editCardRadius" in body
+    assert "EditMode.cardRect(" in text, \
+        "the card's rectangle must come from the same arithmetic as the transform"
+
+
+def test_the_lattice_declares_where_it_sits_rather_than_inheriting_it():
+    # The desktop widgets are EXTERNAL children of the canvas, so declaration
+    # order decides nothing here; a grid Rectangle at the canvas's root is back
+    # to the stacking being whatever each Repeater's model happened to fill
+    # first.
+    text = read(CANVAS)
+    lattice = re.search(r"Item \{\s*id: lattice(.*?)\n    \}", text, re.S)
+    assert lattice, "the lattice is not one item any more"
+    assert re.search(r"^\s*z: -1\s*$", lattice.group(1), re.M), \
+        "the lattice must declare that it sits below the widgets"
+    for match in re.finditer(r"gridSize\b", text):
+        line_start = text.rfind("\n", 0, match.start()) + 1
+        if not re.match(r"\s*(x|y|model):", text[line_start:match.start() + 8]):
+            continue
+        assert lattice.start() < match.start() < lattice.end(), \
+            "a line of the lattice is drawn outside the item that owns its order"
+
+
 def test_the_inset_is_derived_from_one_declared_drawer_width():
     module = read(MODULE)
     assert "function viewportGeometry" in module

--- a/dots/.config/quickshell/imi/tests/tst_edit_mode.qml
+++ b/dots/.config/quickshell/imi/tests/tst_edit_mode.qml
@@ -57,8 +57,6 @@ TestCase {
         // the width is the promise.
         fuzzyCompare(narrow.width, 1152, 0.5);
         fuzzyCompare(narrow.scale, 1152 / 1600, 1e-9);
-        // The space left over on the right is the drawer plus its gap.
-        fuzzyCompare(1600 - (narrow.x + narrow.width), 400 + 24, 0.5);
     }
 
     function test_a_wide_screen_shrinks_by_the_ceiling_instead() {
@@ -70,45 +68,40 @@ TestCase {
         verify(wide.scale < (5120 - 400 - 48) / 5120);
     }
 
-    function test_the_ceiling_can_only_give_the_drawer_more_room_than_it_asked_for() {
-        // The invariant the derivation exists for, asserted across both
-        // regimes: whatever decides the scale, the slot to the right of the
-        // desktop still holds the drawer plus its gap. A ceiling that shrank the
-        // desktop by moving its left edge, or that capped the scale without
-        // re-centring, would break this while looking fine on one screen.
-        for (const [width, geometry] of [[5120, wide], [1600, narrow]]) {
-            verify(width - (geometry.x + geometry.width) >= 400 + 24 - 0.5);
-            verify(geometry.x >= 24 - 1e-9);
+    function test_the_desktop_rests_dead_centre_on_both_axes() {
+        // The reservation for the drawer is in the SIZE, never in the resting
+        // position: a geometry that held the drawer's width back on one side
+        // makes the entry asymmetric from its first frame, which reads as the
+        // desktop being shoved aside rather than shrinking where it is.
+        for (const [screen, geometry] of [[[5120, 1440], wide], [[1600, 1000], narrow]]) {
+            fuzzyCompare(geometry.x, (screen[0] - geometry.width) / 2, 1e-9);
+            fuzzyCompare(geometry.y, (screen[1] - geometry.height) / 2, 1e-9);
+            fuzzyCompare(geometry.height / geometry.width, screen[1] / screen[0], 1e-9);
         }
     }
 
-    function test_the_desktop_keeps_its_aspect_and_is_centred_vertically() {
-        fuzzyCompare(wide.height / wide.width, 1440 / 5120, 1e-9);
-        fuzzyCompare(wide.y, (1440 - wide.height) / 2, 0.5);
-        // On a screen where the drawer is what binds, the desktop sits at the
-        // margin exactly and every spare pixel is the drawer's.
-        fuzzyCompare(narrow.x, 24, 1e-9);
-    }
-
-    function test_room_the_drawer_did_not_ask_for_is_split_rather_than_all_given_to_it() {
-        // The ceiling leaves a wide screen with far more space beside the
-        // desktop than the drawer needs, and putting all of it on one side sits
-        // the desktop against the screen edge with a drawer's width of empty
-        // blur opposite - which reads as the desktop having been shoved aside.
-        // Half each: the left inset grows and the drawer's slot never shrinks
-        // below what it asked for.
-        const slot = 5120 - (wide.x + wide.width);
-        const surplus = (5120 - 24 - wide.width) - (400 + 24);
-        verify(surplus > 0);
-        fuzzyCompare(wide.x, 24 + surplus / 2, 0.5);
-        fuzzyCompare(slot, 400 + 24 + surplus / 2, 0.5);
+    function test_a_centred_desktop_still_leaves_the_drawer_room_to_open_into() {
+        // What the reservation buys, now that it is spent later rather than
+        // held back: each side has at least half a drawer plus a margin free,
+        // so opening a drawer of `drawerWidth + margin` on the right needs the
+        // desktop to travel at most half a drawer left and still leaves a
+        // margin behind it. Asserted in both regimes, because on a wide screen
+        // it is the ceiling rather than the drawer that decides the scale.
+        for (const [screen, geometry] of [[5120, wide], [1600, narrow]]) {
+            const free = (screen - geometry.width) / 2;
+            verify(free >= 400 / 2 + 24 - 0.5);
+            // What stage 5 will have to move the desktop by, and what is left
+            // on the other side of it once it has.
+            const travel = Math.max(0, (400 + 24) - free);
+            verify(free - travel >= 24 - 0.5);
+        }
     }
 
     function test_a_short_screen_is_bound_by_its_height_instead() {
         // On a wide, short panel the vertical margins bind first, so the
-        // horizontal slack grows - and it grows on the drawer's side, which is
-        // where extra room is wanted. A geometry that took only the horizontal
-        // ratio would put the desktop's top and bottom edges off the screen.
+        // horizontal slack grows - and it grows on both sides, because the
+        // desktop is centred. A geometry that took only the horizontal ratio
+        // would put the desktop's top and bottom edges off the screen.
         const panel = EditMode.viewportGeometry({
             screenWidth: 1280, screenHeight: 400, drawerWidth: 120, margin: 40
         });
@@ -116,6 +109,7 @@ TestCase {
         verify(panel.scale < (1280 - 120 - 80) / 1280);
         verify(panel.height <= 400 - 80 + 0.5);
         verify(panel.width <= 1280 - 120 - 80 + 0.5);
+        fuzzyCompare(panel.y, 40, 0.5);
     }
 
     function test_the_inset_does_not_depend_on_the_drawer_being_open() {
@@ -175,6 +169,22 @@ TestCase {
         // in on an overshooting curve; it clamps rather than magnifying.
         compare(EditMode.atProgress(wide, 1.4).scale, wide.scale);
         compare(EditMode.atProgress(wide, -0.3).scale, 1);
+    }
+
+    function test_the_shrink_is_concentric_on_every_frame_and_not_only_at_rest() {
+        // The correction this exists for: a geometry that reserved the drawer's
+        // width on one side made the entry a slide as well as a shrink, and it
+        // was symmetric nowhere - including at rest. The margins are equal in
+        // pairs at every progress because the offset is linear in the scale and
+        // takes the same `t`, so this fails on any transform that centres only
+        // at the end.
+        for (const t of [0, 0.15, 0.5, 0.83, 1]) {
+            const at = EditMode.atProgress(wide, t);
+            const card = EditMode.cardRect(wide, t, 5120, 1440);
+            fuzzyCompare(card.x, 5120 - (card.x + card.width), 1e-6);
+            fuzzyCompare(card.y, 1440 - (card.y + card.height), 1e-6);
+            fuzzyCompare(at.scale, card.width / 5120, 1e-9);
+        }
     }
 
     function test_the_card_is_the_whole_screen_until_the_mode_starts() {

--- a/dots/.config/quickshell/imi/tests/tst_edit_mode.qml
+++ b/dots/.config/quickshell/imi/tests/tst_edit_mode.qml
@@ -78,14 +78,30 @@ TestCase {
         // re-centring, would break this while looking fine on one screen.
         for (const [width, geometry] of [[5120, wide], [1600, narrow]]) {
             verify(width - (geometry.x + geometry.width) >= 400 + 24 - 0.5);
-            fuzzyCompare(geometry.x, 24, 1e-9);
+            verify(geometry.x >= 24 - 1e-9);
         }
     }
 
     function test_the_desktop_keeps_its_aspect_and_is_centred_vertically() {
         fuzzyCompare(wide.height / wide.width, 1440 / 5120, 1e-9);
         fuzzyCompare(wide.y, (1440 - wide.height) / 2, 0.5);
-        fuzzyCompare(wide.x, 24, 1e-9);
+        // On a screen where the drawer is what binds, the desktop sits at the
+        // margin exactly and every spare pixel is the drawer's.
+        fuzzyCompare(narrow.x, 24, 1e-9);
+    }
+
+    function test_room_the_drawer_did_not_ask_for_is_split_rather_than_all_given_to_it() {
+        // The ceiling leaves a wide screen with far more space beside the
+        // desktop than the drawer needs, and putting all of it on one side sits
+        // the desktop against the screen edge with a drawer's width of empty
+        // blur opposite - which reads as the desktop having been shoved aside.
+        // Half each: the left inset grows and the drawer's slot never shrinks
+        // below what it asked for.
+        const slot = 5120 - (wide.x + wide.width);
+        const surplus = (5120 - 24 - wide.width) - (400 + 24);
+        verify(surplus > 0);
+        fuzzyCompare(wide.x, 24 + surplus / 2, 0.5);
+        fuzzyCompare(slot, 400 + 24 + surplus / 2, 0.5);
     }
 
     function test_a_short_screen_is_bound_by_its_height_instead() {

--- a/dots/.config/quickshell/imi/tests/tst_edit_mode.qml
+++ b/dots/.config/quickshell/imi/tests/tst_edit_mode.qml
@@ -44,16 +44,42 @@ TestCase {
     readonly property var wide: EditMode.viewportGeometry({
         screenWidth: 5120, screenHeight: 1440, drawerWidth: 400, margin: 24
     })
+    // A 16:10 laptop panel, where 400px of drawer is a quarter of the width and
+    // the derivation is the tighter of the two constraints.
+    readonly property var narrow: EditMode.viewportGeometry({
+        screenWidth: 1600, screenHeight: 1000, drawerWidth: 400, margin: 24
+    })
 
     function test_the_desktop_shrinks_by_exactly_what_the_drawer_will_need() {
-        // 5120 - 400 - 2*24 = 4672 of room, so the scale is the ratio of that
+        // 1600 - 400 - 2*24 = 1152 of room, so the scale is the ratio of that
         // to the screen and the drawn width is that room exactly. Asserted as
         // the width rather than only as the scale: the scale is the mechanism,
         // the width is the promise.
-        fuzzyCompare(wide.width, 4672, 0.5);
-        fuzzyCompare(wide.scale, 4672 / 5120, 1e-9);
+        fuzzyCompare(narrow.width, 1152, 0.5);
+        fuzzyCompare(narrow.scale, 1152 / 1600, 1e-9);
         // The space left over on the right is the drawer plus its gap.
-        fuzzyCompare(5120 - (wide.x + wide.width), 400 + 24, 0.5);
+        fuzzyCompare(1600 - (narrow.x + narrow.width), 400 + 24, 0.5);
+    }
+
+    function test_a_wide_screen_shrinks_by_the_ceiling_instead() {
+        // The same drawer on a 5120px monitor is 8% of the width, and a desktop
+        // at 92% is the screen with a border round it rather than an object on
+        // it. The ceiling is what keeps the shrink - which IS the mode's signal
+        // - legible at that size.
+        compare(wide.scale, EditMode.MAX_SCALE);
+        verify(wide.scale < (5120 - 400 - 48) / 5120);
+    }
+
+    function test_the_ceiling_can_only_give_the_drawer_more_room_than_it_asked_for() {
+        // The invariant the derivation exists for, asserted across both
+        // regimes: whatever decides the scale, the slot to the right of the
+        // desktop still holds the drawer plus its gap. A ceiling that shrank the
+        // desktop by moving its left edge, or that capped the scale without
+        // re-centring, would break this while looking fine on one screen.
+        for (const [width, geometry] of [[5120, wide], [1600, narrow]]) {
+            verify(width - (geometry.x + geometry.width) >= 400 + 24 - 0.5);
+            fuzzyCompare(geometry.x, 24, 1e-9);
+        }
     }
 
     function test_the_desktop_keeps_its_aspect_and_is_centred_vertically() {
@@ -83,13 +109,17 @@ TestCase {
         // drawer's WIDTH alone - so a caller that started passing 0 while the
         // drawer was shut would have to change this number.
         const closed = EditMode.viewportGeometry({
-            screenWidth: 5120, screenHeight: 1440, drawerWidth: 400, margin: 24
+            screenWidth: 1600, screenHeight: 1000, drawerWidth: 400, margin: 24
         });
-        compare(closed.width, wide.width);
-        compare(closed.x, wide.x);
+        compare(closed.width, narrow.width);
+        compare(closed.x, narrow.x);
+        // Measured where the drawer is what decides the scale, so a caller that
+        // started passing 0 while the drawer was shut has to change this number.
+        // On a screen wide enough for the ceiling to bind, both answers are the
+        // ceiling and the check would be vacuous.
         verify(EditMode.viewportGeometry({
-            screenWidth: 5120, screenHeight: 1440, drawerWidth: 0, margin: 24
-        }).width !== wide.width);
+            screenWidth: 1600, screenHeight: 1000, drawerWidth: 0, margin: 24
+        }).width !== narrow.width);
     }
 
     function test_a_screen_too_narrow_for_the_drawer_still_answers_a_usable_scale() {
@@ -129,5 +159,35 @@ TestCase {
         // in on an overshooting curve; it clamps rather than magnifying.
         compare(EditMode.atProgress(wide, 1.4).scale, wide.scale);
         compare(EditMode.atProgress(wide, -0.3).scale, 1);
+    }
+
+    function test_the_card_is_the_whole_screen_until_the_mode_starts() {
+        // What "the chrome stands down completely on exit" rests on: at rest the
+        // rectangle the corner, the border and the shadow are drawn around is
+        // the screen itself, so there is nothing inset to leave behind.
+        const rest = EditMode.cardRect(wide, 0, 5120, 1440);
+        compare(rest.x, 0);
+        compare(rest.y, 0);
+        compare(rest.width, 5120);
+        compare(rest.height, 1440);
+    }
+
+    function test_the_card_is_the_desktop_and_not_a_second_derivation_of_it() {
+        // The chrome frames the transform's own answer. Checked against
+        // atProgress at three points rather than against the geometry, because
+        // a card computed from `geometry` alone would be right at 1 and wrong
+        // for every frame of the entry - which is where a frame off by the
+        // scale reads as the border sliding across the desktop.
+        for (const t of [0.25, 0.6, 1]) {
+            const applied = EditMode.atProgress(wide, t);
+            const card = EditMode.cardRect(wide, t, 5120, 1440);
+            fuzzyCompare(card.x, applied.x, 1e-9);
+            fuzzyCompare(card.y, applied.y, 1e-9);
+            fuzzyCompare(card.width, 5120 * applied.scale, 1e-9);
+            fuzzyCompare(card.height, 1440 * applied.scale, 1e-9);
+        }
+        const settled = EditMode.cardRect(wide, 1, 5120, 1440);
+        fuzzyCompare(settled.width, wide.width, 1e-9);
+        fuzzyCompare(settled.height, wide.height, 1e-9);
     }
 }


### PR DESCRIPTION
The mechanism from #236 works; the treatment was `bgRoot.editMatrix` applied to three siblings and nothing else. A shrunk desktop with a hard rectangular edge is a cropped screenshot, not a surface you are editing. This is the look: a card lifted off its own wallpaper, shrinking about dead centre, with a lattice that belongs to it.

**Before / after captures (5120×1440, whole frame plus 1:1 corner crops): https://claude.ai/code/artifact/389df71b-ffb1-4901-8c22-ef4d9fc77069**

Both frames come from `EditModeLookProbe.qml` under headless weston, which is also what the new pixel test drives — so the pictures and the check are the same run. The magenta and green blocks in them are probe markers, not chrome: an opaque square pinned to the canvas's own corner, and an opaque panel the lattice has to disappear behind.

## 1. The desktop becomes a card

`modules/imi/background/EditModeCard.qml` is the chrome: the blurred backdrop, the corner, the outline and the shadow, as one component so the four cannot drift apart from each other or from the desktop.

**The obstacle is that QML has no rounded clip.** The desktop is three separately transformed siblings, so no property on any of them rounds a corner, and wrapping all three in one masked layer pushes the wallpaper through an effect for every frame of the shrink — the cost the transform was chosen to avoid in the first place. So the corner is made by **covering it with what is behind it**: the backdrop moves from a sibling at `z: -1` to one at `z: 4` and is cut out to the card's rounded rect. That is visually identical to drawing it behind everywhere except the four corners, and at the corners it is the difference between a rounded card and a square one.

It also gives the shadow somewhere honest to live: inside the same cut, over the backdrop, so only the half outside the card survives and its interior never darkens the desktop it is lifting.

Three decisions, one of them a measurement that stopped a change:

- **The shadow stays `StyledRectangularShadow` at the magnitude the component defines.** Rendered both ways before leaving it alone: raising `blur` from 9 to 40 on a 4403px card spreads the same darkness over four times the distance and the two frames are indistinguishable. Scanned across the card's right edge, the backdrop reads 49/255 next to the card and settles at 54 away from it — at either blur. The edge contrast comes from `colShadow`'s alpha, and most of a `RectangularShadow` sits *under* its target, which the cut removes. A bigger number would have bought a second shadow spelling and no depth.
- **The radius is `rounding.verylarge` times the entry progress**, so the corner grows with the shrink and a desktop at rest has no radius applied at all rather than one that happens to be hidden. The ladder's own name rather than the `extraLarge` alias, which #231 declared for the vendored design system's call sites.
- **The card's rectangle is `edit_mode.js`'s new `cardRect`**, built from the same `atProgress` the transform is, rather than read off the matrix's terms. The corner, the outline and the shadow sit on the desktop's edge exactly, and a second derivation of a registration drifts — which is why `ClockDepthCutout` is one component and not two call sites.

Cost: one full-screen layer and one mask, re-rendered while the card's geometry moves — the 400ms of an entry or an exit, never at rest. The blur itself is the same `WallpaperBlurBackdrop` that was already being drawn, and on a live Wallpaper Engine wallpaper it re-renders every frame regardless.

## 2. The lattice is a substrate, and it dissolves at the edges

Two complaints with two different causes.

**It stopped dead at the canvas bounds** — nothing clipped or faded it, so a screen's worth of full-strength 12px lines ran to the edge and were sliced. It fades on all four sides now: a gradient along each line so it fades at its own two ends, and a per-line opacity across the lattice so the lines nearest an edge are the faintest. Both are needed; either alone leaves the other axis running full strength into the boundary. One shared `Gradient` object per axis rather than one per delegate, because a screen's worth of 12px lines is several hundred delegates and four `GradientStop`s apiece is a few thousand objects built at the moment the mode is entered. The far stops are the line's own colour at zero alpha rather than `"transparent"`, which interpolates through black and draws a smudge at exactly the edge this is meant to make quiet.

**And widgets looked like they were underneath it.** Nothing in `WidgetCanvas.qml` decided that: the grid `Rectangle`s declared no `z`, and the desktop widgets arrive as *external* children of the canvas (`Background.qml`'s `Repeater` over the plugin manifests), so which ended up on top was a consequence of when each `Repeater`'s model filled. The lattice is one item at `z: -1` now — the order stated rather than inherited. A widget whose panel is translucent, which every desktop widget is and which this mode makes more so by standing the frost down, had a crisp full-strength line running across it, and a line is a foreground cue whatever is really in front.

## 3. The shrink: dead centre, with a ceiling

This is where the two follow-up corrections land, and they replace what was originally scoped as "pick a sensible pre-drawer inset".

**The desktop shrinks about dead centre now, and translates only when the drawer opens.** The old geometry reserved the drawer's width inside its resting `x`, so the scale was about the top-left with a translation on top and the entry was a slide as well as a shrink — asymmetric on every frame including the last. No choice of pre-drawer inset repairs that, because the asymmetry is in the shape of the animation rather than in the number.

Two things the geometry fused come apart: the **size** still reserves the drawer's width plus a margin, and the **position** is centred. The reservation is still real and is still spent on the drawer, just later — a centred desktop has `(screenWidth - width) / 2` free per side, and the scale holds `width <= screenWidth - drawerWidth - 2*margin`, so each side has at least `drawerWidth / 2 + margin`. Opening a drawer of `drawerWidth + margin` therefore needs the desktop to travel at most half a drawer's width, leaving exactly a margin behind it. `tst_edit_mode.qml` asserts that invariant in both regimes.

`atProgress` needed no change, and that is the point: a centred geometry's offset is linear in `(1 - scale)`, so multiplying it by the same `t` as the scale is exactly the centring offset of the intermediate scale. The margins are equal in pairs on every frame, not only at the ends. **The matrix stays one matrix** — a centred scale is a different matrix, not a `[Scale, Translate]` pair, and the composition-order reasoning in its comment is untouched.

**And the scale has a ceiling** (`MAX_SCALE = 0.86`). The drawer-derived inset is right while the drawer is a meaningful fraction of the width and stops being one as the screen widens: 380px of drawer plus two 24px margins is a quarter of a 1600px laptop panel and 8% of a 5120px monitor, where the desktop came out at **0.916** — the screen with four thin strips of blur around it. The shrink plus the blur *is* the mode's signal (§1.1 closes the scrim question on exactly that reasoning), so it has to be legible at every screen size. A ceiling cannot break the derivation stage 5 plugs into, because shrinking further only makes the drawer's slot larger; on a screen where the drawer is the tighter constraint it still decides.

Measured at 5120×1440: scale 0.916 → 0.860, position x=24 with 693px of blur opposite → x=358 symmetric.

## 4. The motion

Three things the mode animates, none of which was reaching for a tier properly.

- **The entry and exit carried `duration: 400` beside `expressiveDefaultSpatial`** — neither of the two tiers `docs/M3_GUIDELINES.md` §2 offers (500ms expressiveDefaultSpatial for a spatial move, 400ms emphasizedDecel for an entrance), so it was a third timing nothing else in the shell moves at. It takes `Appearance.animation.elementMove` whole now. Deliberately not `elementMoveEnter`/`Exit`, which would be the entrance reading: both carry `alwaysRunToEnd`, and this toggle has to reverse mid-flight or a mode entered and left again inside 400ms finishes arriving before it starts leaving.
- **The lattice had no transition at all.** Its `Repeater` model went from 0 to a screen's worth of lines in one frame, so it popped on while the desktop eased into the mode beside it — the most likely reading of "not M3E-compliant": an element that pops while its neighbours ease. It fades on `elementMoveFast`, the effects tier the centre lines in the same file already use, with the delegates outliving the flag so the fade-out has something to fade.
- **The resize grip took `elementMoveFaster.duration` and left the curve**, which hands the animation Qt's default of `Easing.Linear` — a generic curve, forbidden outright by the same section. That has been true of every grip in the shell since it was written; it stopped being one control's private detail when the mode began revealing every resizable widget's grip at once. There is a new AGENT.md entry for that shape, because "names a token, still runs on Linear" is invisible in review.

**Looked at and deliberately left alone: the per-widget frost, which the mode stands down in one frame.** It is not decoration being hidden — it is a `ShaderEffectSource` whose sample rect stops being valid the instant the transform starts moving, so easing it out eases out a picture that is wrong for the whole of the fade. Also left: the selection halo's instant appearance (it is the release of a marquee, not the mode), and the 2000ms `OutCubic` snap flash lines, which are on `M3_GUIDELINES.md`'s existing-nonconformance list and are not edit-mode-specific.

## Tests

Baseline re-measured on `gh/main`: **892 passing** in the `qmltestrunner` Totals line, 0 failed. This branch: **897 passing, 0 failed**, full suite exit 0.

One correction to my own measurement worth recording, since it is the same shape as the traps in AGENT.md: I first read the baseline as 896 off a full-suite run I had launched in the background and then started editing during. `run_tests.sh` reaches `qmltestrunner` near the *end* of a half-hour run, so by the time it got there the tree already carried some of my additions. The number above is the runner invoked directly against a clean `gh/main` worktree, which takes two seconds.

`tests/test_edit_mode_chrome.py` + `EditModeLookProbe.qml` + `tests/run_edit_mode_look_probe.sh` — headless weston, the real `EditModeCard`, the real `WidgetCanvas`, the real `edit_mode.js`, four saved frames. The geometry and the pixels are split because `ItemGrabResult.image` is a QImage and a QImage is not scriptable from QML, which is the split `test_card_shadow.py` already runs on; the harness prints the rects it drew so the Python half holds no copy of the geometry it scores. Five pixel checks, each planted and proven to fail:

| check | planted breakage | result |
| --- | --- | --- |
| the desktop after the mode is the desktop before it | a chrome Loader that latches open, with the opacity gate dropped | `(1132, 213) != (0, 0)` |
| the transform returns the desktop to its own coordinates | `atProgress` floors `t` at 0.05 | fails |
| the card's corner is cut | the mask rectangle loses its radius | fails |
| the lattice is under the widgets | `lattice` at `z: 1` | `[(662, 406), (671, 406)] != []` |
| ...and there was a lattice to hide | the grid `Repeater`s' model forced to 0 | `no lattice was drawn, so hiding it proves nothing` |
| the shrink is concentric mid-animation | the drawn matrix loses its centring offset | fails |

The last one is measured off the drawn marker at half progress rather than read back out of the function that positioned it — the frames nobody looks at are where the old geometry was wrong and where it settled plausibly enough to survive. It takes the marker's **centre** rather than its leading edge: a scaled edge is antialiased, so the first pixel of the exact colour sits a pixel inside it and that bias lands entirely on one side of the symmetry being measured.

Two source contracts in `test_edit_mode_contract.py` for things the pixel probe is structurally unable to see, both planted and proven: the chrome stands down through **two** gates (`active` and `opacity`) and either alone hides it, so a frame comparison passes on a tree with one deleted as redundant — measured while planting, a Loader made to latch still produced a frame identical to the one before the mode; and every line of the lattice is drawn inside the item that declares the order, so a `Rectangle` put back at the canvas root returns the stacking to whichever `Repeater` filled first.

`tst_edit_mode.qml` gains the centring, the ceiling's invariant in both regimes, `cardRect`, and the concentric-at-every-progress assertion. Three existing cases moved rather than being loosened: the drawer-binding checks now run on a 1600px screen, because on a 5120px one both sides of the "does the open state matter" comparison are the ceiling and the check was vacuous.

Full suite green.

## Verification, and its limits

**This has not been loaded as a live shell.** The maintainer is at the machine on `gh/main` and can enter the mode while this sits here; a second full instance would put a second bar, dock and desktop on their screen. What has been done instead: all five touched QML files compiled under a real compositor via a `Qt.createComponent` probe (`Background.qml`, `EditModeCard.qml`, `WallpaperBlurBackdrop.qml`, `WidgetCanvas.qml`, `PluginWidget.qml` — `files: 5 failures: 0`), and the chrome, the lattice and the transform rendered and photographed under headless weston at 1600×900, 2560×720 and 5120×1440.

What no harness here can say, unchanged from #236: weston implements no wlr-layer-shell, so nothing about the background *surface* — the compositor's own blur behind it, the alpha map, keyboard focus — is visible. Specifically untested and worth a look on the first live load: the masked backdrop is a new full-screen `layer.enabled` item on that surface, and the alpha-map claim at `Background.qml`'s plugin loader concerns exactly this surface's alpha.

Docs: updated AGENT.md §Layer-shell / desktop-widget notes (the size-vs-position split and the scale ceiling, the backdrop drawn above and cut rather than behind, the two measurements from building it, the lattice's declared order) and §Design language (a new entry: a `NumberAnimation` given a tier's `duration` and nothing else reads as compliant and silently runs on `Easing.Linear`).
