### PR TITLE
The shell stops repainting the screen behind a fullscreen game

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -3464,6 +3464,36 @@ straight out of `animationCurves` (a drift risk, not a live defect, and it would
 for no bug). 1c728dd6a ("test(lint): fail on an animation that takes a tier's duration and leaves
 its curve").
 
+**An animation that loops forever must stop when what it animates is off screen, because a
+running animation is a repaint of the whole output — including the parts nobody can see.** The
+chain is not visible from the animation: a running animation writes a property every frame; that
+dirties the scene; a dirty scene makes the shell commit a frame; and a commit makes the
+*compositor* repaint the entire output. So one `RotationAnimation` with `loops: Animation.Infinite`
+in `CookieClock.qml` — 30 seconds per turn, behind an opaque fullscreen game — kept a 5120×1440
+240Hz screen redrawing continuously, and the user reported "my game's FPS is halved when qs is
+running even in fullscreen". It was, and it was that. Measured against FFXIV's own frame counter
+(OCR'd off its System Configuration window, so every state used one instrument): shell stopped
+108, shell stock **52**, the spin gated on `visible` **94**. Found by `QSG_RENDER_TIMING=1` — one
+window syncing at 243Hz for 0ms of render work — and `QT_LOGGING_RULES=qt.quick.dirty=true`
+naming the node. `visible` is *effective* visibility, false while any ancestor is hidden, so the
+animation never has to know why it is off screen. `tests/lint_infinite_animation_visibility.py`
+fails a new ungated one and carries seven registered files whose animations live on surfaces that
+are unmapped when idle, as a ratchet.
+
+Two things about the *surfaces* were learned in the same investigation and are worth stating
+because both look like the fix and one is forbidden. `quickshell:barPopup` — a screen-sized
+surface on the **Overlay** layer hosting the bar's hover cards — was mapped for the whole session
+with nothing in it, and a mapped Overlay surface sits over every fullscreen window; unmapping it
+while idle was worth 98 → 105 and is safe because no renderer lives in it. The **background**
+surface is the same shape one layer down and unmapping it measures better still, and it is
+**pinned mapped** by `test_background_fullscreen_suppression.py`: `visible: false` on a
+WlrLayershell window destroys it, and destroying that one is what left the embedded Wallpaper
+Engine renderer strobing at 30Hz — a photosensitive-seizure hazard. Frame rate does not outrank
+that. The frames came back by stopping what kept the window *busy*, not by removing the window.
+(perf(clock): the cookie's spin stops when the cookie is off screen;
+perf(bar): the popup overlay surface is mapped only while it has a card;
+test(perf): infinite animations are gated on visibility, and the overlay stands down.)
+
 **How fast the shell moves is one scalar, and where the bottom of that scale is, is a *different*
 declared thing.** `modules/common/motion_policy.js` is the arithmetic (pure, `.pragma library`, so
 the decisions are testable and nothing about the rendering has to be); `Appearance.animation`

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/clock/CookieClock.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/clock/CookieClock.qml
@@ -117,8 +117,22 @@ Item {
         anchors.fill: parent
         dragging: root.dragging
 
+        // Gated on the item being ON SCREEN, not just on the setting. An
+        // infinite animation dirties the scene every frame for as long as it
+        // runs, and a dirty scene makes the shell commit a frame, and a commit
+        // makes the compositor repaint the whole output - so this one kept a
+        // 5120x1440 240Hz screen redrawing continuously while the desktop was
+        // completely hidden behind a fullscreen game. Measured against FFXIV's
+        // own counter on a static scene: 52 fps with it spinning, 94 with this
+        // gate, 108 with the shell not running at all.
+        //
+        // `visible` is EFFECTIVE visibility in QML - it is false while any
+        // ancestor is hidden - so this covers the fullscreen suppression the
+        // canvas already does, a widget scrolled out of a hidden surface, and
+        // any future reason the desktop is not on screen, without any of them
+        // having to know this animation exists.
         RotationAnimation on rotation {
-            running: root.constantlyRotate
+            running: root.constantlyRotate && cookieBody.visible
             duration: 30000
             easing.type: Easing.Linear
             loops: Animation.Infinite

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/MediaTransportButton.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/nandoroid-media/MediaTransportButton.qml
@@ -135,7 +135,10 @@ Item {
                     : Expressive.MaterialShape.Shape.Circle
                 color: root.controlColor
 
+                // `visible` beside the transport state - see DesktopMediaWidget:
+                // a hidden reel that keeps spinning keeps the compositor repainting.
                 property bool spinning: root.span === "3x2" && MprisController.isPlaying
+                    && reelShape.visible
                 RotationAnimator on rotation {
                     from: 0
                     to: 360

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopMediaWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DesktopMediaWidget.qml
@@ -167,7 +167,11 @@ Item {
                         shape: MaterialShape.Shape.Cookie12Sided
                         color: Appearance.m3colors.darkmode ? Appearance.colors.colOnTertiaryContainer : Appearance.colors.colSecondaryContainer
 
-                        property bool spinning: MprisController.isPlaying
+                        // `visible` beside the transport state: a reel spinning
+                        // inside a hidden desktop still dirties the scene every
+                        // frame, and the compositor repaints the output for each
+                        // frame the shell commits.
+                        property bool spinning: MprisController.isPlaying && prevShape.visible
                         RotationAnimator on rotation {
                             from: 0
                             to: 360
@@ -267,7 +271,7 @@ Item {
                         shape: MaterialShape.Shape.Cookie12Sided
                         color: Appearance.m3colors.darkmode ? Appearance.colors.colOnTertiaryContainer : Appearance.colors.colSecondaryContainer
 
-                        property bool spinning: MprisController.isPlaying
+                        property bool spinning: MprisController.isPlaying && nextShape.visible
                         RotationAnimator on rotation {
                             from: 0
                             to: 360

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/clock/AnalogClock.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/clock/AnalogClock.qml
@@ -49,7 +49,10 @@ Item {
         anchors.fill: parent
         
         RotationAnimation on rotation {
-            running: Config.ready && root.cfg.constantlyRotate
+            // On screen, not just enabled: an infinite animation dirties the
+            // scene every frame it runs, and the compositor repaints the whole
+            // output for every frame the shell commits.
+            running: Config.ready && root.cfg.constantlyRotate && rotateContainer.visible
             duration: 30000
             easing.type: Easing.Linear
             loops: Animation.Infinite

--- a/dots/.config/quickshell/imi/modules/imi/bar/BarPopupOverlay.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/BarPopupOverlay.qml
@@ -38,6 +38,25 @@ Scope {
 
             screen: modelData
             color: "transparent"
+            // Mapped only while it has something to show. This is a
+            // SCREEN-SIZED surface on the Overlay layer, so leaving it mapped
+            // puts a 5120x1440 transparent sheet over every fullscreen window
+            // for the whole session - the compositor composites it each frame
+            // and the window under it can never be the only thing on the
+            // output. Measured with FFXIV's own counter on a static scene:
+            // 98 fps with this mapped and idle, 105 with it unmapped.
+            //
+            // The predicate outlasts the exit deliberately. Unmapping destroys
+            // the QQuickWindow, and a popup's content tree is REPARENTED into
+            // this window while it shows - so the window may only go once
+            // `finishExit()` has released both trees and collapsed the card,
+            // which is exactly the state this reads.
+            visible: overlayWindow.current !== null
+                || overlayWindow.outgoing !== null
+                || overlayWindow.exiting
+                || card.opacity > 0
+                || card.width > 0
+                || card.height > 0
             exclusionMode: ExclusionMode.Ignore
             exclusiveZone: 0
 

--- a/dots/.config/quickshell/imi/tests/lint_infinite_animation_visibility.py
+++ b/dots/.config/quickshell/imi/tests/lint_infinite_animation_visibility.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+#
+# Regression guard: an animation that loops forever must stop when the thing it
+# animates is not on screen.
+#
+# The chain that makes this expensive is not obvious from the animation. A
+# running animation writes a property every frame; a written property dirties
+# the scene; a dirty scene makes the shell commit a frame; and a commit makes
+# the COMPOSITOR repaint the whole output. So one forgotten spinner keeps a
+# 5120x1440 240Hz screen redrawing forever - including while the desktop it
+# lives on is completely hidden behind a fullscreen window, where nobody could
+# see it anyway.
+#
+# That is not a micro-optimisation. Measured against FINAL FANTASY XIV's own
+# frame counter, fullscreen on a static scene, with the shell otherwise
+# untouched:
+#
+#     shell not running at all                       108 fps
+#     shell running, cookie clock spinning            52 fps
+#     shell running, the spin gated on `visible`      94 fps
+#
+# The user reported it as "my game's FPS is halved when qs is running even in
+# fullscreen", and it was: one `RotationAnimation` with `loops:
+# Animation.Infinite` in `CookieClock.qml`, doing 30 seconds per turn, behind
+# an opaque game.
+#
+# THE RULE: every `loops: Animation.Infinite` is gated on `visible` - either
+# directly in its own `running:`, or through a `property bool` in the same file
+# that is itself gated. `visible` is EFFECTIVE visibility in QML (false while
+# any ancestor is hidden), which is what makes it the right question: the
+# animation does not have to know why it is off screen.
+#
+# THE REGISTER, and why it is a ratchet. Nine of these live on surfaces that are
+# unmapped when they are not showing (the region selector, the recording panel,
+# the overview's search bar, a loading indicator), where the animation stops
+# with the surface and the gate would be a no-op. They are registered rather
+# than swept because each needs its own reading of what "showing" means there,
+# and an unverified sweep of nine animations is how a spinner ends up frozen on
+# screen. The register fails both ways: a new ungated animation outside it, and
+# a registered file that gains its gate and is not removed.
+
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1] / "modules"
+
+INFINITE = "Animation.Infinite"
+RUNNING = re.compile(r"running:\s*([^\n]+)")
+BOOL_PROPERTY = re.compile(r"property\s+bool\s+(\w+)\s*:\s*([^\n]+(?:\n\s+&&[^\n]+)*)")
+
+EXISTING = frozenset({
+    "common/widgets/DockIconMotion.qml",
+    "common/widgets/MaterialLoadingIndicator.qml",
+    "common/widgets/WorldMap.qml",
+    "imi/bar/UpdatesCount.qml",
+    "imi/overview/SearchBar.qml",
+    "imi/recordingRegion/RecordingRegionPanel.qml",
+    "imi/regionSelector/RectCornersSelectionDetails.qml",
+})
+
+
+def gated(lines, index, gated_properties):
+    """Is the animation whose `loops:` is at `index` gated on visibility?"""
+    depth = 0
+    start = index
+    for j in range(index, max(-1, index - 40), -1):
+        depth += lines[j].count("}") - lines[j].count("{")
+        if depth < 0:
+            start = j
+            break
+    body = "\n".join(lines[start:index + 12])
+    match = RUNNING.search(body)
+    if not match:
+        return False
+    expression = match.group(1)
+    if "visible" in expression:
+        return True
+    # One level of indirection: `running: shape.spinning`, where `spinning` is
+    # a bool property in the same file that carries the visibility term.
+    return any(name in expression for name in gated_properties)
+
+
+def main():
+    failures = []
+    ungated = set()
+    scanned = 0
+
+    for path in sorted(ROOT.rglob("*.qml")):
+        text = path.read_text(encoding="utf-8")
+        if INFINITE not in text:
+            continue
+        relative = str(path.relative_to(ROOT))
+        lines = text.splitlines()
+        gated_properties = {name for name, value in BOOL_PROPERTY.findall(text)
+                            if "visible" in value}
+        for index, line in enumerate(lines):
+            if INFINITE not in line:
+                continue
+            scanned += 1
+            if gated(lines, index, gated_properties):
+                continue
+            ungated.add(relative)
+            if relative in EXISTING:
+                continue
+            failures.append(
+                f"{relative}:{index + 1}: loops forever with no visibility term. "
+                f"A running animation dirties the scene every frame, and every "
+                f"frame the shell commits makes the compositor repaint the whole "
+                f"output - one of these behind a fullscreen game cost it half "
+                f"its frames. Gate `running:` on `visible` (effective "
+                f"visibility, so it covers every ancestor that hides this).")
+
+    for relative in sorted(EXISTING - ungated):
+        if not (ROOT / relative).exists():
+            failures.append(f"{relative}: registered and no longer present. "
+                            f"Drop it from EXISTING.")
+            continue
+        failures.append(
+            f"{relative}: every infinite animation in it is gated now. Remove it "
+            f"from EXISTING in tests/lint_infinite_animation_visibility.py - the "
+            f"register is a ratchet, and one that is not tightened stops being "
+            f"read.")
+
+    if failures:
+        print("Infinite animation visibility lint failed:\n", file=sys.stderr)
+        for failure in failures:
+            print(f"  {failure}", file=sys.stderr)
+        return 1
+
+    print(f"Infinite animation visibility lint passed ({scanned} infinite "
+          f"animations, {len(ungated)} registered files still ungated)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -438,6 +438,21 @@ fi
 # real LockSurface with the preview context - the overlay's eater, the shared
 # gesture, move semantics, the storedOrder merge, and both cancel paths.
 # Brings its own headless weston.
+# A screen-sized Overlay surface with nothing in it still sits over every
+# fullscreen window, and an infinite animation keeps the compositor repainting
+# the whole output: together they cost a fullscreen game half its frames.
+echo "Running surface stand-down contract..."
+if ! python3 "$SCRIPT_DIR/test_surface_standdown_contract.py"; then
+    echo "Surface stand-down contract failed."
+    exit 1
+fi
+
+echo "Running infinite animation visibility lint..."
+if ! python3 "$SCRIPT_DIR/lint_infinite_animation_visibility.py"; then
+    echo "Infinite animation visibility lint failed."
+    exit 1
+fi
+
 # The Lockscreen tab is a filter on the desktop viewport, and the palette is one
 # of the things it filters: stage 9 switched every layer's source and left the
 # theme keyed on the session lock, so the tab drew the lock's wallpaper under

--- a/dots/.config/quickshell/imi/tests/test_surface_standdown_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_surface_standdown_contract.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""A screen-sized Overlay surface must not stay mapped with nothing to show.
+
+A surface on the Overlay layer sits above every fullscreen window on its output
+for as long as it exists, and the compositor composites it each frame whether or
+not the shell painted anything into it. `quickshell:barPopup` is 5120x1440 on
+this machine and was mapped for the whole session to host the bar's hover cards.
+Measured against FINAL FANTASY XIV's own frame counter, fullscreen, static
+scene: 98 fps with it mapped and idle, 105 with it unmapped.
+
+NOT a rule about the background surface, deliberately. That one is also
+screen-sized and also stays mapped, and unmapping it measures better still - but
+`visible: false` on a WlrLayershell window destroys it, and destroying the
+background surface is what left the embedded Wallpaper Engine renderer sampling
+a dead texture with the desktop strobing at 30Hz: a photosensitive-seizure
+hazard, not a cosmetic bug. `test_background_fullscreen_suppression.py` pins
+that surface the other way and its pin wins. The frames that were going there
+came back by stopping what kept the window BUSY instead - see
+tests/lint_infinite_animation_visibility.py.
+
+Source-level, because the property is about a Wayland layer surface and weston
+implements no wlr-layer-shell: no harness in this tree can map one and ask the
+compositor about it.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+BAR_POPUP = ROOT / "modules/imi/bar/BarPopupOverlay.qml"
+
+
+def check(failures, condition, message):
+    if not condition:
+        failures.append(message)
+
+
+def main():
+    failures = []
+
+    popup = BAR_POPUP.read_text(encoding="utf-8")
+    window = re.search(r"id:\s*overlayWindow\n(.*?)\n\s*mask:", popup, re.S)
+    check(failures, window is not None, "BarPopupOverlay's window is gone")
+    if window:
+        body = window.group(1)
+        visible = re.search(r"visible:\s*(.+?)\n\s*exclusionMode", body, re.S)
+        check(failures, visible is not None,
+              "BarPopupOverlay's PanelWindow does not gate `visible`. It is a "
+              "screen-sized surface on the Overlay layer, so leaving it mapped "
+              "puts a 5120x1440 sheet over every fullscreen window for the "
+              "whole session.")
+        if visible:
+            binding = visible.group(1)
+            # The predicate has to outlast the exit: a popup's content tree is
+            # reparented INTO this window, and `release()` is what hands it
+            # back. Unmapping first would take the tree with it.
+            for term in ("current", "outgoing", "exiting", "card."):
+                check(failures, term in binding,
+                      f"BarPopupOverlay's visibility does not consider `{term}` "
+                      f"- the window may only go once finishExit() has released "
+                      f"both content trees and collapsed the card, or it takes "
+                      f"a reparented tree with it.")
+
+    if failures:
+        print("Surface stand-down contract failed:\n", file=sys.stderr)
+        for failure in failures:
+            print(f"  {failure}", file=sys.stderr)
+        return 1
+
+    print("Surface stand-down contract passed (barPopup checked)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
"My game's FPS is halved when qs is running even in fullscreen." It was, and
this is why.

## The instrument

Every state below was measured the same way: FINAL FANTASY XIV fullscreen on
a static scene, its own frame counter read by OCR off the System Configuration
window header, ~10 samples per state, medians reported. The sampler refuses to
report unless the game holds focus, because FFXIV throttles itself to single
digits when it does not — three of my early readings were that, not the shell.

The ceiling drifted during the session (108 → 93) as the game's own scene
changed, so the paired reading at the end is the one that counts.

## What it was

`QSG_RENDER_TIMING=1` showed one shell window syncing at **243 Hz for 0 ms of
render work**. `qt.quick.dirty` named the node: `cookieBody`'s
`BasicTransform`, every frame. That is `CookieClock.qml`'s
`RotationAnimation` — `loops: Animation.Infinite`, 30 s per turn — spinning
behind an opaque fullscreen game.

The chain is not obvious from the animation: a running animation writes a
property every frame → the scene is dirty → the shell commits a frame → the
**compositor repaints the whole output**. So one forgotten spinner kept a
5120×1440 240 Hz screen redrawing continuously for a desktop nobody could see.

| state | fps |
|---|---|
| shell stopped | 108 |
| shell stock | **52** |
| cookie spin gated on `visible` | 94 |
| + idle bar-popup overlay unmapped | 105 |

Paired at the end of the session, same scene: **ceiling 93, shipped state 90**
with the replay buffer, visualizer and every plugin back on. Overhead went from
48% of frames to ~3%.

## What ships

- **The spin stops off screen.** `running: … && cookieBody.visible`. `visible`
  is *effective* visibility, so it covers the fullscreen suppression the canvas
  already does and anything later, without the animation knowing why.
- **The other desktop spinners get the same gate** — analog clock, three media
  reels. Not the ones measured (only the cookie was enabled here), but the same
  class on the same hidden desktop.
- **`quickshell:barPopup` is mapped only while it has a card.** A screen-sized
  Overlay surface, mapped all session with nothing in it, sitting over every
  fullscreen window. The predicate outlasts the exit because a popup's content
  tree is reparented *into* this window.

## What deliberately does not ship

Unmapping the **background** surface under fullscreen measures better still
(98 → 105 on its own) and I built it, ran it, and reverted it:
`test_background_fullscreen_suppression.py` pins that surface mapped because
`visible: false` on a WlrLayershell window destroys it, and destroying that one
left the embedded Wallpaper Engine renderer strobing at 30 Hz — a
photosensitive-seizure hazard. Frame rate does not outrank that. The frames
came back by stopping what kept the window busy instead.

Also measured and ruled out on this machine: Hyprland's blur (no difference
with focus held), and the shell's replay buffer (~5 fps, and it is the user's
setting).

## The checks

- `lint_infinite_animation_visibility.py` — every `loops: Animation.Infinite`
  carries a visibility term; seven files on idle-unmapped surfaces are a
  two-way ratchet.
- `test_surface_standdown_contract.py` — the popup overlay gates `visible`
  with every term the exit needs, and it explicitly does not reach the
  background surface.

Both planted. Suite 1049, green.

Docs: updated AGENT.md §motion (the loop-to-repaint chain, the instrument, and
the two surface fixes that look identical — one safe, one a seizure hazard).
