### PR TITLE
Mechanize the Changelog receipt: [Unreleased] was empty at two releases running

### DIFF
--- a/.github/workflows/changelog-receipt.yml
+++ b/.github/workflows/changelog-receipt.yml
@@ -1,0 +1,52 @@
+# Every PR that changes the shell must say what happened to CHANGELOG.md - see
+# CONTRIBUTING.md, "Keep CHANGELOG.md fed". [Unreleased] was empty at two
+# consecutive releases (0.25.0 with 61 PRs behind it, 0.26.0 with five), so both
+# rebuilt the changelog from the git log afterwards.
+#
+# A sibling of docs-receipt.yml rather than a second step inside it, on purpose.
+# That one is a pure body grep: no checkout, no token, no network, and it is
+# unconditional. This one is conditional on the diff and VERIFIES the `updated`
+# claim against it, so it needs the PR's file list from the API - and folding
+# the two together would make the Docs receipt go red when this half cannot
+# reach GitHub, which is how a check becomes something people re-run instead of
+# read. Separate files also name themselves in the PR's check list, so which
+# receipt is missing is readable without opening a log.
+#
+# The rule itself is NOT spelled here. dots/.config/quickshell/imi/tests/
+# changelog_receipt.py is the one implementation, driven locally by
+# test_changelog_receipt.py and run verbatim below; a `grep -E` in this file
+# would be a second answer to the same question, free to drift from the one the
+# suite proves.
+name: changelog-receipt
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  receipt:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Require a changelog receipt for a PR that changes the shell
+        env:
+          BODY: ${{ github.event.pull_request.body }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # printf, not a here-string: the body is arbitrary text and must reach
+          # the checker byte for byte, without a shell adding or eating one.
+          printf '%s' "$BODY" > "$RUNNER_TEMP/pr-body.txt"
+          gh api --paginate \
+            "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" \
+            --jq '.[].filename' > "$RUNNER_TEMP/pr-files.txt"
+          python3 dots/.config/quickshell/imi/tests/changelog_receipt.py \
+            --body-file "$RUNNER_TEMP/pr-body.txt" \
+            --changed-files-file "$RUNNER_TEMP/pr-files.txt"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -344,6 +344,38 @@ subject line, because this repo merges with "Rebase and merge": a doc entry land
 as the commit it cites will have that SHA rewritten at merge, and the subject is the half that
 survives.
 
+## Keep CHANGELOG.md fed
+
+`CHANGELOG.md`'s `[Unreleased]` section is written by the PR that earns the entry, not by the
+release. A release that finds it empty has to reconstruct what shipped from the git log — a worse
+changelog, written weeks later by someone reading subject lines instead of the change.
+
+**Every PR that changes anything under `dots/` must carry a `Changelog:` receipt line, and CI
+rejects PRs without one** (`.github/workflows/changelog-receipt.yml`). One of:
+
+- `Changelog: updated` — the entry is in this PR, under `[Unreleased]`. **The diff must actually
+  touch `CHANGELOG.md`, and CI checks that**: a receipt satisfiable by typing the line is the prose
+  rule again with a green tick on it, which is what the two empty releases already had.
+- `Changelog: not user-visible — <reason>` — a refactor, a test, a lint, an internal rename.
+  Liberal about the separator (em dash, en dash or a plain hyphen, spaced however you like), strict
+  about the reason: everything after the dash *is* the receipt, so it may not be empty.
+
+A PR that changes nothing under `dots/` — docs-only, CI-only, a proposal — is not asked for one at
+all. Docs-only and CI-only PRs are the common case here, and a receipt every PR must carry whether
+or not it could possibly need one is a receipt people paste without reading.
+
+This exists because `[Unreleased]` was found **empty at two consecutive releases**: 43d1ffd01
+("release: 0.25.0"), with 61 PRs merged behind it, and 58bd53a30 ("release: 0.26.0"), with five
+more — whose own message says "the section was empty again". Both reconstructed the changelog after
+the fact. The rule was prose both times, so a third paragraph is the one repair already known not to
+work: a mistake made twice becomes a failing check in the same PR, never another note.
+
+The matching lives in `dots/.config/quickshell/imi/tests/changelog_receipt.py` and nowhere else —
+the workflow checks the repo out and runs that module rather than carrying its own `grep -E`, so the
+CI half and the local half cannot become two answers. `tests/test_changelog_receipt.py` drives it
+over in-memory PR fixtures, including the two forms offered above, so the rule is testable without
+pushing anything.
+
 ## Multi-agent / parallel workflows (git worktrees)
 
 This repo lives at `~/.config/quickshell/imi` and is loaded by exactly one running process,

--- a/dots/.config/quickshell/imi/tests/changelog_receipt.py
+++ b/dots/.config/quickshell/imi/tests/changelog_receipt.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""The `Changelog:` PR-body receipt: what it accepts, and when it is required.
+
+`CHANGELOG.md`'s `[Unreleased]` section was found EMPTY at two consecutive
+releases - 43d1ffd01 ("release: 0.25.0"), 61 PRs behind it, and 58bd53a30
+("release: 0.26.0"), five more - so both releases reconstructed the changelog
+from the git log after the fact. Writing the rule down a third time is the one
+thing already known not to work; this is the failing check.
+
+The rule, beside CONTRIBUTING.md's `Docs:` receipt and in the same shape:
+
+- a PR that changes nothing under `dots/` carries no receipt at all. Docs-only
+  and CI-only PRs are the common case, and taxing them is how a receipt becomes
+  noise people paste without reading;
+- otherwise the body carries one of
+    Changelog: updated
+    Changelog: not user-visible - <reason>
+  where the separator may be a hyphen, an en dash or an em dash, spaced however
+  the author likes, and the reason must carry at least one letter or digit.
+  Liberal about the separator, strict about the reason: the reason is the whole
+  content of the second form, and a lone dash after a dash is punctuation;
+- `updated` is VERIFIED against the diff. A receipt that is satisfied by typing
+  the line is not a check - it is the prose rule again, with a green tick.
+
+This module is the ONE implementation. `.github/workflows/changelog-receipt.yml`
+does not carry a second copy of the pattern in a `grep -E`; it checks the repo
+out and runs `main()` here, so the CI half and the local half cannot drift into
+two answers. `test_changelog_receipt.py` covers the matching over in-memory
+fixtures and pins that the workflow still delegates rather than re-spelling it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+
+# Anchored per line. `updated` may carry trailing detail the way `Docs: updated
+# AGENT.md §<section>` does. The second form's tail is not detail, it is the
+# reason, so it has to contain something a reader can read: `[0-9A-Za-z]` is
+# what separates a reason from a second dash and a shrug.
+RECEIPT_PATTERN = (
+    r"^Changelog: (updated( .*)?|not user-visible *(-|–|—) *[^ ]*[0-9A-Za-z].*)$"
+)
+
+# What makes a PR owe a receipt. The shell, the installer data and the docs all
+# live in this repo; only the first ships behaviour a user can notice.
+SHELL_PREFIX = "dots/"
+
+# The file the `updated` claim is checked against, repo-relative - the same
+# spelling the diff's file list uses.
+CHANGELOG_PATH = "CHANGELOG.md"
+
+_RECEIPT_RE = re.compile(RECEIPT_PATTERN)
+
+MISSING_MESSAGE = (
+    'PR body needs a Changelog receipt line: either "Changelog: updated" (and '
+    'the diff must touch CHANGELOG.md) or "Changelog: not user-visible — '
+    '<reason>". See CONTRIBUTING.md → "Keep CHANGELOG.md fed".'
+)
+
+UNBACKED_MESSAGE = (
+    'The Changelog receipt says "updated" but the diff does not touch '
+    "CHANGELOG.md. Add the entry under [Unreleased], or say "
+    '"Changelog: not user-visible — <reason>".'
+)
+
+
+def receipt_line(body: str) -> str | None:
+    """The first accepted receipt line in a PR body, or None.
+
+    GitHub delivers bodies with CRLF endings and authors leave trailing spaces,
+    so both are normalized away before matching - a receipt defeated by an
+    invisible character is a receipt that fails for the wrong reason.
+    """
+    for raw in (body or "").replace("\r\n", "\n").replace("\r", "\n").split("\n"):
+        line = raw.rstrip()
+        if _RECEIPT_RE.match(line):
+            return line
+    return None
+
+
+def claims_updated(line: str) -> bool:
+    return line.startswith("Changelog: updated")
+
+
+def touches_shell(changed_files) -> bool:
+    return any(path.startswith(SHELL_PREFIX) for path in changed_files)
+
+
+def verdict(body: str, changed_files) -> tuple[bool, str]:
+    """(ok, message) for one PR. The message is printed either way."""
+    files = [path.strip() for path in changed_files if path.strip()]
+
+    if not touches_shell(files):
+        return True, (
+            f"No file under {SHELL_PREFIX} changed - no Changelog receipt required."
+        )
+
+    line = receipt_line(body)
+    if line is None:
+        return False, MISSING_MESSAGE
+
+    if claims_updated(line) and CHANGELOG_PATH not in files:
+        return False, UNBACKED_MESSAGE
+
+    return True, f"Changelog receipt found: {line}"
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--body-file", required=True, help="file holding the PR body")
+    parser.add_argument(
+        "--changed-files-file",
+        required=True,
+        help="file holding the PR's changed paths, one per line",
+    )
+    args = parser.parse_args(argv)
+
+    with open(args.body_file, encoding="utf-8") as handle:
+        body = handle.read()
+    with open(args.changed_files_file, encoding="utf-8") as handle:
+        changed_files = handle.read().splitlines()
+
+    ok, message = verdict(body, changed_files)
+    if ok:
+        print(message)
+        return 0
+    # GitHub Actions renders this as an annotation on the PR rather than
+    # burying it in the step log, which is what docs-receipt.yml already does.
+    print(f"::error::{message}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -215,6 +215,17 @@ if ! python3 "$SCRIPT_DIR/lint_doc_citations.py"; then
     exit 1
 fi
 
+# The `Changelog:` PR-body receipt, testable without pushing. CHANGELOG.md's
+# [Unreleased] section was empty at two consecutive releases, so both rebuilt
+# it from the git log; changelog_receipt.py is the rule and this drives it over
+# in-memory PR fixtures. The CI half runs the same module rather than carrying
+# a second copy of its pattern.
+echo "Running changelog receipt tests..."
+if ! python3 "$SCRIPT_DIR/test_changelog_receipt.py"; then
+    echo "Changelog receipt tests failed."
+    exit 1
+fi
+
 # Static lint: a manifest's option keys and the host's own per-plugin state
 # share one PluginState namespace, so the `__` prefix is the host's alone.
 echo "Running plugin option key lint..."

--- a/dots/.config/quickshell/imi/tests/test_changelog_receipt.py
+++ b/dots/.config/quickshell/imi/tests/test_changelog_receipt.py
@@ -14,8 +14,13 @@ that way (CONTRIBUTING.md → "New features and bugfixes need tests").
 """
 
 import unittest
+from pathlib import Path
 
 import changelog_receipt as receipt
+
+HERE = Path(__file__).resolve().parent
+REPO = next(p for p in HERE.parents if (p / "AGENT.md").exists())
+WORKFLOW = REPO / ".github" / "workflows" / "changelog-receipt.yml"
 
 SHELL_FILE = "dots/.config/quickshell/imi/shell.qml"
 
@@ -107,6 +112,52 @@ class Verdict(unittest.TestCase):
         self.assertTrue(ok)
         ok, _ = receipt.verdict("", ["dots/.config/hypr/hyprland.conf"])
         self.assertFalse(ok)
+
+
+class OneImplementation(unittest.TestCase):
+    """The workflow delegates to the module; it does not re-spell the rule.
+
+    Two copies of one decision is what this repo keeps paying for -
+    `PluginValidator.js`'s whitelist against `PluginNode.qml`'s renderer switch,
+    `registry_validate.py`'s vocabulary against `PluginManager`'s, the two bars'
+    two answers to one widget url. The usual repair is a source contract pinning
+    the two spellings to each other (`test_phone_connect_contract.py`); the
+    cheaper one, available here because the CI half can check the repo out, is
+    to have one spelling. These checks are what keeps it that way: a `grep -E`
+    inlined back into the workflow reddens the suite instead of quietly becoming
+    a second answer that agrees today.
+    """
+
+    def test_the_workflow_runs_the_module(self):
+        text = WORKFLOW.read_text()
+        self.assertIn("changelog_receipt.py", text)
+        self.assertIn("--body-file", text)
+        self.assertIn("--changed-files-file", text)
+
+    def test_the_workflow_carries_no_pattern_of_its_own(self):
+        text = WORKFLOW.read_text()
+        for spelling in ("Changelog: (", "not user-visible", "^Changelog:"):
+            self.assertNotIn(
+                spelling,
+                text,
+                f"{WORKFLOW.name} spells the receipt itself ({spelling!r}); the "
+                "pattern lives in changelog_receipt.py and nowhere else",
+            )
+
+    def test_the_workflow_asks_github_for_the_changed_files(self):
+        # The `dots/` exemption and the `updated` verification are both
+        # functions of the diff. A workflow that never fetched the file list
+        # would pass every PR and look exactly like this one.
+        text = WORKFLOW.read_text()
+        self.assertIn("/files", text)
+        self.assertIn("pull-requests: read", text)
+
+    def test_the_module_is_reachable_from_the_repository_root(self):
+        # The workflow runs it by repo-relative path from the checkout, which a
+        # move under tests/ would break with nothing else noticing.
+        invoked = REPO / "dots/.config/quickshell/imi/tests/changelog_receipt.py"
+        self.assertTrue(invoked.exists())
+        self.assertIn(str(invoked.relative_to(REPO)), WORKFLOW.read_text())
 
 
 if __name__ == "__main__":

--- a/dots/.config/quickshell/imi/tests/test_changelog_receipt.py
+++ b/dots/.config/quickshell/imi/tests/test_changelog_receipt.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""The Changelog receipt's matching logic, over in-memory fixtures.
+
+`changelog_receipt.py` is the one implementation of the rule; this is what
+proves it, without a push and without a PR. The fixtures are the four things
+the rule has to get right: the accepted forms, the rejected ones, an `updated`
+claim the diff does not back, and the exemption for a PR that touches nothing
+under `dots/`.
+
+Subclasses `unittest.TestCase` deliberately: `run_tests.sh` invokes each Python
+check as `python3 <file>`, so a module of bare `test_*` functions defines them
+and exits zero without running one - three modules shipped as silent no-ops
+that way (CONTRIBUTING.md → "New features and bugfixes need tests").
+"""
+
+import unittest
+
+import changelog_receipt as receipt
+
+SHELL_FILE = "dots/.config/quickshell/imi/shell.qml"
+
+
+class ReceiptMatching(unittest.TestCase):
+    def test_the_accepted_forms_are_accepted(self):
+        for body in (
+            "Changelog: updated",
+            "Changelog: updated — one Fixed entry under [Unreleased]",
+            "Changelog: not user-visible — CI plumbing only",
+            "Changelog: not user-visible - a plain hyphen is fine",
+            "Changelog: not user-visible – and so is an en dash",
+            "Changelog: not user-visible—no spaces around the dash",
+            "Changelog: not user-visible   —   generously spaced",
+            "Some prose.\n\nChangelog: updated\nDocs: updated CONTRIBUTING.md",
+            "Changelog: updated\r\nDocs: updated CONTRIBUTING.md\r\n",
+            "Changelog: not user-visible — trailing spaces on the line   ",
+        ):
+            with self.subTest(body=body):
+                self.assertIsNotNone(receipt.receipt_line(body))
+
+    def test_the_rejected_forms_are_rejected(self):
+        for body in (
+            "",
+            "No receipt anywhere in this body.",
+            # The second form's whole content is its reason.
+            "Changelog: not user-visible",
+            "Changelog: not user-visible —",
+            "Changelog: not user-visible —    ",
+            # A verdict, not a form: "nothing to add" is what the two empty
+            # releases were made of.
+            "Changelog: n/a",
+            "Changelog: none",
+            "Changelog: not needed — wrong receipt's wording",
+            # Must own its line, the way `Docs:` does.
+            "  Changelog: updated",
+            "See also Changelog: updated",
+            "changelog: updated",
+        ):
+            with self.subTest(body=body):
+                self.assertIsNone(receipt.receipt_line(body))
+
+    def test_a_reason_may_not_be_only_a_dash(self):
+        # Liberal about the separator is not liberal about the reason: a second
+        # dash is punctuation, so the reason after it must still be there.
+        self.assertIsNone(receipt.receipt_line("Changelog: not user-visible — -"))
+        self.assertIsNotNone(receipt.receipt_line("Changelog: not user-visible — -ish"))
+
+
+class Verdict(unittest.TestCase):
+    def test_a_pr_touching_nothing_under_dots_needs_no_receipt(self):
+        for files in (
+            ["CONTRIBUTING.md"],
+            [".github/workflows/tests.yml"],
+            ["docs/PLUGINS.md", "README.md"],
+            [],
+        ):
+            with self.subTest(files=files):
+                ok, message = receipt.verdict("no receipt here", files)
+                self.assertTrue(ok, message)
+
+    def test_a_shell_change_without_a_receipt_fails(self):
+        ok, message = receipt.verdict("A body with no receipt.", [SHELL_FILE])
+        self.assertFalse(ok)
+        self.assertEqual(message, receipt.MISSING_MESSAGE)
+
+    def test_updated_must_be_backed_by_a_changelog_diff(self):
+        ok, message = receipt.verdict("Changelog: updated", [SHELL_FILE])
+        self.assertFalse(ok)
+        self.assertEqual(message, receipt.UNBACKED_MESSAGE)
+
+        ok, message = receipt.verdict(
+            "Changelog: updated", [SHELL_FILE, receipt.CHANGELOG_PATH]
+        )
+        self.assertTrue(ok, message)
+
+    def test_not_user_visible_needs_no_changelog_diff(self):
+        ok, message = receipt.verdict(
+            "Changelog: not user-visible — a lint and its fixtures", [SHELL_FILE]
+        )
+        self.assertTrue(ok, message)
+
+    def test_the_exemption_is_by_prefix_not_by_substring(self):
+        # `sdata/` and `docs/` are not the shell, and a path merely CONTAINING
+        # "dots/" is not under it.
+        ok, _ = receipt.verdict("", ["sdata/uv/requirements.in"])
+        self.assertTrue(ok)
+        ok, _ = receipt.verdict("", ["docs/dots/notes.md"])
+        self.assertTrue(ok)
+        ok, _ = receipt.verdict("", ["dots/.config/hypr/hyprland.conf"])
+        self.assertFalse(ok)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dots/.config/quickshell/imi/tests/test_changelog_receipt.py
+++ b/dots/.config/quickshell/imi/tests/test_changelog_receipt.py
@@ -13,6 +13,7 @@ and exits zero without running one - three modules shipped as silent no-ops
 that way (CONTRIBUTING.md → "New features and bugfixes need tests").
 """
 
+import re
 import unittest
 from pathlib import Path
 
@@ -21,6 +22,7 @@ import changelog_receipt as receipt
 HERE = Path(__file__).resolve().parent
 REPO = next(p for p in HERE.parents if (p / "AGENT.md").exists())
 WORKFLOW = REPO / ".github" / "workflows" / "changelog-receipt.yml"
+CONTRIBUTING = REPO / "CONTRIBUTING.md"
 
 SHELL_FILE = "dots/.config/quickshell/imi/shell.qml"
 
@@ -158,6 +160,43 @@ class OneImplementation(unittest.TestCase):
         invoked = REPO / "dots/.config/quickshell/imi/tests/changelog_receipt.py"
         self.assertTrue(invoked.exists())
         self.assertIn(str(invoked.relative_to(REPO)), WORKFLOW.read_text())
+
+
+class ContributingExamples(unittest.TestCase):
+    """Every receipt CONTRIBUTING.md offers must be one the module accepts.
+
+    The workflow delegating to the module removes one second spelling; the doc
+    is the other, and it cannot delegate - an author copies the form out of
+    CONTRIBUTING.md and CI answers with the module. So the doc's own examples
+    are extracted and run through the matcher, which is the same pin
+    `test_bar_widget_parity.py` puts on the two bars: not "both exist" but
+    "both say the same thing".
+    """
+
+    def _examples(self):
+        found = re.findall(r"`(Changelog: [^`]+)`", CONTRIBUTING.read_text())
+        self.assertTrue(found, "CONTRIBUTING.md documents no Changelog receipt")
+        return found
+
+    def test_every_documented_form_is_accepted(self):
+        for example in self._examples():
+            with self.subTest(example=example):
+                self.assertIsNotNone(
+                    receipt.receipt_line(example),
+                    f"CONTRIBUTING.md offers {example!r}, which the matcher rejects",
+                )
+
+    def test_both_forms_are_documented(self):
+        # A doc that lost the `not user-visible` half would push every
+        # refactor toward a `updated` claim it cannot back, or toward silence.
+        examples = self._examples()
+        self.assertTrue(any(receipt.claims_updated(e) for e in examples))
+        self.assertTrue(any(not receipt.claims_updated(e) for e in examples))
+
+    def test_the_rule_names_its_own_workflow_and_module(self):
+        text = CONTRIBUTING.read_text()
+        self.assertIn(WORKFLOW.name, text)
+        self.assertIn("changelog_receipt.py", text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`CHANGELOG.md`'s `[Unreleased]` section was found **empty at two consecutive releases** — 43d1ffd01 ("release: 0.25.0"), with 61 PRs merged behind it, and 58bd53a30 ("release: 0.26.0"), with five more, whose own message says *"the section was empty again"*. Both reconstructed the changelog from the git log weeks after the fact. The rule was prose both times, so this is the failing check rather than a third paragraph.

## What lands

A `Changelog:` receipt beside the existing `Docs:` one, in the same shape:

- `Changelog: updated` — the entry is in this PR, under `[Unreleased]`. **CI verifies it against the diff**: the PR must actually touch `CHANGELOG.md`. A receipt satisfiable by typing the line is the prose rule again with a green tick on it, which is what the two empty releases already had.
- `Changelog: not user-visible — <reason>` — liberal about the separator (em dash, en dash or plain hyphen, spaced however you like), strict about the reason: everything after the dash *is* the receipt, so it must carry at least a letter or a digit. A lone dash after a dash is punctuation, not a reason.
- **A PR that changes nothing under `dots/` is not asked for one at all.** Docs-only and CI-only PRs are the common case here, and a receipt every PR must carry whether or not it could need one is a receipt people paste without reading — which is the failure this exists to fix, wearing a green tick.

## Two decisions worth reviewing

**A sibling workflow, not a step inside `docs-receipt.yml`.** That one is a pure body grep: no checkout, no token, no network, and unconditional. This one is conditional on the diff and verifies its `updated` claim against it, so it needs the PR's file list from the API. Folding them together would make the *Docs* receipt go red whenever this half cannot reach GitHub — a check that fails for a reason unrelated to what it polices is one people learn to re-run rather than read. Two files also name themselves separately in the checks list, so which receipt is missing is readable without opening a log.

**One implementation, not two spellings pinned together.** The repo's usual repair for this is a source contract holding two copies honest (`test_phone_connect_contract.py`, `test_bar_widget_parity.py`). Available here is something cheaper, because this check has a checkout anyway: the workflow *runs* `dots/.config/quickshell/imi/tests/changelog_receipt.py` and spells no pattern of its own, so there is no second answer to drift. `test_changelog_receipt.py` keeps it that way — it reddens if a `grep -E` is inlined back into the workflow, if the file list stops being fetched, or if the module moves out from under the path the workflow invokes. The one second spelling that *cannot* delegate is the doc, since an author copies the form out of `CONTRIBUTING.md` and CI answers with the module — so the test extracts every `Changelog: …` example the doc offers and runs it through the matcher.

## Verifying the CI half

The workflow's own first run **is** the verification, and this PR is the fixture: it touches `dots/`, so it owes a receipt, and the `changelog-receipt` check on this PR reported

```
Changelog receipt found: Changelog: not user-visible — a CI receipt, its module and its tests; ...
```

Then the receipt was **deleted from this PR body** to plant against it live. The `edited` trigger re-ran the workflow, which went red with the annotation it is supposed to produce ([run 32229585252](https://github.com/XephyLon/immaterial-impulse/actions/runs/32229585252)):

```
##[error]PR body needs a Changelog receipt line: either "Changelog: updated" (and the
diff must touch CHANGELOG.md) or "Changelog: not user-visible — <reason>".
See CONTRIBUTING.md → "Keep CHANGELOG.md fed".
##[error]Process completed with exit code 1.
```

The receipt was then restored and the check went green again. Two things could not be driven that way and were driven locally instead.

The module's own tests cover the logic over in-memory PR fixtures — accepted forms, rejected forms, `updated` with no `CHANGELOG.md` in the diff, the dots-untouched exemption. And the workflow's `run:` block was **extracted from the YAML and executed verbatim** against six real merged PRs with a real `gh api .../files` list:

```
PR #265  exempt   No file under dots/ changed - no Changelog receipt required.
PR #264  exempt   No file under dots/ changed - no Changelog receipt required.
PR #263  RED      ::error::PR body needs a Changelog receipt line: ...
PR #262  RED      ::error::PR body needs a Changelog receipt line: ...
PR #261  RED      ::error::PR body needs a Changelog receipt line: ...
PR #260  RED      ::error::PR body needs a Changelog receipt line: ...
```

Four of the last six merged PRs touched `dots/` and carried no receipt. That is the population that left `[Unreleased]` empty twice.

(That replay is what proved the `gh api` + `--jq` + `printf` half before the workflow existed on a branch to run; the live runs above proved it after.)

## Plant-proofs

Every new check was planted against and reverted in a clean tree.

| # | mutation | result |
|---|---|---|
| A | loosen `RECEIPT_PATTERN`'s reason to `not user-visible.*` | `FAILED (failures=4)` — `'Changelog: not user-visible —' is not None` |
| B | stop verifying `updated` against the diff | `FAILED (failures=1)` — `True is not false` |
| C | `dots/` exemption by substring instead of prefix | `FAILED (failures=1)` — `docs/dots/notes.md` no longer exempt |
| D | inline a `grep -qE` back into the workflow | `FAILED (failures=3)` — `'--body-file' not found` |
| E | drop the `gh api .../files` fetch and `pull-requests: read` | `FAILED (failures=1)` — `'/files' not found` |
| F | doc example drifts to `not user visible` | `FAILED (failures=1)` — *"CONTRIBUTING.md offers 'Changelog: not user visible — &lt;reason&gt;', which the matcher rejects"* |
| G | doc drops the `not user-visible` form | `FAILED (failures=1)` — `False is not true` |
| H | break `SHELL_PREFIX`, run the whole suite | suite stops at `Changelog receipt tests failed.`, `EXIT=1` |
| I | **live**: delete the receipt from this PR body | `changelog-receipt` check went red, `Process completed with exit code 1` |

H is also the registration proof: `run_tests.sh` really runs the module (15 checks, `python3 <file>` with `unittest.main()`, not bare `test_*` functions that exit zero without executing).

## Full suite

```
Totals: 1029 passed, 0 failed, 0 skipped, 0 blacklisted, 390481ms
********* Finished testing of qmltestrunner *********
All tests passed successfully!
```

This PR is the first under the new rule and carries both receipts.

Changelog: not user-visible — a CI receipt, its module and its tests; nothing the shell draws or does changes.
Docs: updated CONTRIBUTING.md §"Keep CHANGELOG.md fed"
