### PR TITLE
Edit Mode stage 10: edge snap with hysteresis, and undo

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -2931,10 +2931,20 @@ mode is built out of are worth not re-deriving:
   repair a mistake. The dock-pin entry is the same flip again through
   `TaskbarApps.togglePin`, because restoring the list would need the chrome
   surface to read `Config.options.dock` — the second derivation the
-  one-answer contract forbids, and it caught exactly that draft.
+  one-answer contract forbids, and it caught exactly that draft. Two edges
+  the first cut got wrong, both review-caught: a GESTURE that commits several
+  mutations is one entry, so a group release opens a batch the canvas closes
+  with `Qt.callLater` (the leader's commit runs later in the same signal
+  chain and has to fall inside — without it the leader's entry lands last
+  and the first Ctrl+Z moves the leader alone, deforming the cluster); and
+  `PluginState.setOption` treats null as REMOVE, because undoing a
+  first-ever span commit otherwise persisted a literal null that `option()`
+  — which falls back only on `undefined` — would answer past every later
+  caller's fallback.
   (feat(editMode): the undo stack's arithmetic - bounded, LIFO, copy-on-write;
   feat(editMode): Ctrl+Z reverses the last committed mutation, on the surface the keyboard reaches;
-  test(editMode): drive undo's record, reverse and gate, and pin its shape.)
+  test(editMode): drive undo's record, reverse and gate, and pin its shape;
+  fix(editMode): a group release is one undo entry, and undoing a first commit leaves no null behind.)
 (feat(editMode): shrink the desktop into a viewport on the background surface,
 feat(editMode): stand the per-widget frost down for the mode,
 feat(editMode): draw the shrunk desktop as a card, not as a cropped screenshot,

--- a/AGENT.md
+++ b/AGENT.md
@@ -2869,6 +2869,72 @@ mode is built out of are worth not re-deriving:
   refactor(lock): the three islands become data-driven;
   test(lint): the scope lint reaches the lock surface and admits its lists;
   feat(lock): island contents reorder in the mode.)
