### PR TITLE
An edge-snapping toggle on Edit Mode's toolbar

### DIFF
--- a/dots/.config/quickshell/imi/modules/imi/editMode/EditModeChromeContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/editMode/EditModeChromeContent.qml
@@ -66,6 +66,7 @@ Item {
 
     signal doneRequested()
     signal drawerToggleRequested()
+    signal snapToggleRequested()
     signal widgetDropRequested(var manifest, real dropX, real dropY)
     signal widgetToggleRequested(var manifest)
     signal barWidgetAddRequested(string widgetId, string bucket)
@@ -123,6 +124,27 @@ Item {
             text: Translation.tr("Add widgets")
             toggled: GlobalStates.editDrawerOpen
             onClicked: root.drawerToggleRequested()
+        }
+
+        // Edge snapping, as state like the drawer's toggle. It reads and
+        // toggles `background.showSnapLines` - the key Settings already
+        // offers and the key stage 10's detent rides - rather than a switch of
+        // its own: the guide and the hold travel together on it, and a second
+        // key would be the "two fields that must agree" AGENT.md keeps paying
+        // for. Icon-only, because the toolbar's width is the card's inset and
+        // "Add widgets" plus "Done" already spend the words; the toggled
+        // container says which state it is in.
+        IconToolbarButton {
+            id: snapButton
+            Layout.alignment: Qt.AlignVCenter
+            text: "align_horizontal_left"
+            toggled: Config.options.background.showSnapLines
+            onClicked: root.snapToggleRequested()
+            StyledToolTip {
+                text: Config.options.background.showSnapLines
+                    ? Translation.tr("Edge snapping on")
+                    : Translation.tr("Edge snapping off")
+            }
         }
 
         // The mode's real way out. Two things about it are deliberate. It

--- a/dots/.config/quickshell/imi/modules/imi/editMode/EditModeChromeSurface.qml
+++ b/dots/.config/quickshell/imi/modules/imi/editMode/EditModeChromeSurface.qml
@@ -346,5 +346,10 @@ PanelWindow {
         onLockIslandToggleRequested: (key) => root.toggleLockIsland(key)
         onLockLayoutResetRequested: root.resetLockLayout()
         screenName: root.screen?.name ?? ""
+        // A preference, not a layout mutation: it is not one of §7.3's five
+        // committed mutations and records no undo entry, same as the global
+        // widget lock. The write is here, not in the chrome, because this
+        // surface makes every store write the mode makes.
+        onSnapToggleRequested: Config.options.background.showSnapLines = !Config.options.background.showSnapLines
     }
 }

--- a/dots/.config/quickshell/imi/tests/lint_edit_mode_scope.py
+++ b/dots/.config/quickshell/imi/tests/lint_edit_mode_scope.py
@@ -54,6 +54,12 @@ ALLOWED_CONFIG_PATHS = {
     "lock.islands.main",
     "lock.islands.left",
     "lock.islands.right",
+    # The edge-snap toggle on the mode's toolbar (maintainer, 2026-08-18). It
+    # is the SAME key Settings offers and stage 10's detent rides - the mode
+    # surfaces the switch where the snapping happens, it does not mint one -
+    # and it is a preference rather than a layout mutation, so it records no
+    # undo entry (like the global widget lock). Spelled out, not a prefix.
+    "background.showSnapLines",
 }
 # `lock.showWidgets` / `showToolbars` / `showMedia` are presence-on-a-surface,
 # which the rule admits (spec §9's second edge case).

--- a/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
@@ -553,6 +553,32 @@ def test_the_mode_animates_on_exactly_one_scalar():
         "...and so must the chrome"
 
 
+def test_the_snap_toggle_rides_the_settings_key_and_records_no_undo():
+    # Maintainer, 2026-08-18: a toggle in the mode for edge snapping. It must
+    # be the SAME key Settings offers and stage 10's detent rides -
+    # `background.showSnapLines` - not a second one: the guide and the hold
+    # travel together on that key, and two keys that must agree eventually
+    # disagree. And it is a preference, not a committed mutation: no undo
+    # entry, like the global widget lock. The write lives on the surface,
+    # because that is where every store write the mode makes lives.
+    content = code(CHROME_CONTENT)
+    assert "signal snapToggleRequested()" in content, \
+        "the chrome content no longer offers the snap toggle"
+    button = re.search(r"id:\s*snapButton\n(.*?)\n\s*\}", content, re.S)
+    assert button, "the toolbar has no snapButton"
+    assert "toggled: Config.options.background.showSnapLines" in button.group(1), \
+        "the snap toggle must read background.showSnapLines - the key the detent rides"
+    assert "onClicked: root.snapToggleRequested()" in button.group(1), \
+        "the snap toggle must signal the surface, not write the store from the chrome"
+    surface = code(CHROME_SURFACE)
+    assert re.search(r"onSnapToggleRequested:\s*Config\.options\.background\.showSnapLines\s*=\s*!Config\.options\.background\.showSnapLines",
+                     surface), \
+        "the surface must flip background.showSnapLines on the signal"
+    handler = re.search(r"onSnapToggleRequested:[^\n]*", surface)
+    assert handler and "editUndoPush" not in handler.group(0), \
+        "the snap toggle is a preference and must not spend an undo entry"
+
+
 def test_the_chrome_surface_is_static():
     # On a layer surface, position IS `margins`, so chrome animating into place
     # through them reconfigures the surface every frame - the create-map-destroy


### PR DESCRIPTION
> Also add a toggle in the edit mode for edge snapping.

An icon toggle beside **Add widgets**, drawn as state the way the drawer's
toggle is, with a tooltip naming it.

It reads and flips **`background.showSnapLines`** — the key Settings already
offers and the key stage 10's detent rides — rather than a switch of its own.
Stage 10 tied the guide and the hold to that one key deliberately (a detent
with no line is a drag that sticks for no visible reason), and a second key
that must agree with it would eventually not. The mode surfaces the switch
where the snapping happens; it does not mint one.

A preference, not a layout mutation: no undo entry, like the global widget
lock. The write lives on the chrome surface (where every store write the mode
makes lives) and the key is added to `lint_edit_mode_scope.py`'s allowlist by
name with that reason.

The contract pins the read, the signal, the write and the absence of a push.
Chrome pixel probes unchanged, green. Suite 1051 + 1011, green. Deployed live.

Docs: not needed — the toggle rides an existing documented key, and the reason it does is stated in the code, the lint's allowlist and the contract.