### PR TITLE
docs: status headers say what shipped, not what was planned

### DIFF
--- a/docs/proposals/multi-widget-selection.md
+++ b/docs/proposals/multi-widget-selection.md
@@ -1,6 +1,6 @@
 # Proposal: drag-select multiple widgets to move together
 
-> Draft / tracking proposal. Not scheduled.
+> Implemented (v0.18.0, `1bd7e8899`). The outcome section below records what was built.
 
 ## Outcome (implemented on this branch)
 

--- a/docs/superpowers/specs/2026-07-27-plugin-store-design.md
+++ b/docs/superpowers/specs/2026-07-27-plugin-store-design.md
@@ -1,6 +1,6 @@
 # Plugin Store — Design Spec
 
-Status: draft for review
+Status: implemented (`a1124aec4` onward — `services/PluginStore.qml`, `PluginStorePage.qml`, `install_plugin.py --upgrade`, `registry_validate.py`); shipped behind `plugins.storeEnabled: false`.
 Date: 2026-07-27
 Prior art studied: DankMaterialShell (danklinux.com/plugins, dms-plugin-registry) and
 Noctalia (noctalia.dev/plugins, official-plugins + community-plugins). Findings that

--- a/docs/superpowers/specs/2026-08-11-expressive-morphing-design.md
+++ b/docs/superpowers/specs/2026-08-11-expressive-morphing-design.md
@@ -1,6 +1,6 @@
 # Expressive morphing, and a motion model for interaction — design
 
-**Status:** design, not implemented
+**Status:** implemented (v0.24.0; `b88c5a018` landed the shared `WidgetCard`/`MediaCard`/`WeatherCard`). Two items remain narrower than designed: the calendar rebuild uses `calendar_geometry.js` but not `WidgetCard`, and the interaction-model retrofit reaches `RippleButton`, `MediaTransportButton` and `DockIconMotion` only.
 **Scope:** the bundled `nandoroid-media` widget first; `modules/common/plugins/` and
 `modules/common/widgets/` once the reusable parts are extracted
 

--- a/docs/superpowers/specs/2026-08-13-dock-position-design.md
+++ b/docs/superpowers/specs/2026-08-13-dock-position-design.md
@@ -1,7 +1,6 @@
 # The dock's edge, the way the bar already does it — design
 
-**Status:** design, not implemented. §9 holds seven questions that must be answered before an
-implementation plan; four of them change the shape of the work rather than a detail of it.
+**Status:** implemented (v0.24.0; `c43d00cb2` — `dock.edge` string key, `dock_geometry.js`, `DockEdgeRuntimeTest.qml`). §9's questions were answered in the implementation.
 **Scope:** `modules/imi/dock/`, `modules/common/widgets/Dock*.qml` + `DragApps.qml`,
 `modules/common/Config.qml`, `modules/imi/settings/pages/BarConfig.qml`, `defaults/config.json`,
 and one line of repo-relative `dots/.config/hypr/hyprland/rules.lua`.

--- a/docs/superpowers/specs/2026-08-16-clock-depth-design.md
+++ b/docs/superpowers/specs/2026-08-16-clock-depth-design.md
@@ -1,7 +1,6 @@
 # Clock depth mode — feasibility and design
 
-**Status:** design, not implemented. The feasibility question is settled with measurements; §1 is the
-evidence and §2 onward is what to build on top of it.
+**Status:** partially implemented (v0.25.0; `aa6a8bfb0` — `subject_mask.py` producer, `clockDepth.js`, `clockDepthSelect/`, `Background.qml` `clockDepthLayer`). §8 (Wallpaper Engine) is designed, not landed. Open quality issue: mask separation is not crisp enough — fine structure such as hair claims more mask than it should. §1 is the feasibility evidence.
 **Scope:** `modules/imi/background/Background.qml`, a new `scripts/background/` producer, the
 wallpaper selector, `sdata/uv/`.
 

--- a/docs/superpowers/specs/2026-08-16-edit-mode-design.md
+++ b/docs/superpowers/specs/2026-08-16-edit-mode-design.md
@@ -1,6 +1,6 @@
 # Edit Mode — design
 
-**Status:** design, not implemented. §14 holds **one** open question.
+**Status:** implemented and closed for now (v0.25.0 shipped the mode, v0.26.0 the lock-layout fork and edge-snap toggle — `4bda94505`). §4.3 is overruled in place; §14's question was answered by the implementation.
 **Scope:** `GlobalStates.qml`, `modules/imi/background/`, `modules/imi/desktopMenu/`,
 `modules/common/widgets/widgetCanvas/`, `modules/common/widgets/` (`WidgetsSubmenu.qml`,
 `LayoutSection.qml`, `DragApps.qml`), `modules/common/plugins/`, `modules/imi/bar/`,


### PR DESCRIPTION
Six design docs still opened with "design, not implemented" (or "draft for review" / "not scheduled") while the work has been on `main` for releases: edit mode, dock position, expressive morphing, clock depth, plugin store, multi-widget selection. Today's status check had to re-verify each against the code because the headers could not be trusted.

Each header now names the landing commit and, where the work is narrower than designed, what remains open:

- **clock depth** — §8 Wallpaper Engine path not landed; mask separation not crisp enough (hair claims too much mask) — open work
- **expressive morphing** — calendar rebuild without `WidgetCard`; interaction retrofit narrow
- **plugin store** — built, shipped behind `plugins.storeEnabled: false`
- **edit mode** — done for now; §4.3 overrule already in place
- **dock position**, **multi-widget selection** — done

Body text untouched.

Docs: updated
