### PR TITLE
feat(bar): animate the exclusive zone on a reserver surface, so windows follow the bar

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1179,6 +1179,49 @@ Two non-obvious behaviors have bitten this codebase before and are worth knowing
   blanked, nothing leaks — a `zwp_idle_inhibitor` is destroyed with the `wl_surface` it was created
   on, and a client's surfaces die with its Wayland connection. 83544dedb ("feat(idle): a
   deliberately blanked monitor holds the keep-awake").
+- **An exclusive zone that has to animate belongs on a surface of its own, and
+  `exclusionMode: ExclusionMode.Ignore` is not in force while an `exclusiveZone`
+  sits beside it.** A zone is a protocol value on the surface, so every write is
+  a `set_exclusive_zone` plus a commit plus a compositor-wide re-arrange —
+  animating one in place reconfigures the surface its own contents are being
+  drawn on, once per frame. The bar therefore slid on a margin `Behavior` while
+  its zone snapped between two integers, and the windows behind it jumped at the
+  two ends of a gesture the bar spends 200ms on.
+  `modules/imi/bar/BarExclusiveZoneReserver.qml` is where that animation lives
+  instead: one `PanelWindow` per bar, one pixel thick, `color: "transparent"`,
+  `mask: Region {}`, painting nothing, so a per-frame reconfigure costs a
+  re-arrange and no repaint. **Both bars use the one component** — the zone is
+  exactly the kind of decision the two have drifted on before. Five things about
+  it are worth not re-deriving. Writing `exclusiveZone` at *any* value calls
+  `WlrLayershell::setExclusiveZone`, which forces `exclusionMode` to `Normal`,
+  and a `Normal` surface is placed inside what other surfaces reserve — so both
+  bars had been in `Normal` all along despite declaring `Ignore`, and a bar
+  keeping `exclusiveZone: 0` after this split would be pushed off the screen
+  edge by its own reserver. Hyprland adds the anchored-edge **margin** to a live
+  zone (measured: the bar's 40px zone under its 5px top margin reserves 45), and
+  that margin is folded into the animated value rather than onto the reserver's
+  own `margins`, or the last frame of a hide is a jump from the margin to zero.
+  The namespace is the visible bar's, **passed in rather than minted**, for the
+  reason `BarPopupOverlay` reuses `quickshell:popup`: a new one falls through
+  the catch-all `ignore_alpha = 0.05` and asks the compositor to blur behind a
+  surface that paints nothing — and since both bars' namespaces already carry
+  `blur = false`, borrowing needs no `rules.lua` entry at all, which matters
+  because that file ships separately and the two halves would otherwise come
+  apart on any machine that updated one and not the other. The layer is `Top`
+  and does **not** follow the bar's fullscreen+special promotion: an `Overlay`
+  surface holds the fullscreen fast path shut whatever its size, the promotion
+  exists to stop the bar's *pixels* being buried, and the reserved area is the
+  same on every layer. And the zone must take the **same motion tier** as the
+  bar's own slide — a different one disagrees with the bar for the whole gesture
+  rather than only at its ends. None of this is reachable from the suite:
+  `qmltestrunner` cannot construct the window and weston implements no
+  wlr-layer-shell, so `tests/test_bar_exclusive_zone_reserver.py` pins the
+  source shape and `tests/run_bar_exclusive_zone_probe.sh` reads the reserved
+  area back out of a **nested Hyprland** while the zone animates (45 27 4 1 0
+  through a hide, against 45 0 before). Design taken from
+  `docs/p3drovfx-animation-research-2026-08-16.md` §3.4.
+  97689e338 ("feat(bar): give the bar's exclusive zone a surface of its own"),
+  7b703fc42 ("feat(bar): both bars hand their exclusive zone to the one reserver").
 
 ## State propagation is reactive, or it is a bug waiting
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ own repo; the installer pins which revision it builds.
   boundary at that size, so the outline is about a pixel wide instead of a
   five-pixel ramp. Same cost per run; re-run a wallpaper's models in the depth
   picker to get the new mask.
+- **Windows now follow the auto-hidden bar instead of jumping.** The bar has
+  always slid in and out over ~200ms while the space it reserves changed in one
+  step, so everything behind it snapped a whole bar height at one end of the
+  gesture. The reserved space is animated on the same curve as the bar now, on
+  both the horizontal and the vertical bar. Nothing about where the bar sits at
+  rest changes.
 
 ## [0.26.0] — 2026-08-19
 

--- a/dots/.config/quickshell/imi/BarZoneProbe.qml
+++ b/dots/.config/quickshell/imi/BarZoneProbe.qml
@@ -1,0 +1,35 @@
+import QtQuick
+import Quickshell
+import qs.modules.imi.bar as Bar
+
+// One BarExclusiveZoneReserver, on its own, with its zone flipped between the
+// two ends of auto-hide. Driven by tests/run_bar_exclusive_zone_probe.sh under
+// a nested Hyprland, which is the only place a wlr-layer-shell exclusive zone
+// can be observed at all - see that script's header.
+//
+// Deliberately not the whole bar: what is being measured is the reserved area,
+// and a real bar would put its own surface, its blur region and its content
+// tree between the reader and the one number in question.
+ShellRoot {
+    id: root
+
+    property bool out: false
+
+    Bar.BarExclusiveZoneReserver {
+        screen: Quickshell.screens[0]
+        barNamespace: "quickshell:bar"
+        edgeMargin: 5
+        zone: root.out ? 40 : 0
+        onAnimatedZoneChanged: console.log(`[BarZoneProbe] animated=${animatedZone.toFixed(2)}`)
+    }
+
+    Timer {
+        interval: 3000
+        repeat: true
+        running: true
+        onTriggered: {
+            root.out = !root.out;
+            console.log(`[BarZoneProbe] zone target ${root.out ? "out" : "hidden"}`);
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/DesignSystemCompile.qml
+++ b/dots/.config/quickshell/imi/DesignSystemCompile.qml
@@ -112,6 +112,12 @@ ShellRoot {
                 // defect a47462fcc ("fix(verticalBar): render plugin bar
                 // widgets instead of an empty stub") came out of.
                 Quickshell.shellPath("modules/imi/bar/BarContent.qml"),
+                // The bar's own window. A live load finds anything wrong with
+                // it because it is built on every startup - but only a live
+                // load did, and the two bars' windows are now one edit apart
+                // (they share BarExclusiveZoneReserver), so the horizontal one
+                // belongs in the sweep beside the vertical one.
+                Quickshell.shellPath("modules/imi/bar/Bar.qml"),
                 Quickshell.shellPath("modules/imi/verticalBar/VerticalBar.qml"),
                 Quickshell.shellPath("modules/imi/verticalBar/VerticalBarContent.qml"),
                 Quickshell.shellPath("modules/common/plugins/bundled/docker/DockerPopup.qml"),

--- a/dots/.config/quickshell/imi/modules/imi/bar/Bar.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/Bar.qml
@@ -72,8 +72,24 @@ Scope {
                 property var thisMonitorData: HyprlandData.monitors.find(m => m.name === barRoot.screen?.name)
                 property bool monitorHasFullscreen: HyprlandData.workspaceById[thisMonitorData?.activeWorkspace?.id]?.hasfullscreen ?? false
                 property bool monitorHasSpecialOpen: (thisMonitorData?.specialWorkspace?.name ?? "") !== ""
+                // The zone lives on barSpaceReserver below, so this surface
+                // never reconfigures for it. Do not put an `exclusiveZone`
+                // back here, not even 0: writing that property at all forces
+                // exclusionMode to Normal, and a Normal-mode surface is placed
+                // inside the area other surfaces reserve - so the bar would be
+                // pushed off the screen edge by its own reserver.
                 exclusionMode: ExclusionMode.Ignore
-                exclusiveZone: (Config?.options.bar.autoHide.enable && (!mustShow || !Config?.options.bar.autoHide.pushWindows)) ? 0 : Appearance.sizes.baseBarHeight + (Config.options.bar.cornerStyle === 1 ? Appearance.sizes.hyprlandGapsOut : 0)
+                // A second window, not something in the bar's item tree, which
+                // is why it is a property rather than a child.
+                property QtObject barSpaceReserver: BarExclusiveZoneReserver {
+                    screen: barLoader.modelData
+                    barNamespace: "quickshell:bar"
+                    farEdge: Config.options.bar.bottom
+                    edgeMargin: Config.options.bar.bottom
+                        ? Appearance.sizes.barBottomMargin : Appearance.sizes.barDetachMargin
+                    zone: (Config?.options.bar.autoHide.enable && (!barRoot.mustShow || !Config?.options.bar.autoHide.pushWindows))
+                        ? 0 : Appearance.sizes.baseBarHeight + (Config.options.bar.cornerStyle === 1 ? Appearance.sizes.hyprlandGapsOut : 0)
+                }
                 WlrLayershell.namespace: "quickshell:bar"
                 // Overlay layer only while special workspace sits on top of a fullscreen window on this monitor,
                 // else Top layer so fullscreen apps cover the bar as normal (Hyprland buries Top layer under fullscreen+special).

--- a/dots/.config/quickshell/imi/modules/imi/bar/BarExclusiveZoneReserver.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/BarExclusiveZoneReserver.qml
@@ -1,0 +1,88 @@
+import QtQuick
+import Quickshell
+import Quickshell.Wayland
+import qs.modules.common
+
+// The bar's exclusive zone, moved onto a surface that has nothing else to lose.
+//
+// A layer surface's exclusive zone is a protocol value on the surface itself,
+// not a property of anything drawn in it: every write is a
+// set_exclusive_zone + commit and a compositor-wide re-arrange of the windows
+// behind it. The visible bar slides in and out of auto-hide on a margin
+// Behavior over `elementMoveFast`, while its zone snapped between two integers
+// - so the bar glided and the windows behind it jumped, in opposite directions
+// at the two ends of one gesture. Animating the zone on the bar's own window
+// would reconfigure the surface the bar is being drawn on, once per frame, for
+// the whole slide.
+//
+// This window is that animation's home: one pixel thick, masked to nothing,
+// painting nothing, so a per-frame reconfigure costs a re-arrange and no
+// repaint. Both bars use it - the two must not each decide what their exclusive
+// zone does, for the same reason `bar_widget_source.js` exists.
+PanelWindow {
+    id: reserver
+
+    // What the bar's body occupies when it is out, before the margin the
+    // compositor adds on top of it. 0 means "reserve nothing".
+    property real zone: 0
+    // The margin the visible bar holds off the screen edge with. Hyprland adds
+    // an anchored-edge margin to a live exclusive zone - measured on this
+    // machine, the bar's 40px zone under its 5px top margin reserves 45 - so
+    // the fold is what keeps the reserved area the number it has always been.
+    // It is folded into the ANIMATED value rather than into this surface's own
+    // margins because a margin does not animate: the last frame of a hide would
+    // be a jump from `edgeMargin` to 0.
+    property real edgeMargin: 0
+    // The bar's edge, as the two facts each bar already holds: `vertical` picks
+    // the axis and `farEdge` is that bar's `Config.options.bar.bottom`.
+    property bool vertical: false
+    property bool farEdge: false
+    // The visible bar's own namespace, deliberately reused rather than minted.
+    // A new one falls through the catch-all `ignore_alpha = 0.05` in
+    // rules.lua and asks the compositor to blur behind a surface that paints
+    // nothing; both bars' namespaces already carry `blur = false`, so this
+    // needs no rules.lua entry at all - which is the half that would otherwise
+    // ship silently broken on any machine whose Hyprland config is older than
+    // this commit.
+    required property string barNamespace
+
+    WlrLayershell.namespace: reserver.barNamespace
+    // Never Overlay: an Overlay surface holds the compositor's fullscreen fast
+    // path shut whatever its size. It also does not follow the bar's
+    // fullscreen+special promotion, because that promotion exists to stop the
+    // bar's pixels being buried and this window has none - the reserved area is
+    // the same on every layer.
+    WlrLayershell.layer: WlrLayer.Top
+
+    // Three anchors, the odd one out being the edge the bar is on - that is
+    // what tells the compositor which edge the zone is measured from.
+    anchors {
+        top: reserver.vertical ? true : !reserver.farEdge
+        bottom: reserver.vertical ? true : reserver.farEdge
+        left: reserver.vertical ? !reserver.farEdge : true
+        right: reserver.vertical ? reserver.farEdge : true
+    }
+    implicitWidth: 1
+    implicitHeight: 1
+
+    // Writing `exclusiveZone` at all forces `exclusionMode` to Normal
+    // (`WlrLayershell::setExclusiveZone`), so this is what the window is in
+    // either way - stated rather than left to that side effect.
+    exclusionMode: ExclusionMode.Normal
+    exclusiveZone: Math.round(reserver.animatedZone)
+
+    readonly property real settledZone: reserver.zone > 0 ? reserver.zone + reserver.edgeMargin : 0
+    property real animatedZone: reserver.settledZone
+    // The same tier the bar's own slide takes, so the compositor's reflow rides
+    // the curve the picture does.
+    Behavior on animatedZone {
+        animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(reserver)
+    }
+
+    color: "transparent"
+    // An empty mask is what makes a mapped, permanently-present surface
+    // harmless: Quickshell sets Qt::WindowTransparentForInput for a mask that
+    // resolves to nothing, so this window cannot take a click the bar or the
+    // desktop under it should have had.
+    mask: Region {}
+}

--- a/dots/.config/quickshell/imi/modules/imi/verticalBar/VerticalBar.qml
+++ b/dots/.config/quickshell/imi/modules/imi/verticalBar/VerticalBar.qml
@@ -10,6 +10,7 @@ import qs.services
 import qs.modules.common
 import qs.modules.common.widgets
 import qs.modules.common.functions
+import qs.modules.imi.bar as Bar
 
 Scope {
     id: bar
@@ -59,10 +60,22 @@ Scope {
                 property bool mustShow: hoverRegion.containsMouse || superShow
                     || GlobalStates.editMode
                     || ((GlobalStates.mediaControlsOpen || GlobalStates.sysTrayOverflowOpen) && Config?.options.bar.autoHide.dismissPopups)
+                // Bar.qml's split, through the same component: the animated
+                // zone is on barSpaceReserver and never on this surface, and
+                // an `exclusiveZone` here - even 0 - would put this window back
+                // into Normal mode and let the reserver push it off the edge.
                 exclusionMode: ExclusionMode.Ignore
-                exclusiveZone: (Config?.options.bar.autoHide.enable && (!mustShow || !Config?.options.bar.autoHide.pushWindows)) ? 0 :
-                    Appearance.sizes.baseVerticalBarWidth + (Config.options.bar.cornerStyle === 1 ? Appearance.sizes.hyprlandGapsOut : 0)
-                    + (Config.options.bar.cornerStyle === 3 ? (Config.options.hyprland.general.gapsOut || 5) : 0)
+                property QtObject barSpaceReserver: Bar.BarExclusiveZoneReserver {
+                    screen: barLoader.modelData
+                    barNamespace: "quickshell:verticalBar"
+                    vertical: true
+                    farEdge: Config.options.bar.bottom
+                    // No edgeMargin: this surface declares no margins, so the
+                    // compositor adds nothing to the zone.
+                    zone: (Config?.options.bar.autoHide.enable && (!barRoot.mustShow || !Config?.options.bar.autoHide.pushWindows)) ? 0 :
+                        Appearance.sizes.baseVerticalBarWidth + (Config.options.bar.cornerStyle === 1 ? Appearance.sizes.hyprlandGapsOut : 0)
+                        + (Config.options.bar.cornerStyle === 3 ? (Config.options.hyprland.general.gapsOut || 5) : 0)
+                }
                 WlrLayershell.namespace: "quickshell:verticalBar"
                 // In Appearance for the reason Bar.qml's height is: Edit Mode
                 // keeps its chrome clear of this surface and cannot measure it.

--- a/dots/.config/quickshell/imi/tests/run_bar_exclusive_zone_probe.sh
+++ b/dots/.config/quickshell/imi/tests/run_bar_exclusive_zone_probe.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+# Reads the compositor's reserved area back while the bar's exclusive zone
+# animates, which nothing else in this tree can.
+#
+# An exclusive zone is a wlr-layer-shell request. `qmltestrunner` does not load
+# Quickshell's plugin at all, so it cannot build the window; weston implements
+# no wlr-layer-shell, so every `*RuntimeTest.qml` harness here is blind to it.
+# What is left is a nested Hyprland, on the shape run_notification_blur_probe.sh
+# uses - its own D-Bus session, its own XDG dirs, its own XDG_RUNTIME_DIR, and
+# its wayland parent named by ABSOLUTE path because libwayland only prefixes the
+# runtime dir onto a relative one. It is not headless: Aquamarine aborts with no
+# wayland parent and no seat, so this opens a nested compositor window for about
+# half a minute.
+#
+# BarZoneProbe.qml stands one BarExclusiveZoneReserver up on its own and flips
+# its `zone` between 0 and 40 every three seconds, exactly as auto-hide does.
+# The probe samples `hyprctl monitors` as fast as it can spawn one (~30ms) and
+# prints the reserved top edge, so the animation is visible as intermediate
+# numbers rather than as a pair of endpoints - which is the whole difference the
+# reserver exists to make. Measured when it landed, 40px zone under a 5px edge
+# margin:
+#
+#   45 45 ... 45 19 4 0 0 ... 0 9 26 44 45 45 ...
+#
+# and the surface itself comes out as `quickshell:bar 0 0 <width> 1` - one pixel
+# tall, on the bar's own namespace, masked to nothing.
+#
+# `hyprctl` picks its instance from HYPRLAND_INSTANCE_SIGNATURE and from nothing
+# else, so every call below is made with the NESTED signature exported. Without
+# that they answer for the caller's own session, which is the trap AGENT.md
+# records and the reason the teardown kills by pid rather than dispatching exit.
+#
+# Usage: tests/run_bar_exclusive_zone_probe.sh
+set -u
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+for binary in Hyprland qs dbus-run-session python3; do
+    command -v "$binary" >/dev/null 2>&1 || { echo "SKIPPED: $binary not on PATH"; exit 0; }
+done
+if [ -z "${WAYLAND_DISPLAY:-}" ]; then
+    echo "SKIPPED: no WAYLAND_DISPLAY - the nested compositor needs a parent"
+    exit 0
+fi
+
+PARENT_SOCKET="$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP" 2>/dev/null' EXIT
+
+export XDG_CONFIG_HOME="$TMP/config" XDG_CACHE_HOME="$TMP/cache"
+export XDG_STATE_HOME="$TMP/state" XDG_DATA_HOME="$TMP/data"
+mkdir -p "$XDG_CONFIG_HOME/immaterial-impulse" "$XDG_CACHE_HOME" "$XDG_STATE_HOME" \
+    "$XDG_DATA_HOME" "$TMP/run"
+printf '%s' '{}' > "$XDG_CONFIG_HOME/immaterial-impulse/config.json"
+
+cat > "$TMP/hypr.lua" <<'LUA'
+hl.monitor({ output = "", mode = "1280x720@60", position = "auto", scale = 1 })
+hl.config({
+    misc = { disable_hyprland_logo = true, disable_splash_rendering = true,
+             force_default_wallpaper = 0, disable_autoreload = true },
+    -- Off deliberately: what is being measured is the reserved area, and a
+    -- window-move animation only adds a second curve to read it through.
+    animations = { enabled = false },
+})
+LUA
+
+export XDG_RUNTIME_DIR="$TMP/run"
+export WAYLAND_DISPLAY="$PARENT_SOCKET"
+
+dbus-run-session -- bash -s "$TMP" "$ROOT" <<'NESTED'
+set -u
+TMP="$1"; ROOT="$2"
+
+Hyprland -c "$TMP/hypr.lua" > "$TMP/hypr.log" 2>&1 &
+HPID=$!
+SIG=""
+for _ in $(seq 1 60); do
+    sleep 0.5
+    SIG=$(ls "$XDG_RUNTIME_DIR/hypr" 2>/dev/null | head -1)
+    [ -n "$SIG" ] && [ -S "$XDG_RUNTIME_DIR/hypr/$SIG/.socket.sock" ] && break
+    SIG=""
+done
+if [ -z "$SIG" ]; then
+    echo "FAILED: the nested compositor never came up"
+    tail -20 "$TMP/hypr.log"
+    kill $HPID 2>/dev/null
+    exit 1
+fi
+export HYPRLAND_INSTANCE_SIGNATURE="$SIG"
+NEW=$(ls "$XDG_RUNTIME_DIR" | grep -E '^wayland-[0-9]+$' | head -1)
+echo "nested compositor: signature=$SIG display=$NEW"
+
+reserved_top() {
+    hyprctl monitors -j | python3 -c "import json,sys; print(json.load(sys.stdin)[0]['reserved'][1], end=' ')"
+}
+
+echo "--- reserved top with no shell running ---"
+reserved_top; echo
+
+export WAYLAND_DISPLAY="$NEW"
+cd "$ROOT"
+qs -p "$ROOT/BarZoneProbe.qml" > "$TMP/probe.log" 2>&1 &
+QPID=$!
+sleep 6
+
+echo "--- layer surfaces ---"
+hyprctl layers -j | python3 -c "
+import json, sys
+for monitor, value in json.load(sys.stdin).items():
+    for level, layers in value['levels'].items():
+        for layer in layers:
+            print(f\"  {monitor} level={level} {layer['namespace']} \"
+                  f\"{layer['x']},{layer['y']} {layer['w']}x{layer['h']}\")
+"
+
+echo "--- reserved top, sampled while the zone animates ---"
+for _ in $(seq 1 400); do reserved_top; done
+echo
+
+kill $QPID 2>/dev/null
+sleep 1
+kill $HPID 2>/dev/null
+sleep 1
+kill -9 $HPID 2>/dev/null
+
+echo "--- the zone, from the shell's side ---"
+grep -E "ERROR|WARN scene|BarZoneProbe" "$TMP/probe.log" | head -40
+NESTED

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -843,6 +843,17 @@ if ! python3 "$SCRIPT_DIR/test_bar_geometry_contract.py"; then
     exit 1
 fi
 
+# The bar's exclusive zone lives on an invisible reserver window so the
+# compositor's reflow can ride the same curve as the bar's slide. Nothing about
+# a layer surface's exclusive zone is observable from qmltestrunner or from
+# headless weston, so this is the source contract; the measurement lives in
+# tests/run_bar_exclusive_zone_probe.sh, which needs a nested Hyprland.
+echo "Running bar exclusive zone reserver contract tests..."
+if ! python3 "$SCRIPT_DIR/test_bar_exclusive_zone_reserver.py"; then
+    echo "Bar exclusive zone reserver contract tests failed."
+    exit 1
+fi
+
 echo "Running dock motion contract tests..."
 if ! python3 "$SCRIPT_DIR/test_dock_motion.py"; then
     echo "Dock motion contract tests failed."

--- a/dots/.config/quickshell/imi/tests/test_bar_exclusive_zone_reserver.py
+++ b/dots/.config/quickshell/imi/tests/test_bar_exclusive_zone_reserver.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Source pins holding the bar's animated exclusive zone off the bar's window.
+
+A layer surface's exclusive zone is a protocol value on the surface itself:
+writing it is a set_exclusive_zone + commit and a compositor-wide re-arrange.
+The bar slides in and out of auto-hide on a margin Behavior while its zone
+snapped between two integers, so the bar glided and the windows behind it
+jumped. `BarExclusiveZoneReserver` is a second, invisible, fully-masked
+`PanelWindow` that owns the animated zone; both bars use that one component
+rather than each deciding for themselves, which is the same rule
+`bar_widget_source.js` and `dock_geometry.js` already carry.
+
+None of it is reachable from a runtime harness. `qmltestrunner` cannot
+construct a Quickshell window at all, and weston implements no
+wlr-layer-shell, so no headless harness in this tree can map a layer surface
+let alone ask a compositor what it reserved. It was measured instead in a
+nested Hyprland - `tests/run_bar_exclusive_zone_probe.sh`, which reads the
+reserved area back out of `hyprctl monitors` while the zone animates - and
+what stays behind here is the source contract that probe was pointed at.
+
+The pins are structural rather than textual for the reason recorded in
+`test_background_fullscreen_suppression.py`: a raw pattern over QML decays
+into one that matches nothing after any reformat.
+"""
+import re
+import unittest
+from pathlib import Path
+
+from test_background_fullscreen_suppression import _qml_source
+
+ROOT = Path(__file__).resolve().parents[1]
+RESERVER = ROOT / "modules/imi/bar/BarExclusiveZoneReserver.qml"
+BARS = {
+    "Bar.qml": ROOT / "modules/imi/bar/Bar.qml",
+    "VerticalBar.qml": ROOT / "modules/imi/verticalBar/VerticalBar.qml",
+}
+
+_BEHAVIOR_ON = re.compile(r"\bBehavior\s+on\s+([\w.]+)\s*$")
+_TIER = re.compile(r"Appearance\.animation\.(\w+)\b")
+_RESERVER_TYPE = "BarExclusiveZoneReserver"
+
+
+def _reserver_elements(qml):
+    """The component's instantiations, qualified import or not.
+
+    VerticalBarContent reaches the bar's directory as `qs.modules.imi.bar as
+    Bar`, so the vertical bar spells the type `Bar.BarExclusiveZoneReserver`.
+    Matching the whole name would pin one bar and quietly stop covering the
+    other, which is the drift these files keep having.
+    """
+    return [b for b in qml.elements()
+            if b.name and b.name.split(".")[-1] == _RESERVER_TYPE]
+
+
+def _behavior_tiers(qml):
+    """`{animated property: motion tier}` for every Behavior in the file."""
+    tiers = {}
+    for block in qml.blocks:
+        if block.name != "Behavior" or block.close_at is None:
+            continue
+        target = _BEHAVIOR_ON.search(block.header.strip())
+        tier = _TIER.search(qml.body(block))
+        if target and tier:
+            tiers[target.group(1)] = tier.group(1)
+    return tiers
+
+
+class ReserverContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.reserver = _qml_source(RESERVER)
+        cls.bars = {name: _qml_source(path) for name, path in BARS.items()}
+        windows = cls.reserver.elements("PanelWindow")
+        assert len(windows) == 1, (
+            f"expected exactly one PanelWindow in {RESERVER}, found {len(windows)}")
+        cls.window = windows[0]
+        cls.members = dict(cls.reserver.members(cls.window))
+
+    def test_the_files_parse(self):
+        """Vacuity guard. Every pin below reads structure, so a file the reader
+        cannot balance would pass all of them by finding nothing."""
+        for name, qml in [(RESERVER.name, self.reserver)] + list(self.bars.items()):
+            with self.subTest(file=name):
+                self.assertEqual(qml.unclosed, 0, f"unbalanced braces in {name}")
+        for name, qml in self.bars.items():
+            with self.subTest(file=name):
+                self.assertEqual(len(qml.elements("PanelWindow")), 1,
+                                 f"{name} should still declare exactly one PanelWindow")
+
+    def test_neither_bar_carries_an_exclusive_zone(self):
+        """The visible bar may not name `exclusiveZone` at all, not even as 0.
+
+        `WlrLayershell::setExclusiveZone` forces `exclusionMode` to Normal, and
+        a Normal-mode surface is placed inside the area other surfaces reserve
+        - so a bar spelling `exclusiveZone: 0` beside its `ExclusionMode.Ignore`
+        would be pushed off the screen edge by its own reserver. Comments are
+        blanked by the reader, so the one in Bar.qml saying this does not
+        satisfy the pin.
+        """
+        for name, qml in self.bars.items():
+            with self.subTest(bar=name):
+                self.assertNotIn(
+                    "exclusiveZone", qml.code,
+                    f"{name} names exclusiveZone again. The animated zone "
+                    f"belongs to {RESERVER.name}; writing the property here at "
+                    f"all flips this window into ExclusionMode.Normal.")
+                window = qml.elements("PanelWindow")[0]
+                self.assertEqual(
+                    qml.member(window, "exclusionMode"), "ExclusionMode.Ignore",
+                    f"{name}'s window must stay in Ignore mode, or the "
+                    f"compositor moves it out of the zone the reserver holds.")
+
+    def test_both_bars_reserve_through_the_one_component(self):
+        for name, qml in self.bars.items():
+            with self.subTest(bar=name):
+                found = _reserver_elements(qml)
+                self.assertEqual(
+                    len(found), 1,
+                    f"{name} should instantiate exactly one "
+                    f"{_RESERVER_TYPE}, found {len(found)}. The two bars must "
+                    f"not each work out what their exclusive zone does.")
+                self.assertIsNotNone(
+                    qml.member(found[0], "zone"),
+                    f"{name}'s reserver declares no `zone`, so it reserves "
+                    f"nothing and the bar has silently stopped pushing windows.")
+
+    def test_the_animated_zone_lives_on_the_reserver(self):
+        self.assertIn("animatedZone", self.members.get("exclusiveZone", ""),
+                      "the reserver's exclusiveZone should read the animated "
+                      "value, or nothing about the zone is animated at all")
+        self.assertIn("animatedZone", _behavior_tiers(self.reserver),
+                      "the reserver has no Behavior on animatedZone, so the "
+                      "zone snaps and the windows behind the bar jump again")
+        self.assertEqual(self.members.get("exclusionMode"), "ExclusionMode.Normal",
+                         "the reserver is the window that reserves; Ignore "
+                         "there means nothing is reserved by anything")
+
+    def test_the_zone_and_the_bar_body_ride_the_same_curve(self):
+        """The whole point of the split: the reflow follows the picture.
+
+        A zone animating on a different tier from the slide is worse than one
+        that snaps, because it disagrees with the bar for the whole gesture
+        instead of only at the ends.
+        """
+        zone_tier = _behavior_tiers(self.reserver)["animatedZone"]
+        for name, qml in self.bars.items():
+            tiers = _behavior_tiers(qml)
+            slides = {prop: tier for prop, tier in tiers.items()
+                      if prop.startswith("anchors.")}
+            with self.subTest(bar=name):
+                self.assertTrue(
+                    slides,
+                    f"{name} has no Behavior on an anchor margin any more - "
+                    f"the pin below cannot compare the zone against a slide "
+                    f"that is not there.")
+                self.assertEqual(
+                    sorted(set(slides.values())), [zone_tier],
+                    f"{name}'s body slides on {sorted(set(slides.values()))} "
+                    f"while the exclusive zone animates on {zone_tier!r}.")
+
+    def test_the_reserver_is_masked_to_nothing(self):
+        """An empty mask is what makes a permanently mapped surface harmless.
+
+        Quickshell sets Qt::WindowTransparentForInput only for a mask that
+        resolves to an empty region, so a `Region` here that grew an item, a
+        size or a child region would put an invisible input-taking sheet across
+        the top of the screen.
+        """
+        regions = [b for b in self.reserver.elements("Region")]
+        self.assertEqual(len(regions), 1,
+                         "the reserver should declare exactly one Region, its mask")
+        mask = regions[0]
+        self.assertIn("mask", mask.header,
+                      "the reserver's only Region should be its `mask`")
+        self.assertEqual(self.reserver.members(mask), [],
+                         "the reserver's mask Region binds something; an "
+                         "item, an x/y/width/height or a radius all make it "
+                         "resolve to a non-empty region, and the window then "
+                         "takes input it must never take")
+        self.assertEqual(mask.children, [],
+                         "a child Region makes the mask non-empty")
+
+    def test_the_reserver_paints_nothing_and_asks_for_no_blur(self):
+        self.assertEqual(self.members.get("color"), '"transparent"',
+                         "the reserver's clear colour must stay a literal "
+                         "transparent - see lint_window_clear_color.py for why "
+                         "a bound one costs a surface its blur permanently")
+        self.assertEqual(self.reserver.elements("WindowBlurRegion"), [],
+                         "the reserver paints nothing, so a blur region on it "
+                         "asks the compositor to frost bare wallpaper")
+        self.assertNotIn("WlrLayer.Overlay", self.reserver.code,
+                         "an Overlay surface holds the compositor's fullscreen "
+                         "fast path shut whatever its size, and this one has "
+                         "no pixels to keep above anything")
+
+    def test_the_reserver_borrows_each_bar_namespace_instead_of_minting_one(self):
+        """A minted namespace is absent from `rules.lua`, where the catch-all
+        `ignore_alpha = 0.05` then asks the compositor to blur behind a surface
+        that paints nothing - and the rules.lua half ships in a different file
+        from this one, so the two halves separate on any machine that updates
+        one and not the other. Both bars' namespaces already carry
+        `blur = false`, so borrowing needs no rules.lua entry at all."""
+        namespace = self.members.get("WlrLayershell.namespace", "")
+        self.assertNotIn('"', namespace,
+                         "the reserver mints its own namespace instead of "
+                         f"taking the bar's: {namespace!r}")
+        for name, qml in self.bars.items():
+            with self.subTest(bar=name):
+                window = qml.elements("PanelWindow")[0]
+                reserver = _reserver_elements(qml)[0]
+                self.assertEqual(
+                    qml.member(reserver, "barNamespace"),
+                    qml.member(window, "WlrLayershell.namespace"),
+                    f"{name}'s reserver is on a different namespace from the "
+                    f"bar it reserves for, which is a namespace rules.lua has "
+                    f"never heard of.")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Item 5 of `docs/p3drovfx-animation-research-2026-08-16.md` §3.4.

The auto-hidden bar slides on an `anchors.topMargin` Behavior over
`elementMoveFast` while its `exclusiveZone` snapped between two integers, so the
bar glided and the windows behind it jumped, in opposite directions at the two
ends of the same gesture. A zone is a protocol value on the surface itself —
every write is a `set_exclusive_zone` plus a commit plus a compositor-wide
re-arrange — so animating it in place would reconfigure the surface the bar is
drawn on, once per frame, for the whole slide.

`modules/imi/bar/BarExclusiveZoneReserver.qml` is where the animation lives
instead: a second `PanelWindow` per bar, one pixel thick, `color: "transparent"`,
`mask: Region {}`, painting nothing, so a per-frame reconfigure costs a
re-arrange and no repaint. **Both bars go through the one component** — the two
load the same widget files and share `Config.options.bar.*`, and every time they
have each decided something for themselves they have drifted (a47462fcc is the
last case). Each passes only what it already holds: its edge, its edge margin,
and the zone expression it was already spelling.

### The traps, and what was decided

- **`exclusionMode: ExclusionMode.Ignore` is not in force while an
  `exclusiveZone` sits beside it.** `WlrLayershell::setExclusiveZone` forces the
  mode to `Normal`, so both bars have been in `Normal` all along despite
  declaring `Ignore` — and a `Normal` surface is placed inside what other
  surfaces reserve, so a bar keeping `exclusiveZone: 0` after this split would
  be pushed off the screen edge by its own reserver. The visible bars now name
  the property nowhere at all, and the contract test reddens if it comes back.
- **No `rules.lua` entry, deliberately.** The reserver takes the visible bar's
  own namespace rather than minting one, for the reason `BarPopupOverlay` reuses
  `quickshell:popup`: a new namespace falls through the catch-all
  `ignore_alpha = 0.05` and asks the compositor to blur behind a surface that
  paints nothing. Both bars' namespaces already carry `blur = false`, and
  `rules.lua` ships in a different file from the shell, so borrowing also
  removes the "one half landed" failure for anyone whose Hyprland config is
  older than this branch. `lint_blur_region_pairing.py` is unaffected — the
  namespaces still have their regions, published from the bars. Reuse also
  lands the reserver inside a filter that already exists:
  `RegionSelection.layerRegions` drops Top-layer surfaces whose namespace
  contains `:bar`/`:verticalBar`/`:dock`, so a minted namespace would have
  offered the region selector a 1px screen-wide snap target.
- **Masked to nothing.** Quickshell sets `Qt::WindowTransparentForInput` only
  for a mask that resolves to an empty region
  (`proxywindow.cpp:666`), which is the whole of what makes a permanently mapped
  surface across the screen edge harmless.
- **`Top`, never `Overlay`,** and it does not follow the bar's
  fullscreen+special promotion: an Overlay surface holds the fullscreen fast
  path shut whatever its size, that promotion exists to stop the bar's *pixels*
  being buried, and the reserved area is the same on every layer.
- **The edge margin is folded into the animated value.** Hyprland adds the
  anchored-edge margin to a live zone, so the reserved area is unchanged at rest
  (45 on this machine, as before); folding it in here rather than onto the
  reserver's own `margins` keeps the last frame of a hide from being a jump from
  the margin to zero.
- **The zone takes the same motion tier as the slide** — a different one
  disagrees with the bar for the whole gesture instead of only at its ends, and
  the test pins the two together rather than pinning a tier name.

### Verified

Measured in a nested Hyprland, `tests/run_bar_exclusive_zone_probe.sh` (its own
D-Bus session, its own XDG dirs, its own `XDG_RUNTIME_DIR`, wayland parent by
absolute path, every `hyprctl` carrying the nested signature):

```
no shell:  reserved top 0
layers:    quickshell:bar 0,0 2551x1
reserved:  45 ... 45 27 4 1 0 ... 0 9 33 43 45 ... 45
```

i.e. the reserved area is the number it has always been at rest, and it now
moves through intermediate values instead of 45 → 0.

**Not verified:** nothing was loaded into the user's running shell, so the two
bars have not been seen sliding with real windows behind them; the probe stands
the reserver up on its own. `qmltestrunner` cannot construct a Quickshell window
and weston implements no wlr-layer-shell, so no committed harness in this tree
can map a layer surface or ask a compositor what it reserved — hence a source
contract plus a nested-Hyprland probe rather than a `*RuntimeTest.qml`. The
vertical bar was compiled, not run (it is opt-in and off here).

### Plant-proved

Every check reverted after each plant; the tree was clean throughout.

| planted | check | result |
|---|---|---|
| brace removed from the reserver | `test_the_files_parse` | FAILED — `AssertionError: 1 != 0 : unbalanced braces in BarExclusiveZoneReserver.qml` |
| `exclusiveZone: 0` added back to Bar.qml | `test_neither_bar_carries_an_exclusive_zone` | FAILED — `'exclusiveZone' unexpectedly found in ...` |
| VerticalBar's mode → `ExclusionMode.Normal` | `test_neither_bar_carries_an_exclusive_zone` | FAILED — `'ExclusionMode.Normal' != 'ExclusionMode.Ignore'` |
| VerticalBar instantiates a different type | `test_both_bars_reserve_through_the_one_component` | FAILED — `0 != 1 : VerticalBar.qml should instantiate exactly one BarExclusiveZoneReserver, found 0` |
| zone reads `settledZone`, not the animated one | `test_the_animated_zone_lives_on_the_reserver` | FAILED — `'animatedZone' not found in 'Math.round(reserver.settledZone)'` |
| reserver Behavior → `elementMove` | `test_the_zone_and_the_bar_body_ride_the_same_curve` | FAILED — `Lists differ: ['elementMoveFast'] != ['elementMove']` |
| mask given a width/height | `test_the_reserver_is_masked_to_nothing` | FAILED — `Lists differ: [('width', '100; height: 100')] != []` |
| clear colour bound to `colLayer0` | `test_the_reserver_paints_nothing_and_asks_for_no_blur` | FAILED — `'Appearance.colors.colLayer0' != '"transparent"'` |
| layer → `WlrLayer.Overlay` | `test_the_reserver_paints_nothing_and_asks_for_no_blur` | FAILED — `'WlrLayer.Overlay' unexpectedly found in ...` |
| namespace → `"quickshell:barReserver"` | `test_the_reserver_borrows_each_bar_namespace_instead_of_minting_one` | FAILED — `'"' unexpectedly found in '"quickshell:barReserver"'` |

`DesignSystemCompile.qml` gained `Bar.qml` in the same series and caught a
missing `import QtQuick` in the reserver on its first run.

Docs: updated AGENT.md §Layer-shell (wlr-layer-shell) gotchas

Changelog: updated
