### PR TITLE
feat(editMode): stage 6 - per-widget context menu and the Size stepper

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -2711,6 +2711,35 @@ mode is built out of are worth not re-deriving:
   in-memory fixtures inside the module, and the sweep asserts it still found the
   edit-mode files so a directory move cannot leave it green over nothing.
   (test(lint): fail on an edit-mode write outside placement's scope.)
+- **A right-click on a widget is the per-widget menu in the mode and the global
+  lock toggle outside it, and the boundary between the two is the canvas.**
+  `AbstractWidget` resolves the mode off its owning canvas — the same property
+  the marquee and the Escape ladder already run on, so the overlay's canvas
+  (which never follows the mode) keeps today's behaviour with no special case —
+  and only ANNOUNCES the click (`contextMenuRequested`): the base class knows
+  nothing about what a widget is, and `PluginWidget` is what carries an
+  identity. It maps the click with `mapToItem(null, …)` — Qt's own transform
+  chain, which composes the mode's scale, the drawer's shift and the press
+  scale — never a hand-multiplied viewport scale, which is the compensation the
+  contract forbids and is wrong at every scale but 1. The menu's rows are
+  exactly spec §9's three licences: Pin writes the one existing
+  `positionLocked` writer (`PluginState.setOption` — one writer, two call
+  sites) with its drawn check a BINDING on the stored value, seeded the way the
+  host seeds it; Size is a stepper over `offeredGridSizes` in the manifest's
+  own order writing `__gridSize`, with no row at all for a single-span widget
+  (`rowVisible`, not `visible`) and nothing for a widget that declined `grid`,
+  whose own handles keep the size they chose; Remove is presence —
+  `plugins.enabled` is one global list rendered on every monitor, so it removes
+  everywhere, through the same `EditMode.enabledWithout` the drawer's toggle
+  uses. The window is the desktop menu's shape on its reused
+  `quickshell:desktopMenu` namespace (a minted name would repeat the rules.lua
+  threshold exercise to reach the same treatment), the widget vacates the menu
+  from `Component.onDestruction` (the `BarContent.filterLayout` shape — its own
+  Remove destroys the widget under the open menu), and `closeMenu` is the
+  Escape ladder's FIRST rung, so Escape dismisses the menu rather than exiting
+  the mode. (feat(editMode): the menu's open state, and an Escape rung that
+  dismisses it; feat(editMode): right-click in the mode asks for the widget's
+  menu; feat(editMode): the per-widget menu - Remove, Pin, and a Size stepper.)
 - **`WidgetsSubmenu` is gone.** Its widget list had been empty since the desktop
   widgets became plugins, and its one live control was the global lock the mode
   suppresses — a switch that turns off something the editor turns back on. The

--- a/dots/.config/quickshell/imi/DesignSystemCompile.qml
+++ b/dots/.config/quickshell/imi/DesignSystemCompile.qml
@@ -73,6 +73,8 @@ ShellRoot {
                 // merely running has never compiled either of them.
                 Quickshell.shellPath("modules/imi/editMode/EditModeChromeSurface.qml"),
                 Quickshell.shellPath("modules/imi/editMode/EditModeChromeContent.qml"),
+                Quickshell.shellPath("modules/imi/editMode/EditWidgetMenu.qml"),
+                Quickshell.shellPath("modules/imi/editMode/EditWidgetMenuContent.qml"),
                 // The cheatsheet only compiles when the user presses Super+/,
                 // and the keybind editor only when a row's pencil is clicked.
                 Quickshell.shellPath("modules/imi/cheatsheet/CheatsheetKeybinds.qml"),

--- a/dots/.config/quickshell/imi/EditModeRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/EditModeRuntimeTest.qml
@@ -134,6 +134,23 @@ ShellRoot {
                 scaledScreenHeight: harness.screenHeight
                 wallpaperScale: 1
             }
+
+            // A widget that can stop existing while its menu is open - the
+            // static two above cannot be destroy()ed. The FadeLoader shape a
+            // disabled plugin actually goes through.
+            Loader {
+                id: transientLoader
+                active: false
+                sourceComponent: PluginWidget {
+                    manifest: harness.manifestFor("edit-vanish-probe", { cols: 2, rows: 1 })
+                    screenName: harness.testScreen
+                    screenWidth: harness.screenWidth
+                    screenHeight: harness.screenHeight
+                    scaledScreenWidth: harness.screenWidth
+                    scaledScreenHeight: harness.screenHeight
+                    wallpaperScale: 1
+                }
+            }
         }
     }
 
@@ -447,6 +464,65 @@ ShellRoot {
             // time the mode opens.
             harness.check("...and the cancel takes the lattice with the gesture",
                           !canvas.showGrid);
+        },
+
+        // ---- the right-click: the menu in the mode, the lock outside it ----
+        //
+        // The same click means two things on the two sides of the mode
+        // boundary, and both halves are scored so the branch cannot rot in
+        // either direction: outside, the one quick gesture for the global lock
+        // (spec §4.1's table changes only the in-mode column); inside, the
+        // per-widget menu, anchored at the click's SCREEN position - which is
+        // the widget mapping through the mode's own transform, the half a
+        // hand-multiplied scale gets wrong at every scale but 1.
+        () => {
+            harness.placeWidgets();
+            Config.options.background.widgetsLocked = false;
+        },
+        () => {
+            const x = movableWidget.x + movableWidget.width / 2;
+            const y = movableWidget.y + movableWidget.height / 2;
+            driver.mouseClick(canvas, x, y, Qt.RightButton);
+            harness.check("outside the mode a right-click still toggles the global lock",
+                          Config.options.background.widgetsLocked === true
+                          && !GlobalStates.editWidgetMenuOpen);
+            Config.options.background.widgetsLocked = false;
+        },
+        () => { GlobalStates.editMode = true; },
+        () => {
+            const x = movableWidget.x + movableWidget.width / 2;
+            const y = movableWidget.y + movableWidget.height / 2;
+            driver.mouseClick(canvas, x, y, Qt.RightButton);
+            harness.check("in the mode the same click asks for the widget's menu instead",
+                          GlobalStates.editWidgetMenuOpen
+                          && GlobalStates.editWidgetMenuPluginId === "edit-move-probe"
+                          && GlobalStates.editWidgetMenuScreenName === harness.testScreen
+                          && Config.options.background.widgetsLocked === false);
+            const mapped = canvas.mapToItem(null, x, y);
+            harness.check("...anchored through the mode's own transform",
+                          Math.abs(GlobalStates.editWidgetMenuX - mapped.x) < 1.5
+                          && Math.abs(GlobalStates.editWidgetMenuY - mapped.y) < 1.5);
+            GlobalStates.editWidgetMenuOpen = false;
+        },
+
+        // ---- a widget destroyed while its menu is open vacates it ----------
+        () => {
+            PluginState.setPosition("edit-vanish-probe", harness.testScreen,
+                                    { x: 396, y: 396, placementStrategy: "free" });
+            transientLoader.active = true;
+        },
+        () => {
+            const transient = transientLoader.item;
+            driver.mouseClick(canvas, transient.x + transient.width / 2,
+                              transient.y + transient.height / 2, Qt.RightButton);
+            harness.check("the menu opens for the transient widget",
+                          GlobalStates.editWidgetMenuOpen
+                          && GlobalStates.editWidgetMenuPluginId === "edit-vanish-probe");
+            transientLoader.active = false;
+        },
+        () => {
+            harness.check("a widget destroyed while its menu is open vacates it",
+                          !GlobalStates.editWidgetMenuOpen);
         }
     ]
 

--- a/dots/.config/quickshell/imi/EditModeRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/EditModeRuntimeTest.qml
@@ -5,6 +5,7 @@ import qs
 import qs.modules.common
 import qs.modules.common.plugins
 import qs.modules.common.widgets.widgetCanvas
