### PR TITLE
Edit Mode: the card's edge becomes a catch, not a rim

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -2498,18 +2498,71 @@ mode is built out of are worth not re-deriving:
   component is arranged to avoid. 1df616e62 ("fix(editMode): the card's edge
   stops having a seam drawn through it").
 
+  **And then all three tones went, because the sum of three defensible tones is
+  a border.** Every measurement above scores one tone at a time, and the
+  complaint that followed was about the whole card: *"edit mode's layout having
+  this thick border is what looked ugly for me. I want it to look glassy without
+  it having this thick border."* Walked inward across the left flank on the real
+  desktop — backdrop 28, shade 17, 17, specular 77, 77, highlight 128, desktop
+  105. Five drawn pixels of dark-then-bright piping at one strength the whole way
+  round a 3872px card, which is what a border *is*, and no per-tone number says
+  so. It is now ONE tone, `borderWidth.standard` wide: 0.44 along the top, 0.07
+  along the flank, 0.13 at the bottom.
+
+  Three things about why each tone could go, and they are the reusable part:
+
+  - **The shade band was a hard copy of the shadow.** It existed to carry the
+    edge over a bright picture, and `StyledRectangularShadow` is already a
+    darkening outside the card, from the same lamp, soft where the band was a
+    hard 4px lip. Two darkenings on one edge.
+  - **The inner highlight was 1df616e62's outline in the other colour.**
+    Anything drawn INSIDE the card cannot ride `surround`'s mask — that mask
+    removes exactly the card — so it is a uniform border by construction, at one
+    strength round the whole perimeter, and it composites over the DESKTOP rather
+    than over the backdrop. Measured, it was the brightest thing on the boundary
+    on three edges out of four: +41 levels over a wallpaper at 105 on the flank,
+    +35 over one at 36 along the top. A line brighter than the specular it is
+    supposedly supporting is the edge.
+  - **The catch and the shadow divide the perimeter rather than doubling up**,
+    and that falls out of the shadow's own `offset: (0, 1)` — weakest directly
+    above the card, strongest below, which is the opposite ordering to the catch.
+    Measured over the brightest wallpaper, the backdrop falls 172 → 158 above the
+    card and 237 → 146 below it. The boundary is a bright line where the shade is
+    thin and a pool of shade where the line is not.
+
+  What generalises past the card: **"is this glass or a border" is a question
+  about the whole perimeter, and non-uniformity is a RATIO rather than a
+  direction.** The edge that read as a border was already non-uniform — 0.46
+  along the top against 0.26 down the flank — and 0.26 of white on a 2px band all
+  the way round is a stroke a shade fainter, not a catch. `test_edit_mode_chrome.py`
+  scores three things now: a catch along the top (median 56.5/255), flanks and a
+  bottom that stay inside the range the backdrop and the desktop already span
+  (worst 0.0, against 31.0 and 37.8 before), and a drawn band at most two pixels
+  wide (1, against 5). The first of those is the one that had been missing:
+  **every edge check in that file passed with the edge removed entirely**, because
+  the notch check reads the profile from its crest inward and a bare ramp has no
+  notch in it. `test_edit_mode_contract.py` holds the source half — no
+  `border.width` anywhere in the file (the only way to draw a line the mask does
+  not cut, and what both retired lines were written as), no `colGlassShade`, the
+  width at `borderWidth.standard`, and the flank at most a quarter of the top.
+  ("fix(editMode): the card's edge becomes a catch, not a rim").
+
   Two things generalise.
-  The two outer tones are plain `Rectangle`s declared INSIDE `surround`, whose
-  layer is already masked to the complement of the card — so the mask cuts each
-  of them back to the band outside the card by itself and the shading is the
-  Rectangle's own gradient, which is why the whole treatment adds no layer, no
-  mask and no effect (measured under headless weston's software renderer, 14.91s
-  ± 0.22 of user CPU against 14.68s ± 0.32, indistinguishable on a 3-4% spread).
-  And its two colours are `Appearance.colors.colGlassSpecular`/`colGlassShade`,
-  the one pair in that file deliberately NOT derived from the wallpaper: every
-  other colour there is generated from the picture on screen, so an edge drawn in
-  one of them is guaranteed to be a colour the picture already contains. Same
-  reasoning as the depth picker's hardcoded contour.
+  The one outer tone is a plain `Rectangle` declared INSIDE `surround`, whose
+  layer is already masked to the complement of the card — so the mask cuts it
+  back to the band outside the card by itself and the shading is the Rectangle's
+  own gradient, which is why the whole treatment adds no layer, no mask and no
+  effect (measured under headless weston's software renderer, 14.91s ± 0.22 of
+  user CPU against 14.68s ± 0.32, indistinguishable on a 3-4% spread).
+  And its colour is `Appearance.colors.colGlassSpecular`, the one colour in that
+  file deliberately NOT derived from the wallpaper: every other colour there is
+  generated from the picture on screen, so an edge drawn in one of them is
+  guaranteed to be a colour the picture already contains. Same reasoning as the
+  depth picker's hardcoded contour. Its `colGlassShade` sibling went with the
+  shade band — nothing else had ever read it, and `lint_appearance_tokens.py`
+  fails on a token that is read and not declared, never on one declared and read
+  by nobody, so a dead token there rots silently. ("refactor(appearance): a glass
+  edge is one tone, so colGlassShade goes").
 
   Two things measured rather than argued while building the original. The shadow
   stays `StyledRectangularShadow` at the magnitude the component defines —
@@ -2626,7 +2679,8 @@ feat(editMode): draw the mode's toolbar and tab bar on a surface of their own,
 test(editMode): score the chrome against the desktop it frames,
 fix(widgetCanvas): the lattice comes up with the drag, not with the mode,
 feat(editMode): give the card's edge thickness instead of a drawn line,
-fix(editMode): stop the card's rounded corner biting a widget the user placed.)
+fix(editMode): stop the card's rounded corner biting a widget the user placed,
+fix(editMode): the card's edge becomes a catch, not a rim.)
 
 **The clock depth layer is the counter-case to that rule, and it is why it is a
 FOURTH sibling.** `widgetCanvas` sits at `z: 2` as a sibling of

--- a/dots/.config/quickshell/imi/modules/common/Appearance.qml
+++ b/dots/.config/quickshell/imi/modules/common/Appearance.qml
@@ -213,7 +213,7 @@ Singleton {
         property color colOnTooltip: m3colors.m3inverseOnSurface
         property color colScrim: ColorUtils.transparentize(m3colors.m3scrim, 0.5)
         property color colShadow: ColorUtils.transparentize(m3colors.m3shadow, 0.7)
-        // The two tones a glass edge is drawn in, and the one pair in this file
+        // The tone a glass edge is drawn in, and the one colour in this file
         // deliberately NOT derived from the wallpaper. Everything above is
         // generated from the picture on screen, so an edge drawn in one of those
         // roles is guaranteed to be a colour that picture already contains -
@@ -224,14 +224,20 @@ Singleton {
         // hardcoded contour (refactor(background): one cutout for the layer and
         // the picker to draw).
         //
-        // A PAIR rather than one colour, because that is what carries an edge
-        // over any wallpaper: the specular reads against a dark picture, the
-        // shade against a bright one, and a bevel wearing both is never entirely
-        // invisible. Opaque here - a call site picks its own weight with
-        // Qt.alpha, so one tone can appear at several strengths along the same
-        // edge without a token per strength.
+        // Opaque here - a call site picks its own weight with Qt.alpha, so one
+        // tone appears at several strengths along the same edge without a token
+        // per strength, which is what lets an edge be a catch along the top and
+        // almost nothing along the flanks.
+        //
+        // It shipped as a PAIR, with a `colGlassShade` black beside it, on the
+        // reasoning that a specular reads against a dark picture and a shade
+        // band against a bright one. The shade band went with the thick border
+        // it was half of: what darkens outside Edit Mode's card is `colShadow`
+        // two lines up, already drawn there, from the same lamp, and softly
+        // rather than as a hard 4px lip - so the shade band was a hard copy of
+        // the soft darkening underneath it. Nothing else had ever read the
+        // token. (fix(editMode): the card's edge becomes a catch, not a rim.)
         property color colGlassSpecular: "#ffffff"
-        property color colGlassShade: "#000000"
         property color colOutline: m3colors.m3outline
         property color colOutlineVariant: m3colors.m3outlineVariant
         property color colError: m3colors.m3error

--- a/dots/.config/quickshell/imi/modules/imi/background/EditModeCard.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/EditModeCard.qml
@@ -9,7 +9,7 @@ import qs.modules.common.widgets
  * The mode shrinks the desktop with a transform and nothing else, which leaves
  * a hard rectangular edge with no corner, no border and no shadow - a cropped
  * screenshot rather than a surface being edited. This is the chrome around it:
- * the blurred backdrop, the corner, the drop shadow and the outline, as one
+ * the blurred backdrop, the corner, the drop shadow and the edge, as one
  * component so the four cannot end up a pixel apart from each other or from the
  * desktop. Everything geometric comes from `card`, which is
  * `edit_mode.js`'s `cardRect` - the same arithmetic the transform is built out
@@ -56,38 +56,59 @@ Item {
 
     // ---- the glass edge ---------------------------------------------------
     //
+    // ONE tone, one pixel wide, and mostly not there. That is a correction of
+    // this file's own previous answer rather than a tuning of it.
+    //
     // The card used to end at a 1px colLayer0Border line, which is the shell's
     // outline for a floating surface and is right for a panel sitting on a
     // surface this file's own tokens were derived from. Over a WALLPAPER it is
-    // a drawn line rather than an edge: measured on this library's darkest
-    // picture the outline came back at 27/255 with the desktop at 0 inside it
-    // and the blurred backdrop at 12 outside, so the whole boundary was ten
-    // levels of contrast wide and read as a seam in a screenshot.
+    // a drawn line rather than an edge, so it was replaced by a bevel in three
+    // tones: a 4px shade band outside the card, a 2px specular on the edge, and
+    // a 1px highlight inside it. Each tone was defensible and the sum was a
+    // BORDER - measured on the real desktop at 5120x1440, walking inward across
+    // the left flank: backdrop 28, shade 17, 17, specular 77, 77, highlight
+    // 128, desktop 105. Five drawn pixels of dark-then-bright piping, at one
+    // strength the whole way round a 3872px card. Which is what "edit mode's
+    // layout having this thick border is what looked ugly" names.
     //
-    // What replaces it is a bevel with THICKNESS, in three tones, and the
-    // reason it is three is that no single one survives every wallpaper:
+    // What the three tones were each solving, and why none of them survives:
     //
-    //   - a shade band just OUTSIDE the card, so the card has a lip. It is what
-    //     carries the edge over a bright picture, where a specular cannot.
-    //   - a specular ON the edge, brightest along the top, rolling off round the
-    //     corners to a grazing flank and coming back as a weak bounce at the
-    //     bottom - the same lamp the drop shadow below is drawn for. A uniform
-    //     bright rim reads as a stroke; a rim that is brighter where light would
-    //     catch reads as a surface.
-    //   - a highlight just INSIDE, which is what gives the specular something to
-    //     be the outer face of rather than a line floating on the seam. It is
-    //     the innermost tone on the edge, and there is deliberately nothing
-    //     between it and the specular - see its own comment for the 1px outline
-    //     that used to be there and why a notch is not part of a bevel.
+    //   - the shade band gave the card a lip so the edge carried over a bright
+    //     picture. `StyledRectangularShadow` below is already a darkening
+    //     outside the card, from the same lamp, and it is the one the
+    //     maintainer says is right. Two darkenings outside one edge is the
+    //     shade band drawing a hard 2px copy of the soft one under it.
+    //   - the inner highlight gave the specular a near side. It is a uniform
+    //     line at the card's edge that composites over the DESKTOP, so it is
+    //     the brightest thing on the boundary on three edges out of four (+24
+    //     to +41 levels wherever it lands) - structurally the same object as
+    //     the colLayer0Border outline removed in 1df616e62, in white.
+    //   - the specular is the one that is really an edge: a catch where the
+    //     light hits. It stays, at `standard` rather than `emphasis` width,
+    //     and its flank drops to a value that is nearly nothing rather than to
+    //     a value that is merely less.
     //
-    // The first two cost nothing extra: they are plain Rectangles declared
-    // inside `surround`, whose layer is already masked to the complement of the
-    // card - so the mask cuts each of them down to the band outside the card by
-    // itself, and the gradient that shades them is the Rectangle's own. No
-    // second layer, no second mask, and nothing re-rendering the backdrop, which
-    // is the cost this whole component is arranged to avoid.
-    readonly property real edgeShadeWidth: Appearance.borderWidth.heavy
-    readonly property real edgeSpecularWidth: Appearance.borderWidth.emphasis
+    // Glass is not a ring of even thickness. It is a bright catch along the top
+    // and the corner arcs and almost nothing along the rest; what carries its
+    // presence is the shadow around it, not a drawn perimeter. The shadow is
+    // already there, so the edge does not have to prove the card exists.
+    //
+    // The two divide the perimeter between them rather than doubling up on it,
+    // and that is a property of the shadow rather than a hope: it carries
+    // `offset: (0, 1)`, so it is at its weakest directly above the card and at
+    // its strongest below. Measured over this library's brightest wallpaper, the
+    // backdrop falls 172 -> 158 above the card and 237 -> 146 below it, which is
+    // the opposite ordering to the catch (0.44 at the top, 0.13 at the bottom).
+    // The boundary is a bright line where the shade is thin and a pool of shade
+    // where the line is not there.
+    //
+    // It costs nothing extra: a plain Rectangle declared inside `surround`,
+    // whose layer is already masked to the complement of the card - so the mask
+    // cuts it down to the band outside the card by itself, and the shading is
+    // the Rectangle's own gradient. No second layer, no second mask, and
+    // nothing re-rendering the backdrop, which is the cost this whole component
+    // is arranged to avoid.
+    readonly property real edgeSpecularWidth: Appearance.borderWidth.standard
 
     // Where the light rolls off the edge, as a fraction of the card's height:
     // the corner arc is the piece of the outline whose normal turns from facing
@@ -145,32 +166,13 @@ Item {
         }
 
         // Drawn AFTER the shadow, because the shadow is at its darkest exactly
-        // where these two are: a bright line standing on the near edge of a
-        // pool of shade is the whole of what reads as glass, and a shadow drawn
-        // over it would be a shadow of the card cast onto the card's own rim.
+        // where this is: a bright catch standing on the near edge of a pool of
+        // shade is the whole of what reads as glass, and a shadow drawn over it
+        // would be a shadow of the card cast onto the card's own rim.
         //
-        // Both are grown from the card and cut back to it by `surround`'s mask,
-        // so their inner boundary IS the card's edge - to the same antialiased
-        // pixel as the corner, because it is the same mask that makes the
-        // corner.
-        Rectangle {
-            id: edgeShade
-            x: root.card.x - root.edgeShadeWidth
-            y: root.card.y - root.edgeShadeWidth
-            width: root.card.width + 2 * root.edgeShadeWidth
-            height: root.card.height + 2 * root.edgeShadeWidth
-            radius: root.cardRadius > 0 ? root.cardRadius + root.edgeShadeWidth : 0
-            antialiasing: true
-            // Weakest where the light is and strongest opposite it, and never
-            // at zero on either stop: this is the tone that has to carry the
-            // edge over a bright wallpaper, where the specular cannot, and a
-            // lip that faded out along its own top would have no edge there.
-            gradient: Gradient {
-                GradientStop { position: 0; color: Qt.alpha(Appearance.colors.colGlassShade, 0.3) }
-                GradientStop { position: 1; color: Qt.alpha(Appearance.colors.colGlassShade, 0.5) }
-            }
-        }
-
+        // It is grown from the card and cut back to it by `surround`'s mask, so
+        // its inner boundary IS the card's edge - to the same antialiased pixel
+        // as the corner, because it is the same mask that makes the corner.
         Rectangle {
             id: edgeSpecular
             x: root.card.x - root.edgeSpecularWidth
@@ -179,28 +181,30 @@ Item {
             height: root.card.height + 2 * root.edgeSpecularWidth
             radius: root.cardRadius > 0 ? root.cardRadius + root.edgeSpecularWidth : 0
             antialiasing: true
-            // The non-uniformity is the point. A rim at one strength all the way
-            // round is a stroke however bright it is; light catching the top of
-            // an edge, rolling off round the corners and coming back weakly at
-            // the bottom is what a piece of glass looks like. The bottom is a
-            // bounce off whatever the card is lying on, so it is weaker than the
-            // top rather than symmetric with it.
+            // The non-uniformity is not a flourish on top of a rim, it IS the
+            // edge: everywhere the light does not catch, there is deliberately
+            // almost nothing here, and the shadow outside is what says the card
+            // is a separate object. A rim at one strength all the way round is a
+            // stroke however bright it is, and a rim at two thirds of one
+            // strength all the way round is the same stroke a shade fainter -
+            // which is what shipped, and what still read as a border.
             //
             // The roll-off happens over the CORNER, not over the flank. Shipped
             // as a plain 0 / 0.5 / 1 ramp, the run from the top's value to the
             // side's value was half the card - so both top corners were as
             // bright as the top edge and the whole 3872px top read as one
-            // uniform stroke, which is the thing the paragraph above says a rim
-            // must not be (measured on the real desktop: crest 111/255 median
-            // along the top against 37 along the left, and 0 at its weakest
-            // point). Holding the top's value only to the end of the arc and the
-            // side's value along the whole flank is the same idea the comment
-            // always claimed, applied on the geometry that actually turns.
+            // uniform stroke (measured on the real desktop: crest 111/255 median
+            // along the top against 37 along the left). Holding the top's value
+            // only to the end of the arc and the flank's along the whole flank
+            // is the same idea, applied on the geometry that actually turns.
+            //
+            // The bottom is a bounce off whatever the card is lying on, so it is
+            // a hint above the flank rather than symmetric with the top.
             gradient: Gradient {
-                GradientStop { position: 0; color: Qt.alpha(Appearance.colors.colGlassSpecular, 0.46) }
-                GradientStop { position: root.edgeRollOff; color: Qt.alpha(Appearance.colors.colGlassSpecular, 0.26) }
-                GradientStop { position: 1 - root.edgeRollOff; color: Qt.alpha(Appearance.colors.colGlassSpecular, 0.26) }
-                GradientStop { position: 1; color: Qt.alpha(Appearance.colors.colGlassSpecular, 0.32) }
+                GradientStop { position: 0; color: Qt.alpha(Appearance.colors.colGlassSpecular, 0.44) }
+                GradientStop { position: root.edgeRollOff; color: Qt.alpha(Appearance.colors.colGlassSpecular, 0.07) }
+                GradientStop { position: 1 - root.edgeRollOff; color: Qt.alpha(Appearance.colors.colGlassSpecular, 0.07) }
+                GradientStop { position: 1; color: Qt.alpha(Appearance.colors.colGlassSpecular, 0.13) }
             }
         }
     }
@@ -226,44 +230,30 @@ Item {
         }
     }
 
-    // The inner face of the bevel, and the innermost thing on the edge - which
-    // is a correction rather than a rearrangement.
+    // Nothing is drawn INSIDE the card, and that is the point rather than an
+    // omission.
     //
-    // A 1px `colLayer0Border` outline sat here, between this and the specular,
-    // on the reasoning that it is what every floating surface in this shell
-    // carries beside its shadow. Measured on the real desktop it was a NOTCH:
-    // walking inward from the backdrop the profile went shade, crest, *dark
-    // line*, highlight, desktop - down as much as 70/255 below the lower of the
-    // two bright bands either side of it, on all four edges. A bevel falls off
-    // its crest into the surface; this one fell, rose and fell, so the eye read
-    // the dark line as the card's edge and the bright band as a piping outside
-    // it. That is a stroke with a bevel drawn around it, not a bevel.
+    // Two things have sat here in turn. A 1px `colLayer0Border` outline, on the
+    // reasoning that every floating surface in this shell carries one beside its
+    // shadow - which measured as a notch, a dark line between the two bright
+    // bands either side of it, and went in 1df616e62. Then a 1px
+    // `colGlassSpecular` highlight at 0.16, on the reasoning that the specular
+    // needs a near side or it is a line balanced on the seam.
     //
-    // The outline is gone rather than moved, and docs/M3_GUIDELINES.md §1 is
-    // what licenses that rather than what it is traded against: "visible borders
-    // are not required for every surface", and the job the guideline gives the
-    // outline - to "clearly define edges against complex backgrounds" - is the
-    // job this bevel exists to do, because the outline could not do it over a
-    // wallpaper. One edge treatment, not two stacked.
+    // The second is the first wearing the other colour. It cannot ride
+    // `surround`'s mask - it is inside the card, which is exactly what that mask
+    // removes - so it is a uniform border rather than a shaded band, drawn at
+    // one strength round all 9922px of a 3872x1089 perimeter, compositing over
+    // the DESKTOP rather than over the backdrop. Measured on the real desktop it
+    // was the brightest thing on the boundary on three edges out of four: +41
+    // levels over a wallpaper at 105 on the left flank, +35 over one at 36 along
+    // the top. A line that is brighter than the specular it is supposedly
+    // supporting is the edge, and a line of even thickness all the way round is
+    // a border.
     //
-    // This one cannot ride `surround`'s mask - it is INSIDE the card, which is
-    // exactly what that mask removes - so it is a border rather than a
-    // gradient-filled rect, and it is uniform where the specular is not. A real
-    // bevel's inner face would be the specular's inverse (the inside of the top
-    // edge faces away from the light), and expressing that needs a second mask
-    // and a second layer, which is the cost this whole component is arranged
-    // around. Faint enough not to become a second line on a dark wallpaper,
-    // present enough that the crest has a near side.
-    Rectangle {
-        id: cardInnerHighlight
-        x: root.card.x
-        y: root.card.y
-        width: root.card.width
-        height: root.card.height
-        radius: root.cardRadius
-        color: "transparent"
-        antialiasing: true
-        border.width: Appearance.borderWidth.standard
-        border.color: Qt.alpha(Appearance.colors.colGlassSpecular, 0.16)
-    }
+    // docs/M3_GUIDELINES.md §1 is what licenses the absence: "visible borders
+    // are not required for every surface". The job the guideline gives an
+    // outline - defining edges against complex backgrounds - belongs here to the
+    // shadow and to the specular's catch, and both of those already vary round
+    // the perimeter the way a real edge does.
 }

--- a/dots/.config/quickshell/imi/tests/test_edit_mode_chrome.py
+++ b/dots/.config/quickshell/imi/tests/test_edit_mode_chrome.py
@@ -49,6 +49,14 @@ question about pixels that reads as correct in every source file:
   item that reports a position and paints somewhere else - or that reports one
   and paints nothing, which is what a toolbar whose content failed to resolve
   looks like from every property.
+- **the card's edge is a catch and not a rim.** Whether a boundary reads as
+  glass or as a border is a question about the whole perimeter - how wide the
+  drawn band is, and whether it is there all the way round - and no measurement
+  of any one tone asks it. Three tones that each measured well summed to five
+  drawn pixels of piping at one strength round a 3872px card, which is what
+  "edit mode's layout having this thick border" named. Note the failure this
+  one exists to catch that its neighbour cannot: the notch check passes on a
+  card with no edge at all, because a bare ramp has no notch in it.
 
 The fixture is a flat colour so that "is this pixel a grid line" is answerable
 at all; the check that the lattice is drawn in the first place is what stops the
@@ -379,6 +387,101 @@ class EditModeChromeTest(unittest.TestCase):
                 out.append(self._luma(frame.getpixel((x + w - 1 - d, along))))
         return out
 
+    # How far outside the range spanned by the blurred backdrop and the desktop
+    # a level in the boundary band lies. #241's metric, and the reason it is an
+    # EXCURSION rather than a contrast across the edge: a desktop at 240 over a
+    # backdrop at 148 already has a 92-level boundary whatever is drawn on it,
+    # so "contrast across the edge" scores an edge that is not there, and a pure
+    # ramp from one side to the other scores zero, which is the honest answer
+    # for it.
+    #
+    # The tolerance absorbs the drop shadow, which is the one thing outside the
+    # card that legitimately leaves the range: it darkens smoothly toward the
+    # edge and reaches 9.3 below the far-outside reference on the probe's frame.
+    # The shade band this replaced departed by 23 to 38 at the same pixels, so
+    # 15 separates them with room either way.
+    EDGE_TOLERANCE = 15
+    # The catch has to be along the whole top, not at one sample, so the top is
+    # scored on the MEDIAN; nowhere may be loud, so the rest are scored on the
+    # WORST. Measured on the probe's frame: 56.5 along the top, 0.0 everywhere
+    # else. The old three-tone edge scored 50.9 / 31.0 / 37.8.
+    EDGE_CATCH_FLOOR = 25.0
+
+    def _edge_samples(self):
+        """Where to read the edge, clear of the corner arcs and of the marker."""
+        x, y, w, h = self.card
+        arc = round(self.radius) + 8
+        marker_reach = round(self.marker[2] * self.scale) + 8
+        return (
+            ("top", range(round(x) + marker_reach, round(x + w) - arc, 40)),
+            ("bottom", range(round(x) + arc, round(x + w) - arc, 40)),
+            ("left", range(round(y) + marker_reach, round(y + h) - arc, 40)),
+            ("right", range(round(y) + arc, round(y + h) - arc, 40)),
+        )
+
+    def _edge_excursions(self, frame, side, along, depth=10):
+        """Per-pixel excursion beyond the backdrop/desktop range, outside in."""
+        profile = self._edge_profile(frame, side, along, depth)
+        outside, inside = profile[0], profile[depth + 4]
+        low, high = min(outside, inside), max(outside, inside)
+        return [max(0.0, value - high, low - value) for value in profile[:depth + 2]]
+
+    def test_the_edge_is_a_catch_along_the_top_and_almost_nothing_round_the_rest(self):
+        """Glass is not a ring of even thickness.
+
+        The card's edge shipped as three tones - a 4px shade band outside, a 2px
+        specular on the edge, a 1px highlight inside - and every one of them was
+        defensible on its own. The sum was five drawn pixels of dark-then-bright
+        piping at one strength round the whole perimeter of a 3872px card, which
+        is a border, which is what "edit mode's layout having this thick border
+        is what looked ugly for me" named. No per-tone measurement asks that
+        question; this one does, and it asks it in the two terms the complaint is
+        actually about - how WIDE the drawn band is, and whether it is there all
+        the way round.
+
+        Three assertions, and each fails a different way of getting it wrong:
+
+        - the top carries a real catch, which fails when the edge is deleted
+          outright (a bare ramp from the backdrop to the desktop scores 0.0, and
+          this file's notch check passes happily on one);
+        - the flanks and the bottom stay inside the range the shadow and the
+          picture already span, which fails when a rim comes back at any width -
+          the old flank departed by 31 where the shadow alone departs by 9;
+        - and the band is at most two pixels anywhere, which fails when a tone
+          is widened rather than brightened.
+
+        The probe's wallpaper is one flat colour, so every level in the band is
+        the edge and nothing else - the only place this profile can be read
+        without the picture in the way.
+        """
+        frame = self.frames["editing"]
+        by_side = {}
+        widest = (0, None)
+        for side, rng in self._edge_samples():
+            self.assertTrue(list(rng), f"no {side} samples to take")
+            worst_per_sample = []
+            for along in rng:
+                excursions = self._edge_excursions(frame, side, along)
+                worst_per_sample.append(max(excursions))
+                drawn = sum(1 for e in excursions if e > self.EDGE_TOLERANCE)
+                if drawn > widest[0]:
+                    widest = (drawn, (side, along, [round(e) for e in excursions]))
+            by_side[side] = sorted(worst_per_sample)
+
+        top = by_side["top"][len(by_side["top"]) // 2]
+        self.assertGreater(
+            top, self.EDGE_CATCH_FLOOR,
+            f"the card's top edge carries no catch at all: median excursion {top:.1f}/255")
+        for side in ("left", "right", "bottom"):
+            loudest = by_side[side][-1]
+            self.assertLessEqual(
+                loudest, self.EDGE_TOLERANCE,
+                f"the card's {side} edge is a rim, not a catch: {loudest:.1f}/255 "
+                f"outside the range the backdrop and the desktop already span")
+        self.assertLessEqual(
+            widest[0], 2,
+            f"the card's edge is {widest[0]} drawn pixels wide: {widest[1]}")
+
     def test_the_cards_edge_falls_off_its_crest_into_the_desktop(self):
         """A bevel is monotonic on the inward side of its crest; a stack of
         bands is not.
@@ -391,24 +494,21 @@ class EditModeChromeTest(unittest.TestCase):
         feels off" was: the eye reads the dark line as the card's edge and the
         bright band as a piping outside it.
 
+        Both of the bands that produced that notch are gone now, so this cannot
+        fail on the arrangement it was written for - it stays because the way to
+        bring the notch back is to give the edge a second tone, which is exactly
+        what someone reaching for "the specular needs a near side" would do. On
+        its own it passes on a card with no edge at all, which is what the check
+        above is for.
+
         This is the only place the profile can be read cleanly - the probe's
-        wallpaper is one flat colour, so every level in the band is the bevel
+        wallpaper is one flat colour, so every level in the band is the edge
         and nothing else. Tolerance is 4 levels, which is antialiasing on a
         software renderer; the defect it exists for is an order of magnitude
         past that.
         """
         frame = self.frames["editing"]
-        x, y, w, h = self.card
-        # Clear of the corner arcs, and clear of the corner marker, which is
-        # opaque magenta over the top-left of the card's interior.
-        arc = round(self.radius) + 8
-        marker_reach = round(self.marker[2] * self.scale) + 8
-        samples = (
-            ("top", range(round(x) + marker_reach, round(x + w) - arc, 40)),
-            ("bottom", range(round(x) + arc, round(x + w) - arc, 40)),
-            ("left", range(round(y) + marker_reach, round(y + h) - arc, 40)),
-            ("right", range(round(y) + arc, round(y + h) - arc, 40)),
-        )
+        samples = self._edge_samples()
         worst = (0.0, None)
         for side, rng in samples:
             self.assertTrue(list(rng), f"no {side} samples to take")

--- a/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
@@ -47,6 +47,14 @@ panel in question:
   usable area, which is what put the toolbar on the bar's widgets;
 - and a tone drawn between the specular and the inner highlight, which turns
   the card's bevel into a bevel around a line.
+
+The card's edge then came back a third time, as a whole-card judgement no
+per-tone measurement had asked: three defensible tones summed to five drawn
+pixels of piping at one strength round the whole perimeter, which is a border.
+Two rules hold the replacement in place - nothing may be drawn INSIDE the card
+(anything there misses `surround`'s mask and is a uniform line by construction),
+and the one band outside it is one pixel wide with a flank a fraction of its
+top, not merely less than it.
 """
 
 import re
@@ -705,36 +713,92 @@ def test_the_chrome_is_placed_between_the_card_and_the_usable_area():
         "the usable area must come from the module, not be rebuilt on the surface"
 
 
-def test_the_cards_edge_is_a_bevel_rather_than_a_bevel_around_a_line():
-    """No tone on the edge may be drawn between the specular and the inner
-    highlight.
+def test_the_cards_edge_is_one_tone_and_nothing_is_drawn_inside_the_card():
+    """The edge is a catch on one band outside the card, and there is nothing
+    else on the boundary.
 
-    A 1px `colLayer0Border` outline sat there, and measured on the real desktop
-    it was a notch - up to 70/255 below the lower of the two bright bands either
-    side of it. A bevel falls off its crest into the surface; a stack of bands
-    does not, and the eye reads the dark line as the card's edge with the bright
-    band as a piping outside it. `test_edit_mode_chrome.py` scores the profile
-    in pixels; this is the source half, because the outline is the kind of thing
-    that comes back as "every floating surface carries one".
+    Two lines have sat inside the card in turn and both were the same object. A
+    1px `colLayer0Border` outline, which measured as a notch - up to 70/255
+    below the lower of the two bright bands either side of it - and went in
+    1df616e62. Then a 1px `colGlassSpecular` highlight at 0.16, which measured
+    as the BRIGHTEST thing on the boundary on three edges out of four, +41
+    levels over a wallpaper at 105. Anything inside the card cannot ride
+    `surround`'s mask, so it is a uniform border by construction, at one
+    strength round the whole perimeter, and a border of even thickness is what
+    "edit mode's layout having this thick border" names.
 
-    docs/M3_GUIDELINES.md §1 is what licenses its absence rather than what it is
-    traded against: "visible borders are not required for every surface", and
-    the job it gives the outline - defining edges against complex backgrounds -
-    is the job the bevel exists to do, because the outline could not do it over
-    a wallpaper.
+    The shade band outside is held to the same rule from the other side: what
+    darkens outside the card is `colShadow`, already drawn there by
+    `StyledRectangularShadow`, softly and from the same lamp. A second darkening
+    is a hard copy of the soft one under it, which is the other two of the five
+    drawn pixels the edge used to occupy.
+
+    `test_edit_mode_chrome.py` scores the profile in pixels; this is the source
+    half, because both of these come back as "every floating surface in this
+    shell carries one". docs/M3_GUIDELINES.md §1 is what licenses their absence
+    rather than what they are traded against: "visible borders are not required
+    for every surface", and the job it gives an outline - defining edges against
+    complex backgrounds - belongs here to the shadow and to the catch.
     """
     card = code(CARD)
     assert "colLayer0Border" not in card, \
-        "the card's edge is a bevel; an outline through it is a seam"
+        "the card's edge is a catch; an outline through it is a seam"
+    assert "colGlassShade" not in card, \
+        ("the darkening outside the card is StyledRectangularShadow's; a shade "
+         "band beside it is a hard copy of the soft one underneath")
+    # Every tone the edge is drawn in has to be a child of `surround`, whose
+    # mask cuts it back to the band outside the card. A `border.width` is the
+    # only way to paint a line at the card's edge from outside that item, which
+    # is exactly why both of the lines that have sat there were written as one.
+    assert "border.width" not in card, \
+        "nothing may be drawn inside the card: a border there is the outline again"
     # ...and the roll-off is the corner's, not a number someone picked. A stop
     # at a literal fraction is a rim that is bright right round the bend, which
     # is a stroke however bright it is - the thing the file's own comment
     # forbids.
     roll_off = declaration(card, "edgeRollOff")
     assert "cardRadius" in roll_off, \
-        f"the specular's roll-off must be expressed against the corner radius: {roll_off!r}"
+        f"the catch's roll-off must be expressed against the corner radius: {roll_off!r}"
     assert card.count("root.edgeRollOff") >= 2, \
         "the roll-off must bound the crest at both ends of the flank"
+
+
+def test_the_cards_edge_is_a_catch_rather_than_a_rim():
+    """One pixel wide, and the flank is a fraction of the top rather than a bit
+    less than it.
+
+    This is the rule the previous edge passed on and still read as a border. Its
+    specular was already non-uniform - 0.46 along the top against 0.26 down the
+    flank - and 0.26 of white on a 2px band all the way round a 3872px card is a
+    rim at 57% of full strength, which is a stroke a shade fainter rather than a
+    catch. Glass shows a bright catch where the light hits it and almost nothing
+    along the rest, and what carries its presence is the shadow around it.
+
+    So the two numbers that decide whether this is an edge or a border are the
+    band's WIDTH and the RATIO between its top and its flank, and both are
+    asserted here rather than left to whoever tunes a stop next. The pixel half
+    scores what these produce on screen; a source check is what stops a stop
+    being nudged back up one at a time.
+    """
+    card = code(CARD)
+    width = declaration(card, "edgeSpecularWidth")
+    assert "borderWidth.standard" in width, \
+        (f"the catch is one pixel: a wider band is a rim whatever its alpha is "
+         f"({width!r})")
+
+    stops = [float(v) for v in
+             re.findall(r"colGlassSpecular,\s*([0-9.]+)\s*\)", card)]
+    assert len(stops) == 4, \
+        f"expected four gradient stops on the catch, found {stops}"
+    top, arc_top, arc_bottom, bottom = stops
+    assert arc_top == arc_bottom, \
+        f"the flank is one value between the two corner arcs, not a ramp: {stops}"
+    assert arc_top <= top / 4, \
+        (f"the flank is {arc_top} against a top of {top}: a rim at a fraction "
+         f"under the top is still a rim")
+    assert arc_top < bottom < top, \
+        (f"the bottom is a bounce - above the flank and below the top - not a "
+         f"second catch: {stops}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
"edit mode's layout having this thick border is what looked ugly for me. I want
it to look glassy without it having this thick border."

#243's diagnosis was right and incomplete. Removing the 1px `colLayer0Border`
outline fixed the seam through the middle of the boundary; what was left still
read as a border, because every measurement in that PR and in #241 scores one
tone at a time and **"is this glass or a border" is a question about the whole
perimeter**. Walked inward across the left flank on the real desktop at
5120x1440:

```
backdrop 28 | shade 17, 17 | specular 77, 77 | highlight 128 | desktop 105
```

Five drawn pixels of dark-then-bright piping, at one strength the whole way
round a 3872x1089 card. Three tones that each measured as an improvement, and
their sum is a ring of even thickness, which is what a border *is*.

**Before / after captures (5120x1440 whole frames over three wallpapers, 1:1
crops of a corner, a flank and the top edge, and the per-pixel profile):
https://claude.ai/code/artifact/3f0df065-79a6-4f26-8a81-56bf6eac31f1**

## What was cut, and why each one could go

Glass is not a ring of even thickness. It is a bright catch where the light hits
the edge and almost nothing along the rest, and what carries its presence is the
shadow around it rather than a drawn perimeter. **The shadow is untouched** — not
one property — and it is what licenses all of this: it already separates the card
from the wallpaper, so the edge does not have to prove the card exists.

- **The shade band (4px of black at 0.3–0.5, outside the card) is gone.** It gave
  the card a lip so the edge carried over a bright picture. `StyledRectangularShadow`
  is already a darkening outside the card, from the same lamp, soft where the band
  was a hard copy of it.
- **The inner highlight (1px of white at 0.16, inside the card) is gone.** Anything
  drawn inside the card misses `surround`'s mask — that mask removes exactly the
  card — so it is a **uniform border by construction**, whatever gradient it is
  given, and it composites over the *desktop* rather than over the backdrop.
  Measured, it was the brightest thing on the boundary on three edges out of four:
  +41 levels over a wallpaper at 105 on the flank, +35 over one at 36 along the
  top. A line brighter than the specular it is supposedly supporting is the edge.
  Structurally it is #243's outline in the other colour.
- **The specular stays**, at `standard` rather than `emphasis` width, with the
  flank at 0.07 against 0.26 and the bounce at 0.13 against 0.32. The top is
  0.44 against 0.46 — the catch itself barely moves. **The old edge was already
  non-uniform**; 0.26 of white on a 2px band all the way round is a stroke a shade
  fainter, not a catch. Non-uniformity is a *ratio*, not a direction.
- `colGlassShade` goes with the band it was added for, in its own commit. Nothing
  else had ever read it, and `lint_appearance_tokens.py` fails on a token that is
  read and not declared, never on one declared and read by nobody — so a dead
  token there rots silently, which is the CavaService shape in AGENT.md.

**Why one tone is enough, and it is structural rather than lucky.** The catch and
the shadow divide the perimeter between them, because the shadow carries
`offset: (0, 1)`: it is weakest directly above the card and strongest below,
which is the opposite ordering to the catch. Measured over this library's
brightest wallpaper, the backdrop falls 172 → 158 above the card and 237 → 146
below it. The boundary is a bright line where the shade is thin and a pool of
shade where the line is not.

## The measurement

The look probe's wallpaper is one flat colour, so every level in the band is the
edge and nothing else — the only place the profile reads without the picture in
the way. Walking from outside in, the shadow's slope elided:

| | before | after |
| --- | --- | --- |
| top edge | 46, 45, **141, 138, 117** \| 90 | 63 \| **146** \| 90 |
| left flank | 38, 37, **92, 91, 117** \| 90 | 61 \| **73** \| 90 |
| drawn band | **5 px** | **1 px** |

And round the perimeter of the real card, median excursion beyond the range the
blurred backdrop and the desktop already span (#241's metric — an excursion
rather than a contrast across the edge, because a desktop at 240 over a backdrop
at 148 has a 92-level boundary whatever is drawn on it):

| wallpaper | | top | bottom | left | right |
| --- | --- | --- | --- | --- | --- |
| live WE scene | before | 90.8 | 45.3 | 31.9 | 52.3 |
| | after | **91.0** | **15.6** | **5.3** | **0.0** |
| darkest still (luma 28) | before | 113.0 | 37.0 | 61.0 | 46.5 |
| | after | **109.0** | **16.5** | **16.0** | **14.9** |
| brightest still (luma 212) | before | 55.7 | 87.3 | 69.4 | 75.1 |
| | after | **14.3** | **20.2** | **16.6** | **17.6** |

**Reported as measured rather than as an unbroken win.** Over the brightest
wallpaper the top edge drops from 55.7 to 14.3 — the shade band was doing that
work and the shadow's 14-level ramp is doing it now. That is the trade this
change makes deliberately, and the whole frame over that wallpaper is in the
artifact so it can be judged rather than argued.

## Tests

**The check that was missing matters more than the ones added: every edge check
in `test_edit_mode_chrome.py` passed with the edge removed entirely.** The notch
check reads the profile from its crest inward and asks whether it falls off
monotonically, and a bare ramp from the backdrop to the desktop has no notch in
it. A test that passes with the feature deleted is worse than no test.

`test_edit_mode_chrome.py` 11 → 12 pixel checks. The new one asks three questions
because they fail three different ways:

- the top carries a real catch (**median**, so it is the whole edge and not one
  sample): 56.5/255 now, **0.0** with the edge deleted;
- the flanks and the bottom stay inside the range the backdrop and the desktop
  already span (**worst**, so nowhere may be loud): 0.0 now, 31.0 and 37.8 on the
  three-tone edge, so a rim reddens at any width;
- the drawn band is at most two pixels anywhere: 1 now, 5 before, so widening a
  tone reddens instead of brightening it.

The tolerance is 15 and it is the one number that had to be measured rather than
chosen: the drop shadow legitimately leaves the range — it darkens smoothly
toward the edge — and reaches 9.3 below the far-outside reference, where the
shade band departed by 23 to 38 at the same pixels.

The notch check stays, with a docstring that now says what it is and is not for:
both bands that produced the notch are gone, so it cannot fail on the arrangement
it was written for, but the way to bring a notch back is to give the edge a
second tone — exactly what someone reaching for "the specular needs a near side"
would do.

`test_edit_mode_contract.py` 27 → 28. The source half refuses both shapes that
keep coming back: no `border.width` anywhere in the file (the only way to draw a
line the mask does not cut, and what *both* retired lines were written as), no
`colGlassShade`, the width pinned to `borderWidth.standard`, and the flank held
to at most a quarter of the top. The harness's own count is unchanged at 14 —
none of this is reachable from QML.

**Five mutations planted in a clean tree, each reverted after; every one
reddened, none stayed green:**

| planted | source half | pixel half |
| --- | --- | --- |
| the edge deleted outright | 26/28 | catch 7.4 < 25 |
| a uniform rim at the old 0.26 | 27/28 | flank 19.8 > 15 |
| the inner highlight restored | 26/28 | flank 26.9 > 15 |
| the catch widened to `heavy` | 27/28 | band 4 px > 2 |
| the shade band brought back | 27/28 | flank 68.8 > 15 |

The first row is the one that matters: it reddens the new check and the notch
check stays green, which is the hole this closes.

## Live testing

Deployed to `~/.config/quickshell/imi` and the shell restarted, with the
maintainer's explicit authorisation and at the machine, killing the primary by
pid rather than by name. Entered through a temporary `IpcHandler` on
`GlobalStates.editMode` applied to the deployed copy only — never committed, and
removed by the final clean deploy — rather than through a synthetic click, which
is not evidence here.

Three wallpapers, because #241 found the dark case is where the treatment earns
its keep and the bright case was already close: the live Wallpaper Engine scene
the machine was running, and — with the renderer stopped and restored afterwards
— the library's darkest and brightest stills. Every number above is measured off
those frames.

Docs: updated AGENT.md §Edit Mode (the card's edge — the three tones and why each
one went, plus the two things that generalise: anything drawn inside a masked
shape misses the mask and is a uniform line by construction, and non-uniformity
is a ratio rather than a direction).
