### PR TITLE
The recording stop reaches a recorder that never started capturing

### DIFF
--- a/dots/.config/quickshell/imi/scripts/videos/record.sh
+++ b/dots/.config/quickshell/imi/scripts/videos/record.sh
@@ -216,6 +216,31 @@ echo "$GSR_PID" > "$PIDFILE"
 set_recording_state true "$REGION"
 notify-send "Recording started" "$(basename "$OUT")" -a 'Recorder' & disown
 
+# A recording that never starts must not sit behind an indicator that says
+# it did. The portal path can wedge before the first frame - measured: a
+# hard-hung xdg-desktop-portal-hyprland left gsr at CreateSession for minutes,
+# single-threaded, no output file, while the bar showed "recording" - and the
+# user's only signal was that Stop did nothing. So watch for the OUTPUT FILE
+# to appear: gsr opens it the moment capture begins, and a screen capture
+# begins well inside this window. Past it, tear gsr down through the same
+# ladder the stop uses and say why, then fall through to the cleanup below.
+# The picker (a first-ever portal recording, or a token the portal refused)
+# needs the user's click, so the window is generous rather than tight.
+START_WINDOW_S="${IMI_RECORD_START_WINDOW_S:-25}"   # env override is for the test
+for _ in $(seq 1 $((START_WINDOW_S * 10))); do
+    kill -0 "$GSR_PID" 2>/dev/null || break            # exited on its own: fall through
+    [[ -e "$OUT" ]] && break                            # capturing
+    sleep 0.1
+done
+if kill -0 "$GSR_PID" 2>/dev/null && [[ ! -e "$OUT" ]]; then
+    notify-send "Recording did not start" \
+        "No frames after ${START_WINDOW_S}s - the screen-capture portal is not answering. Try again; if it keeps happening, restart xdg-desktop-portal-hyprland." \
+        -a 'Recorder' -u critical & disown
+    kill -INT "$GSR_PID" 2>/dev/null; sleep 1
+    kill -0 "$GSR_PID" 2>/dev/null && { kill -TERM "$GSR_PID" 2>/dev/null; sleep 1; }
+    kill -0 "$GSR_PID" 2>/dev/null && kill -KILL "$GSR_PID" 2>/dev/null
+fi
+
 # Block until gsr exits (stop toggle, crash, or logout) so the pidfile and the
 # shell's recording indicator are always cleaned up. The saved-file
 # notification comes from the -sc hook with the real path.