+- **A dragged widget holds a neighbour's edge through a Schmitt trigger, and
+  both thresholds read the SHADOW — stage 10, spec §6.**
+  `modules/common/functions/edge_snap.js` owns the arithmetic: four relations
+  per neighbour per axis, each carrying the `target` the widget travels to AND
+  the `guide` the line is drawn at (they differ for half the relations,
+  because the line belongs to the OTHER widget's edge); a perpendicular
+  relevance filter measured as the GAP between extents, boundary excluded; and
+  acquire-at-18/release-at-32 compared against `dragProxy`, never the rendered
+  position — with one threshold the decision boundary and the resulting
+  position are the same number and the widget flip-flops per event.
+  `AbstractWidget` captures neighbour rects at the press (after
+  `widgetDragStarted`, so a group drag's followers are already flagged and
+  excluded), regenerates candidates per event in the drag proxy's handlers
+  (the resolve is stateful, so it lives beside `updateCenterHighlight`, not
+  in the drag Binding), and a held target REPLACES the lattice snap rather
+  than stacking on it — rounding an exact alignment misses the edge by up to
+  half a cell. Snap-then-clamp survives; the group leader snaps and followers
+  ride by delta with no new code. The feature rides
+  `background.showSnapLines` (the switch that already gates the alignment
+  visuals, and the one the dead designsystem duplicate rode for the same
+  feature): the guide and the detent travel together, because either alone is
+  a mystery. Guides draw ABOVE the widgets in the centre-line family's
+  animation tier, travelling while visible and placing instantly while not.
+  Two traps paid for: the hold must be cleared one turn AFTER the drag ends
+  (`Qt.callLater`) — `onDraggingChanged` and the drag Binding's `when` both
+  observe `dragging` with nothing ordering them, and nulling the hold under a
+  still-live Binding rounds an off-lattice landing onto the lattice (measured:
+  released holding 465, committed 468) — and the runtime harness's landings
+  sit on edges the lattice cannot produce (an anchor at x 305), or a wiring
+  that silently fell back to `snapX` passes by coincidence.
+  (feat(widgetCanvas): edge_snap.js, widget edge alignment as arithmetic;
+  feat(widgetCanvas): a dragged widget holds a neighbour's edge, under a travelling guide;
+  fix(widgetCanvas): clear the edge-snap hold after the drag Binding stands down;
+  test(widgetCanvas): the walk pins the detent in raw numbers, not the module's own;
+  test(widgets): drive the edge snap's acquire, detent and release with real drags.)
+- **Ctrl+Z reverses the last COMMITTED mutation, and it lives on the canvas
+  because that is where the keyboard measurably works — stage 10, spec §7.3,
+  gated on §11.4 probe 4 and now measured.** The probe ran in a nested
+  Hyprland on the blur probe's shape, hardened: the nested instance gets its
+  OWN `XDG_RUNTIME_DIR` and reaches its wayland parent through an
+  ABSOLUTE-path `WAYLAND_DISPLAY` (libwayland only prefixes the runtime dir
+  onto a relative name), so its sockets cannot land beside the session's; a
+  fully headless nested Hyprland is not possible — Aquamarine's
+  `CBackend::create()` aborts with no wayland parent and no seat. Keys were
+  injected with wtype (a virtual-keyboard CLIENT of the nested display —
+  ydotool writes uinput into the kernel and reaches the user's real seat, so
+  it is never the tool for this). Measured on 0.56.2: a `Bottom`-layer
+  surface with `keyboardFocus: OnDemand` receives real compositor keys while
+  holding that focus, an Overlay/Exclusive control proved the injection path,
+  and a mapped toplevel beside it did not take the keyboard away
+  (`activewindow: Invalid` throughout). The undo stack sits in `GlobalStates`
+  with its arithmetic in `edit_mode.js` (bounded at 50 dropping the OLDEST,
+  LIFO, copy-on-write because a `property var` signals on reassignment only);
+  recording is gated on the mode, one entry per committed mutation (a release
+  that moved nothing pushes nothing — every click on a draggable widget
+  releases through `commitPosition`), and every entry is a closure over the
+  store write that captures plain data and SINGLETONS only — the mode
+  destroys its overlays, menus and widgets while the stack outlives them, so
+  a closure over a controller throws on the exact keystroke that exists to
+  repair a mistake. The dock-pin entry is the same flip again through
+  `TaskbarApps.togglePin`, because restoring the list would need the chrome
+  surface to read `Config.options.dock` — the second derivation the
+  one-answer contract forbids, and it caught exactly that draft.
+  (feat(editMode): the undo stack's arithmetic - bounded, LIFO, copy-on-write;
+  feat(editMode): Ctrl+Z reverses the last committed mutation, on the surface the keyboard reaches;
+  test(editMode): drive undo's record, reverse and gate, and pin its shape.)
 (feat(editMode): shrink the desktop into a viewport on the background surface,
 feat(editMode): stand the per-widget frost down for the mode,
 feat(editMode): draw the shrunk desktop as a card, not as a cropped screenshot,

--- a/dots/.config/quickshell/imi/EditModeRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/EditModeRuntimeTest.qml
@@ -699,6 +699,58 @@ ShellRoot {
             harness.check("undo puts the stored span back",
                           harness.storedSize("edit-resize-probe") === "3x2"
                           && GlobalStates.editUndoStack.length === 0);
+        },
+        () => {
+            // A FIRST-EVER span commit undone leaves the store the way it
+            // found it: no stored key, so the read answers the caller's
+            // fallback again. A persisted null here would answer null past
+            // every later fallback instead.
+            PluginState.setOption("edit-move-probe", "__gridSize", null);
+            GlobalStates.editUndoStack = [];
+        },
+        () => {
+            movableWidget.commitGridSize({ cols: 2, rows: 1 });
+            harness.check("a first-ever span commit stores and records",
+                          harness.storedSize("edit-move-probe") === "2x1"
+                          && GlobalStates.editUndoStack.length === 1);
+        },
+        () => {
+            GlobalStates.editUndo();
+            harness.check("undoing it removes the key instead of storing null",
+                          harness.storedSize("edit-move-probe") === ""
+                          && PluginState.option("edit-move-probe", "__gridSize", "fallback") === "fallback");
+        },
+        () => {
+            // One gesture, one entry: a group release folds every member's
+            // commit into a single composite, and one Ctrl+Z restores the
+            // whole cluster - not the leader alone, which is what one entry
+            // per member would do with the leader's push landing last.
+            harness.placeWidgets();
+        },
+        () => {
+            driver.mousePress(canvas, 8, 8, Qt.LeftButton);
+            driver.mouseMove(canvas, 600, 600, 20, Qt.LeftButton);
+            driver.mouseRelease(canvas, 600, 600, Qt.LeftButton);
+        },
+        () => {
+            GlobalStates.editUndoStack = [];
+            harness.dragBy(movableWidget, 60, 0);
+        },
+        () => {
+            // Its own step: the batch folds on Qt.callLater, a turn after
+            // the release chain, so a depth read in the drag's own step
+            // still sees the batch open and the stack empty.
+            harness.check("a group release records ONE entry for the gesture",
+                          GlobalStates.editUndoStack.length === 1
+                          && Math.round(harness.storedPosition("edit-move-probe").x) === 96
+                          && Math.round(harness.storedPosition("edit-resize-probe").x) === 96);
+        },
+        () => {
+            GlobalStates.editUndo();
+            harness.check("...and one undo restores the whole cluster",
+                          Math.round(harness.storedPosition("edit-move-probe").x) === 36
+                          && Math.round(harness.storedPosition("edit-resize-probe").x) === 36);
+            canvas.clearSelection();
             GlobalStates.editMode = false;
         }
     ]

--- a/dots/.config/quickshell/imi/EditModeRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/EditModeRuntimeTest.qml
@@ -631,6 +631,75 @@ ShellRoot {
             harness.check("leaving the mode resets the tab with the drawer and the menu",
                           GlobalStates.editTab === EditMode.DESKTOP_TAB
                           && GlobalStates.editLockPreview === false);
+        },
+
+        // ---- undo (spec §7.3): the last committed mutation, reversed ------
+        //
+        // Ctrl+Z's key delivery is a compositor question no weston harness
+        // can see (probe 4 answered it against a nested Hyprland); what this
+        // drives is everything behind the key: the commit paths recording
+        // entries, the entries reversing the store AND the drawn widget, and
+        // the gate that keeps the mode's history the mode's.
+        () => {
+            GlobalStates.editMode = true;
+            harness.placeWidgets();
+        },
+        () => {
+            // The earlier steps' own commits recorded entries; this section
+            // starts from an empty stack so its counts mean something.
+            GlobalStates.editUndoStack = [];
+            GlobalStates.editUndo();
+            harness.check("an empty stack undoes nothing and breaks nothing",
+                          GlobalStates.editUndoStack.length === 0
+                          && GlobalStates.editMode === true);
+        },
+        () => {
+            harness.dragBy(movableWidget, 96, 0);
+            harness.check("a drag committed in the mode records one entry",
+                          GlobalStates.editUndoStack.length === 1
+                          && Math.round(harness.storedPosition("edit-move-probe").x) === 132);
+        },
+        () => {
+            GlobalStates.editUndo();
+            harness.check("undo returns the store to the position the drag found",
+                          Math.round(harness.storedPosition("edit-move-probe").x) === 36
+                          && GlobalStates.editUndoStack.length === 0);
+        },
+        () => {
+            harness.check("...and the widget is drawn there again",
+                          Math.round(movableWidget.x) === 36);
+        },
+        () => {
+            // The gate. A commit with the mode off records nothing: the same
+            // gesture commits all day outside the editor, and Ctrl+Z inside
+            // it must not reach back past the mode's own affordance.
+            GlobalStates.editMode = false;
+        },
+        () => {
+            harness.dragBy(movableWidget, 96, 0);
+            harness.check("the same drag outside the mode records nothing",
+                          GlobalStates.editUndoStack.length === 0
+                          && Math.round(harness.storedPosition("edit-move-probe").x) === 132);
+        },
+        () => {
+            // A span commit, through the one path the grip and the menu's
+            // stepper both call, undone back to the stored choice it found.
+            GlobalStates.editMode = true;
+            PluginState.setOption("edit-resize-probe", "__gridSize", "3x2");
+            GlobalStates.editUndoStack = [];
+        },
+        () => {
+            resizableWidget.commitGridSize({ cols: 2, rows: 1 });
+            harness.check("a span commit records the old choice",
+                          GlobalStates.editUndoStack.length === 1
+                          && harness.storedSize("edit-resize-probe") === "2x1");
+        },
+        () => {
+            GlobalStates.editUndo();
+            harness.check("undo puts the stored span back",
+                          harness.storedSize("edit-resize-probe") === "3x2"
+                          && GlobalStates.editUndoStack.length === 0);
+            GlobalStates.editMode = false;
         }
     ]
 

--- a/dots/.config/quickshell/imi/GlobalStates.qml
+++ b/dots/.config/quickshell/imi/GlobalStates.qml
@@ -192,8 +192,37 @@ Singleton {
     // exit would make Done destroy the very history "I did not mean that"
     // asks for.
     property var editUndoStack: []
+    // One GESTURE can commit several mutations - a group drag's release runs
+    // commitPosition once per member, followers first, leader last - and "the
+    // last thing I did" is the whole gesture: with one entry per member the
+    // leader's sits on top and the first Ctrl+Z would move the leader alone,
+    // deforming the cluster the user moved as a unit. While a batch is open,
+    // pushes collect; closing it folds them into ONE composite entry that
+    // replays every collected closure. The canvas opens it at a group
+    // release and closes it with Qt.callLater, because the leader's own
+    // commit runs later in the same signal chain and has to fall inside.
+    property var editUndoBatch: null
+    function editUndoBeginBatch() {
+        if (root.editUndoBatch === null) root.editUndoBatch = [];
+    }
+    function editUndoEndBatch() {
+        const entries = root.editUndoBatch;
+        root.editUndoBatch = null;
+        if (entries === null || entries.length === 0) return;
+        if (entries.length === 1) {
+            root.editUndoStack = EditMode.undoPush(root.editUndoStack, entries[0]);
+            return;
+        }
+        root.editUndoStack = EditMode.undoPush(root.editUndoStack, () => {
+            for (const entry of entries) entry();
+        });
+    }
     function editUndoPush(entry) {
         if (!root.editMode) return;
+        if (root.editUndoBatch !== null) {
+            root.editUndoBatch.push(entry);
+            return;
+        }
         root.editUndoStack = EditMode.undoPush(root.editUndoStack, entry);
     }
     function editUndo() {

--- a/dots/.config/quickshell/imi/GlobalStates.qml
+++ b/dots/.config/quickshell/imi/GlobalStates.qml
@@ -173,6 +173,35 @@ Singleton {
     property bool editLockDragActive: false
     signal editReorderCancel()
 
+    // The undo stack (spec §7.3): in memory, session-scoped, bounded, one
+    // entry per COMMITTED mutation - a drag's release, a span commit, a
+    // reorder drop, an add, a remove - and ONE stack across all surfaces,
+    // because the user's notion of "the last thing I did" does not partition
+    // by surface. Each entry is a closure over the store write that reverses
+    // the mutation, captured at the call site that committed it; the
+    // arithmetic (LIFO, the ~50 bound, copy-on-write) is edit_mode.js's so a
+    // test can reach it. §7.4's restart argument holds with no code: the
+    // stack only ever offered to reverse committed changes, and it is gone
+    // with the process while the changes are on disk.
+    //
+    // Recording is gated on the mode: the same gestures commit all day with
+    // the mode off, and a Ctrl+Z inside the mode reversing a drag made hours
+    // before it would be undo reaching further back than the editor whose
+    // affordance it is. The stack survives leaving and re-entering the mode
+    // within a session - session-scoped is the spec's word, and clearing on
+    // exit would make Done destroy the very history "I did not mean that"
+    // asks for.
+    property var editUndoStack: []
+    function editUndoPush(entry) {
+        if (!root.editMode) return;
+        root.editUndoStack = EditMode.undoPush(root.editUndoStack, entry);
+    }
+    function editUndo() {
+        const popped = EditMode.undoPop(root.editUndoStack);
+        root.editUndoStack = popped.stack;
+        if (popped.entry !== null) popped.entry();
+    }
+
     property bool dropShelfOpen: false
     property real dropShelfX: 0
     property real dropShelfY: 0

--- a/dots/.config/quickshell/imi/WidgetEdgeSnapRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/WidgetEdgeSnapRuntimeTest.qml
@@ -1,0 +1,378 @@
+import QtQuick
+import QtTest
+import Quickshell
+import qs
+import qs.modules.common
+import qs.modules.common.plugins
+import qs.modules.common.widgets.widgetCanvas
+
+/**
+ * Drives the widget-to-widget edge snap (spec §6) with real mouse events, in
+ * the live drag path - the half `tst_edge_snap.qml` cannot reach. The module's
+ * arithmetic is proven there; what only real events can prove is the WIRING:
+ * that the hold actually overrides the lattice in the drag Binding, that the
+ * hysteresis is fed the shadow position rather than the rendered one, that
+ * the canvas draws the guide where the hold says, that the perpendicular
+ * filter refuses a distant neighbour on a real drag, and that a group drag's
+ * leader snapping an edge moves the cluster whole.
+ *
+ * The anchor's x (305) is deliberately OFF the 12px lattice: every landing
+ * this file asserts on a neighbour's edge is a position the lattice snap
+ * cannot produce, so a broken wiring cannot pass by coincidence.
+ *
+ * Run it against a throwaway config:
+ *   XDG_CONFIG_HOME=$(mktemp -d) XDG_STATE_HOME=$(mktemp -d) qs -p WidgetEdgeSnapRuntimeTest.qml
+ */
+ShellRoot {
+    id: harness
+
+    property int failures: 0
+    property int checksRun: 0
+    readonly property string testScreen: "EDGE-SNAP-TEST"
+
+    function check(label, ok) {
+        harness.checksRun++;
+        console.log(`[WidgetEdgeSnap] ${label}: ${ok ? "ok" : "FAIL"}`);
+        if (!ok)
+            harness.failures++;
+    }
+
+    function finish() {
+        console.log(`[WidgetEdgeSnap] checks: ${harness.checksRun} failures: ${harness.failures}`);
+        Qt.exit(harness.failures === 0 ? 0 : 1);
+    }
+
+    function manifestFor(id) {
+        return {
+            id: id,
+            name: id,
+            defaultWidth: 160,
+            defaultHeight: 100,
+            desktopWidget: { type: "Item" }
+        };
+    }
+
+    readonly property var crosserManifest: harness.manifestFor("runtime_edge_crosser")
+    readonly property var moverManifest: harness.manifestFor("runtime_edge_mover")
+    readonly property var anchorManifest: harness.manifestFor("runtime_edge_anchor")
+    readonly property var buddyManifest: harness.manifestFor("runtime_edge_buddy")
+    readonly property var distantManifest: harness.manifestFor("runtime_edge_distant")
+
+    function at(widget, x, y) {
+        return Math.round(widget.x) === x && Math.round(widget.y) === y;
+    }
+
+    // A held press whose pointer is steered by SHADOW position: the drag's
+    // proxy is dragStart + pointer delta, so aiming the shadow is one
+    // subtraction. Each drag opens with a move past the 10px threshold.
+    property real pressX: 0
+    property real pressY: 0
+    property real startX: 0
+    property real startY: 0
+
+    function beginDrag(widget) {
+        harness.startX = widget.x;
+        harness.startY = widget.y;
+        harness.pressX = widget.x + widget.width / 2;
+        harness.pressY = widget.y + widget.height / 2;
+        driver.mousePress(canvas, harness.pressX, harness.pressY, Qt.LeftButton);
+        driver.mouseMove(canvas, harness.pressX + 12, harness.pressY, 20, Qt.LeftButton);
+    }
+
+    function moveShadowTo(sx, sy) {
+        driver.mouseMove(canvas,
+            harness.pressX + (sx - harness.startX),
+            harness.pressY + (sy - harness.startY), 20, Qt.LeftButton);
+    }
+
+    function releaseAtShadow(sx, sy) {
+        driver.mouseRelease(canvas,
+            harness.pressX + (sx - harness.startX),
+            harness.pressY + (sy - harness.startY), Qt.LeftButton);
+    }
+
+    FloatingWindow {
+        visible: true
+        implicitWidth: 1160
+        implicitHeight: 700
+        color: "black"
+
+        TestCase {
+            id: driver
+            when: false
+            name: "WidgetEdgeSnapDriver"
+        }
+
+        WidgetCanvas {
+            id: canvas
+            anchors.fill: parent
+            selectionEnabled: true
+
+            PluginWidget {
+                id: crosserWidget
+                manifest: harness.crosserManifest
+                screenName: harness.testScreen
+                screenWidth: 1160
+                screenHeight: 700
+                scaledScreenWidth: 1160
+                scaledScreenHeight: 700
+                wallpaperScale: 1
+            }
+
+            PluginWidget {
+                id: moverWidget
+                manifest: harness.moverManifest
+                screenName: harness.testScreen
+                screenWidth: 1160
+                screenHeight: 700
+                scaledScreenWidth: 1160
+                scaledScreenHeight: 700
+                wallpaperScale: 1
+            }
+
+            PluginWidget {
+                id: anchorWidget
+                manifest: harness.anchorManifest
+                screenName: harness.testScreen
+                screenWidth: 1160
+                screenHeight: 700
+                scaledScreenWidth: 1160
+                scaledScreenHeight: 700
+                wallpaperScale: 1
+            }
+
+            PluginWidget {
+                id: buddyWidget
+                manifest: harness.buddyManifest
+                screenName: harness.testScreen
+                screenWidth: 1160
+                screenHeight: 700
+                scaledScreenWidth: 1160
+                scaledScreenHeight: 700
+                wallpaperScale: 1
+            }
+
+            PluginWidget {
+                id: distantWidget
+                manifest: harness.distantManifest
+                screenName: harness.testScreen
+                screenWidth: 1160
+                screenHeight: 700
+                scaledScreenWidth: 1160
+                scaledScreenHeight: 700
+                wallpaperScale: 1
+            }
+        }
+    }
+
+    // crosser and mover are the dragged widgets; anchor (off-lattice at 305)
+    // is the edge they align to; buddy is the group drag's follower; distant
+    // sits 622px across the axis from crosser's column, past the 600px
+    // relevance limit, with its top edge placed so a vertical drag releases
+    // within its acquire band - the refusal is only provable where the snap
+    // would otherwise have fired.
+    function placeWidgets() {
+        PluginState.setPosition("runtime_edge_crosser", harness.testScreen,
+                                { x: 48, y: 48, placementStrategy: "free" });
+        PluginState.setPosition("runtime_edge_mover", harness.testScreen,
+                                { x: 500, y: 48, placementStrategy: "free" });
+        PluginState.setPosition("runtime_edge_anchor", harness.testScreen,
+                                { x: 305, y: 48, placementStrategy: "free" });
+        PluginState.setPosition("runtime_edge_buddy", harness.testScreen,
+                                { x: 700, y: 600, placementStrategy: "free" });
+        PluginState.setPosition("runtime_edge_distant", harness.testScreen,
+                                { x: 830, y: 380, placementStrategy: "free" });
+    }
+
+    // Same settle loop as the sibling harnesses: PluginState's FileView load
+    // lands asynchronously and replays the file over anything written early.
+    Timer {
+        id: setup
+        interval: 250
+        repeat: true
+        running: true
+        onTriggered: {
+            if (!PluginState.ready || !Config.ready)
+                return;
+            Config.options.background.widgetsLocked = false;
+            Config.options.background.showSnapLines = true;
+            if (harness.at(crosserWidget, 48, 48)
+                    && harness.at(moverWidget, 500, 48)
+                    && harness.at(anchorWidget, 305, 48)
+                    && harness.at(buddyWidget, 700, 600)
+                    && harness.at(distantWidget, 830, 380)) {
+                setup.running = false;
+                stepPerp.running = true;
+                return;
+            }
+            harness.placeWidgets();
+        }
+    }
+
+    // ---- the perpendicular relevance filter, on a real drag ---------------
+    // crosser's column (x 48..208) is 622px short of distant (x 830..990), so
+    // distant's far-to-near target at 280 (its top edge 380 minus crosser's
+    // height) must NOT fire even though the drag releases 5px from it. The
+    // lattice takes the release instead: 285 rounds to 288, and 280 is what a
+    // missing filter would have produced.
+    Timer {
+        id: stepPerp
+        interval: 400
+        onTriggered: {
+            harness.check("the helpers ride showSnapLines and it is on",
+                          Config.options.background.showSnapLines === true);
+            harness.beginDrag(crosserWidget);
+            harness.moveShadowTo(48, 285);
+            harness.releaseAtShadow(48, 285);
+            stepPerpVerify.running = true;
+        }
+    }
+
+    Timer {
+        id: stepPerpVerify
+        interval: 400
+        onTriggered: {
+            harness.check("a neighbour across the axis offers no edge",
+                          harness.at(crosserWidget, 48, 288));
+            harness.check("no guide survives the refused drag",
+                          canvas.edgeGuideXActive === false
+                              && canvas.edgeGuideYActive === false);
+            stepAcquire.running = true;
+        }
+    }
+
+    // ---- acquire, the detent, and the release, mid-drag -------------------
+    // mover walks left toward anchor's right edge (465). The shadow stops
+    // 10px short: inside the acquire band, and on a target the lattice cannot
+    // produce (465 is not a multiple of 12).
+    Timer {
+        id: stepAcquire
+        interval: 400
+        onTriggered: {
+            harness.beginDrag(moverWidget);
+            harness.moveShadowTo(475, 48);
+            stepAcquireVerify.running = true;
+        }
+    }
+
+    Timer {
+        id: stepAcquireVerify
+        interval: 300
+        onTriggered: {
+            harness.check("inside the acquire band the widget sits on the neighbour's edge, off the lattice",
+                          Math.round(moverWidget.x) === 465);
+            harness.check("and the vertical guide is up at that edge",
+                          canvas.edgeGuideXActive === true
+                              && Math.round(canvas.edgeGuideXPos) === 465);
+            // 24px past the target: between the two thresholds. A single
+            // threshold - or a resolver fed the rendered position - has
+            // already let go here.
+            harness.moveShadowTo(441, 48);
+            stepDetentVerify.running = true;
+        }
+    }
+
+    Timer {
+        id: stepDetentVerify
+        interval: 300
+        onTriggered: {
+            harness.check("between the thresholds the hold survives - the detent",
+                          Math.round(moverWidget.x) === 465);
+            harness.check("and the guide stays up with it",
+                          canvas.edgeGuideXActive === true);
+            // 40px past: released, and the lattice takes back over (425
+            // rounds to 420).
+            harness.moveShadowTo(425, 48);
+            stepReleaseVerify.running = true;
+        }
+    }
+
+    Timer {
+        id: stepReleaseVerify
+        interval: 300
+        onTriggered: {
+            harness.check("past the release threshold the lattice takes back over",
+                          Math.round(moverWidget.x) === 420);
+            harness.check("and the guide goes down",
+                          canvas.edgeGuideXActive === false);
+            harness.releaseAtShadow(425, 48);
+            stepCommitVerify.running = true;
+        }
+    }
+
+    Timer {
+        id: stepCommitVerify
+        interval: 400
+        onTriggered: {
+            harness.check("the release commits the lattice landing",
+                          harness.at(moverWidget, 420, 48));
+            // A second drag released INSIDE the hold: the commit is the
+            // neighbour's edge, off the lattice, and it sticks.
+            harness.beginDrag(moverWidget);
+            harness.moveShadowTo(470, 48);
+            harness.releaseAtShadow(470, 48);
+            stepHeldCommitVerify.running = true;
+        }
+    }
+
+    Timer {
+        id: stepHeldCommitVerify
+        interval: 400
+        onTriggered: {
+            harness.check("a release inside the hold commits the neighbour's edge, off the lattice",
+                          harness.at(moverWidget, 465, 48));
+            harness.check("the guides do not outlive the gesture",
+                          canvas.edgeGuideXActive === false
+                              && canvas.edgeGuideYActive === false);
+            // Marquee crosser and buddy for the group half - a band that
+            // covers both and neither of the top-row widgets.
+            driver.mousePress(canvas, 20, 270, Qt.LeftButton);
+            driver.mouseMove(canvas, 400, 500, 20, Qt.LeftButton);
+            driver.mouseMove(canvas, 780, 700, 20, Qt.LeftButton);
+            driver.mouseRelease(canvas, 780, 700, Qt.LeftButton);
+            stepGroup.running = true;
+        }
+    }
+
+    // ---- the group drag's leader snaps, the followers keep their offsets --
+    Timer {
+        id: stepGroup
+        interval: 400
+        onTriggered: {
+            harness.check("the marquee selected the pair",
+                          canvas.selectedWidgets.length === 2);
+            harness.beginDrag(crosserWidget);
+            // Toward anchor's left edge at 305, released still pressed: the
+            // leader must hold it while both followers' offsets stand.
+            harness.moveShadowTo(297, 288);
+            stepGroupVerify.running = true;
+        }
+    }
+
+    Timer {
+        id: stepGroupVerify
+        interval: 300
+        onTriggered: {
+            harness.check("the group's leader holds the neighbour's edge mid-drag",
+                          Math.round(crosserWidget.x) === 305);
+            harness.check("the follower keeps its x offset through the snap",
+                          Math.round(buddyWidget.x - crosserWidget.x) === 652);
+            harness.check("the follower keeps its y offset through the snap",
+                          Math.round(buddyWidget.y - crosserWidget.y) === 312);
+            harness.releaseAtShadow(297, 288);
+            stepGroupCommitVerify.running = true;
+        }
+    }
+
+    Timer {
+        id: stepGroupCommitVerify
+        interval: 400
+        onTriggered: {
+            harness.check("the release leaves the cluster where the snap put it",
+                          Math.round(crosserWidget.x) === 305
+                              && Math.round(buddyWidget.x - crosserWidget.x) === 652
+                              && Math.round(buddyWidget.y - crosserWidget.y) === 312);
+            harness.finish();
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/WidgetGroupDragRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/WidgetGroupDragRuntimeTest.qml
@@ -199,6 +199,15 @@ ShellRoot {
             if (!PluginState.ready || !Config.ready)
                 return;
             Config.options.background.widgetsLocked = false;
+            // Every expected landing in this file is a lattice stop, and the
+            // widgets are deliberately packed close enough to marquee in one
+            // gesture - close enough that the widget-to-widget edge snap
+            // (edge_snap.js, which rides this switch) captures some of the
+            // drags onto a neighbour's edge instead. That gesture has its own
+            // harness (WidgetEdgeSnapRuntimeTest.qml); this one is about the
+            // marquee and the group, so the alignment helpers stand down the
+            // same way the lock above is normalised.
+            Config.options.background.showSnapLines = false;
             if (harness.at(alphaWidget, 48, 48)
                     && harness.at(betaWidget, 240, 48)
                     && harness.at(ghostWidget, 48, 240)

--- a/dots/.config/quickshell/imi/modules/common/functions/edge_snap.js
+++ b/dots/.config/quickshell/imi/modules/common/functions/edge_snap.js
@@ -1,0 +1,94 @@
+.pragma library
+
+// Widget-to-widget edge alignment (spec §6): the candidate set, the
+// perpendicular relevance filter and the two-threshold hold, kept pure so the
+// decisions are reachable from tst_edge_snap.qml. Nothing about the rendered
+// guide is - the caller (AbstractWidget) collects the neighbour rects, feeds
+// the drag's SHADOW position through resolveSnap on every event, and draws the
+// guide wherever the held candidate says.
+//
+// The two thresholds are a Schmitt trigger: a guide is acquired close and
+// released only farther away, and BOTH tests compare the unsnapped shadow
+// position, never the rendered one. With one threshold, snapping puts the
+// widget on the target while the pointer sits within it, so the next event
+// re-snaps; pushing just past unsnaps to a position that may be within the
+// threshold again from the other side - a per-event flip-flop, because the
+// decision boundary and the resulting position are the same number. The gap
+// between the two numbers is what makes the hold feel like a detent.
+
+const ACQUIRE_PX = 18;
+const RELEASE_PX = 32;
+
+// A widget far across the axis being snapped offers no alignments: without
+// this, a widget in one corner left-aligns to something in the opposite one,
+// and the guide drawn between them is a screen-long line about nothing the
+// user is arranging. Measured as the GAP between the two perpendicular
+// extents - overlap is zero - and the boundary value is excluded: the limit
+// is the first distance that contributes nothing.
+const PERPENDICULAR_LIMIT_PX = 600;
+
+function perpendicularGap(aPos, aSize, bPos, bSize) {
+    return Math.max(bPos - (aPos + aSize), aPos - (bPos + bSize), 0);
+}
+
+// Four relations per neighbour per axis - near-to-near, far-to-far,
+// near-to-far, far-to-near - each carrying TWO numbers: the `target` the
+// dragged widget travels to and the `guide` the line is drawn at. They differ
+// for two of the four, because the line belongs to the OTHER widget's edge:
+// aligning our right edge to their right edge lands us at far - size, but the
+// alignment the line shows is at far.
+//
+// `neighbours` is iterated by index and length rather than Array methods on
+// purpose: a list that has crossed a QML model boundary keeps its indices and
+// its length and loses its Array brand.
+function candidatesForAxis(neighbours, axis, size, perpPos, perpSize) {
+    const isX = axis === "x";
+    const out = [];
+    for (let i = 0; i < neighbours.length; i++) {
+        const n = neighbours[i];
+        const near = isX ? n.x : n.y;
+        const far = near + (isX ? n.width : n.height);
+        const nPerpPos = isX ? n.y : n.x;
+        const nPerpSize = isX ? n.height : n.width;
+        if (perpendicularGap(perpPos, perpSize, nPerpPos, nPerpSize)
+                >= PERPENDICULAR_LIMIT_PX)
+            continue;
+        out.push({ target: near, guide: near });        // near-to-near
+        out.push({ target: far - size, guide: far });   // far-to-far
+        out.push({ target: far, guide: far });          // near-to-far
+        out.push({ target: near - size, guide: near }); // far-to-near
+    }
+    return out;
+}
+
+// One axis's snap decision for one event: the held candidate, or null.
+//
+// `shadowPos` is the drag proxy's position - where the widget WOULD be with no
+// snap - and `held` is whatever this function answered last event. A held
+// candidate keeps its hold while the shadow stays inside the release
+// threshold AND the candidate is still in the regenerated list (a neighbour
+// the perpendicular filter has since dropped releases immediately: a guide
+// for a neighbour that no longer qualifies is a line about nothing). The
+// match is by VALUE, not reference - the list is rebuilt every event.
+function resolveSnap(shadowPos, candidates, held) {
+    if (held) {
+        for (let i = 0; i < candidates.length; i++) {
+            const c = candidates[i];
+            if (c.target === held.target && c.guide === held.guide) {
+                if (Math.abs(shadowPos - c.target) < RELEASE_PX)
+                    return c;
+                break;
+            }
+        }
+    }
+    let best = null;
+    let bestDistance = ACQUIRE_PX;
+    for (let i = 0; i < candidates.length; i++) {
+        const distance = Math.abs(shadowPos - candidates[i].target);
+        if (distance < bestDistance) {
+            best = candidates[i];
+            bestDistance = distance;
+        }
+    }
+    return best;
+}

--- a/dots/.config/quickshell/imi/modules/common/functions/edit_mode.js
+++ b/dots/.config/quickshell/imi/modules/common/functions/edit_mode.js
@@ -417,3 +417,47 @@ function dropPosition(input) {
         y: Math.max(0, Math.min(screenHeight - Math.max(height, grid), y))
     };
 }
+
+// ---- the undo stack (spec §7.3) -------------------------------------------
+//
+// The stack itself lives in GlobalStates (in memory, session-scoped, gone
+// with a restart - §7.4's argument that a restart mid-edit already does the
+// right thing); these are its arithmetic, kept pure so the bound, the LIFO
+// order and the copy-on-write shape are reachable from tst_edit_mode.qml.
+// Entries are opaque here - at the call sites each one is a closure over the
+// store write that reverses a committed mutation, never a diff, because a
+// diff needs a serialiser per store and there are three stores.
+
+var UNDO_LIMIT = 50;
+
+// A fresh stack on every operation, never a mutation: the stack sits in a
+// `property var`, whose change signal fires on reassignment only, so an
+// in-place push would leave every observer reading a depth that never moves.
+// Bounded by dropping the OLDEST entry - a stack that refuses new work when
+// full has stopped recording exactly the mutations the user is still making.
+function undoPush(stack, entry) {
+    var next = listCopy(stack);
+    next.push(entry);
+    if (next.length > UNDO_LIMIT)
+        next.shift();
+    return next;
+}
+
+function undoPop(stack) {
+    var next = listCopy(stack);
+    if (next.length === 0)
+        return { stack: next, entry: null };
+    var entry = next.pop();
+    return { stack: next, entry: entry };
+}
+
+// The snapshot an undo closure captures, taken by index and length because a
+// store list that has crossed the QML boundary keeps both and loses its
+// Array brand (enabledWithout's rule, one shelf up).
+function listCopy(list) {
+    var out = [];
+    var count = list && typeof list.length === "number" ? list.length : 0;
+    for (var i = 0; i < count; i++)
+        out.push(list[i]);
+    return out;
+}

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginState.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginState.qml
@@ -189,7 +189,15 @@ Singleton {
         const nextState = Object.assign({}, root.state);
         const nextOptions = Object.assign({}, nextState.pluginOptions || {});
         const nextPlugin = Object.assign({}, nextOptions[pluginId] || {});
-        nextPlugin[key] = value;
+        // null means REMOVE, not store: `option()` falls back only on
+        // undefined, so a persisted null would answer every later read in
+        // place of the caller's fallback - a key that never existed,
+        // materialised on disk. Edit Mode's undo is what reaches this branch:
+        // reversing a first-ever commit restores "no stored choice", which
+        // has to leave the store the way it found it. No live caller stored
+        // null before this meaning was assigned (checked, not assumed).
+        if (value === null || value === undefined) delete nextPlugin[key];
+        else nextPlugin[key] = value;
         nextOptions[pluginId] = nextPlugin;
         nextState.version = root.schemaVersion;
         nextState.pluginOptions = nextOptions;

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
@@ -292,7 +292,7 @@ AbstractBackgroundWidget {
         const before = PluginState.option(id, "__gridSize", null);
         if (before !== next)
             GlobalStates.editUndoPush(() => PluginState.setOption(id, "__gridSize", before));
-        PluginState.setOption(id, "__gridSize", next);
+        PluginState.setOption(manifest.id, "__gridSize", next);
     }
 
     function beginGridResize() {

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
@@ -282,7 +282,17 @@ AbstractBackgroundWidget {
 
     function commitGridSize(size) {
         if (!manifest || !size) return;
-        PluginState.setOption(manifest.id, "__gridSize", GridSizes.formatSize(size));
+        // A span commit is one of spec §7.3's five committed mutations. The
+        // undo closure captures plain data and the PluginState singleton,
+        // never `rootWidget` - the stack outlives any widget the mode can
+        // destroy - and an unchanged span pushes nothing, so a commit of the
+        // span the widget already has does not spend an entry.
+        const id = manifest.id;
+        const next = GridSizes.formatSize(size);
+        const before = PluginState.option(id, "__gridSize", null);
+        if (before !== next)
+            GlobalStates.editUndoPush(() => PluginState.setOption(id, "__gridSize", before));
+        PluginState.setOption(id, "__gridSize", next);
     }
 
     function beginGridResize() {
@@ -610,13 +620,33 @@ AbstractBackgroundWidget {
         // pan's worth every time it was dragged. It is clamped here as well as
         // on the way back in, so the store can never hold a position the
         // widget is not drawn at.
+        const beforeX = rootWidget.targetX;
+        const beforeY = rootWidget.targetY;
         rootWidget.targetX = rootWidget.clampX(ParallaxMath.placementFromDrawn(
             rootWidget.x, rootWidget.parallaxCancelX));
         rootWidget.targetY = rootWidget.clampY(ParallaxMath.placementFromDrawn(
             rootWidget.y, rootWidget.parallaxCancelY));
         rootWidget.restoreXYBinding();
         if (!manifest) return;
-        PluginState.setPosition(manifest.id, screenName, {
+        // A drag's release is a committed mutation (spec §7.3), and this is
+        // its one commit path - the leader's release and every group-drag
+        // follower both land here. The closure captures plain values and the
+        // PluginState singleton only; a commit that moved nothing (every
+        // click on a draggable widget releases through here) pushes nothing,
+        // or the stack would fill with entries that undo to where the widget
+        // already is. A group drag therefore records one entry per member -
+        // one entry per committed mutation is the spec's grain.
+        const id = manifest.id;
+        const screen = rootWidget.screenName;
+        if (beforeX !== rootWidget.targetX || beforeY !== rootWidget.targetY) {
+            const before = {
+                x: beforeX,
+                y: beforeY,
+                placementStrategy: rootWidget.placementStrategy
+            };
+            GlobalStates.editUndoPush(() => PluginState.setPosition(id, screen, before));
+        }
+        PluginState.setPosition(id, screenName, {
             x: rootWidget.targetX,
             y: rootWidget.targetY,
             placementStrategy: rootWidget.placementStrategy

--- a/dots/.config/quickshell/imi/modules/common/widgets/DragApps.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/DragApps.qml
@@ -8,6 +8,7 @@ import QtQuick.Controls
 import QtQuick.Effects
 import QtQuick.Layouts
 import Qt5Compat.GraphicalEffects
+import "../functions/edit_mode.js" as EditMode
 import Quickshell.Io
 import Quickshell
 import Quickshell.Widgets
@@ -74,6 +75,18 @@ Item {
 
     function commitOrder() {
         const newOrder = _workOrder.slice()
+        // A reorder drop is a committed mutation (spec §7.3). The push is
+        // gated on the mode inside editUndoPush, so the dock's everyday
+        // reorder records nothing; a drop that changed no order pushes
+        // nothing either, since commitOrder runs for every drag end.
+        const before = EditMode.listCopy(Config.options.dock.pinnedApps)
+        let changed = before.length !== newOrder.length
+        for (let i = 0; !changed && i < newOrder.length; i++)
+            changed = before[i] !== newOrder[i]
+        if (changed)
+            GlobalStates.editUndoPush(() => {
+                Config.options.dock.pinnedApps = before
+            })
         Config.options.dock.pinnedApps = newOrder
         orderChanged(newOrder)
     }
@@ -353,6 +366,11 @@ Item {
                             // pointer (touch) could otherwise remove by a
                             // mid-drag index into the wrong list.
                             if (!GlobalStates.editMode || root._dragging) return;
+                            // A remove is a committed mutation (spec §7.3).
+                            const beforePins = EditMode.listCopy(Config.options.dock.pinnedApps);
+                            GlobalStates.editUndoPush(() => {
+                                Config.options.dock.pinnedApps = beforePins;
+                            });
                             Config.options.dock.pinnedApps =
                                 LayoutOps.remove(root.pinnedApps, slotItem.index);
                         }

--- a/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/AbstractWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/AbstractWidget.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import Quickshell
 import qs.modules.common
+import "../../functions/edge_snap.js" as EdgeSnap
 
 /*
  * Widget to be placed on a WidgetCanvas
@@ -127,6 +128,11 @@ MouseArea {
         dragProxy.y = root.y
         const canvas = findCanvas(root.parent)
         if (canvas && canvas.widgetDragStarted) canvas.widgetDragStarted(root)
+        // After widgetDragStarted: that call is what flags a group drag's
+        // followers, and a follower must not be captured as a neighbour.
+        root.edgeSnapHeldX = null
+        root.edgeSnapHeldY = null
+        root.edgeSnapNeighbours = root.collectEdgeSnapNeighbours()
     }
     onPositionChanged: (mouse) => {
         if (!root.draggable || !(root.pressedButtons & Qt.LeftButton)) return
@@ -214,6 +220,92 @@ MouseArea {
     function snapX(value) { return root.snap(value - root.snapOffsetX) + root.snapOffsetX }
     function snapY(value) { return root.snap(value - root.snapOffsetY) + root.snapOffsetY }
 
+    // ---- widget-to-widget edge snap (spec §6) -----------------------------
+    // The arithmetic is edge_snap.js; this widget owns only the state a drag
+    // needs. Neighbour rects are captured once at the press - nothing else on
+    // the canvas moves during this widget's drag (group-drag followers, which
+    // do, are excluded) - while the candidates are regenerated per event,
+    // because the perpendicular relevance filter reads the DRAGGED widget's
+    // live position across the axis.
+    //
+    // It rides `background.showSnapLines`, not a switch of its own. That key
+    // already gates the alignment visuals (the release flash), and the guide
+    // and the hold have to travel together: a detent with no line is a drag
+    // that sticks for no visible reason, and a line with no detent is a
+    // suggestion the widget ignores. The lattice snap stays ungated beside it,
+    // exactly as today.
+    property var edgeSnapNeighbours: []
+    property var edgeSnapHeldX: null
+    property var edgeSnapHeldY: null
+
+    function edgeSnapEnabled() {
+        return root.snapEnabled && Config.options.background.showSnapLines
+    }
+
+    function collectEdgeSnapNeighbours() {
+        if (!root.edgeSnapEnabled()) return []
+        const canvas = root.findCanvas(root.parent)
+        if (!canvas) return []
+        const rects = []
+        for (const widget of canvas.widgetsUnder(canvas, [])) {
+            // A follower travels with this drag, so an edge captured from it
+            // would chase its own cluster. A hidden or unsized widget (a
+            // FadeLoader mid-exit) has no edge on screen to align to.
+            if (widget === root || widget.groupDragging) continue
+            if (!widget.visible || widget.width <= 0 || widget.height <= 0) continue
+            // Into THIS widget's parent frame, because that is the frame the
+            // drag Binding writes x/y in. Mapping through the parents rather
+            // than reading x/y raw keeps a widget under a differently-placed
+            // loader honest.
+            const pos = widget.parent.mapToItem(root.parent, widget.x, widget.y)
+            rects.push({ x: pos.x, y: pos.y, width: widget.width, height: widget.height })
+        }
+        return rects
+    }
+
+    // Runs from the drag proxy's change handlers - the same home as
+    // updateCenterHighlight, and for the same reason: the resolve is stateful
+    // (this event's hold depends on last event's), so it belongs in a handler,
+    // not inside the drag Binding's own evaluation. The Binding reads the held
+    // target through a property and re-evaluates when it changes.
+    //
+    // Both axes update on any move: the X candidates depend on where the
+    // widget is in Y (the perpendicular filter) and vice versa.
+    function updateEdgeSnap() {
+        if (root.edgeSnapNeighbours.length === 0) return
+        root.edgeSnapHeldX = EdgeSnap.resolveSnap(dragProxy.x,
+            EdgeSnap.candidatesForAxis(root.edgeSnapNeighbours, "x",
+                root.width, dragProxy.y, root.height),
+            root.edgeSnapHeldX)
+        root.edgeSnapHeldY = EdgeSnap.resolveSnap(dragProxy.y,
+            EdgeSnap.candidatesForAxis(root.edgeSnapNeighbours, "y",
+                root.height, dragProxy.x, root.width),
+            root.edgeSnapHeldY)
+        root.publishEdgeGuides()
+    }
+
+    // The guide is drawn at the OTHER widget's edge, by the canvas, in the
+    // canvas's frame - mapped point by point rather than assumed equal to the
+    // parent's, for the same reason the neighbour rects are mapped in.
+    function publishEdgeGuides() {
+        const canvas = root.findCanvas(root.parent)
+        if (!canvas || !canvas.setEdgeGuides) return
+        const heldX = root.edgeSnapHeldX
+        const heldY = root.edgeSnapHeldY
+        canvas.setEdgeGuides(
+            heldX !== null,
+            heldX !== null ? root.parent.mapToItem(canvas, heldX.guide, 0).x : 0,
+            heldY !== null,
+            heldY !== null ? root.parent.mapToItem(canvas, 0, heldY.guide).y : 0)
+    }
+
+    function clearEdgeSnap() {
+        root.edgeSnapNeighbours = []
+        root.edgeSnapHeldX = null
+        root.edgeSnapHeldY = null
+        root.publishEdgeGuides()
+    }
+
     function findCanvas(item) {
         var p = item
         while (p) {
@@ -242,18 +334,28 @@ MouseArea {
         id: dragProxy
         parent: root.parent
 
-        onXChanged: if (root.dragging) root.updateCenterHighlight()
-        onYChanged: if (root.dragging) root.updateCenterHighlight()
+        onXChanged: if (root.dragging) { root.updateCenterHighlight(); root.updateEdgeSnap() }
+        onYChanged: if (root.dragging) { root.updateCenterHighlight(); root.updateEdgeSnap() }
     }
 
     // Snap first, clamp second: clamp-then-snap could round the leader back
     // off the group bound by up to half a grid cell, deforming the cluster at
     // the screen edge by exactly the amount the lattice is meant to guarantee.
+    //
+    // A held edge alignment takes the place of the lattice snap rather than
+    // stacking on it: the neighbour's edge is wherever the neighbour is, and
+    // rounding an exact alignment to the nearest lattice stop would miss the
+    // edge by up to half a cell - a guide drawn at a line the widget is not
+    // on. The clamp still runs last, unchanged. A group drag's followers ride
+    // the leader by delta (WidgetCanvas.syncGroupFollowers), so the leader
+    // snapping an edge moves the cluster whole and every follower keeps its
+    // offset - the existing semantics, not new ones.
     Binding {
         target: root
         property: "x"
         value: Math.max(root.groupDragMinX, Math.min(root.groupDragMaxX,
-            root.snapEnabled ? root.snapX(dragProxy.x) : dragProxy.x))
+            root.edgeSnapHeldX !== null ? root.edgeSnapHeldX.target
+            : root.snapEnabled ? root.snapX(dragProxy.x) : dragProxy.x))
         when: root.dragging
         restoreMode: Binding.RestoreNone
     }
@@ -261,7 +363,8 @@ MouseArea {
         target: root
         property: "y"
         value: Math.max(root.groupDragMinY, Math.min(root.groupDragMaxY,
-            root.snapEnabled ? root.snapY(dragProxy.y) : dragProxy.y))
+            root.edgeSnapHeldY !== null ? root.edgeSnapHeldY.target
+            : root.snapEnabled ? root.snapY(dragProxy.y) : dragProxy.y))
         when: root.dragging
         restoreMode: Binding.RestoreNone
     }
@@ -293,6 +396,7 @@ MouseArea {
 
         dragProxy.x = root.x
         dragProxy.y = root.y
+        if (!dragging) root.clearEdgeSnap()
     }
 
     Behavior on x {

--- a/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/AbstractWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/AbstractWidget.qml
@@ -157,11 +157,17 @@ MouseArea {
         root.dragActive = false
         const canvas = findCanvas(root.parent)
         if (canvas && canvas.widgetDragEnded) canvas.widgetDragEnded(root)
+        // A plain click never raises dragActive, so onDraggingChanged never
+        // schedules the clear and the rects captured at the press would sit
+        // held until the next one. Idempotent for a real drag, which has
+        // already scheduled the same call.
+        Qt.callLater(root.clearEdgeSnap)
     }
     onCanceled: {
         root.dragActive = false
         const canvas = findCanvas(root.parent)
         if (canvas && canvas.widgetDragEnded) canvas.widgetDragEnded(root)
+        Qt.callLater(root.clearEdgeSnap)
     }
 
     // Put the widget back where the press found it and commit nothing. Called

--- a/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/AbstractWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/AbstractWidget.qml
@@ -396,7 +396,14 @@ MouseArea {
 
         dragProxy.x = root.x
         dragProxy.y = root.y
-        if (!dragging) root.clearEdgeSnap()
+        // Deferred, because this handler runs while the drag Binding may not
+        // have deactivated yet - the `when` and this handler both observe
+        // `dragging`, and nothing orders them. Nulling the hold under a
+        // still-live Binding re-evaluates it to the lattice branch and rounds
+        // an edge-snapped landing off the edge it was released on: measured,
+        // a widget released holding 465 committed 468. One turn later the
+        // Binding is inert and the clear touches nothing but the guides.
+        if (!dragging) Qt.callLater(root.clearEdgeSnap)
     }
 
     Behavior on x {

--- a/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/WidgetCanvas.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/WidgetCanvas.qml
@@ -357,11 +357,30 @@ MouseArea {
     property bool centerXActive: false
     property bool centerYActive: false
 
+    // The edge-snap guides (spec §6): one vertical and one horizontal line,
+    // published by whichever widget is dragging (AbstractWidget resolves the
+    // hold; the canvas only draws it). The position keeps its last value while
+    // inactive so the fade-out fades the line where it was, rather than a
+    // line sliding to 0 as it leaves.
+    property bool edgeGuideXActive: false
+    property real edgeGuideXPos: 0
+    property bool edgeGuideYActive: false
+    property real edgeGuideYPos: 0
+
+    function setEdgeGuides(xActive, xPos, yActive, yPos) {
+        if (xActive) root.edgeGuideXPos = xPos
+        if (yActive) root.edgeGuideYPos = yPos
+        root.edgeGuideXActive = xActive
+        root.edgeGuideYActive = yActive
+    }
+
     function setDragging(active) {
         root.showGrid = active
         if (!active) {
             root.centerXActive = false
             root.centerYActive = false
+            root.edgeGuideXActive = false
+            root.edgeGuideYActive = false
         }
     }
 
@@ -493,6 +512,68 @@ MouseArea {
                 animation: Appearance.animation.elementMoveFast.colorAnimation.createObject(this)
             }
             Behavior on height {
+                animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
+            }
+            Behavior on opacity {
+                animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
+            }
+        }
+    }
+
+    // The edge-snap guides join the centre-line family - the same tier's
+    // Behaviors, taken whole through the tier's own factory - rather than
+    // starting a second idiom. Unlike the centre lines they live ABOVE the
+    // widgets, not in the lattice substrate: the line belongs to the OTHER
+    // widget's edge, and an alignment cue drawn under a translucent panel is
+    // an alignment cue the panel dims. They are also not gated on the grid's
+    // visibility, because the hold they announce rides
+    // `background.showSnapLines` (gated where it is resolved, in
+    // AbstractWidget) while the lattice rides `background.showGrid` - two
+    // switches, and a guide the user asked for must not disappear with a grid
+    // they turned off.
+    Item {
+        id: edgeGuides
+        anchors.fill: parent
+        z: 9
+        // Cannot take input, ever - same rule as the lattice.
+        enabled: false
+
+        Rectangle {
+            id: edgeGuideV
+            visible: opacity > 0
+            x: root.edgeGuideXPos - width / 2
+            width: 2
+            height: root.height
+            color: Appearance.colors.colPrimary
+            opacity: root.edgeGuideXActive ? 1 : 0
+
+            Behavior on x {
+                // Instant while invisible, so the first hold of a drag places
+                // the line at its guide instead of sweeping it in from
+                // wherever the previous one faded out. While visible, a hold
+                // moving between neighbours travels: the reference
+                // implementation's guides are two plain Rectangles that pop
+                // and teleport between guides (spec §6.2), which is exactly
+                // what joining the animated family is for.
+                enabled: edgeGuideV.opacity > 0
+                animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
+            }
+            Behavior on opacity {
+                animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
+            }
+        }
+
+        Rectangle {
+            id: edgeGuideH
+            visible: opacity > 0
+            y: root.edgeGuideYPos - height / 2
+            width: root.width
+            height: 2
+            color: Appearance.colors.colPrimary
+            opacity: root.edgeGuideYActive ? 1 : 0
+
+            Behavior on y {
+                enabled: edgeGuideH.opacity > 0
                 animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
             }
             Behavior on opacity {

--- a/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/WidgetCanvas.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/WidgetCanvas.qml
@@ -99,6 +99,22 @@ MouseArea {
     // to a Bottom-layer surface is not established, which is why the mode has a
     // pointer way out as well and no feature depends on this alone.
     focus: root.selectionEnabled
+    // Ctrl+Z, on this surface and no other, because this is the surface the
+    // probe says the keyboard actually works on: measured in a nested
+    // Hyprland, a Bottom-layer surface with keyboardFocus: OnDemand receives
+    // real compositor key events while it holds that focus - which is the
+    // state the mode arms (keyboardFocusHeld below includes editMode). The
+    // chrome surface stays WlrKeyboardFocus.None, exactly as its contract
+    // pins. The Escape ladder below is untouched: undo reverses the last
+    // COMMITTED mutation, Escape cancels the gesture still in flight, and
+    // the two never answer the same moment.
+    Keys.onPressed: (event) => {
+        if (!root.editMode) return
+        if (event.key === Qt.Key_Z && (event.modifiers & Qt.ControlModifier)) {
+            GlobalStates.editUndo()
+            event.accepted = true
+        }
+    }
     Keys.onEscapePressed: {
         const action = EditMode.resolveEscape({
             menuOpen: GlobalStates.editWidgetMenuOpen,

--- a/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/WidgetCanvas.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/WidgetCanvas.qml
@@ -110,7 +110,10 @@ MouseArea {
     // the two never answer the same moment.
     Keys.onPressed: (event) => {
         if (!root.editMode) return
-        if (event.key === Qt.Key_Z && (event.modifiers & Qt.ControlModifier)) {
+        // Exactly Control, not "Control among others": Ctrl+Shift+Z is
+        // convention's redo, and a redo stack is deliberately not built -
+        // answering it with an undo would be worse than ignoring it.
+        if (event.key === Qt.Key_Z && event.modifiers === Qt.ControlModifier) {
             GlobalStates.editUndo()
             event.accepted = true
         }
@@ -310,6 +313,14 @@ MouseArea {
         widget.groupDragMinY = -Infinity
         widget.groupDragMaxY = Infinity
         if (!group || group.leader !== widget) return
+        // One gesture, one undo entry: every follower's commit below and the
+        // leader's own - which runs AFTER this function, later in the same
+        // release chain - collect into one batch, closed a turn later so the
+        // leader's push cannot miss it. Without this the leader's entry sits
+        // on top and the first Ctrl+Z moves the leader alone, deforming the
+        // cluster the user moved as a unit.
+        GlobalStates.editUndoBeginBatch()
+        Qt.callLater(GlobalStates.editUndoEndBatch)
         for (const entry of group.followers) {
             entry.widget.groupDragging = false
             if (entry.widget.commitPosition) entry.widget.commitPosition()

--- a/dots/.config/quickshell/imi/modules/imi/bar/BarEditController.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/BarEditController.qml
@@ -4,6 +4,7 @@ import qs.modules.common
 import qs.modules.common.plugins
 import qs.modules.common.widgets
 import "../../common/functions/layout_ops.js" as LayoutOps
+import "../../common/functions/edit_mode.js" as EditMode
 
 /**
  * One bar's worth of Edit Mode's reorder: the coordinator both content trees
@@ -208,6 +209,25 @@ Item {
         dropIndicator.shown = true;
     }
 
+    // A reorder drop and a badge remove are committed mutations (spec §7.3),
+    // so each pushes ONE undo entry before its writes - one entry even for a
+    // cross-bucket drop, which is one gesture making two writes. The closure
+    // captures the touched buckets' lists and reaches only the Config
+    // singleton, never this controller: the stack outlives the overlays the
+    // mode tears down. Restores are literal paths, writeLayout's own rule.
+    function pushUndoForBuckets(buckets) {
+        const snap = [];
+        for (const bucket of buckets)
+            snap.push({ bucket: bucket, list: EditMode.listCopy(root.storedLayout(bucket)) });
+        GlobalStates.editUndoPush(() => {
+            for (const entry of snap) {
+                if (entry.bucket === 0) Config.options.bar.layouts.leftLayout = entry.list;
+                else if (entry.bucket === 1) Config.options.bar.layouts.middleLayout = entry.list;
+                else Config.options.bar.layouts.rightLayout = entry.list;
+            }
+        });
+    }
+
     // The commits. Guarded on the mode because a drag can outlive it - Done
     // mid-gesture, the exit ladder - and an end the user meant as "stop" must
     // not store an order they never chose.
@@ -217,6 +237,7 @@ Item {
             const flags = root.flagsFor(fromBucket);
             const visibleDest = LayoutOps.moveTargetForInsertion(fromVisible, target.index);
             if (visibleDest === fromVisible) return;
+            root.pushUndoForBuckets([fromBucket]);
             root.writeLayout(fromBucket, LayoutOps.move(root.storedLayout(fromBucket),
                 LayoutOps.nthVisible(flags, fromVisible),
                 LayoutOps.nthVisible(flags, visibleDest)));
@@ -226,6 +247,7 @@ Item {
         const toFlags = root.flagsFor(target.bucket);
         const storedFrom = LayoutOps.nthVisible(fromFlags, fromVisible);
         if (storedFrom === -1) return;
+        root.pushUndoForBuckets([fromBucket, target.bucket]);
         const source = root.storedLayout(fromBucket);
         const id = source[storedFrom];
         root.writeLayout(fromBucket, LayoutOps.remove(source, storedFrom));
@@ -238,6 +260,7 @@ Item {
         const flags = root.flagsFor(bucket);
         const stored = LayoutOps.nthVisible(flags, visibleIndex);
         if (stored === -1) return;
+        root.pushUndoForBuckets([bucket]);
         root.writeLayout(bucket, LayoutOps.remove(root.storedLayout(bucket), stored));
     }
 

--- a/dots/.config/quickshell/imi/modules/imi/editMode/EditModeChromeSurface.qml
+++ b/dots/.config/quickshell/imi/modules/imi/editMode/EditModeChromeSurface.qml
@@ -138,6 +138,12 @@ PanelWindow {
     }
 
     function togglePlugin(manifest) {
+        // Presence flips are §7.3's add and remove: one entry either way,
+        // holding the whole enabled list from before the write. The closure
+        // reaches only the Config singleton and captured data.
+        const before = EditMode.listCopy(Config.options.plugins.enabled);
+        GlobalStates.editUndoPush(() =>
+            Config.setNestedValue("plugins.enabled", before));
         if (Config.options.plugins.enabled.includes(manifest.id))
             Config.setNestedValue("plugins.enabled", root.enabledWithout(manifest.id));
         else
@@ -166,6 +172,24 @@ PanelWindow {
     // rule about this file. Arranging it further is the bar's in-place drag;
     // the widget arrives at the bucket's end, badged and draggable.
     function appendBarWidget(widgetId, bucket) {
+        // An add to a bar bucket (§7.3): the closure restores the one bucket
+        // it touched, at the same literal path the write below uses.
+        if (bucket === "left") {
+            const beforeLeft = EditMode.listCopy(Config.options.bar.layouts.leftLayout);
+            GlobalStates.editUndoPush(() => {
+                Config.options.bar.layouts.leftLayout = beforeLeft;
+            });
+        } else if (bucket === "middle") {
+            const beforeMiddle = EditMode.listCopy(Config.options.bar.layouts.middleLayout);
+            GlobalStates.editUndoPush(() => {
+                Config.options.bar.layouts.middleLayout = beforeMiddle;
+            });
+        } else {
+            const beforeRight = EditMode.listCopy(Config.options.bar.layouts.rightLayout);
+            GlobalStates.editUndoPush(() => {
+                Config.options.bar.layouts.rightLayout = beforeRight;
+            });
+        }
         if (bucket === "left")
             Config.options.bar.layouts.leftLayout = LayoutOps.insert(
                 Config.options.bar.layouts.leftLayout, widgetId,
@@ -186,12 +210,28 @@ PanelWindow {
     // keys are presence-on-a-surface (spec §9 names lock.show* as exactly
     // that), and the same booleans LockIdleConfig's rows write.
     function toggleLockIsland(key) {
-        if (key === "showToolbars")
+        // Presence on the lock surface is §9's fourth licence, so a flip is
+        // recorded like the drawer's widget toggles - one closure per key,
+        // each writing its own literal path back.
+        if (key === "showToolbars") {
+            const beforeToolbars = Config.options.lock.showToolbars;
+            GlobalStates.editUndoPush(() => {
+                Config.options.lock.showToolbars = beforeToolbars;
+            });
             Config.options.lock.showToolbars = !Config.options.lock.showToolbars;
-        else if (key === "showMedia")
+        } else if (key === "showMedia") {
+            const beforeMedia = Config.options.lock.showMedia;
+            GlobalStates.editUndoPush(() => {
+                Config.options.lock.showMedia = beforeMedia;
+            });
             Config.options.lock.showMedia = !Config.options.lock.showMedia;
-        else if (key === "showWidgets")
+        } else if (key === "showWidgets") {
+            const beforeWidgets = Config.options.lock.showWidgets;
+            GlobalStates.editUndoPush(() => {
+                Config.options.lock.showWidgets = beforeWidgets;
+            });
             Config.options.lock.showWidgets = !Config.options.lock.showWidgets;
+        }
     }
 
     function addWidgetAt(manifest, dropX, dropY) {
@@ -217,6 +257,25 @@ PanelWindow {
         // the widget up at the default position and then move it (spec §8.3 -
         // an added widget is placed the moment it is added, and there is no
         // "unplaced" state to park it in).
+        // A drop is ONE add (§7.3), so it is one entry even though it makes
+        // two writes: the closure puts the enabled list back whole and, where
+        // the store already held a position for this widget from an earlier
+        // life, restores that too. A position left behind for a disabled
+        // widget is invisible and harmless, so a first-ever add restores
+        // nothing there.
+        const id = manifest.id;
+        const screen = root.screen?.name ?? "";
+        const beforeEnabled = EditMode.listCopy(Config.options.plugins.enabled);
+        // Existence checked on the raw store: PluginState.position() answers
+        // the DEFAULT for an absent entry, which would read as a stored
+        // position that was never there.
+        const hadPosition = PluginState.state?.desktopPositions?.[screen]?.[id] !== undefined;
+        const beforePosition = hadPosition ? PluginState.position(id, screen) : null;
+        GlobalStates.editUndoPush(() => {
+            Config.setNestedValue("plugins.enabled", beforeEnabled);
+            if (beforePosition)
+                PluginState.setPosition(id, screen, beforePosition);
+        });
         PluginState.setPosition(manifest.id, root.screen?.name ?? "",
             { x: placed.x, y: placed.y, placementStrategy: "free" });
         root.enablePlugin(manifest.id);
@@ -250,7 +309,16 @@ PanelWindow {
         // The dock's presence write goes through its one existing writer -
         // the same togglePin the dock's own context menu calls - rather than
         // a second spelling of the pinnedApps edit here.
-        onDockAppToggleRequested: (appId) => TaskbarApps.togglePin(appId)
+        onDockAppToggleRequested: (appId) => {
+            // A dock pin flip is an add or a remove (§7.3). The write stays
+            // with TaskbarApps.togglePin - the one existing writer - and the
+            // closure restores the pinned list at its literal path.
+            const beforePins = EditMode.listCopy(Config.options.dock.pinnedApps);
+            GlobalStates.editUndoPush(() => {
+                Config.options.dock.pinnedApps = beforePins;
+            });
+            TaskbarApps.togglePin(appId);
+        }
         onLockIslandToggleRequested: (key) => root.toggleLockIsland(key)
     }
 }

--- a/dots/.config/quickshell/imi/modules/imi/editMode/EditModeChromeSurface.qml
+++ b/dots/.config/quickshell/imi/modules/imi/editMode/EditModeChromeSurface.qml
@@ -310,13 +310,15 @@ PanelWindow {
         // the same togglePin the dock's own context menu calls - rather than
         // a second spelling of the pinnedApps edit here.
         onDockAppToggleRequested: (appId) => {
-            // A dock pin flip is an add or a remove (§7.3). The write stays
-            // with TaskbarApps.togglePin - the one existing writer - and the
-            // closure restores the pinned list at its literal path.
-            const beforePins = EditMode.listCopy(Config.options.dock.pinnedApps);
-            GlobalStates.editUndoPush(() => {
-                Config.options.dock.pinnedApps = beforePins;
-            });
+            // A dock pin flip is an add or a remove (§7.3), and its inverse
+            // is the same flip - so the closure calls the one existing
+            // writer again rather than restoring the list, which would need
+            // this file to read `Config.options.dock` and be the second
+            // derivation the one-answer contract forbids. The cost is that
+            // undoing an unpin re-pins at the strip's end rather than the
+            // old slot; the order is the dock's in-place drag's to arrange.
+            const toggled = appId;
+            GlobalStates.editUndoPush(() => TaskbarApps.togglePin(toggled));
             TaskbarApps.togglePin(appId);
         }
         onLockIslandToggleRequested: (key) => root.toggleLockIsland(key)

--- a/dots/.config/quickshell/imi/modules/imi/editMode/EditModeChromeSurface.qml
+++ b/dots/.config/quickshell/imi/modules/imi/editMode/EditModeChromeSurface.qml
@@ -317,6 +317,10 @@ PanelWindow {
             // derivation the one-answer contract forbids. The cost is that
             // undoing an unpin re-pins at the strip's end rather than the
             // old slot; the order is the dock's in-place drag's to arrange.
+            // A self-inverse also goes stale differently from the restores:
+            // applied after the user re-toggled the same app by hand, it
+            // inverts their choice instead of reverting this one - accepted,
+            // because the alternative is a second derivation of the store.
             const toggled = appId;
             GlobalStates.editUndoPush(() => TaskbarApps.togglePin(toggled));
             TaskbarApps.togglePin(appId);

--- a/dots/.config/quickshell/imi/modules/imi/editMode/EditWidgetMenuContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/editMode/EditWidgetMenuContent.qml
@@ -102,7 +102,14 @@ Item {
         const next = GridSizes.steppedSize(root.manifest.grid ?? null,
             root.storedSpan, direction);
         if (!next) return;
-        PluginState.setOption(root.manifest.id, "__gridSize",
+        // A span commit is one of §7.3's committed mutations. The closure
+        // captures the id and the old stored choice, and reaches only the
+        // PluginState singleton - never this card or its widget, both of
+        // which the mode can destroy while the stack outlives them.
+        const id = root.manifest.id;
+        const before = PluginState.option(id, "__gridSize", null);
+        GlobalStates.editUndoPush(() => PluginState.setOption(id, "__gridSize", before));
+        PluginState.setOption(id, "__gridSize",
             GridSizes.formatSize(next));
     }
 
@@ -259,6 +266,13 @@ Item {
             // closes even where no widget instance exists to be destroyed.
             onClicked: {
                 if (!root.manifest) return;
+                // A remove is a committed mutation (§7.3): the closure holds
+                // the whole enabled list from before the write, so undoing
+                // re-enables the widget at the position the store still
+                // holds for it.
+                const before = EditMode.listCopy(Config.options.plugins.enabled);
+                GlobalStates.editUndoPush(() =>
+                    Config.setNestedValue("plugins.enabled", before));
                 Config.setNestedValue("plugins.enabled",
                     EditMode.enabledWithout(Config.options.plugins.enabled, root.manifest.id));
                 root.dismissRequested();

--- a/dots/.config/quickshell/imi/modules/imi/lock/LockIslandReorder.qml
+++ b/dots/.config/quickshell/imi/modules/imi/lock/LockIslandReorder.qml
@@ -2,6 +2,7 @@ import QtQuick
 import qs
 import qs.modules.common
 import "../../common/functions/layout_ops.js" as LayoutOps
+import "../../common/functions/edit_mode.js" as EditMode
 import "../../common/functions/lock_islands.js" as LockIslands
 
 /**
@@ -173,6 +174,27 @@ Item {
         if (!GlobalStates.editMode || !target) return;
         const destination = LayoutOps.moveTargetForInsertion(from, target.index);
         if (destination === from) return;
+        // A reorder drop is a committed mutation (spec §7.3). The restore is
+        // a literal path per island - the scope lint's rule about exactly
+        // these writes - and the closure reaches only the Config singleton
+        // and its captured list, never this controller: the Lockscreen tab
+        // tears these overlays down and the stack outlives them.
+        if (root.island === "main") {
+            const beforeMain = EditMode.listCopy(Config.options.lock.islands.main);
+            GlobalStates.editUndoPush(() => {
+                Config.options.lock.islands.main = beforeMain;
+            });
+        } else if (root.island === "left") {
+            const beforeLeft = EditMode.listCopy(Config.options.lock.islands.left);
+            GlobalStates.editUndoPush(() => {
+                Config.options.lock.islands.left = beforeLeft;
+            });
+        } else {
+            const beforeRight = EditMode.listCopy(Config.options.lock.islands.right);
+            GlobalStates.editUndoPush(() => {
+                Config.options.lock.islands.right = beforeRight;
+            });
+        }
         const moved = LayoutOps.move(root.orderedIds, from, destination);
         root.writeList(LockIslands.storedOrder(moved, root.storedList(), root.defaults()));
     }

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -562,6 +562,13 @@ if ! python3 "$SCRIPT_DIR/test_widget_group_drag_runtime.py"; then
     exit 1
 fi
 
+# Brings its own headless weston, like the interaction runtime tests above.
+echo "Running widget edge snap runtime tests..."
+if ! python3 "$SCRIPT_DIR/test_widget_edge_snap_runtime.py"; then
+    echo "Widget edge snap runtime tests failed."
+    exit 1
+fi
+
 echo "Running widget plugin migration tests..."
 if ! python3 "$SCRIPT_DIR/test_widget_plugin_migration.py"; then
     echo "Widget plugin migration tests failed."

--- a/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
@@ -1279,8 +1279,18 @@ def test_the_undo_stack_is_the_modules_arithmetic_and_records_only_in_the_mode()
     assert re.search(
         r"function editUndoPush\(entry\)\s*\{\s*"
         r"if \(!root\.editMode\) return;\s*"
-        r"root\.editUndoStack = EditMode\.undoPush\(root\.editUndoStack, entry\);",
-        states), "editUndoPush no longer gates on the mode and defers to the module"
+        r"if \(root\.editUndoBatch !== null\)",
+        states), "editUndoPush no longer gates on the mode before anything else"
+    assert "root.editUndoStack = EditMode.undoPush(root.editUndoStack, entry)" in states, \
+        "editUndoPush no longer defers to the module's arithmetic"
+    # A gesture that commits several mutations folds them into one entry: the
+    # batch is opened by the canvas at a group release and closed a turn
+    # later, or the leader's entry sits on top and the first Ctrl+Z deforms
+    # the cluster.
+    canvas_text = code(CANVAS)
+    assert "GlobalStates.editUndoBeginBatch()" in canvas_text \
+        and "Qt.callLater(GlobalStates.editUndoEndBatch)" in canvas_text, \
+        "a group release no longer batches its members into one entry"
     assert "EditMode.undoPop(root.editUndoStack)" in states, \
         "editUndo no longer pops through the module"
     module = code(MODULE)

--- a/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
@@ -85,6 +85,9 @@ DESKTOP_MENU = ROOT / "modules/imi/desktopMenu/DesktopMenu.qml"
 LOCK_SURFACE = ROOT / "modules/imi/lock/LockSurface.qml"
 LOCK_PREVIEW_CONTEXT = ROOT / "modules/common/panels/lock/LockPreviewContext.qml"
 RULES = ROOT.parents[1] / "hypr/hyprland/rules.lua"
+BAR_CONTROLLER = ROOT / "modules/imi/bar/BarEditController.qml"
+LOCK_REORDER = ROOT / "modules/imi/lock/LockIslandReorder.qml"
+DRAG_APPS = ROOT / "modules/common/widgets/DragApps.qml"
 
 # Everything that takes part in the mode. Listed rather than globbed so a new
 # participant is a deliberate addition to this list, which is where someone
@@ -1262,6 +1265,82 @@ def test_the_lockscreen_preview_is_one_derivation():
             assert "GlobalStates.editLockPreview" in line, \
                 f"{path}: a second source for the preview: {line.strip()}"
     assert swept > 400, f"the tree sweep found only {swept} files"
+
+
+def test_the_undo_stack_is_the_modules_arithmetic_and_records_only_in_the_mode():
+    # Spec §7.3. The stack lives in GlobalStates but its bound and its order
+    # are edit_mode.js's tst-covered functions - a shift or a limit open-coded
+    # in the singleton would be a second copy of arithmetic the tests cannot
+    # see. And the push is gated on the mode: the same gestures commit all day
+    # with the mode off, and Ctrl+Z inside the mode reversing a drag made
+    # hours earlier would be undo reaching past the editor whose affordance
+    # it is.
+    states = code(GLOBAL_STATES)
+    assert re.search(
+        r"function editUndoPush\(entry\)\s*\{\s*"
+        r"if \(!root\.editMode\) return;\s*"
+        r"root\.editUndoStack = EditMode\.undoPush\(root\.editUndoStack, entry\);",
+        states), "editUndoPush no longer gates on the mode and defers to the module"
+    assert "EditMode.undoPop(root.editUndoStack)" in states, \
+        "editUndo no longer pops through the module"
+    module = code(MODULE)
+    for name in ("UNDO_LIMIT", "function undoPush", "function undoPop",
+                 "function listCopy"):
+        assert name in module, f"edit_mode.js lost {name}"
+
+
+def test_ctrl_z_lives_on_the_canvas_and_leaves_the_ladder_alone():
+    # Probe 4's measured answer is what licenses the wiring: the BACKGROUND
+    # surface's canvas receives compositor keys under OnDemand focus, so
+    # Ctrl+Z is answered there - gated on the mode, through GlobalStates'
+    # one undo entry point, and accepted so nothing beneath re-answers it.
+    # The chrome surface stays keyboard-None (its own check above), and the
+    # Escape ladder is a different rung entirely: undo reverses the last
+    # COMMITTED mutation, Escape cancels the gesture still in flight.
+    canvas = code(CANVAS)
+    start = canvas.find("Keys.onPressed")
+    assert start != -1, "the canvas lost its key handler"
+    handler = canvas[start:canvas.find("Keys.onEscapePressed", start)]
+    assert "if (!root.editMode) return" in handler, \
+        "Ctrl+Z is no longer gated on the mode"
+    assert "Qt.Key_Z" in handler and "Qt.ControlModifier" in handler, \
+        "the canvas no longer answers Ctrl+Z"
+    assert "GlobalStates.editUndo()" in handler, \
+        "Ctrl+Z stopped going through the one undo entry point"
+    assert "event.accepted = true" in handler, \
+        "an unaccepted Ctrl+Z falls through to whatever sits beneath"
+    assert re.search(r"Keys\.onEscapePressed", canvas), \
+        "the Escape ladder left the canvas"
+
+
+def test_every_committed_mutation_records_exactly_its_entries():
+    # Spec §7.3's five kinds of committed mutation, as push counts per file.
+    # Exact rather than at-least in both directions: a site that stops
+    # pushing is a mutation undo silently forgot, and a NEW push is a new
+    # licence that belongs in this table on review. The closures' discipline
+    # (only singletons and captured data, literal store paths) is stated at
+    # each site; what a count can hold is that the sites exist at all.
+    expected = {
+        PLUGIN_WIDGET: 2,      # a drag's release; a span commit (grip + Size row path)
+        MENU_CONTENT: 2,       # the Size stepper; Remove
+        CHROME_SURFACE: 9,     # presence toggle, 3 bar-bucket adds, 3 lock keys,
+                               # add-at-pointer, dock pin toggle
+        BAR_CONTROLLER: 1,     # one snapshot helper serving reorder and remove
+        LOCK_REORDER: 3,       # one literal path per island
+        DRAG_APPS: 2,          # the dock's reorder commit; the badge unpin
+    }
+    for path, count in expected.items():
+        found = code(path).count("editUndoPush")
+        assert found == count, \
+            f"{path.name}: {found} undo pushes where the contract expects {count}"
+    # The drag-release push is guarded on the commit having MOVED something:
+    # commitPosition runs for every release of a draggable widget, click
+    # included, and an unguarded push fills the stack with entries that undo
+    # to where the widget already is.
+    widget = code(PLUGIN_WIDGET)
+    assert re.search(
+        r"if \(beforeX !== rootWidget\.targetX \|\| beforeY !== rootWidget\.targetY\)",
+        widget), "the drag-release push lost its moved-something guard"
 
 
 if __name__ == "__main__":

--- a/dots/.config/quickshell/imi/tests/test_edit_mode_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_edit_mode_runtime.py
@@ -40,7 +40,7 @@ SOCKET = "wayland-imi-edit-mode"
 # The harness prints how many checks it ran. A literal rather than anything read
 # back out of that output: a harness whose step list shrinks must redden here
 # instead of reporting `failures: 0` for a shorter run.
-EXPECTED_CHECKS = 52
+EXPECTED_CHECKS = 56
 
 
 def _stop(proc):

--- a/dots/.config/quickshell/imi/tests/test_edit_mode_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_edit_mode_runtime.py
@@ -40,7 +40,7 @@ SOCKET = "wayland-imi-edit-mode"
 # The harness prints how many checks it ran. A literal rather than anything read
 # back out of that output: a harness whose step list shrinks must redden here
 # instead of reporting `failures: 0` for a shorter run.
-EXPECTED_CHECKS = 45
+EXPECTED_CHECKS = 52
 
 
 def _stop(proc):

--- a/dots/.config/quickshell/imi/tests/test_widget_edge_snap_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_widget_edge_snap_runtime.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Drives the widget-to-widget edge snap with real mouse events.
+
+`WidgetEdgeSnapRuntimeTest.qml` builds five real `PluginWidget`s on a real
+`WidgetCanvas` and drags one toward another's edge through QtTest, which works
+inside `qs -p`. This module is the driver: it stands up a headless weston,
+points throwaway XDG dirs at it, and fails the suite on any check the harness
+reports.
+
+`tst_edge_snap.qml` proves the module's arithmetic - the candidate set, the
+perpendicular filter, the two-threshold hold. What only real events can prove
+is the wiring: the hold overriding the lattice inside the live drag Binding,
+the hysteresis fed the shadow position rather than the rendered one, the
+canvas's guide standing at the neighbour's edge, the perpendicular filter
+refusing a distant neighbour on a real drag, and a group drag's leader
+snapping while its follower keeps both offsets. The anchor sits off the 12px
+lattice on purpose, so every edge landing the harness asserts is a position
+the lattice snap cannot produce by coincidence.
+
+Headless weston rather than the caller's session because the harness opens a
+window. It implements no wlr-layer-shell, so this proves nothing about the
+`PanelWindow` the real `Background.qml` puts the canvas on - the widget tree,
+the canvas and the guides are ordinary Items and are what this exercises.
+
+Skips when weston or qs is missing, as in CI.
+"""
+
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HARNESS = ROOT / "WidgetEdgeSnapRuntimeTest.qml"
+SOCKET = "wayland-imi-widget-edge-snap"
+
+
+# The harness prints how many checks it ran. This number is a literal rather
+# than anything read back from that output: a harness whose step list shrinks
+# must redden here instead of reporting `failures: 0` for a shorter run.
+EXPECTED_CHECKS = 17
+
+
+def _stop(proc):
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+
+
+def _runtime_available():
+    return shutil.which("qs") is not None and shutil.which("weston") is not None
+
+
+@unittest.skipUnless(_runtime_available(), "needs qs and weston on PATH")
+class WidgetEdgeSnapRuntimeTest(unittest.TestCase):
+    def setUp(self):
+        self.home = Path(tempfile.mkdtemp(prefix="imi-widget-edge-snap-"))
+        self.addCleanup(shutil.rmtree, self.home, ignore_errors=True)
+
+    def test_edge_snap_acquire_hold_and_release(self):
+        env = dict(os.environ)
+        env.setdefault("XDG_RUNTIME_DIR", f"/run/user/{os.getuid()}")
+        env["WAYLAND_DISPLAY"] = SOCKET
+        env.pop("DISPLAY", None)
+
+        weston = subprocess.Popen(
+            ["weston", "--backend=headless", "--renderer=pixman",
+             f"--socket={SOCKET}", "--width=1200", "--height=800"],
+            env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        self.addCleanup(_stop, weston)
+
+        socket_path = Path(env["XDG_RUNTIME_DIR"]) / SOCKET
+        deadline = time.monotonic() + 15
+        while not socket_path.exists() and time.monotonic() < deadline:
+            time.sleep(0.2)
+        self.assertTrue(socket_path.exists(), "headless weston never came up")
+
+        # This box's headless EGL has no driver, so force software rendering.
+        env["LIBGL_ALWAYS_SOFTWARE"] = "1"
+        env["QT_QUICK_BACKEND"] = "software"
+        env["XDG_CONFIG_HOME"] = str(self.home / "config")
+        env["XDG_STATE_HOME"] = str(self.home / "state")
+
+        proc = subprocess.run(["qs", "-p", str(HARNESS)], cwd=str(ROOT), env=env,
+                              capture_output=True, text=True, timeout=180)
+        output = proc.stdout + proc.stderr
+        failed = [line for line in output.splitlines() if "FAIL" in line]
+        self.assertEqual(failed, [], f"harness reported failures:\n{output}")
+        self.assertIn(f"[WidgetEdgeSnap] checks: {EXPECTED_CHECKS} failures: 0", output,
+                      f"harness did not finish cleanly:\n{output}")
+
+        self.assertNotIn("Binding loop", output,
+                         f"the host tree grew a binding loop:\n{output}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dots/.config/quickshell/imi/tests/test_widget_group_selection.py
+++ b/dots/.config/quickshell/imi/tests/test_widget_group_selection.py
@@ -117,6 +117,12 @@ class GroupDragIsRigid(unittest.TestCase):
         """Clamp-then-snap can round the leader back off the group bound by up
         to half a grid cell, deforming the cluster at the edge by exactly the
         amount the lattice was supposed to guarantee.
+
+        The snap has two forms since edge snap landed (spec 6): a held
+        neighbour-edge target, else the lattice. The pin is the ORDERING -
+        the group clamp wraps whichever snap answered - so the regex admits
+        the held branch inside the clamp rather than freezing the lattice-only
+        spelling.
         """
         text = squashed(WIDGET)
         for axis in ("X", "Y"):
@@ -124,7 +130,9 @@ class GroupDragIsRigid(unittest.TestCase):
             self.assertRegex(
                 text,
                 rf"Math\.max\(root\.groupDragMin{axis}, Math\.min\("
-                rf"root\.groupDragMax{axis}, root\.snapEnabled \? "
+                rf"root\.groupDragMax{axis}, "
+                rf"root\.edgeSnapHeld{axis} !== null \? root\.edgeSnapHeld{axis}\.target : "
+                rf"root\.snapEnabled \? "
                 rf"root\.snap{axis}\({re.escape(proxy)}\) : {re.escape(proxy)}\)\)",
                 f"the {axis} drag binding must clamp the snapped value")
 

--- a/dots/.config/quickshell/imi/tests/tst_edge_snap.qml
+++ b/dots/.config/quickshell/imi/tests/tst_edge_snap.qml
@@ -135,6 +135,17 @@ TestCase {
                     `acquired at ${pos}, ${distance}px out - before the near threshold`);
             }
         }
+
+        // The detent again, in raw numbers this time: 24px past the guide
+        // sits between the spec's ~18 acquire and ~32 release. The walk above
+        // reads the thresholds from the module, so a RELEASE_PX collapsed
+        // onto ACQUIRE_PX moves the expectations along with the behaviour and
+        // the walk follows it down - this line is the one a single-threshold
+        // implementation actually fails.
+        held = EdgeSnap.resolveSnap(283, candidates, null);
+        held = EdgeSnap.resolveSnap(324, candidates, held);
+        verify(held !== null && held.target === 300,
+            "released 24px past the guide - inside the detent");
     }
 
     function test_a_held_candidate_survives_regenerated_lists() {

--- a/dots/.config/quickshell/imi/tests/tst_edge_snap.qml
+++ b/dots/.config/quickshell/imi/tests/tst_edge_snap.qml
@@ -1,0 +1,183 @@
+import QtTest
+import "../modules/common/functions/edge_snap.js" as EdgeSnap
+
+// Widget-to-widget edge alignment (spec §6). Three decisions live in the
+// module and nothing else does: which alignments a neighbour offers (four
+// relations per axis, each carrying the position the widget travels to AND the
+// edge the guide is drawn at, because the line belongs to the OTHER widget),
+// which neighbours are close enough across the axis to matter at all, and the
+// two-threshold hold - acquire near, release far, both measured against the
+// UNSNAPPED shadow position. Everything about the rendered guide needs a real
+// canvas `qmltestrunner` cannot construct, so the arithmetic is the part a
+// test can reach.
+TestCase {
+    name: "EdgeSnapTest"
+
+    // One neighbour, seen from the x axis. The dragged widget is 60 wide and
+    // overlaps the neighbour vertically, so every relation is offered.
+    readonly property var xNeighbour: ({ x: 300, y: 100, width: 120, height: 80 })
+
+    function hasCandidate(candidates, target, guide) {
+        for (let i = 0; i < candidates.length; i++) {
+            if (candidates[i].target === target && candidates[i].guide === guide)
+                return true;
+        }
+        return false;
+    }
+
+    function test_four_relations_per_neighbour_on_x() {
+        const candidates = EdgeSnap.candidatesForAxis([xNeighbour], "x", 60, 120, 40);
+        compare(candidates.length, 4);
+        // near-to-near: our left on their left, line at their left.
+        verify(hasCandidate(candidates, 300, 300));
+        // far-to-far: our right on their right - the widget travels to
+        // 420 - 60, but the line is drawn at THEIR edge, not where we land.
+        verify(hasCandidate(candidates, 360, 420));
+        // near-to-far: our left against their right (sitting beside them).
+        verify(hasCandidate(candidates, 420, 420));
+        // far-to-near: our right against their left.
+        verify(hasCandidate(candidates, 240, 300));
+    }
+
+    function test_four_relations_per_neighbour_on_y() {
+        const neighbour = { x: 40, y: 500, width: 90, height: 200 };
+        const candidates = EdgeSnap.candidatesForAxis([neighbour], "y", 80, 60, 50);
+        compare(candidates.length, 4);
+        verify(hasCandidate(candidates, 500, 500));      // top-to-top
+        verify(hasCandidate(candidates, 620, 700));      // bottom-to-bottom
+        verify(hasCandidate(candidates, 700, 700));      // top under their bottom
+        verify(hasCandidate(candidates, 420, 500));      // bottom on their top
+    }
+
+    function test_a_neighbour_across_the_axis_contributes_nothing() {
+        // The neighbour spans y 100..180. A widget whose own vertical extent
+        // sits a gap short of the limit still aligns to it...
+        const nearlyFar = EdgeSnap.candidatesForAxis([xNeighbour], "x", 60,
+            180 + EdgeSnap.PERPENDICULAR_LIMIT_PX - 1, 40);
+        compare(nearlyFar.length, 4);
+        // ...and at exactly the limit it does not: the boundary value is
+        // excluded, so the limit is the first distance that contributes
+        // nothing rather than the last one that does.
+        const atTheLimit = EdgeSnap.candidatesForAxis([xNeighbour], "x", 60,
+            180 + EdgeSnap.PERPENDICULAR_LIMIT_PX, 40);
+        compare(atTheLimit.length, 0);
+        const past = EdgeSnap.candidatesForAxis([xNeighbour], "x", 60,
+            180 + EdgeSnap.PERPENDICULAR_LIMIT_PX + 50, 40);
+        compare(past.length, 0);
+    }
+
+    function test_overlapping_extents_are_distance_zero() {
+        // Perpendicular distance is the GAP between extents, not a
+        // centre-to-centre measure: any overlap is distance zero, so a tall
+        // neighbour cannot be pushed out of relevance by its own height.
+        const tall = { x: 300, y: 0, width: 120, height: 2000 };
+        const candidates = EdgeSnap.candidatesForAxis([tall], "x", 60, 900, 40);
+        compare(candidates.length, 4);
+    }
+
+    function test_acquire_happens_only_inside_the_near_threshold() {
+        const candidates = EdgeSnap.candidatesForAxis([xNeighbour], "x", 60, 120, 40);
+        // 283 is 17 short of the near-to-near target at 300: inside.
+        const held = EdgeSnap.resolveSnap(283, candidates, null);
+        verify(held !== null);
+        compare(held.target, 300);
+        compare(held.guide, 300);
+        // 282 is exactly the acquire threshold away: outside. A boundary that
+        // acquires is a boundary the release test can sit on.
+        compare(EdgeSnap.resolveSnap(300 - EdgeSnap.ACQUIRE_PX, candidates, null), null);
+    }
+
+    function test_the_nearest_candidate_wins() {
+        // Two neighbours whose left edges are 10px apart; a shadow between
+        // them acquires whichever is closer, not whichever came first.
+        const pair = [
+            { x: 300, y: 100, width: 120, height: 80 },
+            { x: 310, y: 100, width: 120, height: 80 }
+        ];
+        const candidates = EdgeSnap.candidatesForAxis(pair, "x", 60, 120, 40);
+        const held = EdgeSnap.resolveSnap(306, candidates, null);
+        verify(held !== null);
+        compare(held.target, 310);
+    }
+
+    function test_a_walk_past_the_guide_acquires_near_and_releases_only_far() {
+        // The assertion the whole section exists for, driven as a sequence of
+        // raw shadow positions the way a drag delivers them. A single-threshold
+        // implementation fails it by flip-flopping: its decision boundary and
+        // the resulting position are the same number, so it releases the
+        // moment the pointer clears the near threshold. An implementation that
+        // compares the RENDERED position instead of the shadow fails the other
+        // way - the rendered position sits on the target, so it never
+        // releases at all.
+        const candidates = EdgeSnap.candidatesForAxis([xNeighbour], "x", 60, 120, 40);
+        let held = null;
+        // The walk stops at 340: past that the shadow starts closing on the
+        // far-to-far target at 360, which is a different acquisition, not this
+        // test's release.
+        for (let pos = 270; pos <= 340; pos++) {
+            held = EdgeSnap.resolveSnap(pos, candidates, held);
+            const distance = Math.abs(pos - 300);
+            if (distance >= EdgeSnap.RELEASE_PX) {
+                verify(held === null,
+                    `still held ${distance}px past the guide, at ${pos}`);
+            } else if (pos > 300) {
+                // Between the two thresholds, approached from inside: the
+                // detent. This is the band a single-threshold implementation
+                // has already let go of.
+                verify(held !== null && held.target === 300,
+                    `released early at ${pos}, ${distance}px from the guide`);
+            } else if (distance < EdgeSnap.ACQUIRE_PX) {
+                verify(held !== null && held.target === 300,
+                    `not acquired at ${pos}, ${distance}px from the guide`);
+            } else {
+                // Approaching from outside, past neither threshold yet.
+                verify(held === null,
+                    `acquired at ${pos}, ${distance}px out - before the near threshold`);
+            }
+        }
+    }
+
+    function test_a_held_candidate_survives_regenerated_lists() {
+        // Candidates are rebuilt on every drag event, so the hold has to be
+        // identity by VALUE - a held object compared by reference against a
+        // fresh list would release on every event.
+        const first = EdgeSnap.candidatesForAxis([xNeighbour], "x", 60, 120, 40);
+        const held = EdgeSnap.resolveSnap(295, first, null);
+        verify(held !== null);
+        const second = EdgeSnap.candidatesForAxis([xNeighbour], "x", 60, 125, 40);
+        const stillHeld = EdgeSnap.resolveSnap(320, second, held);
+        verify(stillHeld !== null);
+        compare(stillHeld.target, 300);
+    }
+
+    function test_a_held_candidate_that_leaves_the_set_releases() {
+        // The neighbour moved out of perpendicular relevance mid-drag (the
+        // dragged widget travelled across the axis), so its candidates are
+        // gone from the regenerated list. The hold releases even though the
+        // shadow is still within the release threshold of the old target -
+        // a guide for a neighbour that no longer qualifies is a line about
+        // nothing.
+        const before = EdgeSnap.candidatesForAxis([xNeighbour], "x", 60, 120, 40);
+        const held = EdgeSnap.resolveSnap(295, before, null);
+        verify(held !== null);
+        const after = EdgeSnap.candidatesForAxis([xNeighbour], "x", 60,
+            180 + EdgeSnap.PERPENDICULAR_LIMIT_PX, 40);
+        compare(EdgeSnap.resolveSnap(295, after, held), null);
+    }
+
+    function test_the_two_thresholds_are_a_detent_not_a_line() {
+        // The mechanism is not the two numbers, it is that they differ: the
+        // gap between them is what makes the hold feel like a detent. Equal
+        // thresholds are the flip-flop the walk above catches behaviourally;
+        // this pins the shape so a "simplification" to one constant reddens
+        // by name.
+        verify(EdgeSnap.ACQUIRE_PX < EdgeSnap.RELEASE_PX);
+        verify(EdgeSnap.ACQUIRE_PX > 0);
+        verify(EdgeSnap.PERPENDICULAR_LIMIT_PX > 0);
+    }
+
+    function test_no_neighbours_means_no_candidates_and_no_hold() {
+        compare(EdgeSnap.candidatesForAxis([], "x", 60, 120, 40).length, 0);
+        compare(EdgeSnap.resolveSnap(300, [], null), null);
+    }
+}

--- a/dots/.config/quickshell/imi/tests/tst_edit_mode.qml
+++ b/dots/.config/quickshell/imi/tests/tst_edit_mode.qml
@@ -574,4 +574,71 @@ TestCase {
             verify(card.y + card.height <= area.y + area.height + 1e-6);
         }
     }
+
+    // ---- the undo stack (spec §7.3) -----------------------------------
+
+    function test_undo_push_appends_and_pop_returns_last_in() {
+        // LIFO, because "the last thing I did" is what Ctrl+Z means. Entries
+        // are opaque to the stack - closures at the call sites - so the test
+        // uses plain markers.
+        let stack = [];
+        stack = EditMode.undoPush(stack, "first");
+        stack = EditMode.undoPush(stack, "second");
+        compare(stack.length, 2);
+        const popped = EditMode.undoPop(stack);
+        compare(popped.entry, "second");
+        compare(popped.stack.length, 1);
+        const again = EditMode.undoPop(popped.stack);
+        compare(again.entry, "first");
+        compare(again.stack.length, 0);
+    }
+
+    function test_undo_pop_on_empty_returns_no_entry() {
+        const popped = EditMode.undoPop([]);
+        compare(popped.entry, null);
+        compare(popped.stack.length, 0);
+    }
+
+    function test_undo_stack_is_bounded_and_drops_the_oldest() {
+        // Bounded at UNDO_LIMIT (spec §7.3's ~50), and it is the OLDEST entry
+        // that goes: an undo stack that refuses new work when full has
+        // stopped recording exactly the mutations the user is still making.
+        verify(EditMode.UNDO_LIMIT >= 50);
+        let stack = [];
+        for (let i = 0; i < EditMode.UNDO_LIMIT + 5; i++)
+            stack = EditMode.undoPush(stack, i);
+        compare(stack.length, EditMode.UNDO_LIMIT);
+        compare(EditMode.undoPop(stack).entry, EditMode.UNDO_LIMIT + 4);
+        compare(stack[0], 5);
+    }
+
+    function test_undo_ops_return_fresh_stacks() {
+        // The stack lives in a GlobalStates `property var`, whose change
+        // signal fires on reassignment and not on mutation - an in-place
+        // push would leave every observer reading a depth that never moves.
+        const original = ["only"];
+        const pushed = EditMode.undoPush(original, "more");
+        compare(original.length, 1);
+        verify(pushed !== original);
+        const popped = EditMode.undoPop(pushed);
+        compare(pushed.length, 2);
+        verify(popped.stack !== pushed);
+    }
+
+    function test_list_copy_walks_indices() {
+        // Store lists cross the QML boundary without their Array brand
+        // (enabledWithout's rule), so the snapshot an undo closure captures
+        // is taken by index and length, never by Array.prototype methods on
+        // the value itself.
+        const arrayLike = { length: 3 };
+        arrayLike[0] = "a";
+        arrayLike[1] = "b";
+        arrayLike[2] = "c";
+        const copy = EditMode.listCopy(arrayLike);
+        compare(copy.length, 3);
+        compare(copy[0], "a");
+        compare(copy[2], "c");
+        verify(Array.isArray(copy));
+        compare(EditMode.listCopy(null).length, 0);
+    }
 }


### PR DESCRIPTION
Stage 10 of Edit Mode — the final stage of the spec's landing plan (§12): widget-to-widget edge snap with hysteresis, and then undo, which was gated on §11.4's probe 4 and is unblocked by a recorded measurement.

**Stacked on #251** (`feat/edit-mode-stage9b-island-reorder`), which stacks on #250 → #249 → #248 → #247 → #246. Merge those first; this PR's base is the stage-9b branch.

## Edge snap and hysteresis (spec §6)

`modules/common/functions/edge_snap.js` owns the arithmetic, TDD-first with `tst_edge_snap.qml` (11 tests): four relations per neighbour per axis, each carrying the `target` the widget travels to and the `guide` the line is drawn at — they differ for half the relations, because the line belongs to the other widget's edge; a perpendicular relevance filter measured as the gap between extents, 600px with the boundary excluded; and a Schmitt trigger — acquire inside 18px, release only at 32 — with both tests against the unsnapped shadow position, matched by value against the per-event candidate list. The named assertion drives a pointer past a guide as a sequence of raw positions, and it pins the detent in raw numbers as well as through the module's constants, because a planted single-threshold module showed the module-relative walk following a collapsed threshold down.

The wiring lives in the live `AbstractWidget.qml`/`WidgetCanvas.qml` only — the stale designsystem duplicate stays dead, its candidate idea ported into a testable module rather than its code revived. A held alignment replaces the lattice snap in the drag Binding (rounding an exact alignment misses the edge by up to half a cell); snap-then-clamp ordering is untouched; a group drag's leader snaps and the followers keep their offsets through the existing delta sync. The guides join the centre-line family — the `elementMoveFast` tier taken whole — travelling while visible and placing instantly while not, drawn above the widgets because an alignment cue under a translucent panel is a cue the panel dims. No new config key: the feature rides `background.showSnapLines`, the switch that already gates the alignment visuals and the one the dead duplicate rode for the same feature — the guide and the detent travel together, because either alone is a mystery.

Two things the new harness (`WidgetEdgeSnapRuntimeTest.qml`, 17 checks, anchor deliberately off-lattice at x 305 so no landing passes by coincidence) caught before landing: the hold was cleared under a still-live drag Binding — `onDraggingChanged` and the Binding's `when` both observe `dragging` with nothing ordering them, and a widget released holding 465 committed 468 — now deferred one turn with `Qt.callLater`; and the group-drag harness's packed layout was legitimately edge-snapped, so it stands the helpers down in setup the way it already normalises the lock.

## Probe 4, recorded (spec §11.4)

The question undo was gated on: does the compositor deliver real key events to a `Bottom`-layer surface with `keyboardFocus: OnDemand`? Measured against a nested Hyprland 0.56.2, isolated harder than the blur probe it is shaped on: the nested instance got its own `XDG_RUNTIME_DIR` and reached its wayland parent through an absolute-path `WAYLAND_DISPLAY` (a fully headless nested Hyprland is impossible with this Aquamarine build — `CBackend::create()` aborts with no parent and no seat, measured first); `HYPRLAND_INSTANCE_SIGNATURE` was unset and re-exported to the nested signature before any `hyprctl`, with `-i "$SIG"` passed as well; keys were injected with `wtype` — a virtual-keyboard client of the nested display, never ydotool, which writes uinput into the kernel the real session reads; teardown by held PID.

Three measurements: an Overlay/Exclusive control received the injected keys (`EXCLUSIVE-CONTROL key delivered: 65 text='a'` — the injection path works); the Bottom/OnDemand surface, confirmed on the bottom layer via `hyprctl -i "$SIG" layers`, received them too (`BOTTOM-ONDEMAND key delivered: 65 text='a'` / `90 text='z'`); and with a mapped toplevel beside it (`hyprctl clients`: `mapped: 1`), `activewindow` stayed `Invalid` and all four follow-up keys still reached the bottom layer. Verdict: keys are delivered while the surface holds OnDemand focus, which is the state the mode arms through the same `keyboardFocusHeld` the Escape ladder already uses. The one stated limit: no pointer injection exists in the nested session, so focus churn from clicking real windows was not exercised — what is proven is delivery under held focus.

## Undo (spec §7.3)

In memory, session-scoped, bounded at 50 dropping the oldest, one stack across all surfaces, one entry per committed mutation, each entry a closure over the store write. The arithmetic is `edit_mode.js`'s (TDD-first, five tests); the stack is `GlobalStates.editUndoStack`; recording is gated on the mode, since the same gestures commit all day outside it. Ctrl+Z is wired on the `WidgetCanvas` and nowhere else — the surface the probe measured — and the Escape ladder is untouched: undo reverses the last committed mutation, Escape cancels the gesture still in flight.

The entries sit at the commit moments that already exist: the drag's release (with a moved-something guard, since every click on a draggable widget releases through `commitPosition`; a group drag records one entry per member, which is the spec's grain), the span commit (grip, Size row and menu stepper share one path), the bar's reorder and remove (one entry for a cross-bucket drop — one gesture, two writes, one closure), the dock's reorder (changed-only) and badge unpin, the lock islands' reorder at literal paths, and the drawer's and menu's presence writes. Every closure captures plain data and reaches only singletons — the mode destroys its overlays and widgets while the stack outlives them. The dock-pin entry is the same flip again through `TaskbarApps.togglePin`, because restoring the list would need the chrome surface to read `Config.options.dock` — the one-answer contract failed on exactly that draft, and the stated cost is that undoing an unpin re-pins at the strip's end.

## Tests

`tst_edge_snap.qml` 11 (red first), `tst_edit_mode.qml` 42, the new `test_widget_edge_snap_runtime.py` (17 checks), `test_edit_mode_runtime.py` grown to 56 checks including the undo record/reverse/gate steps, `test_edit_mode_contract.py` at 47 with three undo checks. Ten planted mutations, each in a committed-clean tree and each reverted, proved every new check able to fail — including the size-row contract catching the undo instrumentation renaming the grip's pinned write spelling, found only by the full suite. One test was changed rather than the code: `test_widget_group_selection.py` froze the drag Binding's lattice-only spelling, and its rule — the group clamp wraps whichever snap answered — still holds with the held branch inside the clamp, which the updated regex still pins.

A code review over the whole branch diff returned no Critical findings and two Important ones, both fixed and both harness-proven: a group drag recorded one entry per member, so the first Ctrl+Z moved the leader alone and deformed the cluster — a group release now batches into one composite entry (opened at the release, closed a turn later so the leader's late commit falls inside), and one undo restores the whole cluster; and undoing a first-ever span commit persisted a literal `null` the store's fallback logic would answer forever — `PluginState.setOption` now treats null as removal, with no prior caller storing null (checked). Minors: Ctrl+Z matches exactly Control (Ctrl+Shift+Z, convention's redo, is deliberately not built and deliberately not answered with an undo), a plain click releases its captured neighbour rects, and the dock-pin entry's self-inverse staleness is stated at the site.

Full `./tests/run_tests.sh` green at the tip; `DesignSystemCompile` 182/0 under headless weston; the motion-tier register is unchanged at 40 and `lint_edit_mode_scope` needed no allowlist change.

Docs: updated AGENT.md §"Edit Mode shrinks that viewport" (two stage-10 entries: the shadow-read detent and its clear-ordering trap; the measured probe and the singletons-only closure rule)
