### PR TITLE
The lattice waits for the drag, the card's edge gets thickness, and the corner stops eating widgets

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -2349,26 +2349,68 @@ mode is built out of are worth not re-deriving:
   `WallpaperBlurBackdrop` component with the lock's, and it works because a
   `ShaderEffectSource` renders its source item in that item's OWN coordinates —
   a transformed wallpaper still yields an untransformed texture.
-- **That backdrop is drawn ABOVE the desktop, cut out to a rounded rect, and
-  that is the only cheap way to round the desktop's corner**
-  (`modules/imi/background/EditModeCard.qml`). QML has no rounded clip and the
-  desktop is three separately transformed siblings, so no property on any of
-  them rounds a corner, and wrapping all three in one masked layer pushes the
-  wallpaper through an effect for every frame of the shrink — the cost the
-  transform was chosen to avoid. Covering the corner with what is behind it is
-  identical to drawing the backdrop behind everywhere except the four corners,
-  and it gives the drop shadow somewhere honest to live: inside the same cut,
-  over the backdrop, so only the half outside the card survives and its interior
-  never darkens the desktop it is lifting. Two things measured rather than
-  argued while building it. The shadow stays `StyledRectangularShadow` at the
-  magnitude the component defines — raising `blur` from 9 to 40 on a 4403px card
-  spreads the same darkness over four times the distance and the two renders are
-  indistinguishable, because the edge contrast comes from `colShadow`'s alpha
-  and most of a `RectangularShadow` sits under its target, which the cut
-  removes. And the chrome stands down through **two** gates, the Loader's
-  `active` and its `opacity`: either alone hides it, so a frame comparison
-  passes on a tree with one of them deleted, which is why
-  `test_edit_mode_contract.py` names both.
+- **That backdrop is drawn ABOVE the wallpaper and BELOW the widget canvas, cut
+  out to a rounded rect, and that is the only cheap way to round the desktop's
+  corner** (`modules/imi/background/EditModeCard.qml`, the `editChrome` Loader
+  at `z: 1`). QML has no rounded clip and the desktop is three separately
+  transformed siblings, so no property on any of them rounds a corner, and
+  wrapping all three in one masked layer pushes the wallpaper through an effect
+  for every frame of the shrink — the cost the transform was chosen to avoid.
+  Covering the corner with what is behind it is identical to drawing the backdrop
+  behind everywhere except the four corners, and it gives the drop shadow
+  somewhere honest to live: inside the same cut, over the backdrop, so only the
+  half outside the card survives and its interior never darkens the desktop it is
+  lifting.
+
+  **A cover over EVERYTHING covers everything, which is what the `z: 1` is for.**
+  It shipped at `z: 4` and cut the widgets too: the desktop scales about its own
+  centre, so the canvas's edge lands exactly on the card's edge and a widget
+  parked against a screen edge is flush with the rounding — at a corner the arc
+  comes in on both axes and takes a bite. Measured at 5120x1440, 20px along each
+  edge and 10px on the diagonal of a block pinned there, and this machine's own
+  `plugin-state.json` keeps `visualizer` at 0,1200 on a 1440-tall screen. The
+  trade is deliberate and is the whole of the fix: a widget in the corner now
+  OVERHANGS the rounding, drawn whole over the blurred backdrop. It says "this
+  widget is at the edge of your desktop", where the alternative was moving
+  widgets the user placed. `test_edit_mode_chrome.py` asks the question from both
+  sides — a marker in the wallpaper viewport that has to be cut, a block on the
+  canvas that has to survive — because a single check either way passes on both
+  arrangements. Note the second copy of the arrangement: `EditModeLookProbe.qml`
+  re-declares the four siblings, because weston implements no layer shell, and it
+  scored one render of that fix against its own stale `z: 4`. The contract pins
+  the two z values against each other now.
+
+  **The card's edge is a bevel, not a line.** A 1px `colLayer0Border` outline is
+  right for a panel on a surface these tokens were derived from and is a drawn
+  line over a WALLPAPER: walked round the perimeter on this library's darkest
+  picture, the worst point departed from the backdrop beside it by 2.8/255. Three
+  tones fix it, and it is three because no single one survives every wallpaper —
+  a shade band just outside (which carries a bright picture), a specular on the
+  edge that is brightest along the top and fades to a weak bounce at the bottom
+  (which carries a dark one), and a faint highlight just inside so the specular
+  is the outer face of something. Re-measured: worst-on-perimeter 24.0/255 over
+  the darkest wallpaper and 38.2/255 over the brightest. Two things generalise.
+  The two outer tones are plain `Rectangle`s declared INSIDE `surround`, whose
+  layer is already masked to the complement of the card — so the mask cuts each
+  of them back to the band outside the card by itself and the shading is the
+  Rectangle's own gradient, which is why the whole treatment adds no layer, no
+  mask and no effect (measured under headless weston's software renderer, 14.91s
+  ± 0.22 of user CPU against 14.68s ± 0.32, indistinguishable on a 3-4% spread).
+  And its two colours are `Appearance.colors.colGlassSpecular`/`colGlassShade`,
+  the one pair in that file deliberately NOT derived from the wallpaper: every
+  other colour there is generated from the picture on screen, so an edge drawn in
+  one of them is guaranteed to be a colour the picture already contains. Same
+  reasoning as the depth picker's hardcoded contour.
+
+  Two things measured rather than argued while building the original. The shadow
+  stays `StyledRectangularShadow` at the magnitude the component defines —
+  raising `blur` from 9 to 40 on a 4403px card spreads the same darkness over
+  four times the distance and the two renders are indistinguishable, because the
+  edge contrast comes from `colShadow`'s alpha and most of a `RectangularShadow`
+  sits under its target, which the cut removes. And the chrome stands down
+  through **two** gates, the Loader's `active` and its `opacity`: either alone
+  hides it, so a frame comparison passes on a tree with one of them deleted,
+  which is why `test_edit_mode_contract.py` names both.
 - **The per-widget frost is stood down for the mode, not aligned to it**
   (`PluginWidget.frostSuspended`, the generalisation of what used to be
   `lockCoversFrost`). Measured on a live desktop with a Wallpaper Engine scene:
@@ -2388,6 +2430,28 @@ mode is built out of are worth not re-deriving:
   is translucent, which every desktop widget is and which this mode makes more
   so by standing the frost down, then has a crisp full-strength line running
   across it, and a line is a foreground cue whatever is really in front.
+- **...and it belongs to the GESTURE, in the mode as well as out of it.** The
+  mode forced it on for the whole mode on the spec's §4.1 discoverability
+  argument, and that argument predates the mode having any chrome: the toolbar
+  and the tab bar say it is on now, and a mode that opens on a screen of graph
+  paper hides the desktop you came to look at. What the mode overrides is the
+  config SWITCH (`background.showGrid`, "draw the grid while I drag"), so
+  `gridVisible` is `showGrid && (editMode || the switch)` — the gesture is a
+  required conjunct and a top-level `||` is what the contract forbids. The
+  trigger is the distinction `AbstractWidget` already draws and never a second
+  one: `showGrid` is written from `onDraggingChanged`, which follows
+  `dragActive`, which `onPositionChanged` raises only past `drag.threshold`.
+  That matters because every one of a widget's own controls presses without
+  travelling — the resize grip, the right-click, a click that selects — and a
+  lattice flashing up under each of them is worse than one that never goes away.
+  Two consequences: the fade is `elementMoveFaster` rather than `elementMoveFast`
+  because its reference is now the pointer rather than the 500ms shrink, and
+  `widgetRemoved` takes the lattice down, because a widget destroyed mid-drag is
+  the one end of a gesture that never reaches `onDraggingChanged`. The pixel half
+  is three frames (at rest, mid-drag, and a whole-frame comparison of after
+  against before), because `gridVisible` goes false the instant a drag ends while
+  the fade still has 150ms to run — a lattice that never finished leaving reports
+  the same false.
 - **The whole mode animates on ONE scalar, and it is `GlobalStates.editProgress`
   rather than a property of the surface that uses it.** The desktop's transform
   and the chrome that frames it are on two different layer surfaces, in two
@@ -2437,7 +2501,10 @@ feat(editMode): shrink the desktop about dead centre, and move it only for the d
 feat(widgetCanvas): the lattice is a substrate, and it dissolves at the edges,
 feat(editMode): animate the mode on one scalar, shared by every surface,
 feat(editMode): draw the mode's toolbar and tab bar on a surface of their own,
-test(editMode): score the chrome against the desktop it frames.)
+test(editMode): score the chrome against the desktop it frames,
+fix(widgetCanvas): the lattice comes up with the drag, not with the mode,
+feat(editMode): give the card's edge thickness instead of a drawn line,
+fix(editMode): stop the card's rounded corner biting a widget the user placed.)
 
 **The clock depth layer is the counter-case to that rule, and it is why it is a
 FOURTH sibling.** `widgetCanvas` sits at `z: 2` as a sibling of
@@ -2455,7 +2522,25 @@ only while everything above it lets clicks through.
 `tests/test_clock_depth_compositing.py` renders it under headless weston and
 samples the pan mid-animation, because a layer bound to the destination settles
 in exactly the right place and passes every settled check.
-(feat(background): draw the wallpaper's subject over the desktop widgets.)
+
+**Being above the widgets is also why it stands down for Edit Mode**
+(`ClockDepthLogic.eligible`'s `editing` refusal). Once the mode's cover moved
+below the widget canvas, this layer was the one thing left drawing above it, and
+it cannot follow the widgets down without putting the widgets under the cover
+again — which is the bite that move removed. Two reasons to refuse rather than
+reorder, and they are both its own: it paints the wallpaper's subject OVER the
+widgets the mode exists to let the user arrange, which is a partly hidden widget
+in the one mode where that matters most (the sibling of the `selecting`
+refusal); and it reconstructs the parallax viewport, which is deliberately
+larger than the screen (`workspaceZoom`, 1.1 by default) with only the layer
+surface's own edge keeping that overscan off screen. The mode's transform pulls
+the desktop's edge away from the surface's and puts the blurred backdrop in
+between, so a subject reaching the picture's edge would be free to paint up to
+154px past the card at 5120x1440. The refusal touches nothing else:
+`ClockDepth.watching` is `enabled || picking`, so entering the mode drops no
+cached answer and leaving it re-runs no segmentation.
+(feat(background): draw the wallpaper's subject over the desktop widgets,
+fix(clockDepth): stand the depth layer down for the mode that arranges widgets.)
 
 **`OpacityMask` masks by the mask's ALPHA channel and nothing else, so a
 grayscale mask is opaque everywhere.** The obvious artifact for a segmentation

--- a/docs/superpowers/specs/2026-08-16-edit-mode-design.md
+++ b/docs/superpowers/specs/2026-08-16-edit-mode-design.md
@@ -333,7 +333,7 @@ Almost nothing new is drawn. What the mode does is stop hiding what is already t
 
 | today | in Edit Mode |
 | --- | --- |
-| the grid appears only mid-drag (`WidgetCanvas.qml:211-217`) | on for the whole mode |
+| the grid appears only mid-drag (`WidgetCanvas.qml:211-217`) | ~~on for the whole mode~~ — reversed after looking at it, see below |
 | the resize grip fades in on hover (`PluginWidget.qml:709-726`) | every resizable widget shows its grip |
 | the global lock is a submenu switch (`WidgetsSubmenu.qml:32-38`) | the mode suppresses it (below) |
 | right-click on a widget toggles the global lock (`AbstractWidget.qml:85-89`) | right-click is a per-widget menu (Remove, Size, Pin) |
@@ -347,12 +347,30 @@ belt — *"'Lock widget positions' must never unlock something the user delibera
 either direction"* (`:37-40`). Writing `widgetsLocked = false` on entry would destroy a stored
 preference and leave the desktop unlocked after the mode ended.
 
+**The grid stays the DRAG's, and the row above is withdrawn.** Written after the mode shipped and
+was looked at: *"in Edit mode, the grid lines should not appear until I try to move a widget."*
+The argument for forcing it on was discoverability — §2 calls the grid "the one thing that
+reliably says this is editable" and complains that it only appears once you have already started
+dragging — and that argument was made before stage 6 gave the mode a toolbar and a tab bar of its
+own. Those say the mode is on now. A mode that opens on a screen of graph paper hides the desktop
+the user came in to look at, which is the opposite of §4.1's own framing.
+
+What the mode overrides is the config SWITCH (`background.showGrid`, whose meaning has always been
+"draw the grid while I drag") rather than the gesture: editing, a drag always draws the lattice it
+is landing on. The trigger is the distinction `AbstractWidget` already draws — `dragActive`, raised
+past `drag.threshold` and never on the press — because every one of a widget's own controls presses
+without travelling.
+(fix(widgetCanvas): the lattice comes up with the drag, not with the mode.)
+
 **The drawn grid becomes 12px.** `WidgetCanvas.qml:7` draws every 24px; `AbstractWidget.qml:23`
 snaps every 12, and `docs/widget-grid.md`'s "Position snapping" section explains why the fine
-lattice is deliberate. While the grid was only up during a drag this read as decoration; with it
-up for the whole mode, a widget landing between two lines reads as broken snapping. Draw 12px
-lines at a lower opacity with every second one emphasised, so the lattice is honest and the rhythm
-stays readable. This changes an existing default, so it lands as its own commit.
+lattice is deliberate. Drawing 24 while snapping 12 puts a widget between two lines at every second
+stop, which reads as broken snapping — and it reads that way exactly when the grid is up, i.e.
+during the drag doing the snapping. (This paragraph originally hung that on the grid being up for
+the whole mode; the mode made it impossible to miss rather than made it true, so it survives the
+row above being withdrawn.) Draw 12px lines at a lower opacity with every second one emphasised, so
+the lattice is honest and the rhythm stays readable. This changes an existing default, so it lands
+as its own commit.
 
 **`WidgetsSubmenu` goes.** Its `widgetList` is empty by decision (`:14-19`) and its only live
 control is the global lock, which the mode suppresses — a switch that turns off something the

--- a/dots/.config/quickshell/imi/EditModeLookProbe.qml
+++ b/dots/.config/quickshell/imi/EditModeLookProbe.qml
@@ -168,11 +168,17 @@ ShellRoot {
                 }
             }
 
+            // BELOW widgetCanvas (z 2), which is the arrangement Background.qml
+            // has: the cover rounds the picture and the widgets draw over it
+            // uncut. test_edit_mode_contract.py pins this z against
+            // Background.qml's, because a probe re-declaring the arrangement can
+            // score one the shell does not have - and it did, for exactly one
+            // render of this fix.
             Loader {
                 id: editChrome
                 active: harness.editProgress > 0
                 anchors.fill: parent
-                z: 4
+                z: 1
                 enabled: false
                 opacity: harness.editProgress
                 sourceComponent: EditModeCard {

--- a/dots/.config/quickshell/imi/EditModeLookProbe.qml
+++ b/dots/.config/quickshell/imi/EditModeLookProbe.qml
@@ -29,10 +29,19 @@ import "modules/common/functions/edit_mode.js" as EditMode
  *   matrix left applied to the live desktop. A property assertion cannot: an
  *   inactive Loader and a zeroed radius are what a still-transformed viewport
  *   reports too.
- * - the desktop's corner is CUT. There is no rounded clip in QML, so the corner
+ * - the PICTURE's corner is CUT. There is no rounded clip in QML, so the corner
  *   is made by covering it with the backdrop, and "did the cover land on the
  *   corner" is a question about one pixel. `cornerMarker` is pinned to the
- *   canvas's own top-left corner so the answer does not depend on the picture.
+ *   wallpaper viewport's own top-left corner so the answer does not depend on
+ *   the picture's content.
+ * - ...and a WIDGET's corner is not. The cover sits below the widget canvas, so
+ *   a widget the user parked against the desktop's corner overhangs the
+ *   rounding instead of losing a bite to it. `cornerWidget` is that widget,
+ *   pinned to the canvas's bottom-left corner because that is where this
+ *   machine's own store keeps `visualizer` (0,1200 on a 1440-tall screen).
+ * - the lattice arrives with the DRAG, not with the mode. Three frames say it:
+ *   in the mode at rest there are no lines, mid-drag there are, and the frame
+ *   after the drag ends is the same picture as the one before it started.
  * - the lattice is a SUBSTRATE. The desktop widgets arrive as external children
  *   of the canvas, so nothing in WidgetCanvas.qml decides whether they are drawn
  *   over the grid; an opaque widget must hide the lines under it completely.
@@ -82,6 +91,7 @@ ShellRoot {
     // rather than "is this a colour the wallpaper might also be".
     readonly property color cornerMarkerColor: "#ff00ff"
     readonly property color opaquePanelColor: "#00ff88"
+    readonly property color cornerWidgetColor: "#ffcc00"
 
     FloatingWindow {
         id: window
@@ -111,6 +121,23 @@ ShellRoot {
                     asynchronous: false
                     source: harness.wallpaperFile === "" ? "" : `file://${harness.wallpaperFile}`
                 }
+
+                // Part of the PICTURE, pinned to the viewport's own top-left
+                // corner, which is the card's top-left corner at every scale.
+                // In the wallpaper layer rather than on the canvas because the
+                // rounding is the picture's now: without a cut this reaches the
+                // card's corner pixel, with one the backdrop does. It is not
+                // what the backdrop samples (that is the Image alone), so the
+                // pixel the cut reveals is blurred wallpaper rather than a
+                // blurred marker.
+                Rectangle {
+                    id: cornerMarker
+                    x: 0
+                    y: 0
+                    width: 220
+                    height: 220
+                    color: harness.cornerMarkerColor
+                }
             }
 
             WidgetCanvas {
@@ -121,16 +148,19 @@ ShellRoot {
                 selectionEnabled: true
                 transform: Matrix4x4 { matrix: harness.matrix }
 
-                // Pinned to the canvas's own top-left corner, which is the
-                // card's top-left corner at every scale. Without a cut it
-                // reaches the card's corner pixel; with one, the backdrop does.
+                // A widget the user parked in the desktop's bottom-left corner,
+                // which is where this machine's own plugin-state.json keeps
+                // `visualizer` - the case the mode was cutting. Opaque for the
+                // same reason opaquePanel is: a translucent one cannot say
+                // whether its corner survived or the backdrop is showing
+                // through it.
                 Rectangle {
-                    id: cornerMarker
+                    id: cornerWidget
                     x: 0
-                    y: 0
-                    width: 220
-                    height: 220
-                    color: harness.cornerMarkerColor
+                    y: widgetCanvas.height - height
+                    width: 240
+                    height: 200
+                    color: harness.cornerWidgetColor
                 }
 
                 // Opaque on purpose: a translucent panel cannot say whether the
@@ -227,7 +257,9 @@ ShellRoot {
             + ` radius=${harness.cardRadius} scale=${harness.applied.scale}`
             + ` marker=${cornerMarker.x},${cornerMarker.y},${cornerMarker.width},${cornerMarker.height}`
             + ` panel=${opaquePanel.x},${opaquePanel.y},${opaquePanel.width},${opaquePanel.height}`
+            + ` corner=${cornerWidget.x},${cornerWidget.y},${cornerWidget.width},${cornerWidget.height}`
             + ` markerColor=${harness.cornerMarkerColor} panelColor=${harness.opaquePanelColor}`
+            + ` cornerColor=${harness.cornerWidgetColor}`
             + ` toolbar=${harness.toolbar?.x ?? -1},${harness.toolbar?.y ?? -1}`
             + `,${harness.toolbar?.width ?? 0},${harness.toolbar?.height ?? 0}`
             + ` tabbar=${harness.tabBar?.x ?? -1},${harness.tabBar?.y ?? -1}`
@@ -321,8 +353,36 @@ ShellRoot {
                     - (harness.card.x + harness.card.width / 2)) < 0.5
                 && Math.abs(gapAbove - gapBelow) < 0.5,
             `gaps=${gapAbove.toFixed(1)},${gapBelow.toFixed(1)}`);
+        harness.check("in the mode at rest the lattice is down",
+            !widgetCanvas.gridVisible && widgetCanvas.gridStrength === 0);
         harness.reportGeometry("geometry");
         harness.shoot("editing", () => {
+            // Through the canvas's own drag reporter, which is what
+            // AbstractWidget calls from onDraggingChanged - there is no QtTest
+            // here to press a real button with, so the harness enters the state
+            // by the same door the gesture does rather than by writing the flag
+            // this check reads. The TRIGGER (press versus press-and-moved) is
+            // scored with real mouse events in EditModeRuntimeTest.qml; what
+            // only this probe can see is what the lattice looks like once it is
+            // up, and that it leaves nothing behind when it goes.
+            widgetCanvas.setDragging(true);
+            harness.after(harness.dragging);
+        });
+    }
+
+    function dragging(): void {
+        harness.check("...and a drag brings it up",
+            widgetCanvas.gridVisible && widgetCanvas.gridStrength === 1);
+        harness.shoot("dragging", () => {
+            widgetCanvas.setDragging(false);
+            harness.after(harness.released);
+        });
+    }
+
+    function released(): void {
+        harness.check("...and letting go takes it away again",
+            !widgetCanvas.gridVisible && widgetCanvas.gridStrength === 0);
+        harness.shoot("released", () => {
             harness.editProgress = 0.5;
             harness.after(harness.midway);
         });

--- a/dots/.config/quickshell/imi/EditModeRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/EditModeRuntimeTest.qml
@@ -324,6 +324,29 @@ ShellRoot {
                           && Math.round(harness.storedPosition("edit-resize-probe").y) === 36);
         },
 
+        // ---- and a widget that stops existing mid-drag ---------------------
+        //
+        // Through `widgetRemoved`, which is the call AbstractWidget's
+        // Component.onDestruction makes - a statically declared widget cannot
+        // be destroy()ed, and what matters is that the canvas answers that
+        // entry point rather than how the widget came to be gone. Nothing else
+        // can take the lattice down here: a destroyed widget never reaches
+        // onDraggingChanged, so a FadeLoader dropping a plugin from under the
+        // pointer (disabling it from Settings mid-drag) used to be invisible
+        // while the grid was up for the whole mode and would now leave it up
+        // for the rest of the mode.
+        () => { harness.placeWidgets(); },
+        () => {
+            const x = movableWidget.x + movableWidget.width / 2;
+            const y = movableWidget.y + movableWidget.height / 2;
+            driver.mousePress(canvas, x, y, Qt.LeftButton);
+            driver.mouseMove(canvas, x + 120, y, 20, Qt.LeftButton);
+            canvas.widgetRemoved(movableWidget);
+            harness.check("a widget that stops existing mid-drag takes the lattice with it",
+                          !canvas.showGrid);
+            driver.mouseRelease(canvas, x + 120, y, Qt.LeftButton);
+        },
+
         // ---- a group drag ends the lattice the same way -------------------
         //
         // Scored separately because only the LEADER reports a drag: a follower

--- a/dots/.config/quickshell/imi/EditModeRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/EditModeRuntimeTest.qml
@@ -223,19 +223,51 @@ ShellRoot {
                               < Math.abs(harness.travelUnscaled.y) - 1);
         },
 
-        // ---- the affordances the mode forces on ---------------------------
+        // ---- the affordances the mode forces on, and the one it does not --
+        //
+        // The lattice belongs to the GESTURE in the mode as well as out of it.
+        // What the mode overrides is the config switch, so the switch is turned
+        // OFF here: what these steps score is then the mode's own behaviour
+        // rather than the user's preference leaking into it.
         () => {
             Config.options.background.showGrid = false;
-            harness.check("the grid is up for the whole mode, not for the drag",
-                          canvas.gridVisible && !canvas.showGrid);
+            harness.check("in the mode at rest there is no lattice",
+                          !canvas.gridVisible && !canvas.showGrid);
             harness.check("the frost stands down for the mode",
                           resizableWidget.frostSuspended);
         },
         () => {
+            // A press is not a drag, and this is the distinction the whole
+            // change turns on: every one of a widget's own controls - the
+            // resize grip, the right-click, a click that selects - presses
+            // without travelling, and a lattice that flashed up under each of
+            // them would be worse than one that never went away. 4 canvas
+            // pixels is comfortably inside AbstractWidget's drag.threshold at
+            // this scale; the drag in the next step is ten times past it.
+            const x = movableWidget.x + movableWidget.width / 2;
+            const y = movableWidget.y + movableWidget.height / 2;
+            driver.mousePress(canvas, x, y, Qt.LeftButton);
+            driver.mouseMove(canvas, x + 4, y + 4, 20, Qt.LeftButton);
+            harness.check("a press that has not travelled draws none of it",
+                          !movableWidget.dragging && !canvas.gridVisible);
+            driver.mouseRelease(canvas, x + 4, y + 4, Qt.LeftButton);
+        },
+        () => {
+            const x = movableWidget.x + movableWidget.width / 2;
+            const y = movableWidget.y + movableWidget.height / 2;
+            driver.mousePress(canvas, x, y, Qt.LeftButton);
+            driver.mouseMove(canvas, x + 120, y, 20, Qt.LeftButton);
+            harness.check("...and a drag past the threshold brings it up",
+                          movableWidget.dragging && canvas.gridVisible);
+            driver.mouseRelease(canvas, x + 120, y, Qt.LeftButton);
+        },
+        () => {
+            harness.check("...and the release takes it away again",
+                          !canvas.showGrid && !canvas.gridVisible);
             Config.options.background.showGrid = true;
             GlobalStates.editMode = false;
-            harness.check("and the grid goes back to being the drag's",
-                          !canvas.gridVisible);
+        },
+        () => {
             harness.check("and the frost comes back", !resizableWidget.frostSuspended);
             GlobalStates.editMode = true;
         },
@@ -292,6 +324,32 @@ ShellRoot {
                           && Math.round(harness.storedPosition("edit-resize-probe").y) === 36);
         },
 
+        // ---- a group drag ends the lattice the same way -------------------
+        //
+        // Scored separately because only the LEADER reports a drag: a follower
+        // is moved imperatively by the canvas and its `dragging` is never true,
+        // so "the lattice goes down when the gesture ends" runs off one widget's
+        // flag while more than one widget was moving. A follower that somehow
+        // did raise it would leave the grid up for the rest of the mode.
+        () => { canvas.clearSelection(); harness.placeWidgets(); },
+        () => {
+            // A marquee from empty canvas across both widgets. Overlap, not
+            // containment, is what selectWidgetsInRect takes.
+            driver.mousePress(canvas, 8, 8, Qt.LeftButton);
+            driver.mouseMove(canvas, 600, 600, 20, Qt.LeftButton);
+            driver.mouseRelease(canvas, 600, 600, Qt.LeftButton);
+        },
+        () => harness.check("a marquee over both widgets selects both",
+                            canvas.selectedWidgets.length === 2),
+        () => harness.dragBy(movableWidget, 60, 0),
+        () => {
+            harness.check("a group drag carries the follower",
+                          Math.round(harness.storedPosition("edit-resize-probe").x) === 96);
+            harness.check("...and the lattice goes down when the group's drag ends",
+                          !canvas.showGrid && !canvas.gridVisible);
+            canvas.clearSelection();
+        },
+
         // ---- leaving mid-drag cancels, it does not commit ------------------
         () => { harness.placeWidgets(); },
         () => {
@@ -314,6 +372,13 @@ ShellRoot {
                           !movableWidget.dragging && Math.round(movableWidget.x) === 36);
             harness.check("...and stores the position the press found",
                           Math.round(harness.storedPosition("edit-move-probe").x) === 36);
+            // The gesture flag rather than gridVisible, because the mode has
+            // ended and gridVisible has a second reason to be false by now. The
+            // question here is whether the cancel reached setDragging at all -
+            // a cancel that did not would leave the lattice armed for the next
+            // time the mode opens.
+            harness.check("...and the cancel takes the lattice with the gesture",
+                          !canvas.showGrid);
         }
     ]
 

--- a/dots/.config/quickshell/imi/modules/common/Appearance.qml
+++ b/dots/.config/quickshell/imi/modules/common/Appearance.qml
@@ -212,6 +212,25 @@ Singleton {
         property color colOnTooltip: m3colors.m3inverseOnSurface
         property color colScrim: ColorUtils.transparentize(m3colors.m3scrim, 0.5)
         property color colShadow: ColorUtils.transparentize(m3colors.m3shadow, 0.7)
+        // The two tones a glass edge is drawn in, and the one pair in this file
+        // deliberately NOT derived from the wallpaper. Everything above is
+        // generated from the picture on screen, so an edge drawn in one of those
+        // roles is guaranteed to be a colour that picture already contains -
+        // which is precisely the edge that disappears against it. Measured on
+        // this library's darkest wallpaper: Edit Mode's card reached 27/255 on
+        // its colLayer0Border outline over a backdrop at 12, ten levels of
+        // contrast for the whole boundary. Same reasoning as the depth picker's
+        // hardcoded contour (refactor(background): one cutout for the layer and
+        // the picker to draw).
+        //
+        // A PAIR rather than one colour, because that is what carries an edge
+        // over any wallpaper: the specular reads against a dark picture, the
+        // shade against a bright one, and a bevel wearing both is never entirely
+        // invisible. Opaque here - a call site picks its own weight with
+        // Qt.alpha, so one tone can appear at several strengths along the same
+        // edge without a token per strength.
+        property color colGlassSpecular: "#ffffff"
+        property color colGlassShade: "#000000"
         property color colOutline: m3colors.m3outline
         property color colOutlineVariant: m3colors.m3outlineVariant
         property color colError: m3colors.m3error

--- a/dots/.config/quickshell/imi/modules/common/functions/clockDepth.js
+++ b/dots/.config/quickshell/imi/modules/common/functions/clockDepth.js
@@ -33,6 +33,17 @@ function eligible(state) {
     // the difference reads as the candidate having claimed something it did
     // not - which is a verdict given against the wrong picture.
     if (s.selecting) return false;
+    // Edit Mode, for that same reason and one more. This layer paints the
+    // wallpaper's subject back OVER the desktop widgets, which is the effect at
+    // rest and is a partly hidden widget in the mode that exists to let the user
+    // place it. The one more: the layer reconstructs the parallax viewport,
+    // which is deliberately larger than the screen (workspaceZoom), and only the
+    // layer surface's own edge keeps that overscan off screen. The mode's
+    // transform pulls the desktop's edge away from the surface's and puts the
+    // blurred backdrop in between, so at 1.07 zoom on a 5120px screen a subject
+    // reaching the picture's edge would paint up to 154px past the card, on the
+    // one part of the screen that is supposed to be what is OUTSIDE the desktop.
+    if (s.editing) return false;
     if (!s.maskPath) return false;
     // A live Wallpaper Engine project is a moving surface with no file to
     // segment, and a mask of the frozen greeter still would be a stale

--- a/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/WidgetCanvas.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/WidgetCanvas.qml
@@ -7,9 +7,11 @@ MouseArea {
     id: root
     // The drawn lattice is the one the drag snaps to (AbstractWidget's 12px),
     // with every second line emphasised so the 24px rhythm this used to draw is
-    // still readable. Drawing 24 while snapping 12 was honest enough while the
-    // grid was only up during a drag; with it up for the whole of Edit Mode, a
-    // widget landing between two lines reads as broken snapping.
+    // still readable. Drawing 24 while snapping 12 puts a widget between two
+    // lines at every second stop, which reads as broken snapping - and it reads
+    // that way exactly when the grid is up, i.e. during the drag that is doing
+    // the snapping. Edit Mode made it impossible to miss rather than made it
+    // true.
     property int gridSize: 12
     property bool showGrid: false
     readonly property bool isWidgetCanvas: true
@@ -17,20 +19,44 @@ MouseArea {
     // the desktop's. The overlay reuses this component and has its own store
     // and its own dismissal, so it must not follow the mode.
     property bool editMode: false
-    // Edit Mode's whole purpose is that the affordances stop hiding, so the
-    // grid is up for the mode rather than for the gesture. It overrides the
-    // config switch, whose meaning is "draw the grid while I drag".
-    readonly property bool gridVisible: root.editMode
-        || (showGrid && Config.options.background.showGrid)
+    // The lattice belongs to the GESTURE, in the mode as well as out of it.
+    // Edit Mode used to force it on for the whole mode, on the spec's
+    // discoverability argument (§4.1: the grid was "the one thing that reliably
+    // says this is editable" and only appeared once you were already dragging).
+    // That argument was written before the mode had any chrome of its own; the
+    // toolbar and the tab bar say it now, and a mode that greets you with a
+    // screen of graph paper hides the desktop you came to look at. So what the
+    // mode overrides is the config SWITCH - whose meaning is "draw the grid
+    // while I drag" - and not the gesture: while editing, a drag always draws
+    // the lattice it is landing on.
+    //
+    // `showGrid` is set from AbstractWidget's onDraggingChanged, so it follows
+    // `dragActive` - which is raised only once the pointer has moved past
+    // `drag.threshold`, never on the press. That is the distinction that
+    // matters: a widget's own controls (the resize grip, a right-click, a click
+    // that selects) all press without dragging, and a lattice flashing up under
+    // every one of them would be worse than one that is always on.
+    readonly property bool gridVisible: root.showGrid
+        && (root.editMode || Config.options.background.showGrid)
     // ...and it arrives and leaves rather than appearing. The lattice used to be
     // a Repeater model going straight from 0 to a screen's worth of lines, so it
     // popped on while the desktop eased into the mode beside it - the reading of
-    // "not M3E-compliant" that costs nothing to fix. An effects tier because
-    // this is an opacity, which is what elementMoveFast is for and what the
-    // centre lines in this same file already animate on.
+    // "not M3E-compliant" that costs nothing to fix.
+    //
+    // The FASTER of the two effects tiers, which is a change from when this
+    // fade arrived with the mode: there it eased in beside a 500ms shrink and
+    // 200ms was the slow half of a pair. Its reference now is the pointer. The
+    // widget is already `drag.threshold` (10px) from where it was pressed when
+    // the lattice is asked for, and it keeps travelling while the lattice
+    // arrives - at an unhurried 1000px/s that is 200px, sixteen 12px cells,
+    // under elementMoveFast against twelve under elementMoveFaster. Neither is
+    // instant and no effects tier below 150ms exists, so the choice is the
+    // faster tier or a literal, and docs/M3_GUIDELINES.md §2 forbids the
+    // literal. Taken whole through the tier's own factory rather than as a
+    // duration, or the curve silently falls back to Easing.Linear.
     property real gridStrength: root.gridVisible ? 1 : 0
     Behavior on gridStrength {
-        animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
+        animation: Appearance.animation.elementMoveFaster.numberAnimation.createObject(this)
     }
 
     // Desktop widgets sit on the background layer surface, which only accepts
@@ -161,6 +187,11 @@ MouseArea {
     }
 
     function widgetRemoved(widget) {
+        // A widget destroyed mid-drag never reaches onDraggingChanged, so
+        // nothing else takes the lattice down again: a FadeLoader dropping the
+        // widget under the pointer (disabling a plugin from Settings while it
+        // is being dragged) would leave the grid up for the rest of the mode.
+        if (widget.dragging) root.setDragging(false)
         const idx = root.selectedWidgets.indexOf(widget)
         if (idx !== -1) {
             const next = root.selectedWidgets.slice()

--- a/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/WidgetCanvas.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/WidgetCanvas.qml
@@ -44,8 +44,8 @@ MouseArea {
     // "not M3E-compliant" that costs nothing to fix.
     //
     // The FASTER of the two effects tiers, which is a change from when this
-    // fade arrived with the mode: there it eased in beside a 500ms shrink and
-    // 200ms was the slow half of a pair. Its reference now is the pointer. The
+    // fade arrived with the mode: there it eased in beside a 500ms shrink, and
+    // 200ms against 500 is already brisk. Its reference now is the pointer. The
     // widget is already `drag.threshold` (10px) from where it was pressed when
     // the lattice is asked for, and it keeps travelling while the lattice
     // arrives - at an unhurried 1000px/s that is 200px, sixteen 12px cells,

--- a/dots/.config/quickshell/imi/modules/imi/background/Background.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/Background.qml
@@ -1453,17 +1453,35 @@ Variants {
         // unaffected - a ShaderEffectSource renders its source item in that
         // item's own coordinates, not the scene's.
         //
-        // ABOVE the desktop rather than behind it, which is what rounds the
+        // ABOVE the wallpaper rather than behind it, which is what rounds the
         // corner: see EditModeCard for why covering the corner with the picture
-        // behind it is the only cheap way to round three separately transformed
-        // siblings. Above the clock depth layer at z 3, and non-interactive,
-        // because desktopRightClickArea at z -2 works only while everything
-        // over it lets clicks through.
+        // behind it is the only cheap way to round a transformed sibling. And
+        // BELOW the widget canvas at z 2, which is the whole of what stops it
+        // rounding the widgets too.
+        //
+        // It sat at z 4, over everything, and a cover over everything cuts
+        // everything: the desktop scales about its own centre, so the canvas's
+        // edge lands exactly on the card's edge and a widget parked against a
+        // screen edge has its own edge flush with it. At a CORNER the rounding
+        // comes in on both axes at once and takes a bite out of whatever is
+        // there - measured at 5120x1440, a widget at the desktop's corner lost
+        // 20px along each edge and 10px on the diagonal. `visualizer` sits at
+        // 0,1200 in this machine's own store, so the desktop editor was cutting
+        // a corner off a widget while the user was arranging it.
+        //
+        // What that costs, and it is the deliberate trade: a widget in the
+        // corner now OVERHANGS the rounding, drawn whole over the blurred
+        // backdrop. It says "this widget is at the edge of your desktop", which
+        // is true and is information; the alternative was hiding part of a
+        // widget in the mode that exists to place it.
+        //
+        // Non-interactive either way, because desktopRightClickArea at z -2
+        // works only while everything over it lets clicks through.
         Loader {
             id: editChrome
             active: bgRoot.editProgress > 0 && !bgRoot.suppressContents
             anchors.fill: parent
-            z: 4
+            z: 1
             enabled: false
             opacity: bgRoot.editProgress
             sourceComponent: EditModeCard {

--- a/dots/.config/quickshell/imi/modules/imi/background/Background.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/Background.qml
@@ -1386,6 +1386,7 @@ Variants {
                 // widgets while it is up; two cutouts arguing is not a thing
                 // anyone can give a verdict on.
                 selecting: GlobalStates.clockDepthSelectOpen,
+                editing: GlobalStates.editMode,
                 weActive: bgRoot.weActive,
                 wallpaperIsVideo: bgRoot.wallpaperIsVideo,
                 centeredWallpaper: bgRoot.centeredWallpaperEnabled,

--- a/dots/.config/quickshell/imi/modules/imi/background/EditModeCard.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/EditModeCard.qml
@@ -54,6 +54,37 @@ Item {
     property rect card: Qt.rect(0, 0, root.width, root.height)
     property real cardRadius: 0
 
+    // ---- the glass edge ---------------------------------------------------
+    //
+    // The card used to end at a 1px colLayer0Border line, which is the shell's
+    // outline for a floating surface and is right for a panel sitting on a
+    // surface this file's own tokens were derived from. Over a WALLPAPER it is
+    // a drawn line rather than an edge: measured on this library's darkest
+    // picture the outline came back at 27/255 with the desktop at 0 inside it
+    // and the blurred backdrop at 12 outside, so the whole boundary was ten
+    // levels of contrast wide and read as a seam in a screenshot.
+    //
+    // What replaces it is a bevel with THICKNESS, in three tones, and the
+    // reason it is three is that no single one survives every wallpaper:
+    //
+    //   - a shade band just OUTSIDE the card, so the card has a lip. It is what
+    //     carries the edge over a bright picture, where a specular cannot.
+    //   - a specular ON the edge, brightest along the top and fading down the
+    //     sides to a weak bounce at the bottom - the same lamp the drop shadow
+    //     below is drawn for. A uniform bright rim reads as a stroke; a rim that
+    //     is brighter where light would catch reads as a surface.
+    //   - a highlight just INSIDE, which is what gives the specular something to
+    //     be the outer face of rather than a line floating on the seam.
+    //
+    // The first two cost nothing extra: they are plain Rectangles declared
+    // inside `surround`, whose layer is already masked to the complement of the
+    // card - so the mask cuts each of them down to the band outside the card by
+    // itself, and the gradient that shades them is the Rectangle's own. No
+    // second layer, no second mask, and nothing re-rendering the backdrop, which
+    // is the cost this whole component is arranged to avoid.
+    readonly property real edgeShadeWidth: Appearance.borderWidth.heavy
+    readonly property real edgeSpecularWidth: Appearance.borderWidth.emphasis
+
     // Everything that lives OUTSIDE the card, composited once and then cut to
     // shape. The mask is inverted, so what survives is the complement of the
     // card: the backdrop, and the outer half of the shadow drawn over it.
@@ -99,6 +130,55 @@ Item {
         StyledRectangularShadow {
             target: cardShape
         }
+
+        // Drawn AFTER the shadow, because the shadow is at its darkest exactly
+        // where these two are: a bright line standing on the near edge of a
+        // pool of shade is the whole of what reads as glass, and a shadow drawn
+        // over it would be a shadow of the card cast onto the card's own rim.
+        //
+        // Both are grown from the card and cut back to it by `surround`'s mask,
+        // so their inner boundary IS the card's edge - to the same antialiased
+        // pixel as the corner, because it is the same mask that makes the
+        // corner.
+        Rectangle {
+            id: edgeShade
+            x: root.card.x - root.edgeShadeWidth
+            y: root.card.y - root.edgeShadeWidth
+            width: root.card.width + 2 * root.edgeShadeWidth
+            height: root.card.height + 2 * root.edgeShadeWidth
+            radius: root.cardRadius > 0 ? root.cardRadius + root.edgeShadeWidth : 0
+            antialiasing: true
+            // Weakest where the light is and strongest opposite it. Note the
+            // far stops are the shade's own colour at zero alpha rather than
+            // "transparent": a stop interpolating toward #00000000 walks the
+            // colour through black, which is the smudge WidgetCanvas's lattice
+            // fade already records - here it would be a second, wider shade.
+            gradient: Gradient {
+                GradientStop { position: 0; color: Qt.alpha(Appearance.colors.colGlassShade, 0.18) }
+                GradientStop { position: 1; color: Qt.alpha(Appearance.colors.colGlassShade, 0.5) }
+            }
+        }
+
+        Rectangle {
+            id: edgeSpecular
+            x: root.card.x - root.edgeSpecularWidth
+            y: root.card.y - root.edgeSpecularWidth
+            width: root.card.width + 2 * root.edgeSpecularWidth
+            height: root.card.height + 2 * root.edgeSpecularWidth
+            radius: root.cardRadius > 0 ? root.cardRadius + root.edgeSpecularWidth : 0
+            antialiasing: true
+            // The non-uniformity is the point. A rim at one strength all the way
+            // round is a stroke however bright it is; light catching the top of
+            // an edge, fading off down the sides and coming back weakly at the
+            // bottom is what a piece of glass looks like. The bottom stop is a
+            // bounce off whatever the card is lying on, so it is much weaker
+            // than the top rather than symmetric with it.
+            gradient: Gradient {
+                GradientStop { position: 0; color: Qt.alpha(Appearance.colors.colGlassSpecular, 0.55) }
+                GradientStop { position: 0.5; color: Qt.alpha(Appearance.colors.colGlassSpecular, 0.18) }
+                GradientStop { position: 1; color: Qt.alpha(Appearance.colors.colGlassSpecular, 0.3) }
+            }
+        }
     }
 
     // The cut. Its colour is an alpha channel rather than a colour - OpacityMask
@@ -137,5 +217,26 @@ Item {
         antialiasing: true
         border.width: Appearance.borderWidth.standard
         border.color: Appearance.colors.colLayer0Border
+    }
+
+    // The inner face of the bevel. This one cannot ride `surround`'s mask - it
+    // is INSIDE the card, which is exactly what that mask removes - so it is a
+    // border rather than a gradient-filled rect, and it is uniform. That is a
+    // deliberate asymmetry rather than an omission: the specular is the tone
+    // that has to look lit, and this is the tone that has to make the specular
+    // look like the outside of something. Faint enough that it does not become
+    // a second line on a dark wallpaper, present enough that the edge has a
+    // near side.
+    Rectangle {
+        id: cardInnerHighlight
+        x: root.card.x + Appearance.borderWidth.standard
+        y: root.card.y + Appearance.borderWidth.standard
+        width: root.card.width - 2 * Appearance.borderWidth.standard
+        height: root.card.height - 2 * Appearance.borderWidth.standard
+        radius: Math.max(0, root.cardRadius - Appearance.borderWidth.standard)
+        color: "transparent"
+        antialiasing: true
+        border.width: Appearance.borderWidth.standard
+        border.color: Qt.alpha(Appearance.colors.colGlassSpecular, 0.14)
     }
 }

--- a/dots/.config/quickshell/imi/modules/imi/background/EditModeCard.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/EditModeCard.qml
@@ -148,11 +148,10 @@ Item {
             height: root.card.height + 2 * root.edgeShadeWidth
             radius: root.cardRadius > 0 ? root.cardRadius + root.edgeShadeWidth : 0
             antialiasing: true
-            // Weakest where the light is and strongest opposite it. Note the
-            // far stops are the shade's own colour at zero alpha rather than
-            // "transparent": a stop interpolating toward #00000000 walks the
-            // colour through black, which is the smudge WidgetCanvas's lattice
-            // fade already records - here it would be a second, wider shade.
+            // Weakest where the light is and strongest opposite it, and never
+            // at zero on either stop: this is the tone that has to carry the
+            // edge over a bright wallpaper, where the specular cannot, and a
+            // lip that faded out along its own top would have no edge there.
             gradient: Gradient {
                 GradientStop { position: 0; color: Qt.alpha(Appearance.colors.colGlassShade, 0.18) }
                 GradientStop { position: 1; color: Qt.alpha(Appearance.colors.colGlassShade, 0.5) }

--- a/dots/.config/quickshell/imi/tests/test_edit_mode_chrome.py
+++ b/dots/.config/quickshell/imi/tests/test_edit_mode_chrome.py
@@ -17,12 +17,23 @@ question about pixels that reads as correct in every source file:
   radius are exactly what a still-transformed viewport also reports, and a
   radius or a shadow left applied to the live desktop is the failure that
   matters most - it is on screen for the rest of the session.
-- **the desktop's corner is cut.** QML has no rounded clip, so the corner is
-  made by covering it with the blurred backdrop, and whether the cover landed on
-  the corner is a question about one pixel. The probe pins an opaque marker to
-  the canvas's own top-left corner, so the answer does not depend on the
-  wallpaper: at rest the card's corner pixel IS the marker, in the mode it is
-  not, and a marker's width further down the same edge it is again.
+- **the picture's corner is cut, and a widget's corner is not.** QML has no
+  rounded clip, so the corner is made by covering it with the blurred backdrop,
+  and whether the cover landed on the corner is a question about one pixel. The
+  probe pins an opaque marker to the wallpaper viewport's top-left corner, so
+  the answer does not depend on the wallpaper: at rest the card's corner pixel
+  IS the marker, in the mode it is not, and a marker's width further down the
+  same edge it is again. The cover sits BELOW the widget canvas, so the same
+  question asked of a widget must come back the other way - a second opaque
+  block is pinned to the canvas's bottom-left corner (where this machine's own
+  store keeps `visualizer`) and its corner pixel must survive. That pair is the
+  whole of "there shouldn't be any clipping": one of them has to be cut and the
+  other has to not be, and a cover at the wrong z reverses exactly one of them.
+- **the lattice arrives with the drag rather than with the mode.** Three frames,
+  because the failure is a state and not a value: in the mode at rest there are
+  no lines, mid-drag there are, and the frame after the drag ends is the same
+  picture as the one before it started - which is the only form of "it went away
+  again" that a leftover half-faded lattice cannot pass.
 - **the lattice is a substrate.** The desktop widgets arrive as external
   children of the canvas, so nothing in `WidgetCanvas.qml` decides whether they
   are drawn over the grid - the order is a consequence of when each Repeater's
@@ -66,12 +77,14 @@ WALLPAPER_RGB = (58, 96, 140)
 # The harness states how many checks it ran; this is the literal it must state.
 # Read back out of its own output it would agree with itself by construction,
 # and `failures: 0` is also what a harness that ran nothing prints.
-EXPECTED_CHECKS = 10
+EXPECTED_CHECKS = 13
 
 GEOMETRY = re.compile(
     r"(geometry|midGeometry): screen=([\d.]+),([\d.]+) card=([\d.]+),([\d.]+),([\d.]+),([\d.]+) "
     r"radius=([\d.]+) scale=([\d.]+) marker=([\d.]+),([\d.]+),([\d.]+),([\d.]+) "
-    r"panel=([\d.]+),([\d.]+),([\d.]+),([\d.]+) markerColor=(\S+) panelColor=(\S+) "
+    r"panel=([\d.]+),([\d.]+),([\d.]+),([\d.]+) "
+    r"corner=([\d.]+),([\d.]+),([\d.]+),([\d.]+) "
+    r"markerColor=(\S+) panelColor=(\S+) cornerColor=(\S+) "
     r"toolbar=(-?[\d.]+),(-?[\d.]+),([\d.]+),([\d.]+) "
     r"tabbar=(-?[\d.]+),(-?[\d.]+),([\d.]+),([\d.]+) chromeColor=(\S+)")
 
@@ -124,11 +137,13 @@ class EditModeChromeTest(unittest.TestCase):
                 "scale": float(values[8]),
                 "marker": tuple(float(v) for v in values[9:13]),
                 "panel": tuple(float(v) for v in values[13:17]),
-                "markerColor": _hex_to_rgb(values[17]),
-                "panelColor": _hex_to_rgb(values[18]),
-                "toolbar": tuple(float(v) for v in values[19:23]),
-                "tabbar": tuple(float(v) for v in values[23:27]),
-                "chromeColor": _hex_to_rgb(values[27]),
+                "corner": tuple(float(v) for v in values[17:21]),
+                "markerColor": _hex_to_rgb(values[21]),
+                "panelColor": _hex_to_rgb(values[22]),
+                "cornerColor": _hex_to_rgb(values[23]),
+                "toolbar": tuple(float(v) for v in values[24:28]),
+                "tabbar": tuple(float(v) for v in values[28:32]),
+                "chromeColor": _hex_to_rgb(values[32]),
             }
         for tag in ("geometry", "midGeometry"):
             self.assertIn(tag, self.reported,
@@ -140,14 +155,16 @@ class EditModeChromeTest(unittest.TestCase):
         self.scale = settled["scale"]
         self.marker = settled["marker"]
         self.panel = settled["panel"]
+        self.corner = settled["corner"]
         self.marker_rgb = settled["markerColor"]
         self.panel_rgb = settled["panelColor"]
+        self.corner_rgb = settled["cornerColor"]
         self.toolbar = settled["toolbar"]
         self.tabbar = settled["tabbar"]
         self.chrome_rgb = settled["chromeColor"]
 
         self.frames = {}
-        for name in ("rest", "editing", "midway", "after"):
+        for name in ("rest", "editing", "dragging", "released", "midway", "after"):
             path = self.tmp / f"{name}.png"
             self.assertTrue(path.exists(), f"the harness saved no {name} frame")
             self.frames[name] = Image.open(path).convert("RGB")
@@ -227,13 +244,16 @@ class EditModeChromeTest(unittest.TestCase):
         self.assertGreater(drawn_scale, self.scale + 0.01)
         self.assertLess(drawn_scale, 0.99)
 
-        # The origin comes from the marker's CENTRE rather than from its leading
-        # edge: a scaled edge is antialiased, so the first pixel that is exactly
-        # the marker's colour sits a pixel or two inside it, and that bias lands
-        # entirely on one side of the symmetry being measured. A centre cancels
-        # it.
-        left = (row[0] + row[-1] + 1) / 2 - mid["marker"][2] / 2 * mid["scale"]
-        top = (column[0] + column[-1] + 1) / 2 - mid["marker"][3] / 2 * mid["scale"]
+        # The origin comes from the marker's FAR edges, which are in the middle
+        # of the card with nothing drawn over them. Not its leading ones: those
+        # sit exactly on the card's edge, where the glass bevel's inner
+        # highlight is painted across them, so the first pixel that is exactly
+        # the marker's colour is a couple inside it. A centre used to cancel
+        # that, and does not any more - the bias is on the leading side only
+        # and it put this check 3.05px outside a 3px tolerance, which is the
+        # instrument moving rather than the desktop.
+        left = row[-1] + 1 - mid["marker"][2] * mid["scale"]
+        top = column[-1] + 1 - mid["marker"][3] * mid["scale"]
         right = left + screen_w * mid["scale"]
         bottom = top + screen_h * mid["scale"]
         self.assertAlmostEqual(left, mid["card"][0], delta=2)
@@ -291,7 +311,7 @@ class EditModeChromeTest(unittest.TestCase):
 
     # ---- the corner ------------------------------------------------------
 
-    def test_the_cards_corner_is_cut_out_of_the_desktop(self):
+    def test_the_cards_corner_is_cut_out_of_the_picture(self):
         inset = 3
         corner = (round(self.card[0]) + inset, round(self.card[1]) + inset)
         # Far enough down the same edge to be past the arc, and still well
@@ -299,9 +319,67 @@ class EditModeChromeTest(unittest.TestCase):
         below = (round(self.card[0]) + inset, round(self.card[1] + self.radius * 2))
 
         self.assertEqual(self.frames["editing"].getpixel(below), self.marker_rgb,
-                         "the desktop does not reach the card's edge at all")
+                         "the picture does not reach the card's edge at all")
         self.assertNotEqual(self.frames["editing"].getpixel(corner), self.marker_rgb,
-                            "the card's corner is square: the desktop reaches it")
+                            "the card's corner is square: the picture reaches it")
+
+    def test_but_a_widget_at_that_corner_is_drawn_whole(self):
+        # The maintainer's report, and the other half of the check above. The
+        # cover that rounds the picture used to sit over everything, and the
+        # desktop scales about its own centre - so the canvas's edge lands on
+        # the card's edge and a widget parked against it is flush with the
+        # rounding. At a corner that took a bite out of the widget: measured at
+        # 5120x1440 before the fix, 20px along each edge and 10px on the
+        # diagonal of a block pinned to the desktop's corner.
+        #
+        # The widget is pinned to the canvas's BOTTOM-left, so its own corner is
+        # (x, y + h) and not (x, y) - reading the wrong end of it samples the
+        # middle of the card's left edge, which is straight and was never cut.
+        # The first version of this check did exactly that and passed on a frame
+        # whose widget was visibly still being bitten.
+        x, y, w, h = self.corner
+        for dx, dy, where in ((2, -2, "its corner"), (2, -10, "just above it"),
+                              (10, -2, "just along from it")):
+            point = self.on_card(x + dx, y + h + dy)
+            self.assertEqual(
+                self.frames["editing"].getpixel(point), self.corner_rgb,
+                f"the card's rounding is eating a widget placed in the corner, at {where}")
+
+    # ---- the lattice arrives with the drag -------------------------------
+
+    def test_the_mode_at_rest_draws_no_lattice(self):
+        # Sampled on the same run of bare wallpaper the vacuity check below
+        # uses, so the two are answering one question from opposite sides: on
+        # the flat fixture anything that is not the wallpaper's own colour is a
+        # line, and at rest in the mode there must be none of them.
+        frame = self.frames["editing"]
+        px, py, pw, ph = self.panel
+        lines = [i for i in range(1, 120)
+                 if frame.getpixel(self.on_card(px + pw * i / 120, py + ph + 60))
+                 != WALLPAPER_RGB]
+        self.assertEqual(lines, [], "the mode drew a lattice before anything was dragged")
+
+    def test_and_the_lattice_leaves_when_the_drag_does(self):
+        # The same shape as the rest/after comparison, one level in: both frames
+        # are taken in the mode, so what can differ between them is the drag and
+        # nothing else. A property assertion cannot say this - `gridVisible` is
+        # false the instant the drag ends while the fade still has 150ms to run,
+        # and a lattice that never finished leaving reports exactly the same
+        # false.
+        editing, released = self.frames["editing"], self.frames["released"]
+        worst = 0
+        differing = 0
+        for y in range(0, editing.height, 3):
+            for x in range(0, editing.width, 3):
+                a, b = editing.getpixel((x, y)), released.getpixel((x, y))
+                delta = max(abs(p - q) for p, q in zip(a, b))
+                if delta:
+                    differing += 1
+                    worst = max(worst, delta)
+        self.assertEqual(
+            (differing, worst), (0, 0),
+            "the drag left something on the desktop behind it: "
+            f"{differing} sampled pixels differ, worst by {worst}/255")
 
     def test_the_corner_is_only_cut_while_the_mode_is_on(self):
         # The other half of the check above, and what stops it passing on a
@@ -313,7 +391,7 @@ class EditModeChromeTest(unittest.TestCase):
     # ---- the substrate ---------------------------------------------------
 
     def test_the_lattice_is_drawn_under_the_widgets_and_not_over_them(self):
-        frame = self.frames["editing"]
+        frame = self.frames["dragging"]
         px, py, pw, ph = self.panel
 
         showing = []
@@ -328,7 +406,7 @@ class EditModeChromeTest(unittest.TestCase):
         # Without this the check above passes on a frame with no grid in it.
         # Sampled on a run of bare wallpaper below the panel: on the flat
         # fixture, anything that is not the wallpaper's own colour is a line.
-        frame = self.frames["editing"]
+        frame = self.frames["dragging"]
         px, py, pw, ph = self.panel
         lines = 0
         for i in range(1, 120):

--- a/dots/.config/quickshell/imi/tests/test_edit_mode_chrome.py
+++ b/dots/.config/quickshell/imi/tests/test_edit_mode_chrome.py
@@ -347,17 +347,35 @@ class EditModeChromeTest(unittest.TestCase):
 
     # ---- the lattice arrives with the drag -------------------------------
 
-    def test_the_mode_at_rest_draws_no_lattice(self):
-        # Sampled on the same run of bare wallpaper the vacuity check below
-        # uses, so the two are answering one question from opposite sides: on
-        # the flat fixture anything that is not the wallpaper's own colour is a
-        # line, and at rest in the mode there must be none of them.
-        frame = self.frames["editing"]
+    SAMPLES = 120
+    # WidgetCanvas.gridSize: the pitch the drag snaps to and the lattice draws.
+    LATTICE = 12
+
+    def lattice_samples(self, frame):
+        """How many of a run of bare wallpaper below the panel are not wallpaper.
+
+        On the flat fixture anything that is not the wallpaper's own colour is a
+        grid line, so this counts the vertical lines crossed by one horizontal
+        run - and the count is what tells the two directions of the question
+        apart. 0 is no lattice; SAMPLES is the whole run, which means the row
+        itself landed on a horizontal line and says nothing about whether there
+        were any vertical ones.
+
+        The row is deliberately offset half a cell off the lattice, because the
+        obvious choice was not: `panel.y + panel.height + 60` is 540 canvas
+        pixels down, which is 45 cells exactly, so every sample in the run
+        differed and this measured a horizontal line rather than the lattice.
+        Planting `model: 0` on the vertical Repeater left it green.
+        """
         px, py, pw, ph = self.panel
-        lines = [i for i in range(1, 120)
-                 if frame.getpixel(self.on_card(px + pw * i / 120, py + ph + 60))
-                 != WALLPAPER_RGB]
-        self.assertEqual(lines, [], "the mode drew a lattice before anything was dragged")
+        row = py + ph + 60 + self.LATTICE / 2
+        return sum(1 for i in range(1, self.SAMPLES)
+                   if frame.getpixel(self.on_card(px + pw * i / self.SAMPLES, row))
+                   != WALLPAPER_RGB)
+
+    def test_the_mode_at_rest_draws_no_lattice(self):
+        self.assertEqual(self.lattice_samples(self.frames["editing"]), 0,
+                         "the mode drew a lattice before anything was dragged")
 
     def test_and_the_lattice_leaves_when_the_drag_does(self):
         # The same shape as the rest/after comparison, one level in: both frames
@@ -404,16 +422,17 @@ class EditModeChromeTest(unittest.TestCase):
 
     def test_and_the_lattice_is_there_to_be_hidden(self):
         # Without this the check above passes on a frame with no grid in it.
-        # Sampled on a run of bare wallpaper below the panel: on the flat
-        # fixture, anything that is not the wallpaper's own colour is a line.
-        frame = self.frames["dragging"]
-        px, py, pw, ph = self.panel
-        lines = 0
-        for i in range(1, 120):
-            point = self.on_card(px + pw * i / 120, py + ph + 60)
-            if frame.getpixel(point) != WALLPAPER_RGB:
-                lines += 1
+        #
+        # Bounded at BOTH ends, and the upper bound is not decoration: the run
+        # is horizontal, so what it crosses is the VERTICAL lines - and if the
+        # row it is read along happens to land on a horizontal line, every
+        # sample differs and the check passes while there is not a vertical
+        # line on the screen. Found by planting exactly that: `model: 0` on the
+        # vertical Repeater alone left this green.
+        lines = self.lattice_samples(self.frames["dragging"])
         self.assertGreater(lines, 0, "no lattice was drawn, so hiding it proves nothing")
+        self.assertLess(lines, self.SAMPLES - 1,
+                        "the sampled row is itself a line, so it says nothing about the lattice")
 
 
 if __name__ == "__main__":

--- a/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
@@ -48,6 +48,8 @@ CANVAS = ROOT / "modules/common/widgets/widgetCanvas/WidgetCanvas.qml"
 WIDGET = ROOT / "modules/common/widgets/widgetCanvas/AbstractWidget.qml"
 BACKGROUND_WIDGET = ROOT / "modules/imi/background/widgets/AbstractBackgroundWidget.qml"
 PLUGIN_WIDGET = ROOT / "modules/common/plugins/PluginWidget.qml"
+CLOCK_DEPTH = ROOT / "modules/common/functions/clockDepth.js"
+LOOK_PROBE = ROOT / "EditModeLookProbe.qml"
 CHROME_SCOPE = ROOT / "modules/imi/editMode/EditModeChrome.qml"
 CHROME_SURFACE = ROOT / "modules/imi/editMode/EditModeChromeSurface.qml"
 CHROME_CONTENT = ROOT / "modules/imi/editMode/EditModeChromeContent.qml"
@@ -64,6 +66,25 @@ PARTICIPANTS = [BACKGROUND, CANVAS, WIDGET, BACKGROUND_WIDGET, PLUGIN_WIDGET,
 def read(path: Path) -> str:
     assert path.exists(), f"{path} is missing - this check has nothing to say"
     return path.read_text()
+
+
+def declared_z(text: str) -> dict:
+    """The z each declared object states, keyed by its id.
+
+    A scan rather than a block match because the objects in question are hundreds
+    of lines apart and a brace matcher over this file is a second thing to be
+    wrong. It records the FIRST z after each id, which is that object's own.
+    """
+    found, current = {}, None
+    for line in text.splitlines():
+        named = re.match(r"\s*id: (\w+)\s*$", line)
+        if named:
+            current = named.group(1)
+            continue
+        depth = re.match(r"\s*z: (-?\d+)\s*$", line)
+        if depth and current is not None and current not in found:
+            found[current] = int(depth.group(1))
+    return found
 
 
 def test_the_mode_is_ephemeral_state_and_not_a_setting():
@@ -242,6 +263,91 @@ def test_the_lattice_declares_where_it_sits_rather_than_inheriting_it():
             continue
         assert lattice.start() < match.start() < lattice.end(), \
             "a line of the lattice is drawn outside the item that owns its order"
+
+
+def test_the_lattice_belongs_to_the_drag_and_not_to_the_mode():
+    # "In Edit mode, the grid lines should not appear until I try to move a
+    # widget." The reversal of §4.1's discoverability argument, which was
+    # written before the mode had a toolbar of its own to say it is on.
+    #
+    # Read as a WHOLE declaration rather than as a line: this one is written
+    # across two, with the `&&` on the continuation, and a line-scoped check
+    # sees `root.showGrid` on its own and passes on anything.
+    text = read(CANVAS)
+    gate = re.search(
+        r"readonly property bool gridVisible:((?:[^\n]*\n)(?:\s*(?:&&|\|\|)[^\n]*\n)*)", text)
+    assert gate, "the canvas no longer resolves whether the lattice is drawn"
+    body = " ".join(gate.group(1).split())
+    # A gesture in flight is REQUIRED, so it is the leading conjunct and
+    # everything after it is joined with `&&`. Written as a shape rather than as
+    # "editMode must not appear" because the mode legitimately appears further
+    # in - it is what overrides the config switch, inside the second operand.
+    # Anything a top-level `||` reaches is a second way to draw the lattice with
+    # nobody dragging, which is the thing being removed.
+    assert body.startswith("root.showGrid"), \
+        f"the lattice is not gated first on a gesture being in flight: {body}"
+    rest = body[len("root.showGrid"):].strip()
+    assert rest == "" or rest.startswith("&&"), \
+        (f"the lattice has a way to be drawn that is not a gesture: {body} - "
+         f"what the mode overrides is the config switch, not the gesture")
+
+    # ...and the flag it is gated on follows the THRESHOLD rather than the
+    # press. A widget's own controls - the grip, the right-click, a click that
+    # selects - all press without travelling, and a lattice answering each of
+    # them would be worse than one that never went away.
+    widget = read(WIDGET)
+    assert "drag.threshold" in widget, \
+        "the drag no longer distinguishes a press from a move"
+    pressed = re.search(r"onPressed: \(mouse\) => \{(.*?)\n    \}", widget, re.S)
+    assert pressed, "AbstractWidget no longer answers a press"
+    assert "dragActive" not in pressed.group(1), \
+        "a press raises the drag flag, so the lattice would answer every click"
+    changed = re.search(r"onDraggingChanged: \{(.*?)\n    \}", widget, re.S)
+    assert changed and "setDragging(dragging)" in changed.group(1), \
+        "the canvas is no longer told when a drag starts and stops"
+
+
+def test_the_cover_that_rounds_the_corner_sits_below_the_widgets():
+    # "There shouldn't be any clipping." The cover makes the card's corner by
+    # covering it, and a cover over EVERYTHING covers the widgets too: the
+    # desktop scales about its own centre, so the canvas's edge lands on the
+    # card's edge and a widget parked against a screen edge is flush with the
+    # rounding. At a corner it lost a bite - measured at 5120x1440, 20px along
+    # each edge of a widget pinned there, which is where this machine's own
+    # store keeps `visualizer`.
+    order = declared_z(read(BACKGROUND))
+    for name in ("editChrome", "widgetCanvas", "clockDepthLayer"):
+        assert name in order, \
+            f"{name} declares no z, so its order is whatever happened to build first"
+    assert order["editChrome"] < order["widgetCanvas"], \
+        (f"the mode's cover is at z {order['editChrome']} and the widget canvas at "
+         f"{order['widgetCanvas']}: the rounding is cutting the widgets")
+
+    # The look probe RE-DECLARES this arrangement, because weston implements no
+    # layer shell and the real one cannot be stood up. That makes it a second
+    # copy of the thing it scores, and a second copy drifts: it scored one
+    # render of this fix against its own z: 4 and reported a widget whose corner
+    # was visibly still being eaten.
+    probe = declared_z(read(LOOK_PROBE))
+    for name in ("editChrome", "widgetCanvas"):
+        assert probe.get(name) == order[name], \
+            (f"the look probe draws {name} at z {probe.get(name)} and Background.qml "
+             f"at {order[name]}: the probe is scoring an arrangement the shell "
+             f"does not have")
+
+
+def test_the_depth_layer_stands_down_for_the_mode():
+    # The one thing left drawing above that cover, and it is above the widgets
+    # by design - so it cannot be put under the cover without putting the
+    # widgets under it too. It stands down instead, which it wants to anyway:
+    # it paints the wallpaper's subject over the widgets the mode exists to let
+    # the user arrange, and it reconstructs the parallax viewport, which is
+    # larger than the screen and would be free to paint outside the card.
+    assert re.search(r"if \(s\.editing\) return false;", read(CLOCK_DEPTH)), \
+        "the eligibility predicate has no refusal for the mode"
+    background = read(BACKGROUND)
+    assert re.search(r"editing:\s*GlobalStates\.editMode", background), \
+        "the depth layer never tells the predicate the mode is on"
 
 
 def test_the_inset_is_derived_from_one_declared_drawer_width():

--- a/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
@@ -49,6 +49,7 @@ WIDGET = ROOT / "modules/common/widgets/widgetCanvas/AbstractWidget.qml"
 BACKGROUND_WIDGET = ROOT / "modules/imi/background/widgets/AbstractBackgroundWidget.qml"
 PLUGIN_WIDGET = ROOT / "modules/common/plugins/PluginWidget.qml"
 CLOCK_DEPTH = ROOT / "modules/common/functions/clockDepth.js"
+CARD = ROOT / "modules/imi/background/EditModeCard.qml"
 LOOK_PROBE = ROOT / "EditModeLookProbe.qml"
 CHROME_SCOPE = ROOT / "modules/imi/editMode/EditModeChrome.qml"
 CHROME_SURFACE = ROOT / "modules/imi/editMode/EditModeChromeSurface.qml"
@@ -334,6 +335,39 @@ def test_the_cover_that_rounds_the_corner_sits_below_the_widgets():
             (f"the look probe draws {name} at z {probe.get(name)} and Background.qml "
              f"at {order[name]}: the probe is scoring an arrangement the shell "
              f"does not have")
+
+
+def test_the_cards_chrome_composites_once_and_only_once():
+    # The card's edge is full-screen and is redrawn on every frame of a 400ms
+    # shrink, so what it may cost is a standing constraint rather than a
+    # one-off measurement: an effect that re-renders the backdrop per frame
+    # would be felt. The bevel's two outer tones are Rectangles declared inside
+    # `surround`, whose layer is already masked to the complement of the card -
+    # they ride a mask that existed rather than bringing one.
+    #
+    # Measured over four runs each of an identical scripted sequence under
+    # headless weston's SOFTWARE renderer, where a full-screen pass costs CPU
+    # instead of being free: 14.91s +/- 0.22 of user CPU with the bevel against
+    # 14.68s +/- 0.32 without, on a run-to-run spread of 3-4%. Indistinguishable.
+    # That number is only true while the shape stays this one, which is what
+    # this check is for - the way to break the finding is to add a second layer
+    # later and never re-measure.
+    text = read(CARD)
+    layers = re.findall(r"^\s*layer\.enabled:\s*true\s*$", text, re.M)
+    assert len(layers) == 1, \
+        (f"the card composites through {len(layers)} layers: every one of them is a "
+         f"full-screen render target reallocated for each frame of the shrink")
+    effects = re.findall(r"^\s*layer\.effect:\s*(\w+)", text, re.M)
+    assert effects == ["OpacityMask"], \
+        f"the card's chrome runs {effects} over the backdrop, not one mask"
+    # Declared objects rather than any mention of the name: the file's own
+    # comments explain why a ShaderEffectSource renders its source in that
+    # item's coordinates, and a check that reads prose is a check about prose.
+    for expensive in ("GaussianBlur", "FastBlur", "MultiEffect", "ShaderEffect",
+                      "ShaderEffectSource"):
+        assert not re.search(rf"^\s*{expensive}\s*\{{", text, re.M), \
+            (f"{expensive} in the card's chrome re-renders the backdrop the "
+             f"component is arranged to render once")
 
 
 def test_the_depth_layer_stands_down_for_the_mode():

--- a/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
@@ -306,6 +306,17 @@ def test_the_lattice_belongs_to_the_drag_and_not_to_the_mode():
     changed = re.search(r"onDraggingChanged: \{(.*?)\n    \}", widget, re.S)
     assert changed and "setDragging(dragging)" in changed.group(1), \
         "the canvas is no longer told when a drag starts and stops"
+    # The one end a drag has that onDraggingChanged never sees. The runtime
+    # harness drives `widgetRemoved` directly, because a statically declared
+    # widget cannot be destroy()ed - so what it cannot say is that a real
+    # destruction reaches that function, and this is that half.
+    destruction = re.search(r"Component\.onDestruction: \{(.*?)\n    \}", widget, re.S)
+    assert destruction and "widgetRemoved" in destruction.group(1), \
+        "a destroyed widget no longer tells the canvas it has gone"
+    removed = re.search(r"function widgetRemoved\(widget\) \{(.*?)\n    \}", read(CANVAS), re.S)
+    assert removed and "setDragging(false)" in removed.group(1), \
+        ("a widget destroyed mid-drag leaves the lattice up: nothing else can "
+         "take it down, because it never reaches onDraggingChanged")
 
 
 def test_the_cover_that_rounds_the_corner_sits_below_the_widgets():

--- a/dots/.config/quickshell/imi/tests/test_edit_mode_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_edit_mode_runtime.py
@@ -40,7 +40,7 @@ SOCKET = "wayland-imi-edit-mode"
 # The harness prints how many checks it ran. A literal rather than anything read
 # back out of that output: a harness whose step list shrinks must redden here
 # instead of reporting `failures: 0` for a shorter run.
-EXPECTED_CHECKS = 19
+EXPECTED_CHECKS = 25
 
 
 def _stop(proc):

--- a/dots/.config/quickshell/imi/tests/test_edit_mode_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_edit_mode_runtime.py
@@ -40,7 +40,7 @@ SOCKET = "wayland-imi-edit-mode"
 # The harness prints how many checks it ran. A literal rather than anything read
 # back out of that output: a harness whose step list shrinks must redden here
 # instead of reporting `failures: 0` for a shorter run.
-EXPECTED_CHECKS = 25
+EXPECTED_CHECKS = 26
 
 
 def _stop(proc):

--- a/dots/.config/quickshell/imi/tests/tst_clock_depth_eligibility.qml
+++ b/dots/.config/quickshell/imi/tests/tst_clock_depth_eligibility.qml
@@ -20,6 +20,7 @@ TestCase {
             maskPath: "/cache/clock-depth/abc.png",
             optedOut: false,
             selecting: false,
+            editing: false,
             weActive: false,
             wallpaperIsVideo: false,
             centeredWallpaper: false,
@@ -69,6 +70,27 @@ TestCase {
         compare(ClockDepth.eligible({
             enable: true, maskPath: "/cache/clock-depth/abc.png",
             optedOut: false, selecting: true
+        }), false);
+    }
+
+    function test_edit_mode_refuses() {
+        // This layer paints the subject back OVER the desktop widgets, which is
+        // the effect at rest and is a widget the user cannot fully see in the
+        // mode that exists to let them place it. It is also the only thing left
+        // drawing above the mode's blurred backdrop, and it reconstructs the
+        // parallax viewport - which is larger than the screen, so with the
+        // desktop shrunk away from the surface's own edge it would be free to
+        // paint outside the card.
+        compare(showing({ editing: true }), false);
+    }
+
+    function test_edit_mode_refuses_even_with_everything_else_perfect() {
+        // Its own case for the reason the selection's is: `editing` is resolved
+        // BEFORE the mask, so a fixture that drifted into having no mask would
+        // refuse anyway and the check above would pass with the clause deleted.
+        compare(ClockDepth.eligible({
+            enable: true, maskPath: "/cache/clock-depth/abc.png",
+            optedOut: false, editing: true
         }), false);
     }
 


### PR DESCRIPTION
Three things from looking at the running mode, and one they turned out to share
a boundary with.

- *"In Edit mode, the grid lines should not appear until I try to move a widget."*
- *"The inset's shadows look good but I want the edges to give it a glassy feeling."*
- *"There shouldn't be any clipping."*

**Before / after captures (5120×1440 whole frames, plus 1:1 crops of the corner,
the edge and the lattice's three states): https://claude.ai/code/artifact/8309f007-428a-4110-b153-87b23a3dd7bb**

Every frame comes out of `EditModeLookProbe.qml` under headless weston, which is
also what the pixel checks drive — the pictures and the checks are the same run.
The magenta, green and yellow blocks in them are probe markers, not chrome: a
square pinned to the wallpaper viewport's corner (which has to be cut), an opaque
panel the lattice has to disappear behind, and a block pinned to the canvas's
bottom-left corner (which has to survive) — that last one standing in for
`visualizer`, which sits at 0,1200 in this machine's own `plugin-state.json`.

## 1. The lattice belongs to the gesture

`gridVisible` was `editMode || (showGrid && the config switch)`. It is
`showGrid && (editMode || the config switch)` now: what the mode overrides is
the SWITCH — whose meaning has always been "draw the grid while I drag" — and
not the gesture.

This reverses §4.1's own row, and the reason it can be reversed is that the
argument for it has expired. The spec called the grid "the one thing that
reliably says this is editable" and complained that it only appeared once you
had already started dragging; that was written before #240 gave the mode a
toolbar and a tab bar. Those say it now, and a mode that opens on a screen of
graph paper hides the desktop you came in to look at.

**The trigger is the distinction `AbstractWidget` already draws**, not a second
one. `showGrid` is written from `onDraggingChanged` → `dragActive`, which
`onPositionChanged` raises only once the pointer has travelled past
`drag.threshold` — never on the press. That is the load-bearing half: every one
of a widget's own controls presses without travelling (the resize grip, the
right-click, a click that selects), and a lattice flashing up under each of them
would be worse than one that never goes away. `widgetDragEnded` /
`widgetDragCancelled` needed no extension — both already funnel through
`dragging`, and a group drag's followers are moved imperatively and never raise
it, so the leader owns the whole gesture's lattice.

Two things fell out.

**The fade takes the faster effects tier.** It used to arrive with the mode,
easing in beside a 500ms shrink where `elementMoveFast`'s 200ms was the quick
half of a pair. Its reference now is the pointer: the widget is already a
threshold's travel from the press when the lattice is asked for and keeps going
while it arrives — at an unhurried 1000px/s that is sixteen 12px cells under
`elementMoveFast` against twelve under `elementMoveFaster`. Neither is instant,
there is no effects tier below 150ms, so the choice was the faster tier or a
literal and §2 forbids the literal. Taken whole through the tier's own factory.

**`widgetRemoved` takes the lattice down.** A widget destroyed mid-drag — a
`FadeLoader` dropping a plugin because it was disabled from Settings while it was
being dragged — never reaches `onDraggingChanged`. Invisible while the grid was
up for the whole mode; it would now leave it up for the rest of the mode.

## 2. The card's edge is a bevel, not a line

The shadow is untouched. #239 measured that one (blur 9 vs 40, indistinguishable)
and it is right. What was wrong is the boundary above it.

A 1px `colLayer0Border` outline is the shell's outline for a floating surface and
is correct for a panel sitting on a surface these tokens were derived from. Over
a WALLPAPER it is a drawn line. Walked all the way round the perimeter on this
library's darkest picture, **at its weakest point the boundary band lay
entirely between the desktop and the backdrop** — no edge at all, just a ramp.

Three tones, and it is three because no single one survives every wallpaper:

- a **shade** band just OUTSIDE the card, so the card has a lip — this is what
  carries the edge over a bright picture, where a specular cannot;
- a **specular** ON the edge, brightest along the top and fading down the sides
  to a weak bounce at the bottom, the same lamp the drop shadow is drawn for. The
  non-uniformity is the point rather than a flourish: a rim at one strength all
  the way round is a stroke however bright it is;
- a faint **highlight** just INSIDE, so the specular is the outer face of
  something rather than a line balanced on the seam.

**The measurement.** Walk the perimeter every 40px, clear of the corner arcs,
and ask how far the boundary band departs from the RANGE spanned by the two
things it sits between — the desktop inside and the blurred backdrop outside. An
excursion, not a step: a desktop at 240 over a backdrop at 148 already has a
92-level boundary whatever is drawn on it, so "contrast across the edge" scores
an edge that is not there. A pure ramp from one side to the other — which is
what a 1px line between them is — scores zero, and that is the honest answer
for it.

| wallpaper | | before | after |
| --- | --- | --- | --- |
| darkest (mean luma 28) | worst on the perimeter | **0.0** | **9.2** |
| | left / right median | 19.2 / 17.0 | 51.4 / 46.2 |
| | top / bottom median | 27.1 / 21.1 | 134.7 / 33.6 |
| brightest (mean luma 212) | worst on the perimeter | 26.2 | 28.7 |
| | left / right median | 41.2 / 58.2 | 56.4 / 62.7 |
| | top / bottom median | 77.0 / 77.5 | 71.9 / 82.3 |

The dark case is the one that needed fixing and it is decisive: at its weakest
point the old edge scored **0.0/255** — the band lay entirely between the desktop
and the backdrop, so there was no edge there, only a ramp. The bright case was
already adequate and improves modestly; its top and bottom medians move a little
each way, which is the specular trading against a dark line that was already
doing the work. Reported as measured rather than as an unbroken win.

**Cost.** The two outer tones are plain `Rectangle`s declared inside `surround`,
whose layer is *already* masked to the complement of the card — the mask cuts
each of them back to the band outside the card by itself, and the shading is the
Rectangle's own gradient. No second layer, no second mask, no effect, nothing
re-rendering the backdrop. Measured anyway, four runs each of an identical
scripted sequence under headless weston's **software** renderer, where a
full-screen pass costs CPU instead of being free on the GPU:

| | user CPU over one run | renderer time / frame |
| --- | --- | --- |
| with the bevel | 14.91s ± 0.22 | 0.64ms |
| without | 14.68s ± 0.32 | 0.64ms |

1.5% apart on a 3–4% run-to-run spread: indistinguishable, by #239's own
standard. That number is only true while the shape stays this one, so the shape
is a check — one `layer.enabled`, one `OpacityMask`, and no blur, `MultiEffect`
or `ShaderEffect` declared in the file.

**Colours.** `Appearance.colors.colGlassSpecular` / `colGlassShade`, the one pair
in that file deliberately not derived from the wallpaper. Everything else there
is generated *from* the picture on screen, so an edge drawn in one of those roles
is guaranteed to be a colour the picture already contains — which is precisely
the edge that disappears against it. Same reasoning as the depth picker's
hardcoded contour. A pair rather than one colour is what carries it over any
wallpaper rather than over the one it was tuned against.

**Standing down** is unchanged and still both gates: everything added lives
inside `EditModeCard`, under the Loader's `active` and its `opacity`.

## 3. There shouldn't be any clipping

Reproduced at 5120×1440 before touching anything: a block pinned to the desktop's
corner lost **20px along each edge and 10px on the diagonal**.

The mechanism is #239's own, working as designed and reaching further than it
meant to. QML has no rounded clip, so the corner is made by COVERING it with the
blurred backdrop cut to the card's rounded rect — and a cover over everything
covers everything. The desktop scales about its own centre, so the widget
canvas's edge lands exactly on the card's edge and a widget parked against a
screen edge is flush with the rounding; at a corner the arc comes in on both axes
at once. `visualizer` sits at 0,1200 on a 1440-tall screen in this machine's own
store, so the desktop editor was cutting a corner off a widget while the user was
arranging it.

**The cover moves from `z: 4` to `z: 1`** — above the wallpaper viewport, which is
what rounds the picture, and below the widget canvas at `z: 2`, which is the whole
of what stops it rounding the widgets. Nothing about the mask, the shadow or the
bevel changes; only what is drawn over them.

The trade is deliberate: a widget in the corner now **overhangs** the rounding,
drawn whole over the blurred backdrop, and the glass edge passes behind it rather
than across it. That says "this widget is at the edge of your desktop", which is
true and is information. Rendered both ways before choosing — the alternative on
offer was stopping widgets from reaching the corner at all, which is the mode
changing where things are allowed to be, a much larger claim than §4.1's "mostly
subtraction" framing supports.

### 3b. Which leaves the clock depth layer

Once the cover is below the widget canvas, the depth layer at `z: 3` is the one
thing left drawing above it — and it cannot follow the widgets down, because it
is above them by design (the wallpaper's subject painting back over the widgets
is the entire feature). Putting it under the cover means putting the widgets under
it again.

It stands down for the mode instead, and it wants to for two reasons of its own:

- it paints the subject OVER the widgets the mode exists to let the user arrange,
  which is a partly hidden widget in the one mode where that matters most —
  `eligible` already refuses while a desktop selection is armed for the sibling
  of this reason;
- it reconstructs the parallax viewport, which is deliberately **larger than the
  screen** (`workspaceZoom`, 1.07 on this machine, 1.1 by default), with only the
  layer surface's own edge keeping that overscan off screen. The mode's transform
  pulls the desktop's edge away from the surface's and puts the blurred backdrop
  in between, so a subject reaching the picture's edge would be free to paint up
  to **154px past the card** at 5120×1440.

A refusal in `ClockDepthLogic.eligible` rather than a gate at the call site: that
is where the other eight live and it is pure and reachable from a test. It touches
nothing else — `ClockDepth.watching` is `enabled || picking`, so entering the mode
drops no cached answer and leaving it re-runs no segmentation.

## Tests

Baseline on `gh/main` (`d3661e59b`), full suite, clean worktree:
**897 passed, 0 failed**, exit 0.
This branch: **899 passed, 0 failed**, exit 0.

New: 4 source contracts (`test_edit_mode_contract.py` 19 → 23), 7 runtime-harness
checks (`EXPECTED_CHECKS` 19 → 26), 3 pixel checks (`test_edit_mode_chrome.py`
8 → 11) and 3 harness checks in the look probe (`EXPECTED_CHECKS` 10 → 13, four
saved frames → six), and 2 `tst_clock_depth_eligibility` cases.

Eighteen mutations, each planted in a clean tree and reverted:

| planted breakage | reddened |
| --- | --- |
| `gridVisible: editMode \|\| (showGrid && switch)` | contract *the lattice belongs to the drag*; runtime *at rest*, *press*, *release*, *group*; pixel *the mode at rest draws no lattice* |
| `dragActive = true` in `onPressed` | contract *the lattice…*; runtime *a press that has not travelled* |
| `drag.threshold` replaced by `0` | contract *the lattice…* |
| `Component.onDestruction` stops calling `widgetRemoved` | contract *the lattice…* |
| `widgetRemoved`'s `setDragging(false)` deleted | contract *the lattice…*; runtime *a widget that stops existing mid-drag* |
| `setDragging` reached only on a drag STARTING | runtime, five checks |
| `setDragging(active)` → `active \|\| showGrid` | runtime, six checks |
| `syncGroupFollowers` stops applying the delta | runtime *a group drag carries the follower* |
| `editChrome` back to `z: 4` in `Background.qml` | contract *the cover sits below the widgets* |
| `editChrome` back to `z: 4` in the look probe | contract *…* (the probe half); pixel *but a widget at that corner is drawn whole* |
| the mask rectangle loses its `radius` | pixel *the card's corner is cut out of the picture* |
| the lattice painted at rest while `gridStrength` still reads 0 | pixel *the mode at rest draws no lattice*, and nothing else |
| the fade becomes a 4000ms linear animation | pixel *the lattice leaves when the drag does*, plus the harness's own settle checks |
| `model: 0` on the vertical grid `Repeater` | pixel *and the lattice is there to be hidden* |
| a second `layer.enabled: true` in the card | contract *the card's chrome composites once* |
| a `MultiEffect` declared in the card | contract *…composites once* |
| `if (s.editing) return false` deleted | contract *the depth layer stands down*; `tst_clock_depth_eligibility` ×2 |
| `editing: GlobalStates.editMode` deleted | contract *…stands down* |

Two of them found real holes rather than confirming anything, and both are their
own commits with the miss in the message:

- **`test_and_the_lattice_is_there_to_be_hidden` was itself vacuous.** Planting
  `model: 0` on the vertical `Repeater` left it green. The run it reads is
  horizontal, so what it crosses is the vertical lines — and the row it read
  along was `panel.y + panel.height + 60`, which is 540 canvas pixels, which is
  45 twelve-pixel cells exactly. It was sitting on a horizontal line: 119 of 119
  samples differed from the wallpaper whatever the vertical lines were doing. The
  row moves half a cell off the lattice and the count is bounded at both ends now
  — a full run is no longer "lots of lattice", it is the sampling failing.
- **The look probe was scoring an arrangement the shell does not have.** It
  re-declares the four siblings, because weston implements no layer shell, and its
  own `z: 4` did not move with `Background.qml`'s. It reported a widget whose
  corner was visibly still being eaten. The two z values are pinned against each
  other now.

One existing measurement was tightened rather than loosened: the concentric
mid-animation check derived the desktop's origin from the corner marker's CENTRE
to cancel antialiasing bias, and the new inner highlight is painted across the
marker's leading edges — a bias on one side only, which put it 3.05px outside a
3px tolerance. It reads the marker's far edges now, which are in the middle of
the card with nothing drawn over them.

Docs: updated AGENT.md §Edit Mode + §clock depth layer, docs/superpowers/specs/2026-08-16-edit-mode-design.md §4.1
