### PR TITLE
fix(clockDepth): crisp masks - two-pass crop-refine, edge hardening, 4096 aspect-true storage

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -3064,8 +3064,8 @@ question to answer about what its mask's alpha actually is.
 **A mask cut at the model's square input is not the wallpaper's aspect, and
 filling it into the same box is not the same crop.** `isnet-anime` squashes the
 whole picture to 1024² (padding is measurably worse — with black bars the model
-returns the entire picture as the subject), so the stored mask is square while
-the wallpaper is drawn `PreserveAspectCrop`. Filling both into the viewport
+returns the entire picture as the subject), so the stored mask WAS square (it is
+aspect-true since the entry below) while the wallpaper is drawn `PreserveAspectCrop`. Filling both into the viewport
 stretches them differently — by 3.5× on this monitor. `ClockDepthLogic.coverRect`
 returns the rectangle the whole wallpaper would occupy if nothing clipped it; the
 mask is `Image.Stretch`ed into that and the surface clips it back, which is
@@ -3074,6 +3074,31 @@ in `modules/common/functions/clockDepth.js` beside the eligibility predicate for
 the same reason `ParallaxMath.sampleOrigin` is: nothing about the rendered layer
 is reachable from `qmltestrunner`, so the arithmetic has to be.
 (feat(background): draw the wallpaper's subject over the desktop widgets.)
+
+**The model's square is the right INPUT and was the wrong STORAGE, and the two
+came apart the moment the mask had more detail than the square could carry.**
+Squashing a 5760x2318 wallpaper into 1024² gives every mask texel ~5.6 picture
+pixels, and the cost was measured to be worse than softness: hair claimed a
+band of wall around itself and a striped wall behind a hairline came through as
+subject, because at that scale the model cannot separate them. The producer
+now runs a salient model twice — the second time over the padded box of what
+the first pass claimed, pasted over the coarse answer (+0.48s; skipped when the
+box already covers 85% of the frame, and never reached when pass 1 found
+nothing, so `.none` is still pass 1's verdict) — hardens every mask around 0.5
+with a k=6 sigmoid (soft band 0.496 → 0.235 Mpx; 0.5 stays at 0.5, so no pixel
+changes sides), and stores the result aspect-true at 4096 on the long side,
+never larger than the wallpaper (357 KB against ~100 KB on that picture). Two
+things to carry forward. **A guided filter was tried between the merge and the
+hardening and rejected**: it widened the band along every low-contrast outline;
+do not put one back. And `coverRect` needed no change for a non-square salient
+mask, for the reason the prompted-model entry below already gives — it is a
+rectangle for the wallpaper and never reads the mask's shape — but the comments
+on both sides of it *said* the mask was square, and now say what it was and
+what it is. `tests/test_subject_mask_refine.py` pins the box, the guard, the
+curve and the storage size without loading a model. Design doc §9.
+038df1083 ("feat(background): run a salient model twice, the second time on the subject's box"),
+77497c63a ("feat(background): harden a mask's edge around the model's own boundary"),
+983e4c529 ("feat(background): store a mask aspect-true at 4096 on the long side").
 
 **Two captures separated in wall-clock time on a desktop somebody is using are
 not an A/B test, and the thing that changes between them becomes your signal.**

--- a/AGENT.md
+++ b/AGENT.md
@@ -3076,29 +3076,32 @@ is reachable from `qmltestrunner`, so the arithmetic has to be.
 (feat(background): draw the wallpaper's subject over the desktop widgets.)
 
 **The model's square is the right INPUT and was the wrong STORAGE, and the two
-came apart the moment the mask had more detail than the square could carry.**
-Squashing a 5760x2318 wallpaper into 1024² gives every mask texel ~5.6 picture
-pixels, and the cost was measured to be worse than softness: hair claimed a
-band of wall around itself and a striped wall behind a hairline came through as
-subject, because at that scale the model cannot separate them. The producer
-now runs a salient model twice — the second time over the padded box of what
-the first pass claimed, pasted over the coarse answer (+0.48s; skipped when the
-box already covers 85% of the frame, and never reached when pass 1 found
-nothing, so `.none` is still pass 1's verdict) — hardens every mask around 0.5
-with a k=6 sigmoid (soft band 0.496 → 0.235 Mpx; 0.5 stays at 0.5, so no pixel
-changes sides), and stores the result aspect-true at 4096 on the long side,
-never larger than the wallpaper (357 KB against ~100 KB on that picture). Two
-things to carry forward. **A guided filter was tried between the merge and the
-hardening and rejected**: it widened the band along every low-contrast outline;
-do not put one back. And `coverRect` needed no change for a non-square salient
-mask, for the reason the prompted-model entry below already gives — it is a
-rectangle for the wallpaper and never reads the mask's shape — but the comments
-on both sides of it *said* the mask was square, and now say what it was and
-what it is. `tests/test_subject_mask_refine.py` pins the box, the guard, the
-curve and the storage size without loading a model. Design doc §9.
-038df1083 ("feat(background): run a salient model twice, the second time on the subject's box"),
+came apart because the softness was being upscaled with the mask.** Squashing a
+5760x2318 wallpaper into 1024² gives every mask texel ~5.6 picture pixels, and
+what shipped was that raw matte upscaled bilinearly by Qt: hair claimed a band
+of wall around itself and a striped wall behind a hairline showed through as
+subject. The producer now hardens every mask around 0.5 with a k=6 sigmoid
+(0.5 stays at 0.5, so no pixel changes sides) AFTER resampling it to the
+storage size — 4096 on the long side, aspect-true, never larger than the
+wallpaper — and the order is what makes it work: soft band 0.307 Mpx as
+shipped, 0.235 with harden-then-resample, 0.119 with resample-then-harden.
+Three things to carry forward. **A second model pass over the subject's box
+was landed and reverted in the same PR**: measured, it lost 17.7% of the
+coarse subject (the neck went 0.994 → 0.671) for 0.5% gained, and the stripe
+cleanup it was credited with was the hardening's — the stripes were already at
+0.257 in the single pass. **A guided filter was tried and rejected** for
+widening the band along low-contrast outlines. And `coverRect` needed no
+change for a non-square salient mask, for the reason the prompted-model entry
+below already gives — it is a rectangle for the wallpaper and never reads the
+mask's shape — but the comments on both sides of it *said* the mask was
+square, and now say what it was and what it is.
+`tests/test_subject_mask_refine.py` pins the curve, the resample-then-harden
+order (against a control that must itself show the ramp) and the storage size
+without loading a model. Design doc §9.
 77497c63a ("feat(background): harden a mask's edge around the model's own boundary"),
-983e4c529 ("feat(background): store a mask aspect-true at 4096 on the long side").
+983e4c529 ("feat(background): store a mask aspect-true at 4096 on the long side"),
+7e0dc5f16 ("revert(background): drop the second model pass over the subject's box"),
+1a6a2b970 ("feat(background): harden the edge after the resample to storage size, not before").
 
 **Two captures separated in wall-clock time on a desktop somebody is using are
 not an A/B test, and the thing that changes between them becomes your signal.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ own repo; the installer pins which revision it builds.
 
 ## [Unreleased]
 
+### Fixed
+- **Clock depth masks are crisp.** On wide wallpapers the subject's outline
+  used to claim a band of background around fine structure like hair, and
+  swallow whatever was behind it — a striped wall came through as subject. The
+  producer now runs the detector a second time on just the subject's box,
+  hardens the edge around the model's own boundary, and stores the mask
+  aspect-true at 4096 on the long side instead of a 1024 square. Costs about
+  half a second more per run; re-run a wallpaper's models in the depth picker
+  to get the new mask.
+
 ## [0.26.0] — 2026-08-19
 
 The lock screen gets its own widget layout, snapping stops gluing widgets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,13 @@ own repo; the installer pins which revision it builds.
 
 ### Fixed
 - **Clock depth masks are crisp.** On wide wallpapers the subject's outline
-  used to claim a band of background around fine structure like hair, and
-  swallow whatever was behind it — a striped wall came through as subject. The
-  producer now runs the detector a second time on just the subject's box,
-  hardens the edge around the model's own boundary, and stores the mask
-  aspect-true at 4096 on the long side instead of a 1024 square. Costs about
-  half a second more per run; re-run a wallpaper's models in the depth picker
-  to get the new mask.
+  used to claim a soft band of background around fine structure like hair, and
+  whatever was behind it showed through — a striped wall came through as
+  subject. The producer now stores the mask aspect-true at 4096 on the long
+  side instead of a 1024 square and hardens the edge around the model's own
+  boundary at that size, so the outline is about a pixel wide instead of a
+  five-pixel ramp. Same cost per run; re-run a wallpaper's models in the depth
+  picker to get the new mask.
 
 ## [0.26.0] — 2026-08-19
 

--- a/docs/superpowers/specs/2026-08-16-clock-depth-design.md
+++ b/docs/superpowers/specs/2026-08-16-clock-depth-design.md
@@ -272,10 +272,10 @@ that upscaling to 5120 px is a `smooth: true` texture fetch the GPU does for fre
 7680×2160 grayscale PNG costs 3 MB per wallpaper and 0.88 s of write time for information that is
 not in the mask. Both halves of that are still true, and the second still rules out wallpaper
 resolution — but the first upscales the *softness* too: at 1024 wide over a 5760-wide picture each
-texel covers ~5.6 picture pixels, so the boundary was inherently ~5 screen px soft, and once §9's
-refinement gives the mask finer structure than that, 1024 texels throw it away again. 4096 keeps
-it: measured on the Violet Evergarden wallpaper (5760×2318), 4096×1648 at 357 KB against ~100 KB
-for the square. A wallpaper smaller than that is stored at its own size. The shell's `coverRect`
+texel covers ~5.6 picture pixels, so the boundary was inherently ~5 screen px soft — and §9's
+hardening only makes it crisp if it is applied *after* that upscale, at a resolution fine enough
+to hold a ~1 px edge. 4096 is that resolution: measured on the Violet Evergarden wallpaper
+(5760×2318), 4096×1648 at 253 KB against ~100 KB for the square. A wallpaper smaller than that is stored at its own size. The shell's `coverRect`
 maps the whole mask onto the whole picture without reading the mask's shape, so nothing on that
 side changed — `tst_clock_depth_eligibility.qml` had already pinned a non-square mask for the
 prompted model.
@@ -379,8 +379,8 @@ otherwise is how the parallax opt-out stayed green through its entire broken lif
   touching the file changes it, that a hit returns without constructing a session, and that the LRU
   sweep keeps the newest N. This is the piece with real edge cases and it is the piece the shell
   trusts blindly, so it is the piece that gets tested hardest.
-- *The refinement arithmetic* (§9), in `tests/test_subject_mask_refine.py`: the crop box and its
-  guard, the hardening curve's shape, and the storage size — pure numpy, no session.
+- *The refinement arithmetic* (§9), in `tests/test_subject_mask_refine.py`: the hardening curve's
+  shape, the resample-then-harden order, and the storage size — pure numpy, no session.
 - *The eligibility predicate*, in `clockDepth.js`, via `tests/tst_clock_depth_eligibility.qml`.
   Six boolean inputs, and the cases that matter are the refusals: video, WE, mid-transition,
   opt-out marker present alongside a valid mask.
@@ -535,41 +535,39 @@ on is the inspect mode this PR adds, so the order is the right way round.
 §1 judged the masks by eye and §3 accepted "~5 screen px soft" as the price of the model's 1024
 square. In use that price turned out to be paid in the wrong places: on the Violet Evergarden
 wallpaper (5760×2318, `isnet-general-use`) hair claimed a band of wall around itself, and a striped
-wall behind a hairline came through as subject — at ~5.6 picture pixels per mask texel the model
-cannot separate the two. Three changes, each measured on that wallpaper before it was written into
-the producer, and one thing tried and rejected.
+wall behind a hairline showed through as subject. Two changes landed, and two things were tried,
+measured on that wallpaper, and rejected.
 
-**Two-pass crop-refine (salient models only).** Pass 1 is the existing full-frame squash. Take the
-box of `mask > 0.5`, pad it by 12% of its own width and height each side, crop the wallpaper to
-it, run the model again on the crop (squashed to 1024² like everything else), upsample the fine
-answer to the crop and paste it over the coarse mask upsampled to the wallpaper. Cost +0.48 s. The
-stripe bleed is gone and the soft band tightens. Two guards: a box covering ≥85% of the frame skips
-pass 2 (same picture, same squash, nothing to gain), and a pass 1 that finds nothing keeps the
-existing `.none` path untouched — the `.none` verdict is pass 1's share, so the refinement can
-neither manufacture nor rescind one. Note what pass 2 also does: it re-decides low-contrast regions
-at the crop's resolution. On that wallpaper the collar and part of the white robe against the cream
-background, which the coarse pass claimed, are not claimed by the fine pass; the foreground share
-went 0.179 → 0.150. That is the model's answer at the better resolution, and the picker's
-accept/decline step (§6) is still where it is judged.
+**Edge hardening, after the resample.** `1 / (1 + exp(-2·6·(m − 0.5)))` — a sigmoid with k = 6
+around 0.5, so 0.5 stays at 0.5 and no pixel changes sides — applied to the matte *after* it is
+resampled to its storage size (`prepare_mask` in the producer). The order is the point: a
+hardened edge put through the 4× bilinear upscale comes back out as a 4 px ramp, which is the band
+the hardening exists to remove. Soft band (0.16 < m < 0.84) on that wallpaper: 0.307 Mpx for the
+shipped 1024² matte upscaled by Qt, 0.235 for harden-then-resample, **0.119 for resample-then-
+harden**. Foreground share unchanged (0.179 → 0.179); the neck (0.98 → 0.996) and collar
+(0.942 → 0.946) are kept. Applied to the prompted model's masks too.
 
-**Edge hardening.** `1 / (1 + exp(-2·6·(m − 0.5)))` after the merge — a sigmoid with k = 6 around
-0.5, so 0.5 stays at 0.5 and no pixel changes sides. Soft band (0.16 < m < 0.84) 0.496 Mpx →
-0.235 Mpx. Applied to the prompted model's masks too.
+**Storage.** §3, amended: aspect-true at 4096 on the long side, never larger than the wallpaper,
+still `LA` with the alpha duplicated for `OpacityMask`.
+
+**Rejected: a second model pass over the subject's box.** Landed as 038df1083 and reverted in the
+same PR after measurement: take the box of `mask > 0.5`, pad 12%, run the model again on the
+crop, paste the fine answer over the coarse. On the reference picture it is net harmful — where the
+coarse pass claimed the subject and the crop pass did not, **17.7% of the coarse subject is lost**
+(neck 0.994 → 0.671, collar 0.996 → 0.317, robe 0.996 → 0.918), against 0.5% gained the other
+way; visually it punches a speckled hole through the neck and collar. And it was not what cleaned
+the stripes: the striped wall above the head is at 0.257 in the coarse pass — already below 0.5 —
+so the visible bleed was the soft band, which the hardening removes on its own. Soft band after
+hardening: 0.112 Mpx from the coarse pass alone, 0.113 for `max(coarse, fine)`, 0.230 for the
+pasted crop. `harden(coarse)` and `harden(max(coarse, fine))` are indistinguishable at the
+hairline. Cost would have been +0.48 s per run.
 
 **Rejected: a guided filter.** He et al.'s fast guided filter on a downscaled luminance guide
-(r = 12, ε = 1e-3, /4) was tried between the merge and the hardening. It widened the band along
-every low-contrast outline — the opposite of the job — and is not in the producer. Recorded here
-and in `HARDEN_K`'s comment so it is not tried again.
+(r = 12, ε = 1e-3, /4) was tried between the matte and the hardening. It widened the band along
+every low-contrast outline — the opposite of the job.
 
-**Storage.** §3, amended: aspect-true at 4096 on the long side, still `LA` with the alpha
-duplicated for `OpacityMask`.
+Both rejections are recorded in the producer (`segment`'s docstring, `HARDEN_K`'s comment) so they
+are not tried a second time.
 
-**Follow-up, not landed:** the prompted path (`mobile-sam`) gets the hardening and the storage but
-not a crop-refine. Its embedding is cached once per wallpaper (that is what makes the second click
-cost 0.34 s), and refining a crop would need an embedding per crop — a per-click encode, which is
-exactly the cost the split exists to avoid. Whether a second, crop-local embedding is worth caching
-alongside the first is the open question there.
-
-`tests/test_subject_mask_refine.py` pins the arithmetic — box, guard, curve, storage size — with
-no model loaded; whether the result is *good* stays with the human at the picker, as §6 says.
-
+`tests/test_subject_mask_refine.py` pins the arithmetic — curve, order, storage size — with no
+model loaded; whether the result is *good* stays with the human at the picker, as §6 says.

--- a/docs/superpowers/specs/2026-08-16-clock-depth-design.md
+++ b/docs/superpowers/specs/2026-08-16-clock-depth-design.md
@@ -1,6 +1,6 @@
 # Clock depth mode — feasibility and design
 
-**Status:** partially implemented (v0.25.0; `aa6a8bfb0` — `subject_mask.py` producer, `clockDepth.js`, `clockDepthSelect/`, `Background.qml` `clockDepthLayer`). §8 (Wallpaper Engine) is designed, not landed. Open quality issue: mask separation is not crisp enough — fine structure such as hair claims more mask than it should. §1 is the feasibility evidence.
+**Status:** implemented (v0.25.0; `aa6a8bfb0` — `subject_mask.py` producer, `clockDepth.js`, `clockDepthSelect/`, `Background.qml` `clockDepthLayer`). Mask-separation quality (hair claiming a band of background, background bleed on wide wallpapers) is addressed by the edge hardening and aspect-true storage in §9. §8 (Wallpaper Engine) is designed, not landed. §1 is the feasibility evidence.
 **Scope:** `modules/imi/background/Background.qml`, a new `scripts/background/` producer, the
 wallpaper selector, `sdata/uv/`.
 
@@ -266,11 +266,19 @@ Invalidation therefore has exactly three sources and no explicit invalidation co
 - the wallpaper file changes in place → different key;
 - the user re-runs the picker on the same wallpaper → the picker overwrites that key's entry.
 
-The mask is stored at **model resolution (1024²), not at wallpaper resolution.** Upscaling to
-5120 px is a `smooth: true` texture fetch the GPU does for free, and storing a 7680×2160 grayscale
-PNG instead costs 3 MB per wallpaper and 0.88 s of write time for information that is not in the
-mask. The boundary is inherently ~5 screen px soft at 5120 wide; against a clock that reads as
-antialiasing, which is the one place this feature gets to be lucky.
+The mask is stored **aspect-true at 4096 on the long side, never larger than the wallpaper**
+(`storage_size` in the producer). It was the model's own 1024² square at first, on the reasoning
+that upscaling to 5120 px is a `smooth: true` texture fetch the GPU does for free, and that a
+7680×2160 grayscale PNG costs 3 MB per wallpaper and 0.88 s of write time for information that is
+not in the mask. Both halves of that are still true, and the second still rules out wallpaper
+resolution — but the first upscales the *softness* too: at 1024 wide over a 5760-wide picture each
+texel covers ~5.6 picture pixels, so the boundary was inherently ~5 screen px soft, and once §9's
+refinement gives the mask finer structure than that, 1024 texels throw it away again. 4096 keeps
+it: measured on the Violet Evergarden wallpaper (5760×2318), 4096×1648 at 357 KB against ~100 KB
+for the square. A wallpaper smaller than that is stored at its own size. The shell's `coverRect`
+maps the whole mask onto the whole picture without reading the mask's shape, so nothing on that
+side changed — `tst_clock_depth_eligibility.qml` had already pinned a non-square mask for the
+prompted model.
 
 ---
 
@@ -371,6 +379,8 @@ otherwise is how the parallax opt-out stayed green through its entire broken lif
   touching the file changes it, that a hit returns without constructing a session, and that the LRU
   sweep keeps the newest N. This is the piece with real edge cases and it is the piece the shell
   trusts blindly, so it is the piece that gets tested hardest.
+- *The refinement arithmetic* (§9), in `tests/test_subject_mask_refine.py`: the crop box and its
+  guard, the hardening curve's shape, and the storage size — pure numpy, no session.
 - *The eligibility predicate*, in `clockDepth.js`, via `tests/tst_clock_depth_eligibility.qml`.
   Six boolean inputs, and the cases that matter are the refusals: video, WE, mid-transition,
   opt-out marker present alongside a valid mask.
@@ -402,7 +412,8 @@ Four stages, each landable and reviewable on its own.
 
 **Stage 1 — the subject-mask producer and its cache.** `scripts/background/subject_mask.py`: takes a
 wallpaper path and a model name, computes the cache key, returns a hit immediately or runs
-ONNX Runtime and writes a 1024² mask plus a `.none` marker when the model returns nothing. Adds
+ONNX Runtime and writes a mask (1024² then; §9 and §3 for what it is now) plus a `.none` marker
+when the model returns nothing. Adds
 `onnxruntime` to `sdata/uv/requirements.in` and a first-use model fetch (two 176 MB files, not
 bundled). Ships with `tests/test_clock_depth_cache.py`. **No shell changes and no visible
 behaviour** — the deliverable is a CLI whose output can be inspected by hand, which is the right
@@ -516,3 +527,49 @@ probes cannot reach any of it; it has to be judged on the real desktop, by
 looking at a moving scene. That is a different kind of change from the ones this
 PR carries, all of which are pinned headlessly — and the instrument §8.4 depends
 on is the inspect mode this PR adds, so the order is the right way round.
+
+---
+
+## 9. Refinement — crisper masks, landed
+
+§1 judged the masks by eye and §3 accepted "~5 screen px soft" as the price of the model's 1024
+square. In use that price turned out to be paid in the wrong places: on the Violet Evergarden
+wallpaper (5760×2318, `isnet-general-use`) hair claimed a band of wall around itself, and a striped
+wall behind a hairline came through as subject — at ~5.6 picture pixels per mask texel the model
+cannot separate the two. Three changes, each measured on that wallpaper before it was written into
+the producer, and one thing tried and rejected.
+
+**Two-pass crop-refine (salient models only).** Pass 1 is the existing full-frame squash. Take the
+box of `mask > 0.5`, pad it by 12% of its own width and height each side, crop the wallpaper to
+it, run the model again on the crop (squashed to 1024² like everything else), upsample the fine
+answer to the crop and paste it over the coarse mask upsampled to the wallpaper. Cost +0.48 s. The
+stripe bleed is gone and the soft band tightens. Two guards: a box covering ≥85% of the frame skips
+pass 2 (same picture, same squash, nothing to gain), and a pass 1 that finds nothing keeps the
+existing `.none` path untouched — the `.none` verdict is pass 1's share, so the refinement can
+neither manufacture nor rescind one. Note what pass 2 also does: it re-decides low-contrast regions
+at the crop's resolution. On that wallpaper the collar and part of the white robe against the cream
+background, which the coarse pass claimed, are not claimed by the fine pass; the foreground share
+went 0.179 → 0.150. That is the model's answer at the better resolution, and the picker's
+accept/decline step (§6) is still where it is judged.
+
+**Edge hardening.** `1 / (1 + exp(-2·6·(m − 0.5)))` after the merge — a sigmoid with k = 6 around
+0.5, so 0.5 stays at 0.5 and no pixel changes sides. Soft band (0.16 < m < 0.84) 0.496 Mpx →
+0.235 Mpx. Applied to the prompted model's masks too.
+
+**Rejected: a guided filter.** He et al.'s fast guided filter on a downscaled luminance guide
+(r = 12, ε = 1e-3, /4) was tried between the merge and the hardening. It widened the band along
+every low-contrast outline — the opposite of the job — and is not in the producer. Recorded here
+and in `HARDEN_K`'s comment so it is not tried again.
+
+**Storage.** §3, amended: aspect-true at 4096 on the long side, still `LA` with the alpha
+duplicated for `OpacityMask`.
+
+**Follow-up, not landed:** the prompted path (`mobile-sam`) gets the hardening and the storage but
+not a crop-refine. Its embedding is cached once per wallpaper (that is what makes the second click
+cost 0.34 s), and refining a crop would need an embedding per crop — a per-click encode, which is
+exactly the cost the split exists to avoid. Whether a second, crop-local embedding is worth caching
+alongside the first is the open question there.
+
+`tests/test_subject_mask_refine.py` pins the arithmetic — box, guard, curve, storage size — with
+no model loaded; whether the result is *good* stays with the human at the picker, as §6 says.
+

--- a/dots/.config/quickshell/imi/modules/common/functions/clockDepth.js
+++ b/dots/.config/quickshell/imi/modules/common/functions/clockDepth.js
@@ -71,16 +71,19 @@ function eligible(state) {
 
 // Where the mask has to be drawn so it lines up with the wallpaper under it.
 //
-// The mask is the model's own output: the whole picture squashed to a square,
-// which is what the feasibility work rendered and judged by eye, so it is what
-// the user accepts. That means it is NOT the wallpaper's aspect, and a mask
-// simply filled into the same box as the wallpaper would be stretched
-// differently from the image it masks - by 3.5x on this monitor.
+// The mask covers the whole picture, whatever shape it is stored at. It was the
+// model's own square (the whole picture squashed to 1024x1024, NOT the
+// wallpaper's aspect) when this was written, and a mask simply filled into the
+// same box as the wallpaper would have been stretched differently from the
+// image it masks - by 3.5x on this monitor. The producer stores it aspect-true
+// now (4096 on the long side), and nothing here changed for that: this
+// function is a rectangle for the WALLPAPER and never reads the mask's shape.
 //
 // The wallpaper is drawn PreserveAspectCrop: scaled by whichever axis needs the
 // most, centred, and clipped by the box. So the mask, stretched, has to cover
 // exactly the rectangle the whole wallpaper would occupy if nothing clipped it.
-// Undoing the squash and re-applying the crop is the same operation.
+// Undoing whatever resample the mask carries and re-applying the crop is the
+// same operation.
 //
 // Returns a rect in the box's own coordinates; x and y are usually negative,
 // because most of the point is that the picture is bigger than the box.

--- a/dots/.config/quickshell/imi/modules/imi/background/ClockDepthCutout.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/ClockDepthCutout.qml
@@ -80,12 +80,14 @@ Item {
 
         Image {
             id: mask
-            // The mask is the model's own output: the whole picture squashed to
-            // a square. So it is NOT the wallpaper's aspect, and filling it
-            // into the same box would stretch it differently from the image it
-            // masks - by 3.5x on this monitor. Stretched into the rectangle the
-            // whole wallpaper would occupy if nothing clipped it, undoing the
-            // squash and re-applying the crop are the same operation.
+            // The mask covers the whole picture, at whatever size and shape
+            // the producer stored it (aspect-true, 4096 on the long side, now;
+            // the model's own 1024 square before, which was NOT the
+            // wallpaper's aspect and would have stretched 3.5x differently
+            // from the image it masks if filled into the same box). Stretched
+            // into the rectangle the whole wallpaper would occupy if nothing
+            // clipped it, undoing the mask's resample and re-applying the crop
+            // are the same operation - so the mask's shape never matters here.
             //
             // What masks is this file's ALPHA - Qt's OpacityMask reads nothing
             // else, so the producer writes the mask into the alpha channel as

--- a/dots/.config/quickshell/imi/scripts/background/subject_mask.py
+++ b/dots/.config/quickshell/imi/scripts/background/subject_mask.py
@@ -138,10 +138,11 @@ HARDEN_K = 6.0
 # The long side a mask is stored at. Model resolution (1024) was the storage
 # size before, on the reasoning that Qt's bilinear upscale is free - which it
 # is, but it upscales the softness too: a 1024-wide mask over a 5760-wide
-# picture is ~5.6 picture pixels per texel, and after the two-pass refinement
-# the mask HAS finer structure than that to keep. 4096 keeps it, at 357 KB on
-# that wallpaper against ~100 KB before; a mask is never stored larger than the
-# wallpaper it is for, since past that there is nothing to keep.
+# picture is ~5.6 picture pixels per texel, and an edge hardened at that size
+# comes back out of the upscale as a ramp. Hardening AFTER the resample
+# (`prepare_mask`) needs a size fine enough to hold a ~1 px edge, and 4096 is
+# it: 253 KB on that wallpaper against ~100 KB before. A mask is never stored
+# larger than the wallpaper it is for, since past that there is nothing to keep.
 MASK_STORE_SIDE = 4096
 
 # Keys, not files: dropping a key's `.off` while keeping its `.png` would

--- a/dots/.config/quickshell/imi/scripts/background/subject_mask.py
+++ b/dots/.config/quickshell/imi/scripts/background/subject_mask.py
@@ -125,20 +125,6 @@ EMPTY_FOREGROUND = 0.005
 # resolution, which is the smallest thing worth compositing over a clock.
 EMPTY_PROMPTED_FOREGROUND = 0.0002
 
-# The second pass of a salient run. Squashing a whole 5760x2318 wallpaper into
-# the model's 1024 square gives every mask texel ~5.6 picture pixels, and the
-# damage is not just softness: measured on the Violet Evergarden wallpaper, hair
-# claimed a band of wall around it and a striped wall behind a hairline came
-# through as subject, because at that scale the model cannot tell them apart.
-# Running the model AGAIN on just the subject's box hands it the same picture at
-# up to several times the resolution, and the fine answer is pasted over the
-# coarse one. Cost +0.48s on that wallpaper; the stripe bleed is gone and the
-# soft band tightens. The box is padded so hair at its edge is inside the crop.
-REFINE_PAD = 0.12
-# A box covering this share of the frame is the same picture at the same
-# squash, so pass 2 would cost the time and change nothing.
-REFINE_SKIP_COVERAGE = 0.85
-
 # The sigmoid that steepens the model's matte around its own boundary. k=6 is
 # the value the soft band was measured under: pixels between 0.16 and 0.84 went
 # from 0.496 Mpx to 0.235 Mpx on the Violet Evergarden wallpaper. 0.5 stays at
@@ -237,37 +223,6 @@ def harden(mask, k=HARDEN_K):
     import numpy as np
 
     return 1.0 / (1.0 + np.exp(-2.0 * k * (np.asarray(mask, dtype=np.float32) - 0.5)))
-
-
-def refine_box(mask, width, height, threshold=0.5, pad=REFINE_PAD):
-    """The subject's box in the wallpaper's own pixels, padded, or None.
-
-    `mask` is the first pass's square; the box is where it claims more than
-    `threshold`, scaled back onto the picture and grown by `pad` of its own
-    width and height each side, clamped to the frame.
-    """
-    import numpy as np
-
-    rows, cols = np.where(np.asarray(mask) > threshold)
-    if rows.size == 0:
-        return None
-    mask_h, mask_w = np.asarray(mask).shape
-    x0 = cols.min() / mask_w * width
-    x1 = (cols.max() + 1) / mask_w * width
-    y0 = rows.min() / mask_h * height
-    y1 = (rows.max() + 1) / mask_h * height
-    pad_w, pad_h = (x1 - x0) * pad, (y1 - y0) * pad
-    return (int(max(0.0, x0 - pad_w)), int(max(0.0, y0 - pad_h)),
-            int(min(float(width), x1 + pad_w) + 0.999999),
-            int(min(float(height), y1 + pad_h) + 0.999999))
-
-
-def refine_wanted(box, width, height, limit=REFINE_SKIP_COVERAGE):
-    """Whether a second pass over `box` can see anything the first did not."""
-    if box is None:
-        return False
-    x0, y0, x1, y1 = box
-    return (x1 - x0) * (y1 - y0) < limit * width * height
 
 
 def parse_point(text):
@@ -538,15 +493,19 @@ def fetch_model(root, model, role="model", progress=None):
 
 
 def segment(image_path, onnx_path, side):
-    """Run one model over one image, twice, and return the mask and pass 1's share.
+    """Run one model over one image and return the normalised mask.
 
-    Pass 1 is the whole picture squashed to the model's square. Pass 2 is the
-    same model over just the subject's padded box (`refine_box`), whose answer
-    is upsampled to the box and pasted over the coarse mask upsampled to the
-    wallpaper - see REFINE_PAD for what that buys and what it costs. The mask
-    comes back at the WALLPAPER's resolution when pass 2 ran, and as pass 1's
-    square when it did not; the share is pass 1's, so a `.none` verdict is the
-    same verdict it always was and a refinement cannot manufacture one.
+    ONE pass, over the whole picture. A second pass over the subject's own box
+    was tried here (038df1083) on the reasoning that the model would separate
+    hair from background better with more pixels of it, and measured to be net
+    harmful on the picture that motivated it: where the coarse pass claimed the
+    subject and the crop pass did not, 17.7% of the coarse subject was LOST
+    (the neck went 0.994 -> 0.671, the collar 0.996 -> 0.317), while only 0.5%
+    was gained the other way; and the striped wall behind the hairline it was
+    meant to clean up was already at 0.257 in the coarse pass - the visible
+    bleed was the soft band, and it is the hardening (`harden`, applied at the
+    storage size) that removes it. Soft band after hardening: 0.112 Mpx from
+    the coarse pass alone against 0.230 Mpx with the crop pass pasted in.
 
     Imported here rather than at module scope so `status` never pays for
     onnxruntime, and so a machine without it can still answer cache questions.
@@ -556,32 +515,16 @@ def segment(image_path, onnx_path, side):
 
     Image.MAX_IMAGE_PIXELS = None
     image = Image.open(image_path).convert("RGB")
+    # Squash to the square input, never pad. With black bars the model reads the
+    # bars as background and returns the entire picture as the subject -
+    # measured at foreground 0.9999 on three separate wallpapers.
+    array = np.asarray(image.resize((side, side), Image.LANCZOS), np.float32) / 255.0
+    array = array - 0.5
     session = session_for(onnx_path)
     name = session.get_inputs()[0].name
-
-    def infer(picture):
-        # Squash to the square input, never pad. With black bars the model
-        # reads the bars as background and returns the entire picture as the
-        # subject - measured at foreground 0.9999 on three separate wallpapers.
-        array = np.asarray(picture.resize((side, side), Image.LANCZOS), np.float32) / 255.0
-        array = array - 0.5
-        mask = session.run(None, {name: array.transpose(2, 0, 1)[None]})[0][0][0]
-        return (mask - mask.min()) / (mask.max() - mask.min() + 1e-8)
-
-    coarse = infer(image)
-    foreground = float((coarse > 0.5).mean())
-    if foreground < EMPTY_FOREGROUND:
-        return coarse, foreground
-
-    box = refine_box(coarse, image.width, image.height)
-    if not refine_wanted(box, image.width, image.height):
-        return coarse, foreground
-
-    x0, y0, x1, y1 = box
-    fine = infer(image.crop(box))
-    merged = resample(coarse, (image.width, image.height))
-    merged[y0:y1, x0:x1] = resample(fine, (x1 - x0, y1 - y0))
-    return merged, foreground
+    mask = session.run(None, {name: array.transpose(2, 0, 1)[None]})[0][0][0]
+    mask = (mask - mask.min()) / (mask.max() - mask.min() + 1e-8)
+    return mask
 
 
 def resample(mask, size):
@@ -590,9 +533,7 @@ def resample(mask, size):
     from PIL import Image
 
     plane = Image.fromarray(np.ascontiguousarray(mask, dtype=np.float32), "F")
-    # np.array, not np.asarray: a view onto Pillow's buffer is read-only, and
-    # `segment` pastes the fine pass into this.
-    return np.array(plane.resize(size, Image.BILINEAR), dtype=np.float32)
+    return np.asarray(plane.resize(size, Image.BILINEAR), dtype=np.float32)
 
 
 def session_for(onnx_path):
@@ -795,7 +736,8 @@ def run(root, wallpaper, model, force=False):
     if not onnx_path.exists():
         onnx_path = fetch_model(root, model)
 
-    mask, foreground = segment(wallpaper, onnx_path, MODELS[model]["side"])
+    mask = segment(wallpaper, onnx_path, MODELS[model]["side"])
+    foreground = float((mask > 0.5).mean())
 
     candidate.unlink(missing_ok=True)
     negative.unlink(missing_ok=True)

--- a/dots/.config/quickshell/imi/scripts/background/subject_mask.py
+++ b/dots/.config/quickshell/imi/scripts/background/subject_mask.py
@@ -20,7 +20,7 @@ garbage the sweep collects.
 Four files can exist per key, and they are the four states of section 5 of
 docs/superpowers/specs/2026-08-16-clock-depth-design.md:
 
-    <key>.<model>.png   a candidate mask a model produced, at model resolution
+    <key>.<model>.png   a candidate mask a model produced (see `write_mask` for its size)
     <key>.<model>.none  that model looked and found no subject
     <key>.png           the candidate the user accepted - the ONLY file the shell draws
     <key>.off           the user declined every candidate for this wallpaper
@@ -148,6 +148,15 @@ REFINE_SKIP_COVERAGE = 0.85
 # what it was for.
 HARDEN_K = 6.0
 
+# The long side a mask is stored at. Model resolution (1024) was the storage
+# size before, on the reasoning that Qt's bilinear upscale is free - which it
+# is, but it upscales the softness too: a 1024-wide mask over a 5760-wide
+# picture is ~5.6 picture pixels per texel, and after the two-pass refinement
+# the mask HAS finer structure than that to keep. 4096 keeps it, at 357 KB on
+# that wallpaper against ~100 KB before; a mask is never stored larger than the
+# wallpaper it is for, since past that there is nothing to keep.
+MASK_STORE_SIDE = 4096
+
 # Keys, not files: dropping a key's `.off` while keeping its `.png` would
 # resurrect a mask the user declined.
 SWEEP_KEEP_KEYS = 200
@@ -202,6 +211,24 @@ def resize_longest_side(width, height, side):
         raise ValueError(f"image has no size: {width}x{height}")
     scale = side / float(max(width, height))
     # round, not floor: the transform SAM's own ResizeLongestSide applies.
+    return (max(1, int(width * scale + 0.5)), max(1, int(height * scale + 0.5)))
+
+
+def storage_size(width, height, side=MASK_STORE_SIDE):
+    """The size a mask is written at: `side` on the long side, aspect kept.
+
+    Aspect-true rather than the model's square, so the file is a picture of
+    the wallpaper's subject rather than a squashed one - and never larger than
+    the wallpaper, because a mask upsampled past its picture stores nothing.
+    `coverRect` on the shell's side maps the whole mask onto the whole picture
+    whatever the mask's own shape is, which is why this needs no partner there.
+    """
+    if width <= 0 or height <= 0:
+        raise ValueError(f"image has no size: {width}x{height}")
+    longest = max(width, height)
+    if longest <= side:
+        return (width, height)
+    scale = side / float(longest)
     return (max(1, int(width * scale + 0.5)), max(1, int(height * scale + 0.5)))
 
 
@@ -370,9 +397,10 @@ def accepted_model(root, key, candidates):
             if path is None:
                 continue
             candidate = Path(path)
-            # Size first: two 1024x1024 masks from different models are
-            # routinely both ~300 KB but never the same 300 KB, so this skips
-            # the read on the mismatching one without deciding anything by it.
+            # Size first: two masks of the same wallpaper from different
+            # models are routinely both a few hundred KB but never the same
+            # few hundred KB, so this skips the read on the mismatching one
+            # without deciding anything by it.
             if candidate.stat().st_size != size:
                 continue
             if blob is None:
@@ -735,7 +763,13 @@ def select(root, wallpaper, model, points):
         return {"state": "empty", "key": key, "model": model,
                 "foreground": foreground, "prompt": points}
 
-    write_mask(candidate, harden(mask), prompt=points)
+    # Hardened and stored at the same size as a salient mask. What this path
+    # does NOT do is re-embed a crop of the picture the way `segment` re-runs
+    # its model: the embedding is cached per wallpaper (see `image_embedding`)
+    # and a crop would need one of its own per click. Follow-up, noted in the
+    # design doc.
+    write_mask(candidate, harden(mask), prompt=points,
+               size=storage_size(*image_size(wallpaper)))
     return {"state": "produced", "key": key, "model": model,
             "mask": str(candidate), "foreground": foreground, "prompt": points}
 
@@ -770,18 +804,30 @@ def run(root, wallpaper, model, force=False):
         negative.write_text("")
         return {"state": "none", "key": key, "model": model, "foreground": foreground}
 
-    write_mask(candidate, harden(mask))
+    write_mask(candidate, harden(mask), size=storage_size(*image_size(wallpaper)))
     return {"state": "produced", "key": key, "model": model,
             "mask": str(candidate), "foreground": foreground}
 
 
-def write_mask(path, mask, prompt=None):
-    """Save a mask at model resolution, carrying it in BOTH channels.
+def image_size(path):
+    """A picture's pixel size without decoding it - Pillow reads the header."""
+    from PIL import Image
 
-    Model resolution rather than the wallpaper's: upscaling to 5120px is a smooth
-    texture fetch the GPU does for free, while a wallpaper-resolution mask costs
-    3MB and nearly a second of write time to store information the mask does not
-    have.
+    Image.MAX_IMAGE_PIXELS = None
+    with Image.open(path) as picture:
+        return picture.size
+
+
+def write_mask(path, mask, prompt=None, size=None):
+    """Save a mask, resampled to `size` if given, carrying it in BOTH channels.
+
+    `size` is `storage_size` of the wallpaper: 4096 on the long side, aspect
+    kept, never larger than the picture. Not the wallpaper's own resolution -
+    a 7680x2160 mask costs 3MB and nearly a second of write time - and no
+    longer the model's 1024 square either, because after the two-pass
+    refinement the mask has finer structure than 1024 texels can carry over a
+    wide picture (see MASK_STORE_SIDE). Without `size` the mask keeps its own
+    resolution, which is what the tests hand in.
 
     Grayscale AND alpha, both the same plane. The alpha is what the shell masks
     with - Qt's OpacityMask reads the mask's alpha channel and nothing else, so a
@@ -814,7 +860,10 @@ def write_mask(path, mask, prompt=None):
     from PIL import Image
     from PIL import PngImagePlugin
 
-    plane = (np.clip(np.asarray(mask, dtype="float32"), 0.0, 1.0) * 255).astype("uint8")
+    mask = np.asarray(mask, dtype="float32")
+    if size is not None and tuple(size) != (mask.shape[1], mask.shape[0]):
+        mask = resample(mask, tuple(size))
+    plane = (np.clip(mask, 0.0, 1.0) * 255).astype("uint8")
     info = None
     if prompt is not None:
         info = PngImagePlugin.PngInfo()

--- a/dots/.config/quickshell/imi/scripts/background/subject_mask.py
+++ b/dots/.config/quickshell/imi/scripts/background/subject_mask.py
@@ -125,6 +125,20 @@ EMPTY_FOREGROUND = 0.005
 # resolution, which is the smallest thing worth compositing over a clock.
 EMPTY_PROMPTED_FOREGROUND = 0.0002
 
+# The second pass of a salient run. Squashing a whole 5760x2318 wallpaper into
+# the model's 1024 square gives every mask texel ~5.6 picture pixels, and the
+# damage is not just softness: measured on the Violet Evergarden wallpaper, hair
+# claimed a band of wall around it and a striped wall behind a hairline came
+# through as subject, because at that scale the model cannot tell them apart.
+# Running the model AGAIN on just the subject's box hands it the same picture at
+# up to several times the resolution, and the fine answer is pasted over the
+# coarse one. Cost +0.48s on that wallpaper; the stripe bleed is gone and the
+# soft band tightens. The box is padded so hair at its edge is inside the crop.
+REFINE_PAD = 0.12
+# A box covering this share of the frame is the same picture at the same
+# squash, so pass 2 would cost the time and change nothing.
+REFINE_SKIP_COVERAGE = 0.85
+
 # Keys, not files: dropping a key's `.off` while keeping its `.png` would
 # resurrect a mask the user declined.
 SWEEP_KEEP_KEYS = 200
@@ -180,6 +194,37 @@ def resize_longest_side(width, height, side):
     scale = side / float(max(width, height))
     # round, not floor: the transform SAM's own ResizeLongestSide applies.
     return (max(1, int(width * scale + 0.5)), max(1, int(height * scale + 0.5)))
+
+
+def refine_box(mask, width, height, threshold=0.5, pad=REFINE_PAD):
+    """The subject's box in the wallpaper's own pixels, padded, or None.
+
+    `mask` is the first pass's square; the box is where it claims more than
+    `threshold`, scaled back onto the picture and grown by `pad` of its own
+    width and height each side, clamped to the frame.
+    """
+    import numpy as np
+
+    rows, cols = np.where(np.asarray(mask) > threshold)
+    if rows.size == 0:
+        return None
+    mask_h, mask_w = np.asarray(mask).shape
+    x0 = cols.min() / mask_w * width
+    x1 = (cols.max() + 1) / mask_w * width
+    y0 = rows.min() / mask_h * height
+    y1 = (rows.max() + 1) / mask_h * height
+    pad_w, pad_h = (x1 - x0) * pad, (y1 - y0) * pad
+    return (int(max(0.0, x0 - pad_w)), int(max(0.0, y0 - pad_h)),
+            int(min(float(width), x1 + pad_w) + 0.999999),
+            int(min(float(height), y1 + pad_h) + 0.999999))
+
+
+def refine_wanted(box, width, height, limit=REFINE_SKIP_COVERAGE):
+    """Whether a second pass over `box` can see anything the first did not."""
+    if box is None:
+        return False
+    x0, y0, x1, y1 = box
+    return (x1 - x0) * (y1 - y0) < limit * width * height
 
 
 def parse_point(text):
@@ -449,7 +494,15 @@ def fetch_model(root, model, role="model", progress=None):
 
 
 def segment(image_path, onnx_path, side):
-    """Run one model over one image and return the normalised mask.
+    """Run one model over one image, twice, and return the mask and pass 1's share.
+
+    Pass 1 is the whole picture squashed to the model's square. Pass 2 is the
+    same model over just the subject's padded box (`refine_box`), whose answer
+    is upsampled to the box and pasted over the coarse mask upsampled to the
+    wallpaper - see REFINE_PAD for what that buys and what it costs. The mask
+    comes back at the WALLPAPER's resolution when pass 2 ran, and as pass 1's
+    square when it did not; the share is pass 1's, so a `.none` verdict is the
+    same verdict it always was and a refinement cannot manufacture one.
 
     Imported here rather than at module scope so `status` never pays for
     onnxruntime, and so a machine without it can still answer cache questions.
@@ -459,16 +512,43 @@ def segment(image_path, onnx_path, side):
 
     Image.MAX_IMAGE_PIXELS = None
     image = Image.open(image_path).convert("RGB")
-    # Squash to the square input, never pad. With black bars the model reads the
-    # bars as background and returns the entire picture as the subject -
-    # measured at foreground 0.9999 on three separate wallpapers.
-    array = np.asarray(image.resize((side, side), Image.LANCZOS), np.float32) / 255.0
-    array = array - 0.5
     session = session_for(onnx_path)
     name = session.get_inputs()[0].name
-    mask = session.run(None, {name: array.transpose(2, 0, 1)[None]})[0][0][0]
-    mask = (mask - mask.min()) / (mask.max() - mask.min() + 1e-8)
-    return mask
+
+    def infer(picture):
+        # Squash to the square input, never pad. With black bars the model
+        # reads the bars as background and returns the entire picture as the
+        # subject - measured at foreground 0.9999 on three separate wallpapers.
+        array = np.asarray(picture.resize((side, side), Image.LANCZOS), np.float32) / 255.0
+        array = array - 0.5
+        mask = session.run(None, {name: array.transpose(2, 0, 1)[None]})[0][0][0]
+        return (mask - mask.min()) / (mask.max() - mask.min() + 1e-8)
+
+    coarse = infer(image)
+    foreground = float((coarse > 0.5).mean())
+    if foreground < EMPTY_FOREGROUND:
+        return coarse, foreground
+
+    box = refine_box(coarse, image.width, image.height)
+    if not refine_wanted(box, image.width, image.height):
+        return coarse, foreground
+
+    x0, y0, x1, y1 = box
+    fine = infer(image.crop(box))
+    merged = resample(coarse, (image.width, image.height))
+    merged[y0:y1, x0:x1] = resample(fine, (x1 - x0, y1 - y0))
+    return merged, foreground
+
+
+def resample(mask, size):
+    """A float mask at another size, bilinear, still float."""
+    import numpy as np
+    from PIL import Image
+
+    plane = Image.fromarray(np.ascontiguousarray(mask, dtype=np.float32), "F")
+    # np.array, not np.asarray: a view onto Pillow's buffer is read-only, and
+    # `segment` pastes the fine pass into this.
+    return np.array(plane.resize(size, Image.BILINEAR), dtype=np.float32)
 
 
 def session_for(onnx_path):
@@ -665,8 +745,7 @@ def run(root, wallpaper, model, force=False):
     if not onnx_path.exists():
         onnx_path = fetch_model(root, model)
 
-    mask = segment(wallpaper, onnx_path, MODELS[model]["side"])
-    foreground = float((mask > 0.5).mean())
+    mask, foreground = segment(wallpaper, onnx_path, MODELS[model]["side"])
 
     candidate.unlink(missing_ok=True)
     negative.unlink(missing_ok=True)

--- a/dots/.config/quickshell/imi/scripts/background/subject_mask.py
+++ b/dots/.config/quickshell/imi/scripts/background/subject_mask.py
@@ -127,11 +127,12 @@ EMPTY_PROMPTED_FOREGROUND = 0.0002
 
 # The sigmoid that steepens the model's matte around its own boundary. k=6 is
 # the value the soft band was measured under: pixels between 0.16 and 0.84 went
-# from 0.496 Mpx to 0.235 Mpx on the Violet Evergarden wallpaper. 0.5 stays at
-# 0.5, so no pixel changes sides - it is an edge that gets crisper, never one
-# that moves. A guided filter was tried in the same place and REJECTED: it
-# widened the band along every low-contrast outline, which is the opposite of
-# what it was for.
+# from 0.496 Mpx to 0.235 Mpx on the Violet Evergarden wallpaper (and to 0.112
+# once applied AFTER the resample to storage size - see `prepare_mask`). 0.5
+# stays at 0.5, so no pixel changes sides - it is an edge that gets crisper,
+# never one that moves. A guided filter was tried in the same place and
+# REJECTED: it widened the band along every low-contrast outline, which is the
+# opposite of what it was for.
 HARDEN_K = 6.0
 
 # The long side a mask is stored at. Model resolution (1024) was the storage
@@ -223,6 +224,21 @@ def harden(mask, k=HARDEN_K):
     import numpy as np
 
     return 1.0 / (1.0 + np.exp(-2.0 * k * (np.asarray(mask, dtype=np.float32) - 0.5)))
+
+
+def prepare_mask(mask, size):
+    """A model's matte as the plane that is written: resampled, THEN hardened.
+
+    The order is the whole point. The matte arrives at the model's resolution
+    (1024 on a side) and the file is 4096 on its long side, so between the two
+    is a bilinear upsample - and a bilinear upsample of a hardened edge is a
+    ramp as wide as the scale factor, exactly the band the hardening exists to
+    remove. Hardening the upsampled ramp instead leaves an edge about one
+    storage pixel wide: measured on the Violet Evergarden wallpaper, the soft
+    band is 0.112 Mpx this way round against 0.235 the other. Both are pure
+    functions of the matte, so this is the only order that has to be pinned.
+    """
+    return harden(resample(mask, tuple(size)))
 
 
 def parse_point(text):
@@ -532,7 +548,10 @@ def resample(mask, size):
     import numpy as np
     from PIL import Image
 
-    plane = Image.fromarray(np.ascontiguousarray(mask, dtype=np.float32), "F")
+    mask = np.ascontiguousarray(mask, dtype=np.float32)
+    if tuple(size) == (mask.shape[1], mask.shape[0]):
+        return mask
+    plane = Image.fromarray(mask, "F")
     return np.asarray(plane.resize(size, Image.BILINEAR), dtype=np.float32)
 
 
@@ -704,13 +723,10 @@ def select(root, wallpaper, model, points):
         return {"state": "empty", "key": key, "model": model,
                 "foreground": foreground, "prompt": points}
 
-    # Hardened and stored at the same size as a salient mask. What this path
-    # does NOT do is re-embed a crop of the picture the way `segment` re-runs
-    # its model: the embedding is cached per wallpaper (see `image_embedding`)
-    # and a crop would need one of its own per click. Follow-up, noted in the
-    # design doc.
-    write_mask(candidate, harden(mask), prompt=points,
-               size=storage_size(*image_size(wallpaper)))
+    # Resampled and hardened exactly as a salient mask is (`prepare_mask`),
+    # so both kinds of file have the same edge.
+    write_mask(candidate, prepare_mask(mask, storage_size(*image_size(wallpaper))),
+               prompt=points)
     return {"state": "produced", "key": key, "model": model,
             "mask": str(candidate), "foreground": foreground, "prompt": points}
 
@@ -746,7 +762,7 @@ def run(root, wallpaper, model, force=False):
         negative.write_text("")
         return {"state": "none", "key": key, "model": model, "foreground": foreground}
 
-    write_mask(candidate, harden(mask), size=storage_size(*image_size(wallpaper)))
+    write_mask(candidate, prepare_mask(mask, storage_size(*image_size(wallpaper))))
     return {"state": "produced", "key": key, "model": model,
             "mask": str(candidate), "foreground": foreground}
 
@@ -760,16 +776,16 @@ def image_size(path):
         return picture.size
 
 
-def write_mask(path, mask, prompt=None, size=None):
-    """Save a mask, resampled to `size` if given, carrying it in BOTH channels.
+def write_mask(path, mask, prompt=None):
+    """Save a mask at the resolution it arrives at, carrying it in BOTH channels.
 
-    `size` is `storage_size` of the wallpaper: 4096 on the long side, aspect
-    kept, never larger than the picture. Not the wallpaper's own resolution -
-    a 7680x2160 mask costs 3MB and nearly a second of write time - and no
-    longer the model's 1024 square either, because after the two-pass
-    refinement the mask has finer structure than 1024 texels can carry over a
-    wide picture (see MASK_STORE_SIDE). Without `size` the mask keeps its own
-    resolution, which is what the tests hand in.
+    The producers hand in `prepare_mask`'s output - `storage_size` of the
+    wallpaper, 4096 on the long side, aspect kept, never larger than the
+    picture. Not the wallpaper's own resolution (a 7680x2160 mask costs 3MB
+    and nearly a second of write time) and no longer the model's 1024 square
+    either, because the hardened edge is finer than 1024 texels can carry
+    over a wide picture (see MASK_STORE_SIDE). This function does no resample
+    of its own, so a test can hand it an 8x8 plane and read the 8x8 back.
 
     Grayscale AND alpha, both the same plane. The alpha is what the shell masks
     with - Qt's OpacityMask reads the mask's alpha channel and nothing else, so a
@@ -802,10 +818,7 @@ def write_mask(path, mask, prompt=None, size=None):
     from PIL import Image
     from PIL import PngImagePlugin
 
-    mask = np.asarray(mask, dtype="float32")
-    if size is not None and tuple(size) != (mask.shape[1], mask.shape[0]):
-        mask = resample(mask, tuple(size))
-    plane = (np.clip(mask, 0.0, 1.0) * 255).astype("uint8")
+    plane = (np.clip(np.asarray(mask, dtype="float32"), 0.0, 1.0) * 255).astype("uint8")
     info = None
     if prompt is not None:
         info = PngImagePlugin.PngInfo()

--- a/dots/.config/quickshell/imi/scripts/background/subject_mask.py
+++ b/dots/.config/quickshell/imi/scripts/background/subject_mask.py
@@ -139,6 +139,15 @@ REFINE_PAD = 0.12
 # squash, so pass 2 would cost the time and change nothing.
 REFINE_SKIP_COVERAGE = 0.85
 
+# The sigmoid that steepens the model's matte around its own boundary. k=6 is
+# the value the soft band was measured under: pixels between 0.16 and 0.84 went
+# from 0.496 Mpx to 0.235 Mpx on the Violet Evergarden wallpaper. 0.5 stays at
+# 0.5, so no pixel changes sides - it is an edge that gets crisper, never one
+# that moves. A guided filter was tried in the same place and REJECTED: it
+# widened the band along every low-contrast outline, which is the opposite of
+# what it was for.
+HARDEN_K = 6.0
+
 # Keys, not files: dropping a key's `.off` while keeping its `.png` would
 # resurrect a mask the user declined.
 SWEEP_KEEP_KEYS = 200
@@ -194,6 +203,13 @@ def resize_longest_side(width, height, side):
     scale = side / float(max(width, height))
     # round, not floor: the transform SAM's own ResizeLongestSide applies.
     return (max(1, int(width * scale + 0.5)), max(1, int(height * scale + 0.5)))
+
+
+def harden(mask, k=HARDEN_K):
+    """Steepen a matte around 0.5 without moving its boundary. See HARDEN_K."""
+    import numpy as np
+
+    return 1.0 / (1.0 + np.exp(-2.0 * k * (np.asarray(mask, dtype=np.float32) - 0.5)))
 
 
 def refine_box(mask, width, height, threshold=0.5, pad=REFINE_PAD):
@@ -719,7 +735,7 @@ def select(root, wallpaper, model, points):
         return {"state": "empty", "key": key, "model": model,
                 "foreground": foreground, "prompt": points}
 
-    write_mask(candidate, mask, prompt=points)
+    write_mask(candidate, harden(mask), prompt=points)
     return {"state": "produced", "key": key, "model": model,
             "mask": str(candidate), "foreground": foreground, "prompt": points}
 
@@ -754,7 +770,7 @@ def run(root, wallpaper, model, force=False):
         negative.write_text("")
         return {"state": "none", "key": key, "model": model, "foreground": foreground}
 
-    write_mask(candidate, mask)
+    write_mask(candidate, harden(mask))
     return {"state": "produced", "key": key, "model": model,
             "mask": str(candidate), "foreground": foreground}
 

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -1123,6 +1123,12 @@ if ! python3 "$SCRIPT_DIR/test_clock_depth_cache.py"; then
     exit 1
 fi
 
+echo "Running subject mask refinement tests..."
+if ! python3 "$SCRIPT_DIR/test_subject_mask_refine.py"; then
+    echo "Subject mask refinement tests failed."
+    exit 1
+fi
+
 echo "Running clock depth model list tests..."
 if ! python3 "$SCRIPT_DIR/test_clock_depth_models.py"; then
     echo "Clock depth model list tests failed."

--- a/dots/.config/quickshell/imi/tests/test_clock_depth_cache.py
+++ b/dots/.config/quickshell/imi/tests/test_clock_depth_cache.py
@@ -132,7 +132,8 @@ class StatusTest(unittest.TestCase):
     def test_two_candidates_of_the_same_size_are_told_apart_by_content(self):
         """Size is a shortcut past a read, never the decision.
 
-        Two 1024x1024 masks are routinely both about 300 KB, so deciding on the
+        Two masks of the same wallpaper (both stored at the same size, see
+        `storage_size`) are routinely both a few hundred KB, so deciding on the
         size alone would credit whichever model happened to be listed first.
         """
         (self.cache / f"{self.key}.isnet-anime.png").write_bytes(b"aaaaaaaa")

--- a/dots/.config/quickshell/imi/tests/test_subject_mask_refine.py
+++ b/dots/.config/quickshell/imi/tests/test_subject_mask_refine.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Pins for the crisp-mask refinement in scripts/background/subject_mask.py.
+
+The salient path squashes the whole wallpaper to the model's 1024 square, so on
+a 5760x2318 wallpaper every mask texel covers ~5.6 picture pixels and the
+stored mask was that raw soft matte, upscaled bilinearly by Qt. Measured on
+that wallpaper: hair claimed a band of background around it, and a striped
+wall behind a hairline came through as subject. Three pieces of arithmetic fix
+it, and all three are testable without a model:
+
+- the crop the second pass runs on (bbox of the first pass, padded), and the
+  guard that skips it when the subject already fills the frame;
+- the hardening curve applied at the end;
+- the size the mask is stored at (aspect-true, 4096 long side, never larger
+  than the wallpaper).
+
+Pure numpy and Pillow, no ONNX session - `test_clock_depth_cache.py` pins that
+`status` never constructs one, and nothing here may loosen that.
+"""
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/background/subject_mask.py"
+
+sys.path.insert(0, str(SCRIPT.parent))
+import subject_mask  # noqa: E402
+
+
+def needs_numpy(test):
+    try:
+        import numpy  # noqa: F401
+        from PIL import Image  # noqa: F401
+    except ImportError:
+        test.skipTest("needs numpy and pillow (the shell's uv venv)")
+
+
+class HardenTest(unittest.TestCase):
+    """The sigmoid that turns the model's soft matte into an edge.
+
+    Measured on the Violet Evergarden wallpaper: the band of pixels between
+    0.16 and 0.84 went from 0.496 Mpx to 0.235 Mpx under this curve. What is
+    pinned is the shape, not the number - 0.5 stays put (so the subject's
+    boundary does not move), the curve is monotonic (so no pixel changes sides),
+    and it does not clip (so the file's alpha stays a smooth ramp rather than a
+    step, which is what reads as a sticker).
+    """
+    def setUp(self):
+        needs_numpy(self)
+
+    def test_the_boundary_stays_at_a_half(self):
+        import numpy as np
+        out = subject_mask.harden(np.array([0.5], np.float32))
+        self.assertAlmostEqual(float(out[0]), 0.5, places=6)
+
+    def test_the_curve_is_monotonic_and_stays_inside_the_unit_range(self):
+        import numpy as np
+        ramp = np.linspace(0.0, 1.0, 1001, dtype=np.float32)
+        out = subject_mask.harden(ramp)
+        self.assertTrue(np.all(np.diff(out) > 0), "a pixel must never change sides")
+        self.assertGreaterEqual(float(out.min()), 0.0)
+        self.assertLessEqual(float(out.max()), 1.0)
+
+    def test_the_curve_is_steeper_than_the_identity_at_the_boundary(self):
+        import numpy as np
+        near = subject_mask.harden(np.array([0.4, 0.6], np.float32))
+        self.assertLess(float(near[0]), 0.4)
+        self.assertGreater(float(near[1]), 0.6)
+
+    def test_the_ends_are_pulled_to_the_rails(self):
+        import numpy as np
+        ends = subject_mask.harden(np.array([0.0, 1.0], np.float32))
+        self.assertLess(float(ends[0]), 0.01)
+        self.assertGreater(float(ends[1]), 0.99)
+
+
+class RefineBoxTest(unittest.TestCase):
+    """The crop the second pass runs on, in the wallpaper's own pixels."""
+    def setUp(self):
+        needs_numpy(self)
+
+    def coarse(self, x0, x1, y0, y1, side=64):
+        import numpy as np
+        mask = np.zeros((side, side), np.float32)
+        mask[y0:y1, x0:x1] = 1.0
+        return mask
+
+    def test_the_box_is_the_subject_scaled_to_the_wallpaper_and_padded(self):
+        # A subject over columns 16-31 and rows 32-47 of a 64-texel mask, on a
+        # 640x320 wallpaper: x spans 160-320, y spans 160-240 before padding.
+        box = subject_mask.refine_box(self.coarse(16, 32, 32, 48), 640, 320, pad=0.0)
+        self.assertEqual(box, (160, 160, 320, 240))
+        padded = subject_mask.refine_box(self.coarse(16, 32, 32, 48), 640, 320, pad=0.5)
+        # Half the width (80) each side in x, half the height (40) in y.
+        self.assertEqual(padded, (80, 120, 400, 280))
+
+    def test_the_padding_stops_at_the_frame(self):
+        box = subject_mask.refine_box(self.coarse(0, 8, 56, 64), 640, 320, pad=1.0)
+        self.assertEqual(box[0], 0)
+        self.assertEqual(box[3], 320)
+        self.assertGreaterEqual(box[1], 0)
+        self.assertLessEqual(box[2], 640)
+
+    def test_an_empty_mask_has_no_box(self):
+        import numpy as np
+        self.assertIsNone(subject_mask.refine_box(np.zeros((64, 64), np.float32), 640, 320))
+
+    def test_the_default_padding_is_the_measured_one(self):
+        # 12% each side is what the prototype was measured with; a smaller pad
+        # cuts hair at the crop's edge, a larger one hands the second pass the
+        # background the first pass was already wrong about.
+        self.assertAlmostEqual(subject_mask.REFINE_PAD, 0.12)
+
+
+class RefineGuardTest(unittest.TestCase):
+    """Pass 2 is skipped when it cannot gain anything.
+
+    A crop that covers ~85% of the frame is the same picture at the same
+    squash, so the second run costs 0.48s and changes nothing.
+    """
+    def test_a_small_subject_is_refined(self):
+        self.assertTrue(subject_mask.refine_wanted((100, 100, 700, 500), 1920, 1080))
+
+    def test_a_subject_filling_the_frame_is_not(self):
+        self.assertFalse(subject_mask.refine_wanted((0, 0, 1920, 1080), 1920, 1080))
+        # Just under the whole frame is still the whole frame for this purpose.
+        self.assertFalse(subject_mask.refine_wanted((10, 10, 1900, 1070), 1920, 1080))
+
+    def test_the_boundary_is_the_coverage_limit(self):
+        # Exactly the limit is not refined; a hair under it is.
+        w, h = 1000, 1000
+        limit = subject_mask.REFINE_SKIP_COVERAGE
+        side_at = int((limit ** 0.5) * w)
+        self.assertFalse(subject_mask.refine_wanted((0, 0, side_at + 1, side_at + 1), w, h))
+        self.assertTrue(subject_mask.refine_wanted((0, 0, side_at - 20, side_at - 20), w, h))
+
+    def test_no_box_means_nothing_to_refine(self):
+        self.assertFalse(subject_mask.refine_wanted(None, 1920, 1080))
+
+
+class StorageSizeTest(unittest.TestCase):
+    """The size a mask is written at: 4096 on the long side, aspect kept."""
+    def test_a_wide_wallpaper_is_stored_at_4096_wide(self):
+        self.assertEqual(subject_mask.storage_size(5760, 2318), (4096, 1648))
+
+    def test_a_tall_wallpaper_is_stored_at_4096_tall(self):
+        self.assertEqual(subject_mask.storage_size(2160, 7680), (1152, 4096))
+
+    def test_a_small_wallpaper_is_never_upsampled(self):
+        self.assertEqual(subject_mask.storage_size(1920, 1080), (1920, 1080))
+        self.assertEqual(subject_mask.storage_size(4096, 1024), (4096, 1024))
+
+    def test_the_aspect_survives(self):
+        w, h = subject_mask.storage_size(7680, 2160)
+        self.assertAlmostEqual(w / h, 7680 / 2160, places=2)
+
+    def test_a_wallpaper_with_no_size_is_refused(self):
+        with self.assertRaises(ValueError):
+            subject_mask.storage_size(0, 100)
+
+
+class WriteMaskSizeTest(unittest.TestCase):
+    """`write_mask` resamples to the storage size it is handed, and stays LA."""
+    def setUp(self):
+        needs_numpy(self)
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+
+    def write(self, mask, size):
+        from PIL import Image
+        path = Path(self.tmp.name) / "mask.png"
+        subject_mask.write_mask(path, mask, size=size)
+        with Image.open(path) as opened:
+            return opened.copy()
+
+    def test_the_file_is_the_storage_size_not_the_models(self):
+        import numpy as np
+        mask = np.zeros((64, 64), np.float32)
+        mask[:, 32:] = 1.0
+        image = self.write(mask, subject_mask.storage_size(6000, 3000))
+        self.assertEqual(image.size, (4096, 2048))
+        self.assertEqual(image.mode, "LA", "Qt's OpacityMask reads the alpha and "
+                         "nothing else - see write_mask")
+
+    def test_a_small_wallpaper_gets_a_mask_its_own_size(self):
+        import numpy as np
+        mask = np.zeros((64, 64), np.float32)
+        image = self.write(mask, subject_mask.storage_size(800, 600))
+        self.assertEqual(image.size, (800, 600))
+
+    def test_no_size_keeps_the_masks_own_resolution(self):
+        import numpy as np
+        image = self.write(np.zeros((8, 8), np.float32), None)
+        self.assertEqual(image.size, (8, 8))
+
+    def test_the_resampled_alpha_is_still_the_mask(self):
+        import numpy as np
+        mask = np.zeros((64, 64), np.float32)
+        mask[:, 32:] = 1.0
+        image = self.write(mask, (640, 320))
+        alpha = image.getchannel("A")
+        self.assertEqual(alpha.getpixel((0, 0)), 0)
+        self.assertEqual(alpha.getpixel((639, 319)), 255)
+        self.assertEqual(alpha.tobytes(), image.getchannel("L").tobytes())
+
+
+class ProducerContractTest(unittest.TestCase):
+    """The producer's own path pays for none of the refinement on `status`."""
+    def test_status_still_imports_nothing_heavy(self):
+        import re
+        source = SCRIPT.read_text()
+        heavy = re.findall(r"(?m)^(?:import numpy|from PIL|import onnxruntime).*$", source)
+        self.assertEqual(heavy, [], "a module-scope import makes every status query "
+                         "pay for it; the refinement's imports stay inside the functions")
+
+    def test_the_run_path_refines_and_hardens_before_writing(self):
+        source = SCRIPT.read_text()
+        run_body = source.split("def run(", 1)[1].split("\ndef ", 1)[0]
+        self.assertIn("storage_size(", run_body)
+        self.assertIn("harden(", run_body)
+        segment_body = source.split("def segment(", 1)[1].split("\ndef ", 1)[0]
+        self.assertIn("refine_box(", segment_body)
+        self.assertIn("refine_wanted(", segment_body)
+
+    def test_the_prompted_path_hardens_and_stores_at_the_same_size(self):
+        source = SCRIPT.read_text()
+        select_body = source.split("def select(", 1)[1].split("\ndef ", 1)[0]
+        self.assertIn("storage_size(", select_body)
+        self.assertIn("harden(", select_body)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dots/.config/quickshell/imi/tests/test_subject_mask_refine.py
+++ b/dots/.config/quickshell/imi/tests/test_subject_mask_refine.py
@@ -99,49 +99,83 @@ class StorageSizeTest(unittest.TestCase):
             subject_mask.storage_size(0, 100)
 
 
-class WriteMaskSizeTest(unittest.TestCase):
-    """`write_mask` resamples to the storage size it is handed, and stays LA."""
+class PrepareMaskTest(unittest.TestCase):
+    """`prepare_mask` resamples to the storage size and hardens AFTER that.
+
+    The order is what makes the stored edge ~1 pixel: a bilinear upsample of an
+    already-hardened edge is a ramp as wide as the scale factor, which is the
+    band the hardening exists to remove. Measured on the Violet Evergarden
+    wallpaper: soft band 0.112 Mpx this way round, 0.235 the other.
+    """
     def setUp(self):
         needs_numpy(self)
         self.tmp = tempfile.TemporaryDirectory()
         self.addCleanup(self.tmp.cleanup)
 
-    def write(self, mask, size):
+    def step(self, side=64):
+        import numpy as np
+        mask = np.zeros((side, side), np.float32)
+        mask[:, side // 2:] = 1.0
+        return mask
+
+    def written(self, mask, size):
         from PIL import Image
         path = Path(self.tmp.name) / "mask.png"
-        subject_mask.write_mask(path, mask, size=size)
+        subject_mask.write_mask(path, subject_mask.prepare_mask(mask, size))
         with Image.open(path) as opened:
             return opened.copy()
 
     def test_the_file_is_the_storage_size_not_the_models(self):
-        import numpy as np
-        mask = np.zeros((64, 64), np.float32)
-        mask[:, 32:] = 1.0
-        image = self.write(mask, subject_mask.storage_size(6000, 3000))
+        image = self.written(self.step(), subject_mask.storage_size(6000, 3000))
         self.assertEqual(image.size, (4096, 2048))
         self.assertEqual(image.mode, "LA", "Qt's OpacityMask reads the alpha and "
                          "nothing else - see write_mask")
 
     def test_a_small_wallpaper_gets_a_mask_its_own_size(self):
-        import numpy as np
-        mask = np.zeros((64, 64), np.float32)
-        image = self.write(mask, subject_mask.storage_size(800, 600))
+        image = self.written(self.step(), subject_mask.storage_size(800, 600))
         self.assertEqual(image.size, (800, 600))
 
-    def test_no_size_keeps_the_masks_own_resolution(self):
+    def test_write_mask_itself_keeps_the_masks_own_resolution(self):
         import numpy as np
-        image = self.write(np.zeros((8, 8), np.float32), None)
-        self.assertEqual(image.size, (8, 8))
+        from PIL import Image
+        path = Path(self.tmp.name) / "raw.png"
+        subject_mask.write_mask(path, np.zeros((8, 8), np.float32))
+        with Image.open(path) as opened:
+            self.assertEqual(opened.size, (8, 8))
 
     def test_the_resampled_alpha_is_still_the_mask(self):
-        import numpy as np
-        mask = np.zeros((64, 64), np.float32)
-        mask[:, 32:] = 1.0
-        image = self.write(mask, (640, 320))
+        image = self.written(self.step(), (640, 320))
         alpha = image.getchannel("A")
-        self.assertEqual(alpha.getpixel((0, 0)), 0)
-        self.assertEqual(alpha.getpixel((639, 319)), 255)
+        # The rails after k=6 hardening are 0.0025 and 0.9975, i.e. 1 and 254
+        # in the file - hardening never quite reaches the ends, by design.
+        self.assertLessEqual(alpha.getpixel((0, 0)), 1)
+        self.assertGreaterEqual(alpha.getpixel((639, 319)), 254)
         self.assertEqual(alpha.tobytes(), image.getchannel("L").tobytes())
+
+    def test_the_edge_is_hardened_after_the_upsample_not_before(self):
+        """A step upsampled 8x bilinearly is a ramp eight pixels wide, four of
+        them between 0.25 and 0.75. Hardening THEN upsampling keeps all four
+        (0.313, 0.438, 0.562, 0.687); upsampling THEN hardening (k=6) leaves
+        two (0.321, 0.679) with the rest pulled to the rails."""
+        import numpy as np
+
+        def mid_band(row):
+            return int(((row > 0.25) & (row < 0.75)).sum())
+
+        row = subject_mask.prepare_mask(self.step(16), (128, 128))[8]
+        control = subject_mask.resample(subject_mask.harden(self.step(16)), (128, 128))[8]
+        self.assertGreaterEqual(mid_band(control), 4, "the control must carry the "
+                                "ramp, or this test cannot tell the two orders apart")
+        self.assertLessEqual(mid_band(row) * 2, mid_band(control),
+                        f"{mid_band(row)} mid-band pixels against {mid_band(control)} "
+                        "for harden-then-resample - the hardening must run after "
+                        "the resample")
+        # And the ramp as a whole is pulled in, not just its middle: distance
+        # from the rails summed across the row (measured 1.19 against 2.31).
+        softness = float(np.minimum(row, 1.0 - row).sum())
+        control_softness = float(np.minimum(control, 1.0 - control).sum())
+        self.assertLess(softness, 0.7 * control_softness)
+        self.assertTrue(np.all(np.diff(row) >= 0), "the edge is still one edge")
 
 
 class ProducerContractTest(unittest.TestCase):
@@ -156,14 +190,20 @@ class ProducerContractTest(unittest.TestCase):
     def test_the_run_path_hardens_and_sizes_before_writing(self):
         source = SCRIPT.read_text()
         run_body = source.split("def run(", 1)[1].split("\ndef ", 1)[0]
+        self.assertIn("prepare_mask(", run_body)
         self.assertIn("storage_size(", run_body)
-        self.assertIn("harden(", run_body)
 
     def test_the_prompted_path_hardens_and_stores_at_the_same_size(self):
         source = SCRIPT.read_text()
         select_body = source.split("def select(", 1)[1].split("\ndef ", 1)[0]
+        self.assertIn("prepare_mask(", select_body)
         self.assertIn("storage_size(", select_body)
-        self.assertIn("harden(", select_body)
+
+    def test_prepare_mask_is_the_only_place_the_order_is_decided(self):
+        source = SCRIPT.read_text()
+        body = source.split("def prepare_mask(", 1)[1].split("\ndef ", 1)[0]
+        self.assertIn("harden(resample(", body.replace(" ", ""),
+                      "prepare_mask must resample first and harden second")
 
 
 if __name__ == "__main__":

--- a/dots/.config/quickshell/imi/tests/test_subject_mask_refine.py
+++ b/dots/.config/quickshell/imi/tests/test_subject_mask_refine.py
@@ -1,18 +1,20 @@
 #!/usr/bin/env python3
 """Pins for the crisp-mask refinement in scripts/background/subject_mask.py.
 
-The salient path squashes the whole wallpaper to the model's 1024 square, so on
-a 5760x2318 wallpaper every mask texel covers ~5.6 picture pixels and the
+The salient path squashes the whole wallpaper to the model's 1024 square, so
+on a 5760x2318 wallpaper every mask texel covers ~5.6 picture pixels and the
 stored mask was that raw soft matte, upscaled bilinearly by Qt. Measured on
 that wallpaper: hair claimed a band of background around it, and a striped
-wall behind a hairline came through as subject. Three pieces of arithmetic fix
-it, and all three are testable without a model:
+wall behind a hairline came through as subject - the soft band, upscaled. Two
+pieces of arithmetic fix it, and both are testable without a model:
 
-- the crop the second pass runs on (bbox of the first pass, padded), and the
-  guard that skips it when the subject already fills the frame;
-- the hardening curve applied at the end;
+- the hardening curve, applied AFTER the mask is resampled to its storage
+  size, so the edge is ~1 storage pixel rather than a bilinear ramp;
 - the size the mask is stored at (aspect-true, 4096 long side, never larger
   than the wallpaper).
+
+A second model pass over the subject's box was here too, and was measured out
+again (see `segment`'s docstring); its tests went with it.
 
 Pure numpy and Pillow, no ONNX session - `test_clock_depth_cache.py` pins that
 `status` never constructs one, and nothing here may loosen that.
@@ -74,70 +76,6 @@ class HardenTest(unittest.TestCase):
         ends = subject_mask.harden(np.array([0.0, 1.0], np.float32))
         self.assertLess(float(ends[0]), 0.01)
         self.assertGreater(float(ends[1]), 0.99)
-
-
-class RefineBoxTest(unittest.TestCase):
-    """The crop the second pass runs on, in the wallpaper's own pixels."""
-    def setUp(self):
-        needs_numpy(self)
-
-    def coarse(self, x0, x1, y0, y1, side=64):
-        import numpy as np
-        mask = np.zeros((side, side), np.float32)
-        mask[y0:y1, x0:x1] = 1.0
-        return mask
-
-    def test_the_box_is_the_subject_scaled_to_the_wallpaper_and_padded(self):
-        # A subject over columns 16-31 and rows 32-47 of a 64-texel mask, on a
-        # 640x320 wallpaper: x spans 160-320, y spans 160-240 before padding.
-        box = subject_mask.refine_box(self.coarse(16, 32, 32, 48), 640, 320, pad=0.0)
-        self.assertEqual(box, (160, 160, 320, 240))
-        padded = subject_mask.refine_box(self.coarse(16, 32, 32, 48), 640, 320, pad=0.5)
-        # Half the width (80) each side in x, half the height (40) in y.
-        self.assertEqual(padded, (80, 120, 400, 280))
-
-    def test_the_padding_stops_at_the_frame(self):
-        box = subject_mask.refine_box(self.coarse(0, 8, 56, 64), 640, 320, pad=1.0)
-        self.assertEqual(box[0], 0)
-        self.assertEqual(box[3], 320)
-        self.assertGreaterEqual(box[1], 0)
-        self.assertLessEqual(box[2], 640)
-
-    def test_an_empty_mask_has_no_box(self):
-        import numpy as np
-        self.assertIsNone(subject_mask.refine_box(np.zeros((64, 64), np.float32), 640, 320))
-
-    def test_the_default_padding_is_the_measured_one(self):
-        # 12% each side is what the prototype was measured with; a smaller pad
-        # cuts hair at the crop's edge, a larger one hands the second pass the
-        # background the first pass was already wrong about.
-        self.assertAlmostEqual(subject_mask.REFINE_PAD, 0.12)
-
-
-class RefineGuardTest(unittest.TestCase):
-    """Pass 2 is skipped when it cannot gain anything.
-
-    A crop that covers ~85% of the frame is the same picture at the same
-    squash, so the second run costs 0.48s and changes nothing.
-    """
-    def test_a_small_subject_is_refined(self):
-        self.assertTrue(subject_mask.refine_wanted((100, 100, 700, 500), 1920, 1080))
-
-    def test_a_subject_filling_the_frame_is_not(self):
-        self.assertFalse(subject_mask.refine_wanted((0, 0, 1920, 1080), 1920, 1080))
-        # Just under the whole frame is still the whole frame for this purpose.
-        self.assertFalse(subject_mask.refine_wanted((10, 10, 1900, 1070), 1920, 1080))
-
-    def test_the_boundary_is_the_coverage_limit(self):
-        # Exactly the limit is not refined; a hair under it is.
-        w, h = 1000, 1000
-        limit = subject_mask.REFINE_SKIP_COVERAGE
-        side_at = int((limit ** 0.5) * w)
-        self.assertFalse(subject_mask.refine_wanted((0, 0, side_at + 1, side_at + 1), w, h))
-        self.assertTrue(subject_mask.refine_wanted((0, 0, side_at - 20, side_at - 20), w, h))
-
-    def test_no_box_means_nothing_to_refine(self):
-        self.assertFalse(subject_mask.refine_wanted(None, 1920, 1080))
 
 
 class StorageSizeTest(unittest.TestCase):
@@ -215,14 +153,11 @@ class ProducerContractTest(unittest.TestCase):
         self.assertEqual(heavy, [], "a module-scope import makes every status query "
                          "pay for it; the refinement's imports stay inside the functions")
 
-    def test_the_run_path_refines_and_hardens_before_writing(self):
+    def test_the_run_path_hardens_and_sizes_before_writing(self):
         source = SCRIPT.read_text()
         run_body = source.split("def run(", 1)[1].split("\ndef ", 1)[0]
         self.assertIn("storage_size(", run_body)
         self.assertIn("harden(", run_body)
-        segment_body = source.split("def segment(", 1)[1].split("\ndef ", 1)[0]
-        self.assertIn("refine_box(", segment_body)
-        self.assertIn("refine_wanted(", segment_body)
 
     def test_the_prompted_path_hardens_and_stores_at_the_same_size(self):
         source = SCRIPT.read_text()


### PR DESCRIPTION
## Problem

Clock depth masks are not crisp: fine structure such as hair claims more mask than it should, and on wide wallpapers background shows through the outline — measured on the Violet Evergarden wallpaper (5760×2318, `isnet-general-use`), a striped wall behind a hairline came through as subject.

## Cause

The salient path squashes the whole wallpaper to the model's 1024² input, so each mask texel covers ~5.6 picture pixels on that wallpaper; the stored PNG was that raw soft matte at 1024², upscaled bilinearly by Qt (`ClockDepthCutout.qml`, `Image.Stretch; smooth: true`). The visible bleed is the soft 0.16–0.84 band, upscaled with the mask.

## What lands

1. **Edge hardening after the resample.** `prepare_mask` = `harden(resample(m, storage_size))`: a k=6 sigmoid around 0.5 (0.5 → 0.5, monotonic), applied *after* the matte is upsampled to storage size. The order is the point — a hardened edge put through the 4× bilinear upscale comes back as a 4 px ramp. Soft band (0.16 < m < 0.84) on the Violet wallpaper: **0.307 Mpx** shipped 1024² → **0.235** harden-then-resample → **0.119** resample-then-harden. Foreground share unchanged (0.179 → 0.179); neck 0.98 → 0.996, collar 0.942 → 0.946 (kept). Applied to `mobile-sam` masks too.
2. **Storage** aspect-true at 4096 on the long side, never larger than the wallpaper, still `LA` with duplicated alpha (`OpacityMask` reads alpha). 4096×1648 at 253 KB on the Violet wallpaper vs ~100 KB for the square. `coverRect` maps the whole mask onto the whole picture without reading its shape, so the shell side needed no change; the two comments that said "the mask is square" now say what it was and what it is.
3. Cost per run unchanged (0.87 s → 0.89 s on this machine).

## Tried and rejected (history preserved, not rewritten)

- **Two-pass crop-refine** (`038df1083`, reverted by `7e0dc5f16`). Re-measured against the coarse and crop passes both upsampled to the picture: where coarse > 0.5 and crop < 0.5, **17.7% of the coarse subject is lost** (neck 0.994 → 0.671, collar 0.996 → 0.317, robe 0.996 → 0.918); only 0.5% gained the other way. The striped wall above the head is at 0.257 in the coarse pass — already below 0.5 — so the "stripe bleed" was the soft band and it is the hardening that removes it. Soft band after hardening: 0.112 Mpx coarse alone, 0.113 `max(coarse, fine)`, 0.230 pasted crop. Visually, `harden(fine-replace)` punched a speckled hole through the neck and collar; `harden(coarse)` keeps them. Recorded in `segment`'s docstring and spec §9.
- **Guided filter** (prototype only): widened the band along low-contrast outlines. Recorded in `HARDEN_K`'s comment and spec §9.

## Before / after (Violet wallpaper, overlay in the session scratchpad `before_after_overlay_v2.png`)

Before: a soft red halo around every hair strand, the striped wall reading through the outline above the head. After: individual strands resolved with no halo, stripes not claimed, neck and collar intact, same subject as before — the outline is about a storage pixel wide instead of a ~5 px ramp.

## Tests

New `tests/test_subject_mask_refine.py` (18 tests, pure numpy/Pillow, no ONNX session; registered in `run_tests.sh`): hardening curve pins 0.5→0.5, monotonic, in range, ends at the rails; `storage_size` 4096 long side / aspect kept / never above source; `prepare_mask` + `write_mask` output size, LA, alpha still the mask; **resample-then-harden order** pinned on the numbers (8× upsampled step: mid-band 0.25–0.75 goes 4 → 2 pixels, summed distance from the rails 2.31 → 1.19, against a harden-then-resample control that must itself carry the ramp) and on `prepare_mask`'s source; source-text checks that `run`/`select` go through `prepare_mask` + `storage_size` and no heavy import sits at module scope.

Plant-proof (each planted in the clean tree, seen failing, reverted):
- `prepare_mask` order swapped to `resample(harden())` → `test_the_edge_is_hardened_after_the_upsample_not_before` + `test_prepare_mask_is_the_only_place_the_order_is_decided`; `prepare_mask` skips harden → same two
- `run` writes the raw mask → `test_the_run_path_hardens_and_sizes_before_writing`; `select` writes the raw mask → `test_the_prompted_path_hardens_and_stores_at_the_same_size`
- `MASK_STORE_SIDE` 2048 → 4 failures; storage upsamples small wallpapers → 2 failures
- harden k sign flipped → 5 failures; `import numpy` at module scope → `test_status_still_imports_nothing_heavy`
- (earlier, for the since-removed crop pass: pad/clamp/scale/guard mutations each caught by their own test — those tests went with the revert)

Run at HEAD: `test_clock_depth_cache.py` 71 OK; `test_subject_mask_refine.py` 18 OK; `test_clock_depth_models.py` OK; `lint_clock_depth_geometry.py` OK; `test_clock_depth_select_contract.py` OK; `lint_doc_citations.py` OK; `lint_runtime_bus_isolation.py` OK; `tst_clock_depth_eligibility.qml` 42 passed; `test_clock_depth_compositing.py` OK (15.3 s, weston); `test_clock_depth_noop.py` OK (5.6 s, weston). Full `run_tests.sh` under `dbus-run-session` on the pre-revision head (a428e081c): 1029 QML passed / 0 failed, "All tests passed successfully!"; the revision touches only the producer, its unit test and docs, and the subset above is green at HEAD.

Live: `subject_mask.py --cache-dir <scratch> run … --model isnet-general-use` → 4096×1648 LA, 253 KB; `select --point 0.6,0.4` → 4096×1648 LA, 129 KB, prompt chunk intact; `status` reads both back. The user's real cache and live shell were not touched.

Docs: updated AGENT.md §clock-depth (the square is the right input and was the wrong storage; cites 77497c63a, 983e4c529, 7e0dc5f16, 1a6a2b970), spec §3 + §6 + new §9 (crop pass and guided filter recorded as rejected, with numbers) + status line, CHANGELOG [Unreleased]