+import qs.modules.imi.editMode
 import "modules/common/functions/edit_mode.js" as EditMode
 
 /**
@@ -133,6 +134,19 @@ ShellRoot {
                 scaledScreenWidth: harness.screenWidth
                 scaledScreenHeight: harness.screenHeight
                 wallpaperScale: 1
+            }
+
+            // The menu's card, driven directly: the window that hosts it on
+            // the desktop is a layer surface no harness can build, and the
+            // card is where the writes live. Beside the canvas, clear of every
+            // gesture the steps above drive.
+            EditWidgetMenuContent {
+                id: menuContent
+                x: 920
+                y: 8
+                width: 260
+                height: implicitHeight
+                manifest: harness.resizableManifest
             }
 
             // A widget that can stop existing while its menu is open - the
@@ -523,6 +537,59 @@ ShellRoot {
         () => {
             harness.check("a widget destroyed while its menu is open vacates it",
                           !GlobalStates.editWidgetMenuOpen);
+        },
+
+        // ---- the menu's rows: Pin, the Size stepper, Remove ----------------
+        //
+        // Real clicks on the real card, read back from the real stores. The
+        // stepper's whole contract is that it INDEXES offeredGridSizes - the
+        // manifest's own order, [3x2, 2x2, 2x1] here - and never sees a pixel
+        // or a pointer delta, so the checks walk the list to both of its ends
+        // and read the stored span after every step.
+        () => {
+            Config.options.plugins.enabled = ["edit-resize-probe"];
+            PluginState.setOption("edit-resize-probe", "positionLocked", false);
+        },
+        () => {
+            const pin = driver.findChild(menuContent, "editMenuPin");
+            driver.mouseClick(pin, pin.width / 2, pin.height / 2, Qt.LeftButton);
+            harness.check("the menu's Pin writes the stored positionLocked and the row follows",
+                          PluginState.option("edit-resize-probe", "positionLocked", false) === true
+                          && menuContent.pinned === true);
+        },
+        () => {
+            const pin = driver.findChild(menuContent, "editMenuPin");
+            driver.mouseClick(pin, pin.width / 2, pin.height / 2, Qt.LeftButton);
+            harness.check("...and a second click unpins",
+                          PluginState.option("edit-resize-probe", "positionLocked", true) === false
+                          && menuContent.pinned === false);
+        },
+        () => {
+            // The grip section above left the span at 2x2, the middle of the
+            // offered order.
+            const down = driver.findChild(menuContent, "editMenuSizeDown");
+            driver.mouseClick(down, down.width / 2, down.height / 2, Qt.LeftButton);
+            harness.check("the stepper steps back through the offered order",
+                          harness.storedSize("edit-resize-probe") === "3x2");
+        },
+        () => {
+            const up = driver.findChild(menuContent, "editMenuSizeUp");
+            driver.mouseClick(up, up.width / 2, up.height / 2, Qt.LeftButton);
+            driver.mouseClick(up, up.width / 2, up.height / 2, Qt.LeftButton);
+            harness.check("...and forward to the other end",
+                          harness.storedSize("edit-resize-probe") === "2x1");
+        },
+        () => {
+            const up = driver.findChild(menuContent, "editMenuSizeUp");
+            driver.mouseClick(up, up.width / 2, up.height / 2, Qt.LeftButton);
+            harness.check("...and holds at the end of the offered list",
+                          harness.storedSize("edit-resize-probe") === "2x1");
+        },
+        () => {
+            const remove = driver.findChild(menuContent, "editMenuRemove");
+            driver.mouseClick(remove, remove.width / 2, remove.height / 2, Qt.LeftButton);
+            harness.check("Remove takes the widget out of plugins.enabled",
+                          Config.options.plugins.enabled.length === 0);
         }
     ]
 

--- a/dots/.config/quickshell/imi/EditModeRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/EditModeRuntimeTest.qml
@@ -138,8 +138,11 @@ ShellRoot {
 
             // The menu's card, driven directly: the window that hosts it on
             // the desktop is a layer surface no harness can build, and the
-            // card is where the writes live. Beside the canvas, clear of every
-            // gesture the steps above drive.
+            // card is where the writes live. Parked at the canvas's far right,
+            // clear of every gesture the steps above drive (their canvas
+            // coordinates all stay left of x=700); QtTest maps clicks through
+            // whatever transform the mode has applied, the same way it maps
+            // the widget gestures.
             EditWidgetMenuContent {
                 id: menuContent
                 x: 920
@@ -549,6 +552,9 @@ ShellRoot {
         () => {
             Config.options.plugins.enabled = ["edit-resize-probe"];
             PluginState.setOption("edit-resize-probe", "positionLocked", false);
+            // Seeded, not inherited from the grip section's end state: the
+            // stepper checks walk the offered order from its middle.
+            PluginState.setOption("edit-resize-probe", "__gridSize", "2x2");
         },
         () => {
             const pin = driver.findChild(menuContent, "editMenuPin");
@@ -565,8 +571,6 @@ ShellRoot {
                           && menuContent.pinned === false);
         },
         () => {
-            // The grip section above left the span at 2x2, the middle of the
-            // offered order.
             const down = driver.findChild(menuContent, "editMenuSizeDown");
             driver.mouseClick(down, down.width / 2, down.height / 2, Qt.LeftButton);
             harness.check("the stepper steps back through the offered order",

--- a/dots/.config/quickshell/imi/GlobalStates.qml
+++ b/dots/.config/quickshell/imi/GlobalStates.qml
@@ -123,6 +123,19 @@ Singleton {
         animation: Appearance.animation.elementMove.numberAnimation.createObject(this)
     }
 
+    // The per-widget context menu - Edit Mode's right-click on a widget
+    // (spec §4.1: Remove / Pin / Size). Session state like the mode itself,
+    // and shaped like the desktop menu's quad: which screen, where on it, and
+    // - the one field the desktop menu does not need - which widget it is
+    // about. The point is in SCREEN coordinates, mapped by the widget through
+    // its own transform chain on the way here, so the menu window needs no
+    // knowledge of the mode's viewport arithmetic.
+    property bool editWidgetMenuOpen: false
+    property string editWidgetMenuScreenName: ""
+    property real editWidgetMenuX: 0
+    property real editWidgetMenuY: 0
+    property string editWidgetMenuPluginId: ""
+
     property bool dropShelfOpen: false
     property real dropShelfX: 0
     property real dropShelfY: 0
@@ -150,8 +163,13 @@ Singleton {
         // The open flag does not outlive the mode: a drawer left latched open
         // would greet the NEXT entry mid-slide, with the desktop already
         // shifted on the first frame of a shrink that is supposed to be
-        // concentric.
-        else root.editDrawerOpen = false;
+        // concentric. The widget menu goes with it for the same reason - it is
+        // the mode's affordance, and one left open would greet the next entry
+        // pointing at wherever a widget used to be.
+        else {
+            root.editDrawerOpen = false;
+            root.editWidgetMenuOpen = false;
+        }
     }
     onClockDepthSelectOpenChanged: if (root.clockDepthSelectOpen) root.editMode = false
 

--- a/dots/.config/quickshell/imi/modules/common/functions/edit_mode.js
+++ b/dots/.config/quickshell/imi/modules/common/functions/edit_mode.js
@@ -23,6 +23,12 @@ var DESKTOP_TAB = "desktop";
 // canvas, a widget or a compositor. The caller does the work each answer names.
 function resolveEscape(state) {
     const s = state || {};
+    // The per-widget context menu is the topmost transient the mode draws - it
+    // opens over the widget it belongs to and everything else waits behind it
+    // until a click lands somewhere else - so it is dismissed before anything
+    // under it is touched.
+    if (s.menuOpen)
+        return "closeMenu";
     if (s.gestureInFlight)
         return "cancelGesture";
     if ((s.selectionCount || 0) > 0)
@@ -30,6 +36,25 @@ function resolveEscape(state) {
     if ((s.tab || DESKTOP_TAB) !== DESKTOP_TAB)
         return "desktopTab";
     return "exit";
+}
+
+// Presence on the desktop is one list (`Config.options.plugins.enabled`), and
+// taking an id out of it has one spelling: the drawer's toggle and the context
+// menu's Remove are two call sites of this function, not two loops that can
+// disagree about order or duplicates.
+//
+// Index-walked rather than filtered because the list arrives as a QML list
+// property: indices and `length` survive the QVariant crossing, the Array
+// brand does not (the boundary gridSizes.js documents), and the result must be
+// a plain array `Config.setNestedValue` can store.
+function enabledWithout(ids, id) {
+    const next = [];
+    const count = ids && typeof ids.length === "number" ? ids.length : 0;
+    for (let index = 0; index < count; index++) {
+        if (ids[index] !== id)
+            next.push(ids[index]);
+    }
+    return next;
 }
 
 // A desktop scaled below this is not an editor any more, it is a thumbnail.

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
@@ -386,6 +386,36 @@ AbstractBackgroundWidget {
         rootWidget.resizePullY = 0;
     }
 
+    // The mode's right-click (AbstractWidget raises it only while the canvas
+    // is editing). The point is mapped to the SCENE - which on the full-screen
+    // background surface is the screen - through Qt's own transform chain, so
+    // the mode's scale, the drawer's shift and the press scale are all
+    // composed by the same arithmetic that draws the widget. Multiplying a
+    // viewport scale in by hand here is the compensation the contract forbids,
+    // and it would be wrong at every scale but 1.
+    onContextMenuRequested: (atX, atY) => {
+        if (!manifest) return;
+        const point = rootWidget.mapToItem(null, atX, atY);
+        GlobalStates.editWidgetMenuPluginId = manifest.id;
+        GlobalStates.editWidgetMenuScreenName = rootWidget.screenName;
+        GlobalStates.editWidgetMenuX = point.x;
+        GlobalStates.editWidgetMenuY = point.y;
+        GlobalStates.editWidgetMenuOpen = true;
+    }
+
+    // A widget destroyed while its menu is open must not strand the menu - the
+    // BarContent.filterLayout shape: disabling a plugin (the menu's own Remove
+    // included) tears this instance down while the menu still points at it, so
+    // the declaring object vacates on its way out. Keyed on the screen as well
+    // as the id, because every monitor holds an instance of this plugin and
+    // only the one the menu was opened on may close it.
+    Component.onDestruction: {
+        if (manifest && GlobalStates.editWidgetMenuOpen
+                && GlobalStates.editWidgetMenuPluginId === manifest.id
+                && GlobalStates.editWidgetMenuScreenName === rootWidget.screenName)
+            GlobalStates.editWidgetMenuOpen = false;
+    }
+
     configEntryName: manifest ? "plugin_" + manifest.id : "plugin_unknown"
 
     // The background layer surface only accepts keyboard input while it is

--- a/dots/.config/quickshell/imi/modules/common/plugins/gridSizes.js
+++ b/dots/.config/quickshell/imi/modules/common/plugins/gridSizes.js
@@ -124,6 +124,32 @@ function resolveSize(grid, stored) {
     return fallback;
 }
 
+// The span one step along the offered order from wherever the widget is
+// drawn, or null when there is nowhere to step. The menu's Size stepper is
+// built on this - "the neighbouring offered span" gets one spelling, beside
+// the resolution it starts from, where qmltestrunner can reach it (the walk
+// used to live in the menu's QML, where only the weston harness could).
+//
+// It starts from resolveSize's answer rather than from the stored string, so
+// a stale stored span - one the manifest no longer offers - steps from the
+// fallback the widget is actually drawn at. Off either end it answers null
+// rather than clamping, because the caller's chevron reads "is there a next
+// span" straight off this, and a clamp would leave a live-looking button that
+// writes the span the widget already has.
+function steppedSize(grid, stored, direction) {
+    const offered = offeredSizes(grid);
+    if (offered.length < 2) return null;
+    const current = resolveSize(grid, stored);
+    if (!current) return null;
+    for (let index = 0; index < offered.length; index++) {
+        if (!sameSize(offered[index], current)) continue;
+        const next = index + direction;
+        if (next < 0 || next >= offered.length) return null;
+        return offered[next];
+    }
+    return null;
+}
+
 // Folding a legacy `sizeMode` option into the host's `__gridSize`.
 //
 // `sizeMode` was a plugin-*declared* choice option on two bundled widgets, in

--- a/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/AbstractWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/AbstractWidget.qml
@@ -82,10 +82,33 @@ MouseArea {
     acceptedButtons: Qt.LeftButton | Qt.RightButton
     cursorShape: (draggable && containsPress) ? Qt.ClosedHandCursor : draggable ? Qt.OpenHandCursor : Qt.ArrowCursor
 
+    // Edit Mode's right-click, announced rather than handled: this base class
+    // knows nothing about what a widget IS, and only a subclass that carries an
+    // identity (PluginWidget's manifest) can open a menu about itself. The
+    // coordinates are this widget's own; whoever answers maps them onward.
+    signal contextMenuRequested(real atX, real atY)
+
     onClicked: (mouse) => {
-        if (mouse.button === Qt.RightButton) {
-            Config.options.background.widgetsLocked = !Config.options.background.widgetsLocked
+        if (mouse.button !== Qt.RightButton) return
+        // The mode is read off the owning canvas - the same property the
+        // marquee and the Escape ladder already run on - rather than from a
+        // second global source, which keeps the overlay's canvas (which never
+        // follows the mode) on today's behaviour without a special case.
+        //
+        // In the mode the click is the widget's menu (spec §4.1). Outside it
+        // the click keeps being the one quick gesture for the global lock -
+        // the spec's table changes only the in-mode column, and this is the
+        // lock's sole sanctioned writer outside Settings
+        // (test_edit_mode_contract.py pins that). It also stops being a
+        // SILENT write: since the mode began suppressing the global lock,
+        // an in-mode right-click flipped a stored preference whose effect
+        // was invisible until the mode ended.
+        const canvas = findCanvas(root.parent)
+        if (canvas && canvas.editMode === true) {
+            root.contextMenuRequested(mouse.x, mouse.y)
+            return
         }
+        Config.options.background.widgetsLocked = !Config.options.background.widgetsLocked
     }
 
     // The canvas cannot see this widget's press/drag on its own, so report it.

--- a/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/WidgetCanvas.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/WidgetCanvas.qml
@@ -101,11 +101,13 @@ MouseArea {
     focus: root.selectionEnabled
     Keys.onEscapePressed: {
         const action = EditMode.resolveEscape({
+            menuOpen: GlobalStates.editWidgetMenuOpen,
             gestureInFlight: root.draggingWidget() !== null,
             selectionCount: root.selectedWidgets.length,
             tab: EditMode.DESKTOP_TAB
         })
-        if (action === "cancelGesture") root.cancelActiveDrag()
+        if (action === "closeMenu") GlobalStates.editWidgetMenuOpen = false
+        else if (action === "cancelGesture") root.cancelActiveDrag()
         else if (action === "clearSelection") root.clearSelection()
         else if (root.editMode) GlobalStates.editMode = false
     }

--- a/dots/.config/quickshell/imi/modules/imi/editMode/EditModeChrome.qml
+++ b/dots/.config/quickshell/imi/modules/imi/editMode/EditModeChrome.qml
@@ -35,4 +35,9 @@ Scope {
             }
         }
     }
+
+    // The per-widget context menu's window - one, not one per screen: it
+    // exists only while a menu is open, on the screen the widget was
+    // right-clicked on, and its own loader is that gate.
+    EditWidgetMenu {}
 }

--- a/dots/.config/quickshell/imi/modules/imi/editMode/EditModeChromeSurface.qml
+++ b/dots/.config/quickshell/imi/modules/imi/editMode/EditModeChromeSurface.qml
@@ -124,12 +124,7 @@ PanelWindow {
     // Widgets makes) and `PluginState`'s placement keys. That boundary is
     // spec §9's, and `lint_edit_mode_scope.py` polices it.
     function enabledWithout(id) {
-        const next = [];
-        for (let i = 0; i < Config.options.plugins.enabled.length; i++) {
-            if (Config.options.plugins.enabled[i] !== id)
-                next.push(Config.options.plugins.enabled[i]);
-        }
-        return next;
+        return EditMode.enabledWithout(Config.options.plugins.enabled, id);
     }
 
     function enablePlugin(id) {

--- a/dots/.config/quickshell/imi/modules/imi/editMode/EditWidgetMenu.qml
+++ b/dots/.config/quickshell/imi/modules/imi/editMode/EditWidgetMenu.qml
@@ -51,6 +51,13 @@ Scope {
             exclusiveZone: 0
             WlrLayershell.namespace: "quickshell:desktopMenu"
             WlrLayershell.layer: WlrLayer.Overlay
+            // Explicitly None, not left to the default: this surface maps on
+            // Overlay while the menu's own Escape rung (`closeMenu`) is
+            // answered by WidgetCanvas on the BACKGROUND surface, so a menu
+            // window holding the keyboard would swallow the exact key that
+            // dismisses it - the same hazard the chrome surface pins, one
+            // surface up.
+            WlrLayershell.keyboardFocus: WlrKeyboardFocus.None
 
             anchors {
                 top: true

--- a/dots/.config/quickshell/imi/modules/imi/editMode/EditWidgetMenu.qml
+++ b/dots/.config/quickshell/imi/modules/imi/editMode/EditWidgetMenu.qml
@@ -1,0 +1,111 @@
+import QtQuick
+import Quickshell
+import Quickshell.Wayland
+import qs
+import qs.modules.common
+import qs.modules.common.plugins
+
+/**
+ * The window that hosts the per-widget context menu: one full-screen `Overlay`
+ * surface on the screen the widget was right-clicked on, existing only while
+ * the menu is open - the desktop menu's exact shape, because it answers the
+ * same question. A menu drawn on the background surface instead would sit on
+ * `WlrLayer.Bottom`, under the bar, the dock and the mode's own chrome; and a
+ * fourth region in the chrome surface's mask could never dismiss on a click
+ * elsewhere, because every pixel outside the chrome's rects deliberately falls
+ * through to the desktop being edited.
+ *
+ * The namespace is `quickshell:desktopMenu`, reused rather than minted: this
+ * is the same kind of surface as the desktop's own context menu - full-screen,
+ * transparent except for a small card of `colLayer0` rows - and that namespace
+ * has carried exactly these pixels under the compositor's catch-all rules for
+ * the life of the shell. A minted name would repeat rules.lua's threshold
+ * exercise (spec §10.3's fourth property) to arrive at the same treatment.
+ *
+ * The card is anchored at the click's screen point, which arrived in
+ * `GlobalStates.editWidgetMenuX/Y` already mapped through the widget's own
+ * transform chain (PluginWidget's `mapToItem(null, ...)`) - so this window
+ * does no viewport arithmetic at all, which is what the no-compensation
+ * contract wants from everything outside `Background.qml`.
+ *
+ * Dismissal: a click anywhere outside the card (the full-screen MouseArea
+ * under it), Escape through the canvas's ladder (`closeMenu` is its first
+ * rung), leaving the mode (GlobalStates closes the menu with the drawer), and
+ * the widget itself being destroyed (PluginWidget vacates from
+ * `Component.onDestruction`).
+ */
+Scope {
+    id: root
+
+    Loader {
+        active: GlobalStates.editWidgetMenuOpen
+        sourceComponent: PanelWindow {
+            id: menuWindow
+
+            screen: Quickshell.screens.find(
+                candidate => candidate.name === GlobalStates.editWidgetMenuScreenName)
+                ?? Quickshell.screens[0]
+
+            color: "transparent"
+            exclusionMode: ExclusionMode.Ignore
+            exclusiveZone: 0
+            WlrLayershell.namespace: "quickshell:desktopMenu"
+            WlrLayershell.layer: WlrLayer.Overlay
+
+            anchors {
+                top: true
+                bottom: true
+                left: true
+                right: true
+            }
+
+            MouseArea {
+                anchors.fill: parent
+                acceptedButtons: Qt.LeftButton | Qt.RightButton
+                onClicked: GlobalStates.editWidgetMenuOpen = false
+            }
+
+            // Swallows what the card's rows do not take (the title row, the
+            // plates' padding), so a click ON the menu is never read as a
+            // click away from it. Under the card in declaration order, over
+            // the closer.
+            MouseArea {
+                x: card.x
+                y: card.y
+                width: card.width
+                height: card.height
+                acceptedButtons: Qt.AllButtons
+            }
+
+            EditWidgetMenuContent {
+                id: card
+                manifest: PluginManager.availablePlugins.find(
+                    entry => entry.id === GlobalStates.editWidgetMenuPluginId) ?? null
+                width: implicitWidth
+                height: implicitHeight
+                x: Math.min(Math.max(GlobalStates.editWidgetMenuX, 8),
+                    menuWindow.width - width - 8)
+                y: Math.min(Math.max(GlobalStates.editWidgetMenuY, 8),
+                    menuWindow.height - height - 8)
+                onDismissRequested: GlobalStates.editWidgetMenuOpen = false
+
+                // The desktop menu's entrance, from the corner the pointer is
+                // at rather than the card's centre - this card belongs to a
+                // point, not to the middle of the screen.
+                scale: 0.85
+                opacity: 0
+                transformOrigin: Item.TopLeft
+                Component.onCompleted: {
+                    scale = 1.0;
+                    opacity = 1.0;
+                }
+                Behavior on scale {
+                    animation: Appearance.animation.elementMoveEnter.numberAnimation.createObject(this)
+                }
+                Behavior on opacity {
+                    animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
+                }
+            }
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/modules/imi/editMode/EditWidgetMenuContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/editMode/EditWidgetMenuContent.qml
@@ -1,0 +1,282 @@
+import QtQuick
+import QtQuick.Layouts
+import qs
+import qs.modules.common
+import qs.modules.common.widgets
+import qs.modules.common.plugins
+import "../../common/functions/edit_mode.js" as EditMode
+import "../../common/plugins/gridSizes.js" as GridSizes
+
+/**
+ * The per-widget context menu's card: Remove, Pin, and the Size stepper
+ * (spec §4.1's in-mode right-click, §5's resize rule, §9's boundary).
+ *
+ * ---- what each row is allowed to be ----------------------------------------
+ *
+ * Everything here is placement, span, or presence - the three things spec §9
+ * lets the mode write, and `lint_edit_mode_scope.py` polices this file like the
+ * rest of the directory:
+ *
+ * - **Pin** is `positionLocked`, one of §9's two deliberate edge cases: a
+ *   "Widget behaviour" toggle that is *about* placement. It writes through the
+ *   one existing writer - `PluginState.setOption(id, "positionLocked", ...)` -
+ *   exactly as the settings page's toggle bar does: one writer, two call
+ *   sites, not two meanings. Its drawn state is a binding on the stored value
+ *   (seeded the way PluginWidget seeds it, from the manifest), never local
+ *   state, so a pin flipped from Settings while this menu is open moves the
+ *   row - the ConfigSwitch intent lesson applied to a row that draws a check.
+ *
+ * - **Size** is a stepper OVER `offeredGridSizes` and nothing else: the two
+ *   chevrons move an index through the spans the manifest offers, in the
+ *   manifest's own order (which gridSizes.js documents as the resize order),
+ *   and the write is the host's `__gridSize` - the same value the grip and the
+ *   settings row commit. No pointer delta and no pixel ever comes near it,
+ *   which is §5's rule: the host can only ever assign an offered span. A
+ *   widget offering one span gets NO row (omitted, not disabled - the
+ *   PluginOptions rule), and a widget that declined `grid` altogether
+ *   (calendar, world-clock, custom-image) offers zero spans, so its own
+ *   handles keep the size they chose and the host never overwrites it.
+ *
+ * - **Remove** is presence on the surface. `plugins.enabled` is one global
+ *   list and the desktop renders it on every monitor, so removing here removes
+ *   the widget everywhere - the same write the drawer's toggle and Settings >
+ *   Widgets make, through the same `EditMode.enabledWithout` spelling. The
+ *   removal destroys this menu's widget, whose Component.onDestruction then
+ *   closes the menu (PluginWidget's vacate); `dismissRequested` is still
+ *   raised so the window does not depend on that round trip.
+ *
+ * ---- why the writes live here ----------------------------------------------
+ *
+ * The drawer reports gestures and lets the chrome surface write, because its
+ * writes need the surface's geometry (a drop point mapped into the canvas).
+ * The menu's writes are id-keyed with no geometry in them, and this item is
+ * what the runtime harness can build and click - a window no harness can
+ * construct (weston implements no wlr-layer-shell) would put the writes where
+ * no test reaches them. The scope lint polices the whole directory either way.
+ */
+Item {
+    id: root
+
+    // The manifest, not an id: the card knows nothing about the catalogue,
+    // and whoever opens it resolves the id against `PluginManager` (the menu
+    // window) or hands in its own (the runtime harness, whose manifests are
+    // synthetic and exist in no catalogue).
+    property var manifest: null
+    signal dismissRequested()
+
+    readonly property var offeredSizes: GridSizes.offeredSizes(root.manifest?.grid ?? null)
+    // Stored choice -> manifest default, resolved the way the host resolves
+    // it, so the value the stepper starts from is the span the widget is
+    // actually drawn at - including when the stored span is one the manifest
+    // no longer offers and resolveSize has fallen back.
+    readonly property var currentSize: GridSizes.resolveSize(root.manifest?.grid ?? null,
+        root.manifest ? PluginState.option(root.manifest.id, "__gridSize") : undefined)
+    readonly property int sizeIndex: {
+        const current = GridSizes.formatSize(root.currentSize);
+        for (let index = 0; index < root.offeredSizes.length; index++) {
+            if (GridSizes.formatSize(root.offeredSizes[index]) === current)
+                return index;
+        }
+        return -1;
+    }
+
+    // The same seed PluginWidget's own binding reads, or the row would
+    // disagree with the widget for a manifest that ships `locked: true`.
+    readonly property bool pinned: root.manifest
+        ? PluginState.option(root.manifest.id, "positionLocked",
+            root.manifest.desktopWidget?.locked === true)
+        : false
+
+    // A step moves the index, never a pixel: the write is the offered entry at
+    // the neighbouring index, formatted the way the grip and the settings row
+    // format it. Out-of-range asks are refused here as well as by the
+    // chevrons' `enabled`, so a click racing the store cannot walk off the
+    // list. The menu stays open - stepping several spans and watching the
+    // widget morph between them is what a stepper is for.
+    function stepSize(direction) {
+        if (!root.manifest) return;
+        const next = root.sizeIndex + direction;
+        if (root.sizeIndex < 0 || next < 0 || next >= root.offeredSizes.length) return;
+        PluginState.setOption(root.manifest.id, "__gridSize",
+            GridSizes.formatSize(root.offeredSizes[next]));
+    }
+
+    implicitWidth: 260
+    implicitHeight: rows.implicitHeight
+
+    GroupedList {
+        id: rows
+        width: parent.width
+        itemVerticalPadding: Appearance.spacing.space200
+        bgcolor: Appearance.colors.colLayer0
+
+        // The widget's name, so the menu says which widget it is about - the
+        // pointer is on the widget, the menu may be clamped away from it.
+        Item {
+            implicitHeight: 40
+            RowLayout {
+                anchors {
+                    fill: parent
+                    leftMargin: Appearance.spacing.space150
+                    rightMargin: Appearance.spacing.space150
+                }
+                spacing: Appearance.spacing.space150
+                MaterialSymbol {
+                    text: "widgets"
+                    iconSize: Appearance.font.pixelSize.larger
+                    color: Appearance.colors.colOnLayer1
+                }
+                StyledText {
+                    Layout.fillWidth: true
+                    text: root.manifest?.name ?? ""
+                    font.pixelSize: Appearance.font.pixelSize.normal
+                    color: Appearance.colors.colOnLayer1
+                    elide: Text.ElideRight
+                }
+            }
+        }
+
+        RippleButton {
+            id: pinRow
+            objectName: "editMenuPin"
+            implicitHeight: 40
+            colBackground: "transparent"
+            colBackgroundHover: Appearance.colors.colLayer2
+            // The intent shape: the click flips the value at its source (the
+            // same read the `pinned` binding makes), and the check beside the
+            // label follows the store - never a local flag the write could
+            // detach from.
+            onClicked: {
+                if (!root.manifest) return;
+                PluginState.setOption(root.manifest.id, "positionLocked", !root.pinned);
+            }
+            contentItem: RowLayout {
+                anchors {
+                    fill: parent
+                    leftMargin: Appearance.spacing.space150
+                    rightMargin: Appearance.spacing.space150
+                }
+                spacing: Appearance.spacing.space150
+                MaterialSymbol {
+                    text: "push_pin"
+                    iconSize: Appearance.font.pixelSize.larger
+                    color: Appearance.colors.colOnLayer1
+                }
+                StyledText {
+                    Layout.fillWidth: true
+                    text: Translation.tr("Pin position")
+                    font.pixelSize: Appearance.font.pixelSize.normal
+                    color: Appearance.colors.colOnLayer1
+                }
+                MaterialSymbol {
+                    visible: root.pinned
+                    text: "check"
+                    iconSize: Appearance.font.pixelSize.larger
+                    color: Appearance.colors.colPrimary
+                }
+            }
+        }
+
+        // The stepper. `rowVisible`, never `visible`: a GroupedList row hidden
+        // the second way keeps its plate (see GroupedList.qml).
+        Item {
+            id: sizeRow
+            property bool rowVisible: root.offeredSizes.length > 1
+            implicitHeight: 40
+            RowLayout {
+                anchors {
+                    fill: parent
+                    leftMargin: Appearance.spacing.space150
+                    rightMargin: Appearance.spacing.space150
+                }
+                spacing: Appearance.spacing.space150
+                MaterialSymbol {
+                    text: "aspect_ratio"
+                    iconSize: Appearance.font.pixelSize.larger
+                    color: Appearance.colors.colOnLayer1
+                }
+                StyledText {
+                    Layout.fillWidth: true
+                    text: Translation.tr("Size")
+                    font.pixelSize: Appearance.font.pixelSize.normal
+                    color: Appearance.colors.colOnLayer1
+                }
+                RippleButton {
+                    id: sizeDownButton
+                    objectName: "editMenuSizeDown"
+                    implicitWidth: 32
+                    implicitHeight: 32
+                    enabled: root.sizeIndex > 0
+                    onClicked: root.stepSize(-1)
+                    colBackground: "transparent"
+                    colBackgroundHover: Appearance.colors.colLayer2
+                    contentItem: MaterialSymbol {
+                        anchors.centerIn: parent
+                        text: "chevron_left"
+                        iconSize: Appearance.font.pixelSize.larger
+                        color: Appearance.colors.colOnLayer1
+                    }
+                }
+                StyledText {
+                    text: root.currentSize
+                        ? `${root.currentSize.cols} × ${root.currentSize.rows}` : ""
+                    font.pixelSize: Appearance.font.pixelSize.normal
+                    color: Appearance.colors.colOnLayer1
+                }
+                RippleButton {
+                    id: sizeUpButton
+                    objectName: "editMenuSizeUp"
+                    implicitWidth: 32
+                    implicitHeight: 32
+                    enabled: root.sizeIndex >= 0 && root.sizeIndex < root.offeredSizes.length - 1
+                    onClicked: root.stepSize(1)
+                    colBackground: "transparent"
+                    colBackgroundHover: Appearance.colors.colLayer2
+                    contentItem: MaterialSymbol {
+                        anchors.centerIn: parent
+                        text: "chevron_right"
+                        iconSize: Appearance.font.pixelSize.larger
+                        color: Appearance.colors.colOnLayer1
+                    }
+                }
+            }
+        }
+
+        RippleButton {
+            id: removeRow
+            objectName: "editMenuRemove"
+            implicitHeight: 40
+            colBackground: "transparent"
+            colBackgroundHover: Appearance.colors.colLayer2
+            // Presence: the same write the drawer's toggle and Settings >
+            // Widgets make, through the one spelling. The dismiss is raised as
+            // well as earned through the widget's own vacate, so the window
+            // closes even where no widget instance exists to be destroyed.
+            onClicked: {
+                if (!root.manifest) return;
+                Config.setNestedValue("plugins.enabled",
+                    EditMode.enabledWithout(Config.options.plugins.enabled, root.manifest.id));
+                root.dismissRequested();
+            }
+            contentItem: RowLayout {
+                anchors {
+                    fill: parent
+                    leftMargin: Appearance.spacing.space150
+                    rightMargin: Appearance.spacing.space150
+                }
+                spacing: Appearance.spacing.space150
+                MaterialSymbol {
+                    text: "delete"
+                    iconSize: Appearance.font.pixelSize.larger
+                    color: Appearance.colors.colOnLayer1
+                }
+                StyledText {
+                    Layout.fillWidth: true
+                    text: Translation.tr("Remove from desktop")
+                    font.pixelSize: Appearance.font.pixelSize.normal
+                    color: Appearance.colors.colOnLayer1
+                }
+            }
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/modules/imi/editMode/EditWidgetMenuContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/editMode/EditWidgetMenuContent.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import QtQuick.Layouts
 import qs
+import qs.services
 import qs.modules.common
 import qs.modules.common.widgets
 import qs.modules.common.plugins

--- a/dots/.config/quickshell/imi/modules/imi/editMode/EditWidgetMenuContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/editMode/EditWidgetMenuContent.qml
@@ -66,20 +66,23 @@ Item {
     signal dismissRequested()
 
     readonly property var offeredSizes: GridSizes.offeredSizes(root.manifest?.grid ?? null)
+    // The stored choice, read once so every derivation below shares one
+    // reactive dependency on the plugin-state store.
+    readonly property var storedSpan: root.manifest
+        ? PluginState.option(root.manifest.id, "__gridSize") : undefined
     // Stored choice -> manifest default, resolved the way the host resolves
     // it, so the value the stepper starts from is the span the widget is
     // actually drawn at - including when the stored span is one the manifest
     // no longer offers and resolveSize has fallen back.
     readonly property var currentSize: GridSizes.resolveSize(root.manifest?.grid ?? null,
-        root.manifest ? PluginState.option(root.manifest.id, "__gridSize") : undefined)
-    readonly property int sizeIndex: {
-        const current = GridSizes.formatSize(root.currentSize);
-        for (let index = 0; index < root.offeredSizes.length; index++) {
-            if (GridSizes.formatSize(root.offeredSizes[index]) === current)
-                return index;
-        }
-        return -1;
-    }
+        root.storedSpan)
+    // The two neighbours, from the module (tst_grid_sizes.qml owns the walk):
+    // null means "nowhere to step", which is exactly what the chevron's
+    // enabled reads.
+    readonly property var stepBack: GridSizes.steppedSize(root.manifest?.grid ?? null,
+        root.storedSpan, -1)
+    readonly property var stepForward: GridSizes.steppedSize(root.manifest?.grid ?? null,
+        root.storedSpan, 1)
 
     // The same seed PluginWidget's own binding reads, or the row would
     // disagree with the widget for a manifest that ships `locked: true`.
@@ -88,18 +91,19 @@ Item {
             root.manifest.desktopWidget?.locked === true)
         : false
 
-    // A step moves the index, never a pixel: the write is the offered entry at
-    // the neighbouring index, formatted the way the grip and the settings row
-    // format it. Out-of-range asks are refused here as well as by the
-    // chevrons' `enabled`, so a click racing the store cannot walk off the
-    // list. The menu stays open - stepping several spans and watching the
+    // A step moves along the offered order, never a pixel: the write is
+    // whatever GridSizes.steppedSize answers, formatted the way the grip and
+    // the settings row format it. A null answer - off either end, or nothing
+    // to step - writes nothing, so a click racing the store cannot walk off
+    // the list. The menu stays open: stepping several spans and watching the
     // widget morph between them is what a stepper is for.
     function stepSize(direction) {
         if (!root.manifest) return;
-        const next = root.sizeIndex + direction;
-        if (root.sizeIndex < 0 || next < 0 || next >= root.offeredSizes.length) return;
+        const next = GridSizes.steppedSize(root.manifest.grid ?? null,
+            root.storedSpan, direction);
+        if (!next) return;
         PluginState.setOption(root.manifest.id, "__gridSize",
-            GridSizes.formatSize(root.offeredSizes[next]));
+            GridSizes.formatSize(next));
     }
 
     implicitWidth: 260
@@ -207,7 +211,7 @@ Item {
                     objectName: "editMenuSizeDown"
                     implicitWidth: 32
                     implicitHeight: 32
-                    enabled: root.sizeIndex > 0
+                    enabled: root.stepBack !== null
                     onClicked: root.stepSize(-1)
                     colBackground: "transparent"
                     colBackgroundHover: Appearance.colors.colLayer2
@@ -229,7 +233,7 @@ Item {
                     objectName: "editMenuSizeUp"
                     implicitWidth: 32
                     implicitHeight: 32
-                    enabled: root.sizeIndex >= 0 && root.sizeIndex < root.offeredSizes.length - 1
+                    enabled: root.stepForward !== null
                     onClicked: root.stepSize(1)
                     colBackground: "transparent"
                     colBackgroundHover: Appearance.colors.colLayer2

--- a/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
@@ -903,5 +903,57 @@ def test_the_cards_edge_is_a_catch_rather_than_a_rim():
          f"second catch: {stops}")
 
 
+def test_the_right_click_is_the_menu_in_the_mode_and_the_lock_outside_it():
+    # One click, two meanings, decided by the mode (spec 4.1's table changes
+    # only the in-mode column). Both halves are pinned because each can rot
+    # alone: losing the in-mode branch brings back a SILENT lock write - the
+    # mode suppresses the global lock, so flipping it from inside has no
+    # visible effect until the mode ends - and losing the outside branch takes
+    # away the lock's one sanctioned quick gesture.
+    widget = code(WIDGET)
+    handler = re.search(r"onClicked:\s*\(mouse\)\s*=>\s*\{(.*?)\n    \}", widget, re.S)
+    assert handler, "AbstractWidget no longer answers the click"
+    body = handler.group(1)
+    menu = re.search(r"canvas\.editMode\s*===\s*true", body)
+    lock = re.search(r"Config\.options\.background\.widgetsLocked\s*=(?!=)", body)
+    assert menu and "contextMenuRequested" in body, \
+        "in the mode the right-click must raise the widget's menu"
+    assert lock, "outside the mode the right-click must still toggle the lock"
+    assert menu.start() < lock.start(), \
+        ("the menu branch must be resolved first, or the in-mode click writes "
+         "the lock as well as opening the menu")
+    # The subclass that answers the request maps the point through Qt's own
+    # transform chain - the scene mapping - never by multiplying a viewport
+    # scale in by hand (the compensation the sweep above already forbids by
+    # name; this is the positive half).
+    plugin = code(PLUGIN_WIDGET)
+    request = re.search(r"onContextMenuRequested:\s*\(atX, atY\)\s*=>\s*\{(.*?)\n    \}",
+                        plugin, re.S)
+    assert request, "PluginWidget no longer answers the menu request"
+    assert "mapToItem(null" in request.group(1), \
+        "the menu's anchor must go through the widget's own transform chain"
+    for field in ("editWidgetMenuPluginId", "editWidgetMenuScreenName",
+                  "editWidgetMenuX", "editWidgetMenuY", "editWidgetMenuOpen"):
+        assert f"GlobalStates.{field}" in request.group(1), \
+            f"the menu request no longer writes {field}"
+
+
+def test_a_destroyed_widget_vacates_the_menu_it_opened():
+    # The BarContent.filterLayout shape: disabling a plugin (the menu's own
+    # Remove included) destroys the widget while the menu still points at it,
+    # and a stranded menu offers Remove/Pin/Size about nothing. The declaring
+    # object vacates from Component.onDestruction, keyed on the id AND the
+    # screen - every monitor holds an instance of the plugin, and only the one
+    # the menu was opened on may close it.
+    plugin = code(PLUGIN_WIDGET)
+    vacate = re.search(
+        r"Component\.onDestruction:\s*\{(.*?)\n    \}", plugin, re.S)
+    assert vacate, "PluginWidget no longer vacates on destruction"
+    body = vacate.group(1)
+    assert "editWidgetMenuOpen = false" in body, "the vacate no longer closes the menu"
+    assert "editWidgetMenuPluginId" in body and "editWidgetMenuScreenName" in body, \
+        "the vacate must match both the id and the screen before closing"
+
+
 if __name__ == "__main__":
     raise SystemExit(run(globals()))

--- a/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
@@ -968,10 +968,12 @@ def test_the_size_affordance_indexes_offered_spans_and_never_a_pixel():
     content = code(MENU_CONTENT)
     assert "GridSizes.offeredSizes(" in content, \
         "the menu no longer takes its spans from the offered list"
+    assert "GridSizes.steppedSize(" in content, \
+        "the step must come from the module, where tst_grid_sizes owns the walk"
     assert re.search(
-        r'setOption\([^)]*"__gridSize",\s*\n?\s*GridSizes\.formatSize\(root\.offeredSizes\[',
+        r'setOption\([^)]*"__gridSize",\s*\n?\s*GridSizes\.formatSize\(next\)',
         content), \
-        "the size write must be an entry of offeredGridSizes and nothing else"
+        "the size write must be the stepped offered span and nothing else"
     # No pointer anywhere near the size: the card's rows are buttons, and a
     # MouseArea is how a pixel delta would arrive.
     assert "MouseArea" not in content, \

--- a/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
@@ -78,6 +78,8 @@ CHROME_SCOPE = ROOT / "modules/imi/editMode/EditModeChrome.qml"
 CHROME_SURFACE = ROOT / "modules/imi/editMode/EditModeChromeSurface.qml"
 CHROME_CONTENT = ROOT / "modules/imi/editMode/EditModeChromeContent.qml"
 DRAWER = ROOT / "modules/imi/editMode/EditModeDrawer.qml"
+MENU = ROOT / "modules/imi/editMode/EditWidgetMenu.qml"
+MENU_CONTENT = ROOT / "modules/imi/editMode/EditWidgetMenuContent.qml"
 INSETS = ROOT / "modules/imi/editMode/EditModeInsets.qml"
 DESKTOP_MENU = ROOT / "modules/imi/desktopMenu/DesktopMenu.qml"
 RULES = ROOT.parents[1] / "hypr/hyprland/rules.lua"
@@ -86,7 +88,8 @@ RULES = ROOT.parents[1] / "hypr/hyprland/rules.lua"
 # participant is a deliberate addition to this list, which is where someone
 # reads what the rules are.
 PARTICIPANTS = [BACKGROUND, CANVAS, WIDGET, BACKGROUND_WIDGET, PLUGIN_WIDGET,
-                CHROME_SCOPE, CHROME_SURFACE, CHROME_CONTENT, DRAWER]
+                CHROME_SCOPE, CHROME_SURFACE, CHROME_CONTENT, DRAWER,
+                MENU, MENU_CONTENT]
 
 
 def read(path: Path) -> str:
@@ -953,6 +956,94 @@ def test_a_destroyed_widget_vacates_the_menu_it_opened():
     assert "editWidgetMenuOpen = false" in body, "the vacate no longer closes the menu"
     assert "editWidgetMenuPluginId" in body and "editWidgetMenuScreenName" in body, \
         "the vacate must match both the id and the screen before closing"
+
+
+def test_the_size_affordance_indexes_offered_spans_and_never_a_pixel():
+    # Spec 5's rule, mechanized (11.2): the host can only ever assign an
+    # offered span, so the menu's Size is a stepper over offeredGridSizes and
+    # the tempting way to build it - a handle over pixels - must be
+    # unreachable. A widget offering one span gets no row at all (omitted, not
+    # disabled), and one that declined `grid` (calendar, world-clock,
+    # custom-image) offers zero, so its own handles keep the size they chose.
+    content = code(MENU_CONTENT)
+    assert "GridSizes.offeredSizes(" in content, \
+        "the menu no longer takes its spans from the offered list"
+    assert re.search(
+        r'setOption\([^)]*"__gridSize",\s*\n?\s*GridSizes\.formatSize\(root\.offeredSizes\[',
+        content), \
+        "the size write must be an entry of offeredGridSizes and nothing else"
+    # No pointer anywhere near the size: the card's rows are buttons, and a
+    # MouseArea is how a pixel delta would arrive.
+    assert "MouseArea" not in content, \
+        "the menu card grew a pointer area - a size handle starts this way"
+    assert "onPositionChanged" not in content
+    # No second copy of the grip's tension walk either.
+    assert "previewGridResize" not in content and "BREAK_PX" not in content, \
+        "the menu re-implements the grip instead of stepping the offered list"
+    # The row comes and goes with the offered count, through GroupedList's own
+    # mechanism - `visible` would leave an empty plate (b949bf24a).
+    assert re.search(r"rowVisible:\s*root\.offeredSizes\.length > 1", content), \
+        "a single-span widget must get no Size row, via rowVisible"
+
+
+def test_the_pin_is_one_writer_with_two_call_sites_and_a_bound_state():
+    # Spec 9's first deliberate edge case: a "Widget behaviour" toggle that is
+    # about placement. The write goes through the one existing writer
+    # (PluginState.setOption), and the drawn state is a BINDING on the stored
+    # value with the host's own manifest seed - never local state, which is the
+    # ConfigSwitch lesson: a row holding its own flag detaches from the store
+    # on the first external write and then lies about it.
+    content = code(MENU_CONTENT)
+    pinned = declaration(content, "pinned")
+    assert pinned, "the pin row no longer binds its state"
+    assert "PluginState.option(" in pinned and "positionLocked" in pinned, \
+        "the pin state must be read from the store"
+    assert "desktopWidget?.locked === true" in pinned, \
+        "the pin state must be seeded the way PluginWidget seeds it"
+    assert re.search(
+        r'PluginState\.setOption\([^)]*"positionLocked",\s*!root\.pinned\)', content), \
+        "the pin click must flip the stored value at its source"
+
+
+def test_remove_is_presence_through_the_one_spelling():
+    # Presence on the surface is one list and one write: the menu's Remove,
+    # the drawer's toggle and Settings > Widgets all mutate plugins.enabled,
+    # and the two edit-mode call sites share EditMode.enabledWithout so they
+    # cannot disagree about order or duplicates.
+    content = code(MENU_CONTENT)
+    assert 'Config.setNestedValue("plugins.enabled"' in content, \
+        "the menu's Remove no longer writes presence"
+    assert "EditMode.enabledWithout(" in content, \
+        "the menu spells its own removal loop instead of the shared one"
+    assert "EditMode.enabledWithout(" in code(CHROME_SURFACE), \
+        "the drawer's toggle left the shared spelling"
+
+
+def test_the_menu_window_is_the_desktop_menus_shape():
+    # A transient full-screen Overlay window that exists only while open, on
+    # the reused quickshell:desktopMenu namespace - the same kind of surface as
+    # the desktop's own menu, under the same compositor rules. A menu on the
+    # background surface would sit under the bar; a fourth mask region on the
+    # chrome surface could never dismiss on an outside click, because every
+    # pixel outside the chrome's rects falls through to the desktop.
+    menu = code(MENU)
+    assert 'WlrLayershell.namespace: "quickshell:desktopMenu"' in menu, \
+        "the menu window left the desktop menu's namespace"
+    assert re.search(r'color:\s*"transparent"', menu), \
+        "the window's clear colour must stay a literal (deba3e3f6)"
+    assert re.search(r"active:\s*GlobalStates\.editWidgetMenuOpen", menu), \
+        "the window must exist only while the menu is open"
+    assert re.search(r"onClicked:\s*GlobalStates\.editWidgetMenuOpen = false", menu), \
+        "a click outside the card must dismiss the menu"
+
+
+def test_the_menu_does_not_outlive_the_mode():
+    states = code(GLOBAL_STATES)
+    handler = re.search(r"onEditModeChanged:\s*\{(.*?)\n    \}", states, re.S)
+    assert handler, "GlobalStates no longer answers the mode ending"
+    assert "editWidgetMenuOpen = false" in handler.group(1), \
+        ("leaving the mode must close the menu - one left open would greet the "
+         "next entry pointing at wherever a widget used to be")
 
 
 if __name__ == "__main__":

--- a/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
@@ -226,8 +226,11 @@ def test_the_escape_ladder_is_the_module_and_not_open_coded():
     body = handler.group(1)
     assert "EditMode.resolveEscape" in body, \
         "the ladder's precedence belongs to the module, where a test can reach it"
-    # The four answers the module gives, and no branch invented beside them.
-    for answer in ("cancelGesture", "clearSelection"):
+    # The answers the module gives, and no branch invented beside them.
+    # `closeMenu` is the first rung: the per-widget menu is the topmost
+    # transient the mode draws, so Escape dismisses it before touching what is
+    # under it - and never exits the mode while it is up.
+    for answer in ("closeMenu", "cancelGesture", "clearSelection"):
         assert answer in body, f"the handler ignores the module's {answer}"
 
 

--- a/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
@@ -1035,6 +1035,20 @@ def test_the_menu_window_is_the_desktop_menus_shape():
         "the window must exist only while the menu is open"
     assert re.search(r"onClicked:\s*GlobalStates\.editWidgetMenuOpen = false", menu), \
         "a click outside the card must dismiss the menu"
+    assert "WlrLayershell.layer: WlrLayer.Overlay" in menu, \
+        "the menu must map above the mode's chrome, or it opens under the toolbar"
+    # Explicit, not defaulted: this Overlay surface must not hold the keyboard,
+    # because the menu's own Escape rung is answered on the background surface
+    # - the same pin the chrome surface carries, for the same reason.
+    assert "WlrLayershell.keyboardFocus: WlrKeyboardFocus.None" in menu, \
+        "the menu window must decline the keyboard the Escape ladder needs"
+    # The click-eater under the card: without it a click on the card's title
+    # row or plate padding falls through to the closer and dismisses the menu -
+    # and no harness can see it, because no harness can build this window.
+    eater = re.search(
+        r"MouseArea\s*\{\s*x:\s*card\.x\s*y:\s*card\.y\s*width:\s*card\.width\s*"
+        r"height:\s*card\.height\s*acceptedButtons:\s*Qt\.AllButtons", menu)
+    assert eater, "a click ON the card must not read as a click away from it"
 
 
 def test_the_menu_does_not_outlive_the_mode():

--- a/dots/.config/quickshell/imi/tests/test_edit_mode_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_edit_mode_runtime.py
@@ -40,7 +40,7 @@ SOCKET = "wayland-imi-edit-mode"
 # The harness prints how many checks it ran. A literal rather than anything read
 # back out of that output: a harness whose step list shrinks must redden here
 # instead of reporting `failures: 0` for a shorter run.
-EXPECTED_CHECKS = 30
+EXPECTED_CHECKS = 35
 
 
 def _stop(proc):

--- a/dots/.config/quickshell/imi/tests/test_edit_mode_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_edit_mode_runtime.py
@@ -40,7 +40,7 @@ SOCKET = "wayland-imi-edit-mode"
 # The harness prints how many checks it ran. A literal rather than anything read
 # back out of that output: a harness whose step list shrinks must redden here
 # instead of reporting `failures: 0` for a shorter run.
-EXPECTED_CHECKS = 35
+EXPECTED_CHECKS = 41
 
 
 def _stop(proc):

--- a/dots/.config/quickshell/imi/tests/tst_edit_mode.qml
+++ b/dots/.config/quickshell/imi/tests/tst_edit_mode.qml
@@ -19,6 +19,24 @@ TestCase {
         }), "cancelGesture");
     }
 
+    function test_escape_dismisses_an_open_menu_before_anything_else() {
+        // The per-widget context menu is the topmost transient the mode draws
+        // - it opens over the widget it belongs to and everything else waits
+        // behind it - so it is the ladder's first rung. Asserted with every
+        // other rung armed, because a rung that only wins against an empty
+        // state would pass a `||` chain.
+        compare(EditMode.resolveEscape({
+            menuOpen: true, gestureInFlight: true, selectionCount: 3, tab: "lockscreen"
+        }), "closeMenu");
+    }
+
+    function test_a_closed_menu_leaves_the_ladder_exactly_as_it_was() {
+        compare(EditMode.resolveEscape({
+            menuOpen: false, gestureInFlight: true, selectionCount: 0
+        }), "cancelGesture");
+        compare(EditMode.resolveEscape({ menuOpen: false }), "exit");
+    }
+
     function test_escape_clears_a_selection_before_changing_tab() {
         compare(EditMode.resolveEscape({
             gestureInFlight: false, selectionCount: 2, tab: "lockscreen"
@@ -470,6 +488,29 @@ TestCase {
         });
         compare(point.x, 1600 - 12);
         compare(point.y, 0);
+    }
+
+    function test_removing_an_id_from_the_enabled_list_keeps_the_rest_in_order() {
+        // Presence on the desktop is one list, and taking an id out of it has
+        // one spelling - the drawer's toggle and the menu's Remove are two call
+        // sites of this, not two loops that can disagree.
+        compare(EditMode.enabledWithout(["clock", "notes", "visualizer"], "notes"),
+                ["clock", "visualizer"]);
+    }
+
+    function test_removing_an_absent_id_returns_an_equal_list() {
+        compare(EditMode.enabledWithout(["clock", "notes"], "docker"),
+                ["clock", "notes"]);
+        compare(EditMode.enabledWithout([], "docker"), []);
+    }
+
+    function test_the_enabled_list_survives_arriving_as_a_qml_list() {
+        // `plugins.enabled` is a QML list property, and a JS array that has
+        // crossed the QML boundary keeps its indices and its length while
+        // losing its Array brand - the trap gridSizes.js already documents. An
+        // array-LIKE input has to come out as a plain array with the id gone.
+        const like = { length: 3, 0: "clock", 1: "notes", 2: "visualizer" };
+        compare(EditMode.enabledWithout(like, "clock"), ["notes", "visualizer"]);
     }
 
     function test_the_chromes_band_closes_in_as_the_desktop_shrinks() {

--- a/dots/.config/quickshell/imi/tests/tst_grid_sizes.qml
+++ b/dots/.config/quickshell/imi/tests/tst_grid_sizes.qml
@@ -238,6 +238,43 @@ TestCase {
         compare(migrated.sizeMode, undefined);
     }
 
+    // --- stepping through the offered order (the menu's Size stepper) -----
+
+    function test_a_step_moves_to_the_neighbouring_offered_span() {
+        // The offered order IS the step order - the manifest's own, which
+        // offeredSizes documents as the resize order.
+        const grid = mediaGrid();
+        compare(GridSizes.formatSize(GridSizes.steppedSize(grid, "2x2", -1)), "3x2");
+        compare(GridSizes.formatSize(GridSizes.steppedSize(grid, "2x2", 1)), "2x1");
+    }
+
+    function test_a_step_off_either_end_answers_null() {
+        // Null rather than clamping to the end: the caller's chevron reads
+        // "is there a next span" straight off this, so a clamp would leave a
+        // live-looking button that writes the span the widget already has.
+        const grid = mediaGrid();
+        compare(GridSizes.steppedSize(grid, "3x2", -1), null);
+        compare(GridSizes.steppedSize(grid, "2x1", 1), null);
+    }
+
+    function test_a_widget_that_cannot_step_answers_null() {
+        // No grid (content-sized: calendar, world-clock, custom-image) and a
+        // single-span grid both have nowhere to step - the same predicate that
+        // gives them no grip and no Size row.
+        compare(GridSizes.steppedSize(undefined, "", 1), null);
+        compare(GridSizes.steppedSize({ cols: 2, rows: 1 }, "2x1", 1), null);
+        compare(GridSizes.steppedSize({ cols: 2, rows: 1 }, "2x1", -1), null);
+    }
+
+    function test_a_stale_stored_span_steps_from_the_resolved_fallback() {
+        // resolveSize already refuses a span the manifest no longer offers and
+        // falls back to the default; the step starts where the widget is
+        // actually drawn, which is that fallback.
+        const grid = mediaGrid();
+        compare(GridSizes.formatSize(GridSizes.steppedSize(grid, "9x9", 1)), "2x2");
+        compare(GridSizes.steppedSize(grid, "9x9", -1), null);
+    }
+
     function test_a_plugin_with_no_sizeMode_is_left_alone() {
         // Answering null rather than a copy is what keeps the store from being
         // rewritten for every plugin on every launch.


### PR DESCRIPTION
Stage 6 of Edit Mode (spec §12): the per-widget context menu and the Size stepper. **Stacks on #246** (`feat/edit-mode-stage5-drawer`), which must merge first; this branch's base is that one.

In the mode, a right-click on a widget now opens a menu about that widget — Pin, Size, Remove — instead of toggling the global widget lock. Outside the mode the click keeps toggling the lock, deliberately: the spec's §4.1 table changes only the in-mode column, the menu is the mode's affordance, and that gesture is the lock's one sanctioned quick writer outside Settings (the contract's writers set pins it and is unchanged). This also retires a silent write: since the mode began suppressing the global lock, an in-mode right-click flipped a stored preference with no visible effect until the mode ended.

What each row is, against §9's boundary (placement, span, presence — nothing else, and `lint_edit_mode_scope.py` polices the new files with no allowlist change):

- **Pin** is `positionLocked`, §9's first deliberate edge case. It writes through the one existing writer — `PluginState.setOption(id, "positionLocked", …)`, the same call the settings page's toggle bar makes — and its drawn check is a readonly binding on the stored value, seeded from the manifest exactly as `PluginWidget` seeds its own, so a pin flipped from Settings while the menu is open moves the row.
- **Size** is a stepper over `offeredGridSizes` (§5): two chevrons move an index through the spans the manifest offers, in the manifest's own order, writing the host's `__gridSize` — the same value the grip and the settings row commit, so the span animation and the stored-position repair run unchanged. No pointer delta or pixel comes near it. A single-span widget gets no row (omitted via `rowVisible`, not disabled), and a widget that declined `grid` — calendar, world-clock, custom-image — offers zero spans, so its own handles keep the size they chose and the host never overwrites it.
- **Remove** is presence. `plugins.enabled` is one global list rendered on every monitor, so Remove removes the widget everywhere — the same write the drawer's toggle and Settings › Widgets make, now through one shared spelling (`edit_mode.js`'s `enabledWithout`, adopted by the drawer's toggle in the same series).

The plumbing: `AbstractWidget` only announces the click (`contextMenuRequested`) and resolves the mode off its owning canvas, so the overlay's canvas keeps today's behaviour with no special case; `PluginWidget` answers it, mapping the point with `mapToItem(null, …)` — Qt's own transform chain, which composes the mode's scale, the drawer's shift and the press scale, never a hand-multiplied viewport scale — and vacates the menu from `Component.onDestruction` when the menu points at this instance (id and screen), because the menu's own Remove destroys the widget under the open menu. The window is the desktop menu's exact shape — a transient full-screen Overlay surface on the reused `quickshell:desktopMenu` namespace, card anchored at the click's screen point, click-away closer underneath — rather than a fourth region in the chrome surface's mask, which could never dismiss on an outside click because every pixel outside the chrome's rects deliberately falls through to the desktop being edited. Escape gains `closeMenu` as the ladder's first rung, extended in `edit_mode.js` and its `tst_` first, so Escape dismisses the menu rather than exiting the mode.

Tests: `tst_edit_mode.qml` 35 passing (+5, watched failing first); `EditModeRuntimeTest.qml` grows from 30 to 41 checks — the right-click's two meanings, the transform-composed anchor, the vacate driven through a Loader-wrapped widget, and real clicks on the real card read back from the real stores (pin on/off, the stepper walked to both ends of the offered order with the end click refused, Remove emptying `plugins.enabled`); `test_edit_mode_contract.py` 37 checks (+7), each new one proven to fail on a planted mutation in a committed-clean tree; `DesignSystemCompile` sweeps both new files (180 checked, 0 failures). Full `./tests/run_tests.sh` at the tip: every section green end to end (qmltestrunner 955 passed, 0 failed), with the one exception noted below, which reproduces on main.

Not verifiable here, owed to a live load: the menu window on a real compositor (weston implements no wlr-layer-shell — stacking above the mode's chrome, blur under the reused namespace's rules, click-away against real surfaces), and whether the compositor delivers Escape to the background surface at all (pre-existing; the pointer paths — click-away and the toolbar — do not depend on it). One known limit stated in the code: a `clickThrough` widget leaves pointer routing entirely, so it cannot be right-clicked even in the mode; its presence and pin stay reachable from the drawer and Settings › Widgets.

A reviewer pass over the branch diff returned "ready with fixes", both landed: the menu window now declares `WlrKeyboardFocus.None` explicitly (it maps on Overlay while its own Escape rung is answered on the background surface — working by default is the class of silent dependency the chrome surface's contract already forbids), and the stepper's walk moved into `gridSizes.js` as `steppedSize` (TDD-first), where `qmltestrunner` reaches it instead of only the local-only weston harness.

One pre-existing suite red, not from this branch: `test_sddm_pin_reachable.py` fails because the pinned `SDDM_REF` (1b0ac8bb6) no longer exists in the external `XephyLon/imi-sddm-theme` repo — reproduced identically on an untouched main checkout, and this branch touches nothing under `sdata/`. Re-pinning the satellite SHA is its own fix, outside a stacked UI stage.

Docs: updated AGENT.md §Edit Mode (the right-click's two meanings, the menu's three licences, the vacate rule, the ladder's first rung), cited by exact subject line.
