### PR TITLE
The Lockscreen tab carries the palette with it

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -2880,6 +2880,23 @@ mode is built out of are worth not re-deriving:
   feat(lock): island contents reorder in the mode;
   test(lock): the reorder harness gets a session bus of its own;
   test(lint): a qs harness must decide which session bus it talks to.)
+- **"The lock's look is on screen" is ONE derivation, and the palette is one
+  of the things it decides.** `GlobalStates.lockLookActive` is
+  `screenLocked || editLockPreview`, and it sits beside `editLockPreview`
+  rather than replacing it because the two answer different questions:
+  `editLockPreview` decides which SOURCE a layer draws, which every layer
+  answers for itself, and `lockLookActive` decides which THEME the picture is
+  in, of which the shell has exactly one. The disjunction had been written out
+  at six sites across three files and the seventh — `MaterialThemeLoader.
+  lockThemeActive` and Appearance's `wallColorQuant`, which the transparency
+  is derived from — was missed, so Edit Mode's Lockscreen tab drew the lock's
+  wallpaper under the desktop's colours. Six copies of a question is how the
+  seventh gets forgotten. `test_edit_mode_contract.py` pins the definition as
+  well as the sites, because every gate now reads it and a narrowed definition
+  un-filters all of them at once.
+  (feat(editMode): one derivation of "the lock's look is on screen";
+  fix(editMode): the Lockscreen tab carries the palette with it;
+  test(editMode): the tab's palette is driven, and the derivation is pinned.)
 - **A dragged widget holds a neighbour's edge through a Schmitt trigger, and
   both thresholds read the SHADOW — stage 10, spec §6.**
   `modules/common/functions/edge_snap.js` owns the arithmetic: four relations

--- a/dots/.config/quickshell/imi/GlobalStates.qml
+++ b/dots/.config/quickshell/imi/GlobalStates.qml
@@ -123,6 +123,20 @@ Singleton {
     readonly property bool editLockPreview: root.editMode
         && root.editTab === EditMode.LOCKSCREEN_TAB
 
+    // "The lock's LOOK is on screen" - the real lock session OR the tab that
+    // filters the viewport into it. Separate from `editLockPreview` because
+    // the two questions have different consumers: the wallpaper, the islands
+    // and the widget filter ask which SOURCE to draw, and answer it per layer;
+    // the palette and the wallpaper's quantizer ask which THEME the picture is
+    // in, and there is only one of those for the whole shell.
+    //
+    // Stated here rather than spelled out at each site for the reason above:
+    // the theme sites keyed on `screenLocked` alone, so the tab switched every
+    // layer's source to the lock's and left the colours the desktop's - the
+    // preview showed the lock's wallpaper under the desktop's palette, which
+    // is a picture the lock screen never shows.
+    readonly property bool lockLookActive: root.screenLocked || root.editLockPreview
+
     // The drawer - Edit Mode's catalogue of desktop widgets. Session state for
     // the same reason the mode is, and beside it for the same reason the
     // progress is: the desktop it translates and the panel that slides in are

--- a/dots/.config/quickshell/imi/LockLookProbe.qml
+++ b/dots/.config/quickshell/imi/LockLookProbe.qml
@@ -1,0 +1,74 @@
+import QtQuick
+import Quickshell
+import qs
+import qs.services
+import qs.modules.common
+import "modules/common/functions/edit_mode.js" as EditMode
+
+/*
+ * Does the lock's PALETTE follow the Lockscreen tab?
+ *
+ * Stage 9 switched every layer's SOURCE on `editLockPreview` - wallpaper, WE
+ * project, islands, the widget filter - and left the theme keyed on
+ * `screenLocked` alone. So the tab drew the lock's wallpaper under the
+ * desktop's colours, which is a picture the lock screen never shows.
+ *
+ * The two things that decide the palette are read here directly: the theme
+ * loader's own gate, and the quantizer path Appearance derives transparency
+ * from. Neither needs matugen to have run - what is under test is which
+ * wallpaper the palette is being taken FROM, not the palette itself.
+ */
+ShellRoot {
+    FloatingWindow {
+        implicitWidth: 400
+        implicitHeight: 300
+        visible: true
+
+        Timer {
+            running: true
+            interval: 1200
+            onTriggered: {
+                Config.options.background.lockWall = Quickshell.shellPath("tests/fixtures/colorful_64.png");
+                Config.options.background.wallpaperPath = Quickshell.shellPath("tests/fixtures/low_chroma_64.png");
+                report.restart();
+            }
+        }
+
+        Timer {
+            id: report
+            interval: 800
+            onTriggered: {
+                console.log("[LOCKLOOK] desktop tab: lockLookActive="
+                    + GlobalStates.lockLookActive
+                    + " lockThemeActive=" + MaterialThemeLoader.lockThemeActive);
+                GlobalStates.editMode = true;
+                GlobalStates.editTab = EditMode.LOCKSCREEN_TAB;
+                afterTab.restart();
+            }
+        }
+
+        Timer {
+            id: afterTab
+            interval: 800
+            onTriggered: {
+                console.log("[LOCKLOOK] lock tab: lockLookActive="
+                    + GlobalStates.lockLookActive
+                    + " lockThemeActive=" + MaterialThemeLoader.lockThemeActive);
+                GlobalStates.editTab = EditMode.DESKTOP_TAB;
+                afterBack.restart();
+            }
+        }
+
+        Timer {
+            id: afterBack
+            interval: 800
+            onTriggered: {
+                console.log("[LOCKLOOK] back: lockLookActive="
+                    + GlobalStates.lockLookActive
+                    + " lockThemeActive=" + MaterialThemeLoader.lockThemeActive);
+                console.log("[LOCKLOOK] done");
+                Qt.quit();
+            }
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/modules/common/Appearance.qml
+++ b/dots/.config/quickshell/imi/modules/common/Appearance.qml
@@ -28,7 +28,7 @@ Singleton {
     // Transparency. The quadratic functions were derived from analysis of hand-picked transparency values.
     ColorQuantizer {
         id: wallColorQuant
-        property string wallpaperPath: (GlobalStates.screenLocked && Config.options.background.lockWall !== "")
+        property string wallpaperPath: (GlobalStates.lockLookActive && Config.options.background.lockWall !== "")
             ? Config.options.background.lockWall
             : Config.options.background.wallpaperPath
         property bool wallpaperIsVideo: wallpaperPath.endsWith(".mp4") || wallpaperPath.endsWith(".webm") || wallpaperPath.endsWith(".mkv") || wallpaperPath.endsWith(".avi") || wallpaperPath.endsWith(".mov")

--- a/dots/.config/quickshell/imi/modules/imi/background/Background.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/Background.qml
@@ -270,13 +270,15 @@ Variants {
             GlobalStates.clockDepthViewports = published
         }
 
-        // The lock terms below say `screenLocked || editLockPreview` because
-        // Edit Mode's Lockscreen tab is a FILTER on this viewport (spec §1.4):
+        // The lock terms below read `GlobalStates.lockLookActive` - the one
+        // spelling of "the lock's look is on screen", which is the session
+        // lock OR Edit Mode's Lockscreen tab - because that tab is a FILTER on
+        // this viewport (spec §1.4):
         // it switches these same layers to their locked inputs rather than
         // drawing a second copy of any of them, so the preview inside the
         // shrunk card is the picture the lock screen will actually show.
         property string effectiveWallpaperPath: {
-            if ((GlobalStates.screenLocked || GlobalStates.editLockPreview)
+            if (GlobalStates.lockLookActive
                     && Config.options.background.lockWall !== "")
                 return Config.options.background.lockWall
             return Wallpapers.previewPath || Wallpapers.confirmedPath || Config.options.background.wallpaperPath
@@ -290,7 +292,7 @@ Variants {
         // on unlock): the WE surface reloads the lock project and the existing
         // WE<->WE peel plays, so one renderer covers both - no second surface.
         property string weProjectPath: {
-            if ((GlobalStates.screenLocked || GlobalStates.editLockPreview)
+            if (GlobalStates.lockLookActive
                     && Config.options.background.lockWallEngine !== "")
                 return Config.options.background.lockWallEngine
             return Config.options.wallpaperSelector.wallpaperEngine.activePath ?? ""
@@ -326,7 +328,7 @@ Variants {
         // Image lock wallpaper only. A WE lock wallpaper (lockWallEngine set) is
         // served by switching weProjectPath instead, so exclude it here even though
         // its preview lives in lockWall for palette generation.
-        property bool lockWallShown: (GlobalStates.screenLocked || GlobalStates.editLockPreview)
+        property bool lockWallShown: GlobalStates.lockLookActive
             && Config.options.background.lockWall !== ""
             && Config.options.background.lockWallEngine === "" && bgRoot.weActive
         property bool lockRevealWe: false // true = peeling back to WE (unlock)
@@ -1037,8 +1039,7 @@ Variants {
                 // Lockscreen tab shows the lock's own blur inside the shrunk
                 // card, through this same loader - a child of the viewport, so
                 // it takes the edit transform with everything else in here.
-                readonly property bool lockLook: GlobalStates.screenLocked
-                    || GlobalStates.editLockPreview
+                readonly property bool lockLook: GlobalStates.lockLookActive
                 active: Config.options.lock.blur.enable && (blurLoader.lockLook || scaleAnim.running)
                 anchors.fill: parent
                 scale: blurLoader.lockLook ? Config.options.lock.blur.extraZoom : 1

--- a/dots/.config/quickshell/imi/modules/imi/background/widgets/AbstractBackgroundWidget.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/widgets/AbstractBackgroundWidget.qml
@@ -26,7 +26,7 @@ AbstractWidget {
     // `editLockPreview` beside the real lock: Edit Mode's Lockscreen tab shows
     // the widgets the lock screen will show, through this same filter rather
     // than a second one that could disagree with it.
-    opacity: ((GlobalStates.screenLocked || GlobalStates.editLockPreview) && !visibleWhenLocked) ? 0 : 1
+    opacity: (GlobalStates.lockLookActive && !visibleWhenLocked) ? 0 : 1
     Behavior on opacity {
         animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
     }

--- a/dots/.config/quickshell/imi/services/MaterialThemeLoader.qml
+++ b/dots/.config/quickshell/imi/services/MaterialThemeLoader.qml
@@ -41,7 +41,7 @@ Singleton {
         m3onTertiaryContainer: true
     })
     readonly property int colorTransitionDuration: Appearance.animation.elementMoveFast.duration
-    readonly property bool lockThemeActive: GlobalStates.screenLocked
+    readonly property bool lockThemeActive: GlobalStates.lockLookActive
         && Config.options.background.lockWall !== ""
 
     function reapplyTheme() {
@@ -178,7 +178,7 @@ Singleton {
 
     function handleLockStateChange() {
         const wallpaper = Config.options.background.lockWall;
-        if (!GlobalStates.screenLocked || wallpaper === "") {
+        if (!GlobalStates.lockLookActive || wallpaper === "") {
             const normalColors = themeFileView.text();
             if (normalColors && normalColors.trim() !== "")
                 root.scheduleTheme(normalColors, false, false);
@@ -248,7 +248,7 @@ Singleton {
         interval: Appearance.animation.elementMoveFast.duration
         onTriggered: {
             if (root.pendingThemeColors === ""
-                    || root.pendingThemeForLockedState !== GlobalStates.screenLocked) return;
+                    || root.pendingThemeForLockedState !== GlobalStates.lockLookActive) return;
             if (root.pendingThemeIsGenerated)
                 root.applyGeneratedColors(root.pendingThemeColors);
             else
@@ -275,9 +275,12 @@ Singleton {
         }
     }
 
+    // One handler for both ways the lock's look arrives: the session lock and
+    // Edit Mode's Lockscreen tab. The tab is a filter on the same layers
+    // (spec 1.4), so the palette it shows has to be the locked one too.
     Connections {
         target: GlobalStates
-        function onScreenLockedChanged() { root.handleLockStateChange(); }
+        function onLockLookActiveChanged() { root.handleLockStateChange(); }
     }
 
     Connections {

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -429,6 +429,16 @@ fi
 # real LockSurface with the preview context - the overlay's eater, the shared
 # gesture, move semantics, the storedOrder merge, and both cancel paths.
 # Brings its own headless weston.
+# The Lockscreen tab is a filter on the desktop viewport, and the palette is one
+# of the things it filters: stage 9 switched every layer's source and left the
+# theme keyed on the session lock, so the tab drew the lock's wallpaper under
+# the desktop's colours.
+echo "Running lock look palette tests..."
+if ! python3 "$SCRIPT_DIR/test_lock_look_palette.py"; then
+    echo "Lock look palette tests failed."
+    exit 1
+fi
+
 echo "Running lock island reorder runtime tests..."
 if ! python3 "$SCRIPT_DIR/test_lock_island_reorder_runtime.py"; then
     echo "Lock island reorder runtime tests failed."

--- a/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
@@ -74,6 +74,8 @@ PLUGIN_WIDGET = ROOT / "modules/common/plugins/PluginWidget.qml"
 CLOCK_DEPTH = ROOT / "modules/common/functions/clockDepth.js"
 CARD = ROOT / "modules/imi/background/EditModeCard.qml"
 LOOK_PROBE = ROOT / "EditModeLookProbe.qml"
+THEME_LOADER = ROOT / "services/MaterialThemeLoader.qml"
+APPEARANCE = ROOT / "modules/common/Appearance.qml"
 CHROME_SCOPE = ROOT / "modules/imi/editMode/EditModeChrome.qml"
 CHROME_SURFACE = ROOT / "modules/imi/editMode/EditModeChromeSurface.qml"
 CHROME_CONTENT = ROOT / "modules/imi/editMode/EditModeChromeContent.qml"
@@ -1093,38 +1095,63 @@ def test_the_tab_is_a_string_beside_the_mode_and_dies_with_it():
          "would greet the next entry already filtered to the lock screen")
 
 
+# "The lock's look is on screen" - either spelled out, or read off the one
+# derivation in GlobalStates. The disjunction was written at six sites and a
+# seventh (the palette) was missed, so the property exists and the sites read
+# it; the check below pins its DEFINITION, and every site may use either form.
+LOCK_LOOK = (r"(?:GlobalStates\.lockLookActive"
+             r"|GlobalStates\.screenLocked\s*\n?\s*\|\|\s*"
+             r"GlobalStates\.editLockPreview)")
+
+
 def test_the_viewport_draws_its_locked_inputs_on_the_lockscreen_tab():
     # Spec §4.3: the tab switches the viewport's wallpaper and blur to their
     # locked inputs - a gate change on things Background.qml already draws,
-    # with `GlobalStates.editLockPreview` joining `GlobalStates.screenLocked`
-    # in each gate rather than a second copy of any layer. Each binding is
-    # named individually because a missing term here is silent: the tab
-    # simply previews the wrong wallpaper, on machines that configured a lock
-    # wallpaper, which is not every machine.
+    # with the preview joining the session lock in each gate rather than a
+    # second copy of any layer. Each binding is named individually because a
+    # missing term here is silent: the tab simply previews the wrong
+    # wallpaper, on machines that configured a lock wallpaper, which is not
+    # every machine.
+    states = code(GLOBAL_STATES)
+    look = declaration(states, "lockLookActive")
+    assert look and re.search(r"screenLocked\s*\|\|\s*"
+                              r"root\.editLockPreview", look), \
+        ("GlobalStates.lockLookActive must stay `screenLocked || "
+         "editLockPreview` - every gate below reads it, so a narrowed "
+         "definition silently un-filters all of them at once")
     background = code(BACKGROUND)
     for name in ("effectiveWallpaperPath", "weProjectPath"):
         value = declaration(background, name)
         assert value, f"Background no longer declares {name}"
-        assert re.search(r"GlobalStates\.screenLocked\s*\|\|\s*"
-                         r"GlobalStates\.editLockPreview", value), \
+        assert re.search(LOCK_LOOK, value), \
             f"{name} does not take the lock preview's term"
     lock_wall = declaration(background, "lockWallShown")
-    assert lock_wall and re.search(
-        r"\(GlobalStates\.screenLocked\s*\|\|\s*GlobalStates\.editLockPreview\)",
-        lock_wall), "lockWallShown does not take the lock preview's term"
+    assert lock_wall and re.search(LOCK_LOOK, lock_wall), \
+        "lockWallShown does not take the lock preview's term"
     blur = re.search(r"id:\s*blurLoader\n(.*?)sourceComponent:", background, re.S)
     assert blur, "the lock blur loader is gone"
-    assert re.search(r"lockLook:\s*GlobalStates\.screenLocked\s*\n?\s*\|\|\s*"
-                     r"GlobalStates\.editLockPreview", blur.group(1)), \
+    assert re.search(r"lockLook:\s*" + LOCK_LOOK, blur.group(1)), \
         "the lock blur's lockLook must cover the preview"
     assert re.search(r"active:.*lockLook", blur.group(1)), \
         "the lock blur must be active for the locked look"
     # And the widget filter: the tab shows the widgets the lock screen will.
     widget = code(BACKGROUND_WIDGET)
-    assert re.search(r"opacity:\s*\(\(GlobalStates\.screenLocked\s*\|\|\s*"
-                     r"GlobalStates\.editLockPreview\)\s*&&\s*!visibleWhenLocked\)",
+    assert re.search(r"opacity:\s*\(" + LOCK_LOOK + r"\s*&&\s*!visibleWhenLocked\)",
                      widget), \
         "AbstractBackgroundWidget's lock filter does not cover the preview"
+    # The palette is a locked input too, and the one that was missed: the tab
+    # switched every SOURCE and left the colours the desktop's.
+    theme = code(THEME_LOADER)
+    gate = declaration(theme, "lockThemeActive")
+    assert gate and re.search(LOCK_LOOK, gate), \
+        ("MaterialThemeLoader.lockThemeActive must cover the preview, or the "
+         "Lockscreen tab shows the lock's wallpaper under the desktop's "
+         "palette")
+    appearance = code(APPEARANCE)
+    quantizer = re.search(r"id:\s*wallColorQuant\n(.*?)\n    \}", appearance, re.S)
+    assert quantizer and re.search(LOCK_LOOK, quantizer.group(1)), \
+        ("Appearance's wallpaper quantizer must cover the preview - it is "
+         "what the shell's transparency is derived from")
 
 
 def test_the_islands_ride_the_edit_transform_above_the_widgets():

--- a/dots/.config/quickshell/imi/tests/test_lock_look_palette.py
+++ b/dots/.config/quickshell/imi/tests/test_lock_look_palette.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""The lock's palette follows the Lockscreen tab, not just the session lock.
+
+Edit Mode's Lockscreen tab is a FILTER on the desktop viewport (spec §1.4): it
+switches the same layers to their locked inputs rather than drawing a second
+copy of anything. Stage 9 switched every SOURCE that way - wallpaper, Wallpaper
+Engine project, the islands host, the widget filter - and left the two places
+that decide the PALETTE keyed on `GlobalStates.screenLocked` alone:
+`MaterialThemeLoader.lockThemeActive` and Appearance's wallpaper quantizer.
+
+So the tab drew the lock's wallpaper under the desktop's colours - a picture
+the lock screen never shows, and the state the maintainer reported as "switching
+to lockscreen does not change the widgets' colors".
+
+`GlobalStates.lockLookActive` is the one spelling of "the lock's look is on
+screen" and both sites now read it. This drives the tab and reads the gate back;
+matugen never has to run, because what is under test is which wallpaper the
+palette is taken FROM, not the palette itself.
+
+Skips when weston, qs or dbus-run-session is missing, as in CI.
+"""
+
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HARNESS = ROOT / "LockLookProbe.qml"
+SOCKET = "wl-imi-locklook"
+
+LINE = re.compile(r"\[LOCKLOOK\] (\S+[^:]*): lockLookActive=(\w+) lockThemeActive=(\w+)")
+
+
+def _stop(proc):
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+
+
+def _runtime_available():
+    return all(shutil.which(binary) is not None
+               for binary in ("qs", "weston", "dbus-run-session"))
+
+
+@unittest.skipUnless(_runtime_available(),
+                     "needs qs, weston and dbus-run-session on PATH")
+class LockLookPaletteTest(unittest.TestCase):
+    def setUp(self):
+        # Short prefix: a Wayland socket path is capped at 108 bytes including
+        # the null, and a descriptive one under a long scratch dir dies in
+        # weston before anything under test runs.
+        self.home = Path(tempfile.mkdtemp(prefix="imil-"))
+        self.addCleanup(shutil.rmtree, self.home, ignore_errors=True)
+
+    def test_the_tab_carries_the_palette_with_it(self):
+        env = dict(os.environ)
+        runtime = self.home / "rt"
+        runtime.mkdir(mode=0o700)
+        env["XDG_RUNTIME_DIR"] = str(runtime)
+        env["WAYLAND_DISPLAY"] = SOCKET
+        env.pop("DISPLAY", None)
+        env.pop("HYPRLAND_INSTANCE_SIGNATURE", None)
+
+        weston = subprocess.Popen(
+            ["weston", "--backend=headless", "--renderer=pixman",
+             f"--socket={SOCKET}", "--width=800", "--height=600"],
+            env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        self.addCleanup(_stop, weston)
+
+        socket_path = runtime / SOCKET
+        deadline = time.monotonic() + 15
+        while not socket_path.exists() and time.monotonic() < deadline:
+            time.sleep(0.2)
+        self.assertTrue(socket_path.exists(), "headless weston never came up")
+
+        env["LIBGL_ALWAYS_SOFTWARE"] = "1"
+        env["QT_QUICK_BACKEND"] = "software"
+        env["XDG_CONFIG_HOME"] = str(self.home / "config")
+        env["XDG_STATE_HOME"] = str(self.home / "state")
+
+        proc = subprocess.run(
+            ["dbus-run-session", "--", "qs", "-p", str(HARNESS)],
+            cwd=str(ROOT), env=env, capture_output=True, text=True, timeout=240)
+        output = proc.stdout + proc.stderr
+        self.assertIn("[LOCKLOOK] done", output, f"probe did not finish:\n{output}")
+
+        states = {stage: (look == "true", theme == "true")
+                  for stage, look, theme in LINE.findall(output)}
+        for stage in ("desktop tab", "lock tab", "back"):
+            self.assertIn(stage, states, f"probe skipped {stage}:\n{output}")
+
+        self.assertEqual(
+            states["desktop tab"], (False, False),
+            f"the desktop tab is showing the lock's look:\n{output}")
+        self.assertEqual(
+            states["lock tab"], (True, True),
+            f"the Lockscreen tab did not carry the palette with it. Both "
+            f"`MaterialThemeLoader.lockThemeActive` and Appearance's wallpaper "
+            f"quantizer must read `GlobalStates.lockLookActive`, or the tab "
+            f"shows the lock's wallpaper under the desktop's colours.\n{output}")
+        self.assertEqual(
+            states["back"], (False, False),
+            f"leaving the tab left the lock's palette applied:\n{output}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Edit Mode's Lockscreen tab showed the lock's wallpaper under the **desktop's**
palette — a picture the lock screen never shows.

## What was missed

Stage 9 built the tab as a filter on the desktop viewport (spec §1.4): the same
layers, switched to their locked inputs. It switched every **source** —
wallpaper, Wallpaper Engine project, the lock blur, the islands host, the
widget filter — and left the two places that decide the **palette** keyed on
`GlobalStates.screenLocked` alone:

- `MaterialThemeLoader.lockThemeActive`, the gate on the whole lock theme;
- `Appearance`'s `wallColorQuant`, which the shell's transparency is derived
  from.

The disjunction `screenLocked || editLockPreview` was spelled out at six sites
across three files. Six copies of a question is how the seventh gets forgotten.

## The fix

`GlobalStates.lockLookActive` — one derivation, read by all of them. It sits
**beside** `editLockPreview`, not instead of it: `editLockPreview` decides which
source a layer draws and every layer answers that for itself, while
`lockLookActive` decides which theme the picture is in, and the shell has
exactly one of those.

## Measured, with a control

Same probe, same process, one line changed:

```
gate on screenLocked    lock tab: lockLookActive=true  lockThemeActive=false
gate on lockLookActive  lock tab: lockLookActive=true  lockThemeActive=true
```

and false again on the way back to the Desktop tab, so the tab does not leave
the lock's palette applied behind it.

## The checks

- `test_lock_look_palette.py` drives the real tab and reads the gate back.
  matugen never runs — what is under test is which wallpaper the palette is
  taken *from*, not the palette itself. Private session bus, per
  `lint_runtime_bus_isolation.py`.
- `test_edit_mode_contract.py` gains the palette's two sites, and pins
  `lockLookActive`'s **definition**: every gate reads it now, so a narrowed
  definition would silently un-filter all of them at once. The existing gates
  accept either spelling, since the derivation and the disjunction are the same
  boolean.

Both planted. The gate reverted to `screenLocked` fails the runtime check with
`lockThemeActive=false` and the contract with the site named; the predicate
narrowed to `screenLocked` fails the definition check.

Suite: 1051 unittest checks, 0 failed, locally.

Docs: updated AGENT.md §Edit Mode (the lock-look derivation, why it sits beside
`editLockPreview`, and the site that was missed).
