### PR TITLE
The drawer's chrome rows stop competing with its list

### DIFF
--- a/dots/.config/quickshell/imi/EditModeDrawerLayoutProbe.qml
+++ b/dots/.config/quickshell/imi/EditModeDrawerLayoutProbe.qml
@@ -1,0 +1,80 @@
+import QtQuick
+import Quickshell
+import qs
+import qs.modules.common
+import qs.modules.imi.editMode
+
+/*
+ * What the drawer's column gives its list, in pixels.
+ *
+ * The drawer is a ColumnLayout of three chrome rows and one ListView per
+ * section. `QtQuick.Layouts` defaults `Layout.fillHeight` to TRUE for a Layout
+ * nested in a Layout, so the header row, the section tabs and the bar's bucket
+ * picker all fill unless they say otherwise - and they compete with the list,
+ * whose own implicitHeight is 0. The tab row won: it took 831 of 936 px, the
+ * list was left 24, and the toggled section chip - `leftRadius: height / 2` -
+ * painted an 831px stadium down the whole panel.
+ *
+ * Nothing in the source shows it. Every binding involved is correct on its own,
+ * the failure is a distribution, and it is only visible as a picture. So this
+ * probe reads the geometry back out of a real EditModeChromeContent and
+ * tests/test_edit_mode_drawer_layout.py asserts what the numbers must be.
+ */
+ShellRoot {
+    FloatingWindow {
+        id: win
+        implicitWidth: 1500
+        implicitHeight: 1200
+        visible: true
+
+        Component.onCompleted: {
+            GlobalStates.editMode = true;
+            GlobalStates.editDrawerOpen = true;
+            GlobalStates.editProgress = 1;
+        }
+
+        EditModeChromeContent {
+            id: chrome
+            anchors.fill: parent
+            card: Qt.rect(120, 120, 900, 900)
+            area: Qt.rect(0, 0, win.width, win.height)
+            drawer: Qt.rect(1100, 120, 370, 960)
+        }
+
+        // The drawer's own column, found by shape rather than by id: the probe
+        // reaches across a component boundary, and an id would be a second
+        // copy of the drawer's internals to keep right.
+        function columnOf(item) {
+            for (const child of item.children) {
+                if (child.toString().startsWith("QQuickColumnLayout"))
+                    return child;
+                const found = win.columnOf(child);
+                if (found)
+                    return found;
+            }
+            return null;
+        }
+
+        Timer {
+            running: true
+            interval: 2500
+            onTriggered: {
+                const column = win.columnOf(chrome.drawerItem);
+                if (!column) {
+                    console.log("[DRAWER] no column found");
+                    Qt.quit();
+                    return;
+                }
+                console.log("[DRAWER] column h=" + Math.round(column.height));
+                for (const child of column.children) {
+                    if (!child.visible)
+                        continue;
+                    console.log("[DRAWER] child " + child.toString().split("(")[0]
+                        + " h=" + Math.round(child.height));
+                }
+                console.log("[DRAWER] done");
+                Qt.quit();
+            }
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/modules/imi/editMode/EditModeDrawer.qml
+++ b/dots/.config/quickshell/imi/modules/imi/editMode/EditModeDrawer.qml
@@ -130,6 +130,11 @@ Item {
 
             RowLayout {
                 Layout.fillWidth: true
+                // A Layout nested in a Layout defaults to fillHeight TRUE, and
+                // a row of chrome that fills is a row that competes with the
+                // list below it for the column's height. Stated on every row
+                // here, never inherited.
+                Layout.fillHeight: false
                 Layout.leftMargin: Appearance.spacing.space75
                 Layout.rightMargin: Appearance.spacing.space75
                 spacing: Appearance.spacing.space100
@@ -150,6 +155,7 @@ Item {
             // One chip per target surface.
             RowLayout {
                 Layout.fillWidth: true
+                Layout.fillHeight: false
                 Layout.leftMargin: Appearance.spacing.space75
                 spacing: Appearance.spacing.space25
 
@@ -179,6 +185,7 @@ Item {
 
             StyledText {
                 Layout.fillWidth: true
+                Layout.fillHeight: false
                 Layout.leftMargin: Appearance.spacing.space75
                 Layout.rightMargin: Appearance.spacing.space75
                 text: root.section === "widgets"
@@ -324,6 +331,7 @@ Item {
             RowLayout {
                 visible: root.section === "bar"
                 Layout.fillWidth: true
+                Layout.fillHeight: false
                 Layout.leftMargin: Appearance.spacing.space75
                 spacing: Appearance.spacing.space25
 

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -382,6 +382,15 @@ if ! python3 "$SCRIPT_DIR/test_edit_mode_chrome.py"; then
     exit 1
 fi
 
+# The drawer's column distributes its height, and a chrome row that fills eats
+# the list: stage 5 shipped with the tab row at 831px of 936 and the list at 24,
+# which no source check can see.
+echo "Running edit mode drawer layout tests..."
+if ! python3 "$SCRIPT_DIR/test_edit_mode_drawer_layout.py"; then
+    echo "Edit mode drawer layout tests failed."
+    exit 1
+fi
+
 echo "Running dock position contract tests..."
 if ! python3 "$SCRIPT_DIR/test_dock_position_contract.py"; then
     echo "Dock position contract tests failed."

--- a/dots/.config/quickshell/imi/tests/test_edit_mode_drawer_layout.py
+++ b/dots/.config/quickshell/imi/tests/test_edit_mode_drawer_layout.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""The drawer's list gets the drawer's height; its chrome rows take what they need.
+
+`EditModeDrawer`'s ColumnLayout holds three chrome rows - the "Add" header, the
+section tabs, the bar's bucket picker - and one ListView per section. A Layout
+nested in a Layout defaults to `Layout.fillHeight: true`, so each of those rows
+fills unless it says otherwise, and they compete with the ListView, whose own
+implicitHeight is 0.
+
+That competition shipped in stage 5. The section tab row took 831px of a 936px
+column, the widget list was left 24, and the toggled chip - whose radius is
+`height / 2` - painted an 831px stadium down the whole panel with the list
+invisible behind it. Every binding in the file was individually right; the
+failure was the distribution, and the only place it appeared was on screen.
+
+Headless weston with its own runtime dir and a private session bus, like every
+other harness here: this builds the real `EditModeChromeContent`, and the numbers
+it reads must not depend on the developer's session. Skips when weston, qs or
+dbus-run-session is missing, as in CI.
+"""
+
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HARNESS = ROOT / "EditModeDrawerLayoutProbe.qml"
+SOCKET = "wl-imi-drawer"
+
+# The list must get most of the column. Not "more than the rows" - that is true
+# at 300px too, and 300px of list under 600px of chrome is the same defect one
+# size down.
+MINIMUM_LIST_SHARE = 0.75
+# A chrome row is a row of chips: one line of them, never a panel.
+MAXIMUM_ROW_HEIGHT = 120
+
+CHILD = re.compile(r"\[DRAWER\] child (\S+) h=(\d+)")
+COLUMN = re.compile(r"\[DRAWER\] column h=(\d+)")
+
+
+def _stop(proc):
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+
+
+def _runtime_available():
+    return all(shutil.which(binary) is not None
+               for binary in ("qs", "weston", "dbus-run-session"))
+
+
+@unittest.skipUnless(_runtime_available(),
+                     "needs qs, weston and dbus-run-session on PATH")
+class EditModeDrawerLayoutTest(unittest.TestCase):
+    def setUp(self):
+        # A SHORT prefix, deliberately: a Wayland socket path is capped at 108
+        # bytes including the null, and the scratch dirs these runs get are
+        # long enough that a descriptive prefix pushes weston past it - the
+        # failure is `socket path ... exceeds 108 bytes`, from weston, before
+        # anything under test has run.
+        self.home = Path(tempfile.mkdtemp(prefix="imid-"))
+        self.addCleanup(shutil.rmtree, self.home, ignore_errors=True)
+
+    def test_the_list_gets_the_column_and_the_chrome_rows_do_not(self):
+        env = dict(os.environ)
+        runtime = self.home / "rt"
+        runtime.mkdir(mode=0o700)
+        env["XDG_RUNTIME_DIR"] = str(runtime)
+        env["WAYLAND_DISPLAY"] = SOCKET
+        env.pop("DISPLAY", None)
+        env.pop("HYPRLAND_INSTANCE_SIGNATURE", None)
+
+        weston = subprocess.Popen(
+            ["weston", "--backend=headless", "--renderer=pixman",
+             f"--socket={SOCKET}", "--width=1500", "--height=1200"],
+            env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        self.addCleanup(_stop, weston)
+
+        socket_path = runtime / SOCKET
+        deadline = time.monotonic() + 15
+        while not socket_path.exists() and time.monotonic() < deadline:
+            time.sleep(0.2)
+        self.assertTrue(socket_path.exists(), "headless weston never came up")
+
+        env["LIBGL_ALWAYS_SOFTWARE"] = "1"
+        env["QT_QUICK_BACKEND"] = "software"
+        env["XDG_CONFIG_HOME"] = str(self.home / "config")
+        env["XDG_STATE_HOME"] = str(self.home / "state")
+
+        proc = subprocess.run(
+            ["dbus-run-session", "--", "qs", "-p", str(HARNESS)],
+            cwd=str(ROOT), env=env, capture_output=True, text=True, timeout=240)
+        output = proc.stdout + proc.stderr
+        self.assertIn("[DRAWER] done", output, f"probe did not finish:\n{output}")
+
+        column = COLUMN.search(output)
+        self.assertIsNotNone(column, f"probe found no column:\n{output}")
+        column_height = int(column.group(1))
+        self.assertGreater(column_height, 400,
+                           f"the drawer's column is not open:\n{output}")
+
+        children = [(name, int(height)) for name, height in CHILD.findall(output)]
+        self.assertTrue(children, f"probe listed no children:\n{output}")
+
+        lists = [height for name, height in children if "ListView" in name]
+        self.assertTrue(lists, f"the widgets section shows no list:\n{output}")
+        share = max(lists) / column_height
+        self.assertGreaterEqual(
+            share, MINIMUM_LIST_SHARE,
+            f"the drawer's list got {share:.0%} of its {column_height}px column "
+            f"and needs at least {MINIMUM_LIST_SHARE:.0%}. A chrome row is "
+            f"filling: a Layout nested in a Layout defaults to "
+            f"Layout.fillHeight true, so every row in that column must state "
+            f"`Layout.fillHeight: false`.\n{output}")
+
+        for name, height in children:
+            if "ListView" in name:
+                continue
+            self.assertLessEqual(
+                height, MAXIMUM_ROW_HEIGHT,
+                f"{name} is {height}px tall in a {column_height}px column - a "
+                f"chrome row is one line of chips, and a filling one paints "
+                f"its toggled chip as a full-height stadium "
+                f"(`leftRadius: height / 2`).\n{output}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The drawer painted a full-height stadium down its own panel with the widget
list invisible behind it.

## What it actually was

Measured on the real `EditModeChromeContent` under headless weston, not read
off the screenshot:

```
QQuickColumnLayout  h=936
  QQuickRowLayout   h=27     <- the "Add" header
  QQuickRowLayout   h=831    <- the section tabs
  StyledText        h=30     <- the hint
  QQuickListView    h=24     <- the widgets
```

`QtQuick.Layouts` defaults `Layout.fillHeight` to **true** for a Layout nested
in a Layout. All three of the drawer's chrome rows are `RowLayout`s inside the
drawer's `ColumnLayout`, so all three filled, and they shared the height with a
`ListView` whose own `implicitHeight` is 0. The tab row won 831 of 936px.

`SelectionGroupButton` takes `leftRadius: height / 2` when toggled, so the
"Widgets" chip at 831px tall drew as a stadium in `colSecondaryContainer` —
the grey slab in the report — and the list it had squeezed to 24px was behind
it.

Every binding in the file is individually correct. The failure is a
distribution, which is why nothing in the source shows it.

## The fix

`Layout.fillHeight: false` on each of the three chrome rows and the hint text.
After: tab row `h=33`, list `h=822`.

## The check

`test_edit_mode_drawer_layout.py` reads the geometry back out of the real
chrome. Two assertions, because "the list is bigger than the rows" is also true
at 300px of list under 600px of chrome — the same defect one size down:

- the list takes at least 75% of the column;
- no chrome row exceeds 120px.

Planted by dropping the tab row's `Layout.fillHeight: false`: the list got 3%
of its 936px column, and the failure message names the cause. Runs on a private
session bus per `lint_runtime_bus_isolation.py`, and takes a short tmpdir prefix
because a Wayland socket path is capped at 108 bytes including the null — a
descriptive prefix pushes weston past it and the run dies before anything under
test executes.

Docs: not needed — a layout distribution fixed at its own call sites, with the
rule stated in the probe's and the test's headers where the next reader of that
column will be.
