### PR TITLE
feat(quickToggles): a keyed model, so a dragged toggle moves instead of the grid being rebuilt

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -2236,6 +2236,44 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   0bc44f475 ("fix(dock): a dragged icon moves to where it was dropped, it does not swap"),
   52da8b43e ("fix(quickToggles): a dropped toggle moves into place instead of swapping"),
   893bfc31a ("test(lint): fail on a reorder spelled out beside a DragHandler").
+- **A drag can only be ANIMATED by a model that moves a delegate, and a row of delegates is not
+  something a model can move one between.** The Android quick toggles are the case: the panel drew a
+  `Column` of row containers, each with a plain array model, deliberately — 81379796b
+  ("fix(sidebar): choose a delegate for the toggle each row entry now holds") reset the row because
+  `DelegateChooser` picks a component when a delegate is *created* and never re-picks for one that
+  survives, so an entry that changed identity in place kept the previous toggle's icon, name and
+  action. That fix is correct and its cost is the delegate: a reorder that rebuilds every tile
+  cannot animate, because there is nothing left to move. Rows repack on nearly every edit (they are
+  packed by toggle size), so an entry crossing a row boundary left one row's model and landed in
+  another's at an index some other toggle held, which is not a move in either.
+  `modules/common/functions/quick_toggle_layout.js` answers both at once: `pack` gives every entry a
+  stable id, its toggle TYPE, a row and a slot, and `syncPlan` diffs one packed list against another
+  into the ops a `ListModel` applies. A reorder comes out as a `move`, so the delegate survives; an
+  id is derived from the type, so the role the chooser reads can never change under a surviving row;
+  and the ops the plan may emit against a live row are the PAYLOAD roles only, so no spelling in
+  `StableQuickToggleModel.qml` can retype one. A row is a coordinate now, not a container — one flat
+  `Item` per section, each tile placed at its own slot from the SETTLED pack (a placement keyed on
+  anything the press bounce moves is b710ef731's frozen `Behavior` again, so the press growth is
+  centred with a `transform` instead). The list edits the plan is simulated against are
+  `layout_ops.js`'s, for the reason the entry above gives.
+  **The half that had to be measured: a live `list<var>` notifies per ELEMENT written.** One
+  `layout_ops.moveInPlace` on the stored toggle list — the splice-out and splice-in a drop commits —
+  was observed in *nine* intermediate states, each a list with a toggle duplicated or missing, and
+  each one a plan that rebuilds rows rather than moving them. So a model synced straight from the
+  observer destroys most of the grid in the middle of the one gesture the delegates exist to
+  survive, and the panel is correct only because the sync is deferred to the end of the turn with
+  `Qt.callLater`. This was invisible until the delegates mattered: the old panel rebuilt the row on
+  every notification anyway, so it paid ten rebuilds per drop and looked right. Anything else here
+  that observes a `Config` array someone mutates in place has the same question to answer.
+  The panel is also why the observation is a SIGNATURE rather than the array: the toggles mutate
+  the live array on purpose (26b625905), so its identity never changes.
+  `tests/tst_quick_toggle_layout.qml` scores the plan's ops rather than the list they produce (a
+  rebuild produces exactly the right list), `tests/test_quick_toggle_model_contract.py` is the half
+  CI can see, and `QuickTogglesLayoutRuntimeTest.qml` compares the delegate by identity across a
+  reorder and samples its position 80ms in — a settled position is the same number whether the tile
+  animated or teleported. 8930baa3c ("feat(quickToggles): the grid's packing and its keyed diff as
+  arithmetic"), b1074b3c1 ("refactor(quickToggles): one flat keyed grid per section, placed by
+  arithmetic"), cb24f9046 ("test(quickToggles): drive the reorder the way a drop spells it").
 - **`MouseArea.drag` cannot accurately drag a target the MouseArea itself follows.** QQuickDrag
   rebases its press origin when the grab is established, silently swallowing the arming move's
   delta — a few threshold pixels under a real pointer, invisible behind the widget lattice's 12px

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ own repo; the installer pins which revision it builds.
   never lands on a live scene, and a project's mask never lands on the static
   fallback the desktop shows when the renderer gives up.
 
+### Changed
+- **Dragging a quick toggle moves it instead of redrawing the grid.** The tiles
+  the dragged one passes now slide into their new places when you drop it,
+  rather than the whole panel being rebuilt at the new order. Nothing about the
+  layout, the sizes or where a drop lands has changed — and a row now fills the
+  panel's width evenly instead of giving the leftover to whichever toggle
+  happened to be first in it.
+
 ### Fixed
 - **The motion speed slider and reduce motion now reach every animation.** Nine
   places read a motion tier's base duration instead of the scaled one, so they

--- a/dots/.config/quickshell/imi/QuickTogglesLayoutRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/QuickTogglesLayoutRuntimeTest.qml
@@ -2,6 +2,7 @@ import QtQuick
 import Quickshell
 import qs.modules.common
 import qs.modules.imi.sidebarRight.quickToggles
+import "modules/common/functions/layout_ops.js" as LayoutOps
 
 /**
  * Drives the real Android quick toggle panel through the layout edits the edit
@@ -20,6 +21,16 @@ import qs.modules.imi.sidebarRight.quickToggles
  * cases that matter are the ones that move an entry across a row boundary. A
  * same-row reorder diffs as a move and was never broken - checking only that is
  * how the first fix passed while the panel stayed scrambled.
+ *
+ * It also drives the half a keyed model added: a reorder must MOVE the tile's
+ * delegate rather than rebuild it, and the tile must be seen travelling to its
+ * new slot rather than arriving there. A settled position is what a snap and an
+ * animation agree on, so the sample is taken mid-flight.
+ *
+ * The reorder is spelled the way a drop spells it - an in-place splice of the
+ * live `Config` array (26b625905) - because that is the path the panel is
+ * observed through, and an edit that reassigns the array would exercise a
+ * trigger the user never takes.
  *
  * Launched by tests/test_quick_toggles_layout_runtime.py against a throwaway
  * XDG_CONFIG_HOME. Never point it at a real config dir - it rewrites the toggle
@@ -72,6 +83,28 @@ ShellRoot {
 
     function typeIndex(list, type) { return list.findIndex(entry => entry.type === type); }
 
+    // The rendered tile for a toggle type, as the object rather than as a
+    // description of it: whether a reorder kept the delegate is a question
+    // about identity, and every readable property survives a rebuild.
+    function tileFor(type) {
+        let found = null;
+        function walk(item) {
+            if (!item || found) return;
+            if (item.buttonData !== undefined && item.toggleModel !== undefined
+                && item.buttonData?.type === type) {
+                found = item;
+                return;
+            }
+            for (let i = 0; i < item.children.length; i++) walk(item.children[i]);
+        }
+        walk(panel);
+        return found;
+    }
+
+    property var movedTile: null
+    property real movedFromX: 0
+    property real movedMidX: 0
+
     Item {
         width: 500
         height: 400
@@ -112,12 +145,55 @@ ShellRoot {
                         harness.editToggles(list => list.push({ type: "mic", size: 2 }));
                         Qt.callLater(() => {
                             harness.verify("adding a toggle back keeps every icon");
-                            console.log(`[QuickToggles] checks: ${harness.checksRun} failures: ${harness.failures}`);
-                            Qt.exit(harness.failures === 0 ? 0 : 1);
+                            harness.startReorder();
                         });
                     });
                 });
             });
+        }
+    }
+
+    // The drop's own commit: the dragged toggle travels to the slot it was
+    // dropped on and the ones it passed shift back one.
+    function startReorder() {
+        harness.movedTile = harness.tileFor("nightLight");
+        harness.movedFromX = harness.movedTile ? harness.movedTile.x : -1;
+        harness.check("the toggle to be moved is not already in the first slot",
+                      harness.movedFromX > 0, `it starts at x ${harness.movedFromX}`);
+        const list = Config.options.sidebar.quickToggles.android.toggles;
+        LayoutOps.moveInPlace(list, harness.typeIndex(list, "nightLight"), 0);
+        Qt.callLater(() => {
+            harness.verify("a reorder keeps every icon");
+            harness.check("a reorder moves the delegate instead of rebuilding it",
+                          harness.movedTile !== null && harness.tileFor("nightLight") === harness.movedTile,
+                          "the tile at that toggle's new position is a different object");
+            midFlight.start();
+        });
+    }
+
+    Timer {
+        id: midFlight
+        interval: 80
+        onTriggered: {
+            harness.movedMidX = harness.movedTile ? harness.movedTile.x : -1;
+            settled.start();
+        }
+    }
+
+    Timer {
+        id: settled
+        interval: 600
+        onTriggered: {
+            const finalX = harness.movedTile ? harness.movedTile.x : -1;
+            harness.check("the moved tile ends up in the first slot", finalX === 0,
+                          `it settled at x ${finalX}`);
+            // A settled position is the same number whether the tile animated
+            // or teleported, so the check that can tell them apart is this one.
+            harness.check("the moved tile travels to its new slot instead of snapping",
+                          harness.movedMidX > finalX && harness.movedMidX < harness.movedFromX,
+                          `80ms in it was at x ${harness.movedMidX}, between ${finalX} and ${harness.movedFromX}`);
+            console.log(`[QuickToggles] checks: ${harness.checksRun} failures: ${harness.failures}`);
+            Qt.exit(harness.failures === 0 ? 0 : 1);
         }
     }
 }

--- a/dots/.config/quickshell/imi/modules/common/functions/quick_toggle_layout.js
+++ b/dots/.config/quickshell/imi/modules/common/functions/quick_toggle_layout.js
@@ -1,0 +1,220 @@
+.pragma library
+
+.import "layout_ops.js" as LayoutOps
+
+// What the Android quick toggle grid holds, in what order, and where each tile
+// sits - as arithmetic, so the decisions are testable and the rendering does
+// not have to be.
+//
+// Two answers live here and they are separate on purpose.
+//
+// `pack` is the grid: entries wrap into rows by size against the column count,
+// and every entry gets a stable id and a slot. `syncPlan` is the DIFF: what a
+// keyed `ListModel` must do to become that list. The second is why this file
+// exists at all. A row entry that changes IDENTITY in place keeps the delegate
+// it already had, and `DelegateChooser` picks a component when a delegate is
+// created and never re-picks for one that survives - so the panel used to show,
+// at each position, whatever toggle used to be there
+// (81379796b ("fix(sidebar): choose a delegate for the toggle each row entry
+// now holds")). That was answered by resetting the whole row, which is correct
+// and costs the delegate: a reorder that rebuilds every tile cannot animate,
+// because there is nothing left to move.
+//
+// The plan makes both true at once. A reorder comes out as a `move`, so the
+// delegate survives and can travel to its new slot; and an id is permanently
+// bound to one toggle TYPE, so the chooser can never be asked to re-pick for a
+// surviving row. A payload change (a size, a slot) is emitted only where it is
+// a real difference, so an edit that repacks nothing writes nothing.
+//
+// The list edits the plan is simulated against are `layout_ops.js`'s, not a
+// second copy: a plan that reorders one way and a call site that reorders
+// another is exactly the disagreement that module was extracted to end.
+
+// A stored size is whatever is in `config.json`, which a human edits and a
+// preset can carry. `ListModel` roles are typed from the first row inserted, so
+// a missing or non-numeric size is not a cosmetic problem - it poisons the
+// role. One place normalises it.
+function sizeOf(entry) {
+    var size = Math.round(Number(entry && entry.size));
+    return (isFinite(size) && size >= 1) ? size : 1;
+}
+
+function columnsOf(columns) {
+    var count = Math.floor(Number(columns));
+    return (isFinite(count) && count >= 1) ? count : 1;
+}
+
+// The id is the toggle's type, because the panel holds one of each - and an
+// occurrence counter behind it, because nothing enforces that. A hand-edited
+// config or an imported preset naming `network` twice would otherwise collapse
+// two rows onto one id: the second toggle would not disappear from the store,
+// only from the screen, which is the quietest failure available here.
+function idFor(type, occurrence) {
+    return occurrence === 1 ? type : type + "#" + occurrence;
+}
+
+// Rows are packed by size, so nearly every edit reflows them - which is what
+// made the delegate identity problem reach across row boundaries in the first
+// place. `layoutSlot` counts CELLS consumed before the tile in its row rather
+// than tiles, so a caller multiplies by one cell pitch and needs no running
+// total of its own.
+//
+// `sourceIndex` is the entry's index in the list handed in, not its index here.
+// The two differ whenever the source holds something unrenderable, and the call
+// sites that delete, resize and reorder write to the SOURCE - a drag that
+// committed a packed index would edit the wrong entry, silently, only in a
+// config that already had a hole in it.
+function pack(entries, columns) {
+    var cols = columnsOf(columns);
+    var packed = [];
+    var occurrences = {};
+    var row = 0;
+    var used = 0;
+
+    for (var i = 0; i < (entries ? entries.length : 0); i++) {
+        var entry = entries[i];
+        if (!entry || !entry.type) continue;
+
+        var size = sizeOf(entry);
+        // `used > 0` guards the row rather than the entry: an entry wider than
+        // the whole grid still has to be placed, and wrapping before it when
+        // nothing is in the row yet leaves an empty row above it.
+        if (used > 0 && used + size > cols) {
+            row++;
+            used = 0;
+        }
+
+        var occurrence = (occurrences[entry.type] || 0) + 1;
+        occurrences[entry.type] = occurrence;
+
+        packed.push({
+            itemId: idFor(entry.type, occurrence),
+            type: entry.type,
+            size: size,
+            layoutRow: row,
+            layoutSlot: used,
+            sourceIndex: i
+        });
+        used += size;
+    }
+
+    return packed;
+}
+
+// A cell is what is left of the grid once the gaps BETWEEN the columns are
+// taken out, and there are one fewer of those than there are columns. The panel
+// used to divide by the column count's worth of gaps and come up one gap short,
+// which never showed because each row was a `RowLayout` and the first tile in
+// it carried `Layout.fillWidth`: the leftover was silently absorbed by whichever
+// tile happened to be first, so the row filled the panel and one tile in it was
+// 8px wider than the pitch said. Placing tiles by arithmetic makes the shortfall
+// visible as a gap at the right-hand edge instead, so the pitch has to be right.
+function cellWidth(contentWidth, spacing, columns) {
+    var cols = columnsOf(columns);
+    return (contentWidth - spacing * (cols - 1)) / cols;
+}
+
+function rowCount(packed) {
+    if (!packed || packed.length === 0) return 0;
+    return packed[packed.length - 1].layoutRow + 1;
+}
+
+// Everything a row carries that is NOT its identity. The two lists are the
+// whole contract between the plan and the model: the payload is what an
+// `update` may write, and what is missing from it - `itemId` and `type` - is
+// what a surviving row may never be given.
+var PAYLOAD_ROLES = ["size", "layoutRow", "layoutSlot", "sourceIndex"];
+var IDENTITY_ROLES = ["itemId", "type"];
+
+function indexOfId(rows, itemId) {
+    for (var i = 0; i < rows.length; i++) {
+        if (rows[i].itemId === itemId) return i;
+    }
+    return -1;
+}
+
+function payloadDiffers(row, wanted) {
+    for (var i = 0; i < PAYLOAD_ROLES.length; i++) {
+        var role = PAYLOAD_ROLES[i];
+        if (row[role] !== wanted[role]) return true;
+    }
+    return false;
+}
+
+// The ops that turn `current` into `desired`, in the order a `ListModel` must
+// apply them - each index is valid at the moment its own op runs, which is why
+// the plan is built against a mirror of the model rather than against the
+// indices of either list.
+//
+// Removals go first and from the end, so an index behind one is still the index
+// the model will see. Then one pass forwards: a row that is present travels to
+// where it belongs and a row that is not is inserted there, so every index at
+// or below the cursor is settled before the cursor moves past it.
+function syncPlan(current, desired) {
+    var ops = [];
+    var mirror = (current || []).map(function (row) {
+        var copy = {};
+        IDENTITY_ROLES.concat(PAYLOAD_ROLES).forEach(function (role) {
+            copy[role] = row[role];
+        });
+        return copy;
+    });
+    var wantedList = desired || [];
+
+    var wanted = {};
+    for (var w = 0; w < wantedList.length; w++) wanted[wantedList[w].itemId] = true;
+
+    for (var i = mirror.length - 1; i >= 0; i--) {
+        if (wanted[mirror[i].itemId]) continue;
+        ops.push({ op: "remove", index: i });
+        mirror = LayoutOps.remove(mirror, i);
+    }
+
+    for (var target = 0; target < wantedList.length; target++) {
+        var entry = wantedList[target];
+        var at = indexOfId(mirror, entry.itemId);
+
+        // An id is bound to one type for the life of the row. Nothing in the
+        // panel can break that - the id is derived from the type - so reaching
+        // here means the input did, and the answer is to rebuild THIS row
+        // rather than to retype a live one: a delegate handed a new type keeps
+        // the component it was built with, which is the bug this file exists
+        // for, one row at a time instead of a whole panel.
+        if (at !== -1 && mirror[at].type !== entry.type) {
+            ops.push({ op: "remove", index: at });
+            mirror = LayoutOps.remove(mirror, at);
+            at = -1;
+        }
+
+        if (at === -1) {
+            ops.push({ op: "insert", index: target, entry: entry });
+            mirror = LayoutOps.insert(mirror, entry, target);
+            continue;
+        }
+
+        if (at !== target) {
+            ops.push({ op: "move", from: at, to: target });
+            mirror = LayoutOps.move(mirror, at, target);
+        }
+
+        if (payloadDiffers(mirror[target], entry)) {
+            ops.push({ op: "update", index: target, entry: entry });
+            mirror[target] = entry;
+        }
+    }
+
+    return ops;
+}
+
+// What the model would be after a sync, as a string. A panel observes this
+// rather than the array it came from: the quick toggles mutate the live
+// `Config` array in place (26b625905 ("Revert \"fix(sidebar): make quick toggle
+// edits actually notify\" and follow-ups")), so the identity of that array is
+// not evidence of anything, and firing on a value that changes exactly when the
+// plan would be non-empty is what makes observing it free.
+function signatureOf(entries, columns) {
+    return pack(entries, columns).map(function (entry) {
+        return entry.itemId + ":" + entry.type + ":" + entry.size + ":"
+            + entry.layoutRow + ":" + entry.layoutSlot + ":" + entry.sourceIndex;
+    }).join(",");
+}

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/quickToggles/AndroidQuickPanel.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/quickToggles/AndroidQuickPanel.qml
@@ -7,71 +7,73 @@ import Quickshell
 import Quickshell.Bluetooth
 
 import qs.modules.imi.sidebarRight.quickToggles.androidStyle
+import "../../../common/functions/quick_toggle_layout.js" as QuickToggleLayout
 
 AbstractQuickPanel {
     id: root
     property bool editMode: false
     Layout.fillWidth: true
 
-    implicitHeight: (editMode ? contentItem.implicitHeight : usedRows.implicitHeight) + root.padding * 2
+    implicitHeight: (editMode ? contentItem.implicitHeight : usedGrid.implicitHeight) + root.padding * 2
     Behavior on implicitHeight {
         animation: Appearance.animation.elementMove.numberAnimation.createObject(this)
     }
     property real spacing: Appearance.spacing.space100
     property real padding: Appearance.spacing.space100
-    readonly property real baseCellWidth: {
-        const availableWidth = root.width - (root.padding * 2) - (root.spacing * (root.columns))
-        return availableWidth / root.columns
-    }
+    readonly property real baseCellWidth: QuickToggleLayout.cellWidth(
+        root.width - root.padding * 2, root.spacing, root.columns)
     readonly property real baseCellHeight: 56
 
     readonly property list<string> availableToggleTypes: ["network", "bluetooth", "vpn", "tailscale", "phoneConnect", "idleInhibitor", "easyEffects", "nightLight", "darkMode", "cloudflareWarp", "gameMode", "screenSnip", "colorPicker", "onScreenKeyboard", "mic", "audio", "notifications", "powerProfile","musicRecognition", "antiFlashbang", "instantReplay"]
     readonly property int columns: Config.options.sidebar.quickToggles.android.columns
     readonly property list<var> toggles: Config.ready ? Config.options.sidebar.quickToggles.android.toggles : []
-    readonly property list<var> toggleRows: toggleRowsForList(toggles)
     readonly property list<var> unusedToggles: {
         const types = availableToggleTypes.filter(type => !toggles.some(toggle => (toggle && toggle.type === type)))
         return types.map(type => { return { type: type, size: 1 } })
     }
-    readonly property list<var> unusedToggleRows: toggleRowsForList(unusedToggles)
 
     property alias dropIndicator: dropIndicator
 
-    // Config and unusedToggles hand out freshly allocated entry objects on every
-    // re-evaluation. ScriptModel only reaches for objectProp once two entries are
-    // already known to differ by strict equality, so brand new objects make it
-    // report "rows 0..n changed" instead of an insert/remove/move -- and
-    // DelegateChooser never re-picks a delegate for a row that merely changed
-    // data, so every toggle after the edit point keeps the previous toggle's
-    // icon, name and action. Handing out one canonical object per (type, size)
-    // keeps identities stable so the diff, and the delegates, stay honest.
-    property var toggleEntryCache: ({})
-    function canonicalToggleEntry(entry) {
-        if (!entry) return entry;
-        const key = entry.type + " " + entry.size;
-        const cached = root.toggleEntryCache[key];
-        if (cached) return cached;
-        const fresh = { type: entry.type, size: entry.size };
-        root.toggleEntryCache[key] = fresh;
-        return fresh;
+    // The models are poked from a SIGNATURE rather than bound to the lists,
+    // because neither list can be observed by identity. The quick toggles
+    // mutate the live `Config` array in place on purpose (26b625905), so that
+    // array is the same object before and after an edit, and `unusedToggles` is
+    // the opposite problem - a fresh array of fresh objects on every
+    // re-evaluation. A string that changes exactly when a sync would do
+    // something answers both, and `sync` is idempotent, so observing generously
+    // costs a compare.
+    readonly property string usedSignature: QuickToggleLayout.signatureOf(root.toggles, root.columns)
+    readonly property string unusedSignature: QuickToggleLayout.signatureOf(root.unusedToggles, root.columns)
+    onUsedSignatureChanged: root.requestSync()
+    onUnusedSignatureChanged: root.requestSync()
+    Component.onCompleted: root.requestSync()
+
+    // ...and the sync itself waits for the turn to finish, because a live
+    // `list<var>` notifies per ELEMENT written. Measured: one
+    // `layout_ops.moveInPlace` on the stored list - the splice-out and
+    // splice-in a drop commits - was observed in nine intermediate states, each
+    // one a list with a toggle duplicated or missing, and each one a plan that
+    // removes and re-inserts rows rather than moving them. Syncing on every
+    // notification therefore destroys most of the grid's delegates in the
+    // middle of the one gesture they exist to survive; syncing once, after the
+    // stack that is mutating the array has unwound, sees the reorder the user
+    // performed and emits it as a move.
+    property bool syncPending: false
+    function requestSync() {
+        if (root.syncPending) return;
+        root.syncPending = true;
+        Qt.callLater(() => {
+            root.syncPending = false;
+            usedModel.sync(root.toggles, root.columns);
+            unusedModel.sync(root.unusedToggles, root.columns);
+        });
     }
 
-    function toggleRowsForList(togglesList) {
-        var rows = [];
-        var row = [];
-        var totalSize = 0;
-        for (var i = 0; i < togglesList.length; i++) {
-            if (!togglesList[i]) continue;
-            if (totalSize + togglesList[i].size > columns) {
-                rows.push(row);
-                row = [];
-                totalSize = 0;
-            }
-            row.push(root.canonicalToggleEntry(togglesList[i]));
-            totalSize += togglesList[i].size;
-        }
-        if (row.length > 0) rows.push(row);
-        return rows;
+    StableQuickToggleModel { id: usedModel }
+    StableQuickToggleModel { id: unusedModel }
+
+    function gridHeight(model) {
+        return model.gridRows * root.baseCellHeight + Math.max(0, model.gridRows - 1) * root.spacing;
     }
 
     Column {
@@ -82,76 +84,33 @@ AbstractQuickPanel {
         }
         spacing: Appearance.spacing.space150
 
-        Column {
-            id: usedRows
-            spacing: root.spacing
+        // One flat grid rather than a Column of row containers, because a row
+        // is not something a model can move a delegate between: an entry
+        // crossing a row boundary leaves one row's model and lands in
+        // another's, at an index some other toggle held. A row is a coordinate
+        // here, not a container.
+        Item {
+            id: usedGrid
+            width: contentItem.width
+            implicitHeight: root.gridHeight(usedModel)
 
             Repeater {
-                id: usedRowsRepeater
-                model: ScriptModel {
-                    values: Array(root.toggleRows.length)
-                }
-                delegate: ButtonGroup {
-                    id: toggleRow
-                    required property int index
-                    property var modelData: root.toggleRows[index]
-                    property int startingIndex: {
-                        const rows = root.toggleRows;
-                        let sum = 0;
-                        for (let i = 0; i < index; i++) sum += rows[i].length;
-                        return sum;
-                    }
+                model: usedModel
+                delegate: AndroidToggleDelegateChooser {
+                    editMode: root.editMode
+                    gridRef: usedGrid
+                    dropIndicatorRef: dropIndicator
+                    isUnused: false
+                    baseCellWidth: root.baseCellWidth
+                    baseCellHeight: root.baseCellHeight
                     spacing: root.spacing
-
-                    Repeater {
-                        // A plain array, deliberately, not a ScriptModel.
-                        //
-                        // DelegateChooser picks a component when a delegate is
-                        // *created* and never re-picks for one that survives.
-                        // ScriptModel exists to keep delegates alive across
-                        // model updates, so the two together mean a row entry
-                        // that changes identity in place keeps the previous
-                        // toggle's component - and therefore its QuickToggleModel,
-                        // icon, name and action - while showing the new entry's
-                        // data. A plain array model resets the Repeater instead,
-                        // so every entry gets a delegate chosen for the type it
-                        // actually holds.
-                        //
-                        // Keeping the identities stable (canonicalToggleEntry
-                        // above) is not enough on its own and was the earlier,
-                        // incomplete fix: it makes a *reorder within one row*
-                        // diff as a move, which is correct, but rows are laid
-                        // out by size and nearly every edit reflows them. Once
-                        // an entry crosses a row boundary it leaves one row's
-                        // model and lands in another's at some index that was
-                        // occupied by something else, which is not a move in
-                        // either model - so the stale-component case survived
-                        // and only pure same-row swaps looked fixed.
-                        //
-                        // The cost is that a layout edit recreates the row's
-                        // delegates. That is fine here: this model changes only
-                        // when the layout does, not when a toggle turns on or
-                        // off, and layout edits are deliberate user actions in
-                        // edit mode.
-                        model: toggleRow?.modelData ?? []
-                        delegate: AndroidToggleDelegateChooser {
-                            startingIndex: toggleRow.startingIndex
-                            editMode: root.editMode
-                            gridRef: usedRows
-                            dropIndicatorRef: dropIndicator
-                            isUnused: false
-                            baseCellWidth: root.baseCellWidth
-                            baseCellHeight: root.baseCellHeight
-                            spacing: root.spacing
-                            onOpenAudioOutputDialog: root.openAudioOutputDialog()
-                            onOpenAudioInputDialog: root.openAudioInputDialog()
-                            onOpenBluetoothDialog: root.openBluetoothDialog()
-                            onOpenNightLightDialog: root.openNightLightDialog()
-                            onOpenWifiDialog: root.openWifiDialog()
-                            onOpenTailscaleDialog: root.openTailscaleDialog()
-                            onOpenPhoneConnectDialog: root.openPhoneConnectDialog()
-                        }
-                    }
+                    onOpenAudioOutputDialog: root.openAudioOutputDialog()
+                    onOpenAudioInputDialog: root.openAudioInputDialog()
+                    onOpenBluetoothDialog: root.openBluetoothDialog()
+                    onOpenNightLightDialog: root.openNightLightDialog()
+                    onOpenWifiDialog: root.openWifiDialog()
+                    onOpenTailscaleDialog: root.openTailscaleDialog()
+                    onOpenPhoneConnectDialog: root.openPhoneConnectDialog()
                 }
             }
 
@@ -199,33 +158,20 @@ AbstractQuickPanel {
 
         FadeLoader {
             shown: root.editMode
-            sourceComponent: Column {
-                id: unusedRows
-                spacing: root.spacing
+            sourceComponent: Item {
+                id: unusedGrid
+                width: contentItem.width
+                implicitHeight: root.gridHeight(unusedModel)
 
                 Repeater {
-                    model: ScriptModel {
-                        values: Array(root.unusedToggleRows.length)
-                    }
-                    delegate: ButtonGroup {
-                        id: unusedToggleRow
-                        required property int index
-                        property var modelData: root.unusedToggleRows[index]
+                    model: unusedModel
+                    delegate: AndroidToggleDelegateChooser {
+                        editMode: root.editMode
+                        gridRef: unusedGrid
+                        isUnused: true
+                        baseCellWidth: root.baseCellWidth
+                        baseCellHeight: root.baseCellHeight
                         spacing: root.spacing
-
-                        Repeater {
-                            // A plain array, for the reason spelled out on the
-                            // used-rows Repeater above.
-                            model: unusedToggleRow?.modelData ?? []
-                            delegate: AndroidToggleDelegateChooser {
-                                startingIndex: -1
-                                editMode: root.editMode
-                                isUnused: true
-                                baseCellWidth: root.baseCellWidth
-                                baseCellHeight: root.baseCellHeight
-                                spacing: root.spacing
-                            }
-                        }
                     }
                 }
             }
@@ -233,7 +179,7 @@ AbstractQuickPanel {
 
         ConfigSpinBox {
             visible: root.editMode
-            width: parent.width 
+            width: parent.width
             enabled: Config.options.sidebar.quickToggles.style === "android"
             icon: "add_column_left"
             text: Translation.tr("Columns")

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/quickToggles/androidStyle/AndroidQuickToggleButton.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/quickToggles/androidStyle/AndroidQuickToggleButton.qml
@@ -51,6 +51,30 @@ GroupButton {
         animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
     }
 
+    // The grid is one flat container and a tile places itself in it, so a
+    // reorder is a delegate travelling to another slot rather than a row of
+    // delegates being rebuilt. Both terms come from the SETTLED pack - a slot
+    // counts the cells consumed before this tile, never a neighbour's live
+    // width - so the Behaviors have a target that rests between edits. Keyed
+    // on anything the press bounce moves they would restart every frame and
+    // never tick at all (b710ef731).
+    x: (root.buttonData?.layoutSlot ?? 0) * (root.baseCellWidth + root.cellSpacing)
+    y: (root.buttonData?.layoutRow ?? 0) * (root.baseCellHeight + root.cellSpacing)
+    Behavior on x {
+        animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
+    }
+    Behavior on y {
+        animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
+    }
+
+    // The press bounce widens the tile while its slot stays where it is, so
+    // left alone the tile would grow into whatever sits to its right. A
+    // transform is not `x`: it composes after placement, so it may move every
+    // frame without reaching the Behavior above.
+    transform: Translate {
+        x: -(root.width - root.baseWidth) / 2
+    }
+
     enabled: available || editMode
     padding: Appearance.spacing.space100
     horizontalPadding: padding
@@ -164,30 +188,29 @@ GroupButton {
             id: dragHandler
             target: null
 
+            // Every tile is a direct child of the one flat grid now, so this is
+            // a filter rather than a walk. The drop indicator and the Repeater
+            // itself are children too; a tile is what carries buttonData.
             function getAllSiblings() {
                 const siblings = [];
                 if (!root.gridRef) return siblings;
-                for (let r = 0; r < root.gridRef.children.length; r++) {
-                    const row = root.gridRef.children[r];
-                    if (!row || !row.visible) continue;
-                    const rowLayout = row.children[0];
-                    if (!rowLayout) continue;
-                    for (let c = 0; c < rowLayout.children.length; c++) {
-                        const sib = rowLayout.children[c];
-                        if (!sib || !sib.visible || !sib.buttonData) continue;
-                        siblings.push(sib);
-                    }
+                for (let i = 0; i < root.gridRef.children.length; i++) {
+                    const sib = root.gridRef.children[i];
+                    if (!sib || !sib.visible || !sib.buttonData) continue;
+                    siblings.push(sib);
                 }
                 return siblings;
             }
 
             // The dragged tile is a hole rather than a candidate: it stays
             // where it was laid out for the whole gesture, so it would be its
-            // own nearest neighbour.
+            // own nearest neighbour. Compared by id rather than by type,
+            // because a config naming one type twice would otherwise punch two
+            // holes and leave the drag unable to reach either.
             function findNearest(sceneX, sceneY) {
                 const siblings = getAllSiblings();
                 const centres = siblings.map(sib =>
-                    sib.buttonData.type === root.buttonData.type
+                    sib.buttonData.itemId === root.buttonData.itemId
                         ? null
                         : sib.mapToItem(null, sib.width / 2, sib.height / 2));
                 const nearest = LayoutOps.indexAt(centres, Qt.point(sceneX, sceneY), null);
@@ -204,10 +227,12 @@ GroupButton {
                     const nearest = findNearest(sceneX, sceneY);
                     if (nearest) {
                         const toggleList = Config.options.sidebar.quickToggles.android.toggles;
-                        const myType = root.buttonData.type;
-                        const sibType = nearest.buttonData.type;
-                        const myIdx = toggleList.findIndex(t => t.type === myType);
-                        const sibIdx = toggleList.findIndex(t => t.type === sibType);
+                        // The model carries each row's index in the stored
+                        // list, so the commit addresses the entry the tile was
+                        // built from. Looking it up by type again asks a
+                        // question the list may answer twice.
+                        const myIdx = root.buttonIndex;
+                        const sibIdx = nearest.buttonIndex;
                         // Mutated in place, deliberately: 26b625905 measured
                         // that every mutation form notifies and reverted the
                         // copy-and-reassign indirection added on the belief
@@ -298,9 +323,8 @@ GroupButton {
             cursorShape: Qt.PointingHandCursor
             onClicked: {
                 const toggleList = Config.options.sidebar.quickToggles.android.toggles;
-                const buttonType = root.buttonData.type;
-                const idx = toggleList.findIndex(t => t.type === buttonType);
-                if (idx !== -1) toggleList.splice(idx, 1);
+                if (root.buttonIndex >= 0 && root.buttonIndex < toggleList.length)
+                    toggleList.splice(root.buttonIndex, 1);
             }
         }
     }
@@ -357,9 +381,8 @@ GroupButton {
                 const newSize = Math.max(1, Math.min(3, pressSize + steps));
                 if (newSize !== root.cellSize) {
                     const toggleList = Config.options.sidebar.quickToggles.android.toggles;
-                    const buttonType = root.buttonData.type;
-                    const idx = toggleList.findIndex(t => t.type === buttonType);
-                    if (idx !== -1) toggleList[idx].size = newSize;
+                    if (root.buttonIndex >= 0 && root.buttonIndex < toggleList.length)
+                        toggleList[root.buttonIndex].size = newSize;
                 }
             }
         }

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/quickToggles/androidStyle/AndroidToggleDelegateChooser.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/quickToggles/androidStyle/AndroidToggleDelegateChooser.qml
@@ -13,7 +13,6 @@ DelegateChooser {
     required property real baseCellWidth
     required property real baseCellHeight
     required property real spacing
-    required property int startingIndex
     property var dropIndicatorRef: null 
     property bool isUnused: false
     property var gridRef: null 
@@ -25,12 +24,17 @@ DelegateChooser {
     signal openTailscaleDialog()
     signal openPhoneConnectDialog()
 
+    // The role a choice is picked by is the one `StableQuickToggleModel`
+    // binds permanently to a row's id, and it is the whole reason a delegate
+    // may be reused across a reorder: a chooser reading anything a surviving
+    // row can be rewritten with is a delegate left showing the toggle that
+    // used to be in that slot.
     role: "type"
 
     DelegateChoice { roleValue: "antiFlashbang"; AndroidAntiFlashbangToggle {
         required property int index
         required property var modelData
-        buttonIndex: root.startingIndex + index
+        buttonIndex: modelData.sourceIndex
         buttonData: modelData
         editMode: root.editMode
         gridRef: root.gridRef
@@ -47,7 +51,7 @@ DelegateChooser {
     DelegateChoice { roleValue: "instantReplay"; AndroidInstantReplayToggle {
         required property int index
         required property var modelData
-        buttonIndex: root.startingIndex + index
+        buttonIndex: modelData.sourceIndex
         buttonData: modelData
         editMode: root.editMode
         gridRef: root.gridRef
@@ -63,7 +67,7 @@ DelegateChooser {
     DelegateChoice { roleValue: "audio"; AndroidAudioToggle {
         required property int index
         required property var modelData
-        buttonIndex: root.startingIndex + index
+        buttonIndex: modelData.sourceIndex
         buttonData: modelData
         editMode: root.editMode
         gridRef: root.gridRef
@@ -80,7 +84,7 @@ DelegateChooser {
     DelegateChoice { roleValue: "bluetooth"; AndroidBluetoothToggle {
         required property int index
         required property var modelData
-        buttonIndex: root.startingIndex + index
+        buttonIndex: modelData.sourceIndex
         buttonData: modelData
         editMode: root.editMode
         gridRef: root.gridRef
@@ -97,7 +101,7 @@ DelegateChooser {
     DelegateChoice { roleValue: "tailscale"; AndroidTailscaleToggle {
         required property int index
         required property var modelData
-        buttonIndex: root.startingIndex + index
+        buttonIndex: modelData.sourceIndex
         buttonData: modelData
         editMode: root.editMode
         gridRef: root.gridRef
@@ -114,7 +118,7 @@ DelegateChooser {
     DelegateChoice { roleValue: "phoneConnect"; AndroidPhoneConnectToggle {
         required property int index
         required property var modelData
-        buttonIndex: root.startingIndex + index
+        buttonIndex: modelData.sourceIndex
         buttonData: modelData
         editMode: root.editMode
         gridRef: root.gridRef
@@ -131,7 +135,7 @@ DelegateChooser {
     DelegateChoice { roleValue: "vpn"; AndroidVpnToggle {
         required property int index
         required property var modelData
-        buttonIndex: root.startingIndex + index
+        buttonIndex: modelData.sourceIndex
         buttonData: modelData
         editMode: root.editMode
         gridRef: root.gridRef
@@ -147,7 +151,7 @@ DelegateChooser {
     DelegateChoice { roleValue: "cloudflareWarp"; AndroidCloudflareWarpToggle {
         required property int index
         required property var modelData
-        buttonIndex: root.startingIndex + index
+        buttonIndex: modelData.sourceIndex
         buttonData: modelData
         editMode: root.editMode
         gridRef: root.gridRef
@@ -163,7 +167,7 @@ DelegateChooser {
     DelegateChoice { roleValue: "colorPicker"; AndroidColorPickerToggle {
         required property int index
         required property var modelData
-        buttonIndex: root.startingIndex + index
+        buttonIndex: modelData.sourceIndex
         buttonData: modelData
         editMode: root.editMode
         gridRef: root.gridRef
@@ -179,7 +183,7 @@ DelegateChooser {
     DelegateChoice { roleValue: "darkMode"; AndroidDarkModeToggle {
         required property int index
         required property var modelData
-        buttonIndex: root.startingIndex + index
+        buttonIndex: modelData.sourceIndex
         buttonData: modelData
         editMode: root.editMode
         gridRef: root.gridRef
@@ -195,7 +199,7 @@ DelegateChooser {
     DelegateChoice { roleValue: "easyEffects"; AndroidEasyEffectsToggle {
         required property int index
         required property var modelData
-        buttonIndex: root.startingIndex + index
+        buttonIndex: modelData.sourceIndex
         buttonData: modelData
         editMode: root.editMode
         gridRef: root.gridRef
@@ -211,7 +215,7 @@ DelegateChooser {
     DelegateChoice { roleValue: "gameMode"; AndroidGameModeToggle {
         required property int index
         required property var modelData
-        buttonIndex: root.startingIndex + index
+        buttonIndex: modelData.sourceIndex
         buttonData: modelData
         editMode: root.editMode
         gridRef: root.gridRef
@@ -227,7 +231,7 @@ DelegateChooser {
     DelegateChoice { roleValue: "idleInhibitor"; AndroidIdleInhibitorToggle {
         required property int index
         required property var modelData
-        buttonIndex: root.startingIndex + index
+        buttonIndex: modelData.sourceIndex
         buttonData: modelData
         editMode: root.editMode
         gridRef: root.gridRef
@@ -243,7 +247,7 @@ DelegateChooser {
     DelegateChoice { roleValue: "mic"; AndroidMicToggle {
         required property int index
         required property var modelData
-        buttonIndex: root.startingIndex + index
+        buttonIndex: modelData.sourceIndex
         buttonData: modelData
         editMode: root.editMode
         gridRef: root.gridRef
@@ -260,7 +264,7 @@ DelegateChooser {
     DelegateChoice { roleValue: "musicRecognition"; AndroidMusicRecognition {
         required property int index
         required property var modelData
-        buttonIndex: root.startingIndex + index
+        buttonIndex: modelData.sourceIndex
         buttonData: modelData
         editMode: root.editMode
         gridRef: root.gridRef
@@ -276,7 +280,7 @@ DelegateChooser {
     DelegateChoice { roleValue: "network"; AndroidNetworkToggle {
         required property int index
         required property var modelData
-        buttonIndex: root.startingIndex + index
+        buttonIndex: modelData.sourceIndex
         buttonData: modelData
         editMode: root.editMode
         gridRef: root.gridRef
@@ -293,7 +297,7 @@ DelegateChooser {
     DelegateChoice { roleValue: "nightLight"; AndroidNightLightToggle {
         required property int index
         required property var modelData
-        buttonIndex: root.startingIndex + index
+        buttonIndex: modelData.sourceIndex
         buttonData: modelData
         editMode: root.editMode
         gridRef: root.gridRef
@@ -310,7 +314,7 @@ DelegateChooser {
     DelegateChoice { roleValue: "notifications"; AndroidNotificationToggle {
         required property int index
         required property var modelData
-        buttonIndex: root.startingIndex + index
+        buttonIndex: modelData.sourceIndex
         buttonData: modelData
         editMode: root.editMode
         gridRef: root.gridRef
@@ -326,7 +330,7 @@ DelegateChooser {
     DelegateChoice { roleValue: "onScreenKeyboard"; AndroidOnScreenKeyboardToggle {
         required property int index
         required property var modelData
-        buttonIndex: root.startingIndex + index
+        buttonIndex: modelData.sourceIndex
         buttonData: modelData
         editMode: root.editMode
         gridRef: root.gridRef
@@ -342,7 +346,7 @@ DelegateChooser {
     DelegateChoice { roleValue: "powerProfile"; AndroidPowerProfileToggle {
         required property int index
         required property var modelData
-        buttonIndex: root.startingIndex + index
+        buttonIndex: modelData.sourceIndex
         buttonData: modelData
         editMode: root.editMode
         gridRef: root.gridRef
@@ -358,7 +362,7 @@ DelegateChooser {
     DelegateChoice { roleValue: "screenSnip"; AndroidScreenSnipToggle {
         required property int index
         required property var modelData
-        buttonIndex: root.startingIndex + index
+        buttonIndex: modelData.sourceIndex
         buttonData: modelData
         editMode: root.editMode
         gridRef: root.gridRef

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/quickToggles/androidStyle/StableQuickToggleModel.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/quickToggles/androidStyle/StableQuickToggleModel.qml
@@ -1,0 +1,49 @@
+import QtQuick
+import "../../../../common/functions/quick_toggle_layout.js" as QuickToggleLayout
+
+/**
+ * The Android quick toggle grid's rows, keyed by a stable id.
+ *
+ * The panel used to hand each row of the grid a plain JS array, so every layout
+ * edit reset that row's `Repeater` and rebuilt its delegates. That is what kept
+ * `DelegateChooser` honest (81379796b ("fix(sidebar): choose a delegate for the
+ * toggle each row entry now holds")) and it is also why a reorder could not
+ * animate: the tile the user dragged is destroyed at the moment it should be
+ * travelling.
+ *
+ * This keeps the delegates and gets the same guarantee from the other side. A
+ * reorder is emitted as a real `move`, so the delegate is reused; a row's id is
+ * derived from its toggle type, so the role the chooser reads never changes
+ * under a surviving delegate; and `update` may write only the payload roles, so
+ * there is no spelling here that could retype a live row even by accident.
+ *
+ * `sync` is the only writer, it is idempotent, and the arithmetic behind it is
+ * in `quick_toggle_layout.js` - this file owns nothing but the model's
+ * lifetime.
+ */
+ListModel {
+    id: root
+
+    // Rows, not tiles: the grid packs by size, so this is a function of the
+    // toggle sizes and the column count rather than of the number of entries.
+    property int gridRows: 0
+
+    function sync(entries, columns) {
+        const desired = QuickToggleLayout.pack(entries, columns);
+
+        const current = [];
+        for (let i = 0; i < root.count; i++) current.push(root.get(i));
+
+        for (const op of QuickToggleLayout.syncPlan(current, desired)) {
+            if (op.op === "remove") root.remove(op.index, 1);
+            else if (op.op === "insert") root.insert(op.index, op.entry);
+            else if (op.op === "move") root.move(op.from, op.to, 1);
+            else if (op.op === "update") {
+                for (const role of QuickToggleLayout.PAYLOAD_ROLES)
+                    root.setProperty(op.index, role, op.entry[role]);
+            }
+        }
+
+        root.gridRows = QuickToggleLayout.rowCount(desired);
+    }
+}

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -929,6 +929,14 @@ if ! python3 "$SCRIPT_DIR/test_sddm_theme_source.py"; then
     exit 1
 fi
 
+# The CI-visible half of the quick toggle grid's delegate rules: the runtime
+# harness below needs a Wayland session and skips where these would be undone.
+echo "Running quick toggle model contract tests..."
+if ! python3 "$SCRIPT_DIR/test_quick_toggle_model_contract.py"; then
+    echo "Quick toggle model contract tests failed."
+    exit 1
+fi
+
 # Renders the real quick toggle panel and performs the layout edits edit mode
 # performs. The failure is invisible in the config and a restart hides it, so
 # it needs a real shell rather than a unit test. See the module docstring.

--- a/dots/.config/quickshell/imi/tests/test_quick_toggle_model_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_quick_toggle_model_contract.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Source contract: what keeps the quick toggle grid's delegates alive.
+
+`tests/tst_quick_toggle_layout.qml` scores the arithmetic and
+`QuickTogglesLayoutRuntimeTest.qml` drives the real panel, but the second needs
+a Wayland session and skips in CI - which is exactly where the three rules below
+would be undone quietly, because every one of them fails by being SILENT. A
+delegate rebuilt where it should have moved renders the right grid; a chooser
+keyed on a rewritable role renders the wrong toggle only after an edit; and a
+sync that runs per notification renders correctly a fraction of a second after
+destroying the tile the user was dragging.
+
+Each rule is a thing this branch measured rather than a preference:
+
+  * the chooser picks on an IDENTITY role, because `DelegateChooser` never
+    re-picks for a delegate it can keep (81379796b);
+  * the model writes only PAYLOAD roles, so no spelling in it can retype a live
+    row;
+  * the panel syncs once per turn, because a live `list<var>` notifies per
+    element written - one `moveInPlace` on the stored list was observed in nine
+    intermediate states, each a list with a toggle duplicated or missing.
+"""
+from pathlib import Path
+import re
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+PANEL = ROOT / "modules/imi/sidebarRight/quickToggles/AndroidQuickPanel.qml"
+CHOOSER = ROOT / "modules/imi/sidebarRight/quickToggles/androidStyle/AndroidToggleDelegateChooser.qml"
+MODEL = ROOT / "modules/imi/sidebarRight/quickToggles/androidStyle/StableQuickToggleModel.qml"
+ARITHMETIC = ROOT / "modules/common/functions/quick_toggle_layout.js"
+
+ROLE_LIST = re.compile(r'var (?P<name>PAYLOAD_ROLES|IDENTITY_ROLES) = \[(?P<body>[^\]]*)\]')
+SET_PROPERTY = re.compile(r'setProperty\s*\([^,]+,\s*(?P<role>[^,]+),')
+CHOOSER_ROLE = re.compile(r'^\s*role:\s*"(?P<role>[^"]+)"', re.MULTILINE)
+REPEATER_MODEL = re.compile(r'Repeater\s*\{\s*(?:\n\s*)?model:\s*(?P<model>\S+)')
+
+
+def roles(name):
+    body = ARITHMETIC.read_text(encoding="utf-8")
+    match = next(m for m in ROLE_LIST.finditer(body) if m.group("name") == name)
+    return [entry.strip().strip('"') for entry in match.group("body").split(",") if entry.strip()]
+
+
+def test_the_role_lists_parse():
+    # Everything below reads these two lists, so a rename that made them
+    # unparseable would turn the whole module green over nothing.
+    assert roles("PAYLOAD_ROLES"), "PAYLOAD_ROLES parsed to nothing"
+    assert roles("IDENTITY_ROLES"), "IDENTITY_ROLES parsed to nothing"
+    assert not set(roles("PAYLOAD_ROLES")) & set(roles("IDENTITY_ROLES")), \
+        "a role is both identity and payload, so an update may rewrite it"
+
+
+def test_the_chooser_picks_on_a_role_a_surviving_row_cannot_be_given():
+    """A delegate that survives a model update keeps the component it was built
+    with. That is only safe while the role the chooser picked it by is one the
+    plan never writes - key it on a payload role and every resize hands the
+    surviving delegate a new answer it will not act on."""
+    role = CHOOSER_ROLE.search(CHOOSER.read_text(encoding="utf-8"))
+    assert role, f"{CHOOSER.name} declares no chooser role"
+    assert role.group("role") in roles("IDENTITY_ROLES"), (
+        f"{CHOOSER.name} picks a delegate by \"{role.group('role')}\", which "
+        f"quick_toggle_layout.js may rewrite on a live row")
+
+
+def test_the_model_writes_no_identity_role():
+    """The one thing this model may not do, written so that it cannot: the
+    update branch iterates PAYLOAD_ROLES, so there is no list in this file for
+    an identity role to be added to by someone extending it."""
+    body = MODEL.read_text(encoding="utf-8")
+    for call in SET_PROPERTY.finditer(body):
+        role = call.group("role").strip()
+        assert role.startswith("role") or "PAYLOAD_ROLES" in role, (
+            f"{MODEL.name} writes {role} by name; a role written by name is one "
+            f"an identity role can be added beside")
+    for identity in roles("IDENTITY_ROLES"):
+        assert f'"{identity}"' not in body, (
+            f"{MODEL.name} names the identity role \"{identity}\"; the only "
+            f"place a row may be given one is an insert")
+
+
+def test_the_grid_is_one_flat_keyed_model_per_section():
+    """A per-row model cannot move a delegate between rows, and rows repack on
+    nearly every edit - which is how the original scrambling reached across row
+    boundaries. Both sections of the panel therefore draw from one keyed model
+    each, and a nested Repeater over a row's contents is the shape that would
+    bring the old behaviour back."""
+    body = PANEL.read_text(encoding="utf-8")
+    models = [match.group("model") for match in REPEATER_MODEL.finditer(body)]
+    assert models == ["usedModel", "unusedModel"], (
+        f"the panel's Repeaters draw from {models}, expected one "
+        f"StableQuickToggleModel per section")
+    for name in models:
+        assert re.search(rf'StableQuickToggleModel\s*\{{\s*id:\s*{name}\b', body), (
+            f"{name} is not a StableQuickToggleModel")
+
+
+def test_the_panel_syncs_once_per_turn_and_not_per_notification():
+    """A live `list<var>` notifies per element written, so the splice-out and
+    splice-in a drop commits is observable in its intermediate states - lists
+    with a toggle duplicated or missing, each of which plans a rebuild rather
+    than a move. Syncing straight from the observer therefore destroys most of
+    the grid in the middle of the gesture the delegates exist to survive."""
+    body = PANEL.read_text(encoding="utf-8")
+    for handler in re.finditer(r'^\s*on(Used|Unused)SignatureChanged:(?P<body>.*)$',
+                               body, re.MULTILINE):
+        assert "requestSync" in handler.group("body"), (
+            "a signature handler syncs a model directly; it must go through "
+            "requestSync, which coalesces the turn")
+    assert re.search(r'function requestSync\(\)[^}]*Qt\.callLater', body, re.DOTALL), (
+        "requestSync no longer defers the sync to the end of the turn")
+
+
+if __name__ == "__main__":
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from contract_runner import run
+    sys.exit(run(globals()))

--- a/dots/.config/quickshell/imi/tests/test_quick_toggles_layout_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_quick_toggles_layout_runtime.py
@@ -20,6 +20,12 @@ that goes unnoticed. A same-row reorder diffs as a move and was never broken -
 covering only that is how the first attempt at this fix passed while the panel
 stayed scrambled.
 
+The same harness scores what the keyed model added on top of that: a reorder
+must MOVE the tile's delegate, and the tile must be caught travelling to its new
+slot rather than found already in it. A settled position is the same number
+whether the tile animated or teleported, so the sample that can tell them apart
+is taken mid-flight.
+
 Needs a Wayland session and `qs` on PATH, so it skips in CI like the other
 runtime harnesses.
 """
@@ -40,7 +46,7 @@ SHIPPED_DEFAULT = ROOT / "defaults/config.json"
 # The harness prints how many checks it ran. This number is a literal rather
 # than anything read back from that output: a harness whose step list shrinks
 # must redden here instead of reporting `failures: 0` for a shorter run.
-EXPECTED_CHECKS = 6
+EXPECTED_CHECKS = 11
 
 
 def _runtime_available():

--- a/dots/.config/quickshell/imi/tests/tst_quick_toggle_layout.qml
+++ b/dots/.config/quickshell/imi/tests/tst_quick_toggle_layout.qml
@@ -1,0 +1,259 @@
+import QtTest
+import "../modules/common/functions/quick_toggle_layout.js" as QuickToggleLayout
+
+// The Android quick toggle grid, as the two decisions behind it: where a tile
+// sits, and what a keyed model must DO to become the list it is handed.
+//
+// The second is the one worth testing hardest. A reorder that comes out as a
+// remove and an insert is a correct list and a destroyed delegate, which is
+// indistinguishable from a move in every assertion about the model's contents -
+// so most of what is checked here is the ops themselves, not the answer they
+// produce.
+TestCase {
+    name: "QuickToggleLayoutTest"
+
+    function entries(spec) {
+        return spec.map(pair => ({ type: pair[0], size: pair[1] }));
+    }
+
+    function ids(packed) {
+        return packed.map(entry => entry.itemId).join(",");
+    }
+
+    function opNames(ops) {
+        return ops.map(op => op.op).join(",");
+    }
+
+    // What a ListModel would hold after applying the plan, so a plan can be
+    // scored against the list it claims to produce rather than only against the
+    // ops someone expected to see.
+    function applied(current, ops) {
+        let rows = current.slice();
+        for (const op of ops) {
+            if (op.op === "remove") rows.splice(op.index, 1);
+            else if (op.op === "insert") rows.splice(op.index, 0, op.entry);
+            else if (op.op === "move") rows.splice(op.to, 0, rows.splice(op.from, 1)[0]);
+            else if (op.op === "update") rows[op.index] = op.entry;
+        }
+        return rows;
+    }
+
+    function compareRows(rows, expected, message) {
+        compare(rows.length, expected.length, message + " (length)");
+        for (let i = 0; i < expected.length; i++) {
+            for (const role of ["itemId", "type", "size", "layoutRow", "layoutSlot", "sourceIndex"])
+                compare(rows[i][role], expected[i][role],
+                        message + " (row " + i + " " + role + ")");
+        }
+    }
+
+    function test_a_row_takes_as_many_cells_as_the_column_count() {
+        const packed = QuickToggleLayout.pack(
+            entries([["network", 2], ["idleInhibitor", 1], ["bluetooth", 2],
+                     ["audio", 2], ["mic", 1], ["nightLight", 2]]), 5);
+        compare(packed.map(entry => entry.layoutRow).join(","), "0,0,0,1,1,1");
+        // A slot counts CELLS consumed before the tile, not tiles: the third
+        // entry of a row that already holds a double and a single starts at 3.
+        compare(packed.map(entry => entry.layoutSlot).join(","), "0,2,3,0,2,3");
+        compare(QuickToggleLayout.rowCount(packed), 2);
+    }
+
+    function test_a_full_row_of_cells_fills_the_grid_exactly() {
+        // There is one fewer gap than there are columns. Dividing by the column
+        // count's worth of gaps leaves a row one gap short of the panel, which
+        // is invisible under a RowLayout - `Layout.fillWidth` hands the
+        // shortfall to whichever tile is first - and is a gap at the right-hand
+        // edge once tiles are placed by arithmetic.
+        const contentWidth = 484;
+        const spacing = 8;
+        for (const columns of [1, 2, 5, 8]) {
+            const cell = QuickToggleLayout.cellWidth(contentWidth, spacing, columns);
+            fuzzyCompare(cell * columns + spacing * (columns - 1), contentWidth, 0.0001,
+                         "a full row of " + columns + " cells does not fill the grid");
+        }
+    }
+
+    function test_an_entry_wider_than_the_grid_leaves_no_empty_row_above_it() {
+        // Wrapping is a question about the ROW, not about the entry: an entry
+        // that cannot fit anywhere still has to be placed, and wrapping before
+        // it while the row is empty puts a row of nothing above it.
+        const packed = QuickToggleLayout.pack(
+            entries([["network", 3], ["mic", 1]]), 2);
+        compare(packed[0].layoutRow, 0);
+        compare(packed[0].layoutSlot, 0);
+        compare(packed[1].layoutRow, 1);
+        compare(QuickToggleLayout.rowCount(packed), 2);
+    }
+
+    function test_an_unusable_entry_is_skipped_and_the_stored_index_survives_it() {
+        // The call sites that delete, resize and reorder write to the stored
+        // list, so a packed entry has to carry where it came from - a hole in
+        // the source is the case where the two framings come apart, and it is
+        // reachable from a hand-edited config.
+        const packed = QuickToggleLayout.pack(
+            [{ type: "network", size: 1 }, null, { type: "mic", size: 1 }], 4);
+        compare(packed.length, 2);
+        compare(packed.map(entry => entry.sourceIndex).join(","), "0,2");
+    }
+
+    function test_a_size_that_is_not_a_size_becomes_one() {
+        // A ListModel types its roles from the first row inserted, so a missing
+        // or non-numeric size does not merely render oddly - it poisons the
+        // role for every row after it.
+        const packed = QuickToggleLayout.pack(
+            [{ type: "network" }, { type: "mic", size: "2" },
+             { type: "audio", size: 0 }, { type: "vpn", size: -3 }], 8);
+        compare(packed.map(entry => entry.size).join(","), "1,2,1,1");
+    }
+
+    function test_one_type_named_twice_is_two_rows() {
+        // Nothing enforces one toggle per type - a hand-edited config or an
+        // imported preset can name one twice - and collapsing them onto one id
+        // would drop the second from the screen while leaving it in the store.
+        const packed = QuickToggleLayout.pack(
+            entries([["network", 1], ["mic", 1], ["network", 1]]), 4);
+        compare(ids(packed), "network,mic,network#2");
+        compare(packed[2].type, "network");
+    }
+
+    function test_a_reorder_is_a_move_and_not_a_rebuild() {
+        // The whole point. A remove-and-insert produces the same list and
+        // destroys the delegate, which is what made an animated reorder
+        // impossible: there is nothing left to travel.
+        const before = QuickToggleLayout.pack(
+            entries([["network", 1], ["mic", 1], ["audio", 1], ["vpn", 1]]), 4);
+        const after = QuickToggleLayout.pack(
+            entries([["vpn", 1], ["network", 1], ["mic", 1], ["audio", 1]]), 4);
+        const ops = QuickToggleLayout.syncPlan(before, after);
+        verify(ops.some(op => op.op === "move"), "no move was planned: " + opNames(ops));
+        verify(!ops.some(op => op.op === "remove" || op.op === "insert"),
+               "a reorder was planned as a rebuild: " + opNames(ops));
+        compareRows(applied(before, ops), after, "the plan did not produce the wanted list");
+    }
+
+    function test_a_move_across_a_row_boundary_is_still_a_move() {
+        // The case a per-row model cannot express at all, and the reason the
+        // grid is one flat model: an entry crossing a row boundary leaves one
+        // row's model and lands in another's, at an index some other toggle
+        // held, which is not a move in either of them.
+        const before = QuickToggleLayout.pack(
+            entries([["network", 2], ["mic", 2], ["audio", 2], ["vpn", 2]]), 4);
+        const after = QuickToggleLayout.pack(
+            entries([["network", 2], ["vpn", 2], ["mic", 2], ["audio", 2]]), 4);
+        compare(before[3].layoutRow, 1);
+        compare(after[1].layoutRow, 0, "the fixture must move an entry between rows");
+        const ops = QuickToggleLayout.syncPlan(before, after);
+        verify(!ops.some(op => op.op === "remove" || op.op === "insert"),
+               "a cross-row move was planned as a rebuild: " + opNames(ops));
+        compareRows(applied(before, ops), after, "the plan did not produce the wanted list");
+    }
+
+    function test_the_indices_in_a_plan_are_valid_as_the_plan_runs() {
+        // Every index is read by the model at the moment its own op runs, not
+        // against either input list - removals from the end, then one forward
+        // pass - so an unapplyable plan is the failure to look for here rather
+        // than a wrong final list.
+        const before = QuickToggleLayout.pack(
+            entries([["network", 1], ["mic", 1], ["audio", 1], ["vpn", 1], ["darkMode", 1]]), 5);
+        const after = QuickToggleLayout.pack(
+            entries([["gameMode", 1], ["vpn", 1], ["network", 1], ["screenSnip", 1]]), 5);
+        const ops = QuickToggleLayout.syncPlan(before, after);
+        let length = before.length;
+        for (const op of ops) {
+            if (op.op === "remove") {
+                verify(op.index >= 0 && op.index < length, "remove index out of range: " + op.index);
+                length--;
+            } else if (op.op === "insert") {
+                verify(op.index >= 0 && op.index <= length, "insert index out of range: " + op.index);
+                length++;
+            } else if (op.op === "move") {
+                verify(op.from >= 0 && op.from < length && op.to >= 0 && op.to < length,
+                       "move out of range: " + op.from + " -> " + op.to);
+            } else {
+                verify(op.index >= 0 && op.index < length, "update index out of range: " + op.index);
+            }
+        }
+        compareRows(applied(before, ops), after, "the plan did not produce the wanted list");
+    }
+
+    function test_an_unchanged_list_plans_nothing() {
+        // The gate that makes observing generously free: a re-evaluation that
+        // produces the same grid must not write to the model, or every
+        // unrelated config change repaints the panel.
+        const packed = QuickToggleLayout.pack(
+            entries([["network", 2], ["mic", 1]]), 4);
+        compare(QuickToggleLayout.syncPlan(packed, packed).length, 0);
+        compare(QuickToggleLayout.syncPlan(
+            packed, QuickToggleLayout.pack(entries([["network", 2], ["mic", 1]]), 4)).length, 0);
+    }
+
+    function test_a_payload_change_never_touches_a_row_identity() {
+        // A resize repacks the grid and must reach the delegates as data. The
+        // roles an update may write are the payload ones; `itemId` and `type`
+        // are not among them, because a delegate handed a new type keeps the
+        // component it was built with.
+        const before = QuickToggleLayout.pack(entries([["network", 1], ["mic", 1]]), 4);
+        const after = QuickToggleLayout.pack(entries([["network", 2], ["mic", 1]]), 4);
+        const ops = QuickToggleLayout.syncPlan(before, after);
+        compare(opNames(ops), "update,update");
+        verify(QuickToggleLayout.PAYLOAD_ROLES.indexOf("type") === -1,
+               "the type is writable as a payload role");
+        verify(QuickToggleLayout.PAYLOAD_ROLES.indexOf("itemId") === -1,
+               "the id is writable as a payload role");
+        compareRows(applied(before, ops), after, "the plan did not produce the wanted list");
+    }
+
+    function test_an_id_that_changes_type_rebuilds_that_row_alone() {
+        // Unreachable from the panel, where the id is derived from the type, so
+        // reaching it means the input broke the contract. The answer is to
+        // rebuild the one row rather than retype a live one - that is the
+        // original bug, contained to a row instead of a panel - and the rows
+        // either side must not be disturbed.
+        const before = QuickToggleLayout.pack(entries([["network", 1], ["mic", 1], ["audio", 1]]), 4);
+        const after = before.map(entry => ({
+            itemId: entry.itemId,
+            type: entry.itemId === "mic" ? "vpn" : entry.type,
+            size: entry.size,
+            layoutRow: entry.layoutRow,
+            layoutSlot: entry.layoutSlot,
+            sourceIndex: entry.sourceIndex
+        }));
+        const ops = QuickToggleLayout.syncPlan(before, after);
+        compare(opNames(ops), "remove,insert");
+        compare(ops[0].index, 1);
+        compare(ops[1].index, 1);
+        compareRows(applied(before, ops), after, "the plan did not produce the wanted list");
+    }
+
+    function test_the_signature_changes_exactly_when_the_plan_would_do_something() {
+        // The panel observes the signature instead of the list, because a list
+        // mutated in place is the same object before and after. That is only a
+        // safe trade while the two agree, in BOTH directions: a signature that
+        // misses a change stops the panel updating, and one that changes for
+        // nothing syncs on every unrelated re-evaluation.
+        const lists = [
+            entries([["network", 2], ["mic", 1]]),
+            entries([["network", 2], ["mic", 1]]),
+            entries([["mic", 1], ["network", 2]]),
+            entries([["network", 1], ["mic", 1]]),
+            entries([["network", 2], ["mic", 1], ["audio", 1]]),
+            entries([["network", 2]]),
+            []
+        ];
+        for (const a of lists) {
+            for (const b of lists) {
+                const sameSignature = QuickToggleLayout.signatureOf(a, 4)
+                    === QuickToggleLayout.signatureOf(b, 4);
+                const planIsEmpty = QuickToggleLayout.syncPlan(
+                    QuickToggleLayout.pack(a, 4), QuickToggleLayout.pack(b, 4)).length === 0;
+                compare(sameSignature, planIsEmpty,
+                        "signature and plan disagree for [" + a.map(e => e.type + e.size)
+                        + "] -> [" + b.map(e => e.type + e.size) + "]");
+            }
+        }
+        // The column count is an input to the pack, so it belongs in the
+        // signature too - the entries are identical here and the grid is not.
+        const one = entries([["network", 2], ["mic", 1]]);
+        verify(QuickToggleLayout.signatureOf(one, 4) !== QuickToggleLayout.signatureOf(one, 2));
+    }
+}


### PR DESCRIPTION
Item 3 of `docs/p3drovfx-animation-research-2026-08-16.md` (§3.2,
`StableQuickToggleModel`): the right sidebar's quick toggles reorder by
dragging, and the reorder rebuilt the row rather than moving a delegate.

## What was wrong, and why the obvious half is not enough

81379796b ("fix(sidebar): choose a delegate for the toggle each row entry now
holds") fed each row a plain array on purpose: `DelegateChooser` picks a
component when a delegate is *created* and never re-picks for one that survives,
so an entry that changed identity in place kept the previous toggle's icon, name
and action. That fix is right, and its cost is the delegate — a reorder that
rebuilds every tile cannot animate, because there is nothing left to move.

Taking the survey's keyed `ListModel` on its own would not have fixed it here.
Our rows are packed by toggle size, so nearly every edit reflows them, and an
entry crossing a row boundary leaves one row's model and lands in another's at
an index some other toggle held — which is not a move in either. So the grid is
one flat model per section now and a row is a coordinate, not a container.

- `modules/common/functions/quick_toggle_layout.js` — `pack` (id, type, row,
  slot, stored index, cell pitch) and `syncPlan` (the ops a `ListModel` applies).
  Every list edit it simulates is `layout_ops.js`'s; no second reorder.
- `StableQuickToggleModel.qml` — the applier. Its update branch iterates
  `PAYLOAD_ROLES`, so no spelling in it can retype a live row.
- The panel places each tile at its own slot from the **settled** pack, with the
  press bounce centred by a `transform` rather than by `x` (b710ef731).

## The thing that had to be measured

**A live `list<var>` notifies per ELEMENT written.** One
`layout_ops.moveInPlace` on the stored toggle list — the splice-out and
splice-in a drop commits — was observed in *nine* intermediate states, each a
list with a toggle duplicated or missing, and each one a plan that rebuilds rows
rather than moving them. A model synced straight from the observer therefore
destroys most of the grid in the middle of the one gesture the delegates exist
to survive. The sync is deferred to the end of the turn. This was invisible
before: the old panel rebuilt the row on every notification anyway, so it paid
~10 rebuilds per drop and looked correct.

## Two behaviour deltas, both deliberate

- A row now fills the panel evenly. The cell pitch had one gap too many in it,
  invisible while each row was a `RowLayout` handing the shortfall to whichever
  tile carried `Layout.fillWidth` (measured: first tile 193px against a 185.6px
  pitch, row flush at 484px). Placing by arithmetic made it an 8px gap at the
  right-hand edge, so the pitch is exact and the slack is spread evenly
  (188.8 / 90.4 / 188.8, still flush at 484).
- The store is addressed by the stored index the model carries rather than by
  looking the type up again, so a config naming one type twice edits the entry
  the tile was built from.

## What I could not verify

The **animation as a picture** — the curve, and how the glide reads on screen —
was not looked at: this is a worktree, the user's shell was not touched, and no
screenshot or capture of the panel was taken. What is verified is that the
delegate survives the reorder and that its position is still in flight 80ms
after the commit, which is the difference between an animation and a snap but
says nothing about how it looks.

## Checks, and the plants that proved them

`tests/tst_quick_toggle_layout.qml` (15 functions, pure arithmetic):

```
plant: syncPlan never emits `move`
  FAIL!  : QuickToggleLayoutTest::test_a_reorder_is_a_move_and_not_a_rebuild() 'no move was planned: ' returned FALSE.
  FAIL!  : QuickToggleLayoutTest::test_a_move_across_a_row_boundary_is_still_a_move() the plan did not produce the wanted list (row 1 itemId)
  FAIL!  : QuickToggleLayoutTest::test_the_indices_in_a_plan_are_valid_as_the_plan_runs() the plan did not produce the wanted list (length)
plant: the old cell pitch (one gap too many)
  FAIL!  : QuickToggleLayoutTest::test_a_full_row_of_cells_fills_the_grid_exactly() a full row of 1 cells does not fill the grid
plant: a retyped id is updated in place instead of rebuilt
  FAIL!  : QuickToggleLayoutTest::test_an_id_that_changes_type_rebuilds_that_row_alone() Compared values are not the same
plant: one id for every duplicate type
  FAIL!  : QuickToggleLayoutTest::test_one_type_named_twice_is_two_rows() Compared values are not the same
plant: wrap before an oversized entry even in an empty row
  FAIL!  : QuickToggleLayoutTest::test_an_entry_wider_than_the_grid_leaves_no_empty_row_above_it() Compared values are not the same
plant: the signature stops carrying the slot
  FAIL!  : QuickToggleLayoutTest::test_the_signature_changes_exactly_when_the_plan_would_do_something() 'verify()' returned FALSE.
```

`tests/test_quick_toggle_model_contract.py` (5 checks, the CI-visible half):

```
plant: the chooser picks on a payload role
  FAIL test_the_chooser_picks_on_a_role_a_surviving_row_cannot_be_given
  AssertionError: AndroidToggleDelegateChooser.qml picks a delegate by "size", which quick_toggle_layout.js may rewrite on a live row
plant: the model writes an identity role
  FAIL test_the_model_writes_no_identity_role
  AssertionError: StableQuickToggleModel.qml writes "type" by name; a role written by name is one an identity role can be added beside
plant: a section draws from something else
  FAIL test_the_grid_is_one_flat_keyed_model_per_section
  AssertionError: the panel's Repeaters draw from ['root.toggles', 'unusedModel'], expected one StableQuickToggleModel per section
plant: the signature handler syncs straight through
  FAIL test_the_panel_syncs_once_per_turn_and_not_per_notification
  AssertionError: a signature handler syncs a model directly; it must go through requestSync, which coalesces the turn
plant: a role is both identity and payload
  FAIL test_the_role_lists_parse
  AssertionError: a role is both identity and payload, so an update may rewrite it
```

`QuickTogglesLayoutRuntimeTest.qml` (6 checks -> 11, `EXPECTED_CHECKS` 6 -> 11):

```
plant: sync per notification instead of once per turn
  [QuickToggles] a reorder moves the delegate instead of rebuilding it: FAIL - the tile at that toggle's new position is a different object
  [QuickToggles] the moved tile ends up in the first slot: FAIL - it settled at x -1
  [QuickToggles] the moved tile travels to its new slot instead of snapping: FAIL - 80ms in it was at x -1, between -1 and 285.9
  [QuickToggles] checks: 11 failures: 3
plant: the tile snaps to its slot instead of travelling (Behavior on x removed)
  [QuickToggles] the moved tile ends up in the first slot: ok
  [QuickToggles] the moved tile travels to its new slot instead of snapping: FAIL - 80ms in it was at x 0, between 0 and 98.4
  [QuickToggles] checks: 11 failures: 1
```

## Suite

`dots/.config/quickshell/imi/tests/run_tests.sh`, run whole from the worktree:

```
Running quick toggle model contract tests...
5/5 contract checks passed
Running quick toggle layout runtime tests...
Ran 1 test in 3.952s
OK
...
Totals: 1048 passed, 0 failed, 0 skipped, 0 blacklisted, 4250ms
********* Finished testing of qmltestrunner *********
All tests passed successfully!
```

(exit 0; the runtime harness ran rather than skipping — this machine has a
Wayland session.)

Changelog: updated

Docs: updated
