### PR TITLE
A widget snapped beside a neighbour sits one gap off it

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -2902,8 +2902,14 @@ mode is built out of are worth not re-deriving:
   `modules/common/functions/edge_snap.js` owns the arithmetic: four relations
   per neighbour per axis, each carrying the `target` the widget travels to AND
   the `guide` the line is drawn at (they differ for half the relations,
-  because the line belongs to the OTHER widget's edge); a perpendicular
-  relevance filter measured as the GAP between extents, boundary excluded; and
+  because the line belongs to the OTHER widget's edge); the two ADJACENCY
+  relations land one `Appearance.sizes.widgetGridGap` off the neighbour, not
+  flush — flush shipped first and glued widgets into a slab, and the gap that
+  already separates cells INSIDE a widget is what makes two widgets read as
+  one grid (the module takes the gap as a parameter to stay pure; the widget
+  hands in the scaled token; the guide is still at the neighbour's own edge);
+  a perpendicular relevance filter measured as the GAP between extents,
+  boundary excluded; and
   acquire-at-18/release-at-32 compared against `dragProxy`, never the rendered
   position — with one threshold the decision boundary and the resulting
   position are the same number and the widget flip-flops per event.

--- a/docs/superpowers/specs/2026-08-16-edit-mode-design.md
+++ b/docs/superpowers/specs/2026-08-16-edit-mode-design.md
@@ -603,6 +603,15 @@ near-to-far, far-to-near — each carrying **two numbers**: the `target` the wid
 filter on the perpendicular axis (a widget more than ~600px away across the axis being snapped
 contributes no candidates) stops a widget left-aligning to something in the opposite corner.
 
+**The two adjacency relations land one grid gap off the neighbour, not flush** (amended
+2026-08-18, maintainer: *"There should be one gap of space between them. Gluing them together is a
+problem."*). The gap is `Appearance.sizes.widgetGridGap` — the same 12px that already separates the
+cells *inside* a multi-cell widget — scaled by `effectiveScale`, so two widgets side by side read as
+one continuous grid rather than a slab. The two alignment relations take no gap: aligning an edge to
+an edge is a line, not a distance. The guide is drawn at the neighbour's own edge for all four; the
+gap is only where the widget lands. `edge_snap.js` takes the gap as a parameter so the module stays
+free of `Appearance` and testable bare.
+
 Three things to get right, from the same research:
 
 - **Do not resurrect the stale duplicate.** A dead copy of this base class sits at

--- a/dots/.config/quickshell/imi/WidgetEdgeSnapRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/WidgetEdgeSnapRuntimeTest.qml
@@ -242,15 +242,18 @@ ShellRoot {
     }
 
     // ---- acquire, the detent, and the release, mid-drag -------------------
-    // mover walks left toward anchor's right edge (465). The shadow stops
-    // 10px short: inside the acquire band, and on a target the lattice cannot
-    // produce (465 is not a multiple of 12).
+    // mover walks left toward anchor's right edge (465). Sitting BESIDE a
+    // neighbour lands one grid gap off its edge, so the adjacency target is
+    // 465 + 12 = 477 - still a position the lattice cannot produce (477 is
+    // not a multiple of 12), which is what keeps this distinguishable from a
+    // lattice landing. The shadow stops 2px short of it: inside the acquire
+    // band.
     Timer {
         id: stepAcquire
         interval: 400
         onTriggered: {
             harness.beginDrag(moverWidget);
-            harness.moveShadowTo(475, 48);
+            harness.moveShadowTo(479, 48);
             stepAcquireVerify.running = true;
         }
     }
@@ -259,15 +262,17 @@ ShellRoot {
         id: stepAcquireVerify
         interval: 300
         onTriggered: {
-            harness.check("inside the acquire band the widget sits on the neighbour's edge, off the lattice",
-                          Math.round(moverWidget.x) === 465);
-            harness.check("and the vertical guide is up at that edge",
+            harness.check("inside the acquire band the widget sits one gap off the neighbour's edge, off the lattice",
+                          Math.round(moverWidget.x) === 477);
+            // The GUIDE is at the neighbour's own edge - the line says what
+            // was aligned to; the gap is where the widget lands.
+            harness.check("and the vertical guide is up at the neighbour's edge",
                           canvas.edgeGuideXActive === true
                               && Math.round(canvas.edgeGuideXPos) === 465);
             // 24px past the target: between the two thresholds. A single
             // threshold - or a resolver fed the rendered position - has
             // already let go here.
-            harness.moveShadowTo(441, 48);
+            harness.moveShadowTo(453, 48);
             stepDetentVerify.running = true;
         }
     }
@@ -277,12 +282,12 @@ ShellRoot {
         interval: 300
         onTriggered: {
             harness.check("between the thresholds the hold survives - the detent",
-                          Math.round(moverWidget.x) === 465);
+                          Math.round(moverWidget.x) === 477);
             harness.check("and the guide stays up with it",
                           canvas.edgeGuideXActive === true);
-            // 40px past: released, and the lattice takes back over (425
-            // rounds to 420).
-            harness.moveShadowTo(425, 48);
+            // 40px past: released, and the lattice takes back over (437
+            // rounds to 432).
+            harness.moveShadowTo(437, 48);
             stepReleaseVerify.running = true;
         }
     }
@@ -292,10 +297,10 @@ ShellRoot {
         interval: 300
         onTriggered: {
             harness.check("past the release threshold the lattice takes back over",
-                          Math.round(moverWidget.x) === 420);
+                          Math.round(moverWidget.x) === 432);
             harness.check("and the guide goes down",
                           canvas.edgeGuideXActive === false);
-            harness.releaseAtShadow(425, 48);
+            harness.releaseAtShadow(437, 48);
             stepCommitVerify.running = true;
         }
     }
@@ -305,12 +310,12 @@ ShellRoot {
         interval: 400
         onTriggered: {
             harness.check("the release commits the lattice landing",
-                          harness.at(moverWidget, 420, 48));
-            // A second drag released INSIDE the hold: the commit is the
-            // neighbour's edge, off the lattice, and it sticks.
+                          harness.at(moverWidget, 432, 48));
+            // A second drag released INSIDE the hold: the commit is one gap
+            // off the neighbour's edge, off the lattice, and it sticks.
             harness.beginDrag(moverWidget);
-            harness.moveShadowTo(470, 48);
-            harness.releaseAtShadow(470, 48);
+            harness.moveShadowTo(482, 48);
+            harness.releaseAtShadow(482, 48);
             stepHeldCommitVerify.running = true;
         }
     }
@@ -319,8 +324,8 @@ ShellRoot {
         id: stepHeldCommitVerify
         interval: 400
         onTriggered: {
-            harness.check("a release inside the hold commits the neighbour's edge, off the lattice",
-                          harness.at(moverWidget, 465, 48));
+            harness.check("a release inside the hold commits one gap off the neighbour's edge, off the lattice",
+                          harness.at(moverWidget, 477, 48));
             harness.check("the guides do not outlive the gesture",
                           canvas.edgeGuideXActive === false
                               && canvas.edgeGuideYActive === false);

--- a/dots/.config/quickshell/imi/modules/common/functions/edge_snap.js
+++ b/dots/.config/quickshell/imi/modules/common/functions/edge_snap.js
@@ -38,11 +38,25 @@ function perpendicularGap(aPos, aSize, bPos, bSize) {
 // aligning our right edge to their right edge lands us at far - size, but the
 // alignment the line shows is at far.
 //
+// The two ADJACENCY relations - sitting beside or below a neighbour - land one
+// `gap` away from it, not flush. Flush was the first cut and it glued widgets
+// into one slab; the gap that already separates the cells INSIDE a multi-cell
+// widget (`Appearance.sizes.widgetGridGap`) is what makes two widgets side by
+// side read as one continuous grid instead. The two ALIGNMENT relations take
+// no gap: aligning our left edge to theirs is a line, not a distance. The
+// guide is still drawn at the neighbour's own edge for all four - the line
+// says what the widget aligned to; the gap is where the widget lands.
+//
+// `gap` is a parameter rather than a constant here so this module stays free
+// of Appearance (it is read by tst_edge_snap.qml with no shell around it) and
+// so a caller on a scaled canvas hands in the scaled value.
+//
 // `neighbours` is iterated by index and length rather than Array methods on
 // purpose: a list that has crossed a QML model boundary keeps its indices and
 // its length and loses its Array brand.
-function candidatesForAxis(neighbours, axis, size, perpPos, perpSize) {
+function candidatesForAxis(neighbours, axis, size, perpPos, perpSize, gap) {
     const isX = axis === "x";
+    const spacing = gap || 0;
     const out = [];
     for (let i = 0; i < neighbours.length; i++) {
         const n = neighbours[i];
@@ -53,10 +67,10 @@ function candidatesForAxis(neighbours, axis, size, perpPos, perpSize) {
         if (perpendicularGap(perpPos, perpSize, nPerpPos, nPerpSize)
                 >= PERPENDICULAR_LIMIT_PX)
             continue;
-        out.push({ target: near, guide: near });        // near-to-near
-        out.push({ target: far - size, guide: far });   // far-to-far
-        out.push({ target: far, guide: far });          // near-to-far
-        out.push({ target: near - size, guide: near }); // far-to-near
+        out.push({ target: near, guide: near });                  // near-to-near
+        out.push({ target: far - size, guide: far });             // far-to-far
+        out.push({ target: far + spacing, guide: far });          // near-to-far
+        out.push({ target: near - size - spacing, guide: near }); // far-to-near
     }
     return out;
 }

--- a/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/AbstractWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/AbstractWidget.qml
@@ -279,13 +279,18 @@ MouseArea {
     // widget is in Y (the perpendicular filter) and vice versa.
     function updateEdgeSnap() {
         if (root.edgeSnapNeighbours.length === 0) return
+        // The gap two adjacent widgets keep is the design system's grid gap,
+        // scaled the way every widget's own span is - so a widget snapped
+        // beside another sits exactly one cell-gap away, as if the two were
+        // cells of one wider widget.
+        const gap = Appearance.sizes.widgetGridGap * Appearance.effectiveScale
         root.edgeSnapHeldX = EdgeSnap.resolveSnap(dragProxy.x,
             EdgeSnap.candidatesForAxis(root.edgeSnapNeighbours, "x",
-                root.width, dragProxy.y, root.height),
+                root.width, dragProxy.y, root.height, gap),
             root.edgeSnapHeldX)
         root.edgeSnapHeldY = EdgeSnap.resolveSnap(dragProxy.y,
             EdgeSnap.candidatesForAxis(root.edgeSnapNeighbours, "y",
-                root.height, dragProxy.x, root.width),
+                root.height, dragProxy.x, root.width, gap),
             root.edgeSnapHeldY)
         root.publishEdgeGuides()
     }

--- a/dots/.config/quickshell/imi/tests/tst_edge_snap.qml
+++ b/dots/.config/quickshell/imi/tests/tst_edge_snap.qml
@@ -26,27 +26,54 @@ TestCase {
     }
 
     function test_four_relations_per_neighbour_on_x() {
-        const candidates = EdgeSnap.candidatesForAxis([xNeighbour], "x", 60, 120, 40);
+        const candidates = EdgeSnap.candidatesForAxis([xNeighbour], "x", 60, 120, 40, 12);
         compare(candidates.length, 4);
         // near-to-near: our left on their left, line at their left.
         verify(hasCandidate(candidates, 300, 300));
         // far-to-far: our right on their right - the widget travels to
         // 420 - 60, but the line is drawn at THEIR edge, not where we land.
         verify(hasCandidate(candidates, 360, 420));
-        // near-to-far: our left against their right (sitting beside them).
-        verify(hasCandidate(candidates, 420, 420));
-        // far-to-near: our right against their left.
-        verify(hasCandidate(candidates, 240, 300));
+        // near-to-far: beside them, ONE GAP off their right - the line is
+        // still at their edge, the widget lands 12 past it.
+        verify(hasCandidate(candidates, 432, 420));
+        // far-to-near: beside them on the other side, one gap off their left.
+        verify(hasCandidate(candidates, 228, 300));
     }
 
     function test_four_relations_per_neighbour_on_y() {
         const neighbour = { x: 40, y: 500, width: 90, height: 200 };
-        const candidates = EdgeSnap.candidatesForAxis([neighbour], "y", 80, 60, 50);
+        const candidates = EdgeSnap.candidatesForAxis([neighbour], "y", 80, 60, 50, 12);
         compare(candidates.length, 4);
         verify(hasCandidate(candidates, 500, 500));      // top-to-top
         verify(hasCandidate(candidates, 620, 700));      // bottom-to-bottom
-        verify(hasCandidate(candidates, 700, 700));      // top under their bottom
-        verify(hasCandidate(candidates, 420, 500));      // bottom on their top
+        verify(hasCandidate(candidates, 712, 700));      // under them, one gap down
+        verify(hasCandidate(candidates, 408, 500));      // over them, one gap up
+    }
+
+    // The invariant the gap exists for: a widget snapped BESIDE a neighbour
+    // never touches it. Every adjacency target leaves exactly `gap` of clear
+    // space between the two rects, and the two ALIGNMENT targets are unmoved
+    // by the gap - aligning an edge to an edge is a line, not a distance.
+    function test_adjacency_leaves_one_gap_and_alignment_takes_none() {
+        const size = 60;
+        for (const gap of [0, 8, 12, 24]) {
+            const c = EdgeSnap.candidatesForAxis([xNeighbour], "x", size, 120, 40, gap);
+            // Beside on the right: clear space = target - neighbourFar.
+            verify(hasCandidate(c, 420 + gap, 420), "right-of at gap " + gap);
+            // Beside on the left: clear space = neighbourNear - (target + size).
+            verify(hasCandidate(c, 300 - size - gap, 300), "left-of at gap " + gap);
+            // Alignments do not move.
+            verify(hasCandidate(c, 300, 300), "near-to-near at gap " + gap);
+            verify(hasCandidate(c, 360, 420), "far-to-far at gap " + gap);
+        }
+    }
+
+    // A caller that hands in no gap gets the flush behaviour, so nothing
+    // that only ever aligned edges changes under it.
+    function test_a_missing_gap_is_flush() {
+        const c = EdgeSnap.candidatesForAxis([xNeighbour], "x", 60, 120, 40);
+        verify(hasCandidate(c, 420, 420));
+        verify(hasCandidate(c, 240, 300));
     }
 
     function test_a_neighbour_across_the_axis_contributes_nothing() {


### PR DESCRIPTION
> When snapping widgets next to each other. There should be one gap of space
> between them. Gluing them together is a problem.

Stage 10's two **adjacency** relations — sitting beside or below a neighbour —
landed the dragged widget flush. They now land one
`Appearance.sizes.widgetGridGap` (12px, scaled) off the neighbour's edge: the
same gap that already separates the cells *inside* a multi-cell widget, so two
widgets side by side read as one continuous grid rather than a slab.

The two **alignment** relations take no gap — aligning an edge to an edge is a
line, not a distance — and the guide is still drawn at the neighbour's own edge
for all four: the line says what was aligned to, the gap is where the widget
lands.

`edge_snap.js` takes the gap as a parameter so it stays pure and
`tst_edge_snap.qml` drives it bare; `AbstractWidget` hands in the scaled token.

## Checks

- `tst_edge_snap.qml`: the four-relation tests carry the gap, and a new
  invariant test says every adjacency target leaves exactly `gap` of clear
  space at several gaps while the alignment targets do not move. Planted by
  putting near-to-far back to flush: **three tests fail**.
- `WidgetEdgeSnapRuntimeTest.qml` had scripted the flush target and every
  shadow position around it; all shift by the same 12 (465 → 477, still off the
  lattice), so acquire, detent, release and held-commit each test the same
  relation to the same threshold as before. Green on the real widget path.

Spec §6.2 amended with the decision and the date. Suite 1051, green.

Docs: updated AGENT.md §Edit Mode stage 10 (the adjacency gap and why it is the intra-widget one); docs/superpowers/specs/2026-08-16-edit-mode-design.md §6.2.