### PR TITLE
An Overlay surface holds the fullscreen fast path shut

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -3494,6 +3494,21 @@ that. The frames came back by stopping what kept the window *busy*, not by remov
 perf(bar): the popup overlay surface is mapped only while it has a card;
 test(perf): infinite animations are gated on visibility, and the overlay stands down.)
 
+**And the last blocker was not the shell at all: any Overlay surface, from anyone, at any size,
+holds the fullscreen fast path shut.** With every shell-side cost gone the game still read 84
+against a 94 ceiling, `solitaryBlockedBy: other overlays`, and the only overlay left was the
+Activate Linux plugin's 340×120 watermark — a process the shell spawns but a surface the shell does
+not own. Killing that one process: `solitary` went from 0 to the game's own address, Hyprland's GPU
+share from ~9% to **0.0%**, the game to 92. The plugin now stands its watermark down while any
+monitor's active workspace has a fullscreen window (`XephyLon/activate-linux-plugin#1`), reading
+`HyprlandData.hasfullscreen` like the bar and dock do — a first cut on `Hyprland.workspaces[..].
+toplevels` did not re-evaluate on workspace change. The general rule is in `docs/PLUGINS.md`
+§"Overlay surfaces and fullscreen windows". Two lessons for the next investigation: `hyprctl
+monitors`' `solitaryBlockedBy` is the first thing to read, because it names the class of blocker
+outright; and the shell's *own* GPU share reading 0.0% does not clear the shell, because what the
+shell spawns and what the compositor does on the shell's behalf are both invisible there.
+(docs(plugins): an Overlay surface holds the fullscreen fast path shut.)
+
 **How fast the shell moves is one scalar, and where the bottom of that scale is, is a *different*
 declared thing.** `modules/common/motion_policy.js` is the arithmetic (pure, `.pragma library`, so
 the decisions are testable and nothing about the rendering has to be); `Appearance.animation`

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -437,6 +437,24 @@ scan) still counts as removed, so such a row can always be cleared rather than b
 error. The id is also dropped from `plugins.enabled` so a stale entry cannot re-enable a package that
 no longer exists.
 
+## Overlay surfaces and fullscreen windows
+
+A plugin that maps a wlr-layer-shell surface on the **Overlay** layer — itself, or through a
+process it spawns — blocks the compositor's fullscreen fast path for as long as that surface exists,
+at any size. Hyprland names it in `hyprctl monitors`: `solitaryBlockedBy: other overlays`. With
+the fast path blocked the compositor composites every frame; with it open it hands the fullscreen
+window the output and does nothing. On the maintainer's machine the bundled Activate Linux
+watermark — a 340×120 Overlay surface from `/usr/bin/activate-linux` — was the last thing between
+a fullscreen game and that path, worth ~8 fps and all of the compositor's remaining GPU time.
+
+If your plugin needs an Overlay surface, stand it down while a fullscreen window is up. Read the
+fact off `HyprlandData` — `hasfullscreen` on each monitor's active workspace, the same field the
+shell's bar and dock gate on — not by walking `Hyprland.workspaces[..].toplevels` in a binding,
+whose nested `.values` reads do not re-evaluate when a workspace changes underneath them. The
+Activate Linux plugin's `ActivateLinuxHost.qml` is the reference: `fullscreenSomewhere` folds into
+`desiredCommand()`, and the process is stopped and relaunched through the same debounced `apply()`
+every other option change goes through.
+
 ## Process lifecycle safety
 
 Never bind a streaming process such as `docker events`, `nmcli monitor`, or `journalctl -f`


### PR DESCRIPTION
Docs-only follow-up to #257. With every shell-side cost gone the game still
read 84 against a 94 ceiling and `hyprctl monitors` said
`solitaryBlockedBy: other overlays`. The only overlay left was the Activate
Linux plugin's 340×120 watermark — a process the shell spawns but a surface the
shell does not own. Killing that one process took `solitary` from 0 to the
game's address, Hyprland's GPU share from ~9% to 0.0%, and the game to 92.

The fix is in the plugin (XephyLon/activate-linux-plugin#1, deployed live).
This PR writes down the rule for plugin authors and the two lessons for the
next investigation: read `solitaryBlockedBy` first, and the shell's own GPU
share reading zero does not clear the shell.

Docs: updated docs/PLUGINS.md §Overlay surfaces and fullscreen windows; AGENT.md §motion (the last blocker, and how it was found).