### PR TITLE
The bar popup card runs on one driver, and unrolls out of its first section

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1103,6 +1103,49 @@ Two non-obvious behaviors have bitten this codebase before and are worth knowing
   per-surface rather than per-region and nothing in-tree had done it before.
   (d29cd6e45 ("feat(bar): add the static overlay surface the popup card will live on"),
   b22a923a5 ("refactor(bar): delete the per-popup layer surface").)
+- **That card runs on ONE scalar, and the properties that used to be assigned are derived from
+  it — including the coordinate the assignment existed to protect.** `card.openProgress` is a
+  `real` 0 → 1 with a single `Behavior` on it; the fade *is* that number, and the height is a plain
+  binding on it through `modules/imi/bar/bar_popup_unroll.js`. Four things about the arrangement
+  are not obvious.
+  1. **The hero-height unroll is why it is worth doing.** The card opens at the height of the
+     content's **first drawn section** and unfurls to the full height along the same progress the
+     fade rides, so the top edge never moves and the primary content is legible on frame one. The
+     section is measured at its **drawn** height: a `Layout` child states its size through
+     `Layout.preferredHeight` and carries no implicit height, so `implicitHeight` answers 0 for
+     exactly the popups whose first section is a card. Measured on the real compositor with a
+     125/100/75 stack at `contentPadding` 8 — hero 141, open 316, height tracking progress exactly.
+  2. **A derived height is what finally lets the bar-adjacent coordinate be a binding.** On the
+     bottom and right edges that coordinate is a function of the animating size, which is why
+     `card.x`/`card.y` were *assigned* — two `Behavior`s easing a position and a size apart put the
+     card's edge where its content is not. Deriving the coordinate from the size the driver already
+     produces cannot drift from it, and neither side carries a `Behavior`, so it is not
+     b710ef731's moving target. Measured: a bottom bar holds its card's bottom edge at 1390.0 on
+     every frame of the open, the overshoot and the exit; a right bar holds 5064.0. Only the
+     coordinate *along* the bar still travels.
+  3. **The window's own `visible` predicate must read the card's INPUTS, never its derived
+     height or opacity.** Reading the derived ones closes a circle through `visible` itself — the
+     card's across-the-bar coordinate is derived from the window's size — and logs
+     `Binding loop detected for property "visible"` twice per window on a live compositor, where
+     the same probe against the old assigned geometry logged nothing. `openProgress`, `width` and
+     `openHeight` are the safe three, and they are also what "collapse to 0x0 when idle" means
+     now: a zero open height answers 0 at every progress, which is what empties the input region.
+  4. **The content sits in a slot held at the settled height, not centred in the host.** A host
+     that is shrinking centres what it holds, so the band on screen while the card is short would
+     be the *middle* of the content — the first section, the one the card opens at the height of,
+     would be the one thing not visible. Pinning it to the top of the host also keeps a leaving
+     block still instead of reflowing it through every intermediate size.
+
+  One tier serves both directions deliberately. Qt refuses a second write to a `Behavior`'s
+  `animation`, so a directional pair would have to be a duration and a curve written onto a bare
+  `NumberAnimation` — half a tier, and silently `Easing.Linear` the day someone drops the curve.
+  The created animations are named properties so `morphing` can still ask whether the card is
+  travelling, which the focus grab needs in order not to arm on a parked square.
+  `tests/lint_bar_popup_overlay_static.py` refuses a second `Behavior` on the driver, any
+  `Behavior` on `height`/`opacity`/`x`/`y`, an inline animation inside a `Behavior`, and a hero
+  height that is a literal rather than a measurement.
+  cd607d416 ("feat(bar): the popup card runs on one driver, and unrolls from its first section"),
+  d01879f4c ("test(lint): hold the popup card to one driver, and its unroll to a measured hero").
 - **Moving content between windows is already how popups work here, and it has two traps.**
   `StyledPopup` reparented its content into its window at completion long before the overlay
   existed; the overlay does the same thing, one popup at a time, and never has more than two

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,16 @@ own repo; the installer pins which revision it builds.
   both the horizontal and the vertical bar. Nothing about where the bar sits at
   rest changes.
 
+### Changed
+- **A bar popup unrolls out of its own first card.** Hovering a bar widget used
+  to grow a card from a dot into its full height; it now appears already the
+  height of the first thing inside it — the weather hero, the calendar's month
+  header — and unfurls to reveal the rest, with the fade riding the same
+  motion. The top edge never moves, so what you came to read is legible on the
+  frame the popup appears rather than once it settles. On a bottom or a side
+  bar it is the bar-adjacent edge that stays put, and it stays put exactly, on
+  every frame of the open and the close.
+
 ## [0.26.0] — 2026-08-19
 
 The lock screen gets its own widget layout, snapping stops gluing widgets

--- a/dots/.config/quickshell/imi/modules/imi/bar/BarPopupOverlay.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/BarPopupOverlay.qml
@@ -7,6 +7,7 @@ import Quickshell.Wayland
 import qs
 import qs.modules.common
 import qs.modules.common.widgets
+import "bar_popup_unroll.js" as BarPopupUnroll
 
 // One always-mapped layer surface per screen, hosting the single card every bar
 // popup morphs. The surface itself never moves, resizes or unmaps: on a
@@ -51,12 +52,21 @@ Scope {
             // this window while it shows - so the window may only go once
             // `finishExit()` has released both trees and collapsed the card,
             // which is exactly the state this reads.
+            //
+            // It reads the card's INPUTS - the open height, the width and the
+            // driver - rather than its drawn height and opacity, and that is
+            // load-bearing rather than tidiness. The drawn ones are derived, and
+            // the card's own across-the-bar coordinate is derived from the
+            // window's size, so a predicate reading them closes a circle through
+            // this very property: measured as `Binding loop detected for
+            // property "visible"` on a real compositor, twice per window, where
+            // the same probe against the assigned geometry logged nothing.
             visible: overlayWindow.current !== null
                 || overlayWindow.outgoing !== null
                 || overlayWindow.exiting
-                || card.opacity > 0
+                || card.openProgress > 0
                 || card.width > 0
-                || card.height > 0
+                || card.openHeight > 0
             exclusionMode: ExclusionMode.Ignore
             exclusiveZone: 0
 
@@ -99,12 +109,14 @@ Scope {
             property var current: null
             property var outgoing: null
             property bool exiting: false
-            // Where the card collapses to on exit. Remembered rather than
-            // recomputed, because the popup that owns it may have been
-            // destroyed by the time the exit runs.
-            property var exitSpot: null
-            readonly property bool morphing: xAnim.running || yAnim.running
-                || widthAnim.running || heightAnim.running
+            // Where along the bar the card collapses to on exit. Remembered
+            // rather than recomputed, because the popup that owns it may have
+            // been destroyed by the time the exit runs. One number, not a
+            // rectangle: the card's across-the-bar coordinate is derived from
+            // its live size, so nothing about the parked square is stored.
+            property var exitAnchor: null
+            readonly property bool morphing: card.alongBarAnim.running || card.widthAnim.running
+                || card.openAnim.running
 
             readonly property var requested: {
                 const popup = GlobalStates.activeBarPopup;
@@ -119,10 +131,14 @@ Scope {
             }
 
             function takeOver(popup) {
-                exitShrinkTimer.stop();
-                exitFadeTimer.stop();
+                exitTimer.stop();
                 overlayWindow.exiting = false;
-                card.opacity = 1;
+                // No opacity or progress write here: retarget() drives the one
+                // scalar, one turn of the event loop from now, and it is the
+                // only place that knows what the card is opening to. Reversing
+                // an exit from here would ramp the card back up against the
+                // outgoing popup's height for a frame.
+                //
                 // An exit disables the leaving content; a re-hover of the very
                 // widget the card was leaving has to hand its controls back.
                 if (overlayWindow.current?.contentItem)
@@ -156,8 +172,8 @@ Scope {
 
                 const arriving = popup.contentItem;
                 if (arriving) {
-                    arriving.parent = contentHost;
-                    arriving.anchors.centerIn = contentHost;
+                    arriving.parent = contentSlot;
+                    arriving.anchors.centerIn = contentSlot;
                     arriving.enabled = true;
                     arriving.opacity = 0;
                     contentEnter.stop();
@@ -169,7 +185,7 @@ Scope {
 
                 // Coming from idle there is no geometry to morph from, so put
                 // the card at the widget it belongs to before anything animates.
-                if (card.width <= 0 || card.height <= 0) overlayWindow.park();
+                if (card.width <= 0 || card.openHeight <= 0) overlayWindow.park();
                 retargetTimer.restart();
             }
 
@@ -187,107 +203,89 @@ Scope {
                 const cardWidth = content.implicitWidth + popup.contentPadding * 2;
                 const cardHeight = content.implicitHeight + popup.contentPadding * 2;
 
-                let cardX;
-                let cardY;
-                if (popup.barVertical) {
+                // The clamp reads the SETTLED size, never the card's animating
+                // one: a rect measured from the far edge of a box that is still
+                // moving crawls behind it.
+                if (overlayWindow.barVertical) {
                     const base = target.QsWindow.mapFromItem(target, 0, (target.height - cardHeight) / 2).y;
-                    cardY = Math.max(margin, Math.min(base, overlayWindow.height - cardHeight - margin - 15));
-                    cardX = popup.barEdge === "right"
-                        ? overlayWindow.width - popup.barThickness - margin - cardWidth
-                        : popup.barThickness + margin;
+                    card.alongBar = Math.max(margin, Math.min(base, overlayWindow.height - cardHeight - margin - 15));
                 } else {
                     const base = target.QsWindow.mapFromItem(target, (target.width - cardWidth) / 2, 0).x;
-                    cardX = Math.max(margin, Math.min(base, overlayWindow.width - cardWidth - margin - 10));
-                    cardY = popup.barEdge === "bottom"
-                        ? overlayWindow.height - popup.barThickness - margin - cardHeight
-                        : popup.barThickness + margin;
+                    card.alongBar = Math.max(margin, Math.min(base, overlayWindow.width - cardWidth - margin - 10));
                 }
 
-                // Assigned, never bound: nothing the card's geometry feeds may
-                // also feed the computation of it, and on the bottom/right
-                // edges the fixed axis is a function of the animating size.
                 card.width = cardWidth;
-                card.height = cardHeight;
-                card.x = cardX;
-                card.y = cardY;
-                overlayWindow.exitSpot = overlayWindow.anchorSpot();
+                card.openHeight = cardHeight;
+                card.heroHeight = BarPopupUnroll.heroSectionHeight(content.children, popup.contentPadding);
+                // The driver, written last and only here: the hero and the full
+                // height it interpolates between have to be the arriving
+                // popup's before the ramp can mean anything. Writing 1 while it
+                // is already 1 is not a restart - Qt drops a Behavior write of
+                // the value it is already animating to.
+                card.openProgress = 1;
+                overlayWindow.exitAnchor = overlayWindow.anchorAlongBar();
             }
 
-            // The card's exit target: a small square on the bar-adjacent edge,
-            // centred on the widget the card belongs to.
-            function anchorSpot() {
+            // Where the card parks: the point ALONG the bar, centred on the
+            // widget the card belongs to. The coordinate across the bar is not
+            // part of it - that one is derived from the card's live size, so
+            // the far edges keep their bar-adjacent edge still by construction
+            // rather than by two Behaviors happening to share a curve.
+            function anchorAlongBar() {
                 const popup = overlayWindow.current ?? overlayWindow.outgoing;
                 const target = popup?.hoverTarget;
-                if (!target?.QsWindow?.window) return overlayWindow.exitSpot;
+                if (!target?.QsWindow?.window) return overlayWindow.exitAnchor;
 
-                const margin = Appearance.sizes.elevationMargin;
-                const floor = margin * 2;
                 const centre = target.QsWindow.mapFromItem(target, target.width / 2, target.height / 2);
-                if (popup.barVertical) {
-                    return {
-                        x: popup.barEdge === "right"
-                            ? overlayWindow.width - popup.barThickness - margin - floor
-                            : popup.barThickness + margin,
-                        y: centre.y - floor / 2,
-                        width: floor,
-                        height: floor
-                    };
-                }
-                return {
-                    x: centre.x - floor / 2,
-                    y: popup.barEdge === "bottom"
-                        ? overlayWindow.height - popup.barThickness - margin - floor
-                        : popup.barThickness + margin,
-                    width: floor,
-                    height: floor
-                };
+                return (overlayWindow.barVertical ? centre.y : centre.x) - card.parkedSize / 2;
             }
 
             function park() {
-                const spot = overlayWindow.anchorSpot();
-                if (!spot) return;
+                const anchor = overlayWindow.anchorAlongBar();
+                if (anchor === null || anchor === undefined) return;
                 card.animate = false;
-                card.opacity = 0;
-                card.x = spot.x;
-                card.y = spot.y;
-                card.width = spot.width;
-                card.height = spot.height;
+                card.openProgress = 0;
+                card.heroHeight = 0;
+                card.openHeight = card.parkedSize;
+                card.width = card.parkedSize;
+                card.alongBar = anchor;
                 card.animate = true;
-                card.opacity = 1;
-                overlayWindow.exitSpot = spot;
+                overlayWindow.exitAnchor = anchor;
             }
 
-            // Shrink toward the owning widget, then fade, then collapse. The
-            // collapse is not cosmetic: an opacity-0 card still publishes a
-            // full-size input region and would eat every click in its rectangle.
+            // Shrink toward the owning widget and fade, on the one scalar, then
+            // collapse. The collapse is not cosmetic: an opacity-0 card still
+            // publishes a full-size input region and would eat every click in
+            // its rectangle.
             function beginExit() {
                 if (overlayWindow.exiting) return;
                 // Already idle. Returning rather than collapsing again matters:
                 // finishExit() vacates the slot, which re-enters here.
                 if (!overlayWindow.current && !overlayWindow.outgoing
-                        && card.width <= 0 && card.height <= 0) return;
-                if (card.width <= 0 && card.height <= 0) {
+                        && card.width <= 0 && card.openHeight <= 0) return;
+                if (card.width <= 0 && card.openHeight <= 0) {
                     overlayWindow.finishExit();
                     return;
                 }
-                const spot = overlayWindow.anchorSpot();
-                if (!spot) {
+                const anchor = overlayWindow.anchorAlongBar();
+                if (anchor === null || anchor === undefined) {
                     overlayWindow.finishExit();
                     return;
                 }
+                // Before the progress write, not after: the card's rest height
+                // becomes the parked square's here, and at progress 1 that
+                // changes nothing, so the exit starts where the card already is.
                 overlayWindow.exiting = true;
                 if (overlayWindow.current?.contentItem)
                     overlayWindow.current.contentItem.enabled = false;
-                card.x = spot.x;
-                card.y = spot.y;
-                card.width = spot.width;
-                card.height = spot.height;
-                exitShrinkTimer.restart();
+                card.alongBar = anchor;
+                card.width = card.parkedSize;
+                card.openProgress = 0;
+                exitTimer.restart();
             }
 
             function finishExit() {
-                exitShrinkTimer.stop();
-                exitFadeTimer.stop();
+                exitTimer.stop();
                 contentEnter.stop();
                 contentExit.stop();
 
@@ -299,9 +297,13 @@ Scope {
                 overlayWindow.exiting = false;
 
                 card.animate = false;
-                card.opacity = 0;
+                card.openProgress = 0;
+                card.heroHeight = 0;
+                // The card's height is derived, so emptying the input region
+                // means emptying what it is derived FROM: a zero open height is
+                // zero at every progress.
+                card.openHeight = 0;
                 card.width = 0;
-                card.height = 0;
                 card.animate = true;
 
                 if (leaving && GlobalStates.activeBarPopup === leaving)
@@ -336,18 +338,16 @@ Scope {
                 onTriggered: overlayWindow.retarget()
             }
 
+            // One timer where there were two chained ones. The shrink and the
+            // fade were staged so they would not fight over the same frames;
+            // riding one scalar makes them the same motion, so what is left to
+            // wait for is that motion finishing. The interval is the driver's
+            // own tier, which is also how the motion multiplier reaches it - a
+            // Timer is one of the two things a Behavior's scaled duration does
+            // not cover.
             Timer {
-                id: exitShrinkTimer
-                interval: Appearance.animation.elementMoveExit.duration
-                onTriggered: {
-                    card.opacity = 0;
-                    exitFadeTimer.restart();
-                }
-            }
-
-            Timer {
-                id: exitFadeTimer
-                interval: Appearance.animation.elementMoveFast.duration
+                id: exitTimer
+                interval: Appearance.animation.elementMove.duration
                 onTriggered: overlayWindow.finishExit()
             }
 
@@ -436,6 +436,15 @@ Scope {
             }
             onBarEdgeChanged: overlayWindow.finishExit()
 
+            // Derived here for the same reason barEdge is: the card's own
+            // across-the-bar coordinate is a binding now, and a binding that
+            // reached through whichever popup currently holds the card would
+            // re-evaluate against a null popup on every takeover.
+            readonly property bool barVertical: Config.options.bar.vertical
+            readonly property real barThickness: overlayWindow.barVertical
+                ? Appearance.sizes.verticalBarWidth
+                : Appearance.sizes.barHeight
+
             SequentialAnimation {
                 id: contentEnter
                 property Item item: null
@@ -485,16 +494,53 @@ Scope {
                 // Gates the Behaviors so the card can be placed instantly when
                 // there is no previous geometry to travel from.
                 property bool animate: true
-                readonly property int motionDuration: overlayWindow.exiting
-                    ? Appearance.animation.elementMoveExit.duration
-                    : Appearance.animation.elementMove.duration
-                readonly property var motionCurve: overlayWindow.exiting
-                    ? Appearance.animationCurves.emphasizedAccel
-                    : Appearance.animationCurves.expressiveDefaultSpatial
+
+                // THE driver. One `real` 0 -> 1 that the fade and the unroll
+                // both ride, so they cannot disagree about where the card is in
+                // its own transition. Everything derivable from it is derived,
+                // never animated a second time: a second Behavior on a quantity
+                // this one already carries is a second timing to keep in step,
+                // and the one place they would visibly differ is mid-flight,
+                // which is the only place nobody looks.
+                property real openProgress: 0
+                // What the card unrolls between. Assigned by retarget(), which
+                // is a turn of the event loop behind the takeover because an
+                // unparented tree does not polish and its implicit size is
+                // stale until it does.
+                property real openHeight: 0
+                property real heroHeight: 0
+                // The parked square on the bar, which the card grows out of and
+                // collapses back into.
+                readonly property real parkedSize: Appearance.sizes.elevationMargin * 2
+                // The card's coordinate ALONG the bar. The only travel left:
+                // the across-the-bar one is derived below.
+                property real alongBar: 0
 
                 width: 0
-                height: 0
-                opacity: 0
+                height: BarPopupUnroll.cardHeight(card.openHeight, card.heroHeight,
+                    card.parkedSize, overlayWindow.exiting, card.openProgress)
+                // Bindings, not assignments, and that is what the driver bought.
+                // On the bottom and right edges the bar-adjacent coordinate is a
+                // function of the animating size, which is why this used to be
+                // assigned: two Behaviors easing x and width apart put the
+                // card's edge where its content is not. Deriving it from the
+                // size the driver already produces cannot drift from it, and
+                // neither carries a Behavior of its own, so nothing here is a
+                // target that moves every frame.
+                x: overlayWindow.barVertical
+                    ? (overlayWindow.barEdge === "right"
+                        ? overlayWindow.width - overlayWindow.barThickness - Appearance.sizes.elevationMargin - card.width
+                        : overlayWindow.barThickness + Appearance.sizes.elevationMargin)
+                    : card.alongBar
+                y: overlayWindow.barVertical
+                    ? card.alongBar
+                    : (overlayWindow.barEdge === "bottom"
+                        ? overlayWindow.height - overlayWindow.barThickness - Appearance.sizes.elevationMargin - card.height
+                        : overlayWindow.barThickness + Appearance.sizes.elevationMargin)
+                // Clamped because the spatial tier overshoots past 1 and
+                // undershoots below 0 on the way back; the geometry keeps the
+                // overshoot deliberately, an alpha cannot use it.
+                opacity: Math.max(0, Math.min(1, card.openProgress))
                 visible: width > 0 && height > 0
 
                 color: Appearance.colors.colLayer1Base
@@ -502,51 +548,35 @@ Scope {
                 border.width: Appearance.borderWidth.standard
                 border.color: Appearance.colors.colLayer0Border
 
-                Behavior on x {
-                    // Position too, for the same reason as width and height: a
-                    // right-anchored card's x is derived from its width, so
-                    // easing one while the other tracks the content puts the
-                    // card's edge where its content is not.
-                    enabled: card.animate && !(overlayWindow.current?.contentDrivesSize ?? false)
-                    NumberAnimation {
-                        id: xAnim
-                        duration: card.motionDuration
-                        easing.type: Easing.BezierSpline
-                        easing.bezierCurve: card.motionCurve
-                    }
+                // Every tier is taken WHOLE - duration, easing type and curve
+                // together, from the tier's own component. Naming the created
+                // objects is what lets `morphing` ask whether the card is still
+                // travelling: the focus grab must not arm while the card is
+                // still the parked square, and a Behavior does not publish its
+                // own animation until after completion.
+                readonly property NumberAnimation openAnim: Appearance.animation.elementMove.numberAnimation.createObject(card)
+                readonly property NumberAnimation alongBarAnim: Appearance.animation.elementMove.numberAnimation.createObject(card)
+                readonly property NumberAnimation widthAnim: Appearance.animation.elementMove.numberAnimation.createObject(card)
+
+                // The only Behavior on the driver, and the one tier serves both
+                // directions. A Behavior's animation cannot be swapped after
+                // construction (Qt refuses the second write), so a directional
+                // pair would have to be a duration and a curve written onto a
+                // bare NumberAnimation - half a tier, which is silently
+                // Easing.Linear the day someone drops the curve.
+                Behavior on openProgress {
+                    enabled: card.animate
+                    animation: card.openAnim
                 }
-                Behavior on y {
-                    enabled: card.animate && !(overlayWindow.current?.contentDrivesSize ?? false)
-                    NumberAnimation {
-                        id: yAnim
-                        duration: card.motionDuration
-                        easing.type: Easing.BezierSpline
-                        easing.bezierCurve: card.motionCurve
-                    }
-                }
-                Behavior on width {
+                Behavior on alongBar {
                     // See StyledPopup.contentDrivesSize: a popup animating its
                     // own size must not be chased by the card.
                     enabled: card.animate && !(overlayWindow.current?.contentDrivesSize ?? false)
-                    NumberAnimation {
-                        id: widthAnim
-                        duration: card.motionDuration
-                        easing.type: Easing.BezierSpline
-                        easing.bezierCurve: card.motionCurve
-                    }
+                    animation: card.alongBarAnim
                 }
-                Behavior on height {
+                Behavior on width {
                     enabled: card.animate && !(overlayWindow.current?.contentDrivesSize ?? false)
-                    NumberAnimation {
-                        id: heightAnim
-                        duration: card.motionDuration
-                        easing.type: Easing.BezierSpline
-                        easing.bezierCurve: card.motionCurve
-                    }
-                }
-                Behavior on opacity {
-                    enabled: card.animate
-                    animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
+                    animation: card.widthAnim
                 }
 
                 HoverHandler {
@@ -564,6 +594,24 @@ Scope {
                     anchors.fill: parent
                     anchors.margins: overlayWindow.current?.contentPadding ?? 0
                     clip: true
+
+                    // The content's own box, held at the SETTLED height for the
+                    // whole unroll and pinned to the top of the host.
+                    //
+                    // Centring the content in a host that is shrinking would
+                    // show the middle band of it while the card is short, so the
+                    // first section - the one the card opens at the height of -
+                    // would be the one thing not on screen on frame one. Holding
+                    // the box still is the other half: a block re-centred
+                    // through every intermediate height reads as being squeezed
+                    // rather than as being revealed, and it is the same reason a
+                    // one-tree widget pins a fading block to its own span's box.
+                    Item {
+                        id: contentSlot
+                        width: parent.width
+                        height: Math.max(0, card.openHeight
+                            - 2 * (overlayWindow.current?.contentPadding ?? 0))
+                    }
                 }
             }
         }

--- a/dots/.config/quickshell/imi/modules/imi/bar/bar_popup_unroll.js
+++ b/dots/.config/quickshell/imi/modules/imi/bar/bar_popup_unroll.js
@@ -1,0 +1,76 @@
+.pragma library
+
+// The bar popup card's height, as arithmetic.
+//
+// Nothing about that card is reachable from a test: it lives on a
+// wlr-layer-shell surface, which qmltestrunner cannot build and headless weston
+// does not implement, so the decisions have to be somewhere a test can call
+// them - the same reason ParallaxMath.sampleOrigin and clockDepth.js are pure.
+//
+// The card runs on ONE scalar, `openProgress`, 0 while idle and 1 while open.
+// The fade rides it and so does the height, which is why the height is a plain
+// binding rather than a second animation: a Behavior whose target moves every
+// frame restarts every frame and never ticks
+// (b710ef731 ("fix(plugins): stop the position Behavior swallowing the parallax
+// cancellation")), and two animations of one quantity are two timings that have
+// to agree.
+
+// The card opens at the height of the content's FIRST drawn section and unfurls
+// from there, instead of appearing at full height or growing out of nothing:
+// the top edge never moves and the primary content is legible on frame one.
+//
+// A section is measured at its DRAWN height. A Layout child states its size
+// through `Layout.preferredHeight` and carries no implicit height of its own,
+// so reading `implicitHeight` here answers 0 for exactly the popups whose first
+// section is a card - which is every popup the unroll exists for. Zero-height
+// and undrawn children are skipped rather than accepted, for the same reason a
+// stagger ranks by visible position: a spacer that spends a slot would make the
+// hero the height of nothing.
+function heroSectionHeight(sections, padding) {
+    if (!sections)
+        return 0;
+    for (let index = 0; index < sections.length; index++) {
+        const section = sections[index];
+        if (!section || section.visible !== true)
+            continue;
+        const height = section.height;
+        if (!(height > 0))
+            continue;
+        return height + padding * 2;
+    }
+    return 0;
+}
+
+// Where the card sits at progress 0, and therefore what it unrolls FROM.
+//
+// Opening with a hero that is the whole content (a one-section popup) leaves
+// rest === open, so such a popup simply has no unroll rather than a special
+// case. Leaving, or opening with no measurable first section, the rest is the
+// small square parked on the widget the card belongs to - the card grows out of
+// and collapses back into the bar, which is what it did before the unroll and
+// is still the honest answer when there is no section to open at.
+function restHeight(openHeight, heroHeight, parkedSize, exiting) {
+    if (!(openHeight > 0))
+        return 0;
+    const rest = (exiting || !(heroHeight > 0)) ? parkedSize : heroHeight;
+    return Math.max(0, Math.min(rest, openHeight));
+}
+
+// An idle card must be exactly 0 tall, because an `opacity: 0` card still
+// publishes a full-size input region and a permanently-reachable one on a
+// screen-sized Overlay surface eats every click in its rectangle. The height is
+// derived, so emptying the region means emptying what it is derived FROM: a
+// zero open height is 0 at every progress, including a progress the exit's
+// curve has undershot below zero.
+//
+// The top end is deliberately NOT clamped: the spatial tier overshoots past 1,
+// and a card that overshoots its content and settles back is the tier's own
+// expressiveness - the same overshoot the height Behavior this replaced already
+// produced.
+function cardHeight(openHeight, heroHeight, parkedSize, exiting, progress) {
+    if (!(openHeight > 0))
+        return 0;
+    const rest = restHeight(openHeight, heroHeight, parkedSize, exiting);
+    const travelled = progress > 0 ? progress : 0;
+    return rest + (openHeight - rest) * travelled;
+}

--- a/dots/.config/quickshell/imi/tests/lint_bar_popup_overlay_static.py
+++ b/dots/.config/quickshell/imi/tests/lint_bar_popup_overlay_static.py
@@ -82,8 +82,11 @@ for transform in ("scale", "rotation"):
             f"animates {transform}; a Region does not track transforms, so the mask would "
             "stop matching the card")
 
-for axis in ("width", "height"):
-    if not re.search(rf"^\s*{axis}\s*:\s*0\b", code, re.MULTILINE):
+# The card's height is derived from the driver, so the two properties that must
+# start at and return to zero are the inputs that produce it: a zero open height
+# is zero at every progress, including one the exit's curve has undershot past.
+for axis in ("width", "openHeight"):
+    if not re.search(rf"^\s*(?:property real )?{axis}\s*:\s*0\b", code, re.MULTILINE):
         failures.append(f"the card does not start at {axis} 0")
     if not re.search(rf"\bcard\.{axis}\s*=\s*0\b", code):
         failures.append(

--- a/dots/.config/quickshell/imi/tests/lint_bar_popup_overlay_static.py
+++ b/dots/.config/quickshell/imi/tests/lint_bar_popup_overlay_static.py
@@ -28,6 +28,29 @@ Two more properties this file must keep, both from the same design:
     publishes a full-size input region and would eat every click in its
     rectangle for the rest of the session.
 
+THE DRIVER, which is the last group of checks.
+
+The card runs on ONE `real` 0 -> 1, `openProgress`. The fade rides it and so
+does the hero-height unroll, and everything else that scalar can produce is a
+binding on it rather than a second animation - a quantity carried by two
+animations is two timings that agree at rest, which is the only place anybody
+looks, and disagree exactly mid-flight. So the checks below refuse a `Behavior`
+on anything the driver already carries, refuse a second one on the driver
+itself, and require the height and the opacity to be derived from it.
+
+The height is a plain binding rather than a Behavior for a second reason: a
+Behavior whose target moves every frame restarts every frame and never ticks
+(b710ef731 ("fix(plugins): stop the position Behavior swallowing the parallax
+cancellation")). The card's bar-adjacent coordinate is a function of that
+height, so on the bottom and right edges an animated height would be exactly
+that shape.
+
+The unroll's start height is the height of the content's FIRST drawn section,
+measured through `bar_popup_unroll.js` once the content has been parented - not
+a literal and not the parked square. A literal there is the failure the whole
+technique exists to avoid: it renders, it looks deliberate, and it is wrong for
+every popup but the one it was tuned against.
+
 Run from `tests/run_tests.sh`. Prove it can fail by planting one of the banned
 forms in a clean tree.
 """
@@ -117,6 +140,114 @@ if "function onBarEdgeChanged" in code:
 
 if "readonly property string barEdge:" not in code:
     failures.append("does not derive barEdge from the config itself")
+
+# --- the one driver, and what may not be animated beside it -------------------
+
+DRIVER = "openProgress"
+
+
+def block_from(text, brace):
+    """The body of the brace block opening at `brace`."""
+    depth = 0
+    for index in range(brace, len(text)):
+        if text[index] == "{":
+            depth += 1
+        elif text[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[brace + 1:index]
+    return ""
+
+
+def block_declaring(text, ident):
+    """The body of the object declaring `id: <ident>`."""
+    marker = re.search(rf"\bid:\s*{ident}\b", text)
+    if not marker:
+        return ""
+    brace = text.rfind("{", 0, marker.start())
+    return block_from(text, brace) if brace >= 0 else ""
+
+
+# The shadow follows the card and reads its opacity, so "which opacity" has to
+# be answered by position rather than by the first match in the file.
+card = block_declaring(code, "card")
+if not card:
+    failures.append("has no `id: card` object; the whole design is one card on one surface")
+
+if not re.search(rf"^\s*property real {DRIVER}\s*:\s*0\b", code, re.MULTILINE):
+    failures.append(
+        f"declares no `property real {DRIVER}: 0`; the card's motion is one scalar and "
+        "the checks below are about what may be derived from it")
+
+behaviors = re.findall(r"Behavior\s+on\s+(\w+)", code)
+
+if behaviors.count(DRIVER) != 1:
+    failures.append(
+        f"carries {behaviors.count(DRIVER)} Behaviors on {DRIVER}; the driver is one scalar "
+        "with one transition, and a second one is a second timing that agrees only at rest")
+
+# `height` and `opacity` ARE the driver, expressed. `x` and `y` are functions of
+# the size it produces on the two far bar edges, so an animation on either is
+# the same defect one step removed.
+for derived in ("height", "opacity", "x", "y"):
+    if derived in behaviors:
+        failures.append(
+            f"animates {derived} with a Behavior; that value is derived from {DRIVER}, and "
+            f"two animations of one quantity disagree exactly mid-flight - for height it is "
+            f"also a target that moves every frame, which restarts every frame and never ticks")
+
+# A Behavior taking a bare NumberAnimation is half a motion tier: it names a
+# duration and leaves easing.type at Qt's default, which is Easing.Linear.
+for behavior in re.finditer(r"Behavior\s+on\s+\w+\s*\{", code):
+    body = block_from(code, behavior.end() - 1)
+    if re.search(r"\b(NumberAnimation|PropertyAnimation)\s*\{", body):
+        failures.append(
+            f"declares an inline animation in `{behavior.group(0).strip()}`; take the motion "
+            "tier whole through its own numberAnimation component, or the curve is whatever "
+            "Qt defaults to")
+
+if not re.search(r"numberAnimation\.createObject\(", code):
+    failures.append("takes no motion tier through its own numberAnimation component")
+
+# The height and the fade must both be the driver, spelled out. Read as whole
+# declarations rather than as lines: both are written across two lines here, and
+# a line-scoped check sees `height: BarPopupUnroll.cardHeight(` and stops.
+def declaration(text, name):
+    match = re.search(rf"^([ \t]*){name}:[ \t]*(.*(?:\n\1[ \t]+.*)*)", text, re.MULTILINE)
+    return match.group(2) if match else ""
+
+
+height_binding = declaration(card, "height")
+if "BarPopupUnroll.cardHeight(" not in height_binding or f"card.{DRIVER}" not in height_binding:
+    failures.append(
+        f"the card's height is not a binding on {DRIVER} through bar_popup_unroll.js; the "
+        "unroll and the fade must be the same scalar or they are two motions")
+
+if f"card.{DRIVER}" not in declaration(card, "opacity"):
+    failures.append(
+        f"the card's opacity is not derived from {DRIVER}; the fade rides the same progress "
+        "as the unroll")
+
+# The hero is measured, never chosen. Zeroing it is how the card is idled, so
+# the only literal allowed on that property is 0.
+if not re.search(r"card\.heroHeight\s*=\s*BarPopupUnroll\.heroSectionHeight\(", code):
+    failures.append(
+        "does not measure the unroll's start height from the content's first section; a "
+        "literal hero renders, looks deliberate, and is wrong for every popup but one")
+
+for literal in re.findall(r"card\.heroHeight\s*=\s*([0-9][\w.]*)", code):
+    if literal != "0":
+        failures.append(
+            f"assigns a literal hero height ({literal}); the card opens at the height of the "
+            "section it is showing, which only the content can answer")
+
+# Measuring the incoming content before it is parented reads a stale implicit
+# size, so the first correct target is one turn of the event loop away.
+if not re.search(r"interval:\s*0\b[\s\S]{0,120}?onTriggered:[^\n]*retarget\(\)", code):
+    failures.append(
+        "has no zero-interval retarget; an unparented content tree does not polish, so its "
+        "implicit size - and its first section's height - are stale until the turn after "
+        "the takeover")
 
 if failures:
     for failure in failures:

--- a/dots/.config/quickshell/imi/tests/test_event_loop_safety_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_event_loop_safety_contract.py
@@ -57,10 +57,20 @@ def test_popups_own_no_surface_and_share_one_static_overlay():
 
     overlay = Path("modules/imi/bar/BarPopupOverlay.qml").read_text()
     # Map through the target's window, never the overlay's own, and assign the
-    # result imperatively so the card's geometry never feeds its own input.
+    # travel imperatively so the card's geometry never feeds its own input.
+    #
+    # This used to read `card.x = cardX`, and both coordinates were assigned for
+    # one reason: on the bottom and right edges the bar-adjacent coordinate is a
+    # function of the animating size, so easing a second copy of that size puts
+    # the card's edge where its content is not. The card runs on one driver
+    # scalar now, so that coordinate is DERIVED from the size the driver already
+    # produces - which cannot drift from it and carries no Behavior of its own,
+    # so there is no chase to lose. What is still assigned is the one axis that
+    # travels, along the bar.
     assert "target.QsWindow.mapFromItem(" in overlay
     assert "overlayWindow.QsWindow" not in overlay
-    assert "card.x = cardX" in overlay and "card.width = cardWidth" in overlay
+    assert "card.alongBar = " in overlay and "card.width = cardWidth" in overlay
+    assert "card.x =" not in overlay and "card.y =" not in overlay
     assert re.search(r"Behavior\s+on\s+width", overlay)
     # An unparented content tree does not polish, so its implicit size is not
     # readable until it is in a window: measure one frame after the reparent.

--- a/dots/.config/quickshell/imi/tests/tst_bar_popup_unroll.qml
+++ b/dots/.config/quickshell/imi/tests/tst_bar_popup_unroll.qml
@@ -1,0 +1,112 @@
+import QtTest
+import "../modules/imi/bar/bar_popup_unroll.js" as BarPopupUnroll
+
+// The bar popup card's height, which is the whole of what its one driver
+// scalar produces. Nothing about the card itself is reachable from here - it
+// lives on a wlr-layer-shell surface qmltestrunner cannot build - so the
+// arithmetic is what the checks reach.
+TestCase {
+    name: "BarPopupUnrollTest"
+
+    readonly property real padding: 8
+    readonly property real parkedSize: 20
+
+    function sections(spec) {
+        // Enough of an Item for the measurement: the module reads `visible`
+        // and `height` and must read nothing else, because a section is any
+        // item a popup happens to declare first.
+        return spec.map(entry => ({ visible: entry[0], height: entry[1] }));
+    }
+
+    function test_the_hero_is_the_first_drawn_section_plus_the_card_inset() {
+        compare(BarPopupUnroll.heroSectionHeight(
+            sections([[true, 125], [true, 80], [true, 40]]), padding),
+            125 + padding * 2);
+    }
+
+    function test_an_undrawn_or_empty_leading_section_is_not_the_hero() {
+        // A spacer or a hidden row spending the first slot would open the card
+        // at the height of nothing, which is the same failure as ranking a
+        // stagger by position in `children`.
+        compare(BarPopupUnroll.heroSectionHeight(
+            sections([[false, 125], [true, 0], [true, 80]]), padding),
+            80 + padding * 2);
+    }
+
+    function test_content_with_no_measurable_section_reports_no_hero() {
+        compare(BarPopupUnroll.heroSectionHeight(sections([]), padding), 0);
+        compare(BarPopupUnroll.heroSectionHeight(
+            sections([[false, 125], [true, 0]]), padding), 0);
+        compare(BarPopupUnroll.heroSectionHeight(undefined, padding), 0);
+    }
+
+    function test_the_card_opens_at_the_hero_and_unrolls_to_the_full_height() {
+        const open = 400;
+        const hero = 141;
+        compare(BarPopupUnroll.cardHeight(open, hero, parkedSize, false, 0), hero);
+        compare(BarPopupUnroll.cardHeight(open, hero, parkedSize, false, 1), open);
+        // The unroll is exactly the progress: half way is half the distance,
+        // which is what lets the fade ride the same scalar.
+        compare(BarPopupUnroll.cardHeight(open, hero, parkedSize, false, 0.5),
+                hero + (open - hero) / 2);
+    }
+
+    function test_the_start_height_is_the_hero_rather_than_the_parked_square() {
+        // The check that reddens if the unroll is rewritten against a literal
+        // or against the floor: two different heroes must give two different
+        // starts, and neither may be the parked square.
+        const first = BarPopupUnroll.cardHeight(400, 141, parkedSize, false, 0);
+        const second = BarPopupUnroll.cardHeight(400, 232, parkedSize, false, 0);
+        compare(first, 141);
+        compare(second, 232);
+        verify(first !== parkedSize);
+        verify(second !== parkedSize);
+    }
+
+    function test_a_hero_taller_than_the_content_is_no_unroll_at_all() {
+        // A one-section popup: the hero IS the content, so rest and open
+        // coincide and the card simply has no unroll rather than a case.
+        compare(BarPopupUnroll.cardHeight(200, 260, parkedSize, false, 0), 200);
+        compare(BarPopupUnroll.cardHeight(200, 200, parkedSize, false, 0.4), 200);
+    }
+
+    function test_without_a_hero_the_card_still_grows_out_of_the_bar() {
+        compare(BarPopupUnroll.cardHeight(400, 0, parkedSize, false, 0), parkedSize);
+        compare(BarPopupUnroll.cardHeight(400, 0, parkedSize, false, 1), 400);
+    }
+
+    function test_leaving_collapses_toward_the_parked_square_not_the_hero() {
+        compare(BarPopupUnroll.cardHeight(400, 141, parkedSize, true, 0), parkedSize);
+        // The moment the exit begins the card has not moved: at a settled
+        // progress the rest height is not in the answer at all, so flipping to
+        // the exit's rest cannot make the card jump.
+        compare(BarPopupUnroll.cardHeight(400, 141, parkedSize, true, 1), 400);
+        compare(BarPopupUnroll.cardHeight(400, 141, parkedSize, false, 1), 400);
+    }
+
+    function test_an_idle_card_is_zero_tall_at_every_progress() {
+        // Load-bearing, not cosmetic: an `opacity: 0` card still publishes a
+        // full-size input region, and the overlay's surface is screen-sized and
+        // on the Overlay layer. A zero-height region is what makes Qt mark the
+        // whole surface transparent for input.
+        for (const progress of [0, 0.5, 1, -0.3, 1.2]) {
+            compare(BarPopupUnroll.cardHeight(0, 0, parkedSize, false, progress), 0);
+            compare(BarPopupUnroll.cardHeight(0, 141, parkedSize, true, progress), 0);
+        }
+    }
+
+    function test_the_exit_curve_undershooting_below_zero_does_not_invert_the_card() {
+        // expressiveDefaultSpatial overshoots past its target, so a 1 -> 0 ramp
+        // passes below 0 before settling. A negative height is a card that
+        // vanishes and comes back at the end of every exit.
+        verify(BarPopupUnroll.cardHeight(400, 141, parkedSize, true, -0.21) >= 0);
+        compare(BarPopupUnroll.cardHeight(400, 141, parkedSize, true, -0.21), parkedSize);
+    }
+
+    function test_the_overshoot_past_one_is_kept() {
+        // The other half of the same curve, and it is deliberate: the card
+        // overshooting its content and settling back is the tier's own
+        // expressiveness, and it is what the height Behavior this replaced did.
+        verify(BarPopupUnroll.cardHeight(400, 141, parkedSize, false, 1.21) > 400);
+    }
+}


### PR DESCRIPTION
Item 2 of `docs/p3drovfx-animation-research-2026-08-16.md` §3.1 — the single-scalar driver, and the hero-height unroll — for our bar popup card.

## What

`modules/imi/bar/BarPopupOverlay.qml`'s card animated four geometry properties and an opacity through five `Behavior`s, each carrying its own copy of a duration and a curve. It runs on one `real` 0 → 1 now — `card.openProgress`, with a single `Behavior` on it — and everything that scalar can produce is derived rather than animated a second time:

- **the fade IS the scalar** (`opacity: clamp(openProgress)`);
- **the height is a plain binding on it**, through the new `modules/imi/bar/bar_popup_unroll.js`, interpolating from the content's **first drawn section** to its full height;
- **the bar-adjacent coordinate is a binding on that height** (or on the width, for a side bar), which is the thing the old "assigned, never bound" comment existed to protect;
- only the coordinate **along** the bar still travels, and the exit's two chained `Timer`s become one.

## Why the unroll is the point

§3.1's payoff: the card appears **already the height of its first card** and unfurls to reveal the rest along the same progress the fade rides, instead of appearing at full height or scaling up out of nothing. The top edge never moves and the primary content is legible on frame one.

A section is measured at its **drawn** height, not its implicit one: a `Layout` child states its size through `Layout.preferredHeight` and carries no implicit height, so `implicitHeight` answers 0 for exactly the popups whose first section is a card — which is every popup this exists for. Undrawn and zero-height children are skipped, for the same reason a stagger ranks by visible position.

## Measurements

All from an isolated `qs -p` probe against the live compositor, with its own `XDG_CONFIG_HOME`/`STATE`/`CACHE` copied from the real one (the user's config was never touched — mtime unchanged). Synthetic popup: three sections 125 / 100 / 75 at `contentPadding: 8`.

**The unroll** — hero 141 (= 125 + 8×2, measured, not a literal), open 316 (= 300 + 16), height exactly the progress:

```
t=0    p=0.265 hero=141.0 open=316.0 h=187.4 op=0.27
t=40   p=0.540 hero=141.0 open=316.0 h=235.5 op=0.54
t=80   p=0.760 hero=141.0 open=316.0 h=274.0 op=0.76
t=160  p=0.988 hero=141.0 open=316.0 h=313.9 op=0.99
t=240  p=1.014 hero=141.0 open=316.0 h=318.4 op=1.00   <- the tier's own overshoot, kept
t=440  p=1.000 hero=141.0 open=316.0 h=316.0 op=1.00
```

The card is never drawn shorter than 141: the first sample is already past the hero.

**The exit**, back down the same scalar to the parked square and then to nothing — including the curve's undershoot to `p=-0.014`, which the arithmetic floors rather than inverting the card:

```
t=800  p=0.735 h=237.5 w=237.5 op=0.73
t=960  p=0.012 h=23.5  w=23.5  op=0.01
t=1040 p=-0.014 h=20.0 w=15.9  op=0.00
t=1280 p=0.000 hero=0.0 open=0.0 h=0.0 w=0.0 op=0.00   <- input region empty
```

**The far edges**, which is what the derived coordinate buys. Bottom bar — the card's bottom edge on every frame of the open, the overshoot, the settle and the exit:

```
bottom=1390.0 1390.0 1390.0 1390.0 1390.0 1390.0 1390.0 1390.0 ... (every sample)
```

Right bar — the card's right edge, same:

```
right=5064.0 5064.0 5064.0 5064.0 5064.0 ... (every sample)
```

That is exact on every frame, where the arrangement it replaces was two `Behavior`s that happened to share a curve.

## Two things the probe found that reading could not

- **A binding loop.** The window's `visible` predicate read `card.height` and `card.opacity`; those are derived now, and the card's across-the-bar coordinate is derived from the *window's* size, so the predicate closed a circle through itself — `Binding loop detected for property "visible"`, twice per window. **The control matters**: the same probe run against `main`'s assigned geometry, in a pristine `git archive` of the tree, logged nothing, so this was this change's defect and not a pre-existing one. The predicate reads the card's inputs (`openProgress`, `width`, `openHeight`) now — which is also what "collapse to 0×0 when idle" means for a derived height.
- **Centred content shows the wrong band.** A host that is shrinking centres what it holds, so the strip on screen while the card is short was the *middle* of the content — the first section, the one the card opens at the height of, would have been the one thing not visible on frame one. The content sits in a slot held at the settled height and pinned to the top of the host, which also keeps a leaving block still instead of reflowing it through every intermediate size.

## Constraints honoured

- Surface geometry is still a constant of the screen — four edges anchored, no margins, no implicit size; `lint_bar_popup_overlay_static.py` still passes on all of it.
- Motion is **geometry only**: no `scale`, no `rotation`; the mask tracks x/y/width/height and every one of those is either assigned or derived, never transformed.
- The card still collapses to 0×0 when idle, expressed as zeroing the inputs the height derives from — a zero open height answers 0 at every progress, including one the exit curve has undershot below zero.
- The zero-interval `Timer` deferral stays: an unparented content tree does not polish, so its implicit size *and its first section's height* are stale until the turn after the takeover.
- **One** `Behavior` on the driver.
- Every tier is taken **whole**, via `Appearance.animation.elementMove.numberAnimation.createObject(...)`. One tier serves both directions deliberately: Qt refuses a second write to a `Behavior`'s `animation`, so a directional pair would have to be a duration and a curve on a bare `NumberAnimation` — half a tier, and silently `Easing.Linear` the day someone drops the curve. The created objects are named properties so `morphing` can still ask whether the card is travelling, which the focus grab needs in order not to arm on a parked square.

## One existing check moved rather than being loosened

`test_event_loop_safety_contract.py` asserted `card.x = cardX`. What it protected — the card's geometry never feeding its own input — is still checked, on the axis that still travels (`card.alongBar = `), plus a new refusal of `card.x =` / `card.y =` anywhere in the file. The reasoning is written into the file in place.

## Tests

- `tests/tst_bar_popup_unroll.qml` — 12 checks over the arithmetic (the hero, the rest height, the idle floor, both ends of the curve). The card itself is unreachable from `qmltestrunner`, which cannot construct Quickshell types, and headless weston implements no wlr-layer-shell, so **no runtime harness is possible here**; the decisions are put where a test can call them, the way `ParallaxMath` and `clockDepth.js` already are.
- `tests/lint_bar_popup_overlay_static.py` — extended with the driver rules.

### Plant-proofs

Each planted in a clean tree and reverted with `git checkout -- <file>`.

`lint_bar_popup_overlay_static.py`:

```
=== second Behavior on the driver ===
  BarPopupOverlay.qml: carries 2 Behaviors on openProgress; the driver is one scalar with one transition, and a second one is a second timing that agrees only at rest
=== Behavior on height ===
  BarPopupOverlay.qml: animates height with a Behavior; that value is derived from openProgress ...
=== Behavior on opacity ===
  BarPopupOverlay.qml: animates opacity with a Behavior; that value is derived from openProgress ...
=== Behavior on x ===
  BarPopupOverlay.qml: animates x with a Behavior; that value is derived from openProgress ...
=== inline NumberAnimation in a Behavior ===
  BarPopupOverlay.qml: declares an inline animation in `Behavior on width {`; take the motion tier whole through its own numberAnimation component, or the curve is whatever Qt defaults to
=== a literal hero height ===
  BarPopupOverlay.qml: does not measure the unroll's start height from the content's first section; a literal hero renders, looks deliberate, and is wrong for every popup but one
  BarPopupOverlay.qml: assigns a literal hero height (140); the card opens at the height of the section it is showing, which only the content can answer
=== the hero stops being measured ===
  BarPopupOverlay.qml: does not measure the unroll's start height from the content's first section ...
=== height stops riding the driver ===
  BarPopupOverlay.qml: the card's height is not a binding on openProgress through bar_popup_unroll.js ...
=== opacity stops riding the driver ===
  BarPopupOverlay.qml: the card's opacity is not derived from openProgress; the fade rides the same progress as the unroll
=== the zero-interval retarget goes ===
  BarPopupOverlay.qml: has no zero-interval retarget; an unparented content tree does not polish ...
=== the card stops collapsing its open height ===
  BarPopupOverlay.qml: never collapses the card back to openHeight 0; an exited card must build an empty input region ...
=== the driver scalar goes ===
  BarPopupOverlay.qml: declares no `property real openProgress: 0` ...
```

`tst_bar_popup_unroll.qml`:

```
=== the hero reads implicitHeight instead of the drawn height ===
  FAIL!  : test_an_undrawn_or_empty_leading_section_is_not_the_hero()
  FAIL!  : test_the_hero_is_the_first_drawn_section_plus_the_card_inset()
=== an undrawn leading section becomes the hero ===
  FAIL!  : test_an_undrawn_or_empty_leading_section_is_not_the_hero()
  FAIL!  : test_content_with_no_measurable_section_reports_no_hero()
=== a zero-height leading section becomes the hero ===
  FAIL!  : test_an_undrawn_or_empty_leading_section_is_not_the_hero()
  FAIL!  : test_content_with_no_measurable_section_reports_no_hero()
=== the unroll starts from the parked square instead of the hero ===
  FAIL!  : test_a_hero_taller_than_the_content_is_no_unroll_at_all()
  FAIL!  : test_the_card_opens_at_the_hero_and_unrolls_to_the_full_height()
  FAIL!  : test_the_start_height_is_the_hero_rather_than_the_parked_square()
=== the undershoot clamp goes ===
  FAIL!  : test_the_exit_curve_undershooting_below_zero_does_not_invert_the_card()
=== the overshoot is clamped away ===
  FAIL!  : test_the_overshoot_past_one_is_kept()
=== a hero taller than the content is not clamped to it ===
  FAIL!  : test_a_hero_taller_than_the_content_is_no_unroll_at_all()
=== both idle guards and the openHeight clamp go ===
  FAIL!  : test_a_hero_taller_than_the_content_is_no_unroll_at_all()
  FAIL!  : test_an_idle_card_is_zero_tall_at_every_progress()
```

(The idle floor is enforced twice on purpose — in `restHeight()` and again in `cardHeight()` — so it takes removing both guards to redden it.)

`test_event_loop_safety_contract.py`:

```
=== the card's own x is assigned again ===
  FAIL test_popups_own_no_surface_and_share_one_static_overlay
  8/9 contract checks passed
```

## Suite

`dots/.config/quickshell/imi/tests/run_tests.sh`, run whole from the worktree, after rebasing onto current `main`:

```
Running bar popup overlay lint...
Bar popup overlay lint passed: the overlay surface's geometry is a constant
...
Running design system compile check...
  [DesignSystemCompile] checked=182 failures=0
...
Totals: 1046 passed, 0 failed, 0 skipped, 0 blacklisted, 4246ms
All tests passed successfully!
```

(exit 0. `DesignSystemCompile.qml` already names `BarPopupOverlay.qml`, so the file is proven to compile.)

## Not verified

The **appearance** of the unroll. Every number above is geometry read back off a live card; nobody has watched it, and no frame capture was taken. The repo's own rule for this area is that it is invisible to the test suite and every bug in it was found by looking at the screen — so the curve's feel, and whether the hero the automatic "first drawn section" rule picks reads as the right opening height for each of the ten real popups (the calendar's month label is a text row, not a card), are open questions a person has to answer on a deployed shell.

Changelog: updated

Docs: updated AGENT.md §Layer-shell (wlr-layer-shell) gotchas
