### PR TITLE
Edit Mode stage 9: the Lockscreen tab, and a preview that cannot authenticate

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -2790,6 +2790,47 @@ mode is built out of are worth not re-deriving:
   feat(bar): bar widgets become inert, badged and reorderable in the mode;
   feat(dock): pinned icons grow remove badges and go inert in the mode;
   feat(editMode): the drawer grows Bar and Dock sections.)
+- **The Lockscreen tab is a filter on the viewport, and its preview cannot
+  authenticate — stage 9.** The tab is `GlobalStates.editTab`, a string beside
+  the mode holding `edit_mode.js`'s tab constants (the literal lives in that
+  file alone), reset on exit like the drawer and the menu; the ONE derivation
+  of "the viewport is showing the lock screen" is
+  `GlobalStates.editLockPreview`, and the contract forbids an `editTab ===`
+  comparison anywhere else — the chrome's tab bar maps index↔tab through the
+  module's `tabAt`/`tabIndex` for exactly that reason, and its two directions
+  are imperative on purpose, because `ToolbarTabBar`'s wheel handler assigns
+  the inner index directly and would destroy a binding placed on it. What the
+  tab changes is gates on things `Background.qml` already draws: the lock
+  wallpaper, the lock WE project, the peel state, the lock blur (through one
+  local `lockLook`), `AbstractBackgroundWidget`'s lock filter, and the clock's
+  four lock-look bindings (one `lockLook` in the plugin — centring, style,
+  show-only-when-locked, the Locked caption). The islands are the REAL
+  `LockSurface`, neutered by construction: `interactive: false` gates the
+  root area, the field (`enabled` AND `readOnly`), `forceFieldFocus` and
+  every click/key handler uniformly — so `tests/test_lock_preview_contract.py`
+  holds ALL handlers to the one guard and asserts how many it found, since a
+  sweep here that matches nothing is a security hole reading as green — and
+  the context is `LockPreviewContext`, a separate component enumerated
+  against `LockContext`'s whole surface that constructs no pam machinery and
+  spawns nothing (never "the real one with a flag"). The host is a fifth
+  sibling carrying the one edit matrix at z 4, above the widgets the way the
+  real session lock surface is. The bar and the dock leave the tab through
+  the lock's own gates (the bars' loader `active`, the dock's `visible` — a
+  surface teardown per tab flip, sanctioned where auto-hide suspension never
+  is), while `EditModeInsets` deliberately does NOT drop with them: the
+  reservation is configuration-only, and a card resized per tab flip is
+  b710ef731's moving target under every widget at once. Island visibility is
+  the drawer's Lock section — rows signal, the chrome surface flips the three
+  `lock.show*` booleans at literal paths. Known fidelity gaps, accepted and
+  stated: no fingerprint glyph in the preview (knowing means asking the
+  daemon), parallax stays desktop-framed (its zoom feeds the viewport's
+  size), and `centeredWallpaperOnlyWhenLocked` does not preview.
+  (feat(lock): LockSurface takes an interactive switch, default on;
+  feat(lock): LockPreviewContext, a context that cannot authenticate;
+  feat(editMode): the mode's tab, a GlobalStates string beside it;
+  feat(background): the viewport draws its locked inputs on the Lockscreen tab;
+  feat(bar): the bar and the dock leave the Lockscreen tab;
+  feat(editMode): the drawer grows a Lock section for island presence.)
 (feat(editMode): shrink the desktop into a viewport on the background surface,
 feat(editMode): stand the per-widget frost down for the mode,
 feat(editMode): draw the shrunk desktop as a card, not as a cropped screenshot,

--- a/dots/.config/quickshell/imi/DesignSystemCompile.qml
+++ b/dots/.config/quickshell/imi/DesignSystemCompile.qml
@@ -75,6 +75,13 @@ ShellRoot {
                 Quickshell.shellPath("modules/imi/editMode/EditModeChromeContent.qml"),
                 Quickshell.shellPath("modules/imi/editMode/EditWidgetMenu.qml"),
                 Quickshell.shellPath("modules/imi/editMode/EditWidgetMenuContent.qml"),
+                // Stage 9's Lockscreen tab: the preview context compiles for
+                // the first time when somebody opens that tab, and the lock
+                // surface itself only when the screen actually locks - so a
+                // bad property in either passes every test on a shell that is
+                // merely running.
+                Quickshell.shellPath("modules/imi/lock/LockSurface.qml"),
+                Quickshell.shellPath("modules/common/panels/lock/LockPreviewContext.qml"),
                 // The cheatsheet only compiles when the user presses Super+/,
                 // and the keybind editor only when a row's pencil is clicked.
                 Quickshell.shellPath("modules/imi/cheatsheet/CheatsheetKeybinds.qml"),

--- a/dots/.config/quickshell/imi/EditModeRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/EditModeRuntimeTest.qml
@@ -594,6 +594,43 @@ ShellRoot {
             driver.mouseClick(remove, remove.width / 2, remove.height / 2, Qt.LeftButton);
             harness.check("Remove takes the widget out of plugins.enabled",
                           Config.options.plugins.enabled.length === 0);
+        },
+
+        // ---- the Lockscreen tab: a filter, and Escape climbs off it --------
+        //
+        // The ladder's desktopTab rung is pure and tst-covered; what only a
+        // real key through the real canvas handler can show is the WIRING -
+        // that the caller passes the live tab and answers the rung by moving
+        // it, rather than falling through to the exit. The key needs the
+        // canvas focused, which the shell does on mode entry; the steps above
+        // clicked other controls, so it is re-asserted rather than assumed.
+        () => {
+            GlobalStates.editMode = true;
+            GlobalStates.editTab = EditMode.LOCKSCREEN_TAB;
+            harness.check("the preview flag follows the mode and the tab",
+                          GlobalStates.editLockPreview === true);
+        },
+        () => {
+            canvas.forceActiveFocus();
+            driver.keyClick(Qt.Key_Escape);
+            harness.check("Escape on the Lockscreen tab returns to Desktop with the mode still on",
+                          GlobalStates.editTab === EditMode.DESKTOP_TAB
+                          && GlobalStates.editMode === true
+                          && GlobalStates.editLockPreview === false);
+        },
+        () => {
+            canvas.forceActiveFocus();
+            driver.keyClick(Qt.Key_Escape);
+            harness.check("...and the next Escape leaves the mode",
+                          GlobalStates.editMode === false);
+        },
+        () => {
+            GlobalStates.editMode = true;
+            GlobalStates.editTab = EditMode.LOCKSCREEN_TAB;
+            GlobalStates.editMode = false;
+            harness.check("leaving the mode resets the tab with the drawer and the menu",
+                          GlobalStates.editTab === EditMode.DESKTOP_TAB
+                          && GlobalStates.editLockPreview === false);
         }
     ]
 

--- a/dots/.config/quickshell/imi/GlobalStates.qml
+++ b/dots/.config/quickshell/imi/GlobalStates.qml
@@ -4,6 +4,7 @@ import QtQuick
 import Quickshell
 import Quickshell.Hyprland
 import Quickshell.Io
+import "modules/common/functions/edit_mode.js" as EditMode
 pragma Singleton
 pragma ComponentBehavior: Bound
 
@@ -105,6 +106,23 @@ Singleton {
         animation: Appearance.animation.elementMove.numberAnimation.createObject(this)
     }
 
+    // The mode's tab (spec §1.4): a FILTER on what the viewport draws, never a
+    // mode of its own - one `editMode`, one entry, one exit ladder, and this
+    // string beside it saying which of the desktop's two faces the viewport is
+    // showing. Session state for the same reason the mode is, and reset on
+    // exit (below) so the next entry opens on the Desktop tab rather than
+    // mid-preview. The strings are edit_mode.js's constants - the ladder's
+    // `desktopTab` rung fires on the same values, so a second spelling here
+    // would be a tab Escape cannot leave.
+    property string editTab: EditMode.DESKTOP_TAB
+    // The ONE derivation of "the viewport is showing the lock screen". The
+    // wallpaper, the blur, the widget filter, the islands host, both bars and
+    // the dock all ask this question, and each comparing the tab itself would
+    // be that many answers to it - the contract holds every other file to
+    // reading this property.
+    readonly property bool editLockPreview: root.editMode
+        && root.editTab === EditMode.LOCKSCREEN_TAB
+
     // The drawer - Edit Mode's catalogue of desktop widgets. Session state for
     // the same reason the mode is, and beside it for the same reason the
     // progress is: the desktop it translates and the panel that slides in are
@@ -186,6 +204,10 @@ Singleton {
         else {
             root.editDrawerOpen = false;
             root.editWidgetMenuOpen = false;
+            // The tab too: it is a filter on a viewport that no longer exists,
+            // and one left latched would greet the next entry already showing
+            // the lock screen's inputs.
+            root.editTab = EditMode.DESKTOP_TAB;
             // The overlays holding a bar drag are torn down with the mode, so
             // no end-of-drag handler is guaranteed to run - clear the flag
             // here or a drag cut short by Done leaves the ladder believing a

--- a/dots/.config/quickshell/imi/modules/common/functions/edit_mode.js
+++ b/dots/.config/quickshell/imi/modules/common/functions/edit_mode.js
@@ -20,6 +20,24 @@ var DESKTOP_TAB = "desktop";
 // this file.
 var LOCKSCREEN_TAB = "lockscreen";
 
+// The chrome's tab bar speaks indices and everything else speaks tab names.
+// The mapping lives here, in the tab list's own order, so the bar's index and
+// the ladder's answers cannot come from two spellings of the same list - the
+// contract forbids an `editTab ===` comparison outside GlobalStates for
+// exactly that reason. Unknown input lands on the Desktop tab both ways: a
+// bad index or a stale stored string must not strand the bar pointing at
+// nothing.
+var TABS = [DESKTOP_TAB, LOCKSCREEN_TAB];
+
+function tabIndex(tab) {
+    const index = TABS.indexOf(tab);
+    return index < 0 ? 0 : index;
+}
+
+function tabAt(index) {
+    return TABS[index] || DESKTOP_TAB;
+}
+
 // Escape is overloaded on the desktop before Edit Mode exists: WidgetCanvas
 // clears a marquee selection with it and PluginWidget cancels a grip resize
 // with it. So the mode may not simply take the key - it resolves in order and

--- a/dots/.config/quickshell/imi/modules/common/functions/edit_mode.js
+++ b/dots/.config/quickshell/imi/modules/common/functions/edit_mode.js
@@ -9,9 +9,16 @@
 // and §1.2 (the inset).
 
 // The tab the mode opens on. A string rather than a boolean because the
-// Lockscreen tab joins it later (spec §1.4) and the ladder already has to say
-// which tab it returns to.
+// Lockscreen tab sits beside it (spec §1.4) and the ladder has to say which
+// tab it returns to.
 var DESKTOP_TAB = "desktop";
+
+// The Lockscreen tab - a FILTER on the viewport, not a mode (spec §1.4): the
+// same entry, the same exit ladder, the same chrome, one GlobalStates.editMode.
+// Declared here so the rung above, GlobalStates' preview derivation and the
+// chrome's tab bar all read one spelling; the contract holds the literal to
+// this file.
+var LOCKSCREEN_TAB = "lockscreen";
 
 // Escape is overloaded on the desktop before Edit Mode exists: WidgetCanvas
 // clears a marquee selection with it and PluginWidget cancels a grip resize

--- a/dots/.config/quickshell/imi/modules/common/panels/lock/LockPreviewContext.qml
+++ b/dots/.config/quickshell/imi/modules/common/panels/lock/LockPreviewContext.qml
@@ -1,0 +1,70 @@
+import QtQuick
+
+/**
+ * The context Edit Mode's Lockscreen tab hands to `LockSurface` - a component
+ * that satisfies `LockContext`'s whole property surface and can do nothing.
+ *
+ * A separate component, deliberately, rather than the real context with a
+ * flag: "the preview context is the real one with a flag" is how a preview
+ * ends up authenticating (spec §4.3). The real `LockContext` constructs two
+ * pam authentication contexts and asks the fingerprint daemon about enrolled
+ * prints the moment it is built; this one is a plain `QtObject` that
+ * constructs nothing, spawns nothing, and whose unlock functions have empty
+ * bodies by contract - `tests/test_lock_preview_contract.py` enumerates the
+ * real context's surface against this file and holds this file to its
+ * negatives (which is also why this comment names none of the forbidden
+ * constructs by their exact spelling: the sweep reads the whole file, so the
+ * words themselves may not appear here), and a property added to
+ * `LockContext` without a counterpart here reddens the suite instead of
+ * reading as `undefined` on the preview.
+ *
+ * It also writes none of the `GlobalStates.screenLock*` flags the real
+ * context maintains: those describe the actual lock session, and a preview
+ * that wrote them would be a second author of the state the bar and the OSDs
+ * read.
+ *
+ * `fingerprintsConfigured` stays false, so the preview never shows the
+ * fingerprint glyph even on a machine that has prints enrolled. That is a
+ * known fidelity gap, accepted: the only way to know is to ask the daemon,
+ * and asking is exactly what this component exists not to do.
+ */
+QtObject {
+    id: root
+
+    signal shouldReFocus()
+    signal unlocked(targetAction: var)
+    signal failed()
+
+    property string currentText: ""
+    property bool unlockInProgress: false
+    property bool showFailure: false
+    property bool fingerprintsConfigured: false
+    property var targetAction: LockContext.ActionEnum.Unlock
+    property bool alsoInhibitIdle: false
+
+    function resetTargetAction() {
+        root.targetAction = LockContext.ActionEnum.Unlock;
+    }
+
+    function clearText() {
+        root.currentText = "";
+    }
+
+    function resetClearTimer() {
+    }
+
+    function reset() {
+        root.resetTargetAction();
+        root.clearText();
+        root.unlockInProgress = false;
+    }
+
+    function tryUnlock(alsoInhibitIdle = false) {
+    }
+
+    function tryFingerUnlock() {
+    }
+
+    function stopFingerPam() {
+    }
+}

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/clock/Widget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/clock/Widget.qml
@@ -37,7 +37,13 @@ Item {
     // `lock.showWidgets`, which is about the *other* desktop widgets, and why
     // it still centres itself there exactly as it always has.
     readonly property bool visibleWhenLocked: true
-    readonly property bool forceCenter: GlobalStates.screenLocked && Config.options.lock.centerClock
+    // The desktop showing its locked face: the real lock, or Edit Mode's
+    // Lockscreen tab previewing it. One derivation for the four lock-look
+    // bindings below (centring, style, presence, the Locked caption), so a
+    // later edit cannot leave one of them keyed on half the condition.
+    readonly property bool lockLook: GlobalStates.screenLocked
+        || GlobalStates.editLockPreview
+    readonly property bool forceCenter: root.lockLook && Config.options.lock.centerClock
     // Only the digital style paints bare text straight onto the wallpaper, so
     // only it needs the host's wallpaper-adaptive colour - and the least-busy
     // region pass that produces it.
@@ -73,8 +79,8 @@ Item {
     readonly property string quoteText: PluginState.option("clock", "quoteText", "")
     readonly property bool quoteFollowClock: PluginState.option("clock", "quoteFollowClock", false)
 
-    readonly property string clockStyle: GlobalStates.screenLocked ? root.styleLocked : root.style
-    readonly property bool shouldShow: !root.showOnlyWhenLocked || GlobalStates.screenLocked
+    readonly property string clockStyle: root.lockLook ? root.styleLocked : root.style
+    readonly property bool shouldShow: !root.showOnlyWhenLocked || root.lockLook
 
     readonly property string customClockColorKey: PluginState.option("clock", "color", "")
     readonly property color resolvedClockColor: {
@@ -208,7 +214,7 @@ Item {
                 }
                 ClockStatusText {
                     id: lockStatusText
-                    shown: GlobalStates.screenLocked && Config.options.lock.showLockedText
+                    shown: root.lockLook && Config.options.lock.showLockedText
                     statusIcon: "lock"
                     statusText: Translation.tr("Locked")
                 }

--- a/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/WidgetCanvas.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/WidgetCanvas.qml
@@ -111,7 +111,10 @@ MouseArea {
             gestureInFlight: root.draggingWidget() !== null
                 || GlobalStates.editBarDragActive,
             selectionCount: root.selectedWidgets.length,
-            tab: EditMode.DESKTOP_TAB
+            // The tab that is actually showing. A hardcoded DESKTOP_TAB was
+            // correct while only one tab existed, and would silently disarm
+            // the ladder's desktopTab rung now that a second one does.
+            tab: GlobalStates.editTab
         })
         if (action === "closeMenu") GlobalStates.editWidgetMenuOpen = false
         else if (action === "cancelGesture") {
@@ -119,6 +122,7 @@ MouseArea {
             if (GlobalStates.editBarDragActive) GlobalStates.editReorderCancel()
         }
         else if (action === "clearSelection") root.clearSelection()
+        else if (action === "desktopTab") GlobalStates.editTab = EditMode.DESKTOP_TAB
         else if (root.editMode) GlobalStates.editMode = false
     }
     readonly property bool keyboardFocusHeld: root.selectedWidgets.length > 0 || root.editMode

--- a/dots/.config/quickshell/imi/modules/imi/background/Background.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/Background.qml
@@ -10,6 +10,8 @@ import "../../common/functions/parallax.js" as ParallaxMath
 import "../../common/functions/clockDepth.js" as ClockDepthLogic
 import "../../common/functions/edit_mode.js" as EditMode
 import qs.modules.imi.editMode
+import qs.modules.imi.lock
+import qs.modules.common.panels.lock
 import QtQuick
 import QtQuick.Layouts
 import Qt5Compat.GraphicalEffects
@@ -268,8 +270,14 @@ Variants {
             GlobalStates.clockDepthViewports = published
         }
 
+        // The lock terms below say `screenLocked || editLockPreview` because
+        // Edit Mode's Lockscreen tab is a FILTER on this viewport (spec §1.4):
+        // it switches these same layers to their locked inputs rather than
+        // drawing a second copy of any of them, so the preview inside the
+        // shrunk card is the picture the lock screen will actually show.
         property string effectiveWallpaperPath: {
-            if (GlobalStates.screenLocked && Config.options.background.lockWall !== "")
+            if ((GlobalStates.screenLocked || GlobalStates.editLockPreview)
+                    && Config.options.background.lockWall !== "")
                 return Config.options.background.lockWall
             return Wallpapers.previewPath || Wallpapers.confirmedPath || Config.options.background.wallpaperPath
         }
@@ -282,7 +290,8 @@ Variants {
         // on unlock): the WE surface reloads the lock project and the existing
         // WE<->WE peel plays, so one renderer covers both - no second surface.
         property string weProjectPath: {
-            if (GlobalStates.screenLocked && Config.options.background.lockWallEngine !== "")
+            if ((GlobalStates.screenLocked || GlobalStates.editLockPreview)
+                    && Config.options.background.lockWallEngine !== "")
                 return Config.options.background.lockWallEngine
             return Config.options.wallpaperSelector.wallpaperEngine.activePath ?? ""
         }
@@ -317,7 +326,7 @@ Variants {
         // Image lock wallpaper only. A WE lock wallpaper (lockWallEngine set) is
         // served by switching weProjectPath instead, so exclude it here even though
         // its preview lives in lockWall for palette generation.
-        property bool lockWallShown: GlobalStates.screenLocked
+        property bool lockWallShown: (GlobalStates.screenLocked || GlobalStates.editLockPreview)
             && Config.options.background.lockWall !== ""
             && Config.options.background.lockWallEngine === "" && bgRoot.weActive
         property bool lockRevealWe: false // true = peeling back to WE (unlock)
@@ -1024,9 +1033,15 @@ Variants {
 
             Loader {
                 id: blurLoader
-                active: Config.options.lock.blur.enable && (GlobalStates.screenLocked || scaleAnim.running)
+                // `lockLook` rather than screenLocked alone: Edit Mode's
+                // Lockscreen tab shows the lock's own blur inside the shrunk
+                // card, through this same loader - a child of the viewport, so
+                // it takes the edit transform with everything else in here.
+                readonly property bool lockLook: GlobalStates.screenLocked
+                    || GlobalStates.editLockPreview
+                active: Config.options.lock.blur.enable && (blurLoader.lockLook || scaleAnim.running)
                 anchors.fill: parent
-                scale: GlobalStates.screenLocked ? Config.options.lock.blur.extraZoom : 1
+                scale: blurLoader.lockLook ? Config.options.lock.blur.extraZoom : 1
                 Behavior on scale {
                     NumberAnimation {
                         id: scaleAnim
@@ -1040,9 +1055,9 @@ Variants {
                     // in play; the live WE surface when it is the wallpaper;
                     // otherwise the static image / transition.
                     source: bgRoot.liveWallpaperLayer
-                    radius: GlobalStates.screenLocked ? Config.options.lock.blur.radius : 0
+                    radius: blurLoader.lockLook ? Config.options.lock.blur.radius : 0
                     samples: Config.options.lock.blur.size
-                    tintOpacity: GlobalStates.screenLocked ? 1 : 0
+                    tintOpacity: blurLoader.lockLook ? 1 : 0
                 }
             }
 
@@ -1456,6 +1471,38 @@ Variants {
                 wallpaperSource: wallpaper.source
                 maskPath: ClockDepth.maskPath
                 maskRevision: ClockDepth.maskRevision
+            }
+        }
+
+        // Edit Mode's Lockscreen tab: the real lock islands, rendered by the
+        // preview context that cannot authenticate (spec §4.3, and the whole
+        // of tests/test_lock_preview_contract.py). A FIFTH sibling carrying
+        // the one edit transform, at z 4 - above the widget canvas (z 2)
+        // because the real session lock surface draws over the desktop
+        // widgets, and above the clock depth layer (z 3), which stands down
+        // for the mode anyway.
+        //
+        // The surface is the real LockSurface, `interactive: false`: its root
+        // area stands down through its own enabled, every handler in it
+        // returns first thing, and the context handed in here is the plain
+        // object whose unlock paths are empty by contract - never the real
+        // LockContext, which runs a fingerprint enumeration and declares two
+        // pam contexts the moment it is built. Declared inside the Loader so
+        // the preview context exists only while the tab is showing.
+        //
+        // Its own copy of the fullscreen gate, like every sibling that left
+        // the viewport: without it the islands would float over fullscreen
+        // video with the wallpaper gone.
+        Loader {
+            id: lockPreviewIslands
+            active: GlobalStates.editLockPreview && !bgRoot.suppressContents
+            width: bgRoot.width
+            height: bgRoot.height
+            z: 4
+            transform: Matrix4x4 { matrix: bgRoot.editMatrix }
+            sourceComponent: LockSurface {
+                interactive: false
+                context: LockPreviewContext {}
             }
         }
 

--- a/dots/.config/quickshell/imi/modules/imi/background/widgets/AbstractBackgroundWidget.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/widgets/AbstractBackgroundWidget.qml
@@ -23,7 +23,10 @@ AbstractWidget {
     x: targetX
     y: targetY
     visible: opacity > 0
-    opacity: (GlobalStates.screenLocked && !visibleWhenLocked) ? 0 : 1
+    // `editLockPreview` beside the real lock: Edit Mode's Lockscreen tab shows
+    // the widgets the lock screen will show, through this same filter rather
+    // than a second one that could disagree with it.
+    opacity: ((GlobalStates.screenLocked || GlobalStates.editLockPreview) && !visibleWhenLocked) ? 0 : 1
     Behavior on opacity {
         animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
     }

--- a/dots/.config/quickshell/imi/modules/imi/bar/Bar.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/Bar.qml
@@ -25,7 +25,11 @@ Scope {
         }
         LazyLoader {
             id: barLoader
+            // The Lockscreen tab takes the bar down exactly as the real lock
+            // does, through the same gate (spec §1.5) - a teardown/rebuild per
+            // tab flip, same as per lock/unlock.
             active: GlobalStates.barOpen && !GlobalStates.screenLocked
+                && !GlobalStates.editLockPreview
             required property ShellScreen modelData
             component: PanelWindow { // Bar window
                 id: barRoot

--- a/dots/.config/quickshell/imi/modules/imi/dock/Dock.qml
+++ b/dots/.config/quickshell/imi/modules/imi/dock/Dock.qml
@@ -34,7 +34,13 @@ Scope {
             id: dockRoot
             required property var modelData
             screen: modelData
+            // The Lockscreen tab rides the lock's own teardown (spec §1.5).
+            // Destroying the surface is this line's existing, deliberate cost
+            // - the dock embeds no renderer - and the tab inherits it per
+            // flip; holding the dock ON screen for the mode's Desktop tab
+            // still goes through `reveal` below, never through this property.
             visible: !GlobalStates.screenLocked
+                && !GlobalStates.editLockPreview
 
             property var monitor: WM.monitorFor(modelData)
             property bool fullscreenOnThisMonitor: WM.fullscreenOnMonitor(monitor?.name)

--- a/dots/.config/quickshell/imi/modules/imi/editMode/EditModeChromeContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/editMode/EditModeChromeContent.qml
@@ -4,6 +4,7 @@ import qs
 import qs.services
 import qs.modules.common
 import qs.modules.common.widgets
+import "../../common/functions/edit_mode.js" as EditMode
 
 /**
  * Edit Mode's chrome: the toolbar above the shrunk desktop and the tab bar
@@ -151,16 +152,30 @@ Item {
         y: root.card.y + root.card.height
             + (root.area.y + root.area.height - root.card.y - root.card.height - height) / 2
 
-        // A tab bar with one tab in it, and not a label that will grow into
-        // one. The Lockscreen tab (spec §1.4) is stage 9's, and it arrives as
-        // a second entry in this list rather than as a rewrite of whatever a
-        // label had become. There is deliberately no `GlobalStates` tab
-        // property yet: a stored choice with one legal value is plumbing for a
-        // feature that does not exist, and the Escape ladder already answers
-        // `desktopTab` from the module.
+        // The mode's two tabs (spec §1.4): the tab is a FILTER on what the
+        // viewport draws, so the bar's index and `GlobalStates.editTab` must
+        // agree from both directions. An index change writes the state -
+        // including the wheel shortcut, which writes the inner index without
+        // passing through any button - and an external state write (Escape's
+        // return to Desktop, the exit's reset) moves the index back. Both
+        // directions are imperative on purpose: the wheel handler assigns the
+        // inner index directly, so a binding placed on `currentIndex` would be
+        // destroyed by the first scroll and the indicator would frame a
+        // viewport showing the other tab. The re-entrant hop each write takes
+        // through the other terminates because both sides no-op on equality.
         ToolbarTabBar {
             id: tabs
-            tabButtonList: [{ name: Translation.tr("Desktop"), icon: "wallpaper" }]
+            tabButtonList: [
+                { name: Translation.tr("Desktop"), icon: "wallpaper" },
+                { name: Translation.tr("Lockscreen"), icon: "lock" }
+            ]
+            onCurrentIndexChanged: GlobalStates.editTab = EditMode.tabAt(tabs.currentIndex)
+            Connections {
+                target: GlobalStates
+                function onEditTabChanged() {
+                    tabs.setCurrentIndex(EditMode.tabIndex(GlobalStates.editTab));
+                }
+            }
         }
     }
 

--- a/dots/.config/quickshell/imi/modules/imi/editMode/EditModeChromeContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/editMode/EditModeChromeContent.qml
@@ -171,6 +171,10 @@ Item {
                 { name: Translation.tr("Lockscreen"), icon: "lock" }
             ]
             onCurrentIndexChanged: GlobalStates.editTab = EditMode.tabAt(tabs.currentIndex)
+            // The sync is change-driven both ways, so a chrome built while a
+            // non-default tab is showing - a monitor hotplugged mid-mode -
+            // needs the one initial alignment no change ever delivers.
+            Component.onCompleted: tabs.setCurrentIndex(EditMode.tabIndex(GlobalStates.editTab))
             Connections {
                 target: GlobalStates
                 function onEditTabChanged() {

--- a/dots/.config/quickshell/imi/modules/imi/editMode/EditModeChromeContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/editMode/EditModeChromeContent.qml
@@ -70,6 +70,7 @@ Item {
     signal widgetToggleRequested(var manifest)
     signal barWidgetAddRequested(string widgetId, string bucket)
     signal dockAppToggleRequested(string appId)
+    signal lockIslandToggleRequested(string key)
 
     // Published for the surface's input mask: these three rects are the only
     // pixels of a screen-sized layer surface that may take a click, because
@@ -201,5 +202,6 @@ Item {
         onToggleRequested: (manifest) => root.widgetToggleRequested(manifest)
         onBarAddRequested: (widgetId, bucket) => root.barWidgetAddRequested(widgetId, bucket)
         onDockToggleRequested: (appId) => root.dockAppToggleRequested(appId)
+        onLockToggleRequested: (key) => root.lockIslandToggleRequested(key)
     }
 }

--- a/dots/.config/quickshell/imi/modules/imi/editMode/EditModeChromeSurface.qml
+++ b/dots/.config/quickshell/imi/modules/imi/editMode/EditModeChromeSurface.qml
@@ -180,6 +180,20 @@ PanelWindow {
                 Config.options.bar.layouts.rightLayout.length);
     }
 
+    // The lock screen's presence toggles: three literal paths, one per
+    // boolean, because an allowlist reachable through a computed key is not
+    // an allowlist (lint_edit_mode_scope's own rule about this file). The
+    // keys are presence-on-a-surface (spec §9 names lock.show* as exactly
+    // that), and the same booleans LockIdleConfig's rows write.
+    function toggleLockIsland(key) {
+        if (key === "showToolbars")
+            Config.options.lock.showToolbars = !Config.options.lock.showToolbars;
+        else if (key === "showMedia")
+            Config.options.lock.showMedia = !Config.options.lock.showMedia;
+        else if (key === "showWidgets")
+            Config.options.lock.showWidgets = !Config.options.lock.showWidgets;
+    }
+
     function addWidgetAt(manifest, dropX, dropY) {
         // A release back over the drawer is the gesture being abandoned, not
         // an instruction to add the widget at the drawer.
@@ -237,5 +251,6 @@ PanelWindow {
         // the same togglePin the dock's own context menu calls - rather than
         // a second spelling of the pinnedApps edit here.
         onDockAppToggleRequested: (appId) => TaskbarApps.togglePin(appId)
+        onLockIslandToggleRequested: (key) => root.toggleLockIsland(key)
     }
 }

--- a/dots/.config/quickshell/imi/modules/imi/editMode/EditModeDrawer.qml
+++ b/dots/.config/quickshell/imi/modules/imi/editMode/EditModeDrawer.qml
@@ -59,6 +59,10 @@ Item {
     // The click-adds: a bar widget into a bucket, a dock app's pin toggled.
     signal barAddRequested(string widgetId, string bucket)
     signal dockToggleRequested(string appId)
+    // The lock screen's presence toggles - which of the lock's pieces appear
+    // while locked. A signal like everything else here; the surface makes the
+    // write at the boolean's own literal path.
+    signal lockToggleRequested(string key)
 
     // Which section is showing, and which bucket a bar-widget click appends
     // to. Session state of the drawer itself; neither survives the mode.
@@ -88,6 +92,24 @@ Item {
     // The drag that is currently out, or null. One ghost for the whole drawer
     // rather than one per row - only one pointer exists.
     property var dragManifest: null
+
+    // The lock screen's three presence toggles (spec §12 stage 9: island
+    // VISIBILITY is what the mode edits; where things sit inside an island is
+    // its own stage). The keys are the lock.show* booleans LockIdleConfig
+    // already offers - presence-on-a-surface, which §9's rule admits and the
+    // scope lint's allowlist has carried since it was written. Translation.tr
+    // in a binding, so a language change re-evaluates the rows.
+    readonly property var lockIslandRows: [
+        { key: "showToolbars", name: Translation.tr("Toolbars"),
+            icon: "call_to_action",
+            description: Translation.tr("The islands beside the password field") },
+        { key: "showMedia", name: Translation.tr("Media player"),
+            icon: "music_note",
+            description: Translation.tr("Playback info while music is playing") },
+        { key: "showWidgets", name: Translation.tr("Desktop widgets"),
+            icon: "widgets",
+            description: Translation.tr("Show every desktop widget while locked") }
+    ]
 
     Rectangle {
         id: panel
@@ -143,10 +165,15 @@ Item {
                     onClicked: root.section = "bar"
                 }
                 SelectionGroupButton {
-                    rightmost: true
                     buttonText: Translation.tr("Dock")
                     toggled: root.section === "dock"
                     onClicked: root.section = "dock"
+                }
+                SelectionGroupButton {
+                    rightmost: true
+                    buttonText: Translation.tr("Lock")
+                    toggled: root.section === "lock"
+                    onClicked: root.section = "lock"
                 }
             }
 
@@ -158,7 +185,9 @@ Item {
                     ? Translation.tr("Drag a widget onto the desktop to place it, or click to add or remove it.")
                     : root.section === "bar"
                         ? Translation.tr("Click a widget to add it to the picked bar section, then drag it into place on the bar.")
-                        : Translation.tr("Click an app to pin or unpin it, then drag it into place on the dock.")
+                        : root.section === "dock"
+                            ? Translation.tr("Click an app to pin or unpin it, then drag it into place on the dock.")
+                            : Translation.tr("Choose what the lock screen shows. The Lockscreen tab previews it.")
                 font.pixelSize: Appearance.font.pixelSize.smaller
                 color: Appearance.colors.colOnSurfaceVariant
                 wrapMode: Text.Wrap
@@ -435,6 +464,78 @@ Item {
                             text: appRow.pinned ? "check_circle" : "add"
                             iconSize: 20
                             color: appRow.pinned
+                                ? Appearance.colors.colPrimary
+                                : Appearance.colors.colOnSurfaceVariant
+                        }
+                    }
+                }
+            }
+
+            // ---- lock screen presence -------------------------------------
+            ListView {
+                id: lockList
+                visible: root.section === "lock"
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                clip: true
+                spacing: Appearance.spacing.space25
+                model: root.section === "lock" ? root.lockIslandRows : []
+
+                delegate: RippleButton {
+                    id: lockRow
+                    required property var modelData
+                    // Read per key rather than bracket-indexed: the scope
+                    // lint forbids a computed lock path even for a read's
+                    // shape, and three keys do not need a lookup.
+                    readonly property bool islandOn: lockRow.modelData.key === "showToolbars"
+                        ? Config.options.lock.showToolbars
+                        : lockRow.modelData.key === "showMedia"
+                            ? Config.options.lock.showMedia
+                            : Config.options.lock.showWidgets
+
+                    width: lockList.width
+                    implicitHeight: 60
+                    buttonRadius: Appearance.rounding.large
+                    colBackground: "transparent"
+                    colBackgroundHover: Appearance.colors.colLayer2Hover
+                    colRipple: Appearance.colors.colLayer2Active
+                    onClicked: root.lockToggleRequested(lockRow.modelData.key)
+
+                    contentItem: RowLayout {
+                        anchors {
+                            fill: parent
+                            leftMargin: Appearance.spacing.space100
+                            rightMargin: Appearance.spacing.space100
+                        }
+                        spacing: Appearance.spacing.space100
+
+                        MaterialSymbol {
+                            text: lockRow.modelData.icon
+                            iconSize: 22
+                            color: Appearance.colors.colOnSurfaceVariant
+                        }
+                        ColumnLayout {
+                            Layout.fillWidth: true
+                            spacing: 0
+                            StyledText {
+                                Layout.fillWidth: true
+                                text: lockRow.modelData.name
+                                font.pixelSize: Appearance.font.pixelSize.normal
+                                color: Appearance.colors.colOnSurface
+                                elide: Text.ElideRight
+                            }
+                            StyledText {
+                                Layout.fillWidth: true
+                                text: lockRow.modelData.description
+                                font.pixelSize: Appearance.font.pixelSize.smaller
+                                color: Appearance.colors.colOnSurfaceVariant
+                                elide: Text.ElideRight
+                            }
+                        }
+                        MaterialSymbol {
+                            text: lockRow.islandOn ? "check_circle" : "add"
+                            iconSize: 20
+                            color: lockRow.islandOn
                                 ? Appearance.colors.colPrimary
                                 : Appearance.colors.colOnSurfaceVariant
                         }

--- a/dots/.config/quickshell/imi/modules/imi/lock/LockSurface.qml
+++ b/dots/.config/quickshell/imi/modules/imi/lock/LockSurface.qml
@@ -178,7 +178,15 @@ MouseArea {
 
             // Synchronizing (across monitors) and unlocking
             onTextChanged: root.context.currentText = this.text
+            // Guarded like every other dispatch even though `enabled: false`
+            // already keeps key events out of a preview field: `accepted()`
+            // is raised from Return handling, which `readOnly` does NOT close
+            // (readOnly stops text mutation, not the signal), so this is the
+            // one belt the disabled field wears alone - and the contract's
+            // action-anchored sweep holds it to the guard by the dispatch
+            // rather than by the handler's name.
             onAccepted: {
+                if (!root.interactive) return;
                 root.context.tryUnlock(ctrlHeld);
             }
             Connections {
@@ -489,10 +497,13 @@ MouseArea {
             }
         }
 
-        // Keyboard layout (Fcitx)
+        // Keyboard layout (Fcitx). `enabled` cascades from this plain root, so
+        // the preview's copy cannot activate the real SNI item - the one
+        // interactive element in the islands that reaches outside the shell.
         Bar.SysTray {
             Layout.rightMargin: Appearance.spacing.space150
             Layout.alignment: Qt.AlignVCenter
+            enabled: root.interactive
             showSeparator: false
             showOverflowMenu: false
             pinnedItems: SystemTray.items.values.filter(i => i.id == "Fcitx")

--- a/dots/.config/quickshell/imi/modules/imi/lock/LockSurface.qml
+++ b/dots/.config/quickshell/imi/modules/imi/lock/LockSurface.qml
@@ -15,8 +15,22 @@ import Quickshell.Services.SystemTray
 
 MouseArea {
     id: root
-    required property LockContext context
+    required property QtObject context
     property bool active: false
+    // The one switch between the real lock screen and Edit Mode's preview of
+    // it (spec §4.3). While false, nothing on this surface may take a
+    // keystroke or dispatch a session action: forceFieldFocus returns before
+    // reaching the field, the field itself is disabled and readOnly, the root
+    // area stops taking presses, and every click handler returns first thing.
+    // The guards are uniform on purpose - every handler starts with the same
+    // line - so tests/test_lock_preview_contract.py can hold ALL of them to it
+    // rather than an allowlist of the ones somebody remembered.
+    //
+    // `context` is typed QtObject rather than LockContext for the same reason:
+    // the preview hands in LockPreviewContext, a separate component with the
+    // same property surface that cannot authenticate, instead of the real
+    // context with a flag on it.
+    property bool interactive: true
     property bool showInputField: active || context.currentText.length > 0
     readonly property bool requirePasswordToPower: Config.options.lock.security.requirePasswordToPower
     readonly property MprisPlayer activePlayer: MprisController.activePlayer
@@ -25,6 +39,7 @@ MouseArea {
 
     // Force focus on entry
     function forceFieldFocus() {
+        if (!root.interactive) return;
         passwordBox.forceActiveFocus();
     }
     Connections {
@@ -35,6 +50,13 @@ MouseArea {
     }
     hoverEnabled: true
     acceptedButtons: Qt.LeftButton
+    // MouseArea's own `enabled`, which stops this area alone: the preview must
+    // not focus-chase the pointer or swallow clicks over the whole screen -
+    // the desktop being edited is underneath. The islands' own controls keep
+    // their input and are gated handler by handler instead, because disabling
+    // the whole subtree would run every control's disabled dim at once and the
+    // preview would stop looking like the lock screen it previews.
+    enabled: root.interactive
     onPressed: mouse => {
         forceFieldFocus();
     }
@@ -66,16 +88,18 @@ MouseArea {
     // Key presses
     property bool ctrlHeld: false
     Keys.onPressed: event => {
+        if (!root.interactive) return;
         root.context.resetClearTimer();
         if (event.key === Qt.Key_Control) {
             root.ctrlHeld = true;
         }
         if (event.key === Qt.Key_Escape) { // Esc to clear
             root.context.currentText = "";
-        } 
+        }
         forceFieldFocus();
     }
     Keys.onReleased: event => {
+        if (!root.interactive) return;
         if (event.key === Qt.Key_Control) {
             root.ctrlHeld = false;
         }
@@ -144,8 +168,11 @@ MouseArea {
             selectedTextColor: materialShapeChars ? "transparent" : Appearance.colors.colOnSecondaryContainer
             selectionColor: materialShapeChars ? "transparent" : Appearance.colors.colSecondaryContainer
 
-            // Password
-            enabled: !root.context.unlockInProgress
+            // Password. Both halves of the preview gate on purpose: `enabled`
+            // stops pointer and key input, `readOnly` closes the programmatic
+            // paths a disabled field still leaves open.
+            enabled: !root.context.unlockInProgress && root.interactive
+            readOnly: !root.interactive
             echoMode: TextInput.Password
             inputMethodHints: Qt.ImhSensitiveData
 
@@ -162,6 +189,7 @@ MouseArea {
             }
 
             Keys.onPressed: event => {
+                if (!root.interactive) return;
                 root.context.resetClearTimer();
             }
             
@@ -212,7 +240,10 @@ MouseArea {
             enabled: !root.context.unlockInProgress
             colBackgroundToggled: Appearance.colors.colPrimary
 
-            onClicked: root.context.tryUnlock()
+            onClicked: {
+                if (!root.interactive) return;
+                root.context.tryUnlock();
+            }
 
             contentItem: MaterialSymbol {
                 anchors.centerIn: parent
@@ -381,16 +412,25 @@ MouseArea {
                         LockMediaButton {
                             icon: "skip_previous"
                             ctlEnabled: MprisController.canGoPrevious
-                            onClicked: MprisController.previous()
+                            onClicked: {
+                                if (!root.interactive) return;
+                                MprisController.previous();
+                            }
                         }
                         LockMediaButton {
                             icon: activePlayer?.isPlaying ? "pause" : "play_arrow"
-                            onClicked: MprisController.togglePlaying()
+                            onClicked: {
+                                if (!root.interactive) return;
+                                MprisController.togglePlaying();
+                            }
                         }
                         LockMediaButton {
                             icon: "skip_next"
                             ctlEnabled: MprisController.canGoNext
-                            onClicked: MprisController.next()
+                            onClicked: {
+                                if (!root.interactive) return;
+                                MprisController.next();
+                            }
                         }
                     }
 
@@ -483,7 +523,10 @@ MouseArea {
 
         IconToolbarButton {
             id: sleepButton
-            onClicked: Session.suspend()
+            onClicked: {
+                if (!root.interactive) return;
+                Session.suspend();
+            }
             text: "dark_mode"
         }
 
@@ -507,6 +550,7 @@ MouseArea {
         toggled: root.context.targetAction === guardedBtn.targetAction
 
         onClicked: {
+            if (!root.interactive) return;
             if (!root.requirePasswordToPower) {
                 root.context.unlocked(guardedBtn.targetAction);
                 return;

--- a/dots/.config/quickshell/imi/modules/imi/verticalBar/VerticalBar.qml
+++ b/dots/.config/quickshell/imi/modules/imi/verticalBar/VerticalBar.qml
@@ -25,7 +25,11 @@ Scope {
         }
         LazyLoader {
             id: barLoader
+            // The Lockscreen tab takes the bar down exactly as the real lock
+            // does, through the same gate (spec §1.5) - a teardown/rebuild per
+            // tab flip, same as per lock/unlock.
             active: GlobalStates.barOpen && !GlobalStates.screenLocked
+                && !GlobalStates.editLockPreview
             required property ShellScreen modelData
             component: PanelWindow {
                 id: barRoot

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -334,6 +334,16 @@ if ! python3 "$SCRIPT_DIR/lint_edit_mode_scope.py"; then
     exit 1
 fi
 
+# Stage 9 of Edit Mode: the lock screen's preview must not be able to
+# authenticate. The one contract in the mode whose failure is a security bug
+# rather than a layout bug - every sweep in it asserts it still FOUND the
+# thing it swept, because a grep that matches nothing must fail, not pass.
+echo "Running lock preview contract tests..."
+if ! python3 "$SCRIPT_DIR/test_lock_preview_contract.py"; then
+    echo "Lock preview contract tests failed."
+    exit 1
+fi
+
 # Whether a drag still lands where the pointer put it once the desktop is drawn
 # at a scale. Nothing static can see that: the drag is hand-computed and the
 # transform is only SUPPOSED to cancel itself out. Brings its own weston.

--- a/dots/.config/quickshell/imi/tests/test_bar_dock_edit_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_bar_dock_edit_contract.py
@@ -102,13 +102,43 @@ def test_the_mode_is_a_term_of_the_docks_reveal():
 def test_suspension_never_reaches_a_surfaces_visible():
     # `visible: false` on a layer surface destroys it (AGENT.md, layer-shell
     # section). The dock's existing `visible: !GlobalStates.screenLocked` is a
-    # deliberate, pre-existing teardown for the lock; the mode may not add one.
+    # deliberate, pre-existing teardown for the lock; the mode may not add one
+    # for AUTO-HIDE SUSPENSION - holding a panel on screen goes through
+    # mustShow/reveal, never through visible.
+    #
+    # `editLockPreview` is the sanctioned exception, and it is the OPPOSITE
+    # gesture: on Edit Mode's Lockscreen tab the panels disappear exactly as
+    # they do on the real lock (spec §1.5 - "the Lockscreen tab adds a term to
+    # each"), so it rides the same teardown screenLocked already takes, cost
+    # and all. The rule this check holds is therefore spelled by name: no
+    # `visible` may be gated on editMode itself.
     for path in (BAR, VERTICAL_BAR, DOCK):
         for line in code(path).splitlines():
             if re.search(r"\bvisible\s*:", line) and "editMode" in line:
                 raise AssertionError(
                     f"{path.name} gates a visible on editMode: {line.strip()} "
                     f"- on a layer surface that destroys the surface")
+
+
+def test_the_panels_leave_the_lockscreen_tab_the_way_they_leave_the_lock():
+    # Spec §1.5: on the Lockscreen tab the bar and the dock simply disappear,
+    # and both halves of "disappear" already exist as the real lock's own
+    # gates - the bars' loader `active` and the dock surface's `visible`. The
+    # tab adds `!GlobalStates.editLockPreview` beside `!screenLocked` in each,
+    # inheriting the same teardown/rebuild per tab flip the lock already pays
+    # (the dock embeds no renderer, so a rebuilt GL context is acceptable
+    # there - and noted, not assumed, per the spec's own caveat).
+    for path in (BAR, VERTICAL_BAR):
+        text = code(path)
+        loader = re.search(r"active:\s*GlobalStates\.barOpen\s*&&\s*"
+                           r"!GlobalStates\.screenLocked\s*\n?\s*&&\s*"
+                           r"!GlobalStates\.editLockPreview", text)
+        assert loader, \
+            f"{path.name}'s loader does not stand down for the Lockscreen tab"
+    dock = code(DOCK)
+    assert re.search(r"visible:\s*!GlobalStates\.screenLocked\s*\n?\s*&&\s*"
+                     r"!GlobalStates\.editLockPreview", dock), \
+        "the dock does not stand down for the Lockscreen tab"
 
 
 def test_a_bar_popup_cannot_claim_the_card_while_the_mode_is_on():

--- a/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
@@ -193,9 +193,10 @@ def test_the_viewport_is_a_transform_and_not_a_resize():
     # The three siblings that draw the desktop all take the SAME matrix, so
     # there is one arithmetic and they cannot drift a pixel apart.
     applied = re.findall(r"transform:\s*Matrix4x4\s*\{\s*matrix:\s*bgRoot\.editMatrix\s*\}", text)
-    assert len(applied) == 3, \
-        (f"expected the wallpaper viewport, the widget canvas and the clock depth "
-         f"layer to carry the edit transform, found {len(applied)}")
+    assert len(applied) == 4, \
+        (f"expected the wallpaper viewport, the widget canvas, the clock depth "
+         f"layer and the lock islands host to carry the edit transform, "
+         f"found {len(applied)}")
     # Nothing may write the geometry the mode is supposed to leave alone.
     for prop in ("width", "height", "x", "y"):
         assert not re.search(rf"^\s*{prop}:[^\n]*editViewport", text, re.M), \
@@ -1087,6 +1088,62 @@ def test_the_tab_is_a_string_beside_the_mode_and_dies_with_it():
     assert handler and "editTab = EditMode.DESKTOP_TAB" in handler.group(1), \
         ("leaving the mode must return the tab to Desktop - a tab left latched "
          "would greet the next entry already filtered to the lock screen")
+
+
+def test_the_viewport_draws_its_locked_inputs_on_the_lockscreen_tab():
+    # Spec §4.3: the tab switches the viewport's wallpaper and blur to their
+    # locked inputs - a gate change on things Background.qml already draws,
+    # with `GlobalStates.editLockPreview` joining `GlobalStates.screenLocked`
+    # in each gate rather than a second copy of any layer. Each binding is
+    # named individually because a missing term here is silent: the tab
+    # simply previews the wrong wallpaper, on machines that configured a lock
+    # wallpaper, which is not every machine.
+    background = code(BACKGROUND)
+    for name in ("effectiveWallpaperPath", "weProjectPath"):
+        value = declaration(background, name)
+        assert value, f"Background no longer declares {name}"
+        assert re.search(r"GlobalStates\.screenLocked\s*\|\|\s*"
+                         r"GlobalStates\.editLockPreview", value), \
+            f"{name} does not take the lock preview's term"
+    lock_wall = declaration(background, "lockWallShown")
+    assert lock_wall and re.search(
+        r"\(GlobalStates\.screenLocked\s*\|\|\s*GlobalStates\.editLockPreview\)",
+        lock_wall), "lockWallShown does not take the lock preview's term"
+    blur = re.search(r"id:\s*blurLoader\n(.*?)sourceComponent:", background, re.S)
+    assert blur, "the lock blur loader is gone"
+    assert re.search(r"lockLook:\s*GlobalStates\.screenLocked\s*\n?\s*\|\|\s*"
+                     r"GlobalStates\.editLockPreview", blur.group(1)), \
+        "the lock blur's lockLook must cover the preview"
+    assert re.search(r"active:.*lockLook", blur.group(1)), \
+        "the lock blur must be active for the locked look"
+    # And the widget filter: the tab shows the widgets the lock screen will.
+    widget = code(BACKGROUND_WIDGET)
+    assert re.search(r"opacity:\s*\(\(GlobalStates\.screenLocked\s*\|\|\s*"
+                     r"GlobalStates\.editLockPreview\)\s*&&\s*!visibleWhenLocked\)",
+                     widget), \
+        "AbstractBackgroundWidget's lock filter does not cover the preview"
+
+
+def test_the_islands_ride_the_edit_transform_above_the_widgets():
+    # The islands host is a FOURTH carrier of the one edit matrix (wallpaper
+    # viewport, widget canvas, clock depth layer, islands) - the count is
+    # pinned so a fifth copy is a deliberate change here, not a drift. It sits
+    # at z 4: above the widget canvas (z 2), because the real session lock
+    # surface draws over the desktop widgets, and above the depth layer (z 3),
+    # which stands down for the mode anyway.
+    background = code(BACKGROUND)
+    host = re.search(r"id:\s*lockPreviewIslands\n(.*?)sourceComponent:",
+                     background, re.S)
+    assert host, "Background.qml no longer declares the islands host"
+    body = host.group(1)
+    assert "GlobalStates.editLockPreview" in body, \
+        "the islands host must be gated on the one preview derivation"
+    assert re.search(r"z:\s*4", body), "the islands must draw above the widgets"
+    assert re.search(r"transform:\s*Matrix4x4\s*\{\s*matrix:\s*bgRoot\.editMatrix\s*\}",
+                     body), "the islands must take the same edit transform"
+    assert "suppressContents" in body, \
+        ("the islands need their own copy of the fullscreen gate, like every "
+         "other sibling that left the viewport")
 
 
 def test_the_tab_bar_offers_both_tabs_and_follows_the_state():

--- a/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
@@ -1146,6 +1146,32 @@ def test_the_islands_ride_the_edit_transform_above_the_widgets():
          "other sibling that left the viewport")
 
 
+def test_island_visibility_is_presence_through_literal_paths():
+    # Spec §12 stage 9: island VISIBILITY is editable in the mode, and the
+    # three lock.show* booleans are presence-on-a-surface - already inside
+    # §7.1's allowlist (`lock.show*` in lint_edit_mode_scope.py) since the
+    # allowlist was written. The drawer offers them as a Lock section and
+    # still writes nothing (its writes-nothing rule is held by the bar/dock
+    # contract); the chrome surface makes the three writes, each at a literal
+    # path, because an allowlist reachable through a computed key is not an
+    # allowlist.
+    drawer = code(DRAWER)
+    assert re.search(r'section === "lock"', drawer), \
+        "the drawer no longer offers the Lock section"
+    assert "lockToggleRequested" in drawer, \
+        "the drawer's lock rows must raise a signal, not write"
+    for key in ("showToolbars", "showMedia", "showWidgets"):
+        assert key in drawer, f"the Lock section no longer offers {key}"
+    surface = code(CHROME_SURFACE)
+    for key in ("showToolbars", "showMedia", "showWidgets"):
+        assert re.search(
+            rf"Config\.options\.lock\.{key}\s*=\s*!Config\.options\.lock\.{key}",
+            surface), \
+            f"the surface must flip lock.{key} at its literal path"
+    assert not re.search(r"Config\.options\.lock\[", surface + drawer), \
+        "a computed lock key routes around the allowlist"
+
+
 def test_the_clock_previews_its_locked_look_through_one_derivation():
     # The clock is THE lock-screen widget - its locked style, its centring,
     # its "show only when locked" presence and its Locked caption are all

--- a/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
@@ -1146,6 +1146,26 @@ def test_the_islands_ride_the_edit_transform_above_the_widgets():
          "other sibling that left the viewport")
 
 
+def test_the_clock_previews_its_locked_look_through_one_derivation():
+    # The clock is THE lock-screen widget - its locked style, its centring,
+    # its "show only when locked" presence and its Locked caption are all
+    # keyed on the real lock. A Lockscreen tab that previews none of them is
+    # a preview of a different lock screen, so all four ride one local
+    # `lockLook` derivation; four separate `screenLocked || editLockPreview`
+    # spellings would be four chances for one of them to lose a term.
+    clock = code(ROOT / "modules/common/plugins/bundled/clock/Widget.qml")
+    assert re.search(r"readonly property bool lockLook:\s*GlobalStates\.screenLocked"
+                     r"\s*\n?\s*\|\|\s*GlobalStates\.editLockPreview", clock), \
+        "the clock no longer derives its locked look once"
+    for name, pattern in (
+            ("forceCenter", r"forceCenter:\s*root\.lockLook"),
+            ("clockStyle", r"clockStyle:\s*root\.lockLook"),
+            ("shouldShow", r"shouldShow:\s*!root\.showOnlyWhenLocked\s*\|\|\s*root\.lockLook"),
+            ("the Locked caption", r"shown:\s*root\.lockLook\s*&&\s*Config\.options\.lock\.showLockedText")):
+        assert re.search(pattern, clock), \
+            f"the clock's {name} does not follow the locked look"
+
+
 def test_the_tab_bar_offers_both_tabs_and_follows_the_state():
     # The tab bar is the pointer's way onto the Lockscreen tab and the state
     # is `GlobalStates.editTab`, so the two must not hold hands loosely: the

--- a/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
@@ -1089,6 +1089,35 @@ def test_the_tab_is_a_string_beside_the_mode_and_dies_with_it():
          "would greet the next entry already filtered to the lock screen")
 
 
+def test_the_tab_bar_offers_both_tabs_and_follows_the_state():
+    # The tab bar is the pointer's way onto the Lockscreen tab and the state
+    # is `GlobalStates.editTab`, so the two must not hold hands loosely: the
+    # widget's index follows any external tab write (the Escape ladder's
+    # return to Desktop, the mode's exit reset), and every index change -
+    # including the tab bar's own wheel shortcut, which writes the index
+    # without going through a button - writes the state back. Both directions
+    # are imperative-to-imperative on purpose: ToolbarTabBar's wheel handler
+    # writes its inner index directly, which would destroy a binding placed
+    # on it and leave the indicator and the viewport disagreeing.
+    text = code(CHROME_CONTENT)
+    tabs = re.search(r"tabButtonList:\s*\[(.*?)\]", text, re.S)
+    assert tabs, "the chrome no longer declares its tab list"
+    names = re.findall(r"name:\s*Translation\.tr\(\"(\w+)\"\)", tabs.group(1))
+    assert names == ["Desktop", "Lockscreen"], \
+        f"expected the Desktop and Lockscreen tabs in that order, found {names}"
+    assert re.search(
+        r"onCurrentIndexChanged:\s*GlobalStates\.editTab\s*=\s*EditMode\.tabAt",
+        text), \
+        ("an index change must write the tab state through the module's "
+         "mapping, or the wheel desyncs them")
+    assert "EditMode.tabIndex(GlobalStates.editTab)" in text, \
+        "the state-to-index direction must go through the module's mapping too"
+    assert re.search(r"function onEditTabChanged\(\)", text), \
+        ("the tab bar must follow an external tab write - Escape's return to "
+         "Desktop moves the state, and an indicator left behind frames a "
+         "viewport showing the other tab")
+
+
 def test_the_lockscreen_preview_is_one_derivation():
     # "The viewport is showing the lock screen's inputs" is asked by the
     # wallpaper, the blur, the widget filter, the islands host, both bars and

--- a/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
@@ -82,6 +82,8 @@ MENU = ROOT / "modules/imi/editMode/EditWidgetMenu.qml"
 MENU_CONTENT = ROOT / "modules/imi/editMode/EditWidgetMenuContent.qml"
 INSETS = ROOT / "modules/imi/editMode/EditModeInsets.qml"
 DESKTOP_MENU = ROOT / "modules/imi/desktopMenu/DesktopMenu.qml"
+LOCK_SURFACE = ROOT / "modules/imi/lock/LockSurface.qml"
+LOCK_PREVIEW_CONTEXT = ROOT / "modules/common/panels/lock/LockPreviewContext.qml"
 RULES = ROOT.parents[1] / "hypr/hyprland/rules.lua"
 
 # Everything that takes part in the mode. Listed rather than globbed so a new
@@ -232,9 +234,17 @@ def test_the_escape_ladder_is_the_module_and_not_open_coded():
     # The answers the module gives, and no branch invented beside them.
     # `closeMenu` is the first rung: the per-widget menu is the topmost
     # transient the mode draws, so Escape dismisses it before touching what is
-    # under it - and never exits the mode while it is up.
-    for answer in ("closeMenu", "cancelGesture", "clearSelection"):
+    # under it - and never exits the mode while it is up. `desktopTab` is the
+    # rung the Lockscreen tab fires: without its branch the answer would fall
+    # through to the exit and Escape on that tab would leave the mode instead
+    # of returning to the Desktop tab.
+    for answer in ("closeMenu", "cancelGesture", "clearSelection", "desktopTab"):
         assert answer in body, f"the handler ignores the module's {answer}"
+    # And the tab the ladder is asked about is the real one. A hardcoded
+    # DESKTOP_TAB here was correct while only one tab existed and silently
+    # disarms the rung above the moment a second one does.
+    assert "tab: GlobalStates.editTab" in body, \
+        "the ladder must be asked about the tab that is actually showing"
 
 
 def test_the_global_lock_is_suppressed_and_never_written():
@@ -1060,6 +1070,55 @@ def test_the_menu_does_not_outlive_the_mode():
     assert "editWidgetMenuOpen = false" in handler.group(1), \
         ("leaving the mode must close the menu - one left open would greet the "
          "next entry pointing at wherever a widget used to be")
+
+
+def test_the_tab_is_a_string_beside_the_mode_and_dies_with_it():
+    # Spec §1.4: the Lockscreen tab is a FILTER on the viewport, not a mode -
+    # one GlobalStates.editMode, and the tab a string beside it. Session state
+    # for the same reason the mode is, and reset on exit so the next entry
+    # opens on the Desktop tab rather than mid-preview.
+    states = code(GLOBAL_STATES)
+    assert re.search(r"property string editTab:\s*EditMode\.DESKTOP_TAB", states), \
+        ("GlobalStates must declare the tab, defaulted through the module's "
+         "constant rather than a second spelling of the string")
+    assert "editTab" not in read(CONFIG), \
+        "a persisted tab is a shell that restarts into the Lockscreen preview"
+    handler = re.search(r"onEditModeChanged:\s*\{(.*?)\n    \}", states, re.S)
+    assert handler and "editTab = EditMode.DESKTOP_TAB" in handler.group(1), \
+        ("leaving the mode must return the tab to Desktop - a tab left latched "
+         "would greet the next entry already filtered to the lock screen")
+
+
+def test_the_lockscreen_preview_is_one_derivation():
+    # "The viewport is showing the lock screen's inputs" is asked by the
+    # wallpaper, the blur, the widget filter, the islands host, both bars and
+    # the dock. One readonly derivation in GlobalStates answers all of them;
+    # a second `editTab === ...` comparison anywhere else is a second answer
+    # to one question, and the two disagree the first time either moves.
+    states = code(GLOBAL_STATES)
+    assert re.search(
+        r"readonly property bool editLockPreview:\s*root\.editMode\s*&&\s*"
+        r"root\.editTab === EditMode\.LOCKSCREEN_TAB", states), \
+        "GlobalStates no longer derives the preview from the mode and the tab"
+    swept = 0
+    for path in PARTICIPANTS + [GLOBAL_STATES, LOCK_SURFACE, LOCK_PREVIEW_CONTEXT]:
+        text = code(path)
+        swept += 1
+        # The literal lives in edit_mode.js and nowhere else, so the constant
+        # cannot drift from the string anyone compares against.
+        assert '"lockscreen"' not in text and "'lockscreen'" not in text, \
+            f"{path.name} spells the Lockscreen tab as a literal"
+        if path == GLOBAL_STATES:
+            continue
+        assert not re.search(r"editTab\s*===", text), \
+            (f"{path.name} compares the tab itself - read "
+             f"GlobalStates.editLockPreview instead")
+        for match in re.finditer(r"(?<![.\w])editLockPreview\b", text):
+            line = text[text.rfind("\n", 0, match.start()) + 1:
+                        text.find("\n", match.start())]
+            assert "GlobalStates.editLockPreview" in line, \
+                f"{path.name}: a second source for the preview: {line.strip()}"
+    assert swept == len(PARTICIPANTS) + 3, "the sweep lost a file"
 
 
 if __name__ == "__main__":

--- a/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
@@ -1232,25 +1232,36 @@ def test_the_lockscreen_preview_is_one_derivation():
         r"readonly property bool editLockPreview:\s*root\.editMode\s*&&\s*"
         r"root\.editTab === EditMode\.LOCKSCREEN_TAB", states), \
         "GlobalStates no longer derives the preview from the mode and the tab"
+    # Tree-wide, not a participant list: the consumers of the preview flag
+    # (both bars, the dock, the clock plugin) live outside the mode's own
+    # files, and the fifth file to grow an `editTab ===` comparison will be
+    # too. `tests/` is excluded - the tst pins the literal against the
+    # constant on purpose - and so are the rule's two named homes:
+    # edit_mode.js for the literal, GlobalStates.qml for the comparison.
     swept = 0
-    for path in PARTICIPANTS + [GLOBAL_STATES, LOCK_SURFACE, LOCK_PREVIEW_CONTEXT]:
+    for path in sorted(list(ROOT.rglob("*.qml")) + list(ROOT.rglob("*.js"))):
+        if (ROOT / "tests") in path.parents:
+            continue
+        # The runtime harnesses live at the root but are tests: their tab
+        # comparisons are assertions about the state, not derivations from it.
+        if path.name.endswith("RuntimeTest.qml") or path.name.endswith("Probe.qml"):
+            continue
         text = code(path)
         swept += 1
-        # The literal lives in edit_mode.js and nowhere else, so the constant
-        # cannot drift from the string anyone compares against.
-        assert '"lockscreen"' not in text and "'lockscreen'" not in text, \
-            f"{path.name} spells the Lockscreen tab as a literal"
+        if path != MODULE:
+            assert '"lockscreen"' not in text and "'lockscreen'" not in text, \
+                f"{path} spells the Lockscreen tab as a literal"
         if path == GLOBAL_STATES:
             continue
         assert not re.search(r"editTab\s*===", text), \
-            (f"{path.name} compares the tab itself - read "
+            (f"{path} compares the tab itself - read "
              f"GlobalStates.editLockPreview instead")
         for match in re.finditer(r"(?<![.\w])editLockPreview\b", text):
             line = text[text.rfind("\n", 0, match.start()) + 1:
                         text.find("\n", match.start())]
             assert "GlobalStates.editLockPreview" in line, \
-                f"{path.name}: a second source for the preview: {line.strip()}"
-    assert swept == len(PARTICIPANTS) + 3, "the sweep lost a file"
+                f"{path}: a second source for the preview: {line.strip()}"
+    assert swept > 400, f"the tree sweep found only {swept} files"
 
 
 if __name__ == "__main__":

--- a/dots/.config/quickshell/imi/tests/test_edit_mode_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_edit_mode_runtime.py
@@ -40,7 +40,7 @@ SOCKET = "wayland-imi-edit-mode"
 # The harness prints how many checks it ran. A literal rather than anything read
 # back out of that output: a harness whose step list shrinks must redden here
 # instead of reporting `failures: 0` for a shorter run.
-EXPECTED_CHECKS = 41
+EXPECTED_CHECKS = 45
 
 
 def _stop(proc):

--- a/dots/.config/quickshell/imi/tests/test_lock_preview_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_lock_preview_contract.py
@@ -218,6 +218,27 @@ def test_the_preview_context_cannot_authenticate_or_spawn_anything():
             f"{name} must have an empty body in the preview context"
 
 
+def test_the_preview_host_passes_interactive_false_and_the_preview_context():
+    # The other half of spec §11.2's last bullet: the one place that renders
+    # LockSurface outside the real session lock is Edit Mode's viewport, and it
+    # must pass `interactive: false` and hand in the preview context - never
+    # the real one. The block is matched whole so a host that keeps the
+    # property but points it at LockContext fails on the second assertion
+    # rather than passing on the first.
+    background = code(ROOT / "modules/imi/background/Background.qml")
+    host = re.search(r"sourceComponent:\s*LockSurface\s*\{(.*?)\n            \}",
+                     background, re.S)
+    assert host, "Background.qml no longer hosts the lock islands preview"
+    body = host.group(1)
+    assert re.search(r"interactive:\s*false", body), \
+        "the preview host must pass interactive: false"
+    assert "LockPreviewContext" in body, \
+        "the preview host must hand the surface the preview context"
+    assert "LockContext {" not in background, \
+        ("Background.qml constructs a real LockContext - the preview must not "
+         "be able to authenticate")
+
+
 def test_the_surface_takes_the_context_as_a_plain_object():
     # The typed `required property LockContext context` would refuse the
     # preview component at assignment; QtObject admits both. The real caller

--- a/dots/.config/quickshell/imi/tests/test_lock_preview_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_lock_preview_contract.py
@@ -144,5 +144,91 @@ def test_the_root_area_and_the_key_handlers_stand_down_too():
                  f"being interactive; its first statement is: {first!r}")
 
 
+def declarations_at_root(text: str):
+    """(properties, signals, functions) declared at the component's root level.
+
+    Depth-tracked rather than regexed flat, because `LockContext.qml` declares
+    children (Timer, Process, PamContext) whose own members are not part of
+    the surface a consumer sees.
+    """
+    properties, signals, functions = set(), set(), set()
+    depth = 0
+    for line in text.splitlines():
+        stripped = line.strip()
+        if depth == 1:
+            prop = re.match(
+                r"(?:readonly\s+|default\s+)?property\s+[\w<>.]+\s+(\w+)", stripped)
+            if prop:
+                properties.add(prop.group(1))
+            sig = re.match(r"signal\s+(\w+)", stripped)
+            if sig:
+                signals.add(sig.group(1))
+            func = re.match(r"function\s+(\w+)\s*\(", stripped)
+            if func:
+                functions.add(func.group(1))
+        depth += stripped.count("{") - stripped.count("}")
+    return properties, signals, functions
+
+
+def test_the_preview_context_declares_the_real_contexts_whole_surface():
+    # The preview is a SEPARATE component, so the one way it stays honest is
+    # enumeration: every property, signal and function the real context
+    # declares at its root must exist on the preview, or the surface reads an
+    # `undefined` from it - which is a value, not an error, and shows up as a
+    # binding that silently stops meaning anything (AGENT.md's undeclared-key
+    # family). The counts guard the parser: a sweep that extracted nothing
+    # from LockContext.qml must fail here, not certify an empty set.
+    properties, signals, functions = declarations_at_root(code(LOCK_CONTEXT))
+    assert len(properties) >= 6, \
+        f"extracted only {sorted(properties)} properties from LockContext.qml"
+    assert len(signals) >= 3, \
+        f"extracted only {sorted(signals)} signals from LockContext.qml"
+    assert len(functions) >= 7, \
+        f"extracted only {sorted(functions)} functions from LockContext.qml"
+    preview_properties, preview_signals, preview_functions = \
+        declarations_at_root(code(PREVIEW_CONTEXT))
+    for name in properties:
+        assert name in preview_properties, \
+            f"LockPreviewContext is missing the property `{name}`"
+    for name in signals:
+        assert name in preview_signals, \
+            f"LockPreviewContext is missing the signal `{name}`"
+    for name in functions:
+        assert name in preview_functions, \
+            f"LockPreviewContext is missing the function `{name}`"
+
+
+def test_the_preview_context_cannot_authenticate_or_spawn_anything():
+    text = read(PREVIEW_CONTEXT)
+    # `read`, not `code`: a PamContext in a comment is not a defect, but this
+    # file has no business even discussing one - and more importantly, the
+    # check must not be routable around by wrapping the construct oddly.
+    for forbidden in ("PamContext", "fprintd", "Process", "Quickshell.Io",
+                      "Quickshell.Services.Pam", "exec", "running"):
+        assert forbidden not in text, \
+            (f"LockPreviewContext contains `{forbidden}` - the preview context "
+             f"must construct nothing that can authenticate or spawn")
+    # And its unlock paths are empty by construction, not merely unused: a
+    # body that forwards to anything is a body a later edit can point at pam.
+    for name in ("tryUnlock", "tryFingerUnlock"):
+        match = re.search(rf"function {name}\([^)]*\)\s*\{{(.*?)\}}",
+                          code(PREVIEW_CONTEXT), re.S)
+        assert match, f"LockPreviewContext no longer declares {name}"
+        assert match.group(1).strip() == "", \
+            f"{name} must have an empty body in the preview context"
+
+
+def test_the_surface_takes_the_context_as_a_plain_object():
+    # The typed `required property LockContext context` would refuse the
+    # preview component at assignment; QtObject admits both. The real caller
+    # (Lock.qml) still passes the real context.
+    text = code(LOCK_SURFACE)
+    assert re.search(r"required property QtObject context", text), \
+        "LockSurface must type its context as QtObject"
+    lock = read(ROOT / "modules/imi/lock/Lock.qml")
+    assert re.search(r"context:\s*root\.context", lock), \
+        "Lock.qml no longer hands the real LockContext to the surface"
+
+
 if __name__ == "__main__":
     raise SystemExit(run(globals()))

--- a/dots/.config/quickshell/imi/tests/test_lock_preview_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_lock_preview_contract.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""The lock screen's preview cannot authenticate, and the sweep proves it looked.
+
+Spec §11.2's last bullet (docs/superpowers/specs/2026-08-16-edit-mode-design.md):
+Edit Mode's Lockscreen tab renders the real lock islands inside the viewport,
+so `LockSurface` gains a single switch - `interactive` - and everything that
+could take a keystroke or dispatch a session action is gated on it. The other
+half is `LockPreviewContext`: a second component satisfying `LockContext`'s
+property surface whose unlock paths are empty and which constructs no
+`PamContext` and runs no `fprintd-list`. "The preview context is the real one
+with a flag" is how a preview ends up authenticating, which is why it is a
+separate file this module can hold to a negative.
+
+This is the one contract in the mode whose failure is a security bug rather
+than a layout bug, so every sweep here asserts it still FOUND the thing it
+swept - a grep that matches nothing must fail, not pass. Concretely:
+
+- the click-handler sweep asserts how many handlers it found before judging
+  them, so a rewrite that renames `onClicked` cannot leave the check green
+  over nothing;
+- the parity sweep asserts how many properties, signals and functions it
+  extracted from `LockContext.qml`, so a parser miss reads as a failure;
+- the negative sweeps (`PamContext`, `fprintd`, `Process`) sit beside a
+  positive assertion that the preview file exists and declares the surface.
+"""
+
+import re
+from pathlib import Path
+
+from contract_runner import run
+
+ROOT = Path(__file__).resolve().parent.parent
+LOCK_SURFACE = ROOT / "modules/imi/lock/LockSurface.qml"
+LOCK_CONTEXT = ROOT / "modules/common/panels/lock/LockContext.qml"
+PREVIEW_CONTEXT = ROOT / "modules/common/panels/lock/LockPreviewContext.qml"
+
+
+def read(path: Path) -> str:
+    assert path.exists(), f"{path} is gone - the sweep has nothing to look at"
+    text = path.read_text()
+    assert text.strip(), f"{path} is empty"
+    return text
+
+
+def code(path: Path) -> str:
+    """The file with its comments stripped, so a rule cannot be satisfied by
+    prose about the rule."""
+    text = read(path)
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.S)
+    return re.sub(r"//[^\n]*", "", text)
+
+
+GUARD = re.compile(r"if\s*\(!root\.interactive\)\s*return")
+
+
+def handler_bodies(text: str, name: str):
+    """Every `<name>:` handler in the file, as (offset, body-text) pairs.
+
+    A body is either the rest of the line (single-expression handler) or the
+    whole brace-matched block. Arrow-function parameter lists (`mouse =>`) are
+    skipped over to reach the body.
+    """
+    bodies = []
+    for match in re.finditer(rf"\b{name}\s*:", text):
+        rest = text[match.end():]
+        rest = re.sub(r"^\s*(?:\([^)]*\)|\w+)\s*=>\s*", "", rest)
+        stripped = rest.lstrip()
+        if not stripped.startswith("{"):
+            bodies.append((match.start(), stripped.split("\n", 1)[0]))
+            continue
+        depth = 0
+        start = rest.index("{")
+        for index in range(start, len(rest)):
+            if rest[index] == "{":
+                depth += 1
+            elif rest[index] == "}":
+                depth -= 1
+                if depth == 0:
+                    bodies.append((match.start(), rest[start:index + 1]))
+                    break
+    return bodies
+
+
+def test_the_surface_declares_the_interactive_switch():
+    text = code(LOCK_SURFACE)
+    assert re.search(r"property bool interactive:\s*true", text), \
+        ("LockSurface must declare `interactive`, default true - the real lock "
+         "screen is the default and the preview is the exception")
+
+
+def test_force_field_focus_returns_before_reaching_the_field():
+    text = code(LOCK_SURFACE)
+    match = re.search(r"function forceFieldFocus\(\)\s*\{(.*?)\n    \}", text, re.S)
+    assert match, "LockSurface no longer defines forceFieldFocus"
+    body = match.group(1)
+    first = next((line.strip() for line in body.splitlines() if line.strip()), "")
+    assert GUARD.search(first), \
+        ("forceFieldFocus must return before touching the field when the "
+         f"surface is not interactive; its first statement is: {first!r}")
+
+
+def test_the_password_field_is_disabled_and_read_only_without_interactive():
+    text = code(LOCK_SURFACE)
+    enabled = re.search(r"^\s*enabled:\s*(.+root\.interactive.*)$", text, re.M)
+    assert enabled, \
+        "the password field's `enabled` must carry the interactive term"
+    assert re.search(r"^\s*readOnly:\s*!root\.interactive\s*$", text, re.M), \
+        ("the password field must be readOnly when the surface is not "
+         "interactive - `enabled` alone still leaves programmatic paths open")
+
+
+def test_every_click_handler_in_the_surface_is_gated():
+    text = code(LOCK_SURFACE)
+    bodies = handler_bodies(text, "onClicked")
+    # The surface carries at least: the confirm button, the sleep button, the
+    # password-guarded power and reboot component, and three media transport
+    # buttons. Fewer matches than that means the sweep is looking at the wrong
+    # thing, not that the surface got safer.
+    assert len(bodies) >= 6, \
+        (f"expected at least 6 onClicked handlers in LockSurface.qml, found "
+         f"{len(bodies)} - the sweep may no longer be finding the file's handlers")
+    for offset, body in bodies:
+        inner = body.strip().lstrip("{").strip()
+        first = next((line.strip() for line in inner.splitlines() if line.strip()), "")
+        assert GUARD.search(first), \
+            (f"an onClicked at offset {offset} is not gated on the surface "
+             f"being interactive; its first statement is: {first!r}")
+
+
+def test_the_root_area_and_the_key_handlers_stand_down_too():
+    text = code(LOCK_SURFACE)
+    assert re.search(r"^\s*enabled:\s*root\.interactive\s*$", text, re.M), \
+        ("the surface's root MouseArea must be disabled when not interactive - "
+         "a preview that swallows every click over the whole screen is a "
+         "broken editor, and one that focuses the field on press is worse")
+    for handler in ("Keys\\.onPressed", "Keys\\.onReleased"):
+        bodies = handler_bodies(text, handler)
+        assert bodies, f"LockSurface no longer declares {handler}"
+        for offset, body in bodies:
+            inner = body.strip().lstrip("{").strip()
+            first = next((line.strip() for line in inner.splitlines() if line.strip()), "")
+            assert GUARD.search(first), \
+                (f"{handler} at offset {offset} is not gated on the surface "
+                 f"being interactive; its first statement is: {first!r}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(run(globals()))

--- a/dots/.config/quickshell/imi/tests/test_lock_preview_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_lock_preview_contract.py
@@ -100,11 +100,26 @@ def test_force_field_focus_returns_before_reaching_the_field():
 
 
 def test_the_password_field_is_disabled_and_read_only_without_interactive():
+    # Anchored to the field's own block rather than matched anywhere in the
+    # file: a term on any OTHER control would otherwise satisfy the sweep
+    # while the field's own gate silently went.
     text = code(LOCK_SURFACE)
-    enabled = re.search(r"^\s*enabled:\s*(.+root\.interactive.*)$", text, re.M)
-    assert enabled, \
+    start = text.find("ToolbarTextField {")
+    assert start != -1, "the password field is no longer a ToolbarTextField"
+    depth = 0
+    end = start
+    for index in range(text.index("{", start), len(text)):
+        if text[index] == "{":
+            depth += 1
+        elif text[index] == "}":
+            depth -= 1
+            if depth == 0:
+                end = index + 1
+                break
+    field = text[start:end]
+    assert re.search(r"^\s*enabled:\s*.+root\.interactive.*$", field, re.M), \
         "the password field's `enabled` must carry the interactive term"
-    assert re.search(r"^\s*readOnly:\s*!root\.interactive\s*$", text, re.M), \
+    assert re.search(r"^\s*readOnly:\s*!root\.interactive\s*$", field, re.M), \
         ("the password field must be readOnly when the surface is not "
          "interactive - `enabled` alone still leaves programmatic paths open")
 
@@ -125,6 +140,67 @@ def test_every_click_handler_in_the_surface_is_gated():
         assert GUARD.search(first), \
             (f"an onClicked at offset {offset} is not gated on the surface "
              f"being interactive; its first statement is: {first!r}")
+
+
+def handler_spans(text: str):
+    """Every `on*:` handler in the file as (name_start, body_start, body_end)
+    character spans, arrow parameters skipped - the span form of
+    `handler_bodies`, for sweeps that need to ask which handler CONTAINS an
+    offset rather than what a named handler says."""
+    spans = []
+    for match in re.finditer(r"\b(?:Keys\.)?on[A-Z]\w*\s*:", text):
+        rest = text[match.end():]
+        without_arrow = re.sub(r"^\s*(?:\([^)]*\)|\w+)\s*=>\s*", "", rest)
+        base = match.end() + (len(rest) - len(without_arrow))
+        base += len(without_arrow) - len(without_arrow.lstrip())
+        if not text[base:].startswith("{"):
+            end = text.find("\n", base)
+            spans.append((match.start(), base, end if end != -1 else len(text)))
+            continue
+        depth = 0
+        for index in range(base, len(text)):
+            if text[index] == "{":
+                depth += 1
+            elif text[index] == "}":
+                depth -= 1
+                if depth == 0:
+                    spans.append((match.start(), base, index + 1))
+                    break
+    return spans
+
+
+def test_every_session_action_sits_in_a_guarded_body():
+    # The handler-name sweeps beside this one anchor on `onClicked`/`Keys.*`,
+    # which leaves a structural blind spot: a dispatch inside a handler with
+    # another name - `onAccepted` was exactly that, and shipped unguarded
+    # behind two other layers - passes them unexamined. So this sweep anchors
+    # on the ACTIONS themselves: every occurrence of an unlock, session or
+    # media dispatch must sit inside a handler whose body starts with the
+    # guard, whatever the handler is called. The site count is asserted first,
+    # as always: a sweep that stops finding the actions must fail, not pass.
+    text = code(LOCK_SURFACE)
+    actions = re.compile(
+        r"tryUnlock\(|\.unlocked\(|Session\.\w+\(|"
+        r"MprisController\.(?:previous|togglePlaying|next)\(")
+    spans = handler_spans(text)
+    sites = list(actions.finditer(text))
+    assert len(sites) >= 7, \
+        (f"expected at least 7 session/media action sites in LockSurface.qml, "
+         f"found {len(sites)} - the sweep may be looking at the wrong thing")
+    for site in sites:
+        containing = [span for span in spans
+                      if span[1] <= site.start() < span[2]]
+        assert containing, \
+            (f"the action {site.group(0)!r} at offset {site.start()} is not "
+             f"inside any handler body - a dispatch outside a handler cannot "
+             f"carry the guard at all")
+        # The innermost containing handler is the one whose guard matters.
+        _, base, end = max(containing, key=lambda span: span[1])
+        body = text[base:end].strip().lstrip("{").strip()
+        first = next((line.strip() for line in body.splitlines() if line.strip()), "")
+        assert GUARD.search(first), \
+            (f"the handler dispatching {site.group(0)!r} is not gated on the "
+             f"surface being interactive; its first statement is: {first!r}")
 
 
 def test_the_root_area_and_the_key_handlers_stand_down_too():
@@ -234,7 +310,9 @@ def test_the_preview_host_passes_interactive_false_and_the_preview_context():
         "the preview host must pass interactive: false"
     assert "LockPreviewContext" in body, \
         "the preview host must hand the surface the preview context"
-    assert "LockContext {" not in background, \
+    # \b + optional whitespace, so neither a respelled `LockContext{` nor
+    # `LockPreviewContext {` confuses it in either direction.
+    assert not re.search(r"(?<![\w])LockContext\s*\{", background), \
         ("Background.qml constructs a real LockContext - the preview must not "
          "be able to authenticate")
 

--- a/dots/.config/quickshell/imi/tests/tst_edit_mode.qml
+++ b/dots/.config/quickshell/imi/tests/tst_edit_mode.qml
@@ -61,6 +61,23 @@ TestCase {
         }), "desktopTab");
     }
 
+    function test_the_tab_and_its_index_map_both_ways() {
+        // The chrome's tab bar speaks indices and everything else speaks tab
+        // names, so the mapping lives here rather than as a comparison at the
+        // call site - the one-derivation contract forbids `editTab ===`
+        // outside GlobalStates precisely so a second answer to "which tab"
+        // cannot grow. Unknown input lands on the Desktop tab in both
+        // directions: a bad index or a stale string must not strand the bar
+        // pointing at nothing.
+        compare(EditMode.tabIndex(EditMode.DESKTOP_TAB), 0);
+        compare(EditMode.tabIndex(EditMode.LOCKSCREEN_TAB), 1);
+        compare(EditMode.tabIndex("no-such-tab"), 0);
+        compare(EditMode.tabIndex(undefined), 0);
+        compare(EditMode.tabAt(0), EditMode.DESKTOP_TAB);
+        compare(EditMode.tabAt(1), EditMode.LOCKSCREEN_TAB);
+        compare(EditMode.tabAt(7), EditMode.DESKTOP_TAB);
+    }
+
     function test_escape_leaves_the_mode_only_when_nothing_else_answers() {
         compare(EditMode.resolveEscape({
             gestureInFlight: false, selectionCount: 0, tab: EditMode.DESKTOP_TAB

--- a/dots/.config/quickshell/imi/tests/tst_edit_mode.qml
+++ b/dots/.config/quickshell/imi/tests/tst_edit_mode.qml
@@ -49,6 +49,18 @@ TestCase {
         }), "desktopTab");
     }
 
+    function test_the_lockscreen_tab_has_one_declared_name() {
+        // The tab the caller passes is `GlobalStates.editTab`, and the string
+        // it holds is this constant - declared in the module so the ladder,
+        // the preview derivation in GlobalStates and the chrome's tab bar
+        // cannot each spell it. A constant that drifted from the string the
+        // rung fires on would make the Lockscreen tab unreachable by name.
+        compare(EditMode.LOCKSCREEN_TAB, "lockscreen");
+        compare(EditMode.resolveEscape({
+            gestureInFlight: false, selectionCount: 0, tab: EditMode.LOCKSCREEN_TAB
+        }), "desktopTab");
+    }
+
     function test_escape_leaves_the_mode_only_when_nothing_else_answers() {
         compare(EditMode.resolveEscape({
             gestureInFlight: false, selectionCount: 0, tab: EditMode.DESKTOP_TAB


### PR DESCRIPTION
Stage 9 of Edit Mode, first half (spec §12 stage 9, §4.3, §1.4, §1.5, §11.2): the
`LockSurface.interactive` refactor, the preview context, and the Lockscreen tab
with island *visibility* editing. Island *contents* reorder — the maintainer's
answer to §14 — follows as its own stacked PR so this one stays the security
review it wants to be.

**Stacked on #249** (`feat/edit-mode-stage8-bar-dock`), which stacks on #248 →
#247 → #246. Those must merge first, in order; this PR's base is the stage 8
branch so its diff shows only stage 9.

## The security refactor, carrying no feature

The stage's first two commits change no behaviour and add no editing:

- `LockSurface` gains `property bool interactive: true`. While false, nothing
  on the surface can take a keystroke or dispatch a session action:
  `forceFieldFocus()` returns before reaching the field (which closes the
  press, the pointer move, `shouldReFocus` and `Component.onCompleted` at
  once), the password field is `enabled: false` **and** `readOnly` (a disabled
  field still leaves programmatic paths open), the root area stands down
  through its own `enabled`, and **every** click and key handler in the file
  starts with the same guard line — uniform on purpose, so the contract holds
  all of them to one rule rather than an allowlist of the ones somebody
  remembered. The media transport buttons are gated too: they are not session
  actions, but a preview whose play button pauses the user's real music is an
  editor reaching through the picture it shows.
- `LockPreviewContext` is a **separate component**, not the real context with a
  flag: a plain `QtObject` satisfying `LockContext`'s whole property surface,
  whose `tryUnlock`/`tryFingerUnlock` bodies are empty by contract and which
  constructs no pam machinery, spawns nothing, and writes none of the
  `GlobalStates.screenLock*` flags.
- `tests/test_lock_preview_contract.py` is spec §11.2's last bullet: it
  enumerates `LockContext`'s root-level surface against the preview (with
  extraction counts asserted, so a parser that finds nothing fails rather than
  certifying an empty set), holds the preview file — comments included — to a
  list of negatives, requires the uniform guard on every handler **after
  asserting how many handlers it found**, and pins the preview host to
  `interactive: false` + `LockPreviewContext`. Every sweep asserts it still
  found the file it swept.

## The tab

Per §1.4 the tab is a filter on the viewport, not a mode: one
`GlobalStates.editMode`, and `GlobalStates.editTab` a string beside it (reset
on exit, like the drawer and the menu). `GlobalStates.editLockPreview` is the
one derivation of "the viewport is showing the lock screen"; the contract
forbids an `editTab ===` comparison anywhere else, which is why the chrome's
tab bar maps index↔tab through `edit_mode.js`'s `tabAt`/`tabIndex` (that
mapping is imperative in both directions because `ToolbarTabBar`'s wheel
handler writes its inner index directly and would destroy a binding).

What the tab changes is gates on things `Background.qml` already draws: the
lock wallpaper, the lock WE project, the peel state, the lock blur (one local
`lockLook`), the widget filter in `AbstractBackgroundWidget`, and the clock
plugin's four lock-look bindings (centring, `styleLocked`, show-only-when-
locked, the Locked caption — one `lockLook` derivation there too). The islands
are the real `LockSurface` neutered as above, a fifth sibling carrying the one
edit matrix at z 4, above the widgets the way the real session lock surface
is. The bar and the dock leave the tab through the lock's own gates (§1.5):
the bars' loader `active` and the dock's `visible`, which means a surface
teardown/rebuild per tab flip — the same cost the lock already pays, accepted
by the spec, and distinct from auto-hide suspension (the never-rule forbidding
a `visible` gated on `editMode` still holds and now names the exception).
`EditModeInsets` deliberately does **not** drop with them: the reservation is
configuration-only, and a card resized per tab flip is b710ef731's moving
target under every widget at once.

Island visibility is the drawer's new Lock section: three rows for
`lock.showToolbars` / `showMedia` / `showWidgets`, drawn in the dock section's
shape. The drawer still writes nothing; the chrome surface flips each boolean
at its literal path. `lint_edit_mode_scope.py` needed **no allowlist change**
— `lock.show*` has been in §7.1's allowlist since stage 5 wrote it.

The Escape ladder's `desktopTab` rung now actually fires: the canvas passes
the live tab and answers the rung by returning to Desktop with the mode still
on. Driven end-to-end with real key events in `EditModeRuntimeTest`
(EXPECTED_CHECKS 41 → 45), and proven able to fail on a planted removal of the
branch.

## Evidence

- TDD throughout: every new check (10 in the lock contract, 6 in the
  edit-mode contract, 1 in the bar/dock contract, 2 tst cases, 4 harness
  steps) was watched failing before its implementation — the action-anchored
  sweep on the real unguarded handler — and the harness checks additionally
  on a planted mutation in a committed-clean tree.
- Full `./tests/run_tests.sh` at the tip: green end to end — Python/shell tier
  all OK, qmltestrunner totals all passed, weston harnesses run inside the
  suite's own sequential order.
- `DesignSystemCompile`: checked=182 failures=0 (LockSurface and
  LockPreviewContext join the explicit list; Background.qml itself compiled
  through a temporary sweep entry, checked=183 failures=0).
- The drawer's Lock section verified beyond compile with a throwaway render
  probe against the session display: three rows, labels resolved, the toggle
  signal carries its key chrome→host.

## Review

A reviewer pass over the whole branch found no Critical issues and one
Important one, fixed on the branch: `onAccepted` dispatched `tryUnlock`
without the uniform guard — dead in the preview only because the disabled
field blocks key events (`readOnly` does **not** close that signal), and
invisible to the handler-*name* sweeps. The guard is there now and the class
is closed: the contract gained an **action-anchored** sweep (every unlock /
session / media dispatch must sit in a guarded body, whatever the handler is
called, site count asserted first), watched failing on the real unguarded
handler. The review's minors are fixed too: the preview's Fcitx tray copy is
gated (it could activate the real SNI item), the password-field check is
anchored to the field's own block, the no-real-LockContext check is a
word-boundary regex, the one-derivation sweep is tree-wide, and a chrome
built mid-mode (monitor hotplug) aligns its tab indicator on completion.

## Known fidelity gaps (accepted, stated)

- No fingerprint glyph in the preview — knowing means asking the daemon, and
  asking is what the preview context exists not to do.
- Parallax stays desktop-framed on the tab (its zoom feeds the viewport's
  size; changing it per tab flip resizes the wallpaper container mid-mode).
- `centeredWallpaperOnlyWhenLocked` does not preview.
- `lock.centerClock` stays a render-time override; a widget has one stored
  position (spec §4.3), and nothing here adds a second.

## Owed to a live load (this branch was never deployed)

- The islands preview on a real compositor: stacking against the mode's
  chrome, the blur under the real transparency setting, and the look of the
  neutered islands inside the card.
- The dock/bar teardown-rebuild per tab flip (spec §1.5's "look at it" item).
- With `lockWallEngine` set, a tab flip reloads the Wallpaper Engine project
  (via `weProjectPath`) — the same reload the real lock performs, but a tab
  flip makes it a heavier gesture on WE setups; worth one look so it is not
  later reported as a bug.
- The Lock section's toggles previewing live on the tab.

Docs: updated AGENT.md §Edit Mode (the stage-9 entry: the tab as a filter, the
preview that cannot authenticate, the panels' stand-down, and the accepted
fidelity gaps).
