### PR TITLE
A qs harness must decide which session bus it talks to

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -2864,11 +2864,22 @@ mode is built out of are worth not re-deriving:
   `test_lock_island_reorder_runtime.py` uses), never a `qs -p` against the
   session, and anything that genuinely needs a real `WlSessionLock` is
   recorded as unverified rather than attempted.
+  **The session BUS is part of that isolation, and was the half this harness
+  missed.** `islandItemVisible` hides `username` and `keyboardLayout` while a
+  media player is registered, so a harness on the developer's own bus drags
+  two invisible slots and commits nothing — the reorder check failed on the
+  maintainer's machine, where a browser held an MPRIS name, and passed
+  everywhere else with the shell's code identical. A harness that launches
+  `qs` now wraps it in `dbus-run-session` (or names a bus it starts itself);
+  `tests/lint_runtime_bus_isolation.py` fails a new one that does neither and
+  carries the 33 existing harnesses as a ratchet.
   (feat(lock): lock_islands.js, the islands' order as arithmetic;
   feat(config): three ordered island lists under lock.islands;
   refactor(lock): the three islands become data-driven;
   test(lint): the scope lint reaches the lock surface and admits its lists;
-  feat(lock): island contents reorder in the mode.)
+  feat(lock): island contents reorder in the mode;
+  test(lock): the reorder harness gets a session bus of its own;
+  test(lint): a qs harness must decide which session bus it talks to.)
 - **A dragged widget holds a neighbour's edge through a Schmitt trigger, and
   both thresholds read the SHADOW — stage 10, spec §6.**
   `modules/common/functions/edge_snap.js` owns the arithmetic: four relations

