### PR TITLE
feat(clockDepth): mask a live Wallpaper Engine scene with a mask of its still

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -3246,6 +3246,32 @@ Four things about that column generalise past it:
   back at 1.6-10% because SAM answers with the sky.
   (fix(background): a click's floor is not the detectors' floor.)
 
+**A live Wallpaper Engine scene is masked by a mask of its own STILL, keyed on the
+project, and the predicate refuses the wrong silhouette from both sides.** The
+shell already photographs every project it renders (`captureGreeterStill`), and
+that still is the viewport itself at the viewport's size, so a mask cut from it
+registers 1:1 - but the still is re-grabbed every session, so keying its cache
+on the file's stat triple would forget the user's acceptance on every restart.
+`subject_mask.py` takes `--identity we:<projectId>` on every verb and
+`ClockDepth.askingWe` decides when to send it (never during a preview - a
+preview is a still picture over the live scene and the question is about that
+picture). `ClockDepthCutout.liveSource` paints the live surface through the same
+`OpacityMask` (a masked still would freeze every animated pixel inside the
+silhouette), falling back to the wallpaper image, which
+`lint_clock_depth_geometry.py` pins. `clockDepth.js` compares `weActive` against
+`maskIsWe` rather than refusing `weActive`: a project's mask over the static
+fallback (`web`, `weFailed`, the safety screen) is the same wrong silhouette as
+a still picture's mask over a live scene, and one comparison holds both. Two
+things a first cut would get wrong: `status` answers before its picture exists
+(`available: false` - a project on screen for the first time has no still until
+600ms after its first frame), so the picker says "waiting for the first frame"
+and the grab's completion pokes `ClockDepth.refresh()` - observed, not polled -
+and the desktop selector cannot sample another window's surface, so it draws the
+candidate cut from the still over the live scene, frozen inside the silhouette,
+which is exactly the §8.4 honesty question the user is asked to judge.
+(feat(clockDepth): the producer takes an identity in place of the stat triple,
+feat(clockDepth): mask a live Wallpaper Engine scene with a mask of its still.)
+
 **And the click belongs on the desktop, because a mask judged at screen size
 cannot be authored on a thumbnail.** The gesture shipped on a ~300px preview
 inside the depth picker, which is a structural mismatch rather than a matter of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ own repo; the installer pins which revision it builds.
 
 ## [Unreleased]
 
+### Added
+- **Clock depth works on a live Wallpaper Engine scene.** The depth picker
+  segments the still the shell already photographs of the active project, keyed
+  on the project rather than on the still (which is re-grabbed every session),
+  and the desktop layer masks the *live* surface with it — the silhouette stays
+  put while the pixels inside it keep moving. The picker says so, and says when
+  a project has not drawn its first frame yet. A mask cut from a still picture
+  never lands on a live scene, and a project's mask never lands on the static
+  fallback the desktop shows when the renderer gives up.
+
 ### Fixed
 - **The motion speed slider and reduce motion now reach every animation.** Nine
   places read a motion tier's base duration instead of the scaled one, so they

--- a/docs/superpowers/specs/2026-08-16-clock-depth-design.md
+++ b/docs/superpowers/specs/2026-08-16-clock-depth-design.md
@@ -435,7 +435,31 @@ Start with **Stage 1: the subject-mask producer and its cache.**
 
 ---
 