--- a/dots/.config/quickshell/imi/scripts/videos/record.sh
+++ b/dots/.config/quickshell/imi/scripts/videos/record.sh
@@ -34,8 +34,31 @@ set_recording_state() {
 # Toggle: a recording we started is running -> stop it gracefully and exit.
 # The pidfile scopes the toggle to OUR recording, never the replay daemon
 # (both are gpu-screen-recorder processes - killing by process name would hit both).
+#
+# INT first, because that is gsr's "finish and save". Then an ESCALATION,
+# because INT is not always enough: gsr installs its own INT handler only once
+# it is capturing, and a recording that never got that far - the portal picker
+# never resolved, the compositor refused the stream - sits in poll() with INT
+# still ignored (a `&` job in non-interactive bash starts with INT and QUIT
+# ignored, and gsr had not yet undone it) and TERM caught but never acted on.
+# That is the recording the maintainer could not stop from the privacy card or
+# the overlay: every stop path funnels here, this sent one signal, and the
+# process was born deaf to it. There is no file to lose in that state, so the
+# ladder ends in KILL rather than leaving an unstoppable process behind an
+# indicator that says "recording".
 if [[ -f "$PIDFILE" ]] && kill -0 "$(cat "$PIDFILE")" 2>/dev/null; then
-    kill -INT "$(cat "$PIDFILE")"
+    gsr_pid="$(cat "$PIDFILE")"
+    kill -INT "$gsr_pid"
+    for _ in $(seq 1 30); do   # 3s: gsr flushes a real capture well inside this
+        kill -0 "$gsr_pid" 2>/dev/null || exit 0
+        sleep 0.1
+    done
+    kill -TERM "$gsr_pid" 2>/dev/null
+    for _ in $(seq 1 20); do   # 2s
+        kill -0 "$gsr_pid" 2>/dev/null || exit 0
+        sleep 0.1
+    done
+    kill -KILL "$gsr_pid" 2>/dev/null
     exit 0
 fi
 rm -f "$PIDFILE"
@@ -179,8 +202,16 @@ else
     ARGS+=(-w region -region "$GEOMETRY")
 fi
 
+# Job control ON for the launch, so gsr is not born with INT and QUIT ignored:
+# a `&` job in a non-interactive shell inherits SIG_IGN for both, and the stop
+# path above leads with INT. gsr normally installs its own handler and undoes
+# that once capturing, but "normally" is the case that already worked; this is
+# for the one that did not. Turned back off after, so the script's own
+# job-control noise does not change anything else about how it runs.
+set -m
 "${ARGS[@]}" &
 GSR_PID=$!
+set +m
 echo "$GSR_PID" > "$PIDFILE"
 set_recording_state true "$REGION"
 notify-send "Recording started" "$(basename "$OUT")" -a 'Recorder' & disown

--- a/dots/.config/quickshell/imi/tests/test_screen_record.py
+++ b/dots/.config/quickshell/imi/tests/test_screen_record.py
@@ -34,8 +34,95 @@ class RecordScriptTests(unittest.TestCase):
     def test_toggle_is_pidfile_scoped_not_pkill(self):
         # pkill by process name would also kill the replay daemon.
         self.assertIn("imi-screenrecord.pid", self.script)
-        self.assertIn('kill -INT "$(cat "$PIDFILE")"', self.script)
+        self.assertIn('kill -INT "$gsr_pid"', self.script)
         self.assertNotIn("pkill", self.script)
+
+    def test_the_stop_reaches_a_recorder_that_ignores_int_and_sits_on_term(self):
+        """The recording the maintainer could not stop from the privacy card or
+        the overlay: gsr blocked at portal selection, never capturing, INT
+        still ignored (a `&` job in non-interactive bash is born with INT and
+        QUIT ignored, and gsr undoes that only once capturing) and TERM caught
+        but never acted on. Every stop path funnels into this script with a
+        live pidfile, and it sent one INT.
+
+        Driven for real: a stand-in `gpu-screen-recorder` on PATH that ignores
+        INT and traps TERM to a no-op, launched through the script's own
+        launch (which is where the mask comes from), then stopped through the
+        script's own toggle. It must be gone within the ladder's window and the
+        pidfile with it. The stand-in exits 0 on any signal it DOES receive,
+        so a launch that stops ignoring INT ends it at the first rung.
+        """
+        import os, tempfile, time, shutil, stat
+        with tempfile.TemporaryDirectory() as directory:
+            home = Path(directory)
+            binstub = home / "bin"; binstub.mkdir()
+            gsr = binstub / "gpu-screen-recorder"
+            # INT and TERM are both trapped to no-ops - handled and ignored,
+            # the way a wedged gsr behaves - so only KILL ends it: the worst
+            # case the ladder must beat. Traps, not `trap '' INT`: that would
+            # set SIG_IGN itself, and the assertion below reads the mask the
+            # LAUNCH handed the process, which must be clean. `exec sleep`
+            # would replace the traps, so it loops instead.
+            gsr.write_text("#!/usr/bin/env bash\n"
+                           "trap ':' INT TERM\n"
+                           "while :; do sleep 0.2; done\n")
+            gsr.chmod(gsr.stat().st_mode | stat.S_IEXEC)
+            for helper in ("notify-send", "slurp", "jq"):
+                stub = binstub / helper
+                if helper == "jq":
+                    # The script reads its config through jq; the real one is
+                    # fine but must be on the stub PATH too.
+                    real = shutil.which("jq")
+                    if real: os.symlink(real, stub); continue
+                stub.write_text("#!/usr/bin/env bash\nexit 0\n")
+                stub.chmod(stub.stat().st_mode | stat.S_IEXEC)
+            runtime = home / "rt"; runtime.mkdir(mode=0o700)
+            cfg = home / ".config/immaterial-impulse"; cfg.mkdir(parents=True)
+            (cfg / "config.json").write_text(json.dumps({"screenRecord": {
+                "fps": 30, "quality": "medium", "audioCodec": "opus", "codec": "auto",
+                "framerateMode": "vfr", "showCursor": True, "recordAudio": False,
+                "recordMic": False, "tonemapSdr": False, "savePath": str(home / "Videos")}}))
+            (home / "Videos").mkdir()
+            state = home / ".local/state/quickshell"; state.mkdir(parents=True)
+            (state / "states.json").write_text(json.dumps({"record": {"enable": False, "region": ""}}))
+            env = dict(os.environ, HOME=str(home), XDG_RUNTIME_DIR=str(runtime),
+                       XDG_CONFIG_HOME=str(home / ".config"),
+                       PATH=f"{binstub}:{os.environ['PATH']}")
+            env.pop("HYPRLAND_INSTANCE_SIGNATURE", None)
+
+            # Start: the script blocks on `wait`, so run it detached.
+            starter = subprocess.Popen(["bash", str(RECORD_SH), "--fullscreen"], env=env,
+                                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            pidfile = runtime / "imi-screenrecord.pid"
+            deadline = time.monotonic() + 10
+            while not pidfile.exists() and time.monotonic() < deadline:
+                time.sleep(0.1)
+            self.assertTrue(pidfile.exists(), "the script never wrote its pidfile")
+            gsr_pid = int(pidfile.read_text().strip())
+            self.assertTrue(Path(f"/proc/{gsr_pid}").exists(), "the stand-in never came up")
+
+            # The launch must not hand gsr an ignored INT.
+            sigign = re.search(r"SigIgn:\s*([0-9a-f]+)",
+                               Path(f"/proc/{gsr_pid}/status").read_text()).group(1)
+            self.assertEqual(int(sigign, 16) & 0x2, 0,
+                             f"gsr was launched with SIGINT ignored (SigIgn={sigign}); "
+                             f"the launch must run under job control")
+
+            # Stop through the toggle - the same path every UI stop takes.
+            t0 = time.monotonic()
+            subprocess.run(["bash", str(RECORD_SH)], env=env, timeout=30, check=True)
+            deadline = time.monotonic() + 8
+            while Path(f"/proc/{gsr_pid}").exists() and time.monotonic() < deadline:
+                time.sleep(0.1)
+            elapsed = time.monotonic() - t0
+            self.assertFalse(Path(f"/proc/{gsr_pid}").exists(),
+                             f"the recorder survived the stop ({elapsed:.1f}s) - the toggle "
+                             f"must escalate INT -> TERM -> KILL")
+            try:
+                starter.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                starter.kill(); self.fail("record.sh did not exit after its recorder died")
+            self.assertFalse(pidfile.exists(), "the pidfile outlived the recording")
 
     def test_keeps_interface_flags(self):
         for flag in ("--sound", "--fullscreen", "--region", "--path"):

--- a/dots/.config/quickshell/imi/tests/test_screen_record.py
+++ b/dots/.config/quickshell/imi/tests/test_screen_record.py
@@ -63,8 +63,11 @@ class RecordScriptTests(unittest.TestCase):
             # set SIG_IGN itself, and the assertion below reads the mask the
             # LAUNCH handed the process, which must be clean. `exec sleep`
             # would replace the traps, so it loops instead.
+            # It also opens its output file, the way gsr does the moment
+            # capture begins - the start watchdog reads that as "capturing".
             gsr.write_text("#!/usr/bin/env bash\n"
                            "trap ':' INT TERM\n"
+                           "while [[ $# -gt 0 ]]; do [[ $1 == -o ]] && : > \"$2\"; shift; done\n"
                            "while :; do sleep 0.2; done\n")
             gsr.chmod(gsr.stat().st_mode | stat.S_IEXEC)
             for helper in ("notify-send", "slurp", "jq"):
@@ -123,6 +126,67 @@ class RecordScriptTests(unittest.TestCase):
             except subprocess.TimeoutExpired:
                 starter.kill(); self.fail("record.sh did not exit after its recorder died")
             self.assertFalse(pidfile.exists(), "the pidfile outlived the recording")
+
+    def test_a_recording_that_never_starts_is_torn_down_and_reported(self):
+        """The bar said "recording" for minutes while gsr sat at CreateSession
+        against a hard-hung portal - single-threaded, no output file - and the
+        user's only signal was that Stop did nothing. The script now waits a
+        bounded window for the OUTPUT FILE (gsr opens it as capture begins)
+        and, past it, tears gsr down and says why. Driven with a stand-in that
+        never opens its file, and the window shortened through the env hook.
+        """
+        import os, tempfile, time, shutil, stat
+        with tempfile.TemporaryDirectory() as directory:
+            home = Path(directory)
+            binstub = home / "bin"; binstub.mkdir()
+            gsr = binstub / "gpu-screen-recorder"
+            gsr.write_text("#!/usr/bin/env bash\n"
+                           "trap ':' INT TERM\n"
+                           "while :; do sleep 0.2; done\n")
+            gsr.chmod(gsr.stat().st_mode | stat.S_IEXEC)
+            notes = home / "notify.log"
+            (binstub / "notify-send").write_text(f"#!/usr/bin/env bash\necho \"$*\" >> {notes}\n")
+            (binstub / "notify-send").chmod(0o755)
+            (binstub / "slurp").write_text("#!/usr/bin/env bash\nexit 0\n"); (binstub / "slurp").chmod(0o755)
+            real_jq = shutil.which("jq"); self.assertTrue(real_jq); os.symlink(real_jq, binstub / "jq")
+            runtime = home / "rt"; runtime.mkdir(mode=0o700)
+            cfg = home / ".config/immaterial-impulse"; cfg.mkdir(parents=True)
+            (cfg / "config.json").write_text(json.dumps({"screenRecord": {
+                "fps": 30, "quality": "medium", "audioCodec": "opus", "codec": "auto",
+                "framerateMode": "vfr", "showCursor": True, "recordAudio": False,
+                "recordMic": False, "tonemapSdr": False, "savePath": str(home / "Videos")}}))
+            (home / "Videos").mkdir()
+            state = home / ".local/state/quickshell"; state.mkdir(parents=True)
+            (state / "states.json").write_text(json.dumps({"record": {"enable": False, "region": ""}}))
+            env = dict(os.environ, HOME=str(home), XDG_RUNTIME_DIR=str(runtime),
+                       XDG_CONFIG_HOME=str(home / ".config"),
+                       PATH=f"{binstub}:{os.environ['PATH']}",
+                       IMI_RECORD_START_WINDOW_S="2")
+            env.pop("HYPRLAND_INSTANCE_SIGNATURE", None)
+
+            t0 = time.monotonic()
+            proc = subprocess.Popen(["bash", str(RECORD_SH), "--fullscreen"], env=env,
+                                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            try:
+                proc.wait(timeout=12)
+            except subprocess.TimeoutExpired:
+                # The pre-fix shape: record.sh blocks on `wait` behind a
+                # recorder that never began, and the bar says "recording"
+                # until someone kills it by hand.
+                proc.kill(); proc.wait()
+                for stray in subprocess.run(["pgrep", "-f", str(gsr)], capture_output=True,
+                                            text=True).stdout.split():
+                    subprocess.run(["kill", "-KILL", stray])
+                self.fail("record.sh never gave up on a recorder that produced no output "
+                          "file - the start watchdog is missing")
+            elapsed = time.monotonic() - t0
+            self.assertFalse((runtime / "imi-screenrecord.pid").exists(),
+                             "the pidfile outlived the never-started recording")
+            self.assertEqual(json.loads((state / "states.json").read_text())["record"]["enable"], False,
+                             "the indicator was left saying 'recording'")
+            self.assertTrue(notes.exists() and "Recording did not start" in notes.read_text(),
+                            "the user was not told the recording never started")
+            self.assertFalse(list((home / "Videos").glob("*.mp4")), "no file should exist")
 
     def test_keeps_interface_flags(self):
         for flag in ("--sound", "--fullscreen", "--region", "--path"):


### PR DESCRIPTION
> I have a recording I just started and I cannot stop it via either the
> privacy widget or the overlay window.

> Recording with the Record Screen option (whole screen) does not save the
> recording when stopped.

Both the same finding, reached twice. Reproduced live on the maintainer's
session with consent, then fixed at the machine and hardened in the shell.

## What it actually was

**The fullscreen recording never started.** `xdg-desktop-portal-hyprland` (pid
7791, up 17h) was hard-hung — main thread `R (running)`, `wchan 0`, would not
answer even a `Properties.Get` on its own bus name — so gsr's
`ScreenCast.CreateSession` queued forever. gsr sat single-threaded with no
output fd, the bar said "recording", and Stop did nothing. Nothing saved
because nothing was captured. Region recordings kept working: they take the
KMS path and never touch the portal.

`systemctl --user restart xdg-desktop-portal-hyprland` → `ScreenCast v6`
answers instantly → a fullscreen recording started (picker once, token
refreshed 23:40), captured at 5120×1440 hevc_nvenc, **stopped through the
toggle at the first rung in 0.2s**, and a 19.8s file is on disk. The portal
delivered SDR (`bt709`) so the tonemap correctly left it alone.

## Why Stop did nothing (and still would, without this)

Every stop path funnels into `record.sh` with a live pidfile, and it sent
**one SIGINT**. A `&` job in non-interactive bash is born with INT and QUIT
ignored (POSIX; `SigIgn=0x6` measured). gsr installs its own INT handler once
capturing — which is why every earlier stop worked — but a gsr stuck before
capture never got there. TERM was caught but its loop never checked the flag.

## What ships

- **Launch under job control** (`set -m` around the `&`) so gsr is never born
  deaf to the stop signal.
- **Stop escalates**: INT → 3s → TERM → 2s → KILL. A real capture flushes at
  rung one; only a never-started one reaches KILL, with no file to lose.
- **A start watchdog**: gsr opens its output file the moment capture begins;
  if it hasn't within 25s (generous — the picker needs a click), gsr is torn
  down through the same ladder and the user is told the portal isn't
  answering and what to try. The indicator and pidfile then clear as they
  always did.

## Driven for real

Stand-in `gpu-screen-recorder` on PATH, launched and stopped through the
script's own paths. Three plants, each failing **by name**: the pre-fix
launch (`SigIgn=0x6`, INT swallowed); the ladder without KILL (survives 13s);
the watchdog removed (record.sh blocks on `wait` behind a recorder that never
began). Suite 1052 + 1011, green. Deployed live — `record.sh` is read per
invocation, no restart needed.

Docs: not needed — every mechanism (job-control mask, gsr's late handler, the escalation, the watchdog and why the window is generous) is stated in the script beside the change it explains, and in the tests.