### PR TITLE
A dangling test-import symlink, and the decision that effectiveScale stays 1

### DIFF
--- a/dots/.config/quickshell/imi/modules/common/Appearance.qml
+++ b/dots/.config/quickshell/imi/modules/common/Appearance.qml
@@ -9,8 +9,25 @@ pragma ComponentBehavior: Bound
 
 Singleton {
     id: root
-    // Compatibility scale used by nandoroid's expressive widget library. Immaterial Impulse
-    // already applies compositor/output scaling, so the logical-pixel multiplier is 1.
+    // The vendored expressive widget library's logical-pixel multiplier, and the
+    // decision is that it stays 1.
+    //
+    // It is not dead: 629 call sites read it, and it multiplies real geometry -
+    // `sizes.widgetGridSpanX/Y` and the drag lattice's gap go through it, so a
+    // value other than 1 moves every desktop widget's box and every span the
+    // store holds. It reads 1 because the shell already gets compositor/output
+    // scaling for free: Quickshell hands each screen its device pixel ratio and
+    // Qt lays the whole scene out in logical pixels, so a second multiplier here
+    // is a second scaling of the same thing, applied to widget geometry only,
+    // fighting the one the compositor already did.
+    //
+    // What it must NOT become is a hand-rolled zoom knob: the honest shape for
+    // "make the shell bigger" is the compositor's scale, and the shape for "make
+    // the corners rounder" is a rounding scale, which is its own decision
+    // (docs/p3drovfx-animation-research-2026-08-16.md §3.7). Either would be a
+    // declared setting with a migration, not this constant quietly leaving 1.
+    // `tests/test_effective_scale_contract.py` fails on a second multiplier
+    // declared beside it.
     readonly property real effectiveScale: 1.0
     property QtObject m3colors
     property QtObject animation

--- a/dots/.config/quickshell/imi/tests/imports/qs/services/Docker.qml
+++ b/dots/.config/quickshell/imi/tests/imports/qs/services/Docker.qml
@@ -1,1 +1,0 @@
-../../../../services/Docker.qml

--- a/dots/.config/quickshell/imi/tests/lint_test_import_symlinks.py
+++ b/dots/.config/quickshell/imi/tests/lint_test_import_symlinks.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+#
+# Regression guard: every symlink under `tests/imports/` resolves.
+#
+# The QML suite reaches the shell's own singletons through a mirror tree of
+# symlinks (`tests/imports/qs/services/Audio.qml -> ../../../../services/
+# Audio.qml` and friends), because `qmltestrunner` needs an import path it can
+# resolve without the Quickshell plugin. A symlink there is the only kind of
+# reference in this repo that survives its target being deleted: git keeps the
+# link, `ls` prints it in the same colour as the rest, and nothing fails until
+# a test happens to import that exact type - which for a service nothing tests
+# is never.
+#
+# `services/Docker.qml` is the case that motivated this. It moved into the
+# bundled plugin as `plugins/bundled/docker/DockerService.qml` when the widget
+# became a plugin; the mirror symlink was left behind pointing at a path that
+# has not existed since, and showed up in every `diff -rq` of the tree for
+# months as a phantom difference between the repo and the deployed config.
+#
+# Exits non-zero listing dangling links. Wired into run_tests.sh / CI.
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+IMPORTS = ROOT / "tests" / "imports"
+
+
+def main() -> int:
+    failures = []
+    if not IMPORTS.is_dir():
+        print(f"test import symlinks: {IMPORTS} is gone - the mirror tree moved "
+              f"without this check", file=sys.stderr)
+        return 1
+
+    links = 0
+    for path in sorted(IMPORTS.rglob("*")):
+        if not path.is_symlink():
+            continue
+        links += 1
+        if path.exists():
+            continue
+        relative = path.relative_to(ROOT).as_posix()
+        failures.append(
+            f"{relative} -> {path.readlink()} does not resolve. A mirror "
+            f"symlink outlives its target silently: nothing fails until a test "
+            f"imports that type, which for an untested singleton is never.")
+
+    if not links:
+        failures.append("no symlinks found under tests/imports - the mirror tree "
+                        "is gone, or this check is looking in the wrong place")
+
+    for failure in failures:
+        print(f"test import symlinks: {failure}", file=sys.stderr)
+    if failures:
+        return 1
+    print(f"Test import symlink lint passed: {links} links, all resolving")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -126,6 +126,16 @@ fi
 # Static lint: every mirror symlink under tests/imports resolves. A link there
 # outlives a deleted target silently - nothing fails until a test imports that
 # exact type, which for an untested singleton is never.
+# Contract: one logical-pixel multiplier, reading 1, with the reason attached.
+# It looks like dead compatibility plumbing and is not - 629 sites read it and
+# it multiplies the widget grid - so both "delete it" and "make it a zoom knob"
+# are mistakes this pins the shape against.
+echo "Running effective scale contract tests..."
+if ! python3 "$SCRIPT_DIR/test_effective_scale_contract.py"; then
+    echo "Effective scale contract tests failed."
+    exit 1
+fi
+
 echo "Running test import symlink lint..."
 if ! python3 "$SCRIPT_DIR/lint_test_import_symlinks.py"; then
     echo "Test import symlink lint failed."

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -123,6 +123,15 @@ fi
 # default, Easing.Linear - the generic curve M3_GUIDELINES §2 forbids - and
 # nothing about the source or the log shows it. Two fixes in two days each
 # repaired the sites someone had noticed and left more in the same file.
+# Static lint: every mirror symlink under tests/imports resolves. A link there
+# outlives a deleted target silently - nothing fails until a test imports that
+# exact type, which for an untested singleton is never.
+echo "Running test import symlink lint..."
+if ! python3 "$SCRIPT_DIR/lint_test_import_symlinks.py"; then
+    echo "Test import symlink lint failed."
+    exit 1
+fi
+
 echo "Running motion tier lint..."
 if ! python3 "$SCRIPT_DIR/lint_motion_tier_partial.py"; then
     echo "Motion tier lint failed."

--- a/dots/.config/quickshell/imi/tests/test_effective_scale_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_effective_scale_contract.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""One logical-pixel multiplier, and it is Appearance's.
+
+`Appearance.effectiveScale` came in with the vendored expressive widget library
+and reads 1.0 - which makes it look like dead compatibility plumbing and invites
+two opposite mistakes. It is not dead: 629 call sites read it, and
+`sizes.widgetGridSpanX/Y` and the drag lattice's gap multiply by it, so a value
+other than 1 moves every desktop widget's box and every span
+`plugin-state.json` holds. And it is not a zoom knob: the shell already gets
+compositor/output scaling, so a second multiplier applied to widget geometry
+alone fights the one Qt already applied to the whole scene.
+
+What this pins is the shape rather than the number - a repo that wants a real
+widget scale one day should get it as a declared setting with a migration, the
+way every other user-facing value here arrives, not as this constant quietly
+leaving 1 while nothing in the suite notices. So: exactly one declaration, no
+second scale multiplier declared beside it, and every consumer reading it from
+Appearance rather than folding a factor of its own into the same arithmetic.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+APPEARANCE = ROOT / "modules/common/Appearance.qml"
+DECLARATION = re.compile(r"^\s*readonly\s+property\s+real\s+effectiveScale\s*:\s*(.+)$",
+                         re.MULTILINE)
+# A literal factor multiplied INTO the scale at a call site: `0.75 *
+# Appearance.effectiveScale` is the one that exists (AndroidToggle's smaller
+# variant) and is fine - a per-widget proportion is not a second global scale.
+# What is not fine is a second GLOBAL multiplier: a singleton declaring its own.
+SINGLETON = re.compile(r"^\s*pragma\s+Singleton\s*$", re.MULTILINE)
+OWN_SCALE = re.compile(
+    r"^\s*(?:readonly\s+)?property\s+real\s+(effectiveScale|logicalScale|uiScale)\s*:",
+    re.MULTILINE)
+
+
+def qml_files():
+    for path in sorted(ROOT.rglob("*.qml")):
+        relative = path.relative_to(ROOT).as_posix()
+        if relative.startswith("tests/"):
+            continue
+        yield relative, path
+
+
+def test_the_multiplier_is_declared_once_and_reads_one():
+    text = APPEARANCE.read_text(encoding="utf-8")
+    declarations = DECLARATION.findall(text)
+    assert len(declarations) == 1, (
+        f"Appearance declares effectiveScale {len(declarations)} times: "
+        f"{declarations}")
+    value = declarations[0].split("//")[0].strip()
+    assert value == "1.0", (
+        f"effectiveScale is {value!r}. It multiplies widgetGridSpanX/Y and the "
+        f"drag lattice's gap, so any other value moves every desktop widget's "
+        f"box and every span the store already holds. Making it real is a "
+        f"declared setting with a migration, not a changed constant - and this "
+        f"test is where that decision gets written down.")
+
+
+def test_the_reason_travels_with_it():
+    text = APPEARANCE.read_text(encoding="utf-8")
+    index = text.index("readonly property real effectiveScale")
+    preamble = text[max(0, index - 1600):index]
+    assert "compositor" in preamble, (
+        "the comment above effectiveScale no longer says why it is 1. It reads "
+        "as dead compatibility plumbing without that sentence, which is how a "
+        "second scaling path gets added on top of the compositor's.")
+
+
+def test_no_singleton_declares_a_second_global_scale():
+    offenders = []
+    for relative, path in qml_files():
+        if relative == "modules/common/Appearance.qml":
+            continue
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        if not SINGLETON.search(text):
+            continue
+        for match in OWN_SCALE.finditer(text):
+            line = text.count("\n", 0, match.start()) + 1
+            offenders.append(f"{relative}:{line} declares {match.group(1)}")
+    assert not offenders, (
+        f"a second global scale multiplier: {offenders}. One is the "
+        f"compositor's job and the other is Appearance's; two of them multiply, "
+        f"and only widget geometry reads the second, so the shell scales "
+        f"unevenly with nothing reporting it.")
+
+
+def test_the_vendored_library_reads_it_rather_than_carrying_one():
+    tokens = ROOT / "modules/common/plugins/designsystem/ExpressiveTokens.qml"
+    text = tokens.read_text(encoding="utf-8")
+    assert re.search(r"readonly\s+property\s+real\s+scale\s*:\s*Appearance\.effectiveScale",
+                     text), (
+        "ExpressiveTokens.scale no longer forwards Appearance.effectiveScale. "
+        "That singleton is the vendored library's whole door onto the shell's "
+        "tokens; a literal there is a scale nothing else can see.")
+
+
+if __name__ == "__main__":
+    failures = 0
+    for name, function in sorted(globals().items()):
+        if not name.startswith("test_") or not callable(function):
+            continue
+        try:
+            function()
+        except AssertionError as error:
+            failures += 1
+            print(f"FAIL: {name}\n  {error}", file=sys.stderr)
+    if failures:
+        print(f"effective scale contract: {failures} failed", file=sys.stderr)
+        sys.exit(1)
+    print("Effective scale contract passed: one multiplier, reading 1, with its reason")


### PR DESCRIPTION
Two leftovers, both from `docs/p3drovfx-animation-research-2026-08-16.md` §7 and the deploy-diff noise around it.

## The mirror symlink outlived its target

`tests/imports/qs/services/Docker.qml` pointed at `services/Docker.qml`, which has not existed since the Docker widget became a bundled plugin and its service moved to `plugins/bundled/docker/DockerService.qml`. A symlink is the one reference here that outlives its target without anything failing — git keeps it, and the QML suite only resolves a link when a test imports that type, which for Docker is never. It showed up in every `diff -rq` between the repo and the deployed config as a phantom difference, on the one check that answers "is the live shell what this branch says".

`tests/lint_test_import_symlinks.py` fails on a link that does not resolve, and on the mirror tree disappearing entirely — the second half because a sweep that finds nothing reports the same clean result as a sweep that finds nothing wrong.

**Plant-proof**: added `tests/imports/qs/services/NotAThing.qml -> ../../../../services/NotAThing.qml` → `test import symlinks: tests/imports/qs/services/NotAThing.qml -> … does not resolve`, exit 1; removed → passes, 82 links checked.

## `effectiveScale` stays 1, and the file says why

The survey flagged it as an inert knob to make real or remove. It is neither, and both mistakes are easy from what the code showed:

- **Not dead.** 629 sites read it, and `sizes.widgetGridSpanX/Y` plus the drag lattice's gap multiply by it — any other value moves every desktop widget's box and every span `plugin-state.json` already holds.
- **Not a zoom knob.** Quickshell hands each screen its device pixel ratio and Qt lays the whole scene out in logical pixels, so a second multiplier applied to widget geometry alone fights the scaling the compositor already did, unevenly, with nothing reporting it. A real widget scale arrives as a declared setting with a migration, the way every other user-facing value here does; a rounding scale is a separate decision (§3.7).

The reasoning now sits beside the declaration, and `tests/test_effective_scale_contract.py` pins the shape rather than the number: one declaration, still `1.0`, its reason still attached, no singleton declaring a second global scale, and `ExpressiveTokens.scale` still forwarding this one rather than carrying a literal.

**Plant-proofs**: `effectiveScale: 1.25` → `test_the_multiplier_is_declared_once_and_reads_one` fails; `ExpressiveTokens.scale: 1.0` → `test_the_vendored_library_reads_it_rather_than_carrying_one` fails; `property real uiScale: 2` added to a singleton → `test_no_singleton_declares_a_second_global_scale` fails naming the file and line. All restored → passes.

## Tests
Full `tests/run_tests.sh`: **1029 QML passed / 0 failed**, every Python check OK, exit 0. Both new checks are registered in `run_tests.sh`.

Changelog: not user-visible — a dangling test-only symlink and a pinned constant that keeps its current value

Docs: not needed — the decision is recorded beside the declaration it is about and in the contract test's docstring, which is where the next reader of that line is standing; AGENT.md's design-language section already routes scaling questions through Appearance
