### PR TITLE
docs(phone-connect): record ii-p3drovfx as prior art, order the next slices

### DIFF
--- a/docs/proposals/phone-connect.md
+++ b/docs/proposals/phone-connect.md
@@ -27,10 +27,163 @@ The first slice exists on this branch:
   keeping the service's parser logic byte-for-byte in sync with the QML
   suite's logic-only double.
 
-Still open: notification mirroring, media, file send, clipboard *receive*,
-`busctl monitor` streaming, and Valent action coverage beyond
-`findmyphone.ring` (its other action names were not verifiable without a live
-Valent daemon — ping/clipboard are KDE Connect-only for now).
+## Prior art: P3DROVFX/ii-p3drovfx
+
+Recorded because the next slice is decided from it, not because any of it is
+imported. [ii-p3drovfx](https://github.com/P3DROVFX/ii-p3drovfx) is a
+standalone illogical-impulse derivative (GPL-3.0, branch `dev`) with a full
+KDE Connect phone tab. Its phone feature landed in `c43837f07` (2026-06-22,
+"feat: bunch of things") and was iterated through `e31a3b00d` (2026-08-17);
+the commits worth reading are `74c5df003` (dedupe kdeconnectd's own desktop
+notifications), `4af16caf0` (`qdbus` binary resolution), `3a7f653b4` (SFTP
+target directory) and `5688f2fbe` (contacts). Paths below are relative to its
+`dots/.config/quickshell/ii/`, checked against a local clone at that head.
+
+**Transport — where we differ, and should keep differing.**
+
+- KDE Connect only. No Valent, no backend abstraction: `org.kde.kdeconnect`
+  is hardcoded in `scripts/kdeconnect/monitor.py:18-24`, and availability is
+  `command -v kdeconnect-cli` (`services/KdeConnectService.qml:292`).
+- Reads go through a Python + Gio sidecar. `services/KdeConnectService.qml`
+  (~1947 lines) spawns `scripts/kdeconnect/monitor.py`, which does an initial
+  `GetAll` dump per device (`monitor.py:168-193`) and then subscribes to
+  signals: `deviceAdded`/`deviceRemoved`/`deviceVisibilityChanged`/
+  `pairingRequestsChanged` on the daemon (`monitor.py:388-391`),
+  `PropertiesChanged` on the device, `battery.refreshed`,
+  `connectivity_report.refreshed`, the four `notifications.*` signals,
+  `share.shareReceived` and `pairStateChanged` per device
+  (`monitor.py:284-334`). Events are JSON-per-line on stdout, parsed by a
+  `SplitParser` (`KdeConnectService.qml:426-448`). Needs PyGObject
+  (`monitor.py:41-45`). On exit the service restarts it from a 4 s one-shot
+  timer with no backoff (`KdeConnectService.qml:460-478`), preceded by a
+  `pkill -f kdeconnect/monitor.py` (`:410`).
+- Writes go through `qdbus`, resolved at call time and interpolated into
+  `Quickshell.execDetached(["bash", "-c", ...])` with a home-grown
+  `_shellQuote` (`_call()` at `KdeConnectService.qml:1429-1442`,
+  `_shellQuote` at `:1500-1502`; `acceptPairing`/`declinePairing` at
+  `:990-1018` splice `devId` in unquoted). That is a string-built shell for
+  every action. A second one-shot script, `scripts/kdeconnect/
+  fetch_notifications.py`, exists because `qdbus` wraps replies in
+  `[Variant(QString): "..."]` and broke `JSON.parse` (its module docstring,
+  and `KdeConnectService.qml:820-826`).
+
+Ours is the stronger transport on every axis that matters here: `busctl
+--json=short` with argv arrays and no shell (`services/PhoneConnect.qml:182-
+184`), no sidecar and no Python dependency, both daemons behind one model, and
+a parser held byte-for-byte to a test double
+(`tests/test_phone_connect_contract.py`). What it lacks is the *shape* of the
+feature above the transport, which is what the fork has and we borrow.
+
+**Feature surface (what a finished phone tab looks like).**
+
+- Device list with a persisted active device and an MRU list
+  (`Persistent.states.sidebar.policies.phone.{activeDeviceId, recentDeviceIds}`,
+  `KdeConnectService.qml:34-58, 712-737`), and a per-device
+  `cachedNotificationsJson` so the tab is not empty on startup
+  (`:1769-1813`).
+- Pairing requests surfaced as accept/decline banners in the tab
+  (`modules/ii/sidebarPolicies/phone/Phone.qml:760,780`), fed by both
+  `pairingRequestsChanged` and `pairStateChanged == 2` (`monitor.py:236-244,
+  329-334`). This answers our open question: pairing *is* driveable from the
+  shell, and it is two D-Bus methods on the device path.
+- Battery plus cellular type/strength from `connectivity_report`
+  (`monitor.py:190-193, 292-297`); `reachableAddresses` is read off the
+  device (`monitor.py:180`) and later reused for wireless ADB. Low-battery
+  hooks: `activeDeviceBatteryLow` at <20% not charging, `Recovered` at ≥25%
+  or charging (`KdeConnectService.qml:615-628`).
+- Actions: `findmyphone.ring`, `ping.sendPing`, `clipboard.sendClipboard`,
+  `share.shareUrl`, `share.shareText` (`:957-988`); file send via
+  kdialog/zenity picker or a `DropArea`, each path sent as
+  `share.shareUrl("file://…")` (`:1401-1427`, `Phone.qml:1125`); incoming
+  `share.shareReceived` re-emitted as a signal (`:552-553`).
+- Full notification mirroring: list, group by app
+  (`modules/common/widgets/RemoteNotification{ListView,Group,Item}.qml`),
+  inline reply via `notifications.sendReply` with a delayed re-fetch because
+  the phone updates the body after the daemon's `notificationUpdated`
+  (`:929-955`), package extracted from `internalId` `0|<pkg>|…`
+  (`monitor.py:222-228`), "open on phone" via scrcpy plus `adb shell monkey`
+  (`:1239-1282`). Dismiss calls the *leaf* method
+  `notifications.notification.dismiss` on
+  `/…/notifications/<publicId>`; the comment at `:883-901` records that
+  `sendAction(key, "cancel")` is a no-op because "cancel" is not a registered
+  Android action, which is the kind of finding worth not re-learning. And it
+  hides kdeconnectd's own desktop notifications while the tab is live:
+  `services/Notifications.qml:206-215` drops any notification whose
+  `appName` is `kdeconnect`/`kde connect`/`org.kde.kdeconnect` or equals a
+  paired device's name, but only when the phone tab is enabled and the active
+  device is reachable — otherwise the daemon's notification is the only one
+  the user would get.
+- SFTP mount/unmount/browse (`:1027-1043`), contacts read from
+  `~/.local/share/kpeoplevcard/kdeconnect-*` vCards
+  (`scripts/kdeconnect/contacts_monitor.py:27-40`), and scrcpy/adb/droidcam
+  glue (`scripts/phone/`, `services/Phone{Scrcpy,Camera,Mic}Service.qml`) —
+  the last group is out of our scope.
+- Not implemented there either: `mprisremote`, `mousepad`, telephony/SMS,
+  `systemvolume`, `lockdevice`, `runcommand`, clipboard *receive*.
+
+UI: sidebar Policies → Phone tab (`modules/ii/sidebarPolicies/phone/*`), a bar
+indicator (`modules/ii/bar/widgets/indicators/PhoneScrcpyIndicator.qml`), a
+dock widget (`modules/ii/dock/DockPhoneWidget.qml`), the dynamic island as a
+drop target (`modules/ii/dynamicIsland/DynamicIslandPanel.qml:1151-1172`),
+desktop battery widgets (`modules/ii/background/widgets/bluetooth/
+MobileBatteryWidget.qml` and siblings), and a settings page
+(`modules/settings/configs/DevicesPhoneConfig.qml`). Config lives under
+`Config.options.phone.*` with a `policies.phone` gate.
+
+Other Quickshell implementations worth a glance before the notification
+slice: AvengeMedia/dms-plugins `DankKDEConnect` (which carries a
+`ValentService.qml`, the only one seen so far) and
+noctalia-dev/legacy-v4-plugins `kde-connect` and `valent-connect`.
+
+## Next slices
+
+Ordered by value. Each borrows the fork's shape and none of its transport:
+every read is a `busctl` argv, every write goes through `runAction`, and both
+backends stay behind the one model.
+
+1. **Signal-driven updates.** Replace the poll with `busctl --user
+   --json=short monitor` on the daemon's bus name, keyed on the same signals
+   the fork's `monitor.py` subscribes to (`PropertiesChanged`,
+   `battery.refreshed`, `deviceAdded`/`Removed`/`VisibilityChanged`,
+   `pairingRequestsChanged`, `pairStateChanged`, `notifications.*`,
+   `share.shareReceived`). Borrow the event set and the initial `GetAll` dump;
+   not the sidecar, not the 4 s restart with no backoff (CONTRIBUTING.md
+   already forbids a persistent `running` binding without backoff and a
+   ceiling). Valent's signal set has to be verified against a live daemon the
+   same way KDE Connect's is.
+2. **Notification mirroring.** Borrow: the leaf `notification.dismiss` (not
+   `sendAction("cancel")`), `sendReply` with a re-fetch, `internalId` →
+   package, group-by-app, and the dedupe rule against kdeconnectd's own
+   desktop notifications with its "only while we are showing them" gate. Not:
+   the second `RemoteNotification*` list — the "Approach" below still says
+   route through the shell's own notification system, and that is the
+   decision to make first; the parallel-list design is what makes the dedupe
+   necessary. Not: the qdbus/`fetch_notifications.py` split; one `busctl`
+   `GetAll` per leaf covers it. Not: "open on phone" — that is scrcpy+adb,
+   out of scope.
+3. **`connectivity_report` and `reachableAddresses`.** One more `GetAll` on
+   the device path and one more signal, both already in the fork's event set;
+   the model gains cellular type/strength. Cheap once (1) exists.
+4. **Pairing requests.** Accept/decline banners in the device dialog, fed by
+   `pairingRequestsChanged` and `pairStateChanged`; the calls are
+   `acceptPairing`/`cancelPairing` on the device path. This closes the "Open
+   questions" item — the fork shows it wraps cleanly. Not: interpolating
+   `devId` into a shell string; the id is validated (`validDeviceId`) and
+   passed as an argument.
+5. **Send and receive.** `share.shareUrl("file://…")` for file send, drop
+   target on the drop shelf (`modules/imi/dropShelf/`) rather than a picker
+   dialog, and `share.shareReceived` surfaced as a notification. Not: the
+   kdialog/zenity picker chain.
+6. **SFTP mount/browse.** `sftp.mount`/`unmount` plus a file-manager open;
+   the fork's `3a7f653b4` records that the mount root is not the user's
+   storage — open `<mount>/storage/emulated/0` when it exists.
+7. **Persisted active device, MRU, and low-battery hooks.** Small; take the
+   thresholds (<20% not charging, recover at ≥25% or charging) as they are.
+
+Still open regardless: media (`mprisremote`), clipboard *receive*, and Valent
+action coverage beyond `findmyphone.ring` (its other action names were not
+verifiable without a live Valent daemon — ping/clipboard are KDE Connect-only
+for now). None of these have prior art in the fork.
 
 ## Transport constraint (read this first)
 


### PR DESCRIPTION
Docs-only. `docs/proposals/phone-connect.md` gains a **Prior art: P3DROVFX/ii-p3drovfx** section after "Current state", and the old "Still open" paragraph becomes a **Next slices** list ordered by value.

**Why now.** The next phone slice is decided from what a finished phone tab looks like, and that fork has one — a KDE Connect tab iterated from `c43837f07` (2026-06-22) to `e31a3b00d` (2026-08-17). Recording it, with paths and line numbers checked against a clone of its `dev` head, stops the next agent from re-deriving its findings or importing its transport along with them.

**What the section says**
- Transport, where we differ and keep differing: KDE Connect only, a Python+Gio sidecar (`scripts/kdeconnect/monitor.py`) for signal-driven reads with a 4 s no-backoff restart, string-built `bash -c` + `qdbus` for every write, a second one-shot script because `qdbus` output broke `JSON.parse`. Ours: argv-only `busctl --json=short`, no sidecar, both daemons, parser pinned by `tests/test_phone_connect_contract.py`.
- Feature surface worth borrowing the shape of: persisted active device + MRU + cached notifications, pairing accept/decline banners, battery + `connectivity_report`, ring/ping/clipboard/share, file send via `share.shareUrl(file://)` and `share.shareReceived`, full notification mirroring (leaf `notification.dismiss` — `sendAction("cancel")` is a no-op — `sendReply`, `internalId` → package, dedupe of kdeconnectd's own desktop notifications in their `Notifications.qml`), SFTP, contacts. Also what it does *not* implement (mprisremote, mousepad, telephony, systemvolume, lock, runcommand, clipboard receive), and its UI surfaces / config keys.
- Pointers to two other Quickshell implementations (dms-plugins `DankKDEConnect` with a `ValentService.qml`; noctalia `kde-connect` / `valent-connect`).

**Next slices** (each says what to borrow and what not to — transport, always): (1) `busctl monitor` signal-driven updates, (2) notification mirroring incl. dismiss/reply/dedupe rules, (3) `connectivity_report` + `reachableAddresses`, (4) pairing requests, (5) send/receive with the drop shelf, (6) SFTP, (7) persisted active device + MRU + low-battery hooks. Media, clipboard receive and Valent action names stay open — no prior art for them.

Every claim was verified against the fork's files before being written; commit SHAs cited are the fork's and sit outside `lint_doc_citations.py`'s scope (AGENT.md / CONTRIBUTING.md only).

Docs: updated
