### PR TITLE
The bar popup card retargets when its window's geometry arrives

### DIFF
--- a/dots/.config/quickshell/imi/modules/imi/bar/BarPopupOverlay.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/BarPopupOverlay.qml
@@ -398,6 +398,21 @@ Scope {
                 else retargetTimer.restart();
             }
 
+            // The window is unmapped while it has nothing to show (a mapped
+            // screen-sized Overlay surface holds the compositor's fullscreen
+            // fast path shut), and a WlrLayershell window that has just gone
+            // visible does not have its size yet: measured on the live
+            // compositor, it reports 500x500 for the same tick AND through
+            // Qt.callLater, and the real 5120x1330 arrives with the configure
+            // ~50ms later. retarget()'s clamp reads overlayWindow.width and
+            // height, so a retarget on the zero-interval timer ran against
+            // 500x500, `min(base, 500 - cardWidth - margin - 10)` went
+            // negative, and `max(margin, ...)` pinned the card to the
+            // top-left - the calendar card at x=margin under a clock at
+            // screen-centre. Re-run when the geometry actually lands.
+            onWidthChanged: if (overlayWindow.current) overlayWindow.retarget()
+            onHeightChanged: if (overlayWindow.current) overlayWindow.retarget()
+
             // There is no sensible interpolation between "below the top edge"
             // and "right of the left edge", so an orientation change idles the
             // card rather than morphing across it.

--- a/dots/.config/quickshell/imi/tests/lint_bar_popup_overlay_static.py
+++ b/dots/.config/quickshell/imi/tests/lint_bar_popup_overlay_static.py
@@ -2,11 +2,22 @@
 """The bar popup overlay's surface geometry must be a constant of the screen.
 
 `modules/imi/bar/BarPopupOverlay.qml` hosts every bar popup's card on one
-always-mapped layer surface. That only works while the *surface* never moves or
-resizes: on a layer-shell surface position is `margins`, so a bound margin, a
-bound implicit size, or an edge anchor that can go false reconfigures the
-surface - which is the create-map-destroy loop StyledPopup's imperative
-positioning was written to escape, reached from the other side.
+layer surface. That only works while the *surface* never moves or resizes: on a
+layer-shell surface position is `margins`, so a bound margin, a bound implicit
+size, or an edge anchor that can go false reconfigures the surface - which is
+the create-map-destroy loop StyledPopup's imperative positioning was written to
+escape, reached from the other side.
+
+The surface is no longer always MAPPED - it unmaps while it has nothing to
+show, because a mapped screen-sized Overlay surface holds the compositor's
+fullscreen fast path shut - and that added a rule of its own. A WlrLayershell
+window that has just gone visible does not have its size yet: measured on the
+live compositor, 500x500 for the same tick and through Qt.callLater, the real
+size arriving with the configure ~50ms later. `retarget()` clamps the card
+against the window's width/height, so a retarget on the zero-interval timer
+alone pinned the card to the top-left margin - the calendar under the clock at
+screen-centre. The overlay must therefore retarget again when its own geometry
+lands (`onWidthChanged`/`onHeightChanged`), which is the last check below.
 
 Two more properties this file must keep, both from the same design:
 
@@ -52,6 +63,17 @@ else:
     for edge in ("top", "bottom", "left", "right"):
         if not re.search(rf"\b{edge}\s*:\s*true\b", anchors.group(1)):
             failures.append(f"anchors.{edge} is not literally true")
+
+# The window retargets when its OWN geometry arrives. Without this the first
+# retarget after unmap->map runs against the placeholder 500x500 and the clamp
+# pins the card to the margin.
+for signal in ("onWidthChanged", "onHeightChanged"):
+    if not re.search(rf"^\s*{signal}:\s*if \(overlayWindow\.current\) overlayWindow\.retarget\(\)",
+                     code, re.MULTILINE):
+        failures.append(
+            f"does not retarget on the window's {signal}; a just-shown layer surface "
+            f"reports a placeholder size for its first tick and the clamp pins the card "
+            f"to the top-left margin")
 
 for transform in ("scale", "rotation"):
     if re.search(rf"^\s*{transform}\s*:", code, re.MULTILINE) \


### PR DESCRIPTION
> The bar widget's popup window is displayed in the wrong spot.

The calendar card pinned to the top-left of the screen under a clock at
screen-centre. A regression from #257, which unmaps the popup overlay while
idle.

## Measured

A WlrLayershell window that has just gone `visible` does not have its size
yet. Probed on the live compositor:

```
before show:            w=100  h=100
same tick after show:   w=500  h=500
Qt.callLater:           w=500  h=500
50ms:                   w=5120 h=1330   ← the configure
```

`retarget()` clamps the card against `overlayWindow.width/height`. On the
zero-interval timer it ran against 500×500, `min(base, 500 − cardWidth −
margin − 10)` went negative, `max(margin, …)` pinned x to the margin. The bar
window's `mapFromItem` was fine throughout — only the overlay's own size was
the placeholder.

## Fix

Retarget again on the window's own `widthChanged`/`heightChanged` while a
popup is current. Nothing else in the placement changes.

`lint_bar_popup_overlay_static.py`'s premise said "always-mapped" — corrected,
the measurement recorded, and a check for the retarget added. Planted by
deleting one line: exit 1 with the reason. Deployed live.

I did not screenshot the fixed card: synthetic cursor moves don't reliably
open a hover card and the repo's own rule says not to turn a shaky run into
a finding. Hover any bar widget from cold and it should land under it.

Docs: not needed — the mechanism is stated at the site and in the lint's header.