### PR TITLE
Edit Mode: the toolbar, Done, and the tab bar, on a surface of their own

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -473,6 +473,12 @@ modules/imi/                 The "imi" (Immaterial Impulse) panel family - one d
                               into a MobileSAM prompt. It redraws neither the wallpaper nor the
                               widgets - both are already on screen, which is what makes the pixels
                               clicked the pixels the depth layer will mask
+  editMode/                   Edit Mode's CHROME only - the toolbar above the shrunk desktop
+                              and the tab bar below it, on one full-screen Overlay surface per
+                              output (quickshell:editMode) whose mask is those two rects and
+                              nothing else, so every other pixel falls through to the desktop
+                              being edited. The desktop itself is not here: it stays on the
+                              background surface, which is what the mode transforms
   overview/                   Workspace/window overview (like GNOME Activities)
   notificationPopup/          Desktop notification popups
   settings/                   The in-shell settings UI (pages/ = one file per settings category)
@@ -2382,11 +2388,56 @@ mode is built out of are worth not re-deriving:
   is translucent, which every desktop widget is and which this mode makes more
   so by standing the frost down, then has a crisp full-strength line running
   across it, and a line is a foreground cue whatever is really in front.
+- **The whole mode animates on ONE scalar, and it is `GlobalStates.editProgress`
+  rather than a property of the surface that uses it.** The desktop's transform
+  and the chrome that frames it are on two different layer surfaces, in two
+  different scene graphs, and both build their geometry out of the progress —
+  so a second `Behavior on (editMode ? 1 : 0)` on the other surface is two
+  numbers that have to agree, agreeing at rest (the only place anyone looks)
+  and disagreeing exactly on the frames where the chrome frames a rectangle the
+  desktop is not at. `test_edit_mode_contract.py` sweeps the tree for a second
+  `Behavior on editProgress` rather than naming files, because the second one is
+  written by whoever adds the next surface.
+- **The chrome is a SECOND surface, and the viewport deliberately does not move
+  onto it** (`modules/imi/editMode/`). The desktop stays on `quickshell:background`
+  because that is where the wallpaper and the `WidgetCanvas` already are and
+  where a `ShaderEffectSource` can still reach the live Wallpaper Engine layer —
+  but that surface is on `WlrLayer.Bottom`, and measured live the layers come out
+  background / dock+bar / screenCorners+barPopup, so chrome drawn there renders
+  under a bar the mode leaves at full size. Three things a screen-sized surface
+  has to get right, all three of which this repo has already paid for once:
+  **input** (the mask is the toolbar's and the tab bar's rects and nothing else,
+  or the desktop underneath — the thing being edited — stops taking clicks; the
+  surface also does not exist while the mode is off, which is the state nobody
+  looks at); **blur** (a minted namespace absent from `rules.lua` falls through
+  the catch-all `ignore_alpha = 0.05`, under which a screen-sized surface of
+  transparent pixels asks the compositor to blur the entire screen —
+  `quickshell:editMode` is listed at `ignore_alpha = 1` because its two toolbar
+  bodies are opaque `m3surfaceContainer`, the same treatment
+  `quickshell:recordingRegion` and `quickshell:overlay` carry, and reusing
+  `quickshell:popup` is the trap `BarPopupOverlay.qml:53-69` records); and
+  **keyboard** (`WlrKeyboardFocus.None`, or a surface on `Overlay` sits in front
+  of the background and swallows the Escape the exit ladder is answered on).
+- **The chrome's placement IS the shrink's arithmetic, which is why it carries no
+  motion of its own.** Both pieces are positioned off `edit_mode.js`'s `cardRect`
+  — the same function the transform is built out of, for the reason
+  `ClockDepthCutout` is one component — and the bands they sit in are opened by
+  the shrink itself, so at progress 0 they are parked half off screen and they
+  arrive *with* the desktop rather than after it. A `Behavior` on either would be
+  a target that moves every frame, which restarts every frame and never ticks
+  (b710ef731). Note also what the pixel probe adds over the geometry checks and
+  what it does not: a chrome item left `visible: false` reports its box, passes
+  every geometry assertion, and paints nothing, so the probe measures the drawn
+  extent — while re-asserting "the chrome is outside the card" in the pixel half
+  would read the harness's own numbers back and agree with itself.
 (feat(editMode): shrink the desktop into a viewport on the background surface,
 feat(editMode): stand the per-widget frost down for the mode,
 feat(editMode): draw the shrunk desktop as a card, not as a cropped screenshot,
 feat(editMode): shrink the desktop about dead centre, and move it only for the drawer,
-feat(widgetCanvas): the lattice is a substrate, and it dissolves at the edges.)
+feat(widgetCanvas): the lattice is a substrate, and it dissolves at the edges,
+feat(editMode): animate the mode on one scalar, shared by every surface,
+feat(editMode): draw the mode's toolbar and tab bar on a surface of their own,
+test(editMode): score the chrome against the desktop it frames.)
 
 **The clock depth layer is the counter-case to that rule, and it is why it is a
 FOURTH sibling.** `widgetCanvas` sits at `z: 2` as a sibling of

--- a/dots/.config/hypr/hyprland/rules.lua
+++ b/dots/.config/hypr/hyprland/rules.lua
@@ -159,6 +159,19 @@ hl.layer_rule({ match = { namespace = "quickshell:clockDepthSelect" }, blur = fa
 -- configured edge. Naming the edge here pinned it to the bottom, and a top
 -- dock then slid downward, into the screen, to leave.
 hl.layer_rule({ match = { namespace = "quickshell:dock" }, animation = "slide"})
+-- Edit Mode's chrome: another full-screen surface that is transparent
+-- everywhere except two opaque toolbars, because the desktop it frames is the
+-- real one underneath it. Same hazard as the subject selector above - under the
+-- catch-all 0.05 its transparent pixels clear the threshold and the compositor
+-- is asked to blur the whole screen - answered the other way round, because the
+-- toolbar bodies are m3surfaceContainer and therefore fully opaque: at
+-- ignore_alpha = 1 the bodies are the only thing blurred, and their shadows and
+-- everything else on the surface are left alone. That is the treatment
+-- quickshell:overlay and quickshell:recordingRegion already carry for this
+-- shape. The surface is created and destroyed by a toggle, so a map animation
+-- on something screen-sized reads as the desktop lurching.
+hl.layer_rule({ match = { namespace = "quickshell:editMode" }, ignore_alpha = 1})
+hl.layer_rule({ match = { namespace = "quickshell:editMode" }, no_anim = true})
 hl.layer_rule({ match = { namespace = "quickshell:screenCorners" }, animation = "popin 120%"})
 hl.layer_rule({ match = { namespace = "quickshell:lockWindowPusher" }, no_anim = true})
 hl.layer_rule({ match = { namespace = "quickshell:notificationPopup" }, animation = "fade"})

--- a/dots/.config/quickshell/imi/DesignSystemCompile.qml
+++ b/dots/.config/quickshell/imi/DesignSystemCompile.qml
@@ -67,6 +67,12 @@ ShellRoot {
                 // arms the mode from that picker, so an ordinary run never
                 // compiles it.
                 Quickshell.shellPath("modules/imi/clockDepthSelect/ClockDepthSelectSurface.qml"),
+                // And again for Edit Mode's chrome: the surface, and the
+                // toolbar and tab bar drawn on it, sit behind a Loader that is
+                // inactive until somebody enters the mode, so a shell that is
+                // merely running has never compiled either of them.
+                Quickshell.shellPath("modules/imi/editMode/EditModeChromeSurface.qml"),
+                Quickshell.shellPath("modules/imi/editMode/EditModeChromeContent.qml"),
                 // The cheatsheet only compiles when the user presses Super+/,
                 // and the keybind editor only when a row's pencil is clicked.
                 Quickshell.shellPath("modules/imi/cheatsheet/CheatsheetKeybinds.qml"),

--- a/dots/.config/quickshell/imi/EditModeLookProbe.qml
+++ b/dots/.config/quickshell/imi/EditModeLookProbe.qml
@@ -3,6 +3,7 @@ import Quickshell
 import qs.modules.common
 import qs.modules.common.widgets.widgetCanvas
 import qs.modules.imi.background
+import qs.modules.imi.editMode
 import "modules/common/functions/edit_mode.js" as EditMode
 
 /*
@@ -182,8 +183,29 @@ ShellRoot {
                     cardRadius: harness.cardRadius
                 }
             }
+
+            // The mode's chrome. On the real shell this is a layer surface of
+            // its own on Overlay, because the bar and the dock sit above the
+            // background - none of which weston can show, so what is rebuilt
+            // here is the arrangement (a full-screen item over the card, at the
+            // card's own geometry) and the content is the shipped component.
+            Loader {
+                id: chromeLoader
+                active: harness.editProgress > 0
+                anchors.fill: parent
+                z: 5
+                opacity: harness.editProgress
+                sourceComponent: EditModeChromeContent {
+                    card: harness.card
+                }
+            }
         }
     }
+
+    // The chrome's two pieces, when there are any. Reached through the loader
+    // rather than held as ids, since they do not exist at rest.
+    readonly property Item toolbar: chromeLoader.item?.toolbarItem ?? null
+    readonly property Item tabBar: chromeLoader.item?.tabBarItem ?? null
 
     readonly property matrix4x4 matrix: Qt.matrix4x4(
         harness.applied.scale, 0, 0, harness.applied.x,
@@ -199,7 +221,12 @@ ShellRoot {
             + ` radius=${harness.cardRadius} scale=${harness.applied.scale}`
             + ` marker=${cornerMarker.x},${cornerMarker.y},${cornerMarker.width},${cornerMarker.height}`
             + ` panel=${opaquePanel.x},${opaquePanel.y},${opaquePanel.width},${opaquePanel.height}`
-            + ` markerColor=${harness.cornerMarkerColor} panelColor=${harness.opaquePanelColor}`);
+            + ` markerColor=${harness.cornerMarkerColor} panelColor=${harness.opaquePanelColor}`
+            + ` toolbar=${harness.toolbar?.x ?? -1},${harness.toolbar?.y ?? -1}`
+            + `,${harness.toolbar?.width ?? 0},${harness.toolbar?.height ?? 0}`
+            + ` tabbar=${harness.tabBar?.x ?? -1},${harness.tabBar?.y ?? -1}`
+            + `,${harness.tabBar?.width ?? 0},${harness.tabBar?.height ?? 0}`
+            + ` chromeColor=${Appearance.m3colors.m3surfaceContainer}`);
     }
 
     function shoot(name, next) {
@@ -234,7 +261,7 @@ ShellRoot {
                     && harness.card.height === harness.screenHeight
                     && harness.cardRadius === 0);
             harness.check("at rest there is no chrome to stand down",
-                !editChrome.active);
+                !editChrome.active && !chromeLoader.active);
             harness.shoot("rest", () => {
                 harness.editProgress = 1;
                 harness.after(harness.editing);
@@ -259,6 +286,35 @@ ShellRoot {
                 && harness.card.y >= harness.margin - 0.5,
             `card=${harness.card.x.toFixed(1)},${harness.card.y.toFixed(1)}`
                 + ` ${harness.card.width.toFixed(1)}x${harness.card.height.toFixed(1)}`);
+        // The chrome frames the desktop, so it has to be OUTSIDE it: a toolbar
+        // overlapping the card covers the widgets it exists to help arrange,
+        // and one that has left the screen is not there at all. Both bands are
+        // opened by the shrink itself, which is why this is asserted against
+        // the card rather than against a chosen inset.
+        harness.check("the toolbar and the tab bar sit in the bands the shrink opened",
+            harness.toolbar !== null && harness.tabBar !== null
+                && harness.toolbar.y >= 0
+                && harness.toolbar.y + harness.toolbar.height <= harness.card.y + 0.5
+                && harness.tabBar.y >= harness.card.y + harness.card.height - 0.5
+                && harness.tabBar.y + harness.tabBar.height <= harness.screenHeight,
+            `toolbar=${harness.toolbar?.y.toFixed(1)}+${harness.toolbar?.height.toFixed(1)}`
+                + ` band=${harness.card.y.toFixed(1)}`);
+        // ...and on the desktop's own axis rather than the screen's, which is
+        // the same point today and stops being one when the drawer translates
+        // the card. The two gaps are compared to each other because the card is
+        // centred: chrome that drifted toward one edge would still be "inside
+        // the band".
+        const gapAbove = harness.toolbar !== null ? harness.toolbar.y : -1;
+        const gapBelow = harness.tabBar !== null
+            ? harness.screenHeight - (harness.tabBar.y + harness.tabBar.height) : -2;
+        harness.check("...centred on the desktop, in two bands of equal height",
+            harness.toolbar !== null && harness.tabBar !== null
+                && Math.abs((harness.toolbar.x + harness.toolbar.width / 2)
+                    - (harness.card.x + harness.card.width / 2)) < 0.5
+                && Math.abs((harness.tabBar.x + harness.tabBar.width / 2)
+                    - (harness.card.x + harness.card.width / 2)) < 0.5
+                && Math.abs(gapAbove - gapBelow) < 0.5,
+            `gaps=${gapAbove.toFixed(1)},${gapBelow.toFixed(1)}`);
         harness.reportGeometry("geometry");
         harness.shoot("editing", () => {
             harness.editProgress = 0.5;
@@ -294,6 +350,11 @@ ShellRoot {
                 && harness.card.width === harness.screenWidth
                 && harness.cardRadius === 0
                 && !editChrome.active);
+        // Its own check rather than a term in the one above: the chrome is a
+        // whole surface on the real shell, and "the desktop came back" and "the
+        // toolbar went away" are two different regressions.
+        harness.check("...and takes the chrome with it", !chromeLoader.active
+            && harness.toolbar === null && harness.tabBar === null);
         harness.shoot("after", () => harness.finish());
     }
 

--- a/dots/.config/quickshell/imi/GlobalStates.qml
+++ b/dots/.config/quickshell/imi/GlobalStates.qml
@@ -83,6 +83,27 @@ Singleton {
     // themselves global, and a per-monitor mode would have to explain why
     // moving a bar chip on one screen changed another.
     property bool editMode: false
+    // The entry and exit, as one animated scalar that every surface the mode
+    // draws on reads. It lives here rather than beside the transform it feeds
+    // because the desktop and the chrome that frames it are on two different
+    // layer surfaces, in two different scene graphs, and both derive their
+    // geometry from this number: a second Behavior on the other surface would
+    // be two values that have to agree, and the frames where they do not are
+    // the ones where the chrome frames a rectangle the desktop is not at.
+    //
+    // Interpolating one scalar rather than animating a scale and an offset
+    // separately is also what keeps the desktop's corner travelling in a
+    // straight line - there is no frame in which the scale has arrived and the
+    // inset has not.
+    //
+    // `elementMove`, taken whole, and deliberately not `elementMoveEnter` /
+    // `elementMoveExit`: those two carry `alwaysRunToEnd`, so a mode toggled
+    // twice inside its own duration would finish arriving before it started
+    // leaving.
+    property real editProgress: root.editMode ? 1 : 0
+    Behavior on editProgress {
+        animation: Appearance.animation.elementMove.numberAnimation.createObject(this)
+    }
 
     property bool dropShelfOpen: false
     property real dropShelfX: 0

--- a/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/WidgetCanvas.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/WidgetCanvas.qml
@@ -291,7 +291,13 @@ MouseArea {
     // Leaving the mode mid-drag cancels the gesture. It cannot commit: a widget
     // is only clamped on release, and the mode ending is not the user letting
     // go of anything.
-    onEditModeChanged: if (!root.editMode) root.cancelActiveDrag()
+    //
+    // The selection goes with it, because Done means "stop" (spec §8.2) and a
+    // selection halo surviving the mode is a marquee the user has no visible
+    // way to clear. Escape never reaches this branch holding one - the ladder
+    // clears the selection before it will exit - so this is the exit that Done
+    // and the screen being taken away both take.
+    onEditModeChanged: if (!root.editMode) { root.cancelActiveDrag(); root.clearSelection() }
 
     Connections {
         target: root.groupDrag ? root.groupDrag.leader : null

--- a/dots/.config/quickshell/imi/modules/imi/background/Background.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/Background.qml
@@ -552,21 +552,12 @@ Variants {
             margin: Appearance.sizes.editModeMargin
         })
         // One animated scalar for the whole entry, so the scale and the offset
-        // cannot arrive on different frames. It moves once per mode change, not
-        // per frame, which is what makes a Behavior legitimate here at all.
-        property real editProgress: GlobalStates.editMode ? 1 : 0
-        // The shell's default spatial move, taken whole rather than spelled out
-        // - the duration used to be a literal 400 beside the spatial curve,
-        // which is neither of the two tiers docs/M3_GUIDELINES.md offers (500ms
-        // expressiveDefaultSpatial for a spatial move, 400ms emphasizedDecel for
-        // an entrance) and so is a third timing nothing else in the shell moves
-        // at. `elementMove` and not `elementMoveEnter`/`Exit`, because those two
-        // carry `alwaysRunToEnd` and this toggle has to be able to reverse
-        // mid-flight: a mode entered and left again inside 400ms would otherwise
-        // finish arriving before it started leaving.
-        Behavior on editProgress {
-            animation: Appearance.animation.elementMove.numberAnimation.createObject(this)
-        }
+        // cannot arrive on different frames - and it is GlobalStates' scalar
+        // rather than this window's, because the chrome that frames this
+        // desktop is a different layer surface deriving its geometry from the
+        // same number. The animation, and why it is `elementMove` rather than
+        // an entrance tier, are stated where the property lives.
+        readonly property real editProgress: GlobalStates.editProgress
         readonly property var editTransform: EditMode.atProgress(bgRoot.editViewport, bgRoot.editProgress)
         // A scale about the top-left followed by a translation, written as one
         // matrix rather than as a [Scale, Translate] pair: the order a transform

--- a/dots/.config/quickshell/imi/modules/imi/desktopMenu/DesktopMenu.qml
+++ b/dots/.config/quickshell/imi/modules/imi/desktopMenu/DesktopMenu.qml
@@ -314,14 +314,21 @@ Scope {
                         // unlike Wallpaper & style and Widgets, this row has no
                         // quick-settings half and no Settings page behind it.
                         //
-                        // The same row is also the way out, which is not what
-                        // the toolbar's Done will be - it stands in for it until
-                        // stage 4 draws one. Escape is the other exit and it
-                        // depends on the compositor delivering keys to a
-                        // Bottom-layer surface, which is not established here;
-                        // a mode whose only way out is unproven is not one to
-                        // ship.
+                        // The way IN, and now only that. It stood in as the way
+                        // out as well while the mode had no toolbar, because
+                        // Escape depends on the compositor delivering keys to a
+                        // Bottom-layer surface and that was never established -
+                        // a mode whose only exit is unproven is not one to ship.
+                        // The toolbar's Done is that exit now, on screen for the
+                        // whole mode, so a second one here would leave the exit
+                        // ALSO hidden behind a right-click, two rows deep in a
+                        // context menu: precisely the discoverability failure
+                        // the mode exists to fix. The row disappears while the
+                        // mode is on rather than becoming a no-op, because a
+                        // control that does nothing is worse than one that is
+                        // not there.
                         RippleButton {
+                            visible: !GlobalStates.editMode
                             implicitHeight: 40
                             colBackground: "transparent"
                             colBackgroundHover: Appearance.colors.colLayer2
@@ -329,20 +336,20 @@ Scope {
                                 anchors { fill: parent; leftMargin: Appearance.spacing.space150; rightMargin: Appearance.spacing.space150 }
                                 spacing: Appearance.spacing.space150
                                 MaterialSymbol {
-                                    text: GlobalStates.editMode ? "done" : "edit"
+                                    text: "edit"
                                     iconSize: Appearance.font.pixelSize.larger
                                     color: Appearance.colors.colOnLayer1
                                 }
                                 StyledText {
                                     Layout.fillWidth: true
-                                    text: GlobalStates.editMode ? "Done editing" : "Edit layout"
+                                    text: "Edit layout"
                                     font.pixelSize: Appearance.font.pixelSize.normal
                                     color: Appearance.colors.colOnLayer1
                                 }
                             }
                             onClicked: {
                                 GlobalStates.desktopMenuOpen = false
-                                GlobalStates.editMode = !GlobalStates.editMode
+                                GlobalStates.editMode = true
                             }
                         }
 

--- a/dots/.config/quickshell/imi/modules/imi/editMode/EditModeChrome.qml
+++ b/dots/.config/quickshell/imi/modules/imi/editMode/EditModeChrome.qml
@@ -1,0 +1,38 @@
+import QtQuick
+import Quickshell
+import qs
+import qs.modules.common
+
+/**
+ * Edit Mode's chrome, one surface per screen.
+ *
+ * The mode is global (`GlobalStates.editMode`) because the layouts it will edit
+ * are, so every monitor's desktop shrinks and every monitor gets its own
+ * toolbar and tab bar - the chrome frames the desktop it is drawn beside, and a
+ * single-screen chrome would frame one of them and float over the others.
+ *
+ * The surfaces exist only while the mode is on the way in, on, or on the way
+ * out. That is the first of the two gates the chrome stands down through, and
+ * it is the one that matters when the mode is OFF: a full-screen `Overlay`
+ * surface left mapped with a stale mask eats clicks on a desktop nobody is
+ * editing, and that is the state nobody looks at.
+ */
+Scope {
+    id: root
+
+    Variants {
+        model: Quickshell.screens
+        delegate: Loader {
+            id: surfaceLoader
+            required property var modelData
+            // The mode itself, plus the tail of the exit animation: the flag
+            // goes false at the first frame of the leave, and the chrome has to
+            // stay on screen to travel back out with the desktop.
+            active: GlobalStates.editMode || GlobalStates.editProgress > 0
+
+            sourceComponent: EditModeChromeSurface {
+                screen: surfaceLoader.modelData
+            }
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/modules/imi/editMode/EditModeChromeContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/editMode/EditModeChromeContent.qml
@@ -1,0 +1,126 @@
+import QtQuick
+import QtQuick.Layouts
+import qs
+import qs.services
+import qs.modules.common
+import qs.modules.common.widgets
+
+/**
+ * Edit Mode's chrome: the toolbar above the shrunk desktop and the tab bar
+ * below it.
+ *
+ * Split out of the surface that hosts it for the reason `EditModeCard` is split
+ * out of `Background.qml` - weston implements no wlr-layer-shell, so the only
+ * way anything here is ever looked at by a test is as a plain `Item` a probe
+ * can put in a window of its own.
+ *
+ * ---- where it sits --------------------------------------------------------
+ *
+ * Everything is placed off `card`, the rectangle the desktop is drawn at, which
+ * is `edit_mode.js`'s `cardRect` - the same arithmetic the desktop's own
+ * transform is built out of. So the chrome cannot be a pixel off the thing it
+ * frames, and it does not need a second copy of the geometry to be wrong about.
+ *
+ * That also gives the motion for free, and gives it the RIGHT shape: `card` is
+ * a function of `GlobalStates.editProgress`, so the toolbar rises out of the
+ * top edge and the tab bar out of the bottom one exactly as fast as the desktop
+ * shrinks away from them. At progress 0 both bands have zero height and both
+ * pieces are parked half off screen, which is why nothing here needs a
+ * `Behavior` of its own - and must not have one: a Behavior whose target moves
+ * every frame restarts every frame and never ticks (b710ef731 ("fix(plugins):
+ * stop the position Behavior swallowing the parallax cancellation")).
+ *
+ * ---- what it is made of ---------------------------------------------------
+ *
+ * `Toolbar` and `ToolbarTabBar`, which is the shell's M3 expressive toolbar and
+ * its toolbar tab bar - the same pieces the cheatsheet, the region selector,
+ * the recording controls and the lock islands are built from. A bespoke card
+ * matching the desktop's own outline and 30px corner was the other option and
+ * would have been a second toolbar look minted for one mode, which is the drift
+ * this repo keeps paying for. What ties it to the card is the shadow both carry
+ * and the symmetry of the two bands, not a copied radius.
+ */
+Item {
+    id: root
+
+    // The desktop's rectangle on screen. Defaults to the whole of this item, so
+    // an unconnected instance parks its chrome off both edges rather than
+    // somewhere arbitrary.
+    property rect card: Qt.rect(0, 0, root.width, root.height)
+
+    signal doneRequested()
+
+    // Published for the surface's input mask: these two rects are the only
+    // pixels of a screen-sized layer surface that may take a click, because
+    // everything else on it is the desktop being edited.
+    readonly property alias toolbarItem: toolbar
+    readonly property alias tabBarItem: tabBar
+
+    Toolbar {
+        id: toolbar
+        // Centred on the CARD rather than on the screen: the two are the same
+        // point today and stop being one the moment stage 5's drawer
+        // translates the desktop, and the chrome belongs to the desktop.
+        x: root.card.x + (root.card.width - width) / 2
+        // Centred in the band between the screen's top edge and the card's.
+        y: (root.card.y - height) / 2
+        spacing: Appearance.spacing.space150
+
+        MaterialSymbol {
+            Layout.alignment: Qt.AlignVCenter
+            Layout.leftMargin: Appearance.spacing.space75
+            text: "edit"
+            iconSize: 22
+            color: Appearance.colors.colOnSurfaceVariant
+        }
+
+        StyledText {
+            Layout.alignment: Qt.AlignVCenter
+            text: Translation.tr("Edit layout")
+            font.pixelSize: Appearance.font.pixelSize.normal
+            color: Appearance.colors.colOnSurface
+        }
+
+        // The mode's real way out. Two things about it are deliberate. It
+        // carries its label rather than being an icon-only button paired off to
+        // the side the way the region selector separates its close - a mode the
+        // user cannot see how to leave is the one failure that costs them the
+        // whole session, and a checkmark is not a word. And it is FILLED, on
+        // the primary role: rendered flat beside the toolbar's own title it
+        // read as a second label rather than as a control, which is the same
+        // "is this clickable" question with a worse answer.
+        IconAndTextToolbarButton {
+            id: doneButton
+            Layout.alignment: Qt.AlignVCenter
+            iconText: "done"
+            text: Translation.tr("Done")
+            colBackground: Appearance.colors.colPrimary
+            colBackgroundHover: Appearance.colors.colPrimaryHover
+            colRipple: Appearance.colors.colPrimaryActive
+            colText: Appearance.colors.colOnPrimary
+            onClicked: root.doneRequested()
+        }
+    }
+
+    Toolbar {
+        id: tabBar
+        x: root.card.x + (root.card.width - width) / 2
+        // ...and the mirror band, between the card's bottom edge and the
+        // screen's. The card is centred, so the two bands are the same height
+        // and the two pieces travel by the same amount.
+        y: root.card.y + root.card.height
+            + (root.height - root.card.y - root.card.height - height) / 2
+
+        // A tab bar with one tab in it, and not a label that will grow into
+        // one. The Lockscreen tab (spec §1.4) is stage 9's, and it arrives as
+        // a second entry in this list rather than as a rewrite of whatever a
+        // label had become. There is deliberately no `GlobalStates` tab
+        // property yet: a stored choice with one legal value is plumbing for a
+        // feature that does not exist, and the Escape ladder already answers
+        // `desktopTab` from the module.
+        ToolbarTabBar {
+            id: tabs
+            tabButtonList: [{ name: Translation.tr("Desktop"), icon: "wallpaper" }]
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/modules/imi/editMode/EditModeChromeSurface.qml
+++ b/dots/.config/quickshell/imi/modules/imi/editMode/EditModeChromeSurface.qml
@@ -1,0 +1,109 @@
+import QtQuick
+import Quickshell
+import Quickshell.Wayland
+import qs
+import qs.modules.common
+import "../../common/functions/edit_mode.js" as EditMode
+
+/**
+ * One screen's worth of Edit Mode's chrome: a full-screen layer surface that is
+ * transparent everywhere except the toolbar and the tab bar on it.
+ *
+ * ---- why it is not on the background surface -------------------------------
+ *
+ * The desktop stays where it is (spec §2.3): it is where the wallpaper and the
+ * `WidgetCanvas` already are, and moving it would cost the live-wallpaper frost
+ * a `ShaderEffectSource` can only reach in its own scene graph. But that surface
+ * is `quickshell:background` on `WlrLayer.Bottom`, and the bar and the dock stay
+ * in place at full size, above it - measured on the live session, the three
+ * layers come out as background / dock+bar / screenCorners+barPopup. Chrome
+ * drawn on the background would be under the bar. So the chrome takes a surface
+ * of its own on `Overlay`, and the viewport does not move.
+ *
+ * ---- the three things a surface this size has to get right ------------------
+ *
+ * **Input.** A screen-sized surface that accepts input everywhere makes the
+ * desktop underneath unclickable - and the desktop underneath is the thing being
+ * edited. The mask is the two chrome rects and nothing else, so every other
+ * pixel falls through to the widgets. The surface also does not exist at all
+ * while the mode is off (`EditModeChrome.qml`'s loader), which is the state
+ * nobody looks at and therefore the dangerous one.
+ *
+ * **Blur.** `rules.lua`'s catch-all is `blur = true` with `ignore_alpha = 0.05`
+ * for every `quickshell:*` namespace, under which a screen-sized surface of
+ * transparent pixels asks the compositor to blur the entire screen. So the
+ * namespace is minted AND listed there, at `ignore_alpha = 1`: the two toolbar
+ * bodies are opaque (`m3surfaceContainer`), so they are the only thing blurred
+ * and their shadows and the whole transparent remainder are left alone. That is
+ * the same treatment `quickshell:recordingRegion` and `quickshell:overlay`
+ * carry, for the same shape of surface. Reusing `quickshell:popup` was the other
+ * temptation and `BarPopupOverlay.qml:53-69` records why not - its
+ * `ignore_alpha = 1` is inherited by every xdg-popup opened from the surface,
+ * which is how the tray menus stopped being blurred.
+ *
+ * **Keyboard.** `None`, deliberately. Escape is answered by `WidgetCanvas` on
+ * the background surface, through `edit_mode.js`'s ladder; a chrome surface
+ * taking `OnDemand` focus would sit in front of it and swallow the key.
+ */
+PanelWindow {
+    id: root
+
+    // A literal, and it has to stay one: a window colour bound to a
+    // transparency-derived token latches the surface opaque the first time its
+    // alpha crosses 255 and costs it its blur for the life of the process
+    // (deba3e3f6).
+    color: "transparent"
+    WlrLayershell.namespace: "quickshell:editMode"
+    WlrLayershell.layer: WlrLayer.Overlay
+    WlrLayershell.keyboardFocus: WlrKeyboardFocus.None
+    exclusionMode: ExclusionMode.Ignore
+    exclusiveZone: 0
+
+    // All four edges and no margins, so this window's coordinate space is the
+    // screen's. On a layer surface position IS `margins`, so a toolbar animating
+    // into place through them would reconfigure the surface every frame - the
+    // create-map-destroy loop BarPopupOverlay exists to avoid. The chrome moves
+    // inside the surface instead.
+    anchors {
+        top: true
+        bottom: true
+        left: true
+        right: true
+    }
+
+    // The same pure function, on the same inputs, that `Background.qml` builds
+    // the desktop's transform out of. Re-derived rather than published across
+    // the window boundary (which is what the clock depth layer's viewport has to
+    // do) because every input is available on both sides: this surface is the
+    // same screen, `GlobalStates.editProgress` is the one animated scalar, and
+    // the drawer width and margin are `Appearance` tokens. There is no live
+    // state here that only the other window can see.
+    readonly property var viewport: EditMode.viewportGeometry({
+        screenWidth: root.width,
+        screenHeight: root.height,
+        drawerWidth: Appearance.sizes.editModeDrawerWidth,
+        margin: Appearance.sizes.editModeMargin
+    })
+
+    mask: Region {
+        item: chrome.toolbarItem
+        Region {
+            item: chrome.tabBarItem
+        }
+    }
+
+    EditModeChromeContent {
+        id: chrome
+        anchors.fill: parent
+        card: EditMode.cardRect(root.viewport, GlobalStates.editProgress,
+            root.width, root.height)
+        // The second of the mode's two stand-down gates, the other being the
+        // loader that creates this window at all. Either alone hides the
+        // chrome, which is exactly why both are named in
+        // tests/test_edit_mode_contract.py: a frame comparison passes happily
+        // on a tree with one of them deleted, and then the surviving one gets
+        // deleted as redundant.
+        opacity: GlobalStates.editProgress
+        onDoneRequested: GlobalStates.editMode = false
+    }
+}

--- a/dots/.config/quickshell/imi/panelFamilies/ImmaterialImpulseFamily.qml
+++ b/dots/.config/quickshell/imi/panelFamilies/ImmaterialImpulseFamily.qml
@@ -7,6 +7,7 @@ import qs.modules.imi.cheatsheet
 import qs.modules.imi.bar
 import qs.modules.imi.clockDepthSelect
 import qs.modules.imi.dock
+import qs.modules.imi.editMode
 import qs.modules.imi.lock
 import qs.modules.imi.mediaControls
 import qs.modules.imi.notificationPopup
@@ -38,6 +39,7 @@ Scope {
     PanelLoader { component: Background {} }
     PanelLoader { component: Cheatsheet {} }
     PanelLoader { component: ClockDepthSelect {} }
+    PanelLoader { component: EditModeChrome {} }
     PanelLoader { extraCondition: Config.options.dock.enable; component: Dock {} }
     PanelLoader { component: Lock {} }
     PanelLoader { component: MediaControls {} }

--- a/dots/.config/quickshell/imi/tests/test_edit_mode_chrome.py
+++ b/dots/.config/quickshell/imi/tests/test_edit_mode_chrome.py
@@ -32,6 +32,12 @@ question about pixels that reads as correct in every source file:
   top-left and slid, and it settled somewhere plausible - which is what let it
   ship. The desktop's position is measured off the drawn marker at half
   progress, not read back out of the function that placed it.
+- **the chrome is drawn where its geometry says it is, and outside the desktop
+  it frames.** The harness asserts the toolbar's and the tab bar's numbers; this
+  finds their bodies in the picture, which is the half that catches a chrome
+  item that reports a position and paints somewhere else - or that reports one
+  and paints nothing, which is what a toolbar whose content failed to resolve
+  looks like from every property.
 
 The fixture is a flat colour so that "is this pixel a grid line" is answerable
 at all; the check that the lattice is drawn in the first place is what stops the
@@ -60,12 +66,14 @@ WALLPAPER_RGB = (58, 96, 140)
 # The harness states how many checks it ran; this is the literal it must state.
 # Read back out of its own output it would agree with itself by construction,
 # and `failures: 0` is also what a harness that ran nothing prints.
-EXPECTED_CHECKS = 7
+EXPECTED_CHECKS = 10
 
 GEOMETRY = re.compile(
     r"(geometry|midGeometry): screen=([\d.]+),([\d.]+) card=([\d.]+),([\d.]+),([\d.]+),([\d.]+) "
     r"radius=([\d.]+) scale=([\d.]+) marker=([\d.]+),([\d.]+),([\d.]+),([\d.]+) "
-    r"panel=([\d.]+),([\d.]+),([\d.]+),([\d.]+) markerColor=(\S+) panelColor=(\S+)")
+    r"panel=([\d.]+),([\d.]+),([\d.]+),([\d.]+) markerColor=(\S+) panelColor=(\S+) "
+    r"toolbar=(-?[\d.]+),(-?[\d.]+),([\d.]+),([\d.]+) "
+    r"tabbar=(-?[\d.]+),(-?[\d.]+),([\d.]+),([\d.]+) chromeColor=(\S+)")
 
 
 def _available():
@@ -118,6 +126,9 @@ class EditModeChromeTest(unittest.TestCase):
                 "panel": tuple(float(v) for v in values[13:17]),
                 "markerColor": _hex_to_rgb(values[17]),
                 "panelColor": _hex_to_rgb(values[18]),
+                "toolbar": tuple(float(v) for v in values[19:23]),
+                "tabbar": tuple(float(v) for v in values[23:27]),
+                "chromeColor": _hex_to_rgb(values[27]),
             }
         for tag in ("geometry", "midGeometry"):
             self.assertIn(tag, self.reported,
@@ -131,6 +142,9 @@ class EditModeChromeTest(unittest.TestCase):
         self.panel = settled["panel"]
         self.marker_rgb = settled["markerColor"]
         self.panel_rgb = settled["panelColor"]
+        self.toolbar = settled["toolbar"]
+        self.tabbar = settled["tabbar"]
+        self.chrome_rgb = settled["chromeColor"]
 
         self.frames = {}
         for name in ("rest", "editing", "midway", "after"):
@@ -232,6 +246,48 @@ class EditModeChromeTest(unittest.TestCase):
                                msg="the desktop is not centred horizontally mid-animation")
         self.assertAlmostEqual(top, screen_h - bottom, delta=3,
                                msg="the desktop is not centred vertically mid-animation")
+
+    # ---- the chrome ------------------------------------------------------
+
+    def _body_span(self, frame, rect):
+        """The horizontal extent of a chrome body, found in the picture.
+
+        Read across the item's own vertical centre, where a stadium's ends are
+        at their widest and the corner arc cannot decide where the body starts.
+        Matched on the toolbar's surface colour with a small tolerance rather
+        than on "not the background": a `Toolbar` draws a soft shadow outside
+        its own bounds, and a strict inequality against the backdrop measures
+        the shadow's reach instead of the body's.
+        """
+        x, y, w, h = rect
+        row = round(y + h / 2)
+        xs = [px for px in range(frame.width)
+              if max(abs(a - b) for a, b in
+                     zip(frame.getpixel((px, row)), self.chrome_rgb)) <= 12]
+        return xs
+
+    def test_the_chrome_is_drawn_where_its_geometry_says_it_is(self):
+        # The harness asserts the numbers; this asserts the paint. A toolbar
+        # whose content fails to resolve - a missing import, a Translation that
+        # is not in scope - still reports a position, a size and a full set of
+        # passing geometry checks, and draws a stub. Found exactly that way.
+        frame = self.frames["editing"]
+        for name, rect in (("toolbar", self.toolbar), ("tab bar", self.tabbar)):
+            xs = self._body_span(frame, rect)
+            self.assertTrue(xs, f"the {name}'s body is not in the picture at all")
+            drawn_x, drawn_width = xs[0], xs[-1] - xs[0] + 1
+            self.assertAlmostEqual(
+                drawn_x, rect[0], delta=2,
+                msg=f"the {name} is drawn {drawn_x - rect[0]:.0f}px from where it reports")
+            self.assertAlmostEqual(
+                drawn_width, rect[2], delta=3,
+                msg=f"the {name} is drawn {drawn_width:.0f}px wide and reports {rect[2]:.0f}")
+
+    # Deliberately NOT repeated here: whether the chrome sits outside the card
+    # and inside the screen. The harness asserts that against the same live
+    # rects, and a copy of it in this file would read those rects back out of
+    # the harness's own report - two checks that agree by construction, which
+    # is one check and a false sense of two.
 
     # ---- the corner ------------------------------------------------------
 

--- a/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """What Edit Mode may do to the desktop, and what it may not.
 
-Stage 3 of docs/superpowers/specs/2026-08-16-edit-mode-design.md, so this
-covers the viewport and the desktop only; the chrome surface's half of §11.2
-lands with the chrome.
+Stages 3 and 4 of docs/superpowers/specs/2026-08-16-edit-mode-design.md: the
+viewport and the desktop, plus the chrome surface's half of §11.2. The drawer,
+the per-widget menu, the bar and the dock are later stages and are not here.
 
 Five of these guard failures that are silent on screen:
 
@@ -21,6 +21,17 @@ Five of these guard failures that are silent on screen:
 - and the mid-drag exit committing rather than cancelling, which stores an
   unclamped overshoot - the defect 705e9006d fixed, where a real store held a
   widget at x: -852 on a 5120px screen.
+
+The chrome surface adds three more of the same kind, none of which any harness
+can see, because weston implements no wlr-layer-shell:
+
+- a screen-sized surface whose input mask is not the chrome makes the desktop
+  underneath unclickable, and the desktop underneath is the thing being edited;
+- a namespace absent from rules.lua falls through the catch-all
+  `ignore_alpha = 0.05`, under which that surface's transparent pixels ask the
+  compositor to blur the whole screen;
+- and a chrome surface taking keyboard focus sits in front of the background
+  and swallows the Escape the exit ladder is answered on.
 """
 
 import re
@@ -37,11 +48,17 @@ CANVAS = ROOT / "modules/common/widgets/widgetCanvas/WidgetCanvas.qml"
 WIDGET = ROOT / "modules/common/widgets/widgetCanvas/AbstractWidget.qml"
 BACKGROUND_WIDGET = ROOT / "modules/imi/background/widgets/AbstractBackgroundWidget.qml"
 PLUGIN_WIDGET = ROOT / "modules/common/plugins/PluginWidget.qml"
+CHROME_SCOPE = ROOT / "modules/imi/editMode/EditModeChrome.qml"
+CHROME_SURFACE = ROOT / "modules/imi/editMode/EditModeChromeSurface.qml"
+CHROME_CONTENT = ROOT / "modules/imi/editMode/EditModeChromeContent.qml"
+DESKTOP_MENU = ROOT / "modules/imi/desktopMenu/DesktopMenu.qml"
+RULES = ROOT.parents[1] / "hypr/hyprland/rules.lua"
 
 # Everything that takes part in the mode. Listed rather than globbed so a new
 # participant is a deliberate addition to this list, which is where someone
 # reads what the rules are.
-PARTICIPANTS = [BACKGROUND, CANVAS, WIDGET, BACKGROUND_WIDGET, PLUGIN_WIDGET]
+PARTICIPANTS = [BACKGROUND, CANVAS, WIDGET, BACKGROUND_WIDGET, PLUGIN_WIDGET,
+                CHROME_SCOPE, CHROME_SURFACE, CHROME_CONTENT]
 
 
 def read(path: Path) -> str:
@@ -75,6 +92,9 @@ def test_nothing_computes_the_mode_from_anything_but_the_one_flag():
                 or re.search(r"property bool editMode: false\s*$", line)
                 or "root.editMode" in line
                 or "rootWidget.editMode" in line
+                # The chrome surface's own layer-shell namespace, which is a
+                # string and not a predicate at all.
+                or "WlrLayershell.namespace" in line
                 or line.lstrip().startswith("//")
             )
             assert allowed, f"{path.name}: a second source for the mode: {line.strip()}"
@@ -236,6 +256,153 @@ def test_the_inset_is_derived_from_one_declared_drawer_width():
     assert not re.search(r"drawerOpen|drawerVisible", module), \
         ("the inset may not depend on the drawer being open - opening it "
          "translates the desktop, it never resizes it")
+
+
+def test_the_mode_animates_on_exactly_one_scalar():
+    # The desktop and the chrome that frames it are on two different layer
+    # surfaces, and both build their geometry out of the progress. A second
+    # Behavior anywhere is two numbers that must agree, and the frames where
+    # they do not are the ones where the chrome frames a rectangle the desktop
+    # is not at - which settles correctly and is therefore invisible at rest.
+    behaviours = []
+    for path in ROOT.rglob("*.qml"):
+        if "/tests/" in str(path):
+            continue
+        if re.search(r"Behavior on editProgress", path.read_text()):
+            behaviours.append(str(path.relative_to(ROOT)))
+    assert behaviours == ["GlobalStates.qml"], \
+        f"the mode's progress is animated in more than one place: {behaviours}"
+    assert re.search(r"readonly property real editProgress: GlobalStates\.editProgress",
+                     read(BACKGROUND)), \
+        "the desktop must read the shared scalar rather than deriving its own"
+    assert "GlobalStates.editProgress" in read(CHROME_SURFACE), \
+        "...and so must the chrome"
+
+
+def test_the_chrome_surface_is_static():
+    # On a layer surface, position IS `margins`, so chrome animating into place
+    # through them reconfigures the surface every frame - the create-map-destroy
+    # loop BarPopupOverlay exists to avoid. The same four properties
+    # lint_bar_popup_overlay_static.py pins there.
+    text = read(CHROME_SURFACE)
+    for edge in ("top", "bottom", "left", "right"):
+        assert re.search(rf"^\s*{edge}: true\s*$", text, re.M), \
+            f"the chrome surface does not anchor its {edge} edge"
+    assert not re.search(r"^\s*margins\b", text, re.M), \
+        "a margin on this surface is a reconfigure per frame"
+    for prop in ("implicitWidth", "implicitHeight"):
+        assert not re.search(rf"^\s*{prop}:", text, re.M), \
+            f"the chrome surface sizes itself with {prop} instead of anchoring"
+    assert re.search(r'^\s*color: "transparent"\s*$', text, re.M), \
+        ("a window colour bound to a token latches the surface opaque and costs "
+         "it its blur for the life of the process (deba3e3f6)")
+
+
+def test_every_pixel_that_is_not_chrome_falls_through_to_the_desktop():
+    # The failure this exists for is the whole point of the mode being usable:
+    # a screen-sized Overlay surface that accepts input everywhere makes the
+    # desktop underneath unclickable, and the desktop underneath is the thing
+    # being edited.
+    text = read(CHROME_SURFACE)
+    mask = re.search(r"mask: Region \{(.*?)\n    \}", text, re.S)
+    assert mask, "the chrome surface publishes no input mask at all"
+    items = re.findall(r"item: (chrome\.\w+)", mask.group(1))
+    assert items == ["chrome.toolbarItem", "chrome.tabBarItem"], \
+        f"the mask is not exactly the two chrome rects: {items}"
+    # ...and nothing else on the surface may take a press. A screen-sized
+    # MouseArea would be inside the mask's own hole and eat nothing, which is
+    # exactly why it would survive review: it does nothing until the mask grows.
+    for path in (CHROME_SURFACE, CHROME_CONTENT):
+        body = read(path)
+        assert "MouseArea" not in body, \
+            f"{path.name} adds a pointer area to a surface whose mask is two rects"
+
+
+def test_the_chrome_surface_leaves_the_keyboard_to_the_desktop():
+    # Escape is answered by WidgetCanvas on the background surface, through
+    # edit_mode.js's ladder. A chrome surface on Overlay taking OnDemand focus
+    # sits in front of it and swallows the key - and the mode's own exit is
+    # what stops working.
+    assert re.search(r"WlrLayershell\.keyboardFocus:\s*WlrKeyboardFocus\.None",
+                     read(CHROME_SURFACE)), \
+        "the chrome surface must not take keyboard focus"
+
+
+def test_the_chrome_surface_mints_a_namespace_and_declares_it_to_the_compositor():
+    # A namespace absent from rules.lua falls through the catch-all
+    # `ignore_alpha = 0.05`, under which a screen-sized surface's transparent
+    # pixels clear the threshold and the compositor is asked to blur the entire
+    # screen. Nothing logs it; it is loud only on the screen.
+    text = read(CHROME_SURFACE)
+    declared = re.search(r'WlrLayershell\.namespace:\s*"([^"]+)"', text)
+    assert declared, "the chrome surface declares no namespace"
+    namespace = declared.group(1)
+    assert namespace not in ("quickshell:popup", "quickshell:background",
+                             "quickshell:bar", "quickshell:dock"), \
+        ("reusing a namespace inherits its ignore_alpha - BarPopupOverlay.qml "
+         "records what that cost the tray menus")
+    rules = RULES.read_text()
+    assert re.search(rf'namespace = "{re.escape(namespace)}" \}}, ignore_alpha =',
+                     rules), \
+        f"{namespace} has no alpha threshold in rules.lua"
+    # Above the bar and the dock, or the chrome renders underneath the two
+    # surfaces the mode deliberately leaves at full size.
+    assert re.search(r"WlrLayershell\.layer:\s*WlrLayer\.Overlay", text), \
+        "the chrome must sit above the bar and the dock"
+
+
+def test_the_chrome_stands_down_through_two_gates_of_its_own():
+    # The same lesson as the desktop card's, on a surface this time: either gate
+    # alone hides the chrome, so a frame comparison passes on a tree with one of
+    # them deleted - and then the survivor gets deleted as redundant.
+    scope = read(CHROME_SCOPE)
+    assert re.search(r"active:\s*GlobalStates\.editMode \|\| GlobalStates\.editProgress > 0",
+                     scope), \
+        "the chrome surface must not exist while the mode is off"
+    assert re.search(r"opacity:\s*GlobalStates\.editProgress", read(CHROME_SURFACE)), \
+        "the chrome must be transparent while the mode is off"
+
+
+def test_the_chrome_is_placed_off_the_desktops_own_rectangle():
+    # One arithmetic for the desktop and the thing that frames it, so the
+    # toolbar cannot end up a pixel off the card - the rule ClockDepthCutout is
+    # one component for. It is re-derived rather than published across the
+    # window boundary because every input is available on both sides; what it
+    # may not do is invent a second geometry.
+    surface = read(CHROME_SURFACE)
+    assert "EditMode.cardRect(" in surface and "EditMode.viewportGeometry(" in surface, \
+        "the chrome must take the desktop's rectangle from the module, not invent one"
+    content = read(CHROME_CONTENT)
+    assert re.search(r"property rect card:", content), \
+        "the chrome content takes the desktop's rectangle"
+    for axis in ("root.card.x", "root.card.y"):
+        assert axis in content, f"the chrome does not place itself off {axis}"
+    # ...and it moves with the progress rather than chasing it. A Behavior whose
+    # target moves every frame restarts every frame and never ticks (b710ef731),
+    # and everything here is a function of the one animated scalar already.
+    declared = [line.strip() for line in content.splitlines()
+                if "Behavior on" in line and not line.lstrip().startswith("*")
+                and not line.lstrip().startswith("//")]
+    assert declared == [], \
+        f"the chrome's motion is the shrink's, and a Behavior on it would freeze: {declared}"
+
+
+def test_the_mode_has_one_way_in_and_the_toolbar_owns_the_way_out():
+    # Two controls that disagree about what they do is the failure; two that
+    # agree is merely redundant. This picks the first: the desktop menu enters,
+    # the toolbar's Done leaves, and neither is the other's second opinion.
+    menu = read(DESKTOP_MENU)
+    writes = re.findall(r"GlobalStates\.editMode = ([^\n]+)", menu)
+    assert writes == ["true"], \
+        f"the desktop menu is no longer only the way in: {writes}"
+    assert re.search(r"visible:\s*!GlobalStates\.editMode", menu), \
+        "the Edit layout row must not sit in the menu doing nothing while the mode is on"
+    assert re.search(r"GlobalStates\.editMode = false", read(CHROME_SURFACE)), \
+        "the toolbar's Done is the mode's exit"
+    # Leaving takes the gesture and the selection with it: Done means stop, and
+    # a selection halo left on the desktop has no visible way to be cleared.
+    assert re.search(r"onEditModeChanged:[^\n]*clearSelection", read(CANVAS)), \
+        "leaving the mode leaves a selection behind"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stage 4 of `docs/superpowers/specs/2026-08-16-edit-mode-design.md`: the toolbar, Done, and the tab bar with only the Desktop tab in it. #236 gave the mode a viewport and #239 made it look like a card; this is the chrome around it, and it is the stage where the surface contract lands.

**Before / after captures (5120×1440 whole frames, plus 1:1 crops of both bands): https://claude.ai/code/artifact/af7db08c-b62e-48cb-825c-3ad3e017c057**

Both frames come out of `EditModeLookProbe.qml` under headless weston, which is also what the new pixel checks drive — the pictures and the checks are the same run. The magenta and green blocks in them are probe markers (an opaque square pinned to the canvas's own corner, an opaque panel the lattice has to disappear behind), not chrome.

## 1. The surface, and the namespace

Probe 3 measured the live session as three levels — `quickshell:background` / `quickshell:dock` + `quickshell:bar` / `quickshell:screenCorners` + `quickshell:barPopup` — so chrome drawn on the background renders *under* a bar the mode deliberately leaves at full size. The viewport stays where it is anyway: it is where the wallpaper and the `WidgetCanvas` already are, and moving it costs the live-wallpaper frost a `ShaderEffectSource` can only reach inside its own scene graph (§2.2). So the chrome takes a full-screen `WlrLayer.Overlay` surface of its own, one per screen, and the viewport does not move.

`modules/imi/editMode/` is three files, split the way `EditModeCard` is split out of `Background.qml`: a `Scope` with the per-screen `Variants`, the `PanelWindow`, and the chrome content as a plain `Item` — which is the only reason any of it is reachable from a probe, since weston implements no wlr-layer-shell.

**The namespace is `quickshell:editMode`, minted, and listed in `rules.lua` at `ignore_alpha = 1`.** A new namespace falls through the catch-all `blur = true` / `ignore_alpha = 0.05`, under which a screen-sized surface of *transparent* pixels clears the threshold and the compositor is asked to blur the entire screen — the trap `modules/imi/clockDepthSelect/` hit. That one answered it with `blur = false` plus a region over its toolbar; this one goes the other way, because both toolbar bodies are `m3colors.m3surfaceContainer` and therefore fully opaque (`#201f20`, no alpha): at `ignore_alpha = 1` the bodies are the only thing blurred, their shadows stay crisp, and the transparent remainder is left alone. That is the treatment `quickshell:recordingRegion` and `quickshell:overlay` already carry for exactly this shape of surface, and it needs no `WindowBlurRegion` — so `lint_blur_region_pairing.py` is not engaged, rather than being satisfied with a region that would blur an opaque rect for nothing.

Reusing `quickshell:popup` is not on the table and the reason is recorded at `BarPopupOverlay.qml:53-69`: its `ignore_alpha = 1` is inherited by every xdg-popup opened from the surface, which is how tray menus stopped being blurred. `no_anim = true` for the same reason `clockDepthSelect` has it — the surface is created and destroyed by a toggle, and a map animation on something screen-sized reads as the desktop lurching.

**Input falls through everywhere that is not chrome.** `mask: Region { item: chrome.toolbarItem; Region { item: chrome.tabBarItem } }` — the union of the two bodies and nothing else, so every other pixel of a screen-sized `Overlay` surface reaches the widgets underneath, which are the thing being edited. Two independent gates rather than one, because the mode being *off* is the dangerous state and the one nobody looks at: the surface **does not exist** while the mode is off (`active: GlobalStates.editMode || GlobalStates.editProgress > 0`), and its content is `opacity: GlobalStates.editProgress`. That is #239's finding applied to a surface — either gate alone hides the chrome, so a frame comparison passes on a tree with one of them deleted, and then the survivor gets deleted as redundant. Both are named in the contract.

**`WlrKeyboardFocus.None`.** Escape is answered by `WidgetCanvas` on the background surface through `edit_mode.js`'s ladder; a chrome surface on `Overlay` taking `OnDemand` focus would sit in front of it and swallow the key, which would break the mode's keyboard exit by adding its pointer one.

**One consequence I am not hiding: the toolbar overlaps the bar, and the tab bar overlaps a bottom dock.** The band the shrink opens is 100.8px at 5120×1440 and the toolbar is 56px centred in it (y 22.4–78.4); a 40px top bar occupies 0–40. There is no placement in that band that clears a bar of unknown height without tuning a literal against `Appearance.sizes.barHeight`, which is the kind of number this repo punishes. Being *above* them is what the `Overlay` layer was chosen for, the bar and the dock are stage 8's, and the overlap is confined to the toolbar's own 216×56 rect.

## 2. One animated scalar, in `GlobalStates`

The desktop's transform and the chrome that frames it now live on two different layer surfaces and both build their geometry out of the entry progress. Two `Behavior`s on two `editMode ? 1 : 0` properties would be two numbers that have to agree — agreeing at rest, which is the only place anyone looks, and disagreeing exactly on the frames where the chrome frames a rectangle the desktop is not at.

So the scalar moved to `GlobalStates.editProgress` and `Background.qml` reads it. The tier is unchanged (`elementMove` whole, not `elementMoveEnter`/`Exit`, which carry `alwaysRunToEnd` and cannot reverse). The contract sweeps the whole tree for a second `Behavior on editProgress` rather than naming files, because the second one is written by whoever adds the next surface.

## 3. What the chrome is, and what it is made of

`Toolbar` and `ToolbarTabBar` — the shell's M3 expressive toolbar and its toolbar tab bar, the same parts the cheatsheet, the region selector, the recording controls and the lock islands are built from. The alternative was a bespoke card repeating the desktop card's `rounding.verylarge` corner and `colLayer0Border` outline, and that would have been a second toolbar look minted for one mode. What ties the chrome to the card is the shadow they share and the symmetry of the two bands, not a copied radius.

**The toolbar** carries the `edit` glyph, "Edit layout", and Done. **Done is filled on the primary role**, which was a correction after looking: rendered flat beside the toolbar's own title it read as a second label rather than a control, and for the mode's one visible exit that is the worst place to leave "is this clickable?" open. It is labelled rather than an icon-only paired FAB (the way the region selector separates its close) for the same reason.

**The tab bar** is a tab bar with one tab in it, not a label that will grow into one — the Lockscreen tab (§1.4) is stage 9's and arrives as a second entry in the same list. There is deliberately **no stored tab state yet**: a choice with one legal value is plumbing for a feature that does not exist, and the Escape ladder already answers `desktopTab` out of the module.

**No dead "Add widgets" button.** The drawer is stage 5; a control for it would be a control that does nothing, which is worse than one that is not there.

## 4. The two Done controls

Stage 3 shipped an `Edit layout` / `Done editing` toggle in the desktop menu, deliberately early, and its comment said why: probe 4 never confirmed the compositor delivers keys to a `Bottom`-layer surface, so Escape could not be the mode's only exit and the row stood in for a toolbar that did not exist.

**The row is now the way in and only the way in, and it disappears while the mode is on.** Keeping its exit half would leave the mode's exit *also* hidden behind a right-click and two rows deep in a context menu, which is the discoverability failure the mode exists to fix, and would give the mode two exits at different depths for no gain. Leaving the row visible as a no-op is the other thing not done. The contract checks it from both ends: the desktop menu writes only `true`, the chrome writes only `false`.

Done means stop (§8.2), so leaving the mode now also **clears the selection**, hung on the same `onEditModeChanged` that already cancelled an in-flight drag — every exit means the same thing, and Escape's ladder clears a selection before it will exit, so the only way to reach a stranded halo was to leave some other way.

## 5. Motion and look

The chrome's position is a pure function of `edit_mode.js`'s `cardRect` — the same arithmetic the desktop's transform is built out of, for the reason `ClockDepthCutout` is one component and not two call sites. The toolbar is centred in the band between the screen's top edge and the card's; the tab bar in the mirror band below. At progress 0 both bands have zero height and both pieces are parked half off screen, so **the chrome rises into place as the desktop shrinks away from it** rather than popping in after the shrink lands, and it needs no animation of its own to do it.

That is also why neither may carry a `Behavior`: a `Behavior` whose target moves every frame restarts every frame and never ticks (b710ef731). The contract fails on one.

Both pieces are centred on the **desktop** rather than on the screen. Those are the same point today and stop being one the moment stage 5's drawer translates the card.

## 6. Tests

`test_edit_mode_contract.py`'s first half, per §12 — and it is the deliverable rather than a receipt, because weston implements no wlr-layer-shell and nothing about a surface is reachable from any harness here. Nine checks: the mask is exactly the two chrome rects and nothing adds a pointer area; the namespace is minted, is not one of the four it would be tempting to reuse, and appears in `rules.lua` with a threshold; the layer is `Overlay`; keyboard focus is `None`; the surface is static (four anchors, no margins, no implicit size, a literal clear colour); it stands down through two gates; the mode animates on exactly one `Behavior`, swept over the tree; the chrome's rect comes from the module and carries no `Behavior`; and one way in, one way out.

**Every one of them was proven to fail by planting the violation in a clean tree and reverting it — sixteen mutations, each reddening exactly one check.** Including the two pixel ones: a toolbar left `visible: false` reports its box, passes every geometry assertion in the harness, and paints nothing; a toolbar carrying a `transform` reports one place and paints 40px from it.

The look probe grew three harness checks (both pieces in the bands the shrink opened, centred on the desktop with the two bands equal, and the chrome leaving with the mode) and one pixel check (both bodies are in the picture at the extent they report). What the pixel half deliberately does **not** repeat is whether the chrome sits outside the card: the harness asserts that against the live rects, and a copy of it would read those same rects back out of the harness's own report — two checks that agree by construction are one check and a false sense of two. The desktop's four margins staying equal in pairs at every frame is already pinned as arithmetic by `tst_edit_mode.qml`'s concentric-shrink sweep and in pixels at half progress, so what is added is the chrome's own symmetry.

Both new components also join `DesignSystemCompile.qml`'s explicit list, for the reason `ClockDepthSelectSurface.qml` is on it: they sit behind a `Loader` that is inactive until somebody enters the mode, so an ordinary shell has never compiled them.

Baseline re-measured on a clean `gh/main` worktree: **897 passed, 0 failed** (`qmltestrunner` Totals, invoked directly — a full-suite run started and then edited during is the contaminated measurement #239 recorded). This branch: **897 passed, 0 failed**, full suite exit 0.

Docs: updated AGENT.md §Directory map, §"Edit Mode shrinks that viewport"
