### PR TITLE
The lock screen's widget layout forks from the desktop's on first edit

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -2897,6 +2897,24 @@ mode is built out of are worth not re-deriving:
   (feat(editMode): one derivation of "the lock's look is on screen";
   fix(editMode): the Lockscreen tab carries the palette with it;
   test(editMode): the tab's palette is driven, and the derivation is pinned.)
+- **The lock screen's widget layout forks from the desktop's on the first Lockscreen-tab
+  edit, and the SPAN forks with the position.** Spec §4.3 chose one shared position and gave two
+  objections; the maintainer overruled it (2026-08-18) and both objections are answered rather than
+  waved off. `modules/common/plugins/layout_surfaces.js` is the arithmetic: `lockPositions` beside
+  `desktopPositions`, same shape, a screen ABSENT from it inherits the desktop's — so every user is
+  still in the one-position model until they move something there — and the first lock write is a
+  SNAPSHOT of the whole screen through one `forkedScreen()` that both writers share. The desktop's
+  span stays the per-plugin `__gridSize` option; a forked lock screen's lives IN the widget's lock
+  record as `gridSize`, so a media widget can be 3×2 on the desktop and 1×2 on the lock (the
+  report). `PluginState.currentSurface` resolves the default from `lockLookActive`; **every
+  undoable write captures the surface at push time** — a closure resolving it at pop time writes
+  the lock's position into the desktop store from the other tab, and the store still reads valid.
+  Planted and caught by name in `EditModeRuntimeTest` for both position and span. Presets carry
+  `lockPositions` under the same `has()` rule as the desktop map, so an older preset keeps a fork.
+  The drawer's Lock section shows "follows the desktop / is separate" and the re-link.
+  (feat(plugins): layout_surfaces.js - two widget layouts, one store, fork on first edit;
+  feat(editMode): every position and span write captures its surface into its undo;
+  test(editMode): the fork is driven through the real drag and the real grip.)
 - **A dragged widget holds a neighbour's edge through a Schmitt trigger, and
   both thresholds read the SHADOW — stage 10, spec §6.**
   `modules/common/functions/edge_snap.js` owns the arithmetic: four relations

--- a/docs/superpowers/specs/2026-08-16-edit-mode-design.md
+++ b/docs/superpowers/specs/2026-08-16-edit-mode-design.md
@@ -457,15 +457,35 @@ switched off. Not acceptable at any price.
   (`LockScreen.qml:15`, `:17-28`), so the tree is not welded to `WlSessionLockSurface` — only its
   one instantiation site is.
 
-**A widget has one position, and the lock screen shows it at that position.**
-`desktopPositions` is keyed `[screenName][pluginId]` and holds `{x, y, placementStrategy}`
-(`PluginState.qml:18-31`) — there is no locked variant. Arranging widgets "for the lock screen"
-arranges them for the desktop too. `lock.centerClock` is the one existing exception and it is a
-per-widget override applied at render, not a second stored position. **Accept it.** A second
-position doubles the placement model, and `scripts/presets.sh` captures `desktopPositions`
-wholesale, so every preset would silently gain one. AGENT.md's rule about two fields that must
-agree eventually disagreeing applies directly. What the tab edits is *which* widgets appear while
-locked, plus the islands.
+**~~A widget has one position, and the lock screen shows it at that position.~~** *Overruled
+2026-08-18* (maintainer: *"lockscreen widget layout is meant to be different from desktop layout if
+the user decides to alter the widgets and their order in lockscreen"*, and the same day: *"a widget
+state is not correctly saved when it's different between desktop and lockscreen (media widget being
+3x2 instead of 1x2 for example)"*). The original paragraph is kept struck through because its two
+objections were real and the replacement answers each:
+
+- *A second position doubles the placement model.* → **Fork on first edit**, not two stores from
+  day one. `lockPositions` sits beside `desktopPositions` with the same `[screen][pluginId]` shape,
+  and a screen **absent** from it shows the desktop's layout — so every user is still in the
+  one-position model until they move something on the Lockscreen tab. That first lock write copies
+  the whole screen across (a snapshot, not a one-widget overlay), and from then on the two are
+  independent. A "Widget layout follows the desktop / is separate" row in the drawer's Lock section
+  says which state a screen is in and, while forked, offers **Use desktop layout** to re-link it.
+- *Every preset would silently gain one.* → It should: a preset *is* the layout. `presets.sh`
+  captures `lockPositions` beside `desktopPositions` and applies it under the same `has()` rule, so
+  a preset from an older shell that lacks the key leaves a user's fork alone.
+- **The span forks with the position.** The desktop's stays the per-plugin `__gridSize` option; a
+  forked lock screen's lives *in* the widget's lock record as `gridSize`, copied by the fork
+  snapshot. A lock record without one reads through to the desktop's.
+- **Undo captures the surface at push time.** A closure that resolved it at pop time would write a
+  lock position into the desktop store when popped from the other tab; every position and span
+  writer names its surface into the closure. The re-link's undo restores whole records.
+
+`modules/common/plugins/layout_surfaces.js` is the arithmetic; `PluginState.currentSurface`
+resolves the default surface from the one lock-look derivation; `tst_layout_surfaces.qml`,
+`test_layout_surfaces_contract.py` and `EditModeRuntimeTest.qml` (a real drag and a real grip pull
+on the Lockscreen tab) hold it. `lock.centerClock` stays a render-time override, and what the tab
+edits for *presence* is unchanged: `visibleWhenLocked` is still the single toggle.
 
 What can be edited in the islands, and what cannot, is §14 — the one open question.
 

--- a/dots/.config/quickshell/imi/EditModeRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/EditModeRuntimeTest.qml
@@ -752,6 +752,134 @@ ShellRoot {
                           && Math.round(harness.storedPosition("edit-resize-probe").x) === 36);
             canvas.clearSelection();
             GlobalStates.editMode = false;
+        },
+
+        // ---- the lock layout forks on the first Lockscreen-tab move ---------
+        //
+        // spec §4.3 as amended 2026-08-18: the lock screen's arrangement
+        // INHERITS the desktop's until a widget is moved on the Lockscreen
+        // tab, which copies the whole screen into a store of its own. What
+        // only the real drag path can show: the widget's own drag commit
+        // writes the LOCK store when the look is the lock's; every other
+        // widget on the screen comes along in the fork; the desktop store is
+        // untouched; the widget goes BACK to its desktop position when the
+        // tab returns; an undo pushed on the lock tab and popped on the
+        // desktop tab still edits the lock store; and the re-link puts the
+        // inheritance back.
+        () => {
+            // The lock has to SHOW the widgets for there to be a lock layout
+            // to arrange - a widget the lock hides is at opacity 0 and takes
+            // no drag, which is the product's own rule and not this test's.
+            Config.options.lock.showWidgets = true;
+            GlobalStates.editMode = true;
+        },
+        () => {
+            harness.check("before any lock edit the screen is not forked",
+                          !PluginState.lockLayoutForked(harness.testScreen));
+            GlobalStates.editTab = EditMode.LOCKSCREEN_TAB;
+        },
+        () => {
+            harness.check("on the Lockscreen tab the widget still sits at its desktop position",
+                          Math.round(movableWidget.x) === 36 && Math.round(movableWidget.y) === 396);
+            harness.dragBy(movableWidget, 120, 0);
+        },
+        () => {
+            harness.check("the first lock move forks the screen",
+                          PluginState.lockLayoutForked(harness.testScreen));
+            harness.check("...the moved widget follows the lock store",
+                          Math.round(PluginState.position("edit-move-probe", harness.testScreen,
+                                                          PluginState.lockSurface).x) === 156);
+            harness.check("...the OTHER widget came along at its own position",
+                          Math.round(PluginState.position("edit-resize-probe", harness.testScreen,
+                                                          PluginState.lockSurface).x) === 36);
+            harness.check("...and the desktop store did not move",
+                          Math.round(PluginState.position("edit-move-probe", harness.testScreen,
+                                                          PluginState.desktopSurface).x) === 36);
+            GlobalStates.editTab = EditMode.DESKTOP_TAB;
+        },
+        () => {
+            harness.check("back on the Desktop tab the widget is at its desktop position again",
+                          Math.round(movableWidget.x) === 36);
+            // The undo was pushed on the LOCK tab. Popping it here must edit
+            // the lock store, not write the lock's old position into the
+            // desktop's.
+            GlobalStates.editUndo();
+        },
+        () => {
+            harness.check("an undo popped on the other tab restores the LOCK store",
+                          Math.round(PluginState.position("edit-move-probe", harness.testScreen,
+                                                          PluginState.lockSurface).x) === 36);
+            harness.check("...and leaves the desktop store alone",
+                          Math.round(PluginState.position("edit-move-probe", harness.testScreen,
+                                                          PluginState.desktopSurface).x) === 36
+                          && Math.round(movableWidget.x) === 36);
+            // The fork itself survives an undo of the move - the screen is
+            // still separate, just back at the same numbers.
+            harness.check("...the screen stays forked",
+                          PluginState.lockLayoutForked(harness.testScreen));
+            PluginState.resetLockLayout(harness.testScreen);
+        },
+        () => {
+            harness.check("the re-link removes the fork",
+                          !PluginState.lockLayoutForked(harness.testScreen));
+            harness.check("...and the lock reads through to the desktop again",
+                          PluginState.rawPosition("edit-move-probe", harness.testScreen,
+                                                  PluginState.lockSurface) !== undefined
+                          && Math.round(PluginState.position("edit-move-probe", harness.testScreen,
+                                                             PluginState.lockSurface).x) === 36);
+        },
+
+        // ---- the SPAN forks with the position -------------------------------
+        //
+        // The maintainer's second report: a media widget at 3x2 on the desktop
+        // and 1x2 on the lock. Driven through the real grip on the Lockscreen
+        // tab: the resize forks the screen and writes the LOCK span; the
+        // desktop's __gridSize option is untouched; back on the Desktop tab
+        // the widget is drawn at the desktop's span; the undo pushed on the
+        // lock tab restores the lock span from the other tab.
+        () => {
+            // A known desktop span to fork from.
+            PluginState.setOption("edit-resize-probe", "__gridSize", "2x2");
+        },
+        () => {
+            harness.check("the desktop span is 2x2 before the lock resize",
+                          harness.storedSize("edit-resize-probe") === "2x2"
+                          && !PluginState.lockLayoutForked(harness.testScreen));
+            GlobalStates.editTab = EditMode.LOCKSCREEN_TAB;
+        },
+        () => {
+            harness.check("on the Lockscreen tab the widget is drawn at the desktop span",
+                          resizableWidget.storedGridSize.cols === 2
+                          && resizableWidget.storedGridSize.rows === 2);
+            // Pull the grip one row up: 2x2 -> 2x1, the next span the probe
+            // offers (its list is 3x2 / 2x2 / 2x1).
+            harness.dragGripBy(resizableWidget, 0, -160);
+        },
+        () => {
+            harness.check("a lock resize forks the screen",
+                          PluginState.lockLayoutForked(harness.testScreen));
+            harness.check("...and writes the LOCK span",
+                          PluginState.gridSize("edit-resize-probe", harness.testScreen,
+                                               PluginState.lockSurface) === "2x1");
+            harness.check("...leaving the desktop's __gridSize option at 2x2",
+                          PluginState.option("edit-resize-probe", "__gridSize", "") === "2x2");
+            harness.check("...and the widget is drawn at 2x1 here",
+                          resizableWidget.storedGridSize.rows === 1);
+            GlobalStates.editTab = EditMode.DESKTOP_TAB;
+        },
+        () => {
+            harness.check("back on the Desktop tab the widget is drawn at 2x2 again",
+                          resizableWidget.storedGridSize.rows === 2);
+            GlobalStates.editUndo();
+        },
+        () => {
+            harness.check("the resize's undo, popped on the Desktop tab, restores the LOCK span",
+                          PluginState.gridSize("edit-resize-probe", harness.testScreen,
+                                               PluginState.lockSurface) === "2x2");
+            harness.check("...and the desktop option is still 2x2",
+                          PluginState.option("edit-resize-probe", "__gridSize", "") === "2x2");
+            PluginState.resetLockLayout(harness.testScreen);
+            GlobalStates.editMode = false;
         }
     ]
 

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginState.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginState.qml
@@ -4,8 +4,10 @@ pragma ComponentBehavior: Bound
 import QtQuick
 import Quickshell
 import Quickshell.Io
