### PR TITLE
Edit Mode stage 9b: island contents reorder

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -2831,6 +2831,44 @@ mode is built out of are worth not re-deriving:
   feat(background): the viewport draws its locked inputs on the Lockscreen tab;
   feat(bar): the bar and the dock leave the Lockscreen tab;
   feat(editMode): the drawer grows a Lock section for island presence.)
+- **The islands' CONTENTS are three ordered lists, resolved by one module —
+  stage 9b, spec §14 answered "reorder".** `Config.options.lock.islands.
+  {main,left,right}` are declared `list<string>` properties (a `JsonAdapter`
+  cannot hold a dynamic map) whose defaults are the hand-placed order the
+  surface always drew, and `modules/common/functions/lock_islands.js` is the
+  only reading of them: `orderedItems` renders a known id MISSING from a
+  stored list at its default position rather than disappearing it, skips an
+  UNKNOWN stored id without destroying it, and `storedOrder` merges a commit
+  back with every unknown id's presence kept — both directions of the
+  version-skew rule, because a list written by one shell version and read by
+  another is where silent removal happens. `LockSurface` draws each island
+  as a Repeater over the resolver's answer through one `IslandSlot` Loader
+  (Layout facts in `islandItemMeta`, components in `islandComponents`, both
+  pinned to the module's whole vocabulary — a missing entry is an empty slot
+  or a zero margin, not an error); the password field is rendered from the
+  list and pinned unmovable by the module's `reorderable()`, reachable
+  through the published `passwordField` property. The reorder is stage 8's
+  machinery with no fifth copy: `LockIslandEditItem` (eater + shared
+  `ReorderDragArea`), `LockIslandReorder` per island (ONE bucket each — a
+  cross-island move would write an id the receiving island's resolver
+  correctly skips, vanishing it from both), commits through `layout_ops` +
+  `storedOrder` at three literal paths, guarded on the mode, with
+  `GlobalStates.editLockDragActive` composed into the Escape ladder beside
+  the bar's flag. The scope lint sweeps `modules/imi/lock` and admits
+  exactly the three list paths.
+  **Verifying any of this must never touch the live display.** A lock-screen
+  probe run against the user's Wayland session locks the real session, and
+  on this machine a real lock suspends the laptop — so every harness and
+  probe for the lock surface runs under headless weston with its OWN
+  `XDG_RUNTIME_DIR` and `WAYLAND_DISPLAY` (the shape
+  `test_lock_island_reorder_runtime.py` uses), never a `qs -p` against the
+  session, and anything that genuinely needs a real `WlSessionLock` is
+  recorded as unverified rather than attempted.
+  (feat(lock): lock_islands.js, the islands' order as arithmetic;
+  feat(config): three ordered island lists under lock.islands;
+  refactor(lock): the three islands become data-driven;
+  test(lint): the scope lint reaches the lock surface and admits its lists;
+  feat(lock): island contents reorder in the mode.)
 (feat(editMode): shrink the desktop into a viewport on the background surface,
 feat(editMode): stand the per-widget frost down for the mode,
 feat(editMode): draw the shrunk desktop as a card, not as a cropped screenshot,

--- a/dots/.config/quickshell/imi/GlobalStates.qml
+++ b/dots/.config/quickshell/imi/GlobalStates.qml
@@ -163,6 +163,14 @@ Singleton {
     // whichever slot holds the grab abandons, and the release still coming
     // lands on nothing.
     property bool editBarDragActive: false
+    // A lock-island reorder in flight (stage 9b's drag inside the Lockscreen
+    // tab's preview). A flag of its own beside the bar's rather than a shared
+    // one: the two gestures live on different surfaces and are cleared by
+    // different teardowns, and one flag cleared by whichever ends first would
+    // strand the other in the ladder. `editReorderCancel` is shared - the
+    // ladder's cancel does not care which reorder is in flight, and each
+    // overlay only answers it while its own drag is.
+    property bool editLockDragActive: false
     signal editReorderCancel()
 
     property bool dropShelfOpen: false
@@ -213,6 +221,7 @@ Singleton {
             // here or a drag cut short by Done leaves the ladder believing a
             // gesture is still in flight.
             root.editBarDragActive = false;
+            root.editLockDragActive = false;
         }
     }
     onClockDepthSelectOpenChanged: if (root.clockDepthSelectOpen) root.editMode = false

--- a/dots/.config/quickshell/imi/LockIslandReorderRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/LockIslandReorderRuntimeTest.qml
@@ -154,6 +154,12 @@ ShellRoot {
         },
 
         // ---- Escape's cancel abandons the gesture --------------------------
+        //
+        // This drives the LISTENER by emitting the signal directly - there is
+        // no WidgetCanvas in this harness, so the ladder's emit gate (the
+        // cancelGesture branch reaching editLockDragActive) is pinned by
+        // test_lock_islands_contract.py rather than exercised here. Do not
+        // read this step as evidence the ladder works end to end.
         () => {
             harness.lockLeftBefore = JSON.stringify([...Config.options.lock.islands.left]);
             const from = harness.centreOf(harness.slot("username"));

--- a/dots/.config/quickshell/imi/LockIslandReorderRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/LockIslandReorderRuntimeTest.qml
@@ -1,0 +1,223 @@
+import QtQuick
+import QtTest
+import Quickshell
+import qs
+import qs.modules.common
+import qs.modules.common.panels.lock
+import qs.modules.imi.lock
+import "modules/common/functions/edit_mode.js" as EditMode
+import "modules/common/functions/lock_islands.js" as LockIslands
+
+/**
+ * Drives the lock islands' reorder with real mouse events, on the real
+ * LockSurface with the real preview context, committing against the real
+ * `Config.options.lock.islands.*` lists.
+ *
+ * What only real events can show here: the press lands on the edit overlay's
+ * eater, `ReorderDragArea`'s handler takes over past the threshold, the drop
+ * maps through `dropTarget` over centres that carry HOLES (an invisible slot
+ * - the fingerprint icon with no prints enrolled, the battery pair on a
+ * desktop - and the dragged one), and the commit merges back through
+ * `storedOrder` without eating an id a newer version stored. The password
+ * slot is the negative: it loads no overlay at all, so the same gesture over
+ * it must move nothing.
+ *
+ * Weston implements no wlr-layer-shell, so nothing about the real session
+ * lock or the background surface is visible here - this drives the surface's
+ * content tree in a plain window, exactly the shape of BarEditRuntimeTest.
+ *
+ * Run against a throwaway config:
+ *   XDG_CONFIG_HOME=$(mktemp -d) XDG_STATE_HOME=$(mktemp -d) qs -p LockIslandReorderRuntimeTest.qml
+ */
+ShellRoot {
+    id: harness
+
+    property int failures: 0
+    property int checksRun: 0
+
+    function check(label, ok) {
+        harness.checksRun++;
+        console.log(`[LockIslands] ${label}: ${ok ? "ok" : "FAIL"}`);
+        if (!ok)
+            harness.failures++;
+    }
+
+    function slot(name) {
+        return driver.findChild(surface, "islandSlot_" + name);
+    }
+
+    // A stepped drag in SURFACE coordinates, so QtTest maps each event the
+    // same way a pointer would arrive.
+    function dragBetween(from, to) {
+        driver.mousePress(surface, from.x, from.y, Qt.LeftButton);
+        driver.mouseMove(surface, from.x + (to.x - from.x) * 0.3,
+                         from.y + (to.y - from.y) * 0.3, 20, Qt.LeftButton);
+        driver.mouseMove(surface, from.x + (to.x - from.x) * 0.7,
+                         from.y + (to.y - from.y) * 0.7, 20, Qt.LeftButton);
+        driver.mouseMove(surface, to.x, to.y, 20, Qt.LeftButton);
+        driver.mouseRelease(surface, to.x, to.y, Qt.LeftButton);
+    }
+
+    function centreOf(item) {
+        return item.mapToItem(surface, item.width / 2, item.height / 2);
+    }
+
+    FloatingWindow {
+        visible: true
+        implicitWidth: 1400
+        implicitHeight: 600
+        color: "black"
+
+        TestCase {
+            id: driver
+            when: false
+            name: "LockIslandDriver"
+        }
+
+        LockSurface {
+            id: surface
+            anchors.fill: parent
+            interactive: false
+            context: LockPreviewContext {}
+        }
+    }
+
+    property var steps: [
+        // ---- the overlays arm with the mode --------------------------------
+        () => {
+            GlobalStates.editMode = true;
+        },
+        () => {
+            harness.check("a movable slot grows its overlay and the field does not",
+                          driver.findChild(harness.slot("sleep"), "lockIslandEditItem") !== null
+                          && driver.findChild(harness.slot("password"), "lockIslandEditItem") === null);
+        },
+
+        // ---- a drag along the right island moves, with move semantics ------
+        () => {
+            const from = harness.centreOf(harness.slot("sleep"));
+            const past = harness.centreOf(harness.slot("reboot"));
+            harness.dragBetween(from, Qt.point(past.x + 30, past.y));
+        },
+        () => {
+            const stored = Config.options.lock.islands.right;
+            harness.check("sleep lands after reboot and the two between shift one",
+                          JSON.stringify([...stored])
+                          === JSON.stringify(["battery", "power", "reboot", "sleep"]));
+        },
+
+        // ---- the rendered order follows the store --------------------------
+        () => {
+            harness.check("the island redraws in the committed order",
+                          JSON.stringify([...surface.rightOrder])
+                          === JSON.stringify(["battery", "power", "reboot", "sleep"]));
+        },
+
+        // ---- the password slot takes no drag -------------------------------
+        () => {
+            const before = JSON.stringify([...surface.mainOrder]);
+            const from = harness.centreOf(harness.slot("password"));
+            const to = harness.centreOf(harness.slot("confirm"));
+            harness.dragBetween(from, Qt.point(to.x + 30, to.y));
+            harness.check("dragging the password field moves nothing",
+                          JSON.stringify([...surface.mainOrder]) === before);
+        },
+
+        // ---- its neighbours still reorder around it ------------------------
+        () => {
+            const from = harness.centreOf(harness.slot("confirm"));
+            const to = harness.centreOf(harness.slot("password"));
+            harness.dragBetween(from, Qt.point(to.x - 60, to.y));
+        },
+        () => {
+            harness.check("confirm moves in front of the field it cannot displace",
+                          JSON.stringify([...surface.mainOrder])
+                          === JSON.stringify(["fingerprint", "confirm", "password"]));
+        },
+
+        // ---- an id a newer shell stored survives a reorder here ------------
+        () => {
+            Config.options.lock.islands.left = ["media", "someFutureItem",
+                "username", "keyboardLayout", "fcitx"];
+        },
+        () => {
+            const from = harness.centreOf(harness.slot("keyboardLayout"));
+            const to = harness.centreOf(harness.slot("username"));
+            harness.dragBetween(from, Qt.point(to.x - 20, to.y));
+        },
+        () => {
+            const stored = [...Config.options.lock.islands.left];
+            harness.check("the unknown id keeps its presence through the commit",
+                          stored.includes("someFutureItem"));
+            harness.check("...and the known ids carry the move",
+                          stored.indexOf("keyboardLayout") < stored.indexOf("username"));
+        },
+
+        // ---- Escape's cancel abandons the gesture --------------------------
+        () => {
+            harness.lockLeftBefore = JSON.stringify([...Config.options.lock.islands.left]);
+            const from = harness.centreOf(harness.slot("username"));
+            driver.mousePress(surface, from.x, from.y, Qt.LeftButton);
+            driver.mouseMove(surface, from.x + 60, from.y, 20, Qt.LeftButton);
+            harness.check("a drag in flight raises the ladder's flag",
+                          GlobalStates.editLockDragActive === true);
+            GlobalStates.editReorderCancel();
+            harness.check("the cancel stands the flag down before the release",
+                          GlobalStates.editLockDragActive === false);
+            driver.mouseRelease(surface, from.x + 60, from.y, Qt.LeftButton);
+        },
+        () => {
+            harness.check("the abandoned drag committed nothing",
+                          JSON.stringify([...Config.options.lock.islands.left])
+                          === harness.lockLeftBefore);
+        },
+
+        // ---- the mode's exit mid-drag commits nothing either ---------------
+        () => {
+            const from = harness.centreOf(harness.slot("username"));
+            driver.mousePress(surface, from.x, from.y, Qt.LeftButton);
+            driver.mouseMove(surface, from.x + 60, from.y, 20, Qt.LeftButton);
+            GlobalStates.editMode = false;
+            harness.check("the exit clears the drag's flag",
+                          GlobalStates.editLockDragActive === false);
+            driver.mouseRelease(surface, from.x + 60, from.y, Qt.LeftButton);
+        },
+        () => {
+            harness.check("a release after the exit stores no order",
+                          JSON.stringify([...Config.options.lock.islands.left])
+                          === harness.lockLeftBefore);
+        }
+    ]
+
+    property string lockLeftBefore: ""
+    property int stepIndex: 0
+
+    Timer {
+        id: setup
+        interval: 250
+        repeat: true
+        running: true
+        onTriggered: {
+            if (!Config.ready)
+                return;
+            setup.running = false;
+            runner.running = true;
+        }
+    }
+
+    Timer {
+        id: runner
+        interval: 500
+        repeat: true
+        running: false
+        onTriggered: {
+            if (harness.stepIndex >= harness.steps.length) {
+                runner.running = false;
+                console.log(`[LockIslands] checks: ${harness.checksRun} failures: ${harness.failures}`);
+                Qt.exit(harness.failures === 0 ? 0 : 1);
+                return;
+            }
+            harness.steps[harness.stepIndex++]();
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/modules/common/Config.qml
+++ b/dots/.config/quickshell/imi/modules/common/Config.qml
@@ -1241,6 +1241,20 @@ Singleton {
                     property bool requirePasswordToPower: false
                 }
                 property bool materialShapeChars: true
+                // The lock islands' item order (spec §14, answered "reorder"):
+                // declared lists, never a dynamic map - a JsonAdapter cannot
+                // hold one. The defaults are the hand-placed order the surface
+                // has always drawn, so a config that never stored these keys
+                // renders exactly what it rendered before they existed - which
+                // is also why no migration is needed: a missing key takes the
+                // QML default. The same lists are spelled in lock_islands.js
+                // (the resolver cannot read this file); the two are pinned
+                // equal by tests/test_lock_islands_contract.py.
+                property JsonObject islands: JsonObject {
+                    property list<string> main: ["fingerprint", "password", "confirm"]
+                    property list<string> left: ["username", "media", "keyboardLayout", "fcitx"]
+                    property list<string> right: ["battery", "sleep", "power", "reboot"]
+                }
             }
 
             property JsonObject media: JsonObject {

--- a/dots/.config/quickshell/imi/modules/common/functions/lock_islands.js
+++ b/dots/.config/quickshell/imi/modules/common/functions/lock_islands.js
@@ -1,0 +1,87 @@
+.pragma library
+
+// The lock islands' order as arithmetic (spec §14, answered "reorder" by the
+// maintainer on 2026-08-17): three ordered lists in `Config.options.lock.
+// islands`, one per island, and this module is the only place that turns a
+// stored list into the order the surface draws.
+//
+// Kept beside `edit_mode.js` for the reason everything else here is: nothing
+// about the rendered islands is reachable from `qmltestrunner`, so the
+// decisions - what renders, in what order, and what survives a version skew -
+// have to be arithmetic a test can hold still.
+
+// The default order of each island is the hand-placed order LockSurface has
+// always drawn, so a config that has never stored a list renders exactly what
+// it rendered before the lists existed. Config.qml's schema defaults must
+// equal these lists - tests/test_lock_islands_contract.py pins the two
+// against each other, because two copies of a default that must agree is the
+// drift AGENT.md keeps recording.
+var MAIN_DEFAULT = ["fingerprint", "password", "confirm"];
+var LEFT_DEFAULT = ["username", "media", "keyboardLayout", "fcitx"];
+var RIGHT_DEFAULT = ["battery", "sleep", "power", "reboot"];
+
+// The password field is rendered from the main list like everything else and
+// is NOT a reorderable item (spec §14: the main island's rewrite is a
+// different job because of it). Its neighbours may move around it; it takes
+// no drag of its own.
+function reorderable(island, id) {
+    return !(island === "main" && id === "password");
+}
+
+// The order the island DRAWS, resolved from the stored list against the
+// island's defaults. Two rules, both about version skew, both the
+// `gridSizes.resolveSize` rule applied to a list:
+//
+// - a known id MISSING from the stored list (a list written by an older
+//   version) renders at its default position rather than disappearing -
+//   silent removal is exactly what a list written by one version and read by
+//   another produces otherwise;
+// - an UNKNOWN stored id (a list written by a newer version) is skipped for
+//   rendering - there is nothing to draw for it - but the store is not
+//   rewritten here: resolving is a read, and destroying a newer version's
+//   entry on read is the other half of the same defect.
+//
+// Index-walked rather than filtered/mapped because the stored list arrives as
+// a QML list property: indices and `length` survive the QVariant crossing,
+// the Array brand does not (the boundary gridSizes.js documents).
+function orderedItems(stored, defaults) {
+    var order = [];
+    var count = stored && typeof stored.length === "number" ? stored.length : 0;
+    for (var i = 0; i < count; i++) {
+        var id = stored[i];
+        if (defaults.indexOf(id) !== -1 && order.indexOf(id) === -1)
+            order.push(id);
+    }
+    for (var d = 0; d < defaults.length; d++) {
+        if (order.indexOf(defaults[d]) !== -1)
+            continue;
+        var at = 0;
+        for (var p = d - 1; p >= 0; p--) {
+            var prev = order.indexOf(defaults[p]);
+            if (prev !== -1) {
+                at = prev + 1;
+                break;
+            }
+        }
+        order.splice(at, 0, defaults[d]);
+    }
+    return order;
+}
+
+// What a committed reorder writes: the rendered order with the move applied,
+// plus every unknown stored id appended in its stored order. Appending loses
+// an unknown id's position but never its presence - a newer version reading
+// the list back still renders its item (and its own resolver decides where),
+// where dropping it would be the silent removal this module exists to
+// prevent. The move itself is layout_ops' move semantics, applied by the
+// caller before this merge; this function only answers what reaches the
+// store.
+function storedOrder(moved, stored, defaults) {
+    var result = moved.slice();
+    var count = stored && typeof stored.length === "number" ? stored.length : 0;
+    for (var i = 0; i < count; i++) {
+        if (defaults.indexOf(stored[i]) === -1 && result.indexOf(stored[i]) === -1)
+            result.push(stored[i]);
+    }
+    return result;
+}

--- a/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/WidgetCanvas.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/WidgetCanvas.qml
@@ -120,7 +120,8 @@ MouseArea {
         if (action === "closeMenu") GlobalStates.editWidgetMenuOpen = false
         else if (action === "cancelGesture") {
             root.cancelActiveDrag()
-            if (GlobalStates.editBarDragActive) GlobalStates.editReorderCancel()
+            if (GlobalStates.editBarDragActive || GlobalStates.editLockDragActive)
+                GlobalStates.editReorderCancel()
         }
         else if (action === "clearSelection") root.clearSelection()
         else if (action === "desktopTab") GlobalStates.editTab = EditMode.DESKTOP_TAB

--- a/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/WidgetCanvas.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/WidgetCanvas.qml
@@ -109,7 +109,8 @@ MouseArea {
             // precedence does not care WHICH gesture is in flight, only that
             // one is.
             gestureInFlight: root.draggingWidget() !== null
-                || GlobalStates.editBarDragActive,
+                || GlobalStates.editBarDragActive
+                || GlobalStates.editLockDragActive,
             selectionCount: root.selectedWidgets.length,
             // The tab that is actually showing. A hardcoded DESKTOP_TAB was
             // correct while only one tab existed, and would silently disarm

--- a/dots/.config/quickshell/imi/modules/imi/lock/LockIslandEditItem.qml
+++ b/dots/.config/quickshell/imi/modules/imi/lock/LockIslandEditItem.qml
@@ -1,0 +1,64 @@
+import QtQuick
+import qs
+import qs.modules.common
+import qs.modules.common.widgets
+
+/**
+ * One island item's edit affordances, loaded over the slot by `LockSurface`
+ * while the Lockscreen tab's preview is editing: the input eater and the
+ * reorder gesture - `BarWidgetEditItem`'s shape without the remove badge,
+ * because island items are hidden through the lock.show* presence booleans
+ * rather than removed one by one.
+ *
+ * The eater is the same reasoning as the bar's: the preview's controls are
+ * already guarded handler by handler, but a covering MouseArea is what stops
+ * their ripples answering a press that is about to become a drag, and what
+ * gives the slot the move cursor - without touching a single binding in the
+ * item below, so the preview keeps looking like the lock screen.
+ *
+ * The gesture is `ReorderDragArea` (the press lands on the eater; the
+ * handler takes over past the drag threshold), and everything it learns goes
+ * to the island's controller, which owns the indicator and the commit - this
+ * file makes no store write of its own.
+ */
+Item {
+    id: root
+    objectName: "lockIslandEditItem"
+
+    property var controller: null
+    property int renderedIndex: 0
+
+    readonly property bool dragging: reorder.dragging
+
+    MouseArea {
+        anchors.fill: parent
+        acceptedButtons: Qt.AllButtons
+        hoverEnabled: true
+        cursorShape: Qt.SizeAllCursor
+        onWheel: wheel => {
+            wheel.accepted = true;
+        }
+    }
+
+    ReorderDragArea {
+        id: reorder
+        anchors.fill: parent
+        axis: "x"
+        bucketsProvider: () => root.controller.dropBuckets()
+        onDragStarted: root.controller.beginDrag(root.renderedIndex)
+        onTargetChanged: if (reorder.dragging) root.controller.dragMoved(reorder.target)
+        onDropped: target => root.controller.commitReorder(root.renderedIndex, target)
+        onDragEnded: root.controller.endDrag()
+    }
+
+    Connections {
+        target: GlobalStates
+        function onEditReorderCancel() {
+            if (!reorder.dragging) return;
+            reorder.cancel();
+            // Cleared now rather than at the release still to come, so the
+            // ladder's gestureInFlight is already false for the next Escape.
+            root.controller.endDrag();
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/modules/imi/lock/LockIslandReorder.qml
+++ b/dots/.config/quickshell/imi/modules/imi/lock/LockIslandReorder.qml
@@ -34,6 +34,16 @@ import "../../common/functions/lock_islands.js" as LockIslands
  * The write-back is `LockIslands.storedOrder`: the moved rendered order plus
  * every unknown stored id appended, so a list written by a newer shell
  * version loses nothing when this one reorders it.
+ *
+ * Two smaller facts, stated so nobody "fixes" either toward the bar's shape:
+ * a drop at an island's END lands before any hidden tail entry (the centres
+ * cap the insertion at the last VISIBLE slot, where the bar's
+ * insertionForVisible maps an append to the stored end) - visible items stay
+ * contiguous ahead of hidden ones, which is the behaviour a pointer gesture
+ * over visible slots can actually mean. And like the bar's flag, a drag
+ * whose overlay is destroyed without its end handlers (an external rebuild
+ * of the model mid-drag) leaves `editLockDragActive` up until the mode's
+ * exit reset - the central endDrag below is the recovery both flags share.
  */
 Item {
     id: root

--- a/dots/.config/quickshell/imi/modules/imi/lock/LockIslandReorder.qml
+++ b/dots/.config/quickshell/imi/modules/imi/lock/LockIslandReorder.qml
@@ -1,0 +1,178 @@
+import QtQuick
+import qs
+import qs.modules.common
+import "../../common/functions/layout_ops.js" as LayoutOps
+import "../../common/functions/lock_islands.js" as LockIslands
+
+/**
+ * One island's worth of Edit Mode's reorder: the coordinator each island
+ * instantiates with its name, its Repeater and its toolbar - the same split
+ * `BarEditController` established, one size down. It owns the drag's
+ * bookkeeping, the drop indicator, and the COMMIT; the gesture itself is
+ * `ReorderDragArea`, instantiated per slot by `LockIslandEditItem`, so this
+ * file has no DragHandler of its own and `layout_ops` + `lock_islands` are
+ * the only arithmetic anywhere in it.
+ *
+ * ---- one bucket, deliberately ----------------------------------------------
+ *
+ * `dropTarget` speaks buckets, and the three islands could have been three of
+ * them - but a cross-island move would write an id into a list whose island
+ * does not know it, and the resolver's unknown-id rule (correctly) skips what
+ * it does not know: the item would vanish from both islands. Each island's
+ * vocabulary is its own defaults, so each controller offers exactly one
+ * bucket and an item reorders within its island.
+ *
+ * ---- rendered indices, not visible ones -------------------------------------
+ *
+ * The drag's indices are the RENDERED order's (the resolver's answer, which
+ * the Repeater models), and an invisible slot - the username while media
+ * shows, the battery pair on a desktop - is a HOLE in the centres, exactly
+ * like the bar's filtered slots. That keeps the indexing aligned with the
+ * model with no flags walk: the centres array is indexed by rendered index by
+ * construction.
+ *
+ * The write-back is `LockIslands.storedOrder`: the moved rendered order plus
+ * every unknown stored id appended, so a list written by a newer shell
+ * version loses nothing when this one reorders it.
+ */
+Item {
+    id: root
+
+    // "main" | "left" | "right", for the literal write below and for the
+    // module's reorderable() rule at the call sites.
+    property string island: ""
+    // The island's rendered order (the resolver's answer), its Repeater, and
+    // the toolbar the indicator is drawn against - handed in by LockSurface.
+    property var orderedIds: []
+    property Repeater repeater: null
+    property Item islandItem: null
+
+    property int dragIndex: -1
+    readonly property bool dragActive: root.dragIndex >= 0
+
+    // The three stored lists as literal paths - an allowlist reachable
+    // through a computed key is not an allowlist (the scope lint's rule
+    // about exactly these writes).
+    function storedList() {
+        if (root.island === "main") return Config.options.lock.islands.main;
+        if (root.island === "left") return Config.options.lock.islands.left;
+        return Config.options.lock.islands.right;
+    }
+
+    function defaults() {
+        if (root.island === "main") return LockIslands.MAIN_DEFAULT;
+        if (root.island === "left") return LockIslands.LEFT_DEFAULT;
+        return LockIslands.RIGHT_DEFAULT;
+    }
+
+    function writeList(list) {
+        if (root.island === "main") Config.options.lock.islands.main = list;
+        else if (root.island === "left") Config.options.lock.islands.left = list;
+        else Config.options.lock.islands.right = list;
+    }
+
+    // layout_ops.dropTarget's one bucket, in scene coordinates, built fresh
+    // per pointer event: an invisible slot and the dragged one are holes, and
+    // the toolbar's own centre is the anchor so an island whose every other
+    // slot is hidden still takes the drop back.
+    function dropBuckets() {
+        const centres = [];
+        const count = root.repeater ? root.repeater.count : 0;
+        for (let index = 0; index < count; index++) {
+            const item = root.repeater.itemAt(index);
+            const hole = !item || !item.visible || index === root.dragIndex;
+            centres.push(hole ? null : item.mapToItem(null, item.width / 2, item.height / 2));
+        }
+        return [{
+            centres: centres,
+            anchor: root.islandItem
+                ? root.islandItem.mapToItem(null, root.islandItem.width / 2,
+                    root.islandItem.height / 2)
+                : null
+        }];
+    }
+
+    function beginDrag(index) {
+        root.dragIndex = index;
+        // For the exit ladder: an island drag is a gesture in flight, and
+        // Escape's first answer to one is cancel-not-exit.
+        GlobalStates.editLockDragActive = true;
+    }
+
+    function endDrag() {
+        root.dragIndex = -1;
+        GlobalStates.editLockDragActive = false;
+        dropIndicator.shown = false;
+    }
+
+    // The mode's exit destroys the overlays holding the gesture's end
+    // handlers, so none is guaranteed to run - the same central reset the bar
+    // controller carries, for the same reason.
+    property Connections modeWatcher: Connections {
+        target: GlobalStates
+        function onEditModeChanged() {
+            if (!GlobalStates.editMode) root.endDrag();
+        }
+    }
+
+    // The indicator marks the GAP the insertion index names: before the slot
+    // it points at, after the last visible one for an append. Positioned
+    // imperatively per pointer event - mapToItem in a binding goes stale.
+    function dragMoved(target) {
+        if (!root.dragActive || !target) {
+            dropIndicator.shown = false;
+            return;
+        }
+        const count = root.repeater ? root.repeater.count : 0;
+        let reference = null;
+        let atEnd = true;
+        for (let index = target.index; index < count; index++) {
+            const item = root.repeater.itemAt(index);
+            if (item && item.visible && index !== root.dragIndex) {
+                reference = item;
+                atEnd = false;
+                break;
+            }
+        }
+        if (reference === null) {
+            for (let index = count - 1; index >= 0; index--) {
+                const item = root.repeater.itemAt(index);
+                if (item && item.visible && index !== root.dragIndex) {
+                    reference = item;
+                    break;
+                }
+            }
+        }
+        if (reference === null) {
+            dropIndicator.shown = false;
+            return;
+        }
+        const topLeft = reference.mapToItem(root, 0, 0);
+        dropIndicator.width = 3;
+        dropIndicator.height = reference.height;
+        dropIndicator.x = (atEnd ? topLeft.x + reference.width : topLeft.x)
+            - dropIndicator.width / 2;
+        dropIndicator.y = topLeft.y;
+        dropIndicator.shown = true;
+    }
+
+    // Guarded on the mode because a drag can outlive it - Done mid-gesture,
+    // the exit ladder - and an end the user meant as "stop" must not store an
+    // order they never chose.
+    function commitReorder(from, target) {
+        if (!GlobalStates.editMode || !target) return;
+        const destination = LayoutOps.moveTargetForInsertion(from, target.index);
+        if (destination === from) return;
+        const moved = LayoutOps.move(root.orderedIds, from, destination);
+        root.writeList(LockIslands.storedOrder(moved, root.storedList(), root.defaults()));
+    }
+
+    Rectangle {
+        id: dropIndicator
+        objectName: "lockIslandDropIndicator"
+        property bool shown: false
+        visible: root.dragActive && shown
+        radius: Appearance.rounding.unsharpen
+        color: Appearance.colors.colPrimary
+    }
+}

--- a/dots/.config/quickshell/imi/modules/imi/lock/LockSurface.qml
+++ b/dots/.config/quickshell/imi/modules/imi/lock/LockSurface.qml
@@ -115,11 +115,16 @@ MouseArea {
     // One slot shape for all three islands: the Loader is the layout's direct
     // child, so it carries the Layout facts, the active/visible gates and the
     // component resolution; the loaded item keeps drawing exactly what the
-    // hand-placed child drew.
+    // hand-placed child drew. In the preview, in the mode, a movable slot
+    // additionally hosts the reorder overlay - never the password field,
+    // which is the module's rule rather than this file's.
     component IslandSlot: Loader {
         id: slot
         required property int index
         required property string modelData
+        objectName: "islandSlot_" + slot.modelData
+        property string island: ""
+        property var reorder: null
         readonly property var meta: root.islandItemMeta[slot.modelData] ?? ({})
         Layout.alignment: Qt.AlignVCenter
         Layout.leftMargin: slot.meta.leftMargin ?? 0
@@ -128,6 +133,22 @@ MouseArea {
         active: root.islandItemActive(slot.modelData)
         visible: slot.active && root.islandItemVisible(slot.modelData)
         sourceComponent: root.islandComponents[slot.modelData] ?? null
+        // The gesture's dim: "this one is moving", on the slot rather than on
+        // a ghost - island items carry no catalogued display name to put on a
+        // chip, and the dim plus the indicator says everything a chip would.
+        opacity: (editOverlay.item?.dragging ?? false) ? 0.4 : 1
+
+        Loader {
+            id: editOverlay
+            anchors.fill: parent
+            z: 2
+            active: !root.interactive && GlobalStates.editMode
+                && LockIslands.reorderable(slot.island, slot.modelData)
+            sourceComponent: LockIslandEditItem {
+                controller: slot.reorder
+                renderedIndex: slot.index
+            }
+        }
     }
 
     // The field lives inside a delegate component now, so the surface reaches
@@ -221,8 +242,12 @@ MouseArea {
         opacity: root.toolbarOpacity
 
         Repeater {
+            id: mainRepeater
             model: root.mainOrder
-            delegate: IslandSlot {}
+            delegate: IslandSlot {
+                island: "main"
+                reorder: mainReorder
+            }
         }
     }
 
@@ -240,8 +265,12 @@ MouseArea {
         opacity: root.toolbarOpacity
 
         Repeater {
+            id: leftRepeater
             model: root.leftOrder
-            delegate: IslandSlot {}
+            delegate: IslandSlot {
+                island: "left"
+                reorder: leftReorder
+            }
         }
     }
 
@@ -260,9 +289,46 @@ MouseArea {
         opacity: root.toolbarOpacity
 
         Repeater {
+            id: rightRepeater
             model: root.rightOrder
-            delegate: IslandSlot {}
+            delegate: IslandSlot {
+                island: "right"
+                reorder: rightReorder
+            }
         }
+    }
+
+    // ---- the reorder coordinators, one per island ------------------------
+    //
+    // Full-surface siblings of the islands so their drop indicators can be
+    // drawn in surface coordinates over any slot. One per island rather than
+    // one with three buckets, deliberately: each island's vocabulary is its
+    // own defaults, and a cross-island move would write an id the receiving
+    // island's resolver (correctly) skips as unknown - the item would vanish
+    // from both. See LockIslandReorder for the rest of the reasoning.
+    LockIslandReorder {
+        id: mainReorder
+        anchors.fill: parent
+        island: "main"
+        orderedIds: root.mainOrder
+        repeater: mainRepeater
+        islandItem: mainIsland
+    }
+    LockIslandReorder {
+        id: leftReorder
+        anchors.fill: parent
+        island: "left"
+        orderedIds: root.leftOrder
+        repeater: leftRepeater
+        islandItem: leftIsland
+    }
+    LockIslandReorder {
+        id: rightReorder
+        anchors.fill: parent
+        island: "right"
+        orderedIds: root.rightOrder
+        repeater: rightRepeater
+        islandItem: rightIsland
     }
 
     // ---- the items, one component per id --------------------------------

--- a/dots/.config/quickshell/imi/modules/imi/lock/LockSurface.qml
+++ b/dots/.config/quickshell/imi/modules/imi/lock/LockSurface.qml
@@ -12,6 +12,7 @@ import qs.modules.common.panels.lock
 import qs.modules.imi.bar as Bar
 import Quickshell
 import Quickshell.Services.SystemTray
+import "../../common/functions/lock_islands.js" as LockIslands
 
 MouseArea {
     id: root
@@ -37,10 +38,108 @@ MouseArea {
 
     property var    artUrl:      activePlayer?.trackArtUrl ?? ""
 
+    // ---- the islands' contents, as data --------------------------------
+    //
+    // Spec §14, answered "reorder": each island renders its stored order
+    // through the one resolver, so a list written by an older shell still
+    // shows a later version's items at their default positions, and a list
+    // written by a newer shell loses nothing on the way through this one.
+    // The Repeaters below model these, never the stored lists directly.
+    readonly property var mainOrder: LockIslands.orderedItems(
+        Config.options.lock.islands.main, LockIslands.MAIN_DEFAULT)
+    readonly property var leftOrder: LockIslands.orderedItems(
+        Config.options.lock.islands.left, LockIslands.LEFT_DEFAULT)
+    readonly property var rightOrder: LockIslands.orderedItems(
+        Config.options.lock.islands.right, LockIslands.RIGHT_DEFAULT)
+
+    // One filter, shared by the fcitx slot's visibility and the component
+    // that draws it, so the two cannot disagree about what counts as present.
+    readonly property var fcitxItems: SystemTray.items.values.filter(i => i.id == "Fcitx")
+
+    // Which component draws each id. An id missing here would render as an
+    // empty slot - the Loader resolves null and draws nothing - which is why
+    // tests/test_lock_islands_contract.py holds this map to the module's
+    // whole default vocabulary.
+    readonly property var islandComponents: ({
+        fingerprint: fingerprintComponent,
+        password: passwordComponent,
+        confirm: confirmComponent,
+        username: usernameComponent,
+        media: mediaComponent,
+        keyboardLayout: keyboardLayoutComponent,
+        fcitx: fcitxComponent,
+        battery: batteryComponent,
+        sleep: sleepComponent,
+        power: powerComponent,
+        reboot: rebootComponent
+    })
+
+    // Each item's Layout facts, which used to live as attached properties on
+    // the hand-placed children. They move to the slot Loader because a Layout
+    // only honours attached properties on its DIRECT children, and the slot
+    // is the direct child now. Held to the same vocabulary as the components
+    // by the contract, since a missing entry is not an error - it is a margin
+    // of 0 that reads as a design choice.
+    readonly property var islandItemMeta: ({
+        fingerprint: { leftMargin: Appearance.spacing.space150, rightMargin: Appearance.spacing.space100 },
+        password: { fillHeight: true },
+        confirm: { fillHeight: true },
+        username: { leftMargin: Appearance.spacing.space100, rightMargin: Appearance.spacing.space150, fillHeight: true },
+        media: { leftMargin: Appearance.spacing.space25, rightMargin: Appearance.spacing.space25 },
+        keyboardLayout: { rightMargin: Appearance.spacing.space100, fillHeight: true },
+        fcitx: { rightMargin: Appearance.spacing.space150 },
+        battery: { leftMargin: Appearance.spacing.space150, rightMargin: Appearance.spacing.space150, fillHeight: true },
+        sleep: { fillHeight: true },
+        power: { fillHeight: true },
+        reboot: { fillHeight: true }
+    })
+
+    // The per-item visibility the hand-placed children carried, unchanged in
+    // meaning: visibility stays per item, order is the list - the lists and
+    // the lock.show* booleans divide the work rather than fighting over it.
+    function islandItemActive(id) {
+        if (id === "fingerprint") return root.context.fingerprintsConfigured === true;
+        if (id === "media") return MprisController.activePlayer !== null;
+        return true;
+    }
+
+    function islandItemVisible(id) {
+        if (id === "username" || id === "keyboardLayout")
+            return !Config.options.lock.showMedia || MprisController.activePlayer === null;
+        if (id === "media") return Config.options.lock.showMedia;
+        if (id === "fcitx") return root.fcitxItems.length > 0;
+        if (id === "battery") return Battery.available;
+        return true;
+    }
+
+    // One slot shape for all three islands: the Loader is the layout's direct
+    // child, so it carries the Layout facts, the active/visible gates and the
+    // component resolution; the loaded item keeps drawing exactly what the
+    // hand-placed child drew.
+    component IslandSlot: Loader {
+        id: slot
+        required property int index
+        required property string modelData
+        readonly property var meta: root.islandItemMeta[slot.modelData] ?? ({})
+        Layout.alignment: Qt.AlignVCenter
+        Layout.leftMargin: slot.meta.leftMargin ?? 0
+        Layout.rightMargin: slot.meta.rightMargin ?? 0
+        Layout.fillHeight: slot.meta.fillHeight === true
+        active: root.islandItemActive(slot.modelData)
+        visible: slot.active && root.islandItemVisible(slot.modelData)
+        sourceComponent: root.islandComponents[slot.modelData] ?? null
+    }
+
+    // The field lives inside a delegate component now, so the surface reaches
+    // it through this property rather than an id that no longer resolves at
+    // file scope. Null while the main island has not built (or is rebuilt by
+    // a reorder), which forceFieldFocus already tolerates.
+    property Item passwordField: null
+
     // Force focus on entry
     function forceFieldFocus() {
         if (!root.interactive) return;
-        passwordBox.forceActiveFocus();
+        root.passwordField?.forceActiveFocus();
     }
     Connections {
         target: context
@@ -106,25 +205,6 @@ MouseArea {
         forceFieldFocus();
     }
 
-    // RippleButton {
-    //     anchors {
-    //         top: parent.top
-    //         left: parent.left
-    //         leftMargin: 10
-    //         topMargin: 10
-    //     }
-    //     implicitHeight: 40
-    //     colBackground: Appearance.colors.colLayer2
-    //     onClicked: {
-    //         context.unlocked(LockContext.ActionEnum.Unlock);
-    //         GlobalStates.screenLocked = false;
-    //     }
-    //     contentItem: StyledText {
-    //         text: "[[ DEBUG BYPASS ]]"
-    //     }
-    // }
-
-
     // Main toolbar: password box
     Toolbar {
         id: mainIsland
@@ -140,27 +220,71 @@ MouseArea {
         scale: root.toolbarScale
         opacity: root.toolbarOpacity
 
-        // Fingerprint
-        Loader {
-            Layout.leftMargin: Appearance.spacing.space150
-            Layout.rightMargin: Appearance.spacing.space100
-            Layout.alignment: Qt.AlignVCenter
-            active: root.context.fingerprintsConfigured
-            visible: active
+        Repeater {
+            model: root.mainOrder
+            delegate: IslandSlot {}
+        }
+    }
 
-            sourceComponent: MaterialSymbol {
-                id: fingerprintIcon
-                fill: 1
-                text: "fingerprint"
-                iconSize: Appearance.font.pixelSize.hugeass
-                color: Appearance.colors.colOnSurfaceVariant
-            }
+    // Left toolbar
+    Toolbar {
+        id: leftIsland
+        visible: Config.options.lock.showToolbars
+        anchors {
+            right: mainIsland.left
+            top: mainIsland.top
+            bottom: mainIsland.bottom
+            rightMargin: Appearance.spacing.space150
+        }
+        scale: root.toolbarScale
+        opacity: root.toolbarOpacity
+
+        Repeater {
+            model: root.leftOrder
+            delegate: IslandSlot {}
+        }
+    }
+
+    // Right toolbar
+    Toolbar {
+        id: rightIsland
+        visible: Config.options.lock.showToolbars
+        anchors {
+            left: mainIsland.right
+            top: mainIsland.top
+            bottom: mainIsland.bottom
+            leftMargin: Appearance.spacing.space150
         }
 
+        scale: root.toolbarScale
+        opacity: root.toolbarOpacity
+
+        Repeater {
+            model: root.rightOrder
+            delegate: IslandSlot {}
+        }
+    }
+
+    // ---- the items, one component per id --------------------------------
+
+    Component {
+        id: fingerprintComponent
+        MaterialSymbol {
+            fill: 1
+            text: "fingerprint"
+            iconSize: Appearance.font.pixelSize.hugeass
+            color: Appearance.colors.colOnSurfaceVariant
+        }
+    }
+
+    Component {
+        id: passwordComponent
         ToolbarTextField {
             id: passwordBox
-            Layout.rightMargin: -Layout.leftMargin
             placeholderText: GlobalStates.screenUnlockFailed ? Translation.tr("Incorrect password") : Translation.tr("Enter password")
+
+            Component.onCompleted: root.passwordField = passwordBox
+            Component.onDestruction: if (root.passwordField === passwordBox) root.passwordField = null
 
             // Style
             clip: true
@@ -200,7 +324,7 @@ MouseArea {
                 if (!root.interactive) return;
                 root.context.resetClearTimer();
             }
-            
+
             layer.enabled: true
             layer.effect: OpacityMask {
                 maskSource: Rectangle {
@@ -240,7 +364,10 @@ MouseArea {
                 }
             }
         }
+    }
 
+    Component {
+        id: confirmComponent
         ToolbarButton {
             id: confirmButton
             implicitWidth: height
@@ -272,283 +399,252 @@ MouseArea {
         }
     }
 
-    // Left toolbar
-    Toolbar {
-        id: leftIsland
-        visible: Config.options.lock.showToolbars
-        anchors {
-            right: mainIsland.left
-            top: mainIsland.top
-            bottom: mainIsland.bottom
-            rightMargin: Appearance.spacing.space150
-        }
-        scale: root.toolbarScale
-        opacity: root.toolbarOpacity
-
-        // Username
+    Component {
+        id: usernameComponent
         IconAndTextPair {
-            Layout.leftMargin: Appearance.spacing.space100
             icon: "account_circle"
-            visible: !Config.options.lock.showMedia || MprisController.activePlayer === null
             text: SystemInfo.username
         }
+    }
 
-        // Media player info 
-        Loader {
-            Layout.leftMargin: Appearance.spacing.space25
-            Layout.rightMargin: Appearance.spacing.space25
-            Layout.alignment: Qt.AlignVCenter
-            active: MprisController.activePlayer !== null
-            visible: active && Config.options.lock.showMedia
-            
-            sourceComponent: Item {
-                implicitWidth: mediaRow.implicitWidth
-                implicitHeight: mediaRow.implicitHeight
-                
-                readonly property MprisPlayer activePlayer: MprisController.activePlayer
-                readonly property string cleanedTitle: StringUtils.cleanMusicTitle(activePlayer?.trackTitle) || ""
-                
-                Timer {
-                    running: activePlayer?.playbackState == MprisPlaybackState.Playing
-                    interval: Config.options.resources.updateInterval
-                    repeat: true
-                    onTriggered: activePlayer.positionChanged()
+    Component {
+        id: mediaComponent
+        Item {
+            implicitWidth: mediaRow.implicitWidth
+            implicitHeight: mediaRow.implicitHeight
+
+            readonly property MprisPlayer activePlayer: MprisController.activePlayer
+            readonly property string cleanedTitle: StringUtils.cleanMusicTitle(activePlayer?.trackTitle) || ""
+
+            Timer {
+                running: activePlayer?.playbackState == MprisPlaybackState.Playing
+                interval: Config.options.resources.updateInterval
+                repeat: true
+                onTriggered: activePlayer.positionChanged()
+            }
+
+            // Compact playback controls for the lock-screen media widget.
+            component LockMediaButton: MouseArea {
+                property string icon
+                property bool ctlEnabled: true
+                implicitWidth: 28
+                implicitHeight: 28
+                enabled: ctlEnabled
+                opacity: ctlEnabled ? 1 : 0.4
+                hoverEnabled: true
+                cursorShape: Qt.PointingHandCursor
+                Layout.alignment: Qt.AlignVCenter
+                MaterialSymbol {
+                    anchors.centerIn: parent
+                    fill: 1
+                    text: parent.icon
+                    iconSize: Appearance.font.pixelSize.huge
+                    color: Appearance.colors.colOnSurfaceVariant
                 }
-                
-                // Compact playback controls for the lock-screen media widget.
-                component LockMediaButton: MouseArea {
-                    property string icon
-                    property bool ctlEnabled: true
-                    implicitWidth: 28
-                    implicitHeight: 28
-                    enabled: ctlEnabled
-                    opacity: ctlEnabled ? 1 : 0.4
-                    hoverEnabled: true
-                    cursorShape: Qt.PointingHandCursor
+            }
+
+            RowLayout {
+                id: mediaRow
+                spacing: Appearance.spacing.space100
+                anchors.centerIn: parent
+
+                Rectangle {
+                    id: artRect
+                    implicitWidth: 40
+                    implicitHeight: 40
+                    radius: Appearance.rounding.full
+                    color: Appearance.colors.colPrimaryContainer
                     Layout.alignment: Qt.AlignVCenter
+                    clip: true
+
+                    layer.enabled: true
+                    layer.effect: OpacityMask {
+                        maskSource: Rectangle {
+                            width: artRect.width
+                            height: artRect.height
+                            radius: artRect.radius
+                        }
+                    }
+
+                    StyledImage {
+                        anchors.centerIn: parent
+                        width: artRect.width
+                        height: artRect.height
+                        source: root.artUrl
+                        fillMode: Image.PreserveAspectCrop
+                        cache: false
+                        antialiasing: true
+                        sourceSize.width: artRect.width * 2
+                        sourceSize.height: artRect.height * 2
+                        visible: root.artUrl !== ""
+                    }
+
                     MaterialSymbol {
                         anchors.centerIn: parent
                         fill: 1
-                        text: parent.icon
-                        iconSize: Appearance.font.pixelSize.huge
+                        text: "music_note"
+                        iconSize: Appearance.font.pixelSize.normal
+                        color: Appearance.colors.colOnSecondaryContainer
+                        visible: root.artUrl === ""
+                    }
+                }
+
+                Column {
+                    Layout.alignment: Qt.AlignVCenter
+                    spacing: -Appearance.spacing.space25
+
+                    StyledText {
+                        horizontalAlignment: Text.AlignLeft
+                        elide: Text.ElideRight
+                        maximumLineCount: 1
+                        width: Math.min(implicitWidth, 180)
                         color: Appearance.colors.colOnSurfaceVariant
+                        text: {
+                            var artist = activePlayer?.trackArtist || " ";
+                            return artist.length > 25 ? artist.substring(0, 25) + "..." : artist;
+                        }
+                        font.pixelSize: Appearance.font.pixelSize.smaller
+                    }
+
+                    StyledText {
+                        horizontalAlignment: Text.AlignLeft
+                        elide: Text.ElideRight
+                        maximumLineCount: 1
+                        width: Math.min(implicitWidth, 180)
+                        color: Appearance.colors.colOnSurfaceVariant
+                        text: {
+                            var title = cleanedTitle;
+                            return title.length > 30 ? title.substring(0, 30) + "..." : title;
+                        }
+                        font.weight: Font.Medium
+                        font.pixelSize: Appearance.font.pixelSize.small
                     }
                 }
 
                 RowLayout {
-                    id: mediaRow
-                    spacing: Appearance.spacing.space100
-                    anchors.centerIn: parent
+                    Layout.alignment: Qt.AlignVCenter
+                    spacing: Appearance.spacing.space25
 
-                    Rectangle {
-                        id: artRect
-                        implicitWidth: 40
-                        implicitHeight: 40
-                        radius: Appearance.rounding.full
-                        color: Appearance.colors.colPrimaryContainer
-                        Layout.alignment: Qt.AlignVCenter
-                        clip: true 
-
-                        layer.enabled: true
-                        layer.effect: OpacityMask {
-                            maskSource: Rectangle {
-                                width: artRect.width
-                                height: artRect.height
-                                radius: artRect.radius
-                            }
+                    LockMediaButton {
+                        icon: "skip_previous"
+                        ctlEnabled: MprisController.canGoPrevious
+                        onClicked: {
+                            if (!root.interactive) return;
+                            MprisController.previous();
                         }
-
-                        StyledImage {
-                            anchors.centerIn: parent
-                            width: artRect.width
-                            height: artRect.height
-                            source: root.artUrl
-                            fillMode: Image.PreserveAspectCrop
-                            cache: false
-                            antialiasing: true
-                            sourceSize.width: artRect.width * 2
-                            sourceSize.height: artRect.height * 2
-                            visible: root.artUrl !== ""
+                    }
+                    LockMediaButton {
+                        icon: activePlayer?.isPlaying ? "pause" : "play_arrow"
+                        onClicked: {
+                            if (!root.interactive) return;
+                            MprisController.togglePlaying();
                         }
+                    }
+                    LockMediaButton {
+                        icon: "skip_next"
+                        ctlEnabled: MprisController.canGoNext
+                        onClicked: {
+                            if (!root.interactive) return;
+                            MprisController.next();
+                        }
+                    }
+                }
+
+                ClippedFilledCircularProgress {
+                    id: mediaCircProg
+                    Layout.alignment: Qt.AlignVCenter
+                    lineWidth: Appearance.rounding.unsharpen
+                    value: activePlayer?.position / activePlayer?.length
+                    implicitSize: 24
+                    colPrimary: Appearance.colors.colOnSurfaceVariant
+                    enableAnimation: false
+
+                    Item {
+                        anchors.centerIn: parent
+                        width: mediaCircProg.implicitSize
+                        height: mediaCircProg.implicitSize
 
                         MaterialSymbol {
                             anchors.centerIn: parent
                             fill: 1
                             text: "music_note"
                             iconSize: Appearance.font.pixelSize.normal
-                            color: Appearance.colors.colOnSecondaryContainer
-                            visible: root.artUrl === ""
-                        }
-                    }
-                    
-                    Column {
-                        Layout.alignment: Qt.AlignVCenter
-                        spacing: -Appearance.spacing.space25
-                        
-                        StyledText {
-                            horizontalAlignment: Text.AlignLeft
-                            elide: Text.ElideRight
-                            maximumLineCount: 1
-                            width: Math.min(implicitWidth, 180) 
                             color: Appearance.colors.colOnSurfaceVariant
-                            text: {
-                                var artist = activePlayer?.trackArtist || " ";
-                                return artist.length > 25 ? artist.substring(0, 25) + "..." : artist;
-                            }
-                            font.pixelSize: Appearance.font.pixelSize.smaller
-                        }
-                        
-                        StyledText {
-                            horizontalAlignment: Text.AlignLeft
-                            elide: Text.ElideRight
-                            maximumLineCount: 1
-                            width: Math.min(implicitWidth, 180) 
-                            color: Appearance.colors.colOnSurfaceVariant
-                            text: {
-                                var title = cleanedTitle;
-                                return title.length > 30 ? title.substring(0, 30) + "..." : title;
-                            }
-                            font.weight: Font.Medium
-                            font.pixelSize: Appearance.font.pixelSize.small
-                        }
-                    }
-                    
-                    RowLayout {
-                        Layout.alignment: Qt.AlignVCenter
-                        spacing: Appearance.spacing.space25
-
-                        LockMediaButton {
-                            icon: "skip_previous"
-                            ctlEnabled: MprisController.canGoPrevious
-                            onClicked: {
-                                if (!root.interactive) return;
-                                MprisController.previous();
-                            }
-                        }
-                        LockMediaButton {
-                            icon: activePlayer?.isPlaying ? "pause" : "play_arrow"
-                            onClicked: {
-                                if (!root.interactive) return;
-                                MprisController.togglePlaying();
-                            }
-                        }
-                        LockMediaButton {
-                            icon: "skip_next"
-                            ctlEnabled: MprisController.canGoNext
-                            onClicked: {
-                                if (!root.interactive) return;
-                                MprisController.next();
-                            }
-                        }
-                    }
-
-                    ClippedFilledCircularProgress {
-                        id: mediaCircProg
-                        Layout.alignment: Qt.AlignVCenter
-                        lineWidth: Appearance.rounding.unsharpen
-                        value: activePlayer?.position / activePlayer?.length
-                        implicitSize: 24
-                        colPrimary: Appearance.colors.colOnSurfaceVariant
-                        enableAnimation: false
-                        
-                        Item {
-                            anchors.centerIn: parent
-                            width: mediaCircProg.implicitSize
-                            height: mediaCircProg.implicitSize
-                            
-                            MaterialSymbol {
-                                anchors.centerIn: parent
-                                fill: 1
-                                text: "music_note"
-                                iconSize: Appearance.font.pixelSize.normal
-                                color: Appearance.colors.colOnSurfaceVariant
-                            }
                         }
                     }
                 }
             }
-        }
-
-        // Keyboard layout (Xkb)
-        Loader {
-            Layout.rightMargin: Appearance.spacing.space100
-            Layout.fillHeight: true
-            visible: !Config.options.lock.showMedia || MprisController.activePlayer === null
-
-            sourceComponent: Row {
-                spacing: Appearance.spacing.space100
-
-                MaterialSymbol {
-                    id: keyboardIcon
-                    anchors.verticalCenter: parent.verticalCenter
-                    fill: 1
-                    text: "keyboard_alt"
-                    iconSize: Appearance.font.pixelSize.huge
-                    color: Appearance.colors.colOnSurfaceVariant
-                }
-                Loader {
-                    anchors.verticalCenter: parent.verticalCenter
-                    sourceComponent: StyledText {
-                        text: HyprlandXkb.currentLayoutCode
-                        color: Appearance.colors.colOnSurfaceVariant
-                        animateChange: true
-                    }
-                }
-            }
-        }
-
-        // Keyboard layout (Fcitx). `enabled` cascades from this plain root, so
-        // the preview's copy cannot activate the real SNI item - the one
-        // interactive element in the islands that reaches outside the shell.
-        Bar.SysTray {
-            Layout.rightMargin: Appearance.spacing.space150
-            Layout.alignment: Qt.AlignVCenter
-            enabled: root.interactive
-            showSeparator: false
-            showOverflowMenu: false
-            pinnedItems: SystemTray.items.values.filter(i => i.id == "Fcitx")
-            visible: pinnedItems.length > 0
         }
     }
 
-    // Right toolbar
-    Toolbar {
-        id: rightIsland
-        visible: Config.options.lock.showToolbars
-        anchors {
-            left: mainIsland.right
-            top: mainIsland.top
-            bottom: mainIsland.bottom
-            leftMargin: Appearance.spacing.space150
+    Component {
+        id: keyboardLayoutComponent
+        Row {
+            spacing: Appearance.spacing.space100
+
+            MaterialSymbol {
+                id: keyboardIcon
+                anchors.verticalCenter: parent.verticalCenter
+                fill: 1
+                text: "keyboard_alt"
+                iconSize: Appearance.font.pixelSize.huge
+                color: Appearance.colors.colOnSurfaceVariant
+            }
+            Loader {
+                anchors.verticalCenter: parent.verticalCenter
+                sourceComponent: StyledText {
+                    text: HyprlandXkb.currentLayoutCode
+                    color: Appearance.colors.colOnSurfaceVariant
+                    animateChange: true
+                }
+            }
         }
+    }
 
-        scale: root.toolbarScale
-        opacity: root.toolbarOpacity
+    Component {
+        id: fcitxComponent
+        // `enabled` cascades from SysTray's plain Item root, so the preview's
+        // copy cannot activate the real SNI item - the one interactive element
+        // in the islands that reaches outside the shell.
+        Bar.SysTray {
+            enabled: root.interactive
+            showSeparator: false
+            showOverflowMenu: false
+            pinnedItems: root.fcitxItems
+        }
+    }
 
+    Component {
+        id: batteryComponent
         IconAndTextPair {
-            visible: Battery.available
             icon: Battery.isCharging ? "bolt" : "battery_android_full"
             text: Math.round(Battery.percentage * 100)
             color: (Battery.isLow && !Battery.isCharging) ? Appearance.colors.colError : Appearance.colors.colOnSurfaceVariant
         }
+    }
 
+    Component {
+        id: sleepComponent
         IconToolbarButton {
-            id: sleepButton
             onClicked: {
                 if (!root.interactive) return;
                 Session.suspend();
             }
             text: "dark_mode"
         }
+    }
 
+    Component {
+        id: powerComponent
         PasswordGuardedIconToolbarButton {
-            id: powerButton
             text: "power_settings_new"
             targetAction: LockContext.ActionEnum.Poweroff
         }
+    }
 
+    Component {
+        id: rebootComponent
         PasswordGuardedIconToolbarButton {
-            id: rebootButton
             text: "restart_alt"
             targetAction: LockContext.ActionEnum.Reboot
         }
@@ -582,10 +678,6 @@ MouseArea {
         property color color: Appearance.colors.colOnSurfaceVariant
 
         spacing: Appearance.spacing.space50
-        Layout.fillHeight: true
-        Layout.leftMargin: Appearance.spacing.space150
-        Layout.rightMargin: Appearance.spacing.space150
-        
 
         MaterialSymbol {
             anchors.verticalCenter: parent.verticalCenter

--- a/dots/.config/quickshell/imi/modules/imi/lock/LockSurface.qml
+++ b/dots/.config/quickshell/imi/modules/imi/lock/LockSurface.qml
@@ -349,7 +349,15 @@ MouseArea {
             id: passwordBox
             placeholderText: GlobalStates.screenUnlockFailed ? Translation.tr("Incorrect password") : Translation.tr("Enter password")
 
-            Component.onCompleted: root.passwordField = passwordBox
+            // The pull as well as the publication: a slot rebuild (a reorder
+            // committing, an external write to the main list) creates a
+            // fresh field, and one that only followed onCurrentTextChanged
+            // would show empty over a context still holding text - then
+            // overwrite that text with the next keystroke alone.
+            Component.onCompleted: {
+                root.passwordField = passwordBox;
+                passwordBox.text = root.context.currentText;
+            }
             Component.onDestruction: if (root.passwordField === passwordBox) root.passwordField = null
 
             // Style

--- a/dots/.config/quickshell/imi/tests/lint_edit_mode_scope.py
+++ b/dots/.config/quickshell/imi/tests/lint_edit_mode_scope.py
@@ -36,7 +36,11 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 
-EDIT_MODE_DIRS = [ROOT / "modules/imi/editMode"]
+# The lock module joined for stage 9b: the island reorder commits its lists
+# from LockSurface's own edit machinery, which lives beside the surface rather
+# than under editMode/ - and a scope rule that stops at a directory boundary is
+# an invitation to move the write one directory sideways.
+EDIT_MODE_DIRS = [ROOT / "modules/imi/editMode", ROOT / "modules/imi/lock"]
 
 ALLOWED_CONFIG_PATHS = {
     "plugins.enabled",
@@ -44,6 +48,12 @@ ALLOWED_CONFIG_PATHS = {
     "bar.layouts.middleLayout",
     "bar.layouts.rightLayout",
     "dock.pinnedApps",
+    # Stage 9b: the islands' ORDER is placement (spec §9's rule admits order
+    # by name), and the three lists are spelled out rather than a prefix so a
+    # future lock.islands.* key does not inherit the licence unreviewed.
+    "lock.islands.main",
+    "lock.islands.left",
+    "lock.islands.right",
 }
 # `lock.showWidgets` / `showToolbars` / `showMedia` are presence-on-a-surface,
 # which the rule admits (spec §9's second edge case).
@@ -184,6 +194,7 @@ class EditModeScopeLint(unittest.TestCase):
             'Config.options.plugins.enabled = next\n'
             'Config.setNestedValue("dock.pinnedApps", apps)\n'
             'Config.setNestedValue("lock.showWidgets", true)\n'
+            'Config.options.lock.islands.left = next\n'
             'PluginState.setOption(id, "positionLocked", true)\n'
             'PluginState.setOption(id, "__gridSize", "2x1")\n'
             'PluginState.setPosition(id, screen, { x: 0, y: 0 })\n'

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -344,6 +344,15 @@ if ! python3 "$SCRIPT_DIR/test_lock_preview_contract.py"; then
     exit 1
 fi
 
+# Stage 9b: the lock islands' order - the schema's defaults pinned to the
+# resolver's, the islands rendered through the one resolver, and the reorder
+# committing through the shared arithmetic at literal paths.
+echo "Running lock islands contract tests..."
+if ! python3 "$SCRIPT_DIR/test_lock_islands_contract.py"; then
+    echo "Lock islands contract tests failed."
+    exit 1
+fi
+
 # Whether a drag still lands where the pointer put it once the desktop is drawn
 # at a scale. Nothing static can see that: the drag is hand-computed and the
 # transform is only SUPPOSED to cancel itself out. Brings its own weston.

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -415,6 +415,16 @@ if ! python3 "$SCRIPT_DIR/test_bar_edit_runtime.py"; then
     exit 1
 fi
 
+# Stage 9b: the lock islands' reorder, driven with real mouse events on the
+# real LockSurface with the preview context - the overlay's eater, the shared
+# gesture, move semantics, the storedOrder merge, and both cancel paths.
+# Brings its own headless weston.
+echo "Running lock island reorder runtime tests..."
+if ! python3 "$SCRIPT_DIR/test_lock_island_reorder_runtime.py"; then
+    echo "Lock island reorder runtime tests failed."
+    exit 1
+fi
+
 # A column of dock icons can lay out perfectly and still refuse to reorder,
 # because every slot centre shares an x - only real mouse events see that.
 # Brings its own headless weston.

--- a/dots/.config/quickshell/imi/tests/test_lock_island_reorder_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_lock_island_reorder_runtime.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Drives the lock islands' reorder with real mouse events.
+
+`LockIslandReorderRuntimeTest.qml` builds the REAL `LockSurface` with the real
+`LockPreviewContext` and drags its slots, committing against the real
+`Config.options.lock.islands.*` lists in a throwaway config. What only real
+events can show: the press lands on the overlay's eater and `ReorderDragArea`
+takes over past the threshold; the drop resolves over centres carrying holes
+(invisible slots, the dragged one); the commit runs move semantics and the
+`storedOrder` merge, so an id a newer shell stored survives; the password slot
+loads no overlay and the same gesture over it moves nothing; and both cancel
+paths - the ladder's `editReorderCancel` and the mode's exit - leave the
+stored lists untouched.
+
+Headless weston because the harness opens a window; weston implements no
+wlr-layer-shell, so the real session lock surface is outside what this can
+say. Skips when weston or qs is missing, as in CI.
+"""
+
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HARNESS = ROOT / "LockIslandReorderRuntimeTest.qml"
+SOCKET = "wayland-imi-lock-islands"
+
+# A literal, never read back out of the harness's own output: a step list that
+# shrinks must redden here instead of reporting `failures: 0` for a shorter
+# run.
+EXPECTED_CHECKS = 12
+
+
+def _stop(proc):
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+
+
+def _runtime_available():
+    return shutil.which("qs") is not None and shutil.which("weston") is not None
+
+
+@unittest.skipUnless(_runtime_available(), "needs qs and weston on PATH")
+class LockIslandReorderRuntimeTest(unittest.TestCase):
+    def setUp(self):
+        self.home = Path(tempfile.mkdtemp(prefix="imi-lock-islands-"))
+        self.addCleanup(shutil.rmtree, self.home, ignore_errors=True)
+
+    def test_the_islands_reorder_and_the_field_does_not(self):
+        env = dict(os.environ)
+        # A runtime dir of the harness's OWN, not the session's: everything
+        # this test starts talks to its own weston and can never reach the
+        # user's compositor - a lock-screen surface probed on the live display
+        # locks the real session, and on this machine a real lock suspends
+        # the laptop.
+        runtime = self.home / "runtime"
+        runtime.mkdir(mode=0o700)
+        env["XDG_RUNTIME_DIR"] = str(runtime)
+        env["WAYLAND_DISPLAY"] = SOCKET
+        env.pop("DISPLAY", None)
+        env.pop("HYPRLAND_INSTANCE_SIGNATURE", None)
+
+        weston = subprocess.Popen(
+            ["weston", "--backend=headless", "--renderer=pixman",
+             f"--socket={SOCKET}", "--width=1500", "--height=700"],
+            env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        self.addCleanup(_stop, weston)
+
+        socket_path = Path(env["XDG_RUNTIME_DIR"]) / SOCKET
+        deadline = time.monotonic() + 15
+        while not socket_path.exists() and time.monotonic() < deadline:
+            time.sleep(0.2)
+        self.assertTrue(socket_path.exists(), "headless weston never came up")
+
+        env["LIBGL_ALWAYS_SOFTWARE"] = "1"
+        env["QT_QUICK_BACKEND"] = "software"
+        env["XDG_CONFIG_HOME"] = str(self.home / "config")
+        env["XDG_STATE_HOME"] = str(self.home / "state")
+
+        proc = subprocess.run(["qs", "-p", str(HARNESS)], cwd=str(ROOT), env=env,
+                              capture_output=True, text=True, timeout=240)
+        output = proc.stdout + proc.stderr
+        failed = [line for line in output.splitlines() if "FAIL" in line]
+        self.assertEqual(failed, [], f"harness reported failures:\n{output}")
+        self.assertIn(f"[LockIslands] checks: {EXPECTED_CHECKS} failures: 0", output,
+                      f"harness did not finish cleanly:\n{output}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dots/.config/quickshell/imi/tests/test_lock_islands_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_lock_islands_contract.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""The lock islands' order: one schema, one resolver, one commit path.
+
+Stage 9b (spec §14, answered "reorder" by the maintainer): three ordered lists
+in `Config.options.lock.islands` and a data-driven rewrite of the three
+islands in `LockSurface.qml`. What this module pins is the drift that would be
+silent:
+
+- the schema's defaults and the resolver's defaults are two spellings of one
+  order, so they are pinned equal - a divergence renders existing users a
+  different lock screen than the one their (empty) store means;
+- every island renders through the resolver, so a version-skewed list cannot
+  silently drop an item;
+- the reorder commits go through `layout_ops` + `lock_islands` at literal
+  config paths, guarded on the mode.
+
+Like the lock preview contract, sweeps here assert they FOUND what they swept.
+"""
+
+import re
+from pathlib import Path
+
+from contract_runner import run
+
+ROOT = Path(__file__).resolve().parent.parent
+CONFIG = ROOT / "modules/common/Config.qml"
+MODULE = ROOT / "modules/common/functions/lock_islands.js"
+LOCK_SURFACE = ROOT / "modules/imi/lock/LockSurface.qml"
+
+
+def read(path: Path) -> str:
+    assert path.exists(), f"{path} is gone - the sweep has nothing to look at"
+    text = path.read_text()
+    assert text.strip(), f"{path} is empty"
+    return text
+
+
+def code(path: Path) -> str:
+    text = re.sub(r"/\*.*?\*/", "", read(path), flags=re.S)
+    return "\n".join(re.sub(r"//.*$", "", line) for line in text.splitlines())
+
+
+def module_default(name: str):
+    match = re.search(rf"var {name}_DEFAULT = \[(.*?)\];", code(MODULE), re.S)
+    assert match, f"lock_islands.js no longer declares {name}_DEFAULT"
+    return re.findall(r'"(\w+)"', match.group(1))
+
+
+def test_the_schema_and_the_resolver_agree_on_the_default_order():
+    # Config.qml cannot import the module (a JsonAdapter default is safest as
+    # a literal), so the two spellings of the hand-placed order are pinned
+    # against each other here instead of trusted to stay equal.
+    config = code(CONFIG)
+    islands = re.search(
+        r"property JsonObject islands: JsonObject \{(.*?)\n            \}",
+        config, re.S)
+    assert islands, "Config.qml declares no lock.islands schema"
+    body = islands.group(1)
+    for name in ("main", "left", "right"):
+        declared = re.search(
+            rf"property list<string> {name}:\s*\[(.*?)\]", body, re.S)
+        assert declared, f"lock.islands.{name} is not declared"
+        stored = re.findall(r'"(\w+)"', declared.group(1))
+        expected = module_default(name.upper())
+        assert stored == expected, \
+            (f"lock.islands.{name} defaults to {stored} while the resolver's "
+             f"default is {expected} - two spellings of one order have split")
+
+
+if __name__ == "__main__":
+    raise SystemExit(run(globals()))

--- a/dots/.config/quickshell/imi/tests/test_lock_islands_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_lock_islands_contract.py
@@ -67,5 +67,68 @@ def test_the_schema_and_the_resolver_agree_on_the_default_order():
              f"default is {expected} - two spellings of one order have split")
 
 
+def all_default_ids():
+    ids = []
+    for name in ("MAIN", "LEFT", "RIGHT"):
+        ids.extend(module_default(name))
+    assert len(ids) >= 10, f"the module's defaults shrank to {ids}"
+    return ids
+
+
+def test_the_islands_render_through_the_one_resolver():
+    # Each island's Repeater models the resolver's answer, never the stored
+    # list directly: the resolver is where the version-skew rules live (a
+    # missing known id renders at its default position; an unknown one is
+    # skipped without being destroyed), and a Repeater over the raw list
+    # would silently drop both rules.
+    raw = read(LOCK_SURFACE)
+    assert "lock_islands.js" in raw, \
+        "LockSurface no longer imports the islands module"
+    text = code(LOCK_SURFACE)
+    for name, default in (("mainOrder", "MAIN_DEFAULT"),
+                          ("leftOrder", "LEFT_DEFAULT"),
+                          ("rightOrder", "RIGHT_DEFAULT")):
+        assert re.search(
+            rf"property var {name}:\s*LockIslands\.orderedItems\(\s*\n?\s*"
+            rf"Config\.options\.lock\.islands\.\w+,\s*LockIslands\.{default}\)",
+            text), \
+            f"{name} is not the resolver over the stored list and its defaults"
+    models = re.findall(r"model:\s*root\.(main|left|right)Order", text)
+    assert sorted(models) == ["left", "main", "right"], \
+        f"expected the three islands to model the three orders, found {models}"
+
+
+def test_every_default_id_has_a_component_and_its_layout_metadata():
+    # A default id with no component entry renders as an empty slot - the
+    # Loader resolves null and draws nothing, silently, which is the exact
+    # disappearance the resolver exists to prevent arriving from the other
+    # side. Same for the layout metadata: a missing entry is not an error,
+    # it is a margin of 0 that reads as a design choice.
+    text = code(LOCK_SURFACE)
+    components = re.search(r"islandComponents:\s*\(\{(.*?)\}\)", text, re.S)
+    assert components, "LockSurface declares no islandComponents map"
+    meta = re.search(r"islandItemMeta:\s*\(\{(.*?)\n    \}\)", text, re.S)
+    assert meta, "LockSurface declares no islandItemMeta map"
+    for item in all_default_ids():
+        assert re.search(rf"\b{item}:", components.group(1)), \
+            f"islandComponents has no entry for {item}"
+        assert re.search(rf"\b{item}:", meta.group(1)), \
+            f"islandItemMeta has no entry for {item}"
+
+
+def test_the_password_field_is_reachable_and_pinned_by_the_module():
+    # The field lives inside a delegate component now, so forceFieldFocus
+    # reaches it through the property the component publishes - and the
+    # module, not the surface, is what says it cannot be reordered.
+    text = code(LOCK_SURFACE)
+    assert re.search(r"property Item passwordField", text), \
+        "the surface no longer publishes the password field"
+    assert re.search(r"root\.passwordField\?\.forceActiveFocus\(\)", text), \
+        "forceFieldFocus no longer reaches the field through the property"
+    module = code(MODULE)
+    assert re.search(r'island === "main" && id === "password"', module), \
+        "the module no longer pins the password field as unmovable"
+
+
 if __name__ == "__main__":
     raise SystemExit(run(globals()))

--- a/dots/.config/quickshell/imi/tests/test_lock_islands_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_lock_islands_contract.py
@@ -130,5 +130,72 @@ def test_the_password_field_is_reachable_and_pinned_by_the_module():
         "the module no longer pins the password field as unmovable"
 
 
+CONTROLLER = ROOT / "modules/imi/lock/LockIslandReorder.qml"
+EDIT_ITEM = ROOT / "modules/imi/lock/LockIslandEditItem.qml"
+CANVAS = ROOT / "modules/common/widgets/widgetCanvas/WidgetCanvas.qml"
+GLOBAL_STATES = ROOT / "GlobalStates.qml"
+
+
+def test_the_reorder_commits_through_the_shared_arithmetic_at_literal_paths():
+    # No fifth copy of the reorder (spec §10.2): the gesture is ReorderDragArea,
+    # the list arithmetic is layout_ops, the write-back merge is the module's
+    # storedOrder, and the three stored lists are literal paths - an allowlist
+    # reachable through a computed key is not an allowlist, which is the scope
+    # lint's own rule about these files.
+    text = code(CONTROLLER)
+    # `dropTarget` itself lives inside ReorderDragArea - the controller's half
+    # of that seam is the buckets provider the gesture calls.
+    for required in ("LayoutOps.move(", "LayoutOps.moveTargetForInsertion(",
+                     "LockIslands.storedOrder(", "function dropBuckets"):
+        assert required in text, f"the controller no longer uses {required}"
+    item = code(EDIT_ITEM)
+    assert "ReorderDragArea" in item and "bucketsProvider" in item, \
+        ("the edit item's gesture must be the shared ReorderDragArea over the "
+         "controller's buckets - anything else is the fifth copy")
+    for island in ("main", "left", "right"):
+        assert re.search(rf"Config\.options\.lock\.islands\.{island}\s*=", text), \
+            f"the controller does not write lock.islands.{island} at its literal path"
+    commit = re.search(r"function commitReorder\([^)]*\)\s*\{(.*?)\n    \}", text, re.S)
+    assert commit, "the controller no longer declares commitReorder"
+    assert re.search(r"if \(!GlobalStates\.editMode", commit.group(1)), \
+        ("the commit must be guarded on the mode - a drag can outlive it, and "
+         "an end the user meant as stop must not store an order")
+    assert "DragHandler" not in text, \
+        ("the controller grew a DragHandler - the gesture is ReorderDragArea, "
+         "and a second handler is the fifth copy §10.2 forbids")
+
+
+def test_the_overlay_arms_only_for_the_preview_and_movable_items():
+    text = code(LOCK_SURFACE)
+    overlay = re.search(r"sourceComponent:\s*LockIslandEditItem", text)
+    assert overlay, "LockSurface no longer loads the island edit overlay"
+    loader = re.search(
+        r"active:\s*!root\.interactive\s*&&\s*GlobalStates\.editMode\s*\n?\s*"
+        r"&&\s*LockIslands\.reorderable\(", text)
+    assert loader, \
+        ("the overlay must arm only in the preview, in the mode, and never on "
+         "the password field - the module's reorderable() is what says so")
+
+
+def test_the_ladder_sees_a_lock_island_drag():
+    # Escape mid-drag must cancel the gesture, not exit the mode - the same
+    # composition the bar drag earned in stage 8, through a flag of its own
+    # because the two gestures live on different surfaces and are cleared by
+    # different teardowns.
+    states = code(GLOBAL_STATES)
+    assert re.search(r"property bool editLockDragActive:\s*false", states), \
+        "GlobalStates no longer declares the lock drag flag"
+    handler = re.search(r"onEditModeChanged:\s*\{(.*?)\n    \}", states, re.S)
+    assert handler and "editLockDragActive = false" in handler.group(1), \
+        "leaving the mode must clear the lock drag flag"
+    canvas = code(CANVAS)
+    ladder = re.search(r"gestureInFlight:(.*?),\s*\n\s*selectionCount", canvas, re.S)
+    assert ladder and "editLockDragActive" in ladder.group(0), \
+        "the canvas ladder does not see a lock island drag"
+    item = code(EDIT_ITEM)
+    assert "onEditReorderCancel" in item, \
+        "the edit item does not answer the ladder's cancel"
+
+
 if __name__ == "__main__":
     raise SystemExit(run(globals()))

--- a/dots/.config/quickshell/imi/tests/test_lock_islands_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_lock_islands_contract.py
@@ -192,6 +192,17 @@ def test_the_ladder_sees_a_lock_island_drag():
     ladder = re.search(r"gestureInFlight:(.*?),\s*\n\s*selectionCount", canvas, re.S)
     assert ladder and "editLockDragActive" in ladder.group(0), \
         "the canvas ladder does not see a lock island drag"
+    # Seeing the drag is only half the wiring: the cancel branch must also
+    # EMIT the return path for it. With only the bar's flag in the emit gate,
+    # Escape mid-lock-drag resolves to cancelGesture, is consumed doing
+    # nothing, and the eventual release COMMITS the order the user tried to
+    # abandon - the commit's own guard checks the mode, which is still on.
+    cancel = re.search(r'else if \(action === "cancelGesture"\)\s*\{(.*?)\n\s*\}',
+                       canvas, re.S)
+    assert cancel, "the canvas no longer has a cancelGesture branch"
+    assert "editLockDragActive" in cancel.group(1), \
+        ("the cancel branch never reaches a lock island drag - Escape is "
+         "swallowed and the release commits")
     item = code(EDIT_ITEM)
     assert "onEditReorderCancel" in item, \
         "the edit item does not answer the ladder's cancel"

--- a/dots/.config/quickshell/imi/tests/tst_lock_islands.qml
+++ b/dots/.config/quickshell/imi/tests/tst_lock_islands.qml
@@ -1,0 +1,94 @@
+import QtTest
+import "../modules/common/functions/lock_islands.js" as LockIslands
+
+// The lock islands' order, resolved and written back - the only part of the
+// island rewrite qmltestrunner can reach. The version-skew rules are the whole
+// point: a list written by one shell version and read by another is where a
+// silent removal happens, so both directions (a known id the store lacks, an
+// unknown id the store carries) are pinned here.
+TestCase {
+    name: "LockIslandsTest"
+
+    function test_the_defaults_are_the_hand_placed_order() {
+        compare(LockIslands.MAIN_DEFAULT, ["fingerprint", "password", "confirm"]);
+        compare(LockIslands.LEFT_DEFAULT, ["username", "media", "keyboardLayout", "fcitx"]);
+        compare(LockIslands.RIGHT_DEFAULT, ["battery", "sleep", "power", "reboot"]);
+    }
+
+    function test_a_stored_order_wins_for_the_ids_it_names() {
+        compare(LockIslands.orderedItems(["media", "username", "keyboardLayout", "fcitx"],
+                                         LockIslands.LEFT_DEFAULT),
+                ["media", "username", "keyboardLayout", "fcitx"]);
+    }
+
+    function test_no_stored_list_renders_the_defaults() {
+        compare(LockIslands.orderedItems(undefined, LockIslands.LEFT_DEFAULT),
+                LockIslands.LEFT_DEFAULT);
+        compare(LockIslands.orderedItems([], LockIslands.RIGHT_DEFAULT),
+                LockIslands.RIGHT_DEFAULT);
+    }
+
+    function test_a_known_id_missing_from_the_store_renders_at_its_default_position() {
+        // A list written by an older version: fcitx did not exist when it was
+        // stored. It renders anyway, after keyboardLayout - its default
+        // neighbour - rather than disappearing.
+        compare(LockIslands.orderedItems(["media", "username", "keyboardLayout"],
+                                         LockIslands.LEFT_DEFAULT),
+                ["media", "username", "keyboardLayout", "fcitx"]);
+        // ...and one missing from the MIDDLE lands between its default
+        // neighbours, not at either end.
+        compare(LockIslands.orderedItems(["reboot", "battery", "sleep"],
+                                         LockIslands.RIGHT_DEFAULT),
+                ["reboot", "battery", "sleep", "power"]);
+    }
+
+    function test_a_missing_leading_id_lands_at_the_front() {
+        compare(LockIslands.orderedItems(["media", "keyboardLayout", "fcitx"],
+                                         LockIslands.LEFT_DEFAULT),
+                ["username", "media", "keyboardLayout", "fcitx"]);
+    }
+
+    function test_an_unknown_stored_id_is_skipped_without_eating_its_neighbours() {
+        // A list written by a NEWER version: nothing to draw for the unknown
+        // id, and the neighbours keep their stored order around the gap.
+        compare(LockIslands.orderedItems(["media", "someFutureItem", "username",
+                                          "keyboardLayout", "fcitx"],
+                                         LockIslands.LEFT_DEFAULT),
+                ["media", "username", "keyboardLayout", "fcitx"]);
+    }
+
+    function test_a_duplicated_stored_id_renders_once() {
+        compare(LockIslands.orderedItems(["media", "media", "username",
+                                          "keyboardLayout", "fcitx"],
+                                         LockIslands.LEFT_DEFAULT),
+                ["media", "username", "keyboardLayout", "fcitx"]);
+    }
+
+    function test_the_password_field_is_the_one_item_that_cannot_move() {
+        verify(!LockIslands.reorderable("main", "password"));
+        verify(LockIslands.reorderable("main", "fingerprint"));
+        verify(LockIslands.reorderable("main", "confirm"));
+        verify(LockIslands.reorderable("left", "media"));
+        verify(LockIslands.reorderable("right", "power"));
+    }
+
+    function test_a_write_back_keeps_an_unknown_id_instead_of_deleting_it() {
+        // The committed order is the moved rendered list plus every unknown
+        // stored id appended: its position is lost, its PRESENCE is not - a
+        // newer version reading the list back still renders its item, where
+        // dropping it here would be the silent removal the module exists to
+        // prevent.
+        const stored = ["username", "someFutureItem", "media", "keyboardLayout", "fcitx"];
+        const moved = ["media", "username", "keyboardLayout", "fcitx"];
+        compare(LockIslands.storedOrder(moved, stored, LockIslands.LEFT_DEFAULT),
+                ["media", "username", "keyboardLayout", "fcitx", "someFutureItem"]);
+    }
+
+    function test_a_write_back_with_no_unknowns_is_the_moved_order_itself() {
+        const moved = ["sleep", "battery", "power", "reboot"];
+        compare(LockIslands.storedOrder(moved,
+                                        ["battery", "sleep", "power", "reboot"],
+                                        LockIslands.RIGHT_DEFAULT),
+                moved);
+    }
+}


### PR DESCRIPTION
Stage 9b of Edit Mode: island **contents** reorder — the maintainer's answer
to spec §14 (2026-08-17: reorderable, not visibility-only), landed as its own
separately reviewable unit per §14's own closing rule, so the security
refactor in the PR below never carries a feature.

**Stacked on #250** (`feat/edit-mode-stage9-lockscreen`), which stacks on
#249 → #248 → #247 → #246. Those must merge first, in order; this PR's base
is the stage-9 branch so its diff shows only the reorder work.

## The store and the resolver

Three ordered lists join `Config.options.lock.islands` as declared
`list<string>` properties (a `JsonAdapter` cannot hold a dynamic map), whose
defaults are the hand-placed order `LockSurface` has always drawn — so
nothing moves for existing users and no migration is needed: the keys have
never been written, a missing key takes the QML default, and the first write
declares exactly these properties.

`lock_islands.js` is the only reading of them, and it owns both directions of
the version-skew rule — a list written by one shell version and read by
another is exactly where a silent removal happens (§14's own warning):

- `orderedItems`: a known id **missing** from a stored list (written by an
  older shell) renders at its default position rather than disappearing; an
  **unknown** stored id (written by a newer shell) is skipped for rendering
  but never destroyed by the read; duplicates render once.
- `storedOrder`: what a commit writes back — the moved rendered order plus
  every unknown id appended, so an unknown id's position can be lost but its
  presence cannot.
- `reorderable`: the password field is the one item that cannot move (§14:
  the main island's rewrite is a different job because of it); its
  neighbours reorder around it.

The schema's defaults and the module's are two spellings of one order, pinned
equal by the new contract. `tst_lock_islands.qml` covers the resolver's rules
including the middle-insertion and duplicate cases.

## The rewrite

Each island is a Repeater over the resolver's answer, through one
`IslandSlot` Loader delegate: Layout facts in one metadata map (a Layout
honours attached properties only on its direct children, and the slot is the
direct child now), components in one map — both pinned to the module's whole
vocabulary, because a missing entry is an empty slot or a zero margin, not an
error — and the per-item visibility conditions unchanged in meaning:
**visibility stays per item, order is the list**, so the lists and the
`lock.show*` booleans divide the work rather than fighting. The password
field publishes itself as `passwordField`; every one of PR A's interactive
guards survives the move verbatim, and the preview contract's handler- and
action-anchored sweeps still bind over the moved text (10/10).

## The gesture

Stage 8's machinery, no fifth copy: `LockIslandEditItem` is
`BarWidgetEditItem`'s shape without the remove badge (island items are hidden
through the presence booleans, not removed one by one) — the input eater plus
the shared `ReorderDragArea`; `LockIslandReorder` is the per-island
coordinator — `dropTarget` buckets built fresh per pointer event from
rendered-index centres with holes for invisible and dragged slots, commits
through `layout_ops.move` + `moveTargetForInsertion` + `storedOrder` at three
literal paths, guarded on the mode, with the central end-drag on mode exit
the bar controller established. One bucket per island deliberately: a
cross-island move would write an id the receiving island's resolver
(correctly) skips as unknown, and the item would vanish from both islands.

Escape mid-drag cancels rather than exits: `GlobalStates.editLockDragActive`
joins the bar's flag in the canvas ladder's `gestureInFlight` — a flag of its
own because the two gestures live on different surfaces and are cleared by
different teardowns.

The scope lint now sweeps `modules/imi/lock` and admits exactly the three
list paths (spelled out, not a prefix, so a future `lock.islands.*` key does
not inherit the licence unreviewed) — its own commit, and the lock files
carried no Config writes when it landed, so every write here arrived against
a lint already watching.

## Evidence

- TDD throughout: the tst failed on the missing module, the schema check on
  the missing schema, the three rewrite checks against the hand-placed
  surface, and the three reorder checks against the missing components.
- `LockIslandReorderRuntimeTest.qml` (headless weston, 12 checks, literal
  `EXPECTED_CHECKS`): real mouse drags on the real `LockSurface` with the
  real preview context — the overlay arms and the field's does not, a drag
  lands with move semantics and the island redraws from the store, the
  password slot takes no drag while its neighbours reorder around it, an
  unknown stored id survives a commit, and both cancel paths (the ladder's
  signal, the mode's exit) leave the lists untouched. The driver gives
  weston and qs their **own** `XDG_RUNTIME_DIR`, so nothing this test starts
  can ever reach the live compositor.
- Proven able to fail on planted mutations in a committed-clean tree:
  dropping the `storedOrder` merge reddened the contract **and** the
  harness's unknown-id check; removing the commit's mode guard and the
  overlay's `reorderable()` term each reddened the contract.
- Full `./tests/run_tests.sh` at the tip: green end to end.
- `DesignSystemCompile` under an isolated headless weston: checked=182
  failures=0.

## Not verifiable here

- The real session lock rendering the reordered islands (and the real
  fingerprint slot, which the preview cannot show): needs a live lock, and a
  lock-screen probe on the live display locks the real session — on this
  machine a real lock suspends the laptop — so it is recorded here rather
  than attempted. The data path is identical for the real surface (the same
  Repeaters draw it), and the weston harness drives that path with real
  events.
- The reorder gesture under the Lockscreen tab's edit transform on a real
  compositor (the harness drives the surface untransformed; the gesture maps
  through `mapToItem`, which composes whatever transform is present — the
  same argument the stage-6 menu anchor rests on).

## Review

A reviewer pass over the whole branch found one Critical, fixed on the
branch: the canvas ladder saw a lock drag (`gestureInFlight`) but its
cancelGesture branch emitted `editReorderCancel` only for the bar's flag —
Escape mid-lock-drag was consumed doing nothing and the release committed
the order the user tried to abandon. Both test layers had looked elsewhere
(the contract pinned the flag and the listener, not the emit gate between
them; the harness emits the signal directly, having no WidgetCanvas). Fixed
with the missing disjunct, a contract pin watched failing on the unfixed
tree, and a harness comment naming its own limitation. The review's minors
are fixed too: a rebuilt password field pulls the context's held text at
completion, and the controller's comment records the deliberate
append-before-hidden-tail divergence from the bar and the stuck-flag
recovery both reorder flags share. The reviewer verified the Layout-fact
port line by line against the base and traced the resolver and hole-indexing
arithmetic by hand.

Docs: updated AGENT.md §Edit Mode (the stage-9b entry: the lists, the
resolver's version-skew rules, the one-bucket reasoning, and the rule that
lock probes never touch the live display).