--- a/dots/.config/quickshell/imi/tests/lint_runtime_bus_isolation.py
+++ b/dots/.config/quickshell/imi/tests/lint_runtime_bus_isolation.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+#
+# Regression guard: a harness that launches `qs` must decide which session bus
+# it talks to. One that inherits `DBUS_SESSION_BUS_ADDRESS` is not testing the
+# shell - it is testing the shell plus whatever the developer happens to be
+# running, and the answer changes between their machine and CI.
+#
+# The failure that bought this check, in full, because it is the exact shape
+# the register below is about.
+#
+# `test_lock_island_reorder_runtime.py` drags the lock screen's left island.
+# `LockSurface.islandItemVisible` hides `username` and `keyboardLayout` while a
+# media player is registered, so the slots the drag names exist only when
+# nothing holds an MPRIS name. The harness already took great care to be
+# isolated - its own XDG_RUNTIME_DIR, its own weston, its own config and state
+# home, HYPRLAND_INSTANCE_SIGNATURE popped so it can never reach the user's
+# compositor - and then inherited the session bus, where the maintainer's
+# browser was registered as a player. The drag landed on two invisible slots,
+# committed nothing, and the check failed. CI never saw it: the runner has no
+# player, and it skips this test for want of `qs` anyway.
+#
+# So the same measurement passed on one machine and failed on another while the
+# shell's own code was identical. That is the class AGENT.md records as "a
+# measurement needs a control": the variable under test was the reorder, and
+# the thing that actually moved was a browser tab.
+#
+# THE REGISTER, and why it is a ratchet rather than a bulk fix.
+#
+# Thirty-three harnesses in the tree launch `qs` on the inherited bus. Most
+# read nothing off it and are fine today by luck rather than by design, and
+# wrapping all of them in one branch means thirty-three unverified changes to
+# tests whose whole job is to be trustworthy - `dbus-run-session` starts a bus
+# with no services on it at all, so a harness that quietly depended on one
+# (UPower, a portal, a notification daemon) would start failing for a new
+# reason. They are fixed one at a time, each verified by running it.
+#
+# EXISTING is therefore the list of harnesses still on the inherited bus, and
+# the check fails two ways:
+#
+#   - a harness outside the register launches `qs` without deciding its bus
+#     (new code cannot add one);
+#   - a registered harness now decides its bus (fixing one is required to take
+#     it OUT of the list, so the register cannot rot into a permanent
+#     allowlist nobody rechecks).
+#
+# "Decides" means either `dbus-run-session` (a private bus with nothing on it)
+# or an explicit `DBUS_SESSION_BUS_ADDRESS` in the harness's env - pointing at
+# a bus the test starts itself is as deliberate as isolating from it, and
+# `test_notification_cards_runtime.py` needs exactly that.
+#
+# Lints are exempt: they read source, they start no shell.
+
+import pathlib
+import re
+import sys
+
+TESTS = pathlib.Path(__file__).resolve().parent
+
+LAUNCHES_QS = re.compile(r'"qs"|\bqs\s+-[pc]\b')
+DECIDES_BUS = re.compile(r"dbus-run-session|DBUS_SESSION_BUS_ADDRESS")
+
+EXISTING = frozenset({
+    "test_app_usage_runtime.py",
+    "test_bar_edit_runtime.py",
+    "test_calendar_card.py",
+    "test_card_shadow.py",
+    "test_clight_integration_runtime.py",
+    "test_clock_depth_compositing.py",
+    "test_clock_depth_noop.py",
+    "test_config_control_write_back.py",
+    "test_config_dir_migration_runtime.py",
+    "test_conflict_killer_contract.py",
+    "test_dock_edge_runtime.py",
+    "test_edit_mode_chrome.py",
+    "test_edit_mode_runtime.py",
+    "test_get_keybinds.py",
+    "test_kboptions_migration_runtime.py",
+    "test_keybind_overrides_runtime.py",
+    "test_launcher_qalc_runtime.py",
+    "test_motion_multiplier_runtime.py",
+    "test_nightlight_state_runtime.py",
+    "test_notes_migration_runtime.py",
+    "test_notes_surfaces_runtime.py",
+    "test_parallax_migration_runtime.py",
+    "test_quick_toggles_layout_runtime.py",
+    "test_widget_edge_snap_runtime.py",
+    "test_widget_elevation.py",
+    "test_widget_grip_lock.py",
+    "test_widget_group_drag_runtime.py",
+    "test_widget_group_selection.py",
+    "test_widget_interaction_modes.py",
+    "test_widget_interaction_runtime.py",
+    "test_widget_parallax_optout.py",
+    "test_widget_resize_grip_runtime.py",
+    "test_widget_resize_motion_runtime.py",
+})
+
+
+def main():
+    failures = []
+    inherited = set()
+    scanned = 0
+
+    for path in sorted(TESTS.glob("*.py")):
+        if path.name.startswith("lint_"):
+            continue
+        text = path.read_text(encoding="utf-8", errors="replace")
+        if not LAUNCHES_QS.search(text):
+            continue
+        scanned += 1
+        if DECIDES_BUS.search(text):
+            continue
+        inherited.add(path.name)
+        if path.name in EXISTING:
+            continue
+        failures.append(
+            f"{path.name}: launches `qs` on the inherited session bus. Wrap the "
+            f"launch in `dbus-run-session --` (and skip unless it is on PATH) "
+            f"so the harness sees the services it declares, never the ones the "
+            f"developer is running - a shell that reads MPRIS, UPower or a "
+            f"portal off the user's bus measures their session, not this tree.")
+
+    for name in sorted(EXISTING - inherited):
+        if not (TESTS / name).exists():
+            failures.append(
+                f"{name}: registered in tests/lint_runtime_bus_isolation.py and "
+                f"no longer present. Drop it from EXISTING.")
+            continue
+        failures.append(
+            f"{name}: now decides its own session bus. Remove it from EXISTING "
+            f"in tests/lint_runtime_bus_isolation.py - the register is a "
+            f"ratchet, and one that is not tightened stops being read.")
+
+    if failures:
+        print("Runtime bus isolation lint failed:\n", file=sys.stderr)
+        for failure in failures:
+            print(f"  {failure}", file=sys.stderr)
+        return 1
+
+    print(f"Runtime bus isolation lint passed ({scanned} qs harnesses, "
+          f"{len(inherited)} still on the inherited bus)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -199,6 +199,16 @@ if ! python3 "$SCRIPT_DIR/lint_self_matching_process_patterns.py"; then
     exit 1
 fi
 
+# A harness that launches qs on the inherited session bus measures the
+# developer's session as much as this tree: the lock island reorder test read
+# the maintainer's browser as an MPRIS player, which hides the two slots it
+# drags, and failed on their machine while passing everywhere else.
+echo "Running runtime bus isolation lint..."
+if ! python3 "$SCRIPT_DIR/lint_runtime_bus_isolation.py"; then
+    echo "Runtime bus isolation lint failed."
+    exit 1
+fi
+
 echo "Running doc citation lint..."
 if ! python3 "$SCRIPT_DIR/lint_doc_citations.py"; then
     echo "Doc citation lint failed."

--- a/dots/.config/quickshell/imi/tests/test_lock_island_reorder_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_lock_island_reorder_runtime.py
@@ -14,7 +14,14 @@ stored lists untouched.
 
 Headless weston because the harness opens a window; weston implements no
 wlr-layer-shell, so the real session lock surface is outside what this can
-say. Skips when weston or qs is missing, as in CI.
+say.
+
+A PRIVATE session bus, for the same reason the runtime dir is private: the
+left island's `username` and `keyboardLayout` slots hide while a media player
+is registered (`LockSurface.islandItemVisible`), so on the user's own session
+bus a browser holding an MPRIS name makes both invisible and the drag lands on
+nothing - the test then passes or fails on whether a tab was playing. Skips
+when weston, qs or dbus-run-session is missing, as in CI.
 """
 
 import os
@@ -45,10 +52,12 @@ def _stop(proc):
 
 
 def _runtime_available():
-    return shutil.which("qs") is not None and shutil.which("weston") is not None
+    return all(shutil.which(binary) is not None
+               for binary in ("qs", "weston", "dbus-run-session"))
 
 
-@unittest.skipUnless(_runtime_available(), "needs qs and weston on PATH")
+@unittest.skipUnless(_runtime_available(),
+                     "needs qs, weston and dbus-run-session on PATH")
 class LockIslandReorderRuntimeTest(unittest.TestCase):
     def setUp(self):
         self.home = Path(tempfile.mkdtemp(prefix="imi-lock-islands-"))
@@ -85,8 +94,12 @@ class LockIslandReorderRuntimeTest(unittest.TestCase):
         env["XDG_CONFIG_HOME"] = str(self.home / "config")
         env["XDG_STATE_HOME"] = str(self.home / "state")
 
-        proc = subprocess.run(["qs", "-p", str(HARNESS)], cwd=str(ROOT), env=env,
-                              capture_output=True, text=True, timeout=240)
+        # dbus-run-session, not the inherited DBUS_SESSION_BUS_ADDRESS: the
+        # harness must see the services this test declares, never the ones the
+        # user happens to be running.
+        proc = subprocess.run(
+            ["dbus-run-session", "--", "qs", "-p", str(HARNESS)],
+            cwd=str(ROOT), env=env, capture_output=True, text=True, timeout=240)
         output = proc.stdout + proc.stderr
         failed = [line for line in output.splitlines() if "FAIL" in line]
         self.assertEqual(failed, [], f"harness reported failures:\n{output}")


### PR DESCRIPTION
Merging stages 5-10 turned up a check that fails on the maintainer's machine
and passes everywhere else, with the shell's code identical.

`test_lock_island_reorder_runtime.py` isolates everything except the session
bus: its own `XDG_RUNTIME_DIR`, its own headless weston, its own config and
state home, `HYPRLAND_INSTANCE_SIGNATURE` popped so it can never reach the
user's compositor — and then inherits `DBUS_SESSION_BUS_ADDRESS`.

`LockSurface.islandItemVisible` hides `username` and `keyboardLayout` while a
media player is registered. On the maintainer's session a browser holds an
MPRIS name, so both slots are invisible, the left island's step drags from one
invisible slot to another, and the commit that check reads never happens.
Measured before assuming: the harness reported `slot username visible=false`,
`slot keyboardLayout visible=false`, `slot media visible=true w=356`, and the
stored list came back byte-identical to what the step had written.

CI never saw it. The runner has no player, and it skips this test for want of
`qs` on PATH — so the whole runtime layer of stage 9b merged unexercised by CI
and green only where a control was missing.

## The fix, and the control

`dbus-run-session --` in front of the launch: a bus with nothing on it, which
is exactly what the test means by "no player". Verified on the same machine in
the same minute with the browser still registered — the failure reproduced 2/2
before, and the test passes after. The full suite is green locally
(1049 unittest checks, 1011 QML checks, 0 failed).

## The mechanization

`tests/lint_runtime_bus_isolation.py`. The rule was already written down twice
— AGENT.md's "a measurement needs a control", and this harness's own comment
about isolation — and the harness broke it while doing everything else right,
so it becomes a check rather than a third note.

A harness "decides" its bus with `dbus-run-session` or with a
`DBUS_SESSION_BUS_ADDRESS` it starts itself (which
`test_notification_cards_runtime.py` needs). The 33 harnesses still on the
inherited bus are a register, not a bulk fix: `dbus-run-session` starts a bus
with NOTHING on it, so a harness quietly depending on a real service would
start failing for a new reason, and 33 unverified changes to tests whose job is
to be trustworthy is worse than 33 known ones. It ratchets both ways — a new
harness outside the register fails, and a registered one that starts isolating
fails until it is removed.

Both failure modes planted and proven in a clean tree:

- an unregistered harness launching `qs` → `launches \`qs\` on the inherited
  session bus`
- a registered harness gaining isolation → `now decides its own session bus.
  Remove it from EXISTING`

Docs: updated AGENT.md §the lock islands' reorder (the session bus is part of
the harness isolation rule, the MPRIS visibility trap, and the new lint).