-## 8. Wallpaper Engine — designed, not landed
+## 8. Wallpaper Engine — landed
+
+> Landed 2026-08-19 (feat(clockDepth): the producer takes an identity in place
+> of the stat triple; feat(clockDepth): mask a live Wallpaper Engine scene with a
+> mask of its still). What shipped follows §8.1–8.5 as written, with three
+> things decided in the doing:
+>
+> - The predicates compare `weActive` against `maskIsWe` rather than refusing
+>   `weActive` outright, so the wrong silhouette is refused from BOTH sides — a
+>   project's mask over the static fallback (a `web` project, `weFailed`, the
+>   safety screen) as well as a still picture's mask over a live scene.
+> - `status` reports `available` — whether the picture exists — because an
+>   identity-keyed query is the one query answerable before its picture; the
+>   picker turns that into "Waiting for the scene's first frame", and
+>   `Background.captureGreeterStill` pokes a refresh when the grab lands.
+> - The desktop selector draws the candidate cut from the still over the live
+>   scene (it is another window and cannot sample the scene's surface): frozen
+>   inside the silhouette, live everywhere else — which is the honesty question
+>   §8.4 asks the user to judge, made visible for free.
+>
+> Verified on the real desktop against project 3008040633 (a seated figure in a
+> rain scene): the clock widget placed under the figure is hidden with depth on
+> and shown with it off, and 1% of the pixels inside the silhouette change
+> between two frames — the rain — so the surface under the mask is live.
+
 
 §4 refused a live Wallpaper Engine project on the reasoning that it is "a moving
 surface with no file to segment". The first half is true and the second is not:

--- a/dots/.config/quickshell/imi/modules/common/functions/clockDepth.js
+++ b/dots/.config/quickshell/imi/modules/common/functions/clockDepth.js
@@ -45,10 +45,14 @@ function eligible(state) {
     // one part of the screen that is supposed to be what is OUTSIDE the desktop.
     if (s.editing) return false;
     if (!s.maskPath) return false;
-    // A live Wallpaper Engine project is a moving surface with no file to
-    // segment, and a mask of the frozen greeter still would be a stale
-    // silhouette over animated content.
-    if (s.weActive) return false;
+    // The mask has to have been cut from the picture on screen. A live
+    // Wallpaper Engine project is masked by a mask of its own STILL (spec §8:
+    // the silhouette is static, the pixels under it are live) and never by the
+    // static wallpaper's; and when the desktop has fallen back to the static
+    // wallpaper - a `web` project, a renderer that failed, the safety screen -
+    // the project's mask is the wrong silhouette the other way round. One
+    // comparison for both directions, so the two halves cannot drift.
+    if (!!s.weActive !== !!s.maskIsWe) return false;
     // mpvpaper is a separate Wayland client on its own layer surface. The shell
     // does not own those pixels and parallaxViewport does not move them, so a
     // cutout built from the ffmpeg first frame would be a still ghost of frame 1
@@ -176,9 +180,14 @@ function selectable(state) {
     // gesture is entered by closing it - so the picture under the click would
     // not be the picture the clicks get stored against.
     if (s.previewing) return false;
-    // A live Wallpaper Engine project owns the screen; the still this service
-    // names is not what is being drawn, so a cutout of it is a sticker.
-    if (s.weActive) return false;
+    // A live Wallpaper Engine project is picked on through its still: the
+    // clicks are measured in the box the live surface fills, and the still is
+    // that box photographed, so the geometry is the identity. What refuses is
+    // the service asking about a different picture than the one on screen -
+    // and a project whose still has not been grabbed yet, because then there
+    // is no picture to send the clicks to at all.
+    if (!!s.weActive !== !!s.maskIsWe) return false;
+    if (s.stillMissing) return false;
     // Centred mode draws the wallpaper at its own size in its own shape, which
     // is not the geometry the cutout is registered against.
     if (s.centeredWallpaper) return false;

--- a/dots/.config/quickshell/imi/modules/imi/background/Background.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/Background.qml
@@ -429,8 +429,15 @@ Variants {
             // next unrelated color event. The grab's completion is the event
             // the sync has to observe - see GreeterSync.
             weLoader.item.grabToImage(result => {
-                if (result.saveToFile(target))
+                if (result.saveToFile(target)) {
                     GreeterSync.request();
+                    // The depth picker's other consumer of this still. A
+                    // project on screen for the first time had no still when
+                    // it was asked about, and the grab's completion is the
+                    // event that changes the answer - observed, not polled.
+                    if (ClockDepth.watching)
+                        ClockDepth.refresh();
+                }
             });
         }
 
@@ -1424,6 +1431,14 @@ Variants {
                 selecting: GlobalStates.clockDepthSelectOpen,
                 editing: GlobalStates.editMode,
                 weActive: bgRoot.weActive,
+                // Whether the mask on offer was cut from the project's still
+                // rather than the static wallpaper. Compared against
+                // weActive INSIDE the predicate: this instance can fall back
+                // to the static image on its own (weFailed, the safety
+                // screen) while the service is still asking about the
+                // project, and that mismatch is the wrong silhouette either
+                // way round.
+                maskIsWe: ClockDepth.askingWe,
                 wallpaperIsVideo: bgRoot.wallpaperIsVideo,
                 centeredWallpaper: bgRoot.centeredWallpaperEnabled,
                 screenLocked: GlobalStates.screenLocked,
@@ -1453,7 +1468,14 @@ Variants {
                     y: clockDepthLayer.y,
                     width: clockDepthLayer.width,
                     height: clockDepthLayer.height,
-                    source: String(wallpaper.source)
+                    // A live project's picture is its still (spec §8): the
+                    // selector is another window and cannot sample this
+                    // scene's surface, so it draws the candidate cut from the
+                    // still over the live scene - frozen inside the
+                    // silhouette, live everywhere else - which is exactly the
+                    // honesty question §8.4 asks the user to judge.
+                    source: bgRoot.weActive && ClockDepth.askingWe
+                        ? `file://${ClockDepth.weStillPath}` : String(wallpaper.source)
                 })
                 : null
             onPublishedViewportChanged: bgRoot.publishDepthViewport(clockDepthLayer.publishedViewport)
@@ -1470,6 +1492,11 @@ Variants {
                 // outgoing frame, and reading the path would put the incoming
                 // image under the outgoing image's mask for the length of it.
                 wallpaperSource: wallpaper.source
+                // The live surface, never its still (spec §8.3): a masked
+                // still would freeze every animated pixel inside the
+                // silhouette. weLiveSource is the texture the WE transition
+                // already samples, so this adds no second render pass.
+                liveSource: bgRoot.weActive ? weLiveSource : null
                 maskPath: ClockDepth.maskPath
                 maskRevision: ClockDepth.maskRevision
             }

--- a/dots/.config/quickshell/imi/modules/imi/background/ClockDepthCutout.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/ClockDepthCutout.qml
@@ -26,6 +26,15 @@ Item {
     // frame first, so reading the path would put the incoming image under the
     // outgoing image's mask for the length of every switch.
     property url wallpaperSource
+    // A live Wallpaper Engine surface to mask INSTEAD of the wallpaper image
+    // (spec §8.3). Set, it is what the OpacityMask paints, so the pixels under
+    // the silhouette are live and only the silhouette is static; the mask was
+    // cut from that surface's own still, grabbed at the viewport's size, so it
+    // is at the surface's aspect and covers the box exactly - the un-squash
+    // below is the identity for it. Null draws the wallpaper image, which is
+    // every call site but the desktop layer's.
+    property Item liveSource: null
+    readonly property Item paintedSource: root.liveSource ?? cutoutWallpaper
     property string maskPath: ""
     // A token that changes when the mask file's bytes do, hung on the URL as a
     // fragment. Qt caches a pixmap by URL and a mask is rewritten at the SAME
@@ -94,8 +103,12 @@ Item {
             // well as the luminance. A plain grayscale mask is opaque
             // everywhere and lets the whole wallpaper through, which draws the
             // picture flat over the clock rather than the subject behind it.
+            // A live surface's picture is the box: the still it was masked
+            // from IS the box photographed, so the source has the box's own
+            // size and the rect comes back as the box.
             readonly property var coverRect: ClockDepthLogic.coverRect(
-                cutoutWallpaper.implicitWidth, cutoutWallpaper.implicitHeight,
+                root.liveSource ? maskSurface.width : cutoutWallpaper.implicitWidth,
+                root.liveSource ? maskSurface.height : cutoutWallpaper.implicitHeight,
                 maskSurface.width, maskSurface.height)
             x: mask.coverRect.x
             y: mask.coverRect.y
@@ -115,7 +128,7 @@ Item {
     // degrades to today's flat clock instead of to a wallpaper pasted over it.
     OpacityMask {
         anchors.fill: parent
-        source: cutoutWallpaper
+        source: root.paintedSource
         maskSource: maskSurface
     }
 }

--- a/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/ClockDepthPicker.qml
+++ b/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/ClockDepthPicker.qml
@@ -167,6 +167,19 @@ Item {
                         : Appearance.colors.colSubtext
                     wrapMode: Text.WordWrap
                 }
+                StyledText {
+                    Layout.fillWidth: true
+                    // Spec §8.4: a static silhouette over a moving scene is
+                    // right exactly while the subject stands still, and no
+                    // measurement can tell. It is judged the same way the
+                    // mask's own quality is - said here, where the verdict is
+                    // given, and only for a live scene.
+                    visible: ClockDepth.askingWe
+                    text: Translation.tr("This is a live scene, cut from a still of it. The silhouette stays put while the picture moves - keep it only if the subject does too. Turn on Inspect and let the scene run.")
+                    font.pixelSize: Appearance.font.pixelSize.smaller
+                    color: Appearance.colors.colSubtext
+                    wrapMode: Text.WordWrap
+                }
             }
             // A RippleButton rather than the IconToolbarButton this started as:
             // ToolbarButton carries `Layout.fillHeight: true` for the toolbars
@@ -502,6 +515,8 @@ Item {
                                             ? Translation.tr("Cutting…")
                                             : Translation.tr("Looking for a subject…")
                                     if (candidate.prompted) {
+                                        if (ClockDepth.askingWe && !ClockDepth.stillAvailable)
+                                            return Translation.tr("Waiting for the scene's first frame")
                                         if (!ClockDepth.selectable)
                                             return Translation.tr("Apply this wallpaper to pick on the desktop")
                                         if (candidate.points.length === 0)
@@ -512,6 +527,13 @@ Item {
                                     }
                                     if (candidate.maskPath !== "")
                                         return ""
+                                    // A live project is segmented from its
+                                    // still, which the shell grabs a moment
+                                    // after the scene's first frame (spec
+                                    // §8.5) - so there is nothing to run on
+                                    // yet, rather than nothing found.
+                                    if (ClockDepth.askingWe && !ClockDepth.stillAvailable)
+                                        return Translation.tr("Waiting for the scene's first frame")
                                     return candidate.refused
                                         ? (candidate.otherFound
                                             ? Translation.tr("Nothing here — another column found something")
@@ -531,7 +553,7 @@ Item {
                         DialogButton {
                             id: runButton
                             visible: !candidate.prompted
-                            enabled: !root.busy && root.wallpaper !== ""
+                            enabled: !root.busy && root.wallpaper !== "" && ClockDepth.stillAvailable
                             buttonText: candidate.maskPath !== "" || candidate.refused
                                 ? Translation.tr("Run again")
                                 : Translation.tr("Run")

--- a/dots/.config/quickshell/imi/scripts/background/subject_mask.py
+++ b/dots/.config/quickshell/imi/scripts/background/subject_mask.py
@@ -177,8 +177,22 @@ def cache_root(explicit=None):
     return Path(base) / "quickshell" / "clock-depth"
 
 
-def cache_key(wallpaper):
-    """The wallpaper's identity for this cache: path, mtime and size."""
+def cache_key(wallpaper, identity=None):
+    """The wallpaper's identity for this cache: path, mtime and size.
+
+    Or a caller-supplied identity in place of all three. A Wallpaper Engine
+    project has no file of its own to segment - the shell photographs it into a
+    still, and that still is re-grabbed on every load of the project, so its
+    mtime moves every session. Keyed on the file, the user's acceptance would be
+    minted a new key on every restart and silently forgotten. The shell hands in
+    `we:<projectId>` and the still is only the picture. The trade is the mirror
+    of the stat triple's: editing the project does NOT invalidate its mask, and
+    that is the right way round - an edited project is something the user did on
+    purpose and can re-judge from the picker, where an edited file is the case
+    nothing prompts them about.
+    """
+    if identity:
+        return hashlib.sha256(f"identity\0{identity}".encode("utf-8")).hexdigest()[:32]
     path = Path(wallpaper).expanduser().resolve()
     st = path.stat()
     material = f"{path}\0{st.st_mtime_ns}\0{st.st_size}".encode("utf-8")
@@ -384,15 +398,33 @@ def accepted_model(root, key, candidates):
     return None
 
 
-def status(root, wallpaper):
+def require_picture(wallpaper):
+    """A verb that loads a model needs the picture to exist, in words.
+
+    The stat-keyed path fails on its own inside `cache_key`; the identity-keyed
+    one keys without touching the file, so a still that has not been grabbed
+    yet would otherwise surface as whatever Pillow says about a missing path.
+    """
+    path = Path(wallpaper).expanduser()
+    if not path.exists():
+        raise RuntimeError(f"nothing to segment: {path} does not exist yet")
+
+
+def status(root, wallpaper, identity=None):
     """What the shell asks. Reads directory entries; loads nothing."""
     try:
-        key = cache_key(wallpaper)
+        key = cache_key(wallpaper, identity)
     except OSError as exc:
         return {"state": "unreadable", "error": str(exc), "wallpaper": str(wallpaper)}
 
     result = {"key": key, "wallpaper": str(Path(wallpaper).expanduser().resolve()),
               "cacheDir": str(root),
+              # Only an identity-keyed query can answer without its picture: a
+              # Wallpaper Engine project that has not rendered this session has
+              # no still yet, and the picker says so rather than failing. For
+              # the stat-keyed path this is always true, because the key
+              # itself came from the file.
+              "available": Path(wallpaper).expanduser().exists(),
               # The models and what each one is asked with, so the picker draws
               # one column per model without carrying its own copy of the list -
               # a second list of model names is the pair that drifts, and the
@@ -695,7 +727,7 @@ def decode_mask(root, model, embedding, resized, points):
     return 1.0 / (1.0 + np.exp(-masks[0][best].astype(np.float32)))
 
 
-def select(root, wallpaper, model, points):
+def select(root, wallpaper, model, points, identity=None):
     """Cut a mask from clicks, or clear the one that is there.
 
     No `.none` marker is ever written here, and that is the difference between a
@@ -707,7 +739,8 @@ def select(root, wallpaper, model, points):
     """
     if MODELS.get(model, {}).get("kind") != "prompted":
         raise RuntimeError(f"{model!r} takes no clicks; use `run --model {model}`")
-    key = cache_key(wallpaper)
+    require_picture(wallpaper)
+    key = cache_key(wallpaper, identity)
     root.mkdir(parents=True, exist_ok=True)
     candidate = root / f"{key}.{model}.png"
 
@@ -732,13 +765,14 @@ def select(root, wallpaper, model, points):
             "mask": str(candidate), "foreground": foreground, "prompt": points}
 
 
-def run(root, wallpaper, model, force=False):
+def run(root, wallpaper, model, force=False, identity=None):
     if model not in MODELS:
         raise SystemExit(f"unknown model {model!r}; expected one of {', '.join(MODELS)}")
     if MODELS[model]["kind"] == "prompted":
         raise RuntimeError(f"{model!r} needs clicks; use `select --model {model} "
                            f"--point x,y`")
-    key = cache_key(wallpaper)
+    require_picture(wallpaper)
+    key = cache_key(wallpaper, identity)
     root.mkdir(parents=True, exist_ok=True)
     candidate = root / f"{key}.{model}.png"
     negative = root / f"{key}.{model}.none"
@@ -828,7 +862,7 @@ def write_mask(path, mask, prompt=None):
     Image.fromarray(np.dstack([plane, plane]), "LA").save(path, pnginfo=info)
 
 
-def accept(root, wallpaper, model):
+def accept(root, wallpaper, model, identity=None):
     """Promote one model's candidate to the mask the shell draws.
 
     A copy rather than a link or a rename: the candidate stays where it is so the
@@ -842,7 +876,7 @@ def accept(root, wallpaper, model):
     """
     if model not in MODELS:
         raise SystemExit(f"unknown model {model!r}; expected one of {', '.join(MODELS)}")
-    key = cache_key(wallpaper)
+    key = cache_key(wallpaper, identity)
     candidate = root / f"{key}.{model}.png"
     if not candidate.exists():
         raise RuntimeError(f"no {model} candidate to accept for this wallpaper")
@@ -857,7 +891,7 @@ def accept(root, wallpaper, model):
     return {"state": "accepted", "key": key, "model": model, "mask": str(accepted)}
 
 
-def decline(root, wallpaper):
+def decline(root, wallpaper, identity=None):
     """Record that this wallpaper gets no depth, and drop any accepted mask.
 
     A file beside the mask rather than a config entry: a per-wallpaper map keyed
@@ -865,7 +899,7 @@ def decline(root, wallpaper):
     keeping the marker at the key means it invalidates with the key - edit the
     wallpaper in place and the refusal goes with the mask it was about.
     """
-    key = cache_key(wallpaper)
+    key = cache_key(wallpaper, identity)
     root.mkdir(parents=True, exist_ok=True)
     (root / f"{key}.off").write_text("")
     (root / f"{key}.png").unlink(missing_ok=True)
@@ -908,16 +942,23 @@ def main(argv=None):
                         help="override the cache root (tests)")
     sub = parser.add_subparsers(dest="command", required=True)
 
-    p_status = sub.add_parser("status", help="what the cache holds for a wallpaper")
+    def with_identity(sub_parser):
+        # `we:<projectId>` for a Wallpaper Engine still. See `cache_key`.
+        sub_parser.add_argument("--identity", default=None,
+                                help="key the cache on this string instead of the "
+                                     "file's path, mtime and size")
+        return sub_parser
+
+    p_status = with_identity(sub.add_parser("status", help="what the cache holds for a wallpaper"))
     p_status.add_argument("wallpaper")
 
-    p_run = sub.add_parser("run", help="produce a candidate mask, or return a cached one")
+    p_run = with_identity(sub.add_parser("run", help="produce a candidate mask, or return a cached one"))
     p_run.add_argument("wallpaper")
     p_run.add_argument("--model", default="isnet-anime", choices=salient_models())
     p_run.add_argument("--force", action="store_true",
                        help="re-run even when a candidate is already cached")
 
-    p_select = sub.add_parser("select", help="cut a mask from clicks on the picture")
+    p_select = with_identity(sub.add_parser("select", help="cut a mask from clicks on the picture"))
     p_select.add_argument("wallpaper")
     p_select.add_argument("--model", default="mobile-sam", choices=prompted_models())
     p_select.add_argument("--point", action="append", default=[], metavar="X,Y[,LABEL]",
@@ -927,11 +968,11 @@ def main(argv=None):
                                "for one it must not. Repeatable; no points at all "
                                "clears the candidate.")
 
-    p_accept = sub.add_parser("accept", help="draw this model's candidate from now on")
+    p_accept = with_identity(sub.add_parser("accept", help="draw this model's candidate from now on"))
     p_accept.add_argument("wallpaper")
     p_accept.add_argument("--model", required=True, choices=sorted(MODELS))
 
-    p_decline = sub.add_parser("decline", help="this wallpaper gets no depth")
+    p_decline = with_identity(sub.add_parser("decline", help="this wallpaper gets no depth"))
     p_decline.add_argument("wallpaper")
 
     p_sweep = sub.add_parser("sweep", help="drop the oldest keys")
@@ -942,16 +983,18 @@ def main(argv=None):
 
     try:
         if args.command == "status":
-            result = status(root, args.wallpaper)
+            result = status(root, args.wallpaper, identity=args.identity)
         elif args.command == "run":
-            result = run(root, args.wallpaper, args.model, force=args.force)
+            result = run(root, args.wallpaper, args.model, force=args.force,
+                         identity=args.identity)
         elif args.command == "select":
             result = select(root, args.wallpaper, args.model,
-                            [parse_point(p) for p in args.point])
+                            [parse_point(p) for p in args.point],
+                            identity=args.identity)
         elif args.command == "accept":
-            result = accept(root, args.wallpaper, args.model)
+            result = accept(root, args.wallpaper, args.model, identity=args.identity)
         elif args.command == "decline":
-            result = decline(root, args.wallpaper)
+            result = decline(root, args.wallpaper, identity=args.identity)
         else:
             result = sweep(root, keep=args.keep)
     except Exception as exc:  # noqa: BLE001 - the shell needs a parseable failure

--- a/dots/.config/quickshell/imi/services/ClockDepth.qml
+++ b/dots/.config/quickshell/imi/services/ClockDepth.qml
@@ -45,12 +45,37 @@ Singleton {
     readonly property bool watching: root.enabled || root.picking
         || GlobalStates.clockDepthSelectOpen
 
+    // A live Wallpaper Engine project, as the config names it. Case-insensitive
+    // on the type because the scanner emits "Web"; a web project falls back to
+    // the static wallpaper and is that wallpaper's question, not this one.
+    readonly property string weProject: Config.options.wallpaperSelector.wallpaperEngine.activeProject ?? ""
+    readonly property bool weActive: root.weProject !== ""
+        && (Config.options.wallpaperSelector.wallpaperEngine.activePath ?? "") !== ""
+        && (Config.options.wallpaperSelector.wallpaperEngine.activeType ?? "").toLowerCase() !== "web"
+    // The project has no file to segment; the shell photographs it (spec §8.1,
+    // Background.captureGreeterStill) and that still is the picture. The path
+    // is derived from the project the config already names, never stored -
+    // see the note where `activeStill` used to be declared in Config.qml.
+    readonly property string weStillPath: root.weProject === "" ? ""
+        : `${Directories.wallpaperEngineStills}/${root.weProject}.png`
+    // Whether the question on the table is the project's. A preview always wins
+    // - the selector is showing a still picture over the live scene and the
+    // picker beside it is about THAT picture - and outside a preview it is the
+    // project's exactly when the project is what the desktop draws.
+    readonly property bool askingWe: Wallpapers.previewPath === "" && root.weActive
+    // The producer keys a project's cache on this rather than on the still's
+    // stat triple, which moves every session (spec §8.2).
+    readonly property string identity: root.askingWe ? `we:${root.weProject}` : ""
     // The wallpaper on screen, not the one in the config: the selector previews
     // by path while the user arrows through the grid, and a mask belonging to
     // the previous wallpaper drawn over this one is a silhouette in the wrong
     // place rather than a missing effect.
-    readonly property string wallpaperPath:
-        Wallpapers.previewPath || Wallpapers.confirmedPath || Config.options.background.wallpaperPath
+    readonly property string wallpaperPath: root.askingWe ? root.weStillPath
+        : (Wallpapers.previewPath || Wallpapers.confirmedPath || Config.options.background.wallpaperPath)
+    // False only for a project whose still has not been grabbed yet - the one
+    // query that can be answered before its picture exists. Reported by the
+    // producer's status, so the shell never stats the file itself.
+    property bool stillAvailable: true
 
     // One of: "" (nothing asked yet), "absent", "candidate", "none",
     // "accepted", "declined", "unreadable", "error".
@@ -86,7 +111,9 @@ Singleton {
     readonly property bool selectable: ClockDepthLogic.selectable({
         wallpaperPath: root.wallpaperPath,
         previewing: Wallpapers.previewPath !== "",
-        weActive: (Config.options.wallpaperSelector.wallpaperEngine.activePath ?? "") !== "",
+        weActive: root.weActive,
+        maskIsWe: root.askingWe,
+        stillMissing: root.askingWe && !root.stillAvailable,
         centeredWallpaper: Config.options.background.centeredWallpaper ?? false,
         screenLocked: GlobalStates.screenLocked
     })
@@ -216,7 +243,7 @@ Singleton {
             `source "\${IMMATERIAL_IMPULSE_VIRTUAL_ENV:-$ILLOGICAL_IMPULSE_VIRTUAL_ENV}/bin/activate" && ` +
             `python3 '${Directories.scriptPath}/background/subject_mask.py' select ` +
             `'${StringUtils.shellSingleQuoteEscape(root.wallpaperPath)}' ` +
-            `--model ${root.promptedModel} ${args}`]
+            `--model ${root.promptedModel} ${args}${root.identityArg()}`]
         selectProcess.running = true
     }
 
@@ -232,7 +259,7 @@ Singleton {
         maskProcess.command = ["bash", "-c",
             `source "\${IMMATERIAL_IMPULSE_VIRTUAL_ENV:-$ILLOGICAL_IMPULSE_VIRTUAL_ENV}/bin/activate" && ` +
             `python3 '${Directories.scriptPath}/background/subject_mask.py' run ` +
-            `'${StringUtils.shellSingleQuoteEscape(root.wallpaperPath)}' --model ${model}`]
+            `'${StringUtils.shellSingleQuoteEscape(root.wallpaperPath)}' --model ${model}${root.identityArg()}`]
         maskProcess.running = true
     }
 
@@ -253,7 +280,16 @@ Singleton {
         verdictProcess.command = ["python3",
             `${Directories.scriptPath}/background/subject_mask.py`,
             args[0], root.wallpaperPath].concat(args.slice(1))
+            .concat(root.identity === "" ? [] : ["--identity", root.identity])
         verdictProcess.running = true
+    }
+
+    // The identity as a shell argument, for the two verbs that go through
+    // bash. A project id is digits, and the prefix is ours, but it is quoted
+    // like the path anyway rather than trusted.
+    function identityArg(): string {
+        return root.identity === "" ? ""
+            : ` --identity '${StringUtils.shellSingleQuoteEscape(root.identity)}'`
     }
 
     function refresh(): void {
@@ -266,6 +302,7 @@ Singleton {
 
     function forget(): void {
         root.state = ""
+        root.stillAvailable = true
         root.key = ""
         root.maskPath = ""
         root.candidates = ({})
@@ -320,7 +357,7 @@ Singleton {
         // shell's read path fail on a machine whose venv has not been built -
         // silently, and identically to a wallpaper that has no mask.
         command: ["python3", `${Directories.scriptPath}/background/subject_mask.py`,
-            "status", root.queriedPath]
+            "status", root.queriedPath].concat(root.identity === "" ? [] : ["--identity", root.identity])
         stdout: StdioCollector {
             id: statusCollector
             onStreamFinished: {
@@ -344,6 +381,7 @@ Singleton {
                 }
                 root.state = parsed.state ?? "error"
                 root.key = parsed.key ?? ""
+                root.stillAvailable = parsed.available ?? true
                 root.maskPath = parsed.state === "accepted" ? (parsed.mask ?? "") : ""
                 root.candidates = parsed.candidates ?? ({})
                 root.acceptedModel = parsed.acceptedModel ?? ""

--- a/dots/.config/quickshell/imi/tests/lint_clock_depth_geometry.py
+++ b/dots/.config/quickshell/imi/tests/lint_clock_depth_geometry.py
@@ -34,6 +34,8 @@ CANVAS_ID = "widgetCanvas"
 CUTOUT_TYPE = "ClockDepthCutout"
 DEPTH_IMAGE_ID = "cutoutWallpaper"
 MASK_SURFACE_ID = "maskSurface"
+PAINTED_SOURCE = "paintedSource"
+LIVE_SOURCE = "liveSource"
 WALLPAPER_ID = "wallpaper"
 
 # The registration - un-squashing the model's square mask and re-applying the
@@ -268,8 +270,18 @@ def check(raw, cutout_raw=None):
              f"whole wallpaper over the clock, not the subject")
     else:
         body = mask.group(1)
-        if declaration(body, "source") != DEPTH_IMAGE_ID:
-            fail(f"the OpacityMask does not mask {DEPTH_IMAGE_ID}")
+        # The mask paints the wallpaper image OR a live Wallpaper Engine surface
+        # handed in by the desktop layer (spec §8.3), through one property whose
+        # fallback has to be the image - so a call site that hands in nothing
+        # still draws the wallpaper, and the source the two-image sharing rule
+        # above is about is still the one that gets painted.
+        painted = declaration(cutout, PAINTED_SOURCE)
+        if declaration(body, "source") != f"root.{PAINTED_SOURCE}":
+            fail(f"the OpacityMask does not paint root.{PAINTED_SOURCE}")
+        if painted != f"root.{LIVE_SOURCE} ?? {DEPTH_IMAGE_ID}":
+            fail(f"{PAINTED_SOURCE} is {painted!r}, expected "
+                 f"'root.{LIVE_SOURCE} ?? {DEPTH_IMAGE_ID}': with no live surface "
+                 f"the mask must fall back to {DEPTH_IMAGE_ID}")
         if declaration(body, "maskSource") != MASK_SURFACE_ID:
             fail(f"the OpacityMask's maskSource is not {MASK_SURFACE_ID}")
     surface = block_for(cutout, MASK_SURFACE_ID)
@@ -314,6 +326,8 @@ Image {
 SELF_CHECK_CUTOUT = """
 Item {
     id: root
+    property Item liveSource: null
+    readonly property Item paintedSource: root.liveSource ?? cutoutWallpaper
     Image {
         id: cutoutWallpaper
         anchors.fill: parent
@@ -333,7 +347,7 @@ Item {
     }
     OpacityMask {
         anchors.fill: parent
-        source: cutoutWallpaper
+        source: root.paintedSource
         maskSource: maskSurface
     }
 }
@@ -419,6 +433,13 @@ def self_check():
             "        clip: true\n", ""),
         "the OpacityMask masking something else": SELF_CHECK_CUTOUT.replace(
             "        maskSource: maskSurface", "        maskSource: somethingElse"),
+        "the OpacityMask painting the image directly, live surface unreachable":
+            SELF_CHECK_CUTOUT.replace(
+                "        source: root.paintedSource", "        source: cutoutWallpaper"),
+        "the painted source no longer falling back to the wallpaper image":
+            SELF_CHECK_CUTOUT.replace(
+                "readonly property Item paintedSource: root.liveSource ?? cutoutWallpaper",
+                "readonly property Item paintedSource: root.liveSource"),
         "the cutout image no longer shares the wallpaper's request":
             SELF_CHECK_CUTOUT.replace(
                 "        fillMode: Image.PreserveAspectCrop", "        fillMode: Image.Stretch"),

--- a/dots/.config/quickshell/imi/tests/test_clock_depth_cache.py
+++ b/dots/.config/quickshell/imi/tests/test_clock_depth_cache.py
@@ -80,6 +80,80 @@ class CacheKeyTest(unittest.TestCase):
                          subject_mask.cache_key(link))
 
 
+class IdentityKeyTest(unittest.TestCase):
+    """A caller-supplied identity replaces the stat triple.
+
+    The Wallpaper Engine still is re-grabbed on every load of the project, so
+    its mtime moves every session - keyed on the file, the user's acceptance
+    would be minted a new key and lost on every restart. The shell hands in
+    `we:<projectId>` instead, and the file is only the picture to segment.
+    """
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.dir = Path(self.tmp.name)
+        self.cache = self.dir / "cache"
+        self.cache.mkdir()
+        self.still = self.dir / "3008040633.png"
+        self.still.write_bytes(b"a frame of a live scene")
+        self.addCleanup(self.tmp.cleanup)
+
+    def test_the_identity_key_ignores_the_files_stat_triple(self):
+        before = subject_mask.cache_key(self.still, identity="we:3008040633")
+        self.still.write_bytes(b"a different frame, grabbed a session later")
+        later = time.time() + 120
+        os.utime(self.still, (later, later))
+        self.assertEqual(before, subject_mask.cache_key(self.still, identity="we:3008040633"))
+        self.assertRegex(before, r"^[0-9a-f]{32}$")
+
+    def test_two_identities_over_one_file_are_two_keys(self):
+        self.assertNotEqual(subject_mask.cache_key(self.still, identity="we:1"),
+                            subject_mask.cache_key(self.still, identity="we:2"))
+
+    def test_the_identity_key_is_not_the_stat_key(self):
+        self.assertNotEqual(subject_mask.cache_key(self.still),
+                            subject_mask.cache_key(self.still, identity="we:3008040633"))
+
+    def test_status_answers_for_an_identity_whose_still_is_not_there_yet(self):
+        # A project that has not rendered this session has no still, and the
+        # picker has to say so rather than the query failing.
+        missing = self.dir / "never-rendered.png"
+        result = subject_mask.status(self.cache, missing, identity="we:never")
+        self.assertEqual(result["state"], "absent")
+        self.assertFalse(result["available"])
+        present = subject_mask.status(self.cache, self.still, identity="we:3008040633")
+        self.assertTrue(present["available"])
+
+    def test_the_verdicts_land_at_the_identity_key(self):
+        key = subject_mask.cache_key(self.still, identity="we:3008040633")
+        (self.cache / f"{key}.isnet-anime.png").write_bytes(b"a candidate")
+        result = subject_mask.accept(self.cache, self.still, "isnet-anime",
+                                     identity="we:3008040633")
+        self.assertEqual(result["state"], "accepted")
+        self.assertTrue((self.cache / f"{key}.png").exists())
+        result = subject_mask.decline(self.cache, self.still, identity="we:3008040633")
+        self.assertEqual(result["state"], "declined")
+        self.assertTrue((self.cache / f"{key}.off").exists())
+
+    def test_the_cli_carries_the_identity_on_every_verb(self):
+        key = subject_mask.cache_key(self.still, identity="we:3008040633")
+        (self.cache / f"{key}.isnet-anime.png").write_bytes(b"a candidate")
+        for verb, extra in (("status", []), ("accept", ["--model", "isnet-anime"]),
+                            ("decline", [])):
+            proc = run_cli("--cache-dir", str(self.cache), verb, str(self.still),
+                           "--identity", "we:3008040633", *extra)
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertEqual(json.loads(proc.stdout)["key"], key, verb)
+
+    def test_a_run_on_a_missing_still_fails_in_words(self):
+        missing = self.dir / "never-rendered.png"
+        proc = run_cli("--cache-dir", str(self.cache), "run", str(missing),
+                       "--identity", "we:never", "--model", "isnet-anime")
+        self.assertNotEqual(proc.returncode, 0)
+        payload = json.loads(proc.stdout)
+        self.assertEqual(payload["state"], "error")
+        self.assertIn("never-rendered.png", payload["error"])
+
+
 class StatusTest(unittest.TestCase):
     def setUp(self):
         self.tmp = tempfile.TemporaryDirectory()

--- a/dots/.config/quickshell/imi/tests/test_clock_depth_select_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_clock_depth_select_contract.py
@@ -422,8 +422,12 @@ class TheDesktopHandsOverItsGeometry(unittest.TestCase):
                 f"the published {axis} is not the depth layer's own - the "
                 "surface would draw its cutout somewhere the desktop does not")
         # The wallpaper ITEM's source, not the config path: a switch assigns
-        # that source imperatively so it can snapshot the outgoing frame.
-        self.assertRegex(value, r"source:\s*String\(wallpaper\.source\)")
+        # that source imperatively so it can snapshot the outgoing frame. A
+        # live Wallpaper Engine project publishes its STILL instead (spec §8):
+        # the selector is another window and cannot sample this scene's
+        # surface, and the still is what the project's mask was cut from.
+        self.assertRegex(value, r"source:\s*bgRoot\.weActive && ClockDepth\.askingWe\s*\n?\s*"
+                                r"\?\s*`file://\$\{ClockDepth\.weStillPath\}`\s*:\s*String\(wallpaper\.source\)")
         # Null while disarmed, so the binding is a comparison rather than a
         # fresh object on every frame of every pan for the rest of the session.
         self.assertRegex(value, r"GlobalStates\.clockDepthSelectOpen\s*\?")

--- a/dots/.config/quickshell/imi/tests/test_greeter_sync.py
+++ b/dots/.config/quickshell/imi/tests/test_greeter_sync.py
@@ -43,8 +43,11 @@ class ObserverTests(unittest.TestCase):
         # announced the wallpaper - the grab's completion is the event that
         # closes the copy-before-still race, and it must fire only on a write
         # that actually happened.
+        # A block now, because the depth picker observes the same completion
+        # (a project's still is what it segments) - the poke has to be the
+        # first thing inside the guarded write, not merely near it.
         self.assertRegex(BACKGROUND,
-                         r"if \(result\.saveToFile\(target\)\)\s*\n\s*GreeterSync\.request\(\)")
+                         r"if \(result\.saveToFile\(target\)\)\s*\{?\s*\n\s*GreeterSync\.request\(\)")
 
     def test_requests_are_debounced(self):
         # A wallpaper switch writes several observed leaves back to back.

--- a/dots/.config/quickshell/imi/tests/tst_clock_depth_eligibility.qml
+++ b/dots/.config/quickshell/imi/tests/tst_clock_depth_eligibility.qml
@@ -22,6 +22,7 @@ TestCase {
             selecting: false,
             editing: false,
             weActive: false,
+            maskIsWe: false,
             wallpaperIsVideo: false,
             centeredWallpaper: false,
             screenLocked: false,
@@ -94,8 +95,23 @@ TestCase {
         }), false);
     }
 
-    function test_a_live_wallpaper_engine_project_refuses() {
-        compare(showing({ weActive: true }), false);
+    function test_a_live_wallpaper_engine_project_refuses_a_still_pictures_mask() {
+        // The mask was cut from the static wallpaper; the screen is showing a
+        // live scene. A silhouette of the wrong picture.
+        compare(showing({ weActive: true, maskIsWe: false }), false);
+    }
+
+    function test_a_live_wallpaper_engine_project_shows_its_own_mask() {
+        // Spec §8: the mask was cut from the project's still, and the layer
+        // masks the live surface with it.
+        compare(showing({ weActive: true, maskIsWe: true }), true);
+    }
+
+    function test_a_projects_mask_refuses_when_the_desktop_fell_back_to_the_still_picture() {
+        // The renderer gave up (a `web` project, `weFailed`, the safety screen)
+        // and the desktop shows the static wallpaper, while the service is
+        // still asking about the project. The other half of the same mismatch.
+        compare(showing({ weActive: false, maskIsWe: true }), false);
     }
 
     function test_a_video_wallpaper_refuses() {
@@ -359,6 +375,8 @@ TestCase {
             wallpaperPath: "/home/user/Pictures/Wallpapers/aishot-3263.jpg",
             previewing: false,
             weActive: false,
+            maskIsWe: false,
+            stillMissing: false,
             centeredWallpaper: false,
             screenLocked: false
         };
@@ -383,8 +401,18 @@ TestCase {
         compare(picking({ previewing: true }), false);
     }
 
-    function test_a_live_wallpaper_engine_project_cannot_be_picked_on() {
-        compare(picking({ weActive: true }), false);
+    function test_a_live_wallpaper_engine_project_cannot_be_picked_on_with_a_still_pictures_identity() {
+        compare(picking({ weActive: true, maskIsWe: false }), false);
+    }
+
+    function test_a_live_wallpaper_engine_project_can_be_picked_on_through_its_still() {
+        compare(picking({ weActive: true, maskIsWe: true }), true);
+    }
+
+    function test_a_project_whose_still_has_not_been_grabbed_yet_cannot_be_picked_on() {
+        // There is no picture to send the clicks to. The picker says "show
+        // this wallpaper first" (spec §8.5) instead of the gesture failing.
+        compare(picking({ weActive: true, maskIsWe: true, stillMissing: true }), false);
     }
 
     function test_centred_mode_cannot_be_picked_on() {


### PR DESCRIPTION
Spec `2026-08-16-clock-depth-design.md` §8, landed. The desktop layer refused every live Wallpaper Engine project as "a moving surface with no file to segment" — but the shell already photographs each project it renders, and that still is the viewport itself, so a mask cut from it registers 1:1.

**Producer** — every verb takes `--identity we:<projectId>`, hashed in place of the still's path/mtime/size (the still is re-grabbed every session; keyed on the file the acceptance would be forgotten on every restart — §8.2). `status` reports `available` because an identity-keyed query is the one answerable before its picture exists; `run`/`select` refuse a missing picture in words.

**Service** — `ClockDepth.askingWe` / `identity` / `weStillPath`; a preview always wins (it is a still picture over the live scene and the question is about that picture); `stillAvailable` from status; `captureGreeterStill` pokes a refresh when the grab lands.

**Layer** — `ClockDepthCutout.liveSource` paints the live surface (`weLiveSource`, the texture the WE transition already samples) through the same `OpacityMask`, falling back to the wallpaper image; the geometry lint pins the fallback. `clockDepth.js` compares `weActive` against `maskIsWe` instead of refusing `weActive`: a project's mask over the static fallback (`web`, `weFailed`, safety screen) and a still picture's mask over a live scene are the same wrong silhouette from either side. `selectable` admits a live project through its still and refuses one whose still is not grabbed yet; the picker says which, and says (§8.4) the silhouette stays put while the picture moves.

**Verified on the real desktop** (project 3008040633, seated figure in rain): clock widget moved under the figure — hidden with depth on, shown with depth off (control); 1% of pixels inside the silhouette change between two "on" frames (the rain), so the surface under the mask is live, not the still. Clean load, no `WARN scene` from the change. Not driven on the desktop: the picker's WE captions and the desktop selector over a live scene (contract-pinned; the selector cannot be reached without a real click).

**Tests**: `test_clock_depth_cache.py` +7 (identity key ignores stat, two identities two keys, status without picture, verdicts at the identity key, CLI carries it on every verb, run on a missing still fails in words); `tst_clock_depth_eligibility.qml` +5 (both mismatch directions, WE with its own mask shows / picks, still-missing refuses); `lint_clock_depth_geometry.py` self-check +2 mutations (mask painting the image directly; painted source without the fallback); `test_clock_depth_select_contract.py` pin updated for the published still; `test_greeter_sync.py` pin follows the block. Plant-proof: each new lint mutation is asserted caught inside the lint's own self-check; the eligibility cases were run red before the predicate changed (7 errors → 46 pass). Full `run_tests.sh`: 1033 QML passed / 0 failed, all Python checks OK.

Overlaps `#266` in `subject_mask.py` (different functions) and in AGENT.md/CHANGELOG — will rebase whichever lands second.

Docs: updated AGENT.md §clock depth (live WE point), spec §8 landed note, CHANGELOG
