### PR TITLE
Edit Mode: the menu's empty row, the chrome on the bar, and the seam in the glass

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -478,7 +478,10 @@ modules/imi/                 The "imi" (Immaterial Impulse) panel family - one d
                               output (quickshell:editMode) whose mask is those two rects and
                               nothing else, so every other pixel falls through to the desktop
                               being edited. The desktop itself is not here: it stays on the
-                              background surface, which is what the mode transforms
+                              background surface, which is what the mode transforms.
+                              EditModeInsets.qml is the one derivation of what the bar and
+                              the dock occupy - both surfaces read it, and nothing else in
+                              the mode may work out where either panel is
   overview/                   Workspace/window overview (like GNOME Activities)
   notificationPopup/          Desktop notification popups
   settings/                   The in-shell settings UI (pages/ = one file per settings category)
@@ -2177,6 +2180,28 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   to do nothing. This only surfaces where focus is obtained by clicking - `LockSurface.qml`'s
   password box uses the identical overlay structure but never hit this, since it
   `forceActiveFocus()`s itself programmatically instead of depending on a click.
+- **`Item.visible` reads back EFFECTIVE visibility, so a container that hides
+  itself from its child's `visible` latches.** The sibling of the `enabled`
+  trap below, and it bites the other way round: `visible` is the item's own flag
+  AND its parents', so an item whose parent is hidden reports `false` no matter
+  what its own binding says. A wrapper bound to `child.visible` therefore hides
+  the child, then reads `false`, then can never let it back. Probed with `qml6`
+  against a control row: the control followed a gate true/false/true/false while
+  the mirrored one read `false` on every sample after the first hide, with no
+  warning and no binding-loop message. `GroupedList` is where this landed —
+  it builds one plate per declared row and sizes it from the row's
+  `implicitHeight`, which never asked whether the row was drawn, so a row hidden
+  with `visible: false` kept a full-height plate painting the group's background
+  with nothing in it (the desktop menu grew one between Widgets and DropShelf
+  for the whole life of Edit Mode; Settings > Services > Weather has the same
+  hole on wttr.in). A row that comes and goes therefore declares **`rowVisible`**,
+  a property of its own; a row that never disappears declares nothing and reads
+  `undefined`, which takes the `?? true`. The group's outer corners follow the
+  rows that are DRAWN, not the declared first and last, or a hidden plate holds
+  the rounding while the row above it is square. `tst_grouped_list.qml` covers
+  all of it, and the case that earns its place is "a hidden row that comes back
+  is drawn again" — the one the plausible alternative fix fails.
+  b949bf24a ("fix(widgets): a GroupedList row that is not drawn takes no room").
 - **`enabled: false` on a `MouseArea` disables that area and nothing under it.**
   `QQuickMouseArea` declares its own `enabled` property, which shadows `Item.enabled` — so the
   usual "`enabled` cascades to the whole subtree" intuition, which is true of a plain `Item`, is
@@ -2342,6 +2367,48 @@ mode is built out of are worth not re-deriving:
   92%, which is the mode's whole signal spent on a border. A ceiling cannot
   break the derivation, because shrinking further only makes the drawer's slot
   larger.
+- **...and "dead centre" means dead centre of what the bar and the dock leave,
+  because they stay where they are.** Editing them in place is spec §12 stage 8;
+  until then they keep their edges at full size, and a mode that ignores them
+  draws its chrome on top of them — which is what shipped. `viewportGeometry`
+  takes four INSETS and a CHROME THICKNESS on top of the drawer's width, and the
+  two answer different questions: the insets say which part of the screen the
+  mode may use, and the chrome thickness makes the band above and below the card
+  `margin + toolbarHeight + margin`, so the toolbar centred in that band has a
+  whole margin at each end by construction rather than by whatever the ceiling
+  left over. (It left 100.8px at 5120x1440 for a 56px toolbar, which starts
+  22.4px into a screen whose bar occupies the first 68.) Passing neither term
+  reproduces the old geometry property for property, which
+  `tst_edit_mode.qml` pins.
+
+  Three things about it are worth not re-deriving. **The insets have exactly one
+  derivation** (`modules/imi/editMode/EditModeInsets.qml`): everything else in
+  the mode is re-derived on both surfaces because every input is an `Appearance`
+  token and the same screen, and these are not — they come from
+  `Config.options.bar.*`, `Config.options.dock.*` and `dock_geometry.js`, so a
+  second file working them out is a second answer to where the dock is, which is
+  what `test_dock_position_contract.py` already exists to prevent for the dock's
+  own tree. **What is reserved is each panel's LAYER SURFACE, not its painted
+  body** — the bar's carries the screen-corner decorators below its body and the
+  dock's carries its elevation margin, both take clicks there, and the surface
+  extent is the number `hyprctl layers` reports, so the compositor is a check on
+  it rather than an unrelated measurement (`quickshell:bar` at y=5 h=63 and
+  `quickshell:dock` 75 tall, which is `Appearance.sizes.barSurfaceThickness` and
+  `DockGeometry.thickness`). And **the reservation is a function of
+  CONFIGURATION only** — never of auto-hide, a hover reveal, `GlobalStates.barOpen`,
+  or a fullscreen window dropping the dock's exclusive zone. All four move while
+  the mode is on, and a viewport that changes size mid-edit is b710ef731's moving
+  target: it is the same decision the module already makes about the drawer.
+
+  What this costs is the one symmetry an off-centre destination cannot keep: the
+  four margins are no longer equal in pairs *mid-flight*. What replaced it in
+  the checks is stronger and is what the eye follows — every corner still
+  travels in a straight line, because both terms of each corner's position are
+  linear in `t`. At rest the margins are equal in pairs against the USABLE AREA,
+  and on the machine this was measured on that centre is 3.5px from the screen's
+  own on a 1440-tall panel. b23c3f0f3 ("feat(editMode): shrink the desktop
+  inside what the bar and the dock leave"), 07940391a ("feat(appearance): name
+  what a bar's layer surface occupies").
 - **The blurred backdrop cannot be the lock's `blurLoader` with a second gate**,
   which is what the spec asked for: that loader is a *child* of
   `parallaxViewport`, so it takes the edit transform and shrinks along with the
@@ -2389,7 +2456,42 @@ mode is built out of are worth not re-deriving:
   edge that is brightest along the top and fades to a weak bounce at the bottom
   (which carries a dark one), and a faint highlight just inside so the specular
   is the outer face of something. Re-measured: worst-on-perimeter 24.0/255 over
-  the darkest wallpaper and 38.2/255 over the brightest. Two things generalise.
+  the darkest wallpaper and 38.2/255 over the brightest.
+
+  **It shipped as a bevel around a LINE, though, and that is what "the glassy
+  border effect feels off" turned out to be.** The 1px outline stayed, drawn
+  between the specular outside the card and the highlight inside it, so walking
+  inward the profile went shade, crest, *dark line*, highlight, desktop — a
+  NOTCH of up to 70/255 below the lower of the two bright bands either side of
+  it, measured on the real desktop at 5120x1440. A bevel falls off its crest
+  into the surface; this one fell, rose and fell, so the eye reads the dark line
+  as the card's edge and the bright band as a piping outside it, which at the
+  top-left corner looks exactly like chrome trim with a seam in it. The outline
+  is gone, and `docs/M3_GUIDELINES.md` §1 is what licenses that rather than what
+  it is traded against: "visible borders are not required for every surface",
+  and the job the guideline gives an outline — defining edges against complex
+  backgrounds — is the job this bevel exists to do, *because* the outline could
+  not do it over a wallpaper. One edge treatment, not two stacked.
+
+  **And "brightest along the top" was a stroke, because the gradient ran over
+  the bounding box.** The run from the top's value to the flank's was half the
+  card, so the whole 4403px top edge sat at one strength and both top corners
+  with it — 113/255 median along the top against 42 down the left flank. The
+  roll-off belongs to the CORNER ARC, which is precisely the run over which the
+  outline's normal turns from facing up to facing sideways, and it is expressed
+  as `cardRadius / card.height` rather than as a stop someone picked, so a
+  change to the corner moves the light with it. Re-measured after both: the
+  notch is 0.0 median / 5.3 worst (from 6.8 / 50.1) and the crest's spread
+  narrows from 0-125 to 0-109 with the top down at 89 and the flanks and bottom
+  up. The weakest point on the perimeter is 1.8/255 against 6.4 before — both
+  are "no edge here", over the brightest part of the blurred backdrop, and the
+  cause is structural: the shade band is drawn UNDER the specular, so the crest
+  composites on a darkened base and cannot clear a bright backdrop by much at
+  the bottom. Separating them costs a second mask, which is the cost this
+  component is arranged to avoid. 1df616e62 ("fix(editMode): the card's edge
+  stops having a seam drawn through it").
+
+  Two things generalise.
   The two outer tones are plain `Rectangle`s declared INSIDE `surround`, whose
   layer is already masked to the complement of the card — so the mask cuts each
   of them back to the band outside the card by itself and the shading is the
@@ -2483,17 +2585,30 @@ mode is built out of are worth not re-deriving:
   **keyboard** (`WlrKeyboardFocus.None`, or a surface on `Overlay` sits in front
   of the background and swallows the Escape the exit ladder is answered on).
 - **The chrome's placement IS the shrink's arithmetic, which is why it carries no
-  motion of its own.** Both pieces are positioned off `edit_mode.js`'s `cardRect`
-  — the same function the transform is built out of, for the reason
-  `ClockDepthCutout` is one component — and the bands they sit in are opened by
-  the shrink itself, so at progress 0 they are parked half off screen and they
-  arrive *with* the desktop rather than after it. A `Behavior` on either would be
-  a target that moves every frame, which restarts every frame and never ticks
+  motion of its own.** Both pieces sit between two rectangles from
+  `edit_mode.js` — `cardRect`, the desktop's own, and `areaRect`, the screen
+  minus what the bar and the dock occupy — for the reason `ClockDepthCutout` is
+  one component. Placed against the SURFACE's own edges instead, which is how
+  stage 4 shipped, the chrome clears the card and lands on whatever is on that
+  edge; `areaRect` is what makes clearing the two panels a property of the
+  arithmetic rather than a literal tuned against `Appearance.sizes.barHeight`.
+  Both are functions of the same progress, and `areaRect` closes in from the
+  whole screen rather than being fixed at the usable area — so at progress 0 the
+  two rectangles coincide, both bands have zero height, and both pieces are
+  parked half off screen and arrive *with* the desktop rather than sliding in
+  from wherever the bar happens to end. A `Behavior` on either would be a target
+  that moves every frame, which restarts every frame and never ticks
   (b710ef731). Note also what the pixel probe adds over the geometry checks and
   what it does not: a chrome item left `visible: false` reports its box, passes
   every geometry assertion, and paints nothing, so the probe measures the drawn
   extent — while re-asserting "the chrome is outside the card" in the pixel half
-  would read the harness's own numbers back and agree with itself.
+  would read the harness's own numbers back and agree with itself. The probe
+  stands two opaque bands on the reserved edges now, UNDER the chrome, because
+  the class no rect assertion can reach is chrome whose geometry is right and
+  whose shadow or content overhangs into one: planted as a decoration 40px above
+  the toolbar, that is the only check in either half that reddens.
+  620a480de ("test(editMode): score the chrome against the panels, and the edge
+  as a bevel").
 (feat(editMode): shrink the desktop into a viewport on the background surface,
 feat(editMode): stand the per-widget frost down for the mode,
 feat(editMode): draw the shrunk desktop as a card, not as a cropped screenshot,
@@ -3012,7 +3127,10 @@ pages - don't reintroduce a second single-line text-entry widget.
 controls form one continuous semantic unit (for example, the fields and actions for a single custom
 AI provider). Cohesive mode removes internal spacing and corner rounding while retaining the outer
 group corners. Controls rendered inside a group should rely on the group's inset; avoid adding a
-second horizontal inset that misaligns their icons or labels with neighboring rows.
+second horizontal inset that misaligns their icons or labels with neighboring rows. **A row that
+comes and goes declares `rowVisible`, never `visible`** — see the effective-visibility note under
+[Dynamic/data-driven QML gotchas](#dynamicdata-driven-qml-gotchas) for the empty plate the second
+spelling leaves behind and why the widget cannot repair it by mirroring `visible`.
 
 **`colLayer0` vs `colLayer1`/`colLayer2`/...** - these are not interchangeable "just pick one that
 looks transparent enough" tokens:

--- a/dots/.config/quickshell/imi/EditModeLookProbe.qml
+++ b/dots/.config/quickshell/imi/EditModeLookProbe.qml
@@ -45,6 +45,14 @@ import "modules/common/functions/edit_mode.js" as EditMode
  * - the lattice is a SUBSTRATE. The desktop widgets arrive as external children
  *   of the canvas, so nothing in WidgetCanvas.qml decides whether they are drawn
  *   over the grid; an opaque widget must hide the lines under it completely.
+ * - the chrome KEEPS OFF the bar and the dock. Two opaque bands stand in for
+ *   them on the two edges the mode may not draw on, under the chrome rather
+ *   than over it, so an overlap paints the toolbar's own colour inside a band
+ *   instead of being hidden by it.
+ * - the card's edge FALLS OFF its crest. The wallpaper here is flat, so every
+ *   level in the band across that edge is the bevel and nothing else - which is
+ *   the one place a profile through it can be read without the picture in the
+ *   way.
  *
  * The wallpaper is whatever EDIT_MODE_WALLPAPER names, so the same probe serves
  * the synthetic fixture the suite runs and a real photograph a human looks at.
@@ -70,6 +78,17 @@ ShellRoot {
 
     readonly property real drawerWidth: Appearance.sizes.editModeDrawerWidth
     readonly property real margin: Appearance.sizes.editModeMargin
+    readonly property real chromeThickness: Appearance.sizes.toolbarHeight
+
+    // What the bar and the dock occupy. `EditModeInsets` answers this on the
+    // real shell from the two panels' configuration; here they are literals,
+    // and they are the numbers this machine's compositor actually reports
+    // (`hyprctl layers`: quickshell:bar at y=5 h=63, quickshell:dock 75 tall).
+    // Deliberately UNEQUAL, because a top and a bottom inset that match are
+    // indistinguishable from a symmetric margin and every "which edge did you
+    // subtract" bug passes on them.
+    readonly property real insetTop: parseFloat(Quickshell.env("EDIT_MODE_INSET_TOP") || "68")
+    readonly property real insetBottom: parseFloat(Quickshell.env("EDIT_MODE_INSET_BOTTOM") || "75")
 
     // The one thing that moves. Driven directly rather than through a Behavior:
     // every frame here is a settled one, and a curve sampled mid-flight is a
@@ -80,10 +99,15 @@ ShellRoot {
         screenWidth: harness.screenWidth,
         screenHeight: harness.screenHeight,
         drawerWidth: harness.drawerWidth,
-        margin: harness.margin
+        margin: harness.margin,
+        chromeThickness: harness.chromeThickness,
+        insetTop: harness.insetTop,
+        insetBottom: harness.insetBottom
     })
     readonly property var applied: EditMode.atProgress(harness.viewport, harness.editProgress)
     readonly property rect card: EditMode.cardRect(harness.viewport, harness.editProgress,
+        harness.screenWidth, harness.screenHeight)
+    readonly property rect area: EditMode.areaRect(harness.viewport, harness.editProgress,
         harness.screenWidth, harness.screenHeight)
     readonly property real cardRadius: Appearance.rounding.verylarge * harness.editProgress
 
@@ -92,6 +116,7 @@ ShellRoot {
     readonly property color cornerMarkerColor: "#ff00ff"
     readonly property color opaquePanelColor: "#00ff88"
     readonly property color cornerWidgetColor: "#ffcc00"
+    readonly property color reservedColor: "#ff4400"
 
     FloatingWindow {
         id: window
@@ -225,6 +250,28 @@ ShellRoot {
             // background - none of which weston can show, so what is rebuilt
             // here is the arrangement (a full-screen item over the card, at the
             // card's own geometry) and the content is the shipped component.
+            // Stand-ins for the bar and the dock: opaque bands on the two edges
+            // the mode must not draw on. UNDER the chrome (z 3 against 5), so
+            // an overlap paints the toolbar's own colour inside a band and the
+            // pixel half can see it. Drawn at all, rather than left as two
+            // numbers, because a saved frame with them in it is a frame a human
+            // can judge the clearance in.
+            Rectangle {
+                z: 3
+                x: 0; y: 0
+                width: field.width
+                height: harness.insetTop
+                color: harness.reservedColor
+            }
+            Rectangle {
+                z: 3
+                x: 0
+                y: field.height - harness.insetBottom
+                width: field.width
+                height: harness.insetBottom
+                color: harness.reservedColor
+            }
+
             Loader {
                 id: chromeLoader
                 active: harness.editProgress > 0
@@ -233,6 +280,7 @@ ShellRoot {
                 opacity: harness.editProgress
                 sourceComponent: EditModeChromeContent {
                     card: harness.card
+                    area: harness.area
                 }
             }
         }
@@ -264,6 +312,8 @@ ShellRoot {
             + `,${harness.toolbar?.width ?? 0},${harness.toolbar?.height ?? 0}`
             + ` tabbar=${harness.tabBar?.x ?? -1},${harness.tabBar?.y ?? -1}`
             + `,${harness.tabBar?.width ?? 0},${harness.tabBar?.height ?? 0}`
+            + ` area=${harness.area.x},${harness.area.y},${harness.area.width},${harness.area.height}`
+            + ` reserved=${harness.insetTop},${harness.insetBottom}`
             + ` chromeColor=${Appearance.m3colors.m3surfaceContainer}`);
     }
 
@@ -312,18 +362,23 @@ ShellRoot {
             harness.applied.scale <= EditMode.MAX_SCALE + 1e-9
                 && harness.applied.scale > EditMode.MIN_SCALE,
             `scale=${harness.applied.scale.toFixed(3)}`);
-        // Dead centre, with room on each side for the drawer to translate the
-        // desktop into later. A shrink that opened one edge is a crop, and one
-        // that opened three is the desktop being shoved aside.
-        const freeX = harness.screenWidth - (harness.card.x + harness.card.width);
-        const freeY = harness.screenHeight - (harness.card.y + harness.card.height);
-        harness.check("...about dead centre, with room for the drawer on each side",
-            Math.abs(harness.card.x - freeX) < 0.5
-                && Math.abs(harness.card.y - freeY) < 0.5
-                && harness.card.x >= harness.drawerWidth / 2 + harness.margin - 0.5
-                && harness.card.y >= harness.margin - 0.5,
+        // Dead centre OF THE USABLE AREA, with room on each side for the drawer
+        // to translate the desktop into later. A shrink that opened one edge is
+        // a crop, and one that opened three is the desktop being shoved aside.
+        // Measured against the area rather than the screen because the two stop
+        // being the same rectangle the moment the bar and the dock are
+        // subtracted, and the whole point is that the desktop sits in what is
+        // left rather than in the middle of a panel it overlaps.
+        const freeX = harness.area.x + harness.area.width - (harness.card.x + harness.card.width);
+        const freeY = harness.area.y + harness.area.height - (harness.card.y + harness.card.height);
+        harness.check("...about dead centre of the usable area, with room for the drawer",
+            Math.abs((harness.card.x - harness.area.x) - freeX) < 0.5
+                && Math.abs((harness.card.y - harness.area.y) - freeY) < 0.5
+                && harness.card.x - harness.area.x >= harness.drawerWidth / 2 + harness.margin - 0.5
+                && harness.card.y - harness.area.y >= harness.margin - 0.5,
             `card=${harness.card.x.toFixed(1)},${harness.card.y.toFixed(1)}`
-                + ` ${harness.card.width.toFixed(1)}x${harness.card.height.toFixed(1)}`);
+                + ` ${harness.card.width.toFixed(1)}x${harness.card.height.toFixed(1)}`
+                + ` area=${harness.area.y.toFixed(1)}+${harness.area.height.toFixed(1)}`);
         // The chrome frames the desktop, so it has to be OUTSIDE it: a toolbar
         // overlapping the card covers the widgets it exists to help arrange,
         // and one that has left the screen is not there at all. Both bands are
@@ -337,14 +392,30 @@ ShellRoot {
                 && harness.tabBar.y + harness.tabBar.height <= harness.screenHeight,
             `toolbar=${harness.toolbar?.y.toFixed(1)}+${harness.toolbar?.height.toFixed(1)}`
                 + ` band=${harness.card.y.toFixed(1)}`);
+        // ...and clear of the two edges the bar and the dock own, by a whole
+        // margin at each end. This is the check stage 4 did not have: its bands
+        // were whatever the ceiling left over, so the toolbar started 22px into
+        // a screen whose bar occupies the first 68 and the tab bar landed on the
+        // dock. Asserted against the reserved insets rather than against the
+        // area, so it cannot be satisfied by an area that forgot to subtract
+        // them.
+        harness.check("...clear of the bar's and the dock's own edges",
+            harness.toolbar !== null && harness.tabBar !== null
+                && harness.toolbar.y >= harness.insetTop + harness.margin - 0.5
+                && harness.tabBar.y + harness.tabBar.height
+                    <= harness.screenHeight - harness.insetBottom - harness.margin + 0.5
+                && harness.card.y >= harness.insetTop
+                && harness.card.y + harness.card.height
+                    <= harness.screenHeight - harness.insetBottom,
+            `toolbar=${harness.toolbar?.y.toFixed(1)} reserved=${harness.insetTop},${harness.insetBottom}`);
         // ...and on the desktop's own axis rather than the screen's, which is
         // the same point today and stops being one when the drawer translates
         // the card. The two gaps are compared to each other because the card is
-        // centred: chrome that drifted toward one edge would still be "inside
-        // the band".
-        const gapAbove = harness.toolbar !== null ? harness.toolbar.y : -1;
+        // centred in the area: chrome that drifted toward one edge would still
+        // be "inside the band".
+        const gapAbove = harness.toolbar !== null ? harness.toolbar.y - harness.area.y : -1;
         const gapBelow = harness.tabBar !== null
-            ? harness.screenHeight - (harness.tabBar.y + harness.tabBar.height) : -2;
+            ? harness.area.y + harness.area.height - (harness.tabBar.y + harness.tabBar.height) : -2;
         harness.check("...centred on the desktop, in two bands of equal height",
             harness.toolbar !== null && harness.tabBar !== null
                 && Math.abs((harness.toolbar.x + harness.toolbar.width / 2)
@@ -395,13 +466,22 @@ ShellRoot {
         // at are the ones in between. Held at half progress and photographed,
         // so the pixel half can measure where the desktop is actually drawn
         // rather than read the number back out of the same function.
+        // Horizontally the destination is still the screen's centre, so the old
+        // symmetry holds on that axis and is still asserted. Vertically it is
+        // not - the card lands between a 68px band and a 75px one - so what is
+        // checked there is the property that survives the re-centring and is
+        // what the eye actually follows: every corner travels in a straight
+        // line from the whole screen to the card, i.e. the drawn offset is the
+        // settled offset times the same t the scale is at.
         const freeX = harness.screenWidth - (harness.card.x + harness.card.width);
-        const freeY = harness.screenHeight - (harness.card.y + harness.card.height);
-        harness.check("half way in, the desktop is still dead centre",
-            Math.abs(harness.card.x - freeX) < 0.5 && Math.abs(harness.card.y - freeY) < 0.5
+        const t = (1 - harness.applied.scale) / (1 - harness.viewport.scale);
+        harness.check("half way in, the desktop is on the straight line to its slot",
+            Math.abs(harness.card.x - freeX) < 0.5
+                && Math.abs(harness.card.y - harness.viewport.y * t) < 0.5
                 && harness.applied.scale > harness.viewport.scale
                 && harness.applied.scale < 1,
             `card=${harness.card.x.toFixed(1)},${harness.card.y.toFixed(1)}`
+                + ` expectedY=${(harness.viewport.y * t).toFixed(1)}`
                 + ` scale=${harness.applied.scale.toFixed(3)}`);
         harness.reportGeometry("midGeometry");
         harness.shoot("midway", () => {

--- a/dots/.config/quickshell/imi/modules/common/Appearance.qml
+++ b/dots/.config/quickshell/imi/modules/common/Appearance.qml
@@ -702,6 +702,28 @@ Singleton {
         property real barBottomMargin: (Config?.options.bar.bottom && root.sizes.barDeadPixelOverhang !== 0)
             ? root.sizes.barDeadPixelOverhang
             : root.sizes.barDetachMargin
+        // The bar's layer SURFACE, as opposed to the body it paints: what
+        // Bar.qml asks the compositor for, and how far that lands from the
+        // screen edge. One expression each, because anything that has to keep
+        // clear of the bar without editing it - Edit Mode's chrome is the first
+        // - would otherwise carry its own copy of a four-term sum, and a copy
+        // of that is a copy that drifts. Checked against the live compositor at
+        // cornerStyle 3 with auto-hide off: `hyprctl layers` reports
+        // `quickshell:bar` at y=5 h=63, which is these two.
+        property real barSurfaceHeight: root.sizes.barHeight
+            + root.rounding.screenRounding + root.sizes.barDetachInset
+        property real barSurfaceMargin: Config?.options.bar.bottom
+            ? root.sizes.barBottomMargin : root.sizes.barDetachMargin
+        // A negative margin is the dead-pixel overhang, which pulls the surface
+        // PAST the screen edge - it takes no room from anything inside.
+        property real barSurfaceThickness: root.sizes.barSurfaceHeight
+            + Math.max(0, root.sizes.barSurfaceMargin)
+        // ...and the same for the vertical bar, which anchors flush to its edge
+        // and so has no margin term.
+        property real verticalBarSurfaceWidth: root.sizes.verticalBarWidth
+            + root.rounding.screenRounding
+            + (Config?.options.bar.cornerStyle === 3
+                ? (Config?.options.hyprland.general.gapsOut || 5) : 0)
         property real barCenterSideModuleWidth: Config.options?.bar.verbose ? 360 : 140
         property real barCenterSideModuleWidthShortened: 280
         property real barCenterSideModuleWidthHellaShortened: 190
@@ -729,6 +751,13 @@ Singleton {
         // The gap outside the shrunk desktop on its three free sides, and
         // between it and the drawer's slot on the fourth.
         property real editModeMargin: root.spacing.space300
+        // M3's toolbar height (m3.material.io/components/toolbars). It is a
+        // token rather than a literal inside Toolbar.qml because Edit Mode's
+        // viewport reserves a band for the toolbar on the BACKGROUND surface,
+        // where no toolbar exists to measure - so the reservation and the thing
+        // reserved for have to read the same number or the chrome lands in a
+        // band that is not its size.
+        property real toolbarHeight: 56
         property real baseVerticalBarWidth: 46
         property real verticalBarWidth: Config.options.bar.cornerStyle === 1 ? 
             (baseVerticalBarWidth + root.sizes.hyprlandGapsOut * 2) : baseVerticalBarWidth

--- a/dots/.config/quickshell/imi/modules/common/functions/edit_mode.js
+++ b/dots/.config/quickshell/imi/modules/common/functions/edit_mode.js
@@ -99,10 +99,11 @@ function usableArea(input) {
 // desktop has to sit in the space the chrome frames and the chrome has to clear
 // the bar and the dock; on the machine this was measured against the two
 // centres are 3.5px apart on a 1440-tall screen, so "dead centre" survives the
-// re-reading rather than being traded away by it. Entering
-// the mode is a concentric shrink - the desktop gets smaller where it is, and
-// nothing slides - because reserving the drawer's width inside the resting
-// geometry makes the entry asymmetric from its first frame: the desktop drifts
+// re-reading rather than being traded away by it.
+//
+// Entering the mode is a concentric shrink - the desktop gets smaller where it
+// is, and nothing slides - because reserving the drawer's width inside the
+// resting geometry makes the entry asymmetric from its first frame: it drifts
 // toward one edge on the way in, which reads as being shoved aside rather than
 // lifted off the wallpaper, and it does it whether or not a drawer exists yet.
 // The drawer's width is still what decides how far the desktop moves when the

--- a/dots/.config/quickshell/imi/modules/common/functions/edit_mode.js
+++ b/dots/.config/quickshell/imi/modules/common/functions/edit_mode.js
@@ -55,11 +55,51 @@ var MIN_SCALE = 0.2;
 // screen where it is the tighter constraint it still decides.
 var MAX_SCALE = 0.86;
 
+// The part of the screen Edit Mode may use: the screen minus what the bar and
+// the dock occupy. Those two stay where they are and at full size (spec §12
+// stage 8 is editing them in place, and this is not it), so a mode that ignores
+// them draws its chrome on top of them - which is what shipped, and what this
+// exists to stop.
+//
+// Insets rather than a rectangle as the input because that is the shape the two
+// panels answer in: each occupies one EDGE, across its own axis, and nothing
+// about either is a rectangle in the middle of the screen. `EditModeInsets` is
+// the one place that turns the bar's and the dock's configuration into these
+// four numbers.
+function usableArea(input) {
+    const screenWidth = (input && input.screenWidth) || 0;
+    const screenHeight = (input && input.screenHeight) || 0;
+    const top = (input && input.insetTop) || 0;
+    const bottom = (input && input.insetBottom) || 0;
+    const left = (input && input.insetLeft) || 0;
+    const right = (input && input.insetRight) || 0;
+    return {
+        x: left,
+        y: top,
+        width: Math.max(0, screenWidth - left - right),
+        height: Math.max(0, screenHeight - top - bottom)
+    };
+}
+
 // The SIZE is derived, not chosen: the desktop shrinks by at least what the
 // drawer will need, so the drawer opens into space that already exists rather
-// than covering the desktop or resizing it (spec §1.2, §1.3).
+// than covering the desktop or resizing it (spec §1.2, §1.3) - and by at least
+// what the CHROME will need above and below it, so the toolbar and the tab bar
+// have somewhere to be rather than wherever the ceiling happens to leave them.
 //
-// The POSITION is dead centre, and the two are deliberately separate. Entering
+// That second term is the one that was missing. The band the shrink opened was
+// whatever fell out of `MAX_SCALE` - 100.8px at 5120x1440 - and the toolbar is
+// 56px centred in it, which starts 22.4px down a screen whose bar occupies the
+// first 68. Reserving the chrome's own thickness plus a margin either side of
+// it, inside the usable area, is what makes the clearance a property of the
+// arithmetic instead of a literal tuned against `Appearance.sizes.barHeight`.
+//
+// The POSITION is dead centre OF THE USABLE AREA, and the two are deliberately
+// separate. Centre of the usable area rather than of the panel, because the
+// desktop has to sit in the space the chrome frames and the chrome has to clear
+// the bar and the dock; on the machine this was measured against the two
+// centres are 3.5px apart on a 1440-tall screen, so "dead centre" survives the
+// re-reading rather than being traded away by it. Entering
 // the mode is a concentric shrink - the desktop gets smaller where it is, and
 // nothing slides - because reserving the drawer's width inside the resting
 // geometry makes the entry asymmetric from its first frame: the desktop drifts
@@ -89,19 +129,35 @@ var MAX_SCALE = 0.86;
 //
 // `margin` is one token: the gap between the desktop and the screen's edge, and
 // the gap between the desktop and the drawer's slot once there is a drawer.
+//
+// `chromeThickness` is the toolbar's own height, and it is passed rather than
+// measured for the same reason `drawerWidth` is: the desktop's transform is
+// built out of this function on the BACKGROUND surface, where neither the
+// toolbar nor the tab bar exists. `Appearance.sizes.toolbarHeight` is the one
+// number both this and the toolbars themselves read.
 function viewportGeometry(input) {
     const screenWidth = (input && input.screenWidth) || 0;
     const screenHeight = (input && input.screenHeight) || 0;
     const drawerWidth = (input && input.drawerWidth) || 0;
     const margin = (input && input.margin) || 0;
+    const chromeThickness = (input && input.chromeThickness) || 0;
     if (screenWidth <= 0 || screenHeight <= 0)
-        return { scale: 1, x: 0, y: 0, width: screenWidth, height: screenHeight };
+        return {
+            scale: 1, x: 0, y: 0, width: screenWidth, height: screenHeight,
+            area: { x: 0, y: 0, width: screenWidth, height: screenHeight }
+        };
 
+    const area = usableArea(input);
     // Two margins horizontally (outside the desktop, and between the desktop
-    // and the drawer) and two vertically, so the desktop is inset by the same
-    // amount on every side it does not share with the drawer.
-    const roomX = screenWidth - drawerWidth - margin * 2;
-    const roomY = screenHeight - margin * 2;
+    // and the drawer). Vertically the desktop gives up a whole band on each
+    // side: a margin, the chrome, and another margin - so the toolbar centred
+    // in that band has `margin` above and below it by construction, whatever
+    // the screen is and wherever the bar happens to be. With no chrome the band
+    // collapses back to one margin, which is what the geometry was before the
+    // chrome existed.
+    const band = chromeThickness > 0 ? margin * 2 + chromeThickness : margin;
+    const roomX = area.width - drawerWidth - margin * 2;
+    const roomY = area.height - band * 2;
     const scale = Math.max(MIN_SCALE,
         Math.min(MAX_SCALE, roomX / screenWidth, roomY / screenHeight));
     const width = screenWidth * scale;
@@ -109,14 +165,20 @@ function viewportGeometry(input) {
 
     return {
         scale: scale,
-        // Centred on both axes, which is what makes `atProgress` a concentric
-        // shrink rather than a slide: the offset is linear in the scale, so
-        // `x * t` is exactly the centring offset of the intermediate scale and
-        // the four margins stay equal in pairs on every frame of the entry.
-        x: (screenWidth - width) / 2,
-        y: (screenHeight - height) / 2,
+        // Centred in the usable area on both axes. With no insets that is the
+        // screen's centre and `atProgress` is a concentric shrink: the offset
+        // is linear in the scale, so `x * t` is exactly the centring offset of
+        // the intermediate scale and the four margins stay equal in pairs on
+        // every frame. With insets the destination is off the screen's centre
+        // by half their difference, so what `atProgress` interpolates is a
+        // straight line from the whole screen to the card - every corner still
+        // travels straight, and the four margins are equal in pairs against the
+        // USABLE AREA at rest.
+        x: area.x + (area.width - width) / 2,
+        y: area.y + (area.height - height) / 2,
         width: width,
-        height: height
+        height: height,
+        area: area
     };
 }
 
@@ -127,12 +189,16 @@ function viewportGeometry(input) {
 // all - there is no frame in which the scale has arrived and the offset has
 // not.
 //
-// The offset is scaled by the SAME t as the scale, and that is what makes the
-// shrink concentric rather than merely centred at the end: a centred geometry's
-// `x` is `screenWidth * (1 - scale) / 2`, which is linear in `(1 - scale)`, so
-// `x * t` is the exact centring offset for the intermediate scale
-// `1 + (scale - 1) * t`. The desktop's four margins are therefore equal in
-// pairs at every point of the animation and not only at rest.
+// The offset is scaled by the SAME t as the scale. With no insets that makes
+// the shrink concentric rather than merely centred at the end: a centred
+// geometry's `x` is `screenWidth * (1 - scale) / 2`, which is linear in
+// `(1 - scale)`, so `x * t` is the exact centring offset for the intermediate
+// scale `1 + (scale - 1) * t`, and the desktop's four margins are equal in
+// pairs at every point of the animation. With insets the destination is not the
+// screen's centre, so that particular symmetry cannot hold mid-flight and is
+// not claimed; what does hold either way, and is what the eye follows, is that
+// every corner of the desktop travels in a straight line, because both terms of
+// each corner's position are linear in `t`.
 function atProgress(geometry, progress) {
     const t = Math.max(0, Math.min(1, progress || 0));
     return {
@@ -161,5 +227,27 @@ function cardRect(geometry, progress, screenWidth, screenHeight) {
         y: applied.y,
         width: screenWidth * applied.scale,
         height: screenHeight * applied.scale
+    };
+}
+
+// Where the chrome's two bands live at a given progress: the usable area,
+// closing in from the whole screen at the same rate the desktop shrinks out of
+// it. The toolbar is centred between this rectangle's top edge and the card's,
+// the tab bar between the card's bottom edge and this one's.
+//
+// Interpolated rather than fixed at the usable area for the same reason the
+// card is: at progress 0 the two rectangles coincide, so both bands have zero
+// height and both pieces of chrome are parked half off screen and arrive WITH
+// the desktop rather than sliding in from wherever the bar happens to end. A
+// fixed usable area would park the toolbar just below the bar, visible from the
+// first frame of the entry if either stand-down gate were ever lost.
+function areaRect(geometry, progress, screenWidth, screenHeight) {
+    const t = Math.max(0, Math.min(1, progress || 0));
+    const area = geometry.area || { x: 0, y: 0, width: screenWidth, height: screenHeight };
+    return {
+        x: area.x * t,
+        y: area.y * t,
+        width: screenWidth + (area.width - screenWidth) * t,
+        height: screenHeight + (area.height - screenHeight) * t
     };
 }

--- a/dots/.config/quickshell/imi/modules/common/widgets/GroupedList.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/GroupedList.qml
@@ -2,6 +2,31 @@ import qs.modules.common
 import QtQuick
 import QtQuick.Layouts
 
+/**
+ * A list of rows drawn as one grouped surface: each row gets its own tinted
+ * plate, the outer corners are rounded and the inner ones are not.
+ *
+ * ---- a row that comes and goes declares `rowVisible`, never `visible` -------
+ *
+ * The plates are built by a `Repeater` over the declared items and each one
+ * sizes itself from its item's `implicitHeight`. That arithmetic never asked
+ * whether the item was drawn, so a row hidden with `visible: false` kept its
+ * plate: a row-height band of `bgcolor` with nothing in it. Two call sites had
+ * it - the desktop menu's Edit layout row, which disappears while Edit Mode is
+ * on, and Settings > Services > Weather's API-key field, which is OWM-only.
+ *
+ * The fix cannot be for the plate to mirror its item's `visible`, and that is
+ * worth stating because it is the obvious shape. `Item.visible` reads back
+ * EFFECTIVE visibility - the item's own flag AND its parents' - and the item is
+ * a descendant of the plate, so a plate that hid itself from it would hide the
+ * item too, and the item would then report false for ever. Probed with `qml6`
+ * against a control row: the item toggled true/false/true while the mirrored
+ * one read `false` on every one of the four samples after the first hide.
+ *
+ * So the declaration is a property of its own. A row that never disappears
+ * declares nothing and reads `undefined`, which takes the `?? true` and costs
+ * one property lookup.
+ */
 Item {
     id: root
     default property list<Item> items
@@ -13,6 +38,21 @@ Item {
     Layout.fillWidth: true
     implicitHeight: col.implicitHeight
 
+    // Which rows are drawn, in declaration order. A binding rather than a
+    // function so that a row flipping its own `rowVisible` re-rounds the group:
+    // the outer corners belong to the first and last row ON SCREEN, and reading
+    // `isFirst` off the declared index leaves a hidden row holding the group's
+    // rounding while the row above it is drawn square.
+    readonly property var drawnIndices: {
+        const drawn = [];
+        for (let i = 0; i < root.items.length; i++) {
+            const item = root.items[i];
+            if (item && (item.rowVisible ?? true))
+                drawn.push(i);
+        }
+        return drawn;
+    }
+
     ColumnLayout {
         id: col
         anchors.fill: parent
@@ -22,8 +62,13 @@ Item {
             model: root.items.length
             delegate: Rectangle {
                 required property int index
-                readonly property bool isFirst: index === 0
-                readonly property bool isLast: index === root.items.length - 1
+                readonly property bool isFirst: index === root.drawnIndices[0]
+                readonly property bool isLast: index === root.drawnIndices[root.drawnIndices.length - 1]
+                // A `ColumnLayout` leaves an invisible child out of the layout
+                // entirely, so this is what takes the plate's height AND the
+                // spacing beside it out of the group rather than collapsing one
+                // and leaving the other.
+                visible: root.drawnIndices.indexOf(index) !== -1
                 Layout.fillWidth: true
                 implicitHeight: (root.items[index]?.implicitHeight ?? 0) + root.itemVerticalPadding
                 color: root.bgcolor

--- a/dots/.config/quickshell/imi/modules/common/widgets/Toolbar.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/Toolbar.qml
@@ -32,7 +32,7 @@ Item {
         id: background
         anchors.fill: parent
         color: Appearance.m3colors.m3surfaceContainer
-        implicitHeight: 56
+        implicitHeight: Appearance.sizes.toolbarHeight
         implicitWidth: toolbarLayout.implicitWidth + root.padding * 2
         radius: height / 2
 

--- a/dots/.config/quickshell/imi/modules/imi/background/Background.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/Background.qml
@@ -9,6 +9,7 @@ import qs.modules.common.functions as CF
 import "../../common/functions/parallax.js" as ParallaxMath
 import "../../common/functions/clockDepth.js" as ClockDepthLogic
 import "../../common/functions/edit_mode.js" as EditMode
+import qs.modules.imi.editMode
 import QtQuick
 import QtQuick.Layouts
 import Qt5Compat.GraphicalEffects
@@ -545,11 +546,21 @@ Variants {
         // all take one transform, so what the user is arranging keeps its
         // proportions and its coordinates. Derived, never chosen - see
         // edit_mode.js for why the drawer's width is the input.
+        // The bar and the dock keep their edges at full size, so the desktop
+        // shrinks inside what is LEFT of the screen rather than inside the raw
+        // screen - see EditModeInsets for why the two surfaces share one object
+        // for those four numbers and re-derive everything else.
+        readonly property var editInsets: EditModeInsets.insetsFor(bgRoot.screen?.name ?? "")
         readonly property var editViewport: EditMode.viewportGeometry({
             screenWidth: bgRoot.width,
             screenHeight: bgRoot.height,
             drawerWidth: Appearance.sizes.editModeDrawerWidth,
-            margin: Appearance.sizes.editModeMargin
+            margin: Appearance.sizes.editModeMargin,
+            chromeThickness: Appearance.sizes.toolbarHeight,
+            insetTop: bgRoot.editInsets.top,
+            insetBottom: bgRoot.editInsets.bottom,
+            insetLeft: bgRoot.editInsets.left,
+            insetRight: bgRoot.editInsets.right
         })
         // One animated scalar for the whole entry, so the scale and the offset
         // cannot arrive on different frames - and it is GlobalStates' scalar

--- a/dots/.config/quickshell/imi/modules/imi/background/EditModeCard.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/EditModeCard.qml
@@ -69,12 +69,16 @@ Item {
     //
     //   - a shade band just OUTSIDE the card, so the card has a lip. It is what
     //     carries the edge over a bright picture, where a specular cannot.
-    //   - a specular ON the edge, brightest along the top and fading down the
-    //     sides to a weak bounce at the bottom - the same lamp the drop shadow
-    //     below is drawn for. A uniform bright rim reads as a stroke; a rim that
-    //     is brighter where light would catch reads as a surface.
+    //   - a specular ON the edge, brightest along the top, rolling off round the
+    //     corners to a grazing flank and coming back as a weak bounce at the
+    //     bottom - the same lamp the drop shadow below is drawn for. A uniform
+    //     bright rim reads as a stroke; a rim that is brighter where light would
+    //     catch reads as a surface.
     //   - a highlight just INSIDE, which is what gives the specular something to
-    //     be the outer face of rather than a line floating on the seam.
+    //     be the outer face of rather than a line floating on the seam. It is
+    //     the innermost tone on the edge, and there is deliberately nothing
+    //     between it and the specular - see its own comment for the 1px outline
+    //     that used to be there and why a notch is not part of a bevel.
     //
     // The first two cost nothing extra: they are plain Rectangles declared
     // inside `surround`, whose layer is already masked to the complement of the
@@ -84,6 +88,15 @@ Item {
     // is the cost this whole component is arranged to avoid.
     readonly property real edgeShadeWidth: Appearance.borderWidth.heavy
     readonly property real edgeSpecularWidth: Appearance.borderWidth.emphasis
+
+    // Where the light rolls off the edge, as a fraction of the card's height:
+    // the corner arc is the piece of the outline whose normal turns from facing
+    // UP to facing SIDEWAYS, so it is exactly the run over which a lamp
+    // overhead stops reaching the edge. Expressed against `cardRadius` rather
+    // than as a number, so a change to the corner moves the roll-off with it
+    // instead of leaving a rim that is bright right round the bend.
+    readonly property real edgeRollOff: root.card.height > 0
+        ? Math.min(0.5, root.cardRadius / root.card.height) : 0
 
     // Everything that lives OUTSIDE the card, composited once and then cut to
     // shape. The mask is inverted, so what survives is the complement of the
@@ -153,7 +166,7 @@ Item {
             // edge over a bright wallpaper, where the specular cannot, and a
             // lip that faded out along its own top would have no edge there.
             gradient: Gradient {
-                GradientStop { position: 0; color: Qt.alpha(Appearance.colors.colGlassShade, 0.18) }
+                GradientStop { position: 0; color: Qt.alpha(Appearance.colors.colGlassShade, 0.3) }
                 GradientStop { position: 1; color: Qt.alpha(Appearance.colors.colGlassShade, 0.5) }
             }
         }
@@ -168,14 +181,26 @@ Item {
             antialiasing: true
             // The non-uniformity is the point. A rim at one strength all the way
             // round is a stroke however bright it is; light catching the top of
-            // an edge, fading off down the sides and coming back weakly at the
-            // bottom is what a piece of glass looks like. The bottom stop is a
-            // bounce off whatever the card is lying on, so it is much weaker
-            // than the top rather than symmetric with it.
+            // an edge, rolling off round the corners and coming back weakly at
+            // the bottom is what a piece of glass looks like. The bottom is a
+            // bounce off whatever the card is lying on, so it is weaker than the
+            // top rather than symmetric with it.
+            //
+            // The roll-off happens over the CORNER, not over the flank. Shipped
+            // as a plain 0 / 0.5 / 1 ramp, the run from the top's value to the
+            // side's value was half the card - so both top corners were as
+            // bright as the top edge and the whole 3872px top read as one
+            // uniform stroke, which is the thing the paragraph above says a rim
+            // must not be (measured on the real desktop: crest 111/255 median
+            // along the top against 37 along the left, and 0 at its weakest
+            // point). Holding the top's value only to the end of the arc and the
+            // side's value along the whole flank is the same idea the comment
+            // always claimed, applied on the geometry that actually turns.
             gradient: Gradient {
-                GradientStop { position: 0; color: Qt.alpha(Appearance.colors.colGlassSpecular, 0.55) }
-                GradientStop { position: 0.5; color: Qt.alpha(Appearance.colors.colGlassSpecular, 0.18) }
-                GradientStop { position: 1; color: Qt.alpha(Appearance.colors.colGlassSpecular, 0.3) }
+                GradientStop { position: 0; color: Qt.alpha(Appearance.colors.colGlassSpecular, 0.46) }
+                GradientStop { position: root.edgeRollOff; color: Qt.alpha(Appearance.colors.colGlassSpecular, 0.26) }
+                GradientStop { position: 1 - root.edgeRollOff; color: Qt.alpha(Appearance.colors.colGlassSpecular, 0.26) }
+                GradientStop { position: 1; color: Qt.alpha(Appearance.colors.colGlassSpecular, 0.32) }
             }
         }
     }
@@ -201,12 +226,36 @@ Item {
         }
     }
 
-    // The 1px outline every floating surface in this shell carries beside its
-    // shadow (docs/M3_GUIDELINES.md §1). Drawn over the seam between the
-    // desktop and the cut rather than inside the mask, where the half of it
-    // outside the card would be removed along with everything else there.
+    // The inner face of the bevel, and the innermost thing on the edge - which
+    // is a correction rather than a rearrangement.
+    //
+    // A 1px `colLayer0Border` outline sat here, between this and the specular,
+    // on the reasoning that it is what every floating surface in this shell
+    // carries beside its shadow. Measured on the real desktop it was a NOTCH:
+    // walking inward from the backdrop the profile went shade, crest, *dark
+    // line*, highlight, desktop - down as much as 70/255 below the lower of the
+    // two bright bands either side of it, on all four edges. A bevel falls off
+    // its crest into the surface; this one fell, rose and fell, so the eye read
+    // the dark line as the card's edge and the bright band as a piping outside
+    // it. That is a stroke with a bevel drawn around it, not a bevel.
+    //
+    // The outline is gone rather than moved, and docs/M3_GUIDELINES.md §1 is
+    // what licenses that rather than what it is traded against: "visible borders
+    // are not required for every surface", and the job the guideline gives the
+    // outline - to "clearly define edges against complex backgrounds" - is the
+    // job this bevel exists to do, because the outline could not do it over a
+    // wallpaper. One edge treatment, not two stacked.
+    //
+    // This one cannot ride `surround`'s mask - it is INSIDE the card, which is
+    // exactly what that mask removes - so it is a border rather than a
+    // gradient-filled rect, and it is uniform where the specular is not. A real
+    // bevel's inner face would be the specular's inverse (the inside of the top
+    // edge faces away from the light), and expressing that needs a second mask
+    // and a second layer, which is the cost this whole component is arranged
+    // around. Faint enough not to become a second line on a dark wallpaper,
+    // present enough that the crest has a near side.
     Rectangle {
-        id: cardEdge
+        id: cardInnerHighlight
         x: root.card.x
         y: root.card.y
         width: root.card.width
@@ -215,27 +264,6 @@ Item {
         color: "transparent"
         antialiasing: true
         border.width: Appearance.borderWidth.standard
-        border.color: Appearance.colors.colLayer0Border
-    }
-
-    // The inner face of the bevel. This one cannot ride `surround`'s mask - it
-    // is INSIDE the card, which is exactly what that mask removes - so it is a
-    // border rather than a gradient-filled rect, and it is uniform. That is a
-    // deliberate asymmetry rather than an omission: the specular is the tone
-    // that has to look lit, and this is the tone that has to make the specular
-    // look like the outside of something. Faint enough that it does not become
-    // a second line on a dark wallpaper, present enough that the edge has a
-    // near side.
-    Rectangle {
-        id: cardInnerHighlight
-        x: root.card.x + Appearance.borderWidth.standard
-        y: root.card.y + Appearance.borderWidth.standard
-        width: root.card.width - 2 * Appearance.borderWidth.standard
-        height: root.card.height - 2 * Appearance.borderWidth.standard
-        radius: Math.max(0, root.cardRadius - Appearance.borderWidth.standard)
-        color: "transparent"
-        antialiasing: true
-        border.width: Appearance.borderWidth.standard
-        border.color: Qt.alpha(Appearance.colors.colGlassSpecular, 0.14)
+        border.color: Qt.alpha(Appearance.colors.colGlassSpecular, 0.16)
     }
 }

--- a/dots/.config/quickshell/imi/modules/imi/bar/Bar.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/Bar.qml
@@ -78,7 +78,11 @@ Scope {
                 // content carries the gap instead, which looks identical and
                 // costs no surface reconfiguration.
                 readonly property real detachInset: Appearance.sizes.barDetachInset
-                implicitHeight: Appearance.sizes.barHeight + Appearance.rounding.screenRounding + detachInset
+                // The sum lives in Appearance because Edit Mode has to know how
+                // much of the screen this surface occupies and cannot measure
+                // it - the two are on different layer surfaces, in different
+                // scene graphs.
+                implicitHeight: Appearance.sizes.barSurfaceHeight
                 // When Overlay-layer, bar shares a layer with the screen-corner click zones (ScreenCorners.qml)
                 // and same-layer overlap is resolved by stacking, not layer priority - bar was winning and
                 // swallowing the tiny corner-open hit rects. Carve them out of the bar's own mask so clicks

--- a/dots/.config/quickshell/imi/modules/imi/desktopMenu/DesktopMenu.qml
+++ b/dots/.config/quickshell/imi/modules/imi/desktopMenu/DesktopMenu.qml
@@ -328,7 +328,12 @@ Scope {
                         // control that does nothing is worse than one that is
                         // not there.
                         RippleButton {
-                            visible: !GlobalStates.editMode
+                            // `rowVisible`, not `visible`: a GroupedList row
+                            // hidden the second way keeps its plate, which is
+                            // the row-height band of empty `colLayer0` this
+                            // menu grew between Widgets and DropShelf while the
+                            // mode was on. See GroupedList.qml.
+                            property bool rowVisible: !GlobalStates.editMode
                             implicitHeight: 40
                             colBackground: "transparent"
                             colBackgroundHover: Appearance.colors.colLayer2

--- a/dots/.config/quickshell/imi/modules/imi/editMode/EditModeChromeContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/editMode/EditModeChromeContent.qml
@@ -48,6 +48,14 @@ Item {
     // somewhere arbitrary.
     property rect card: Qt.rect(0, 0, root.width, root.height)
 
+    // The screen minus what the bar and the dock occupy - `edit_mode.js`'s
+    // `areaRect`, interpolated on the same progress as `card`. The two bands the
+    // chrome sits in are the gaps between the two rectangles, so a bar of any
+    // height and a dock on any edge push the chrome rather than being drawn over
+    // by it. Defaults to the whole item, which is the geometry the mode had
+    // before it knew about either panel.
+    property rect area: Qt.rect(0, 0, root.width, root.height)
+
     signal doneRequested()
 
     // Published for the surface's input mask: these two rects are the only
@@ -62,8 +70,11 @@ Item {
         // point today and stop being one the moment stage 5's drawer
         // translates the desktop, and the chrome belongs to the desktop.
         x: root.card.x + (root.card.width - width) / 2
-        // Centred in the band between the screen's top edge and the card's.
-        y: (root.card.y - height) / 2
+        // Centred in the band between the usable area's top edge and the card's
+        // - the screen's top edge only while nothing is on that edge. The
+        // viewport reserves `margin + toolbarHeight + margin` there, so this
+        // lands with a margin above and below it and cannot reach the bar.
+        y: root.area.y + (root.card.y - root.area.y - height) / 2
         spacing: Appearance.spacing.space150
 
         MaterialSymbol {
@@ -105,11 +116,13 @@ Item {
     Toolbar {
         id: tabBar
         x: root.card.x + (root.card.width - width) / 2
-        // ...and the mirror band, between the card's bottom edge and the
-        // screen's. The card is centred, so the two bands are the same height
-        // and the two pieces travel by the same amount.
+        // ...and the mirror band, between the card's bottom edge and the usable
+        // area's. The card is centred in that area, so the two bands are the
+        // same height and the two pieces travel by the same amount - which is
+        // true with a bar on one edge and a dock on the other, and was true
+        // before only because neither was accounted for.
         y: root.card.y + root.card.height
-            + (root.height - root.card.y - root.card.height - height) / 2
+            + (root.area.y + root.area.height - root.card.y - root.card.height - height) / 2
 
         // A tab bar with one tab in it, and not a label that will grow into
         // one. The Lockscreen tab (spec §1.4) is stage 9's, and it arrives as

--- a/dots/.config/quickshell/imi/modules/imi/editMode/EditModeChromeSurface.qml
+++ b/dots/.config/quickshell/imi/modules/imi/editMode/EditModeChromeSurface.qml
@@ -76,13 +76,24 @@ PanelWindow {
     // the window boundary (which is what the clock depth layer's viewport has to
     // do) because every input is available on both sides: this surface is the
     // same screen, `GlobalStates.editProgress` is the one animated scalar, and
-    // the drawer width and margin are `Appearance` tokens. There is no live
-    // state here that only the other window can see.
+    // the drawer width, the margin and the toolbar's height are `Appearance`
+    // tokens. There is no live state here that only the other window can see.
+    //
+    // The one input that is NOT re-derived is what the bar and the dock occupy:
+    // that comes from `Config.options.bar.*` and `Config.options.dock.*` through
+    // `dock_geometry.js`, and a second file working it out is a second answer to
+    // where the dock is. `EditModeInsets` is that one answer.
+    readonly property var insets: EditModeInsets.insetsFor(root.screen?.name ?? "")
     readonly property var viewport: EditMode.viewportGeometry({
         screenWidth: root.width,
         screenHeight: root.height,
         drawerWidth: Appearance.sizes.editModeDrawerWidth,
-        margin: Appearance.sizes.editModeMargin
+        margin: Appearance.sizes.editModeMargin,
+        chromeThickness: Appearance.sizes.toolbarHeight,
+        insetTop: root.insets.top,
+        insetBottom: root.insets.bottom,
+        insetLeft: root.insets.left,
+        insetRight: root.insets.right
     })
 
     mask: Region {
@@ -96,6 +107,12 @@ PanelWindow {
         id: chrome
         anchors.fill: parent
         card: EditMode.cardRect(root.viewport, GlobalStates.editProgress,
+            root.width, root.height)
+        // The part of the screen the bar and the dock have not taken, closing in
+        // at the same rate the card shrinks out of it. The chrome is placed
+        // between the two rectangles, so it clears both panels by construction
+        // rather than by a literal measured against one of them.
+        area: EditMode.areaRect(root.viewport, GlobalStates.editProgress,
             root.width, root.height)
         // The second of the mode's two stand-down gates, the other being the
         // loader that creates this window at all. Either alone hides the

--- a/dots/.config/quickshell/imi/modules/imi/editMode/EditModeInsets.qml
+++ b/dots/.config/quickshell/imi/modules/imi/editMode/EditModeInsets.qml
@@ -1,0 +1,81 @@
+pragma Singleton
+
+import Quickshell
+import qs.modules.common
+import "../dock/dock_geometry.js" as DockGeometry
+
+/**
+ * What Edit Mode may not draw on: the edges the bar and the dock occupy.
+ *
+ * The mode leaves both where they are and at full size - editing them in place
+ * is stage 8 and this is not it - so the desktop shrinks inside what is left,
+ * and the toolbar and the tab bar sit in bands opened inside that. Stage 4
+ * shipped without this and put the toolbar on top of the bar's widgets and the
+ * tab bar on top of the dock's.
+ *
+ * ---- why this is one singleton rather than two derivations -----------------
+ *
+ * `EditModeChromeSurface` re-derives the viewport rather than having it
+ * published, on the grounds that every input is available on both sides. That
+ * reasoning still holds for the geometry and stops holding here: these numbers
+ * come from `Config.options.bar.*`, `Config.options.dock.*` and
+ * `dock_geometry.js`, and a second file reading them is a second answer to
+ * "where is the dock" - which is exactly what `test_dock_position_contract.py`
+ * exists to prevent for the dock's own tree. So the two surfaces read one
+ * object, and it lives beside the mode that is its only caller.
+ *
+ * ---- what is reserved, and what deliberately is not ------------------------
+ *
+ * The bar's and the dock's LAYER SURFACES, whole. Not their painted bodies: the
+ * bar's surface carries the screen-corner decorators below its body, the dock's
+ * carries its elevation margin, and both take clicks there. The surface extent
+ * is also the number the compositor reports, so `hyprctl layers` is a check on
+ * this rather than an unrelated measurement.
+ *
+ * The reservation is a function of CONFIGURATION only - never of auto-hide,
+ * hover reveal, `GlobalStates.barOpen`, or a fullscreen window dropping the
+ * dock's exclusive zone. Those all move while the mode is on, and a viewport
+ * that changes size mid-edit rescales every widget under the cursor and hands
+ * every `Behavior` carrying the box a moving target (b710ef731). It is the same
+ * decision `edit_mode.js` makes about the drawer's width, for the same reason:
+ * reserve the space whether or not the thing is currently in it.
+ */
+Singleton {
+    id: root
+
+    // Exactly one bar exists - `ImmaterialImpulseFamily.qml` loads Bar or
+    // VerticalBar on `Config.options.bar.vertical` - so this is which edge it
+    // is on, not which of two.
+    readonly property bool barVertical: Config.options?.bar.vertical ?? false
+    readonly property string barSide: root.barVertical
+        ? ((Config.options?.bar.bottom ?? false) ? "right" : "left")
+        : ((Config.options?.bar.bottom ?? false) ? "bottom" : "top")
+    readonly property real barThickness: root.barVertical
+        ? Appearance.sizes.verticalBarSurfaceWidth
+        : Appearance.sizes.barSurfaceThickness
+
+    readonly property string dockSide: DockGeometry.outwardSide(
+        Config.options?.dock.edge ?? "bottom")
+    readonly property real dockThickness: (Config.options?.dock.enable ?? false)
+        ? DockGeometry.thickness(Config.options?.dock.height ?? 60,
+            Appearance.sizes.elevationMargin, Appearance.sizes.hyprlandGapsOut)
+        : 0
+
+    // A screen the bar is not drawn on gets none of its inset. The dock has no
+    // such list - `Dock.qml` runs over every screen - so nothing here does
+    // either, rather than inventing a second rule for it.
+    function barShownOn(screenName) {
+        const list = Config.options?.bar.screenList;
+        return !list || list.length === 0 || list.indexOf(screenName) !== -1;
+    }
+
+    // The two panels can share an edge (a bottom bar over a bottom dock), so
+    // the terms add rather than the larger winning.
+    function insetsFor(screenName) {
+        const insets = { top: 0, bottom: 0, left: 0, right: 0 };
+        if (root.barShownOn(screenName))
+            insets[root.barSide] += root.barThickness;
+        insets[root.dockSide] += root.dockThickness;
+        return insets;
+    }
+}

--- a/dots/.config/quickshell/imi/modules/imi/editMode/EditModeInsets.qml
+++ b/dots/.config/quickshell/imi/modules/imi/editMode/EditModeInsets.qml
@@ -45,16 +45,21 @@ Singleton {
 
     // Exactly one bar exists - `ImmaterialImpulseFamily.qml` loads Bar or
     // VerticalBar on `Config.options.bar.vertical` - so this is which edge it
-    // is on, not which of two.
+    // is on, not which of two. Through `DockGeometry.barEdge` rather than
+    // spelled out, because that overloaded pair (`bar.bottom` means "right"
+    // when the bar is vertical) already has one place it becomes an edge name,
+    // and `test_dock_position_contract.py` caught this file re-deriving it.
     readonly property bool barVertical: Config.options?.bar.vertical ?? false
-    readonly property string barSide: root.barVertical
-        ? ((Config.options?.bar.bottom ?? false) ? "right" : "left")
-        : ((Config.options?.bar.bottom ?? false) ? "bottom" : "top")
+    readonly property string barSide: DockGeometry.barEdge(
+        root.barVertical, Config.options?.bar.bottom ?? false)
     readonly property real barThickness: root.barVertical
         ? Appearance.sizes.verticalBarSurfaceWidth
         : Appearance.sizes.barSurfaceThickness
 
-    readonly property string dockSide: DockGeometry.outwardSide(
+    // The dock's outward side IS its edge, so this is `normalizedEdge` and not
+    // `outwardSide` reading it: a file may take the stored key only straight
+    // into that call, which is the same one-derivation rule.
+    readonly property string dockSide: DockGeometry.normalizedEdge(
         Config.options?.dock.edge ?? "bottom")
     readonly property real dockThickness: (Config.options?.dock.enable ?? false)
         ? DockGeometry.thickness(Config.options?.dock.height ?? 60,

--- a/dots/.config/quickshell/imi/modules/imi/settings/pages/ServicesConfig.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/pages/ServicesConfig.qml
@@ -641,7 +641,9 @@ ContentPage {
                 ConfigTextArea {
                     id: weatherApiKeyField
                     Layout.fillWidth: true
-                    visible: Config.options.bar.weather.provider === "owm"
+                    // A GroupedList row declares its visibility this way or it
+                    // leaves an empty plate behind - see GroupedList.qml.
+                    property bool rowVisible: Config.options.bar.weather.provider === "owm"
                     fieldWidth: 250
                     buttonIcon: "vpn_key"
                     text: Translation.tr("OpenWeatherMap API key (leave empty for the built-in key)")

--- a/dots/.config/quickshell/imi/modules/imi/verticalBar/VerticalBar.qml
+++ b/dots/.config/quickshell/imi/modules/imi/verticalBar/VerticalBar.qml
@@ -56,8 +56,9 @@ Scope {
                     Appearance.sizes.baseVerticalBarWidth + (Config.options.bar.cornerStyle === 1 ? Appearance.sizes.hyprlandGapsOut : 0)
                     + (Config.options.bar.cornerStyle === 3 ? (Config.options.hyprland.general.gapsOut || 5) : 0)
                 WlrLayershell.namespace: "quickshell:verticalBar"
-                implicitWidth: Appearance.sizes.verticalBarWidth + Appearance.rounding.screenRounding
-                    + (Config.options.bar.cornerStyle === 3 ? (Config.options.hyprland.general.gapsOut || 5) : 0)
+                // In Appearance for the reason Bar.qml's height is: Edit Mode
+                // keeps its chrome clear of this surface and cannot measure it.
+                implicitWidth: Appearance.sizes.verticalBarSurfaceWidth
                 mask: Region { item: hoverMaskRegion }
                 color: "transparent"
 

--- a/dots/.config/quickshell/imi/tests/fixtures/GroupedListRows.qml
+++ b/dots/.config/quickshell/imi/tests/fixtures/GroupedListRows.qml
@@ -1,0 +1,35 @@
+import QtQuick
+import qs.modules.common.widgets
+
+/**
+ * Three rows in a real `GroupedList`, for tst_grouped_list.qml.
+ *
+ * A separate file rather than an inline `Component` because the widget uses
+ * per-corner `Rectangle` radii, which Qt gained in 6.7 - and an inline
+ * component is compiled with the test file, so on an older Qt the whole
+ * TestCase fails to compile and every case in it is lost rather than one being
+ * skipped. Loaded through `Qt.createComponent`, the version dependency is a
+ * status the test can read and report.
+ */
+GroupedList {
+    width: 300
+
+    property alias firstRow: first
+    property alias middleRow: middle
+    property alias lastRow: last
+
+    Item {
+        id: first
+        implicitHeight: 40
+        property bool rowVisible: true
+    }
+    Item {
+        id: middle
+        implicitHeight: 40
+        property bool rowVisible: true
+    }
+    // Declares nothing, which is what almost every row in the shell does - it
+    // must still be drawn, and it must still be able to hold the group's
+    // bottom corner.
+    Item { id: last; implicitHeight: 40 }
+}

--- a/dots/.config/quickshell/imi/tests/imports/qs/modules/common/widgets/GroupedList.qml
+++ b/dots/.config/quickshell/imi/tests/imports/qs/modules/common/widgets/GroupedList.qml
@@ -1,0 +1,1 @@
+../../../../../../modules/common/widgets/GroupedList.qml

--- a/dots/.config/quickshell/imi/tests/imports/qs/modules/common/widgets/qmldir
+++ b/dots/.config/quickshell/imi/tests/imports/qs/modules/common/widgets/qmldir
@@ -1,3 +1,4 @@
 module qs.modules.common.widgets
+GroupedList 1.0 GroupedList.qml
 LiveDesktopEntry 1.0 LiveDesktopEntry.qml
 WallpaperBlurSurface 1.0 WallpaperBlurSurface.qml

--- a/dots/.config/quickshell/imi/tests/imports/qs/modules/imi/dock/dock_geometry.js
+++ b/dots/.config/quickshell/imi/tests/imports/qs/modules/imi/dock/dock_geometry.js
@@ -1,0 +1,1 @@
+../../../../../../modules/imi/dock/dock_geometry.js

--- a/dots/.config/quickshell/imi/tests/imports/qs/modules/imi/editMode/EditModeInsets.qml
+++ b/dots/.config/quickshell/imi/tests/imports/qs/modules/imi/editMode/EditModeInsets.qml
@@ -1,0 +1,1 @@
+../../../../../../modules/imi/editMode/EditModeInsets.qml

--- a/dots/.config/quickshell/imi/tests/imports/qs/modules/imi/editMode/qmldir
+++ b/dots/.config/quickshell/imi/tests/imports/qs/modules/imi/editMode/qmldir
@@ -1,0 +1,2 @@
+module qs.modules.imi.editMode
+singleton EditModeInsets EditModeInsets.qml

--- a/dots/.config/quickshell/imi/tests/test_edit_mode_chrome.py
+++ b/dots/.config/quickshell/imi/tests/test_edit_mode_chrome.py
@@ -77,7 +77,7 @@ WALLPAPER_RGB = (58, 96, 140)
 # The harness states how many checks it ran; this is the literal it must state.
 # Read back out of its own output it would agree with itself by construction,
 # and `failures: 0` is also what a harness that ran nothing prints.
-EXPECTED_CHECKS = 13
+EXPECTED_CHECKS = 14
 
 GEOMETRY = re.compile(
     r"(geometry|midGeometry): screen=([\d.]+),([\d.]+) card=([\d.]+),([\d.]+),([\d.]+),([\d.]+) "
@@ -86,7 +86,9 @@ GEOMETRY = re.compile(
     r"corner=([\d.]+),([\d.]+),([\d.]+),([\d.]+) "
     r"markerColor=(\S+) panelColor=(\S+) cornerColor=(\S+) "
     r"toolbar=(-?[\d.]+),(-?[\d.]+),([\d.]+),([\d.]+) "
-    r"tabbar=(-?[\d.]+),(-?[\d.]+),([\d.]+),([\d.]+) chromeColor=(\S+)")
+    r"tabbar=(-?[\d.]+),(-?[\d.]+),([\d.]+),([\d.]+) "
+    r"area=(-?[\d.]+),(-?[\d.]+),([\d.]+),([\d.]+) "
+    r"reserved=([\d.]+),([\d.]+) chromeColor=(\S+)")
 
 
 def _available():
@@ -143,7 +145,9 @@ class EditModeChromeTest(unittest.TestCase):
                 "cornerColor": _hex_to_rgb(values[23]),
                 "toolbar": tuple(float(v) for v in values[24:28]),
                 "tabbar": tuple(float(v) for v in values[28:32]),
-                "chromeColor": _hex_to_rgb(values[32]),
+                "area": tuple(float(v) for v in values[32:36]),
+                "reserved": tuple(float(v) for v in values[36:38]),
+                "chromeColor": _hex_to_rgb(values[38]),
             }
         for tag in ("geometry", "midGeometry"):
             self.assertIn(tag, self.reported,
@@ -161,6 +165,8 @@ class EditModeChromeTest(unittest.TestCase):
         self.corner_rgb = settled["cornerColor"]
         self.toolbar = settled["toolbar"]
         self.tabbar = settled["tabbar"]
+        self.area = settled["area"]
+        self.reserved = settled["reserved"]
         self.chrome_rgb = settled["chromeColor"]
 
         self.frames = {}
@@ -255,7 +261,6 @@ class EditModeChromeTest(unittest.TestCase):
         left = row[-1] + 1 - mid["marker"][2] * mid["scale"]
         top = column[-1] + 1 - mid["marker"][3] * mid["scale"]
         right = left + screen_w * mid["scale"]
-        bottom = top + screen_h * mid["scale"]
         self.assertAlmostEqual(left, mid["card"][0], delta=2)
         self.assertAlmostEqual(top, mid["card"][1], delta=2)
         # Three pixels: an edge measured off a scaled, antialiased marker is
@@ -264,8 +269,18 @@ class EditModeChromeTest(unittest.TestCase):
         # width of a whole margin - 60px here - not at three.
         self.assertAlmostEqual(left, screen_w - right, delta=3,
                                msg="the desktop is not centred horizontally mid-animation")
-        self.assertAlmostEqual(top, screen_h - bottom, delta=3,
-                               msg="the desktop is not centred vertically mid-animation")
+
+        # Vertically the destination is no longer the screen's centre - the card
+        # sits between the bar's band and the dock's - so the symmetry that used
+        # to be asserted here is gone and this is what replaced it: the desktop
+        # travels in a STRAIGHT LINE from the whole screen to its slot, which is
+        # the property the eye follows and the one a scale about the top-left
+        # still fails (it would put `top` at 0 for every t). `t` is recovered
+        # from the drawn scale, so nothing here reads the interpolation back out
+        # of the function that produced it.
+        t = (1 - drawn_scale) / (1 - self.scale)
+        self.assertAlmostEqual(top, self.card[1] * t, delta=3,
+                               msg="the desktop does not travel in a straight line to its slot")
 
     # ---- the chrome ------------------------------------------------------
 
@@ -308,6 +323,109 @@ class EditModeChromeTest(unittest.TestCase):
     # rects, and a copy of it in this file would read those rects back out of
     # the harness's own report - two checks that agree by construction, which
     # is one check and a false sense of two.
+
+    def test_the_chrome_keeps_off_the_bar_and_the_dock(self):
+        """Stage 4 shipped the toolbar over the bar's widgets and the tab bar
+        over the dock's, on the reasoning that no placement clears a bar of
+        unknown height without a literal. The viewport reserves both edges now,
+        so this asks the question in paint rather than in numbers: does the
+        toolbar's own surface colour appear anywhere in the two bands?
+
+        The bands are drawn UNDER the chrome in the probe, so an overlap is
+        visible rather than covered up - and the failure this catches is not
+        only "the chrome is at the wrong y". A chrome whose geometry is right
+        and whose shadow, ripple or content overhangs into a band fails here and
+        passes every rect assertion the harness makes.
+        """
+        frame = self.frames["editing"]
+        inset_top, inset_bottom = self.reserved
+        self.assertGreater(inset_top, 0)
+        self.assertGreater(inset_bottom, 0)
+
+        bands = (("bar", range(0, round(inset_top))),
+                 ("dock", range(round(self.screen[1] - inset_bottom), round(self.screen[1]))))
+        for name, rows in bands:
+            hits = [(x, y) for y in rows for x in range(0, round(self.screen[0]), 4)
+                    if max(abs(a - b) for a, b in
+                           zip(frame.getpixel((x, y)), self.chrome_rgb)) <= 12]
+            self.assertEqual(hits[:6], [],
+                             f"the chrome is painted on the {name}'s own band")
+
+        # ...and it is there to be found. Without this the check above passes on
+        # a probe that drew no chrome at all, which is the vacuity the lattice
+        # count already had to be repaired for.
+        self.assertTrue(self._body_span(frame, self.toolbar),
+                        "no toolbar was drawn, so keeping off the bar proves nothing")
+
+    # ---- the glass edge --------------------------------------------------
+
+    @staticmethod
+    def _luma(pixel):
+        return 0.299 * pixel[0] + 0.587 * pixel[1] + 0.114 * pixel[2]
+
+    def _edge_profile(self, frame, side, along, depth=8):
+        """Luma walking inward across the card's edge, starting `depth` px
+        outside it. Index `depth` is the card's own outermost pixel."""
+        x, y, w, h = (round(v) for v in self.card)
+        out = []
+        for d in range(-depth, depth + 1):
+            if side == "top":
+                out.append(self._luma(frame.getpixel((along, y + d))))
+            elif side == "bottom":
+                out.append(self._luma(frame.getpixel((along, y + h - 1 - d))))
+            elif side == "left":
+                out.append(self._luma(frame.getpixel((x + d, along))))
+            else:
+                out.append(self._luma(frame.getpixel((x + w - 1 - d, along))))
+        return out
+
+    def test_the_cards_edge_falls_off_its_crest_into_the_desktop(self):
+        """A bevel is monotonic on the inward side of its crest; a stack of
+        bands is not.
+
+        The card carried a 1px `colLayer0Border` outline BETWEEN the specular
+        outside it and the inner highlight inside it, so walking inward the
+        profile went shade, crest, dark line, highlight, desktop - measured on
+        the real desktop, a notch of up to 70/255 below the lower of the two
+        bright bands either side of it. That is what "the glassy border effect
+        feels off" was: the eye reads the dark line as the card's edge and the
+        bright band as a piping outside it.
+
+        This is the only place the profile can be read cleanly - the probe's
+        wallpaper is one flat colour, so every level in the band is the bevel
+        and nothing else. Tolerance is 4 levels, which is antialiasing on a
+        software renderer; the defect it exists for is an order of magnitude
+        past that.
+        """
+        frame = self.frames["editing"]
+        x, y, w, h = self.card
+        # Clear of the corner arcs, and clear of the corner marker, which is
+        # opaque magenta over the top-left of the card's interior.
+        arc = round(self.radius) + 8
+        marker_reach = round(self.marker[2] * self.scale) + 8
+        samples = (
+            ("top", range(round(x) + marker_reach, round(x + w) - arc, 40)),
+            ("bottom", range(round(x) + arc, round(x + w) - arc, 40)),
+            ("left", range(round(y) + marker_reach, round(y + h) - arc, 40)),
+            ("right", range(round(y) + arc, round(y + h) - arc, 40)),
+        )
+        worst = (0.0, None)
+        for side, rng in samples:
+            self.assertTrue(list(rng), f"no {side} samples to take")
+            for along in rng:
+                profile = self._edge_profile(frame, side, along)
+                crest = max(range(len(profile)), key=lambda i: profile[i])
+                # Only the band. Further in is the desktop's own picture, and a
+                # bright thing a few pixels inside it is not a seam in the edge.
+                inward = profile[crest:crest + 5]
+                for i in range(1, len(inward) - 1):
+                    later = max(inward[i + 1:])
+                    if inward[i] <= inward[i - 1] and inward[i] <= later:
+                        depth = min(inward[i - 1], later) - inward[i]
+                        if depth > worst[0]:
+                            worst = (depth, (side, along, [round(v) for v in profile]))
+        self.assertLess(worst[0], 4.0,
+                        f"the card's edge has a notch in it: {worst[1]}")
 
     # ---- the corner ------------------------------------------------------
 
@@ -403,8 +521,16 @@ class EditModeChromeTest(unittest.TestCase):
         # The other half of the check above, and what stops it passing on a
         # desktop that simply is not where the geometry says it is: at rest the
         # card is the whole screen and its corner is the marker's own pixel.
-        self.assertEqual(self.frames["rest"].getpixel((3, 3)), self.marker_rgb)
-        self.assertEqual(self.frames["after"].getpixel((3, 3)), self.marker_rgb)
+        #
+        # Three pixels below the bar's band rather than three below the screen's
+        # top edge - the probe now stands a band there for the chrome to keep
+        # off, and it is opaque. The marker is 220 canvas pixels tall and the
+        # band is 68, so this is still well inside a corner that must not be cut
+        # while the mode is off; what it is NOT is a sample of the band itself,
+        # which is what the first version of this read after the bands landed.
+        corner = (3, round(self.reserved[0]) + 3)
+        self.assertEqual(self.frames["rest"].getpixel(corner), self.marker_rgb)
+        self.assertEqual(self.frames["after"].getpixel(corner), self.marker_rgb)
 
     # ---- the substrate ---------------------------------------------------
 

--- a/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
@@ -32,6 +32,21 @@ can see, because weston implements no wlr-layer-shell:
   compositor to blur the whole screen;
 - and a chrome surface taking keyboard focus sits in front of the background
   and swallows the Escape the exit ladder is answered on.
+
+Four more came out of the first live load, and three of the four are silent in
+the same way - they are geometry that is only wrong on a machine that has the
+panel in question:
+
+- two surfaces working out where the bar and the dock are separately, which
+  frames a rectangle the desktop is not at, and only where the two derivations
+  differ;
+- a reservation that follows something which MOVES while the mode is on
+  (auto-hide, a hover reveal, a fullscreen window), which resizes the viewport
+  mid-edit - b710ef731's defect reached from a new direction;
+- the chrome placed against the screen's own edges rather than against the
+  usable area, which is what put the toolbar on the bar's widgets;
+- and a tone drawn between the specular and the inner highlight, which turns
+  the card's bevel into a bevel around a line.
 """
 
 import re
@@ -54,6 +69,7 @@ LOOK_PROBE = ROOT / "EditModeLookProbe.qml"
 CHROME_SCOPE = ROOT / "modules/imi/editMode/EditModeChrome.qml"
 CHROME_SURFACE = ROOT / "modules/imi/editMode/EditModeChromeSurface.qml"
 CHROME_CONTENT = ROOT / "modules/imi/editMode/EditModeChromeContent.qml"
+INSETS = ROOT / "modules/imi/editMode/EditModeInsets.qml"
 DESKTOP_MENU = ROOT / "modules/imi/desktopMenu/DesktopMenu.qml"
 RULES = ROOT.parents[1] / "hypr/hyprland/rules.lua"
 
@@ -67,6 +83,42 @@ PARTICIPANTS = [BACKGROUND, CANVAS, WIDGET, BACKGROUND_WIDGET, PLUGIN_WIDGET,
 def read(path: Path) -> str:
     assert path.exists(), f"{path} is missing - this check has nothing to say"
     return path.read_text()
+
+
+def code(path: Path) -> str:
+    """The file with its comments removed.
+
+    Every check below that forbids a NAME has to read this rather than the raw
+    text, because the comment explaining why the name is forbidden contains it.
+    Three of these checks failed on their own rationale the first time they ran,
+    which is a way for a rule to be unwritable rather than a way for it to be
+    wrong.
+    """
+    text = re.sub(r"/\*.*?\*/", "", read(path), flags=re.S)
+    return "\n".join(re.sub(r"//.*$", "", line) for line in text.splitlines())
+
+
+def declaration(text: str, name: str) -> str:
+    """One property's whole value, continuation lines included.
+
+    A line-scoped read of a QML property is the mistake this repo keeps making:
+    `edgeRollOff` carries its guard on the first line and its arithmetic on the
+    second, so a check that reads the line finds a comparison and passes on
+    anything below it. Same lesson as the settled-span sweep.
+    """
+    lines = text.splitlines()
+    for index, line in enumerate(lines):
+        match = re.match(rf"^(\s*)(?:readonly\s+)?property\s+\w+\s+{name}:(.*)$", line)
+        if not match:
+            continue
+        indent = len(match.group(1))
+        body = [match.group(2)]
+        for following in lines[index + 1:]:
+            if following.strip() and len(following) - len(following.lstrip()) <= indent:
+                break
+            body.append(following)
+        return "\n".join(body)
+    return ""
 
 
 def declared_z(text: str) -> dict:
@@ -546,14 +598,138 @@ def test_the_mode_has_one_way_in_and_the_toolbar_owns_the_way_out():
     writes = re.findall(r"GlobalStates\.editMode = ([^\n]+)", menu)
     assert writes == ["true"], \
         f"the desktop menu is no longer only the way in: {writes}"
-    assert re.search(r"visible:\s*!GlobalStates\.editMode", menu), \
+    # `rowVisible`, not `visible`. A GroupedList row hidden the second way keeps
+    # its plate - a row-height band of the group's own background with nothing
+    # in it, which is what this menu grew between Widgets and DropShelf for the
+    # whole life of the mode. GroupedList.qml says why the widget cannot simply
+    # mirror `visible`; this pins the call site that reported it.
+    assert re.search(r"property bool rowVisible:\s*!GlobalStates\.editMode", menu), \
         "the Edit layout row must not sit in the menu doing nothing while the mode is on"
+    assert not re.search(r"^\s*visible:\s*!GlobalStates\.editMode", menu, re.M), \
+        "a GroupedList row hidden with `visible` leaves an empty plate behind"
     assert re.search(r"GlobalStates\.editMode = false", read(CHROME_SURFACE)), \
         "the toolbar's Done is the mode's exit"
     # Leaving takes the gesture and the selection with it: Done means stop, and
     # a selection halo left on the desktop has no visible way to be cleared.
     assert re.search(r"onEditModeChanged:[^\n]*clearSelection", read(CANVAS)), \
         "leaving the mode leaves a selection behind"
+
+
+def test_the_bar_and_the_dock_have_exactly_one_answer_for_where_they_are():
+    """The insets are derived once, and both surfaces read that one object.
+
+    Everything else about the mode's geometry is re-derived on the background
+    surface and on the chrome surface, because every input is an `Appearance`
+    token and the same screen. These four numbers are not: they come from
+    `Config.options.bar.*`, `Config.options.dock.*` and `dock_geometry.js`, so a
+    second file working them out is a second answer to where the dock is - the
+    thing `test_dock_position_contract.py` exists to prevent for the dock's own
+    tree. The failure is silent in the worst way: two surfaces that disagree
+    frame a rectangle the desktop is not at, and only on the machine whose bar
+    is the height that makes them differ.
+    """
+    insets = code(INSETS)
+    assert re.search(r"^pragma Singleton", insets, re.M), \
+        "the insets are one object, not a component each surface instantiates"
+    assert "DockGeometry.thickness(" in insets and "DockGeometry.outwardSide(" in insets, \
+        "the dock's edge and thickness come from the dock's own module"
+
+    for path in (BACKGROUND, CHROME_SURFACE):
+        text = code(path)
+        assert "EditModeInsets.insetsFor(" in text, \
+            f"{path.name} must take the insets from the one derivation"
+        for term in ("insetTop:", "insetBottom:", "insetLeft:", "insetRight:"):
+            assert term in text, f"{path.name} drops {term} on the way in"
+        assert "chromeThickness: Appearance.sizes.toolbarHeight" in text, \
+            f"{path.name} must reserve the toolbar's own height, not a literal"
+
+    # Nothing else in the mode may reach for either panel's configuration. A
+    # file that reads `dock.edge` to decide where the chrome goes is the second
+    # derivation this exists to stop, whatever it then does with it.
+    for path in PARTICIPANTS + [CARD, LOOK_PROBE]:
+        if path is BACKGROUND:
+            continue
+        text = code(path)
+        for key in ("Config.options.dock", "Config.options?.dock",
+                    "Config.options.bar.bottom", "Config.options?.bar.bottom"):
+            assert key not in text, \
+                f"{path.name} works out where a panel is instead of asking EditModeInsets"
+
+
+def test_the_reservation_does_not_move_while_the_mode_is_on():
+    """A viewport that changes size mid-edit rescales every widget under the
+    cursor and hands every Behavior carrying the box a moving target
+    (b710ef731). So the insets are a function of CONFIGURATION - never of
+    auto-hide, hover reveal, `barOpen`, or a fullscreen window dropping the
+    dock's exclusive zone, all of which move while the user is editing.
+
+    It is the same decision `edit_mode.js` makes about the drawer's width, and
+    the same reason: reserve the space whether or not the thing is in it.
+    """
+    insets = code(INSETS)
+    for moving in ("GlobalStates.barOpen", "hoverToReveal", "pinnedOnStartup",
+                   "containsMouse", "fullscreen", "ToplevelManager",
+                   "autoHide.enable"):
+        assert moving not in insets, \
+            f"the reservation follows {moving}, which moves while the mode is on"
+    # `viewportGeometry` has no input for the drawer's open state either, and
+    # this is the check that keeps the two consistent as stage 5 lands.
+    assert "drawerOpen" not in code(MODULE), \
+        "the geometry must not learn whether the drawer is open"
+
+
+def test_the_chrome_is_placed_between_the_card_and_the_usable_area():
+    """The band the toolbar sits in is the gap between the two rectangles, not
+    between the card and the screen.
+
+    Placed against the surface's own height, the chrome clears the card and
+    lands on whatever is on that edge - which is what stage 4 shipped: the
+    toolbar over the bar's widgets and the tab bar over the dock's. Both
+    rectangles come from the module and both are functions of the same
+    progress, so the placement carries no motion of its own either.
+    """
+    content = code(CHROME_CONTENT)
+    assert re.search(r"property rect area:", content), \
+        "the chrome content takes the usable area as well as the card"
+    for term in ("root.area.y", "root.area.height"):
+        assert term in content, f"the chrome does not place itself off {term}"
+    # The screen's own edges are exactly what it may no longer measure from.
+    assert not re.search(r"\(root\.height\s*-\s*root\.card", content), \
+        "the tab bar is placed against the screen's bottom edge, not the usable area's"
+    assert "EditMode.areaRect(" in code(CHROME_SURFACE), \
+        "the usable area must come from the module, not be rebuilt on the surface"
+
+
+def test_the_cards_edge_is_a_bevel_rather_than_a_bevel_around_a_line():
+    """No tone on the edge may be drawn between the specular and the inner
+    highlight.
+
+    A 1px `colLayer0Border` outline sat there, and measured on the real desktop
+    it was a notch - up to 70/255 below the lower of the two bright bands either
+    side of it. A bevel falls off its crest into the surface; a stack of bands
+    does not, and the eye reads the dark line as the card's edge with the bright
+    band as a piping outside it. `test_edit_mode_chrome.py` scores the profile
+    in pixels; this is the source half, because the outline is the kind of thing
+    that comes back as "every floating surface carries one".
+
+    docs/M3_GUIDELINES.md §1 is what licenses its absence rather than what it is
+    traded against: "visible borders are not required for every surface", and
+    the job it gives the outline - defining edges against complex backgrounds -
+    is the job the bevel exists to do, because the outline could not do it over
+    a wallpaper.
+    """
+    card = code(CARD)
+    assert "colLayer0Border" not in card, \
+        "the card's edge is a bevel; an outline through it is a seam"
+    # ...and the roll-off is the corner's, not a number someone picked. A stop
+    # at a literal fraction is a rim that is bright right round the bend, which
+    # is a stroke however bright it is - the thing the file's own comment
+    # forbids.
+    roll_off = declaration(card, "edgeRollOff")
+    assert "cardRadius" in roll_off, \
+        f"the specular's roll-off must be expressed against the corner radius: {roll_off!r}"
+    assert card.count("root.edgeRollOff") >= 2, \
+        "the roll-off must bound the crest at both ends of the flank"
 
 
 if __name__ == "__main__":

--- a/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
@@ -631,8 +631,13 @@ def test_the_bar_and_the_dock_have_exactly_one_answer_for_where_they_are():
     insets = code(INSETS)
     assert re.search(r"^pragma Singleton", insets, re.M), \
         "the insets are one object, not a component each surface instantiates"
-    assert "DockGeometry.thickness(" in insets and "DockGeometry.outwardSide(" in insets, \
-        "the dock's edge and thickness come from the dock's own module"
+    assert "DockGeometry.thickness(" in insets, \
+        "the dock's thickness comes from the dock's own module"
+    # The bar's overloaded pair and the dock's stored edge both become an edge
+    # NAME in dock_geometry.js and nowhere else - `test_dock_position_contract.py`
+    # owns that rule and caught this file re-deriving both on its first run.
+    assert "DockGeometry.barEdge(" in insets and "DockGeometry.normalizedEdge(" in insets, \
+        "an edge name is derived in the dock's module, not spelled out again"
 
     for path in (BACKGROUND, CHROME_SURFACE):
         text = code(path)

--- a/dots/.config/quickshell/imi/tests/tst_edit_mode.qml
+++ b/dots/.config/quickshell/imi/tests/tst_edit_mode.qml
@@ -216,4 +216,140 @@ TestCase {
         fuzzyCompare(settled.width, wide.width, 1e-9);
         fuzzyCompare(settled.height, wide.height, 1e-9);
     }
+
+    // ---- the bar and the dock keep their edges ---------------------------
+    //
+    // The two panels stay where they are at full size (spec §12 stage 8 is
+    // editing them in place, and this is not it), so the mode's whole geometry
+    // happens inside what is left of the screen. Stage 4 shipped without this
+    // and put the toolbar over the bar's widgets and the tab bar over the
+    // dock's; every case below is a way that comes back.
+
+    // The numbers this machine's compositor reports for its own two panels
+    // (`hyprctl layers`: quickshell:bar at y=5 h=63, quickshell:dock 75 tall),
+    // and deliberately UNEQUAL - a top and a bottom inset that match are
+    // indistinguishable from a symmetric margin, and every "which edge did you
+    // subtract" bug passes on them.
+    readonly property real barInset: 68
+    readonly property real dockInset: 75
+    readonly property real chrome: 56
+
+    readonly property var framed: EditMode.viewportGeometry({
+        screenWidth: 5120, screenHeight: 1440, drawerWidth: 400, margin: 24,
+        chromeThickness: chrome, insetTop: barInset, insetBottom: dockInset
+    })
+
+    function test_the_usable_area_is_the_screen_minus_what_the_panels_occupy() {
+        const area = EditMode.usableArea({
+            screenWidth: 5120, screenHeight: 1440,
+            insetTop: barInset, insetBottom: dockInset, insetLeft: 12, insetRight: 30
+        });
+        compare(area.x, 12);
+        compare(area.y, barInset);
+        compare(area.width, 5120 - 12 - 30);
+        compare(area.height, 1440 - barInset - dockInset);
+        // Absent insets are zero, which is the geometry the mode had before it
+        // knew about either panel - not an error and not a default guess.
+        const bare = EditMode.usableArea({ screenWidth: 800, screenHeight: 600 });
+        compare(bare.x, 0);
+        compare(bare.y, 0);
+        compare(bare.width, 800);
+        compare(bare.height, 600);
+    }
+
+    function test_the_desktop_leaves_the_chrome_a_band_of_its_own() {
+        // The band above and below the card is a margin, the toolbar, and
+        // another margin - so the toolbar centred in it has a whole margin at
+        // each end BY CONSTRUCTION rather than by whatever the ceiling left
+        // over. That is the correction: the old band was 100.8px at this screen
+        // size and the toolbar is 56 centred in it, which starts 22.4px into a
+        // screen whose bar occupies the first 68.
+        const bandTop = framed.y - barInset;
+        const bandBottom = (1440 - dockInset) - (framed.y + framed.height);
+        fuzzyCompare(bandTop, 24 + chrome + 24, 0.5);
+        fuzzyCompare(bandBottom, 24 + chrome + 24, 0.5);
+        // ...and the vertical constraint is what decides the scale here, which
+        // is what makes the two numbers above a promise rather than a
+        // coincidence of the ceiling.
+        verify(framed.scale < EditMode.MAX_SCALE);
+    }
+
+    function test_the_desktop_rests_dead_centre_of_the_usable_area() {
+        // Centre of what is LEFT, not of the panel: the margins are equal in
+        // pairs against the area's edges, and the card is strictly inside the
+        // two panels' bands. A geometry that centred on the screen would put
+        // the card 3.5px lower here and its chrome on the bar, which is the
+        // failure this replaces - so the check is the containment as well as
+        // the symmetry.
+        const area = framed.area;
+        fuzzyCompare(framed.x - area.x,
+            (area.x + area.width) - (framed.x + framed.width), 1e-6);
+        fuzzyCompare(framed.y - area.y,
+            (area.y + area.height) - (framed.y + framed.height), 1e-6);
+        verify(framed.y >= barInset);
+        verify(framed.y + framed.height <= 1440 - dockInset);
+    }
+
+    function test_a_panel_on_a_side_edge_takes_from_the_horizontal_room_too() {
+        // The bar is vertical on this setting and the dock has four edges, so
+        // the left and right insets are not decoration. Measured where the
+        // horizontal constraint binds, or the ceiling answers for both.
+        const sided = EditMode.viewportGeometry({
+            screenWidth: 1600, screenHeight: 1000, drawerWidth: 400, margin: 24,
+            insetLeft: 60, insetRight: 40
+        });
+        fuzzyCompare(sided.width, 1600 - 60 - 40 - 400 - 48, 0.5);
+        verify(sided.x >= 60);
+        verify(sided.x + sided.width <= 1600 - 40);
+    }
+
+    function test_no_insets_and_no_chrome_is_the_geometry_the_mode_had_before() {
+        // The regression pin for every case above this section: adding the two
+        // terms must not have moved the answer for a caller that passes
+        // neither. If this ever needs updating, the mode's geometry changed for
+        // a screen with no bar and no dock, which nothing here intends.
+        const plain = EditMode.viewportGeometry({
+            screenWidth: 5120, screenHeight: 1440, drawerWidth: 400, margin: 24
+        });
+        compare(plain.scale, wide.scale);
+        compare(plain.x, wide.x);
+        compare(plain.y, wide.y);
+        compare(plain.area.x, 0);
+        compare(plain.area.y, 0);
+        compare(plain.area.width, 5120);
+        compare(plain.area.height, 1440);
+    }
+
+    function test_the_chromes_band_closes_in_as_the_desktop_shrinks() {
+        // The chrome is placed between `areaRect` and `cardRect`, and at
+        // progress 0 the two coincide - so both bands have zero height and both
+        // pieces are parked half off screen, arriving WITH the desktop rather
+        // than sliding in from wherever the bar happens to end. A band fixed at
+        // the usable area would put the toolbar just under the bar from the
+        // first frame of the entry.
+        const start = EditMode.areaRect(framed, 0, 5120, 1440);
+        compare(start.x, 0);
+        compare(start.y, 0);
+        compare(start.width, 5120);
+        compare(start.height, 1440);
+
+        const end = EditMode.areaRect(framed, 1, 5120, 1440);
+        fuzzyCompare(end.y, barInset, 1e-9);
+        fuzzyCompare(end.height, 1440 - barInset - dockInset, 1e-9);
+
+        const half = EditMode.areaRect(framed, 0.5, 5120, 1440);
+        fuzzyCompare(half.y, barInset / 2, 1e-9);
+        fuzzyCompare(half.height, (1440 + (1440 - barInset - dockInset)) / 2, 1e-9);
+
+        // And the band it opens is never negative once the mode has arrived,
+        // at any progress: the card is inside the area for every t, because
+        // both rectangles are linear in t and the containment holds at both
+        // ends.
+        for (const t of [0.2, 0.5, 0.9, 1]) {
+            const card = EditMode.cardRect(framed, t, 5120, 1440);
+            const area = EditMode.areaRect(framed, t, 5120, 1440);
+            verify(card.y >= area.y - 1e-6);
+            verify(card.y + card.height <= area.y + area.height + 1e-6);
+        }
+    }
 }

--- a/dots/.config/quickshell/imi/tests/tst_edit_mode_insets.qml
+++ b/dots/.config/quickshell/imi/tests/tst_edit_mode_insets.qml
@@ -1,0 +1,152 @@
+import QtQuick
+import QtTest
+import qs.modules.common
+import qs.modules.imi.editMode
+import "../modules/imi/dock/dock_geometry.js" as DockGeometry
+
+// What Edit Mode subtracts from the screen before it shrinks the desktop into
+// what is left: the bar's edge and the dock's.
+//
+// `tst_edit_mode.qml` proves the arithmetic that consumes these four numbers
+// and takes them as arguments. This is the other half - that the numbers handed
+// in are the ones the two panels really occupy - and it is reachable here for
+// the same reason `tst_bar_geometry.qml` is: they are arithmetic between real
+// `Appearance` tokens and real `Config` values, with no surface involved.
+//
+// The expectations are the sizes the compositor reports on the machine this was
+// measured against (`hyprctl layers`: `quickshell:bar` at y=5 h=63,
+// `quickshell:dock` 5120x75), rather than the expression restated - a check
+// that restates the expression agrees with itself whatever the expression says.
+TestCase {
+    name: "EditModeInsetsTest"
+
+    property int savedCornerStyle: 0
+    property bool savedBottom: false
+    property bool savedVertical: false
+    property bool savedAutoHide: false
+    property bool savedDockEnable: true
+    property string savedDockEdge: "bottom"
+
+    function initTestCase() {
+        savedCornerStyle = Config.options.bar.cornerStyle;
+        savedBottom = Config.options.bar.bottom;
+        savedVertical = Config.options.bar.vertical;
+        savedAutoHide = Config.options.bar.autoHide.enable;
+        savedDockEnable = Config.options.dock.enable;
+        savedDockEdge = Config.options.dock.edge;
+    }
+
+    function cleanupTestCase() {
+        Config.options.bar.cornerStyle = savedCornerStyle;
+        Config.options.bar.bottom = savedBottom;
+        Config.options.bar.vertical = savedVertical;
+        Config.options.bar.autoHide.enable = savedAutoHide;
+        Config.options.dock.enable = savedDockEnable;
+        Config.options.dock.edge = savedDockEdge;
+    }
+
+    function detached() {
+        Config.options.bar.cornerStyle = 3;
+        Config.options.bar.bottom = false;
+        Config.options.bar.vertical = false;
+        Config.options.bar.autoHide.enable = false;
+    }
+
+    function test_the_bars_surface_is_the_size_the_compositor_reports() {
+        detached();
+        compare(Appearance.sizes.barSurfaceHeight, 63);
+        compare(Appearance.sizes.barSurfaceMargin, 5);
+        compare(Appearance.sizes.barSurfaceThickness, 68);
+    }
+
+    function test_the_bar_reserves_its_body_and_its_corner_decorators_alike() {
+        // The surface is 23px taller than the 40px body: `screenRounding`, for
+        // the corner decorators that hang below it and take clicks there. The
+        // reservation is the SURFACE, which is also the number `hyprctl layers`
+        // reports, so a regression here is a number rather than an impression
+        // that something moved.
+        detached();
+        compare(Appearance.sizes.barSurfaceHeight - Appearance.sizes.barHeight,
+            Appearance.rounding.screenRounding);
+    }
+
+    function test_auto_hide_moves_the_gap_inside_the_surface_without_changing_its_reach() {
+        // `barDetachInset` takes the gap off the margin and puts it inside the
+        // window, so the surface reaches the same distance from the edge either
+        // way - which is what makes reserving against configuration rather than
+        // against the current hidden/shown state a stable number.
+        detached();
+        const shown = Appearance.sizes.barSurfaceThickness;
+        Config.options.bar.autoHide.enable = true;
+        compare(Appearance.sizes.barSurfaceThickness, shown);
+        compare(Appearance.sizes.barSurfaceMargin, 0);
+        Config.options.bar.autoHide.enable = false;
+    }
+
+    function test_the_dock_reserves_the_thickness_its_own_module_derives() {
+        // Not a second copy of the sum: `dock_geometry.js` is where the dock's
+        // thickness lives and this is the same call the dock's own window
+        // makes. At the defaults it is the 75 the compositor reports.
+        compare(DockGeometry.thickness(60, Appearance.sizes.elevationMargin,
+            Appearance.sizes.hyprlandGapsOut), 75);
+    }
+
+    function test_the_insets_land_on_the_edges_the_two_panels_are_on() {
+        detached();
+        Config.options.dock.enable = true;
+        Config.options.dock.edge = "bottom";
+        let insets = EditModeInsets.insetsFor("DP-1");
+        compare(insets.top, 68);
+        compare(insets.bottom, 75);
+        compare(insets.left, 0);
+        compare(insets.right, 0);
+
+        // A bottom bar over a bottom dock share an edge, so the two terms ADD
+        // rather than the larger winning - the chrome has to clear both.
+        Config.options.bar.bottom = true;
+        insets = EditModeInsets.insetsFor("DP-1");
+        compare(insets.top, 0);
+        compare(insets.bottom, 68 + 75);
+
+        // A vertical bar moves onto a side edge, where `bar.bottom` means right
+        // rather than bottom.
+        Config.options.bar.vertical = true;
+        insets = EditModeInsets.insetsFor("DP-1");
+        compare(insets.bottom, 75);
+        compare(insets.right, Appearance.sizes.verticalBarSurfaceWidth);
+        compare(insets.left, 0);
+
+        Config.options.bar.vertical = false;
+        Config.options.bar.bottom = false;
+    }
+
+    function test_a_dock_that_is_switched_off_reserves_nothing() {
+        detached();
+        Config.options.dock.enable = false;
+        const insets = EditModeInsets.insetsFor("DP-1");
+        compare(insets.bottom, 0);
+        // ...and the bar's edge is still reserved, so this cannot pass by
+        // returning zeros for everything.
+        compare(insets.top, 68);
+        Config.options.dock.enable = true;
+    }
+
+    function test_a_screen_the_bar_is_not_drawn_on_gets_none_of_its_inset() {
+        detached();
+        verify(EditModeInsets.barShownOn("DP-1"));
+        Config.options.bar.screenList = ["HDMI-A-1"];
+        verify(!EditModeInsets.barShownOn("DP-1"));
+        verify(EditModeInsets.barShownOn("HDMI-A-1"));
+        compare(EditModeInsets.insetsFor("DP-1").top, 0);
+        Config.options.bar.screenList = [];
+        verify(EditModeInsets.barShownOn("DP-1"));
+    }
+
+    function test_the_toolbar_reserves_the_height_a_toolbar_is() {
+        // The viewport reserves a band on the background surface, where no
+        // toolbar exists to measure. This is the one number both it and
+        // `Toolbar.qml` read; if they ever stop agreeing the chrome lands in a
+        // band that is not its size.
+        compare(Appearance.sizes.toolbarHeight, 56);
+    }
+}

--- a/dots/.config/quickshell/imi/tests/tst_grouped_list.qml
+++ b/dots/.config/quickshell/imi/tests/tst_grouped_list.qml
@@ -23,29 +23,34 @@ TestCase {
     height: 400
     visible: true
 
-    Component {
-        id: groupComponent
-        GroupedList {
-            id: group
-            width: 300
-            property alias firstRow: first
-            property alias middleRow: middle
-            property alias lastRow: last
-            Item {
-                id: first
-                implicitHeight: 40
-                property bool rowVisible: true
-            }
-            Item {
-                id: middle
-                implicitHeight: 40
-                property bool rowVisible: true
-            }
-            // Declares nothing, which is what almost every row in the shell
-            // does - it must still be drawn, and it must still be able to hold
-            // the group's bottom corner.
-            Item { id: last; implicitHeight: 40 }
+    // Built from a URL rather than declared inline. `GroupedList` uses
+    // per-corner `Rectangle` radii, which arrived in Qt 6.7 - and an inline
+    // component is compiled with this file, so on an older Qt the whole
+    // TestCase goes unavailable and all five cases are lost with it. CI runs
+    // Ubuntu's Qt and that is exactly what happened the first time this landed:
+    // one FAIL reading `Type GroupedList unavailable`, with the real cause
+    // ("Cannot assign to non-existent property bottomRightRadius") one line
+    // further down.
+    //
+    // Through `createComponent` the version dependency is a STATUS, so the
+    // skip is specific: an error naming a per-corner radius is a Qt too old for
+    // the widget the shell ships, and any other error is still a failure.
+    property Component groupComponent: null
+
+    function initTestCase() {
+        groupComponent = Qt.createComponent("fixtures/GroupedListRows.qml");
+        if (groupComponent.status === Component.Error) {
+            const reason = groupComponent.errorString();
+            verify(/(top|bottom)(Left|Right)Radius/.test(reason),
+                "GroupedList failed to build for a reason that is not Qt's version: " + reason);
         }
+    }
+
+    function ensureComponent() {
+        if (groupComponent.status === Component.Error)
+            skip("Qt is older than 6.7, so the per-corner radii GroupedList "
+                + "draws its group with do not exist here");
+        compare(groupComponent.status, Component.Ready, groupComponent.errorString());
     }
 
     function plates(group) {
@@ -62,6 +67,7 @@ TestCase {
     }
 
     function test_a_hidden_row_takes_no_height_and_no_spacing() {
+        ensureComponent();
         const group = createTemporaryObject(groupComponent, this);
         verify(group);
         waitForRendering(group);
@@ -81,6 +87,7 @@ TestCase {
     }
 
     function test_the_rows_either_side_of_it_close_up() {
+        ensureComponent();
         const group = createTemporaryObject(groupComponent, this);
         verify(group);
         waitForRendering(group);
@@ -93,6 +100,7 @@ TestCase {
     }
 
     function test_the_groups_corners_follow_the_rows_that_are_drawn() {
+        ensureComponent();
         const group = createTemporaryObject(groupComponent, this);
         verify(group);
         waitForRendering(group);
@@ -117,6 +125,7 @@ TestCase {
         // `undefined`, and the group must take the `?? true` rather than
         // reading it as hidden - which is what a plain truthiness test on the
         // wrong side of the `??` would do, silently, to every group.
+        ensureComponent();
         const group = createTemporaryObject(groupComponent, this);
         verify(group);
         waitForRendering(group);
@@ -132,6 +141,7 @@ TestCase {
         // four more toggles while the control followed every one. The Edit
         // layout row toggles on every entry to and exit from the mode, so the
         // latch would cost the menu that row permanently after the first edit.
+        ensureComponent();
         const group = createTemporaryObject(groupComponent, this);
         verify(group);
         waitForRendering(group);

--- a/dots/.config/quickshell/imi/tests/tst_grouped_list.qml
+++ b/dots/.config/quickshell/imi/tests/tst_grouped_list.qml
@@ -1,0 +1,149 @@
+import QtQuick
+import QtTest
+import qs.modules.common
+import qs.modules.common.widgets
+
+// A `GroupedList` row that is not drawn must take no room.
+//
+// The plates are built by a `Repeater` over the declared items and each sizes
+// itself from its item's `implicitHeight`; nothing asked whether the item was
+// drawn, so a hidden row kept a row-height band of `bgcolor` with nothing in
+// it. Two call sites had it - the desktop menu's Edit layout row, which
+// disappears while Edit Mode is on, and Settings > Services > Weather's
+// OWM-only API-key field.
+//
+// The mechanism the fix could NOT use has its own case below: `Item.visible`
+// reads back EFFECTIVE visibility, so a plate that hid itself from its own
+// child's `visible` would hide the child and then read false for ever. That is
+// the one regression a reviewer would introduce while "simplifying" this.
+TestCase {
+    name: "GroupedListTest"
+    when: windowShown
+    width: 400
+    height: 400
+    visible: true
+
+    Component {
+        id: groupComponent
+        GroupedList {
+            id: group
+            width: 300
+            property alias firstRow: first
+            property alias middleRow: middle
+            property alias lastRow: last
+            Item {
+                id: first
+                implicitHeight: 40
+                property bool rowVisible: true
+            }
+            Item {
+                id: middle
+                implicitHeight: 40
+                property bool rowVisible: true
+            }
+            // Declares nothing, which is what almost every row in the shell
+            // does - it must still be drawn, and it must still be able to hold
+            // the group's bottom corner.
+            Item { id: last; implicitHeight: 40 }
+        }
+    }
+
+    function plates(group) {
+        // The plates are the Repeater's delegates: the children of the
+        // ColumnLayout the group builds, which is its only child item.
+        const column = group.children[0];
+        const out = [];
+        for (let i = 0; i < column.children.length; i++) {
+            const child = column.children[i];
+            if (child.hasOwnProperty("topLeftRadius"))
+                out.push(child);
+        }
+        return out;
+    }
+
+    function test_a_hidden_row_takes_no_height_and_no_spacing() {
+        const group = createTemporaryObject(groupComponent, this);
+        verify(group);
+        waitForRendering(group);
+        const full = group.implicitHeight;
+        verify(full > 0);
+
+        group.middleRow.rowVisible = false;
+        waitForRendering(group);
+        // One plate and one spacing gone: the plate is the row plus the group's
+        // vertical padding, and a ColumnLayout leaves an invisible child out of
+        // the spacing too. Both terms, because collapsing only the height
+        // leaves a doubled gap where the row was - which is the other half of
+        // "an empty row-height gap between Widgets and DropShelf".
+        const expected = full - (40 + group.itemVerticalPadding)
+            - Appearance.spacing.space25;
+        fuzzyCompare(group.implicitHeight, expected, 0.5);
+    }
+
+    function test_the_rows_either_side_of_it_close_up() {
+        const group = createTemporaryObject(groupComponent, this);
+        verify(group);
+        waitForRendering(group);
+        group.middleRow.rowVisible = false;
+        waitForRendering(group);
+
+        const drawn = plates(group).filter(plate => plate.visible);
+        compare(drawn.length, 2);
+        fuzzyCompare(drawn[1].y, drawn[0].y + drawn[0].height + Appearance.spacing.space25, 0.5);
+    }
+
+    function test_the_groups_corners_follow_the_rows_that_are_drawn() {
+        const group = createTemporaryObject(groupComponent, this);
+        verify(group);
+        waitForRendering(group);
+        const all = plates(group);
+        compare(all.length, 3);
+        compare(all[0].topLeftRadius, group.bigRadius);
+        compare(all[1].topLeftRadius, group.smallRadius);
+
+        // Hiding the FIRST row must move the group's outer corner onto the new
+        // first, or the group is drawn with a square top on a hidden plate's
+        // behalf. `isFirst` read off the declared index does exactly that.
+        group.firstRow.rowVisible = false;
+        waitForRendering(group);
+        compare(all[1].topLeftRadius, group.bigRadius);
+        compare(all[1].bottomLeftRadius, group.smallRadius);
+        compare(all[2].bottomLeftRadius, group.bigRadius);
+    }
+
+    function test_a_row_that_declares_nothing_is_drawn() {
+        // The last row declares no `rowVisible` at all, which is what almost
+        // every row in the shell does. An undeclared property reads
+        // `undefined`, and the group must take the `?? true` rather than
+        // reading it as hidden - which is what a plain truthiness test on the
+        // wrong side of the `??` would do, silently, to every group.
+        const group = createTemporaryObject(groupComponent, this);
+        verify(group);
+        waitForRendering(group);
+        const drawn = plates(group).filter(plate => plate.visible);
+        compare(drawn.length, 3);
+    }
+
+    function test_a_row_that_comes_back_is_drawn_again() {
+        // The case that rules out the obvious fix. `Item.visible` is EFFECTIVE
+        // visibility, so a plate bound to its own child's `visible` hides the
+        // child, then reads false, then never lets it back - probed with
+        // `qml6` against a control row, the mirrored one stayed false through
+        // four more toggles while the control followed every one. The Edit
+        // layout row toggles on every entry to and exit from the mode, so the
+        // latch would cost the menu that row permanently after the first edit.
+        const group = createTemporaryObject(groupComponent, this);
+        verify(group);
+        waitForRendering(group);
+        const full = group.implicitHeight;
+
+        group.middleRow.rowVisible = false;
+        waitForRendering(group);
+        verify(group.implicitHeight < full);
+
+        group.middleRow.rowVisible = true;
+        waitForRendering(group);
+        fuzzyCompare(group.implicitHeight, full, 0.5);
+        compare(plates(group).filter(plate => plate.visible).length, 3);
+    }
+}


### PR DESCRIPTION
Three corrections to Edit Mode, all three found by looking at it on the real
desktop at 5120x1440 rather than by reasoning about the source. This is the
first branch in the series that was loaded as a live shell.

## 1. The desktop menu's hole was a plate, not a row

The menu grew an empty row-height band of `colLayer0` between **Widgets** and
**DropShelf** whenever the mode was on. The row was hidden correctly; its PLATE
was not.

`GroupedList` builds one `Rectangle` per declared item and sizes it as
`item.implicitHeight + itemVerticalPadding`, which never asked whether the item
was drawn — so `visible: false` left a full-height plate painting the group's own
background with nothing in it, and the group's outer corners still belonged to
whichever row was first or last by *declaration*. Settings > Services > Weather
has the same hole: the OpenWeatherMap API-key field is provider-gated and leaves
the same empty plate on wttr.in. Both call sites are fixed, but the defect is the
widget's.

**The plate cannot simply mirror its item's `visible`, and that is the reason for
the new property rather than a smaller diff.** `Item.visible` reads back
EFFECTIVE visibility — the item's own flag AND its parents' — and the item is
reparented INTO the plate, so a plate bound to it hides the item and then reads
`false` for ever. Probed with `qml6` against a control row:

```
gate=true   A(child)=false  B(child)=false B(wrapper)=false
gate=false  A(child)=true   B(child)=false B(wrapper)=false
gate=true   A(child)=false  B(child)=false B(wrapper)=false
gate=false  A(child)=true   B(child)=false B(wrapper)=false
```

The control follows every toggle; the mirrored one latches on the first hide,
with no warning and no binding-loop message. The Edit layout row toggles on every
entry to and exit from the mode, so that would cost the menu the row permanently
after one edit. So a row that comes and goes declares `rowVisible`; a row that
never disappears declares nothing, reads `undefined`, and takes the `?? true`.

## 2. The chrome overlapping the bar and the dock

Stage 4 shipped this knowingly, and the reasoning was that no placement clears a
bar of unknown height without tuning a literal against
`Appearance.sizes.barHeight`. That is true of a *placement* and false of a
*derivation*.

`viewportGeometry` takes four **insets** and a **chrome thickness** on top of the
drawer's width, and the two answer different questions:

- the insets say which part of the screen the mode may use, so the desktop
  shrinks inside what is left and rests dead centre **of that**;
- the chrome thickness makes the band above and below the card
  `margin + toolbarHeight + margin`, so the toolbar centred in it has a whole
  margin at each end **by construction**. The old band was whatever the ceiling
  left over — 100.8px at 5120x1440 for a 56px toolbar, which starts 22.4px into a
  screen whose bar occupies the first 68.

Passing neither term reproduces the old geometry property for property, which
`tst_edit_mode.qml` pins as its own case.

**What is reserved is each panel's LAYER SURFACE**, not its painted body: the
bar's carries the screen-corner decorators below it and the dock's carries its
elevation margin, both take clicks there, and the surface extent is the number
the compositor reports — so `hyprctl layers` is a check on this rather than an
unrelated measurement. Measured on this machine: `quickshell:bar` at y=5 h=63 and
`quickshell:dock` 5120x75, which are `Appearance.sizes.barSurfaceThickness` (68)
and `DockGeometry.thickness(60, 10, 5)` (75).

**And the reservation is a function of CONFIGURATION only** — never of auto-hide,
a hover reveal, `GlobalStates.barOpen`, or a fullscreen window dropping the
dock's exclusive zone. All four move while the mode is on, and a viewport that
changes size mid-edit rescales every widget under the cursor and hands every
`Behavior` carrying the box a moving target (b710ef731). It is the same decision
`edit_mode.js` already makes about the drawer's width.

`EditModeInsets` is the one derivation. Everything else about the geometry is
re-derived on both surfaces because every input is an `Appearance` token and the
same screen; these four are not, and a second file working out where the dock is
is a second answer to that question.

**What it costs, stated rather than buried:** the four margins are no longer
equal in pairs *mid-flight*, because the destination is no longer the screen's
centre. What replaced that in the checks is stronger and is what the eye follows
— every corner still travels in a straight line, because both terms of each
corner's position are linear in `t`. At rest the margins are equal in pairs
against the usable area, and the card's centre is **3.5px** from the screen's own
on a 1440-tall panel, so "shrink at dead centre" survives the re-reading rather
than being traded away by it.

Measured live afterwards: the card lands at 624,172 3872x1089; the toolbar body
occupies y 92-148 against a bar that ends at 68, and the tab bar y 1286-1341
against a dock that starts at 1365. 24px clear at both, which is
`editModeMargin`.

## 3. The glass edge

"The glassy border effect... I don't know why but it feels off" is a perception
with no diagnosis attached, so this starts with the measurement. Walked round the
perimeter of the real card, over the wallpaper the machine was showing:

| | before | after |
| --- | --- | --- |
| notch depth, median / worst | 6.8 / **50.1** | **0.0 / 5.3** |
| crest above the range it sits in — top median | 113.5 | 88.8 |
| ...left flank median | 42.7 | 27.2 |
| ...spread across the perimeter | 0 – 125 | 0 – 109 |
| worst excursion anywhere | 6.4 | 1.8 |

Two defects, and the first is the answer:

**It was a bevel around a LINE.** The 1px `colLayer0Border` outline stayed, drawn
between the specular outside the card and the highlight inside it, so walking
inward the profile went shade, crest, *dark line*, highlight, desktop — a notch of
up to 70/255 below the lower of the two bright bands either side of it, on all
four edges. A bevel falls off its crest into the surface; this one fell, rose and
fell, so the eye reads the dark line as the card's edge and the bright band as a
piping outside it. At the top-left corner that is exactly what it looks like:
chrome trim with a seam in it.

The outline is gone, and `docs/M3_GUIDELINES.md` §1 is what licenses that rather
than what it is traded against — "visible borders are not required for every
surface", and the job the guideline gives an outline, to "clearly define edges
against complex backgrounds", is the job this bevel exists to do *because* the
outline could not do it over a wallpaper. One edge treatment, not two stacked.

**And "brightest along the top" was a stroke**, because the gradient ran over the
bounding box: the run from the top's value to the flank's was half the card, so
the whole 4403px top edge sat at one strength and both top corners with it. The
roll-off belongs to the **corner arc**, which is precisely the run over which the
outline's normal turns from facing up to facing sideways, and it is expressed as
`cardRadius / card.height` rather than as a stop someone picked — so a change to
the corner moves the light with it.

Reported as measured rather than as an unbroken win: the worst point on the
perimeter is 1.8/255 against 6.4 before. Both are "no edge here", at the same
place — over the brightest part of the blurred backdrop — and the cause is
structural rather than a tuning miss: the shade band is drawn UNDER the specular,
so the crest composites on a darkened base and cannot clear a bright backdrop by
much at the bottom. Separating them costs a second mask, which is the cost this
component is arranged to avoid.

## Tests

Suite: `run_tests.sh` green end to end. `qmltestrunner` **899 -> 922 passed, 0
failed** — re-measured on `gh/main` in its own worktree rather than taken from
the record. It ran alongside another agent's suite in a second worktree, which
share weston socket names; nothing failed, but that is worth knowing if CI
disagrees.

New:

- `tst_grouped_list.qml` — 5 cases on a real `GroupedList`. The one that earns
  its place is *a hidden row that comes back is drawn again*, which is the case
  the plausible alternative fix fails.
- `tst_edit_mode.qml` — 6 cases: the usable area, the chrome's band, dead centre
  of the area, a side inset, the band closing in from the whole screen, and the
  regression pin that neither term changes the old geometry. The insets used are
  68 and 75 and are deliberately UNEQUAL — a matching pair is indistinguishable
  from a symmetric margin and every "which edge did you subtract" bug passes on
  it.
- `tst_edit_mode_insets.qml` — 8 cases on the real singleton against a real
  `Config`, with `hyprctl layers`' numbers as the expectations rather than the
  expressions restated.
- `test_edit_mode_contract.py` 23 → 27: one answer for where the panels are; the
  reservation cannot follow anything that moves; the chrome is placed between the
  card and the usable area; and no tone between the specular and the inner
  highlight.
- `test_edit_mode_chrome.py` 11 → 13 pixel checks, look probe 13 → 14 harness
  checks. The probe stands two opaque bands on the reserved edges, **under** the
  chrome, so an overlap paints the toolbar's colour inside a band instead of
  being hidden by it.

Changed rather than loosened: the mid-animation pixel check asserted vertical
centring, which an off-centre destination cannot keep; it asserts the straight
line now, with `t` recovered from the *drawn* scale so nothing reads the
interpolation back out of the function that produced it — and a scale about the
top-left, the regression it was written for, still fails it.

**Nineteen mutations planted in a clean tree, each reverted after; every one
reddened, none stayed green.** Two are worth naming:

- *the plate mirrors the row's own `visible`* — the latch. Reddens four of the
  five GroupedList cases, which is what makes the probe above worth having
  written down rather than described.
- *the chrome grows a decoration that overhangs its own rect* (a 40px block above
  the toolbar, geometry untouched) — reddens `test_the_chrome_keeps_off_the_bar_
  and_the_dock` **and nothing else in either half**, which is the class the pixel
  check exists for and no rect assertion can reach.

`test_dock_position_contract.py` caught the new singleton on its first full-suite
run, on both of its one-derivation rules, and was right on both — the dock's
stored edge may go only straight into `normalizedEdge()`, and the bar's
overloaded pair becomes an edge name in `DockGeometry.barEdge()` and nowhere
else. Its own commit, with the miss in the message.

## Live testing

Deployed to `~/.config/quickshell/imi` and the shell restarted, with the
maintainer's explicit authorisation and at the machine. Entered through a
temporary `IpcHandler` on `GlobalStates.editMode` applied to the deployed copy
only — never committed, and removed by the final clean deploy — rather than
through a synthetic click, which is not evidence here. Full 5120x1440 frames and
1:1 crops for everything edge-sized; every number in this description is measured
off those frames.

Docs: updated AGENT.md §Edit Mode (the mode's size and position, the chrome's
placement, the card's edge), §Dynamic/data-driven QML gotchas (effective
visibility), §Design language (GroupedList), and the directory map.