+import qs
 import qs.modules.common
 import "gridSizes.js" as GridSizes
+import "layout_surfaces.js" as Surfaces
 
 Singleton {
     id: root
@@ -19,6 +21,11 @@ Singleton {
         return {
             version: root.schemaVersion,
             desktopPositions: {},
+            // The lock screen's layout, per screen, present only once that
+            // screen has been edited on the Lockscreen tab - an absent screen
+            // shows the desktop's layout (layout_surfaces.js, spec §4.3 as
+            // amended 2026-08-18).
+            lockPositions: {},
             pluginOptions: {},
             // Plugin ids whose options/positions/enabled state survive preset
             // application (never captured INTO presets - see presets.sh).
@@ -54,22 +61,92 @@ Singleton {
         };
     }
 
-    function position(pluginId, screenName) {
-        const screens = root.state?.desktopPositions;
-        const saved = screens?.[screenName]?.[pluginId];
-        return root.normalizedPosition(saved);
+    // ---- two layouts, one store ------------------------------------------
+    //
+    // Which layout the DESKTOP is drawing right now: the lock's while the
+    // session is locked or Edit Mode's Lockscreen tab is filtering the
+    // viewport into it, the desktop's otherwise. This is the default surface
+    // every position read and write takes, so the widget code that predates
+    // the fork keeps its call shape and follows the look automatically.
+    //
+    // A caller that must NOT follow the look names its surface explicitly.
+    // Undo is the one that must not: a closure pushed on the Lockscreen tab
+    // and popped on the Desktop tab would otherwise write the lock's position
+    // into the desktop's store. It captures `currentSurface` at push time.
+    readonly property string currentSurface: GlobalStates.lockLookActive
+        ? Surfaces.LOCK : Surfaces.DESKTOP
+    // The two surface names, exported so a caller that must name one (undo)
+    // spells it the way the module does rather than as a string of its own.
+    readonly property string lockSurface: Surfaces.LOCK
+    readonly property string desktopSurface: Surfaces.DESKTOP
+
+    // Has this screen's lock layout been edited apart from the desktop's?
+    function lockLayoutForked(screenName) {
+        return Surfaces.isForked(root.state, screenName);
     }
 
-    function setPosition(pluginId, screenName, value) {
-        if (!pluginId || !screenName) return;
+    // The raw stored entry, or undefined - for callers that need to tell
+    // "absent" from "at the default", which position() cannot.
+    function rawPosition(pluginId, screenName, surface) {
+        return Surfaces.rawPosition(root.state, surface ?? root.currentSurface,
+            screenName, pluginId);
+    }
 
-        const nextState = Object.assign({}, root.state);
-        const nextScreens = Object.assign({}, nextState.desktopPositions || {});
-        const nextScreen = Object.assign({}, nextScreens[screenName] || {});
-        nextScreen[pluginId] = root.normalizedPosition(value);
-        nextScreens[screenName] = nextScreen;
+    function position(pluginId, screenName, surface) {
+        return root.normalizedPosition(root.rawPosition(pluginId, screenName, surface));
+    }
+
+    function setPosition(pluginId, screenName, value, surface) {
+        if (!pluginId || !screenName) return;
+        const nextState = Surfaces.withPosition(root.state, surface ?? root.currentSurface,
+            screenName, pluginId, root.normalizedPosition(value));
         nextState.version = root.schemaVersion;
-        nextState.desktopPositions = nextScreens;
+        root.state = nextState;
+        writeTimer.restart();
+    }
+
+    // A widget's span, per surface (layout_surfaces.js): the desktop's is the
+    // `__gridSize` plugin option it has always been; a forked lock screen's
+    // lives in the widget's lock record. Same default-surface rule as
+    // position(), same explicit-surface rule for undo.
+    function gridSize(pluginId, screenName, surface) {
+        return Surfaces.rawGridSize(root.state, surface ?? root.currentSurface,
+            screenName, pluginId);
+    }
+
+    function setGridSize(pluginId, screenName, value, surface) {
+        if (!pluginId) return;
+        const nextState = Surfaces.withGridSize(root.state, surface ?? root.currentSurface,
+            screenName, pluginId, value);
+        nextState.version = root.schemaVersion;
+        root.state = nextState;
+        writeTimer.restart();
+    }
+
+    // The whole lock record for a widget on a screen, and its restore - for
+    // the re-link's undo, which has to put back position AND span together.
+    function lockRecords(screenName) {
+        return Object.assign({}, root.state?.lockPositions?.[screenName] ?? {});
+    }
+
+    function restoreLockRecords(screenName, records) {
+        if (!screenName || !records) return;
+        const nextState = Object.assign({}, root.state);
+        const store = Object.assign({}, nextState.lockPositions || {});
+        store[screenName] = Object.assign({}, records);
+        nextState.lockPositions = store;
+        nextState.version = root.schemaVersion;
+        root.state = nextState;
+        writeTimer.restart();
+    }
+
+    // Re-link a screen's lock layout to the desktop's: its lock entry goes,
+    // and every widget on that screen reads through again. A no-op on a
+    // screen that was never forked.
+    function resetLockLayout(screenName) {
+        const nextState = Surfaces.withoutLockLayout(root.state, screenName);
+        if (nextState === root.state) return;
+        nextState.version = root.schemaVersion;
         root.state = nextState;
         writeTimer.restart();
     }
@@ -324,6 +401,11 @@ Singleton {
                     && typeof parsed.desktopPositions === "object"
                     && !Array.isArray(parsed.desktopPositions)
                     ? parsed.desktopPositions
+                    : {},
+                lockPositions: parsed.lockPositions
+                    && typeof parsed.lockPositions === "object"
+                    && !Array.isArray(parsed.lockPositions)
+                    ? parsed.lockPositions
                     : {},
                 pluginOptions: parsed.pluginOptions
                     && typeof parsed.pluginOptions === "object"

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
@@ -138,7 +138,7 @@ AbstractBackgroundWidget {
     readonly property bool gridResizable: rootWidget.offeredGridSizes.length > 1
     // Stored -> manifest default -> null, which is the content-sized path.
     readonly property var storedGridSize: GridSizes.resolveSize(rootWidget.gridSpec,
-        manifest ? PluginState.option(manifest.id, "__gridSize") : undefined)
+        manifest ? PluginState.gridSize(manifest.id, screenName) : undefined)
     // The span the grip's drag is currently previewing, null when no resize is
     // in flight. The widget resizes as the pointer moves, so the size on screen
     // is the size a release commits - and Escape cancels by clearing this, with
@@ -288,11 +288,15 @@ AbstractBackgroundWidget {
         // destroy - and an unchanged span pushes nothing, so a commit of the
         // span the widget already has does not spend an entry.
         const id = manifest.id;
+        const screen = rootWidget.screenName;
+        // The surface, captured now - see commitPosition for why the closure
+        // must not resolve it at pop time.
+        const surface = PluginState.currentSurface;
         const next = GridSizes.formatSize(size);
-        const before = PluginState.option(id, "__gridSize", null);
+        const before = PluginState.gridSize(id, screen, surface) ?? null;
         if (before !== next)
-            GlobalStates.editUndoPush(() => PluginState.setOption(id, "__gridSize", before));
-        PluginState.setOption(manifest.id, "__gridSize", next);
+            GlobalStates.editUndoPush(() => PluginState.setGridSize(id, screen, before, surface));
+        PluginState.setGridSize(id, screen, next, surface);
     }
 
     function beginGridResize() {
@@ -638,19 +642,24 @@ AbstractBackgroundWidget {
         // one entry per committed mutation is the spec's grain.
         const id = manifest.id;
         const screen = rootWidget.screenName;
+        // The surface this drag happened on, captured NOW: the undo closure
+        // runs later, from whichever tab the user is on then, and a closure
+        // that resolved the surface at pop time would write a lock position
+        // into the desktop store (or the reverse).
+        const surface = PluginState.currentSurface;
         if (beforeX !== rootWidget.targetX || beforeY !== rootWidget.targetY) {
             const before = {
                 x: beforeX,
                 y: beforeY,
                 placementStrategy: rootWidget.placementStrategy
             };
-            GlobalStates.editUndoPush(() => PluginState.setPosition(id, screen, before));
+            GlobalStates.editUndoPush(() => PluginState.setPosition(id, screen, before, surface));
         }
         PluginState.setPosition(id, screenName, {
             x: rootWidget.targetX,
             y: rootWidget.targetY,
             placementStrategy: rootWidget.placementStrategy
-        });
+        }, surface);
     }
 
     // A declared grid span drives the pixel size directly; otherwise the widget

--- a/dots/.config/quickshell/imi/modules/common/plugins/layout_surfaces.js
+++ b/dots/.config/quickshell/imi/modules/common/plugins/layout_surfaces.js
@@ -1,0 +1,175 @@
+.pragma library
+
+// Two widget layouts, one store: the desktop's and the lock screen's, and the
+// rule by which the second inherits the first until it is edited.
+//
+// Spec §4.3 chose ONE stored position per widget, shared by both surfaces, and
+// gave two reasons - a second position doubles the placement model, and
+// presets capture positions wholesale. The maintainer overruled it on
+// 2026-08-18: "lockscreen widget layout is meant to be different from desktop
+// layout if the user decides to alter the widgets and their order in
+// lockscreen." The `if` is load-bearing and is what this module encodes.
+//
+// FORK ON FIRST EDIT. `lockPositions` sits beside `desktopPositions` with the
+// same [screen][pluginId] shape, and a screen ABSENT from it means "the lock
+// shows the desktop's layout" - the spec's model is still the state every
+// user is in until they move something on the Lockscreen tab. The first lock
+// write for a screen copies that screen's whole desktop layout across before
+// applying the move, so the fork is a snapshot: after it, every widget on that
+// screen follows the lock store, none half-follows the desktop. Deleting the
+// screen's entry re-links it.
+//
+// Pure, .pragma library, no QML: the decisions here are the ones that would
+// otherwise be reachable only through a running PluginState with a file behind
+// it, and tst_layout_surfaces.qml drives every branch bare. PluginState is the
+// caller that turns "the lock look is on" into a surface name and writes the
+// result to disk.
+
+var DESKTOP = "desktop";
+var LOCK = "lock";
+
+// Which store a surface name reads. Anything that is not the lock is the
+// desktop, so a caller that passes nothing gets the desktop, which is what
+// every pre-fork call site meant.
+function storeKey(surface) {
+    return surface === LOCK ? "lockPositions" : "desktopPositions";
+}
+
+// Has this screen's lock layout been forked from the desktop's?
+function isForked(state, screenName) {
+    var lock = state && state.lockPositions;
+    return !!(lock && typeof lock === "object" && lock[screenName]
+        && typeof lock[screenName] === "object");
+}
+
+// The raw stored entry for a widget on a surface, or undefined. On the lock
+// surface an unforked screen READS THROUGH to the desktop - that is the
+// inheritance - and a forked one reads only its own store, so a widget added
+// to the desktop after the fork is absent from the lock rather than leaking
+// in at the desktop's position. `undefined` here is what a caller normalises
+// to the default; the distinction between "absent" and "at the default"
+// matters to undo, which is why this returns the raw value.
+function rawPosition(state, surface, screenName, pluginId) {
+    if (!state || !screenName || !pluginId)
+        return undefined;
+    if (surface === LOCK && isForked(state, screenName)) {
+        var lockScreen = state.lockPositions[screenName];
+        return lockScreen[pluginId];
+    }
+    var desktop = state.desktopPositions;
+    var desktopScreen = desktop && typeof desktop === "object" ? desktop[screenName] : undefined;
+    return desktopScreen && typeof desktopScreen === "object" ? desktopScreen[pluginId] : undefined;
+}
+
+// A widget's SPAN is part of its layout, and it forks with the position -
+// the maintainer's second report was a media widget at 3x2 on the desktop
+// and 1x2 on the lock, which one shared span cannot hold. On the desktop the
+// span stays where it has always been, `pluginOptions[id].__gridSize`, which
+// is per plugin and not per screen (a widget is one size on every desktop).
+// On a FORKED lock screen it lives IN the widget's lock record as
+// `gridSize`, beside x and y: the record is already the per-surface,
+// per-screen thing, and the fork snapshot copies the current span into each
+// record so a freshly forked screen looks exactly like the desktop did.
+//
+// A lock record WITHOUT `gridSize` (a fork made before this key existed, or
+// a preset from that shell) reads through to the desktop's option, so it
+// still inherits rather than dropping to the manifest default.
+function rawGridSize(state, surface, screenName, pluginId) {
+    if (surface === LOCK && isForked(state, screenName)) {
+        var record = state.lockPositions[screenName][pluginId];
+        if (record && typeof record === "object" && record.gridSize !== undefined)
+            return record.gridSize;
+    }
+    var options = state && state.pluginOptions;
+    var plugin = options && typeof options === "object" ? options[pluginId] : undefined;
+    return plugin && typeof plugin === "object" ? plugin.__gridSize : undefined;
+}
+
+// The fork itself: a fresh lock screen seeded from the desktop's records,
+// each carrying the span the widget currently has. Shared by both writers
+// below so the two cannot disagree about what a fork copies.
+function forkedScreen(state, screenName) {
+    var desktopScreen = (state && state.desktopPositions
+        && state.desktopPositions[screenName]) || {};
+    var screen = {};
+    for (var pluginId in desktopScreen) {
+        var record = Object.assign({}, desktopScreen[pluginId]);
+        var span = rawGridSize(state, DESKTOP, screenName, pluginId);
+        if (span !== undefined)
+            record.gridSize = span;
+        screen[pluginId] = record;
+    }
+    return screen;
+}
+
+// The next state after writing one widget's position on one surface. Returns
+// a NEW top-level object and never mutates the one passed in - PluginState
+// reassigns `state` wholesale so bindings notice, and a mutated-in-place
+// object is one they would not.
+//
+// A lock write on an unforked screen forks it first, then the write lands.
+// The position value REPLACES x/y/placementStrategy and keeps whatever
+// gridSize the record already carried: a move is not a resize.
+function withPosition(state, surface, screenName, pluginId, value) {
+    var next = Object.assign({}, state || {});
+    var key = storeKey(surface);
+    var store = Object.assign({}, next[key] || {});
+    var screen = (surface === LOCK && !isForked(state, screenName))
+        ? forkedScreen(state, screenName)
+        : Object.assign({}, store[screenName] || {});
+    var previous = screen[pluginId];
+    var record = Object.assign({}, value);
+    if (surface === LOCK && previous && typeof previous === "object"
+            && previous.gridSize !== undefined && record.gridSize === undefined)
+        record.gridSize = previous.gridSize;
+    screen[pluginId] = record;
+    store[screenName] = screen;
+    next[key] = store;
+    return next;
+}
+
+// The next state after writing one widget's span on one surface. On the
+// desktop this is the plugin option, unchanged from before the fork existed
+// (null removes, as PluginState.setOption always meant). On the lock it
+// forks the screen if needed and writes `gridSize` into the widget's record
+// - creating a position-less record if the widget has none there yet, which
+// rawPosition then answers as the default position; that only happens for a
+// widget added to the desktop after the fork, and is the same "absent" the
+// position side already reports for it.
+function withGridSize(state, surface, screenName, pluginId, value) {
+    var next = Object.assign({}, state || {});
+    if (surface !== LOCK) {
+        var options = Object.assign({}, next.pluginOptions || {});
+        var plugin = Object.assign({}, options[pluginId] || {});
+        if (value === null || value === undefined) delete plugin.__gridSize;
+        else plugin.__gridSize = value;
+        options[pluginId] = plugin;
+        next.pluginOptions = options;
+        return next;
+    }
+    var store = Object.assign({}, next.lockPositions || {});
+    var screen = isForked(state, screenName)
+        ? Object.assign({}, store[screenName] || {})
+        : forkedScreen(state, screenName);
+    var record = Object.assign({}, screen[pluginId] || {});
+    if (value === null || value === undefined) delete record.gridSize;
+    else record.gridSize = value;
+    screen[pluginId] = record;
+    store[screenName] = screen;
+    next.lockPositions = store;
+    return next;
+}
+
+// The next state after re-linking a screen's lock layout to the desktop's:
+// the screen's lock entry is removed, and rawPosition reads through again.
+// A screen that was never forked is returned unchanged (same object), so a
+// caller can tell a no-op from a change by identity.
+function withoutLockLayout(state, screenName) {
+    if (!isForked(state, screenName))
+        return state;
+    var next = Object.assign({}, state);
+    var lock = Object.assign({}, state.lockPositions);
+    delete lock[screenName];
+    next.lockPositions = lock;
+    return next;
+}

--- a/dots/.config/quickshell/imi/modules/imi/editMode/EditModeChromeContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/editMode/EditModeChromeContent.qml
@@ -71,6 +71,10 @@ Item {
     signal barWidgetAddRequested(string widgetId, string bucket)
     signal dockAppToggleRequested(string appId)
     signal lockIslandToggleRequested(string key)
+    signal lockLayoutResetRequested()
+
+    // The screen this chrome belongs to, for the drawer's fork question.
+    property string screenName: ""
 
     // Published for the surface's input mask: these three rects are the only
     // pixels of a screen-sized layer surface that may take a click, because
@@ -207,5 +211,7 @@ Item {
         onBarAddRequested: (widgetId, bucket) => root.barWidgetAddRequested(widgetId, bucket)
         onDockToggleRequested: (appId) => root.dockAppToggleRequested(appId)
         onLockToggleRequested: (key) => root.lockIslandToggleRequested(key)
+        onLockLayoutResetRequested: root.lockLayoutResetRequested()
+        screenName: root.screenName
     }
 }

--- a/dots/.config/quickshell/imi/modules/imi/editMode/EditModeChromeSurface.qml
+++ b/dots/.config/quickshell/imi/modules/imi/editMode/EditModeChromeSurface.qml
@@ -157,7 +157,7 @@ PanelWindow {
     // size exists only once it instantiates.
     function spanSizeFor(manifest) {
         const span = GridSizes.resolveSize(manifest.grid,
-            PluginState.option(manifest.id, "__gridSize", ""));
+            PluginState.gridSize(manifest.id, root.screen?.name ?? "") ?? "");
         if (!span)
             return { width: 0, height: 0 };
         return {
@@ -234,6 +234,20 @@ PanelWindow {
         }
     }
 
+    // Re-link this screen's lock layout to the desktop's. One committed
+    // mutation, one undo entry: the closure puts the whole forked screen back
+    // by writing each widget's lock position again on the LOCK surface, named
+    // explicitly - the user may undo from the Desktop tab.
+    function resetLockLayout() {
+        const screen = root.screen?.name ?? "";
+        if (!PluginState.lockLayoutForked(screen)) return;
+        // The whole records - position AND span - so the undo puts back
+        // exactly the fork that was there, not a re-fork from the desktop.
+        const forked = PluginState.lockRecords(screen);
+        GlobalStates.editUndoPush(() => PluginState.restoreLockRecords(screen, forked));
+        PluginState.resetLockLayout(screen);
+    }
+
     function addWidgetAt(manifest, dropX, dropY) {
         // A release back over the drawer is the gesture being abandoned, not
         // an instruction to add the widget at the drawer.
@@ -266,18 +280,22 @@ PanelWindow {
         const id = manifest.id;
         const screen = root.screen?.name ?? "";
         const beforeEnabled = EditMode.listCopy(Config.options.plugins.enabled);
+        // The surface the drop lands on, captured now for the same reason the
+        // widget's own drag captures it: the closure runs from whichever tab
+        // the user is on when they undo.
+        const surface = PluginState.currentSurface;
         // Existence checked on the raw store: PluginState.position() answers
         // the DEFAULT for an absent entry, which would read as a stored
         // position that was never there.
-        const hadPosition = PluginState.state?.desktopPositions?.[screen]?.[id] !== undefined;
-        const beforePosition = hadPosition ? PluginState.position(id, screen) : null;
+        const beforeRaw = PluginState.rawPosition(id, screen, surface);
+        const beforePosition = beforeRaw !== undefined ? PluginState.position(id, screen, surface) : null;
         GlobalStates.editUndoPush(() => {
             Config.setNestedValue("plugins.enabled", beforeEnabled);
             if (beforePosition)
-                PluginState.setPosition(id, screen, beforePosition);
+                PluginState.setPosition(id, screen, beforePosition, surface);
         });
         PluginState.setPosition(manifest.id, root.screen?.name ?? "",
-            { x: placed.x, y: placed.y, placementStrategy: "free" });
+            { x: placed.x, y: placed.y, placementStrategy: "free" }, surface);
         root.enablePlugin(manifest.id);
     }
 
@@ -326,5 +344,7 @@ PanelWindow {
             TaskbarApps.togglePin(appId);
         }
         onLockIslandToggleRequested: (key) => root.toggleLockIsland(key)
+        onLockLayoutResetRequested: root.resetLockLayout()
+        screenName: root.screen?.name ?? ""
     }
 }

--- a/dots/.config/quickshell/imi/modules/imi/editMode/EditModeDrawer.qml
+++ b/dots/.config/quickshell/imi/modules/imi/editMode/EditModeDrawer.qml
@@ -63,6 +63,14 @@ Item {
     // while locked. A signal like everything else here; the surface makes the
     // write at the boolean's own literal path.
     signal lockToggleRequested(string key)
+    // The lock layout's re-link: this screen's widgets go back to following
+    // the desktop's arrangement. Only offered while the screen is forked.
+    signal lockLayoutResetRequested()
+
+    // Which screen this drawer is arranging - handed in by the surface, so
+    // the fork question below is asked about the right monitor.
+    property string screenName: ""
+    readonly property bool lockLayoutForked: PluginState.lockLayoutForked(root.screenName)
 
     // Which section is showing, and which bucket a bar-widget click appends
     // to. Session state of the drawer itself; neither survives the mode.
@@ -547,6 +555,70 @@ Item {
                                 ? Appearance.colors.colPrimary
                                 : Appearance.colors.colOnSurfaceVariant
                         }
+                    }
+                }
+            }
+
+            // ---- lock screen layout: forked or following ------------------
+            //
+            // The widgets' arrangement on the lock screen inherits the
+            // desktop's until the first move on the Lockscreen tab forks it
+            // (spec §4.3 as amended). This row says which state the screen is
+            // in, and while forked offers the way back - the drawer never
+            // forks by itself; a drag does that.
+            RippleButton {
+                id: lockLayoutRow
+                visible: root.section === "lock"
+                enabled: root.lockLayoutForked
+                Layout.fillWidth: true
+                Layout.fillHeight: false
+                implicitHeight: 60
+                buttonRadius: Appearance.rounding.large
+                colBackground: "transparent"
+                colBackgroundHover: Appearance.colors.colLayer2Hover
+                colRipple: Appearance.colors.colLayer2Active
+                onClicked: root.lockLayoutResetRequested()
+
+                contentItem: RowLayout {
+                    anchors {
+                        fill: parent
+                        leftMargin: Appearance.spacing.space100
+                        rightMargin: Appearance.spacing.space100
+                    }
+                    spacing: Appearance.spacing.space100
+
+                    MaterialSymbol {
+                        text: root.lockLayoutForked ? "call_split" : "link"
+                        iconSize: 22
+                        color: Appearance.colors.colOnSurfaceVariant
+                    }
+                    ColumnLayout {
+                        Layout.fillWidth: true
+                        spacing: 0
+                        StyledText {
+                            Layout.fillWidth: true
+                            text: root.lockLayoutForked
+                                ? Translation.tr("Widget layout is separate")
+                                : Translation.tr("Widget layout follows the desktop")
+                            font.pixelSize: Appearance.font.pixelSize.normal
+                            color: Appearance.colors.colOnSurface
+                            elide: Text.ElideRight
+                        }
+                        StyledText {
+                            Layout.fillWidth: true
+                            text: root.lockLayoutForked
+                                ? Translation.tr("Click to use the desktop layout again")
+                                : Translation.tr("Move a widget here to arrange the lock screen on its own")
+                            font.pixelSize: Appearance.font.pixelSize.smaller
+                            color: Appearance.colors.colOnSurfaceVariant
+                            elide: Text.ElideRight
+                        }
+                    }
+                    MaterialSymbol {
+                        visible: root.lockLayoutForked
+                        text: "restart_alt"
+                        iconSize: 20
+                        color: Appearance.colors.colOnSurfaceVariant
                     }
                 }
             }

--- a/dots/.config/quickshell/imi/modules/imi/editMode/EditWidgetMenu.qml
+++ b/dots/.config/quickshell/imi/modules/imi/editMode/EditWidgetMenu.qml
@@ -88,6 +88,7 @@ Scope {
                 id: card
                 manifest: PluginManager.availablePlugins.find(
                     entry => entry.id === GlobalStates.editWidgetMenuPluginId) ?? null
+                screenName: menuWindow.screen?.name ?? ""
                 width: implicitWidth
                 height: implicitHeight
                 x: Math.min(Math.max(GlobalStates.editWidgetMenuX, 8),

--- a/dots/.config/quickshell/imi/modules/imi/editMode/EditWidgetMenuContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/editMode/EditWidgetMenuContent.qml
@@ -63,13 +63,16 @@ Item {
     // window) or hands in its own (the runtime harness, whose manifests are
     // synthetic and exist in no catalogue).
     property var manifest: null
+    // The screen the widget lives on: a span is per surface AND per screen
+    // once the lock layout is forked, so the stepper has to say which.
+    property string screenName: ""
     signal dismissRequested()
 
     readonly property var offeredSizes: GridSizes.offeredSizes(root.manifest?.grid ?? null)
     // The stored choice, read once so every derivation below shares one
     // reactive dependency on the plugin-state store.
     readonly property var storedSpan: root.manifest
-        ? PluginState.option(root.manifest.id, "__gridSize") : undefined
+        ? PluginState.gridSize(root.manifest.id, root.screenName) : undefined
     // Stored choice -> manifest default, resolved the way the host resolves
     // it, so the value the stepper starts from is the span the widget is
     // actually drawn at - including when the stored span is one the manifest
@@ -107,10 +110,11 @@ Item {
         // PluginState singleton - never this card or its widget, both of
         // which the mode can destroy while the stack outlives them.
         const id = root.manifest.id;
-        const before = PluginState.option(id, "__gridSize", null);
-        GlobalStates.editUndoPush(() => PluginState.setOption(id, "__gridSize", before));
-        PluginState.setOption(id, "__gridSize",
-            GridSizes.formatSize(next));
+        const screen = root.screenName;
+        const surface = PluginState.currentSurface;
+        const before = PluginState.gridSize(id, screen, surface) ?? null;
+        GlobalStates.editUndoPush(() => PluginState.setGridSize(id, screen, before, surface));
+        PluginState.setGridSize(id, screen, GridSizes.formatSize(next), surface);
     }
 
     implicitWidth: 260

--- a/dots/.config/quickshell/imi/scripts/presets.sh
+++ b/dots/.config/quickshell/imi/scripts/presets.sh
@@ -48,6 +48,7 @@ case "$action" in
             plugin_state="$(printf '%s' "$plugin_state_snapshot" | jq -ce '{
                 version: (.version // 2),
                 desktopPositions: (.desktopPositions // {}),
+                lockPositions: (.lockPositions // {}),
                 pluginOptions: (.pluginOptions // {})
             }' 2>/dev/null)" || plugin_state=""
         else
@@ -57,9 +58,10 @@ case "$action" in
             plugin_state="$(jq -c '{
             version: (.version // 2),
             desktopPositions: (.desktopPositions // {}),
+            lockPositions: (.lockPositions // {}),
             pluginOptions: (.pluginOptions // {})
         }' "$PLUGIN_STATE_FILE" 2>/dev/null \
-            || printf '{"version":2,"desktopPositions":{},"pluginOptions":{}}')"
+            || printf '{"version":2,"desktopPositions":{},"lockPositions":{},"pluginOptions":{}}')"
         fi
         # A preset is a document people SHARE, and `config.json` holds the
         # user's own OpenWeatherMap key. Saving one used to copy it verbatim,
@@ -99,10 +101,11 @@ case "$action" in
             current_plugin_state="$(jq -c '{
                 version: (.version // 2),
                 desktopPositions: (.desktopPositions // {}),
+                lockPositions: (.lockPositions // {}),
                 pluginOptions: (.pluginOptions // {}),
                 presetPersist: (.presetPersist // {})
             }' "$PLUGIN_STATE_FILE" 2>/dev/null \
-                || printf '{"version":2,"desktopPositions":{},"pluginOptions":{},"presetPersist":{}}')"
+                || printf '{"version":2,"desktopPositions":{},"lockPositions":{},"pluginOptions":{},"presetPersist":{}}')"
             # Top-level merging keeps fields omitted by older position-only
             # presets, while a new preset's complete maps replace current state.
             jq -n --argjson current "$current_plugin_state" --argjson preset "$preset_plugin_state" \
@@ -112,6 +115,9 @@ case "$action" in
                     | .desktopPositions = (if ($preset | has("desktopPositions"))
                         then ($preset.desktopPositions // {})
                         else ($current.desktopPositions // {}) end)
+                    | .lockPositions = (if ($preset | has("lockPositions"))
+                        then ($preset.lockPositions // {})
+                        else ($current.lockPositions // {}) end)
                     | .pluginOptions = (if ($preset | has("pluginOptions"))
                         then ($preset.pluginOptions // {})
                         else ($current.pluginOptions // {}) end)

--- a/dots/.config/quickshell/imi/tests/imports/qs/modules/common/plugins/layout_surfaces.js
+++ b/dots/.config/quickshell/imi/tests/imports/qs/modules/common/plugins/layout_surfaces.js
@@ -1,0 +1,1 @@
+../../../../../../modules/common/plugins/layout_surfaces.js

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -457,6 +457,15 @@ fi
 # of the things it filters: stage 9 switched every layer's source and left the
 # theme keyed on the session lock, so the tab drew the lock's wallpaper under
 # the desktop's colours.
+# Two widget layouts in one store: the lock's inherits the desktop's until the
+# first Lockscreen-tab move forks it. The arithmetic is tst_layout_surfaces
+# (qmltestrunner, below); this pins the writers, the store shape and presets.
+echo "Running layout surfaces contract..."
+if ! python3 "$SCRIPT_DIR/test_layout_surfaces_contract.py"; then
+    echo "Layout surfaces contract failed."
+    exit 1
+fi
+
 echo "Running lock look palette tests..."
 if ! python3 "$SCRIPT_DIR/test_lock_look_palette.py"; then
     echo "Lock look palette tests failed."

--- a/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
@@ -987,7 +987,7 @@ def test_the_size_affordance_indexes_offered_spans_and_never_a_pixel():
     assert "GridSizes.steppedSize(" in content, \
         "the step must come from the module, where tst_grid_sizes owns the walk"
     assert re.search(
-        r'setOption\([^)]*"__gridSize",\s*\n?\s*GridSizes\.formatSize\(next\)',
+        r'setGridSize\(id, screen, GridSizes\.formatSize\(next\), surface\)',
         content), \
         "the size write must be the stepped offered span and nothing else"
     # No pointer anywhere near the size: the card's rows are buttons, and a
@@ -1360,8 +1360,10 @@ def test_every_committed_mutation_records_exactly_its_entries():
     expected = {
         PLUGIN_WIDGET: 2,      # a drag's release; a span commit (grip + Size row path)
         MENU_CONTENT: 2,       # the Size stepper; Remove
-        CHROME_SURFACE: 9,     # presence toggle, 3 bar-bucket adds, 3 lock keys,
-                               # add-at-pointer, dock pin toggle
+        CHROME_SURFACE: 10,    # presence toggle, 3 bar-bucket adds, 3 lock keys,
+                               # add-at-pointer, dock pin toggle, and the lock
+                               # layout re-link (spec §4.3 as amended: one entry
+                               # that puts a forked screen back whole)
         BAR_CONTROLLER: 1,     # one snapshot helper serving reorder and remove
         LOCK_REORDER: 3,       # one literal path per island
         DRAG_APPS: 2,          # the dock's reorder commit; the badge unpin

--- a/dots/.config/quickshell/imi/tests/test_edit_mode_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_edit_mode_runtime.py
@@ -40,7 +40,7 @@ SOCKET = "wayland-imi-edit-mode"
 # The harness prints how many checks it ran. A literal rather than anything read
 # back out of that output: a harness whose step list shrinks must redden here
 # instead of reporting `failures: 0` for a shorter run.
-EXPECTED_CHECKS = 56
+EXPECTED_CHECKS = 77
 
 
 def _stop(proc):

--- a/dots/.config/quickshell/imi/tests/test_layout_surfaces_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_layout_surfaces_contract.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Two widget layouts in one store, and the places that must agree about it.
+
+Spec §4.3 as amended 2026-08-18: the lock screen's widget layout inherits the
+desktop's until the first move on the Lockscreen tab forks it. The arithmetic
+is `layout_surfaces.js` and `tst_layout_surfaces.qml` drives it bare; the real
+drag path is `EditModeRuntimeTest.qml`. What this module pins is the drift that
+would be silent between them:
+
+- every position WRITE that can be undone captures the surface at push time -
+  a closure that resolved it at pop time writes a lock position into the
+  desktop store when the user undoes from the other tab, and the store still
+  reads as valid;
+- the store carries `lockPositions` beside `desktopPositions` from the empty
+  state, through the loader's shape check, and through `presets.sh` in BOTH
+  directions - a preset saved by this shell carries the lock layout, and a
+  preset from an older shell that lacks the key does not wipe a user's fork
+  (the same `has()` shape the desktop map already uses);
+- the surface a read or write follows by DEFAULT is the one derivation of the
+  lock look, so a widget on the Lockscreen tab and a widget under a real lock
+  read the same store.
+
+Sweeps assert they FOUND what they swept.
+"""
+
+import re
+from pathlib import Path
+
+from contract_runner import run
+
+ROOT = Path(__file__).resolve().parent.parent
+MODULE = ROOT / "modules/common/plugins/layout_surfaces.js"
+STATE = ROOT / "modules/common/plugins/PluginState.qml"
+WIDGET = ROOT / "modules/common/plugins/PluginWidget.qml"
+CHROME_SURFACE = ROOT / "modules/imi/editMode/EditModeChromeSurface.qml"
+PRESETS = ROOT / "scripts/presets.sh"
+
+
+def read(path: Path) -> str:
+    assert path.exists(), f"{path} is gone - the sweep has nothing to look at"
+    text = path.read_text()
+    assert text.strip(), f"{path} is empty"
+    return text
+
+
+def code(path: Path) -> str:
+    text = re.sub(r"/\*.*?\*/", "", read(path), flags=re.S)
+    return "\n".join(re.sub(r"//.*$", "", line) for line in text.splitlines())
+
+
+def test_the_default_surface_is_the_lock_look_derivation():
+    state = code(STATE)
+    match = re.search(r"currentSurface:\s*GlobalStates\.lockLookActive", state)
+    assert match, ("PluginState.currentSurface must read GlobalStates.lockLookActive - "
+                   "the ONE derivation of the lock look - so the Lockscreen tab and a "
+                   "real lock read the same store")
+    for fn in ("rawPosition", "position", "setPosition"):
+        sig = re.search(rf"function {fn}\(([^)]*)\)", state)
+        assert sig and "surface" in sig.group(1), \
+            f"PluginState.{fn} must take an explicit surface parameter"
+    assert "surface ?? root.currentSurface" in state, \
+        "an omitted surface must fall back to currentSurface, not to the desktop"
+
+
+def test_every_undoable_position_write_captures_its_surface_at_push_time():
+    # The widget's own drag commit.
+    widget = code(WIDGET)
+    drag = re.search(r"const surface = PluginState\.currentSurface;(.*?)PluginState\.setPosition\(id, screenName,",
+                     widget, re.S)
+    assert drag, "PluginWidget's drag commit must capture `surface` before pushing its undo"
+    assert re.search(r"editUndoPush\(\(\) => PluginState\.setPosition\(id, screen, before, surface\)\)",
+                     drag.group(1)), \
+        ("PluginWidget's undo closure must pass the CAPTURED surface - resolving it at "
+         "pop time writes a lock position into the desktop store from the other tab")
+    assert re.search(r"placementStrategy: rootWidget\.placementStrategy\s*\}, surface\);", widget), \
+        "PluginWidget's forward write must land on the captured surface too"
+
+    # The drawer's drop.
+    chrome = code(CHROME_SURFACE)
+    drop = re.search(r"const surface = PluginState\.currentSurface;(.*?)root\.enablePlugin\(manifest\.id\);",
+                     chrome, re.S)
+    assert drop, "the drawer drop must capture `surface` before pushing its undo"
+    assert "PluginState.setPosition(id, screen, beforePosition, surface)" in drop.group(1), \
+        "the drop's undo closure must pass the captured surface"
+    assert re.search(r"placementStrategy: \"free\" \}, surface\);", drop.group(1)), \
+        "the drop's forward write must land on the captured surface"
+    assert "PluginState.rawPosition(id, screen, surface)" in drop.group(1), \
+        ("the drop's 'had a position before' check must ask the RAW store on the same "
+         "surface - position() answers the default for an absent entry")
+
+    # The re-link.
+    assert re.search(r"function resetLockLayout\(\)", chrome), \
+        "the chrome surface no longer offers the lock layout re-link"
+    reset = re.search(r"function resetLockLayout\(\)(.*?)\n    \}", chrome, re.S)
+    assert reset and "GlobalStates.editUndoPush" in reset.group(1), \
+        "the re-link must be undoable"
+
+
+def test_every_span_read_and_write_goes_through_the_surface_api():
+    # The span forks with the position: a widget at 3x2 on the desktop and
+    # 1x2 on the lock (the report) needs the lock's span in the lock record.
+    # No live reader or writer of a widget's span may reach `__gridSize`
+    # through PluginState.option/setOption any more - those are the DESKTOP
+    # store by definition and would read/write the wrong surface on the
+    # Lockscreen tab. Settings' size row is the one exception (PluginOptions):
+    # it is a desktop-only control by construction.
+    for path, label in ((WIDGET, "PluginWidget"),
+                        (ROOT / "modules/imi/editMode/EditWidgetMenuContent.qml", "EditWidgetMenuContent"),
+                        (CHROME_SURFACE, "EditModeChromeSurface")):
+        text = code(path)
+        assert not re.search(r'PluginState\.(option|setOption)\([^)]*"__gridSize"', text), \
+            f"{label} reads or writes __gridSize through option()/setOption(); use PluginState.gridSize()/setGridSize()"
+    widget = code(WIDGET)
+    assert "PluginState.gridSize(manifest.id, screenName)" in widget, \
+        "PluginWidget.storedGridSize must read the span through PluginState.gridSize()"
+    grip = re.search(r"const surface = PluginState\.currentSurface;\s*const next = GridSizes\.formatSize\(size\);(.*?)PluginState\.setGridSize\(id, screen, next, surface\);",
+                     widget, re.S)
+    assert grip, "PluginWidget's span commit must capture the surface and write through setGridSize on it"
+    assert "PluginState.setGridSize(id, screen, before, surface)" in grip.group(1), \
+        "the span commit's undo must pass the captured surface"
+    menu = code(ROOT / "modules/imi/editMode/EditWidgetMenuContent.qml")
+    assert "PluginState.setGridSize(id, screen, before, surface)" in menu, \
+        "the Size stepper's undo must pass the captured surface"
+    assert 'property string screenName' in menu, \
+        "EditWidgetMenuContent must be told its screen - a span is per screen once forked"
+    state = code(STATE)
+    for fn in ("gridSize", "setGridSize", "lockRecords", "restoreLockRecords"):
+        assert re.search(rf"function {fn}\(", state), f"PluginState lost {fn}()"
+    # The re-link's undo restores whole records (position AND span), not a
+    # position-only re-write that would drop every forked span.
+    chrome = code(CHROME_SURFACE)
+    reset = re.search(r"function resetLockLayout\(\)(.*?)\n    \}", chrome, re.S)
+    assert reset and "PluginState.restoreLockRecords(screen, forked)" in reset.group(1), \
+        "the re-link's undo must restore the whole lock records, or forked spans are lost on undo"
+
+
+def test_the_store_carries_the_lock_layout_from_empty_through_load():
+    state = code(STATE)
+    empty = re.search(r"function emptyState\(\)\s*\{(.*?)\n    \}", state, re.S)
+    assert empty and "lockPositions: {}" in empty.group(1), \
+        "PluginState.emptyState() must declare lockPositions beside desktopPositions"
+    assert re.search(r"lockPositions: parsed\.lockPositions\s*&&\s*typeof parsed\.lockPositions === \"object\"",
+                     state), \
+        "PluginState's loader must shape-check lockPositions like it does desktopPositions"
+
+
+def test_presets_carry_the_lock_layout_both_ways():
+    presets = read(PRESETS)
+    saves = re.findall(r"lockPositions: \(\.lockPositions // \{\}\)", presets)
+    assert len(saves) >= 3, \
+        (f"presets.sh captures lockPositions at {len(saves)} sites; the two --save "
+         f"paths and the --apply current-state read all need it")
+    apply_rule = re.search(
+        r"\.lockPositions = \(if \(\$preset \| has\(\"lockPositions\"\)\)\s*"
+        r"then \(\$preset\.lockPositions // \{\}\)\s*"
+        r"else \(\$current\.lockPositions // \{\}\) end\)", presets)
+    assert apply_rule, \
+        ("presets.sh --apply must take the preset's lockPositions only if the preset "
+         "HAS the key, and keep the user's otherwise - an older preset must not wipe "
+         "a fork")
+
+
+def test_the_module_states_the_inheritance_rule():
+    module = code(MODULE)
+    for fn in ("storeKey", "isForked", "rawPosition", "withPosition", "withoutLockLayout"):
+        assert re.search(rf"function {fn}\(", module), f"layout_surfaces.js lost {fn}()"
+    # ONE fork helper, seeded from the DESKTOP screen and carrying each
+    # widget's span - shared by both writers so they cannot disagree about
+    # what a fork copies.
+    fork = re.search(r"function forkedScreen\(state, screenName\) \{(.*?)\n\}", module, re.S)
+    assert fork, "layout_surfaces.js lost forkedScreen()"
+    assert "state.desktopPositions" in fork.group(1), \
+        "forkedScreen must seed the new lock screen from desktopPositions"
+    assert "rawGridSize(state, DESKTOP" in fork.group(1), \
+        "forkedScreen must copy each widget's desktop span into its lock record"
+    assert module.count("forkedScreen(state, screenName)") >= 3, \
+        "both withPosition and withGridSize must fork through forkedScreen()"
+
+
+if __name__ == "__main__":
+    raise SystemExit(run(globals()))

--- a/dots/.config/quickshell/imi/tests/test_presets.py
+++ b/dots/.config/quickshell/imi/tests/test_presets.py
@@ -243,6 +243,74 @@ class PresetTests(unittest.TestCase):
         )
 
 
+    def _sandbox(self, home, state):
+        """A HOME with a plugin state, stub helpers and a copy of presets.sh."""
+        config_dir = home / ".config/immaterial-impulse"
+        script_dir = home / ".config/quickshell/imi/scripts"
+        wallpaper_dir = script_dir / "wallpapers"
+        colors_dir = script_dir / "colors"
+        for d in (config_dir, wallpaper_dir, colors_dir):
+            d.mkdir(parents=True, exist_ok=True)
+        (config_dir / "config.json").write_text(json.dumps({
+            "background": {"wallpaperPath": "/tmp/wallpaper.jpg"},
+            "wallpaperSelector": {"wallpaperEngine": {"activePath": ""}},
+        }))
+        state_file = config_dir / "plugin-state.json"
+        state_file.write_text(json.dumps(state))
+        for helper in (wallpaper_dir / "wallpaper-engine.sh", colors_dir / "switchwall.sh"):
+            helper.write_text("#!/usr/bin/env bash\nexit 0\n")
+            helper.chmod(0o755)
+        presets = script_dir / "presets.sh"
+        shutil.copy(PRESETS, presets)
+        presets.chmod(0o755)
+        return config_dir, state_file, presets, dict(os.environ, HOME=str(home))
+
+    def test_the_lock_layout_round_trips_and_an_old_preset_keeps_the_fork(self):
+        """Two layouts, one store (spec §4.3 as amended 2026-08-18).
+
+        A preset saved by this shell carries `lockPositions`; applying it
+        restores the fork exactly. A preset from an OLDER shell has no such
+        key, and applying it must leave the user's fork alone rather than
+        wipe it - the same `has()` rule the desktop map already follows.
+        """
+        forked = {
+            "version": 2,
+            "desktopPositions": {"DP-1": {"clock": {"x": 100, "y": 200, "placementStrategy": "free"}}},
+            "lockPositions": {"DP-1": {"clock": {"x": 900, "y": 900, "placementStrategy": "free"}}},
+            "pluginOptions": {},
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            config_dir, state_file, presets, env = self._sandbox(Path(directory), forked)
+
+            subprocess.run(["bash", str(presets), "--save", "forked"], env=env, check=True)
+            preset = json.loads((config_dir / "presets/forked.json").read_text())
+            self.assertEqual(preset["_pluginState"]["lockPositions"]["DP-1"]["clock"]["x"], 900,
+                             "a saved preset must carry the lock layout")
+
+            # Scribble on the fork, then apply the preset: the fork comes back.
+            state_file.write_text(json.dumps({
+                "version": 2,
+                "desktopPositions": {"DP-1": {"clock": {"x": 1, "y": 1}}},
+                "lockPositions": {"DP-1": {"clock": {"x": 2, "y": 2}}},
+                "pluginOptions": {},
+            }))
+            subprocess.run(["bash", str(presets), "--apply", "forked"], env=env, check=True)
+            restored = json.loads(state_file.read_text())
+            self.assertEqual(restored["desktopPositions"]["DP-1"]["clock"]["x"], 100)
+            self.assertEqual(restored["lockPositions"]["DP-1"]["clock"]["x"], 900)
+
+            # An OLDER preset: same document with the lock key removed, as a
+            # pre-fork shell would have written it.
+            old = json.loads((config_dir / "presets/forked.json").read_text())
+            del old["_pluginState"]["lockPositions"]
+            (config_dir / "presets/older.json").write_text(json.dumps(old))
+            state_file.write_text(json.dumps(forked))
+            subprocess.run(["bash", str(presets), "--apply", "older"], env=env, check=True)
+            after_old = json.loads(state_file.read_text())
+            self.assertEqual(after_old["desktopPositions"]["DP-1"]["clock"]["x"], 100)
+            self.assertEqual(after_old["lockPositions"]["DP-1"]["clock"]["x"], 900,
+                             "a preset without lockPositions must not wipe the user's fork")
+
     def test_saving_a_preset_does_not_publish_the_users_weather_key(self):
         """A preset is a document people share; config.json holds their key.
 

--- a/dots/.config/quickshell/imi/tests/test_widget_size_row.py
+++ b/dots/.config/quickshell/imi/tests/test_widget_size_row.py
@@ -37,10 +37,19 @@ class TheRowAndTheGripShareOneValue(unittest.TestCase):
         self.host = squashed(HOST)
 
     def test_the_row_writes_the_key_the_grip_writes(self):
+        # Settings' size row writes the DESKTOP span option directly, and the
+        # grip writes through PluginState.setGridSize(), whose desktop surface
+        # is that same option (layout_surfaces.js `withGridSize`). The two
+        # meet at `__gridSize` in pluginOptions - pinned at both ends, since
+        # a row writing a key nothing reads is the failure this exists for.
         self.assertIn('key: "__gridSize"', self.options)
-        self.assertIn('PluginState.setOption(manifest.id, "__gridSize"', self.host,
+        self.assertIn("PluginState.setGridSize(id, screen, next, surface)", self.host,
                       "the grip's writer moved; the row now writes a key "
                       "nothing reads")
+        surfaces = squashed(ROOT / "modules/common/plugins/layout_surfaces.js")
+        self.assertIn("plugin.__gridSize = value", surfaces,
+                      "setGridSize's desktop surface no longer lands on the "
+                      "__gridSize option Settings' row writes")
 
     def test_the_choices_are_formatted_by_the_module_that_parses_them(self):
         """A row spelling the span itself is a second format to keep in step,

--- a/dots/.config/quickshell/imi/tests/tst_layout_surfaces.qml
+++ b/dots/.config/quickshell/imi/tests/tst_layout_surfaces.qml
@@ -1,0 +1,176 @@
+import QtTest
+import "../modules/common/plugins/layout_surfaces.js" as Surfaces
+
+// Two widget layouts in one store, and the fork-on-first-edit rule between
+// them (spec §4.3 as amended 2026-08-18). Every decision - what the lock reads
+// before and after the fork, what a lock write copies, what a desktop write
+// leaves alone, what re-linking removes - is pinned here bare, because the
+// alternative is a running PluginState with a file behind it.
+TestCase {
+    name: "LayoutSurfacesTest"
+
+    readonly property var desktopOnly: ({
+        desktopPositions: {
+            "DP-1": {
+                clock: { x: 100, y: 200, placementStrategy: "free" },
+                weather: { x: 500, y: 200, placementStrategy: "free" }
+            },
+            "DP-2": {
+                clock: { x: 10, y: 20, placementStrategy: "free" }
+            }
+        },
+        pluginOptions: {
+            weather: { __gridSize: "3x2", blurEnabled: true }
+        }
+    })
+
+    function test_the_lock_store_is_named_and_everything_else_is_the_desktop() {
+        compare(Surfaces.storeKey(Surfaces.LOCK), "lockPositions");
+        compare(Surfaces.storeKey(Surfaces.DESKTOP), "desktopPositions");
+        compare(Surfaces.storeKey(undefined), "desktopPositions");
+        compare(Surfaces.storeKey("anything"), "desktopPositions");
+    }
+
+    function test_an_unforked_screen_reads_the_desktop_on_both_surfaces() {
+        verify(!Surfaces.isForked(desktopOnly, "DP-1"));
+        compare(Surfaces.rawPosition(desktopOnly, Surfaces.DESKTOP, "DP-1", "clock").x, 100);
+        // The inheritance: the lock shows the desktop's layout.
+        compare(Surfaces.rawPosition(desktopOnly, Surfaces.LOCK, "DP-1", "clock").x, 100);
+        compare(Surfaces.rawPosition(desktopOnly, Surfaces.LOCK, "DP-1", "weather").x, 500);
+    }
+
+    function test_the_first_lock_write_forks_the_whole_screen() {
+        const next = Surfaces.withPosition(desktopOnly, Surfaces.LOCK, "DP-1", "clock",
+            { x: 900, y: 900, placementStrategy: "free" });
+        verify(Surfaces.isForked(next, "DP-1"));
+        // The moved widget follows the lock store...
+        compare(Surfaces.rawPosition(next, Surfaces.LOCK, "DP-1", "clock").x, 900);
+        // ...and so does every OTHER widget on that screen, at the position it
+        // had - the fork is a snapshot, not a one-widget overlay.
+        compare(Surfaces.rawPosition(next, Surfaces.LOCK, "DP-1", "weather").x, 500);
+        // The desktop is untouched.
+        compare(Surfaces.rawPosition(next, Surfaces.DESKTOP, "DP-1", "clock").x, 100);
+        // The other screen is untouched and unforked.
+        verify(!Surfaces.isForked(next, "DP-2"));
+        compare(Surfaces.rawPosition(next, Surfaces.LOCK, "DP-2", "clock").x, 10);
+    }
+
+    function test_after_the_fork_the_two_surfaces_are_independent() {
+        let state = Surfaces.withPosition(desktopOnly, Surfaces.LOCK, "DP-1", "clock",
+            { x: 900, y: 900, placementStrategy: "free" });
+        // A desktop move afterwards does not reach the lock.
+        state = Surfaces.withPosition(state, Surfaces.DESKTOP, "DP-1", "clock",
+            { x: 1, y: 1, placementStrategy: "free" });
+        compare(Surfaces.rawPosition(state, Surfaces.DESKTOP, "DP-1", "clock").x, 1);
+        compare(Surfaces.rawPosition(state, Surfaces.LOCK, "DP-1", "clock").x, 900);
+        // A widget added to the desktop after the fork is absent from the
+        // lock rather than leaking in at the desktop's position.
+        state = Surfaces.withPosition(state, Surfaces.DESKTOP, "DP-1", "media",
+            { x: 50, y: 50, placementStrategy: "free" });
+        compare(Surfaces.rawPosition(state, Surfaces.DESKTOP, "DP-1", "media").x, 50);
+        compare(Surfaces.rawPosition(state, Surfaces.LOCK, "DP-1", "media"), undefined);
+    }
+
+    function test_relinking_removes_the_screen_and_reads_through_again() {
+        let state = Surfaces.withPosition(desktopOnly, Surfaces.LOCK, "DP-1", "clock",
+            { x: 900, y: 900, placementStrategy: "free" });
+        state = Surfaces.withPosition(state, Surfaces.LOCK, "DP-2", "clock",
+            { x: 700, y: 700, placementStrategy: "free" });
+        const relinked = Surfaces.withoutLockLayout(state, "DP-1");
+        verify(!Surfaces.isForked(relinked, "DP-1"));
+        compare(Surfaces.rawPosition(relinked, Surfaces.LOCK, "DP-1", "clock").x, 100);
+        // The other screen's fork survives.
+        verify(Surfaces.isForked(relinked, "DP-2"));
+        compare(Surfaces.rawPosition(relinked, Surfaces.LOCK, "DP-2", "clock").x, 700);
+    }
+
+    function test_relinking_an_unforked_screen_is_a_no_op_by_identity() {
+        const same = Surfaces.withoutLockLayout(desktopOnly, "DP-1");
+        verify(same === desktopOnly);
+    }
+
+    function test_writes_never_mutate_the_state_they_were_given() {
+        const before = JSON.stringify(desktopOnly);
+        Surfaces.withPosition(desktopOnly, Surfaces.LOCK, "DP-1", "clock",
+            { x: 900, y: 900, placementStrategy: "free" });
+        Surfaces.withPosition(desktopOnly, Surfaces.DESKTOP, "DP-1", "clock",
+            { x: 1, y: 1, placementStrategy: "free" });
+        compare(JSON.stringify(desktopOnly), before);
+    }
+
+    // ---- the span forks with the position ------------------------------
+
+    function test_the_span_inherits_the_desktop_option_until_forked() {
+        compare(Surfaces.rawGridSize(desktopOnly, Surfaces.DESKTOP, "DP-1", "weather"), "3x2");
+        compare(Surfaces.rawGridSize(desktopOnly, Surfaces.LOCK, "DP-1", "weather"), "3x2");
+        compare(Surfaces.rawGridSize(desktopOnly, Surfaces.LOCK, "DP-1", "clock"), undefined);
+    }
+
+    function test_the_fork_snapshot_carries_each_widgets_span() {
+        const next = Surfaces.withPosition(desktopOnly, Surfaces.LOCK, "DP-1", "clock",
+            { x: 900, y: 900, placementStrategy: "free" });
+        // The forked record for weather carries the span it had.
+        compare(next.lockPositions["DP-1"].weather.gridSize, "3x2");
+        compare(Surfaces.rawGridSize(next, Surfaces.LOCK, "DP-1", "weather"), "3x2");
+        // A desktop resize afterwards does not reach the lock...
+        const resized = Surfaces.withGridSize(next, Surfaces.DESKTOP, "DP-1", "weather", "1x2");
+        compare(Surfaces.rawGridSize(resized, Surfaces.DESKTOP, "DP-1", "weather"), "1x2");
+        compare(Surfaces.rawGridSize(resized, Surfaces.LOCK, "DP-1", "weather"), "3x2");
+        // ...and a lock resize does not reach the desktop - the report.
+        const lockResized = Surfaces.withGridSize(resized, Surfaces.LOCK, "DP-1", "weather", "2x2");
+        compare(Surfaces.rawGridSize(lockResized, Surfaces.LOCK, "DP-1", "weather"), "2x2");
+        compare(Surfaces.rawGridSize(lockResized, Surfaces.DESKTOP, "DP-1", "weather"), "1x2");
+        compare(lockResized.pluginOptions.weather.__gridSize, "1x2");
+    }
+
+    function test_a_lock_resize_on_an_unforked_screen_forks_it() {
+        const next = Surfaces.withGridSize(desktopOnly, Surfaces.LOCK, "DP-1", "weather", "1x2");
+        verify(Surfaces.isForked(next, "DP-1"));
+        compare(Surfaces.rawGridSize(next, Surfaces.LOCK, "DP-1", "weather"), "1x2");
+        // The fork snapshot still copied everything else on the screen.
+        compare(Surfaces.rawPosition(next, Surfaces.LOCK, "DP-1", "clock").x, 100);
+        // The desktop's span is what it was.
+        compare(Surfaces.rawGridSize(next, Surfaces.DESKTOP, "DP-1", "weather"), "3x2");
+    }
+
+    function test_a_lock_move_keeps_the_records_span() {
+        let state = Surfaces.withGridSize(desktopOnly, Surfaces.LOCK, "DP-1", "weather", "1x2");
+        state = Surfaces.withPosition(state, Surfaces.LOCK, "DP-1", "weather",
+            { x: 5, y: 5, placementStrategy: "free" });
+        compare(Surfaces.rawPosition(state, Surfaces.LOCK, "DP-1", "weather").x, 5);
+        compare(Surfaces.rawGridSize(state, Surfaces.LOCK, "DP-1", "weather"), "1x2");
+    }
+
+    function test_a_forked_record_without_a_span_reads_through_to_the_desktop() {
+        // A fork made by an older shell, or a preset from one: records carry
+        // no gridSize. The lock still inherits rather than dropping to the
+        // manifest default.
+        const older = {
+            desktopPositions: desktopOnly.desktopPositions,
+            lockPositions: { "DP-1": { weather: { x: 1, y: 1, placementStrategy: "free" } } },
+            pluginOptions: desktopOnly.pluginOptions
+        };
+        compare(Surfaces.rawGridSize(older, Surfaces.LOCK, "DP-1", "weather"), "3x2");
+    }
+
+    function test_null_removes_a_span_on_either_surface() {
+        let state = Surfaces.withGridSize(desktopOnly, Surfaces.LOCK, "DP-1", "weather", "1x2");
+        state = Surfaces.withGridSize(state, Surfaces.LOCK, "DP-1", "weather", null);
+        // Removed from the lock record -> reads through to the desktop's 3x2.
+        compare(Surfaces.rawGridSize(state, Surfaces.LOCK, "DP-1", "weather"), "3x2");
+        state = Surfaces.withGridSize(state, Surfaces.DESKTOP, "DP-1", "weather", null);
+        compare(Surfaces.rawGridSize(state, Surfaces.DESKTOP, "DP-1", "weather"), undefined);
+        verify(!("__gridSize" in state.pluginOptions.weather));
+        // The other option on the plugin survives.
+        compare(state.pluginOptions.weather.blurEnabled, true);
+    }
+
+    function test_an_empty_state_and_missing_names_answer_undefined() {
+        compare(Surfaces.rawPosition({}, Surfaces.LOCK, "DP-1", "clock"), undefined);
+        compare(Surfaces.rawPosition(desktopOnly, Surfaces.LOCK, "", "clock"), undefined);
+        compare(Surfaces.rawPosition(desktopOnly, Surfaces.LOCK, "DP-1", ""), undefined);
+        compare(Surfaces.rawPosition(desktopOnly, Surfaces.DESKTOP, "DP-9", "clock"), undefined);
+        verify(!Surfaces.isForked(undefined, "DP-1"));
+        verify(!Surfaces.isForked({ lockPositions: [] }, "DP-1"));
+    }
+}


### PR DESCRIPTION
> lockscreen widget layout is meant to be different from desktop layout if the
> user decides to alter the widgets and their order in lockscreen.

> a widget state is not correctly saved when it's different between desktop
> and lockscreen (media widget being 3x2 instead of 1x2 for example)

Spec §4.3 chose **one** stored position per widget shared by both surfaces
and gave two objections. This overrules it in the shape you picked —
**fork on first edit** — and answers each objection instead of waving it off.

## The model

`modules/common/plugins/layout_surfaces.js`, pure, tested bare.

- `lockPositions` beside `desktopPositions`, same `[screen][pluginId]` shape.
  A screen **absent** from it shows the desktop's layout — every existing user
  is still in the one-position model, no migration.
- The first lock write **snapshots the whole screen** through one
  `forkedScreen()` both writers share: after it every widget follows the lock
  store, none half-follows the desktop. Deleting the entry re-links.
- **The span forks with the position.** Desktop: the per-plugin `__gridSize`
  option, unchanged. Forked lock: `gridSize` *in* the widget's lock record,
  copied by the snapshot. A record without one reads through.
- `PluginState.currentSurface` resolves the default from `lockLookActive` —
  the one derivation — so the Lockscreen tab and a real lock read the same
  store, and every pre-fork call site keeps its shape.
- **Undo captures its surface at push time.** A closure that resolved it at
  pop time writes the lock's position into the desktop store when popped from
  the other tab, and the store still reads valid. Every position and span
  writer names its surface into its closure.
- Presets carry `lockPositions` under the same `has()` rule as the desktop
  map: a preset from an older shell keeps your fork.
- The drawer's Lock section: "Widget layout follows the desktop / is
  separate", with **Use desktop layout** while forked (one undoable mutation
  that restores whole records).

`visibleWhenLocked` stays the single presence toggle — you chose the full
fork, but nothing in "positions and order" implies changing *presence*.

## Measured on the real path

`EditModeRuntimeTest` grows two legs on the Lockscreen tab, 56 → 77 checks:

- **A drag**: forks; moved widget follows the lock store; every *other* widget
  came along at its own position; desktop store untouched; back on Desktop
  the widget is at its desktop position; an undo popped on Desktop restores
  the **lock** store; re-link restores inheritance.
- **A grip pull**: forks; writes the lock span; desktop `__gridSize` untouched;
  drawn at the lock span there and the desktop span here; undo from the other
  tab restores the lock span.

Both undo traps planted (captured surface dropped from the closure): each
fails its one check **by name**.

`tst_layout_surfaces.qml` (16), `test_layout_surfaces_contract.py` (6),
`test_presets.py` gains a real jq round-trip both directions. Suite 1052 +
1027 QML, green.

## What I did not verify

The drawer row's pixels. My headless probe hung on the private bus activating
portals before "Configuration Loaded" — the row is a `RippleButton` reading
one bound bool, so I'm not worried, but I have not *seen* it. It is deployed
live; open the drawer's Lock section and look.

Docs: updated AGENT.md §Edit Mode (the fork, and the undo trap in bold); docs/superpowers/specs/2026-08-16-edit-mode-design.md §4.3 (the original kept struck through, each objection answered).