### PR TITLE
Six widget harnesses get their own session bus, and the ratchet's check learns to read code

### DIFF
--- a/dots/.config/quickshell/imi/tests/lint_runtime_bus_isolation.py
+++ b/dots/.config/quickshell/imi/tests/lint_runtime_bus_isolation.py
@@ -48,6 +48,14 @@
 # a bus the test starts itself is as deliberate as isolating from it, and
 # `test_notification_cards_runtime.py` needs exactly that.
 #
+# It has to be decided AT THE LAUNCH, and the first version of this check did
+# not require that: it searched the whole file, so a harness naming
+# `dbus-run-session` only in its `shutil.which` availability gate satisfied it
+# while launching `qs` bare. Found by planting exactly that - unwrapping one
+# converted harness's launch and watching the lint stay green. The argv list
+# carrying `qs` must carry the wrapper too, which is a question about one list
+# rather than about a file, so `ast` answers it.
+#
 # Lints are exempt: they read source, they start no shell.
 
 import pathlib
@@ -59,6 +67,53 @@ TESTS = pathlib.Path(__file__).resolve().parent
 
 LAUNCHES_QS = re.compile(r'"qs"|\bqs\s+-[pc]\b')
 DECIDES_BUS = re.compile(r"dbus-run-session|DBUS_SESSION_BUS_ADDRESS")
+WRAPPER = "dbus-run-session"
+EXPLICIT_BUS = "DBUS_SESSION_BUS_ADDRESS"
+
+
+def launch_lists(tree):
+    """Every argv list literal that carries `qs` as one of its executables.
+
+    A shell-string launch (`bash -c "... qs -p ..."`) is not one of these and
+    falls back to the file-wide question below.
+    """
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.List, ast.Tuple)):
+            continue
+        strings = [element.value for element in node.elts
+                   if isinstance(element, ast.Constant)
+                   and isinstance(element.value, str)]
+        if "qs" in strings:
+            yield strings
+
+
+def decides_at_the_launch(raw):
+    """Whether every argv list carrying `qs` also carries the wrapper.
+
+    Asked of the RAW source through `ast`, which is the point: a comment is not
+    in the tree at all, so the sentence a correct harness writes above its
+    wrapper ("dbus-run-session, not the inherited DBUS_SESSION_BUS_ADDRESS")
+    cannot be mistaken for the decision itself. Stripping the prose textually
+    and parsing THAT does not work - the token stream is no longer valid
+    Python, the parse fails, and the check falls back to the file-wide search
+    it was written to replace, which is how a planted unwrapped launch stayed
+    green twice while this was being written.
+
+    A file that sets the bus address explicitly in the env it passes has made
+    the decision somewhere this cannot see, and is trusted - the
+    `test_notification_cards_runtime.py` case the header describes.
+    """
+    try:
+        tree = ast.parse(raw)
+    except SyntaxError:
+        return WRAPPER in raw
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Constant) and node.value == EXPLICIT_BUS:
+            return True
+    lists = list(launch_lists(tree))
+    if not lists:
+        return WRAPPER in raw
+    return all(WRAPPER in strings for strings in lists)
 
 EXISTING = frozenset({
     "test_app_usage_runtime.py",
@@ -144,12 +199,15 @@ def main():
     for path in sorted(TESTS.glob("*.py")):
         if path.name.startswith("lint_"):
             continue
-        text = code_only(path.read_text(encoding="utf-8", errors="replace"))
+        raw = path.read_text(encoding="utf-8", errors="replace")
+        # The prose is stripped for the launch question. The bus question is
+        # asked of the raw source instead - see decides_at_the_launch.
+        text = code_only(raw)
         if not LAUNCHES_QS.search(text):
             continue
         launchers.add(path.name)
         scanned += 1
-        if DECIDES_BUS.search(text):
+        if decides_at_the_launch(raw):
             continue
         inherited.add(path.name)
         if path.name in EXISTING:

--- a/dots/.config/quickshell/imi/tests/lint_runtime_bus_isolation.py
+++ b/dots/.config/quickshell/imi/tests/lint_runtime_bus_isolation.py
@@ -51,6 +51,7 @@
 # Lints are exempt: they read source, they start no shell.
 
 import pathlib
+import ast
 import re
 import sys
 
@@ -83,17 +84,55 @@ EXISTING = frozenset({
     "test_notes_surfaces_runtime.py",
     "test_parallax_migration_runtime.py",
     "test_quick_toggles_layout_runtime.py",
-    "test_widget_edge_snap_runtime.py",
     "test_widget_elevation.py",
-    "test_widget_grip_lock.py",
-    "test_widget_group_drag_runtime.py",
-    "test_widget_group_selection.py",
-    "test_widget_interaction_modes.py",
-    "test_widget_interaction_runtime.py",
-    "test_widget_parallax_optout.py",
-    "test_widget_resize_grip_runtime.py",
-    "test_widget_resize_motion_runtime.py",
 })
+
+
+def code_only(text: str) -> str:
+    """The file's executable text: docstrings and comments dropped.
+
+    A prose mention of `qs -p` in a module docstring is not a launch, and three
+    harnesses were registered on the strength of one - `test_widget_grip_lock`,
+    `test_widget_group_selection` and `test_widget_interaction_modes` are
+    source-contract checks that start no process at all and say so in the
+    sentence the pattern matched. A register carrying files that cannot be
+    fixed is a register nobody can finish, which is the failure mode the
+    ratchet exists to avoid.
+
+    Parsed rather than regexed: `ast` knows a docstring from a string literal
+    that happens to contain the same words, and `tokenize` knows a comment from
+    a `#` inside a string.
+    """
+    import io
+    import tokenize
+    out = []
+    try:
+        for token in tokenize.generate_tokens(io.StringIO(text).readline):
+            if token.type == tokenize.COMMENT:
+                continue
+            out.append((token.type, token.string, token.start, token.end, token.line))
+    except (tokenize.TokenError, IndentationError, SyntaxError):
+        return text
+    try:
+        tree = ast.parse(text)
+    except SyntaxError:
+        return text
+    docstrings = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef,
+                                 ast.AsyncFunctionDef)):
+            continue
+        doc = ast.get_docstring(node, clean=False)
+        if doc is None:
+            continue
+        first = node.body[0]
+        docstrings.add((first.lineno, first.col_offset))
+    kept = []
+    for kind, string, start, end, line in out:
+        if kind == tokenize.STRING and (start[0], start[1]) in docstrings:
+            continue
+        kept.append(string)
+    return "\n".join(kept)
 
 
 def main():
@@ -101,12 +140,14 @@ def main():
     inherited = set()
     scanned = 0
 
+    launchers = set()
     for path in sorted(TESTS.glob("*.py")):
         if path.name.startswith("lint_"):
             continue
-        text = path.read_text(encoding="utf-8", errors="replace")
+        text = code_only(path.read_text(encoding="utf-8", errors="replace"))
         if not LAUNCHES_QS.search(text):
             continue
+        launchers.add(path.name)
         scanned += 1
         if DECIDES_BUS.search(text):
             continue
@@ -125,6 +166,12 @@ def main():
             failures.append(
                 f"{name}: registered in tests/lint_runtime_bus_isolation.py and "
                 f"no longer present. Drop it from EXISTING.")
+            continue
+        if name not in launchers:
+            failures.append(
+                f"{name}: registered, and starts no `qs` at all. Drop it from "
+                f"EXISTING - a register carrying files that cannot be fixed is "
+                f"a register nobody can finish.")
             continue
         failures.append(
             f"{name}: now decides its own session bus. Remove it from EXISTING "

--- a/dots/.config/quickshell/imi/tests/test_widget_edge_snap_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_widget_edge_snap_runtime.py
@@ -54,7 +54,8 @@ def _stop(proc):
 
 
 def _runtime_available():
-    return shutil.which("qs") is not None and shutil.which("weston") is not None
+    return all(shutil.which(binary) is not None
+               for binary in ("qs", "weston", "dbus-run-session"))
 
 
 @unittest.skipUnless(_runtime_available(), "needs qs and weston on PATH")
@@ -87,7 +88,13 @@ class WidgetEdgeSnapRuntimeTest(unittest.TestCase):
         env["XDG_CONFIG_HOME"] = str(self.home / "config")
         env["XDG_STATE_HOME"] = str(self.home / "state")
 
-        proc = subprocess.run(["qs", "-p", str(HARNESS)], cwd=str(ROOT), env=env,
+        proc = subprocess.run(
+            # dbus-run-session, not the inherited DBUS_SESSION_BUS_ADDRESS: a
+            # shell reading MPRIS, UPower or a portal off the developer's bus
+            # measures their session rather than this tree, and a harness that
+            # passes everywhere except on the maintainer's machine is the
+            # failure this costs nothing to prevent.
+            ["dbus-run-session", "--", "qs", "-p", str(HARNESS)], cwd=str(ROOT), env=env,
                               capture_output=True, text=True, timeout=180)
         output = proc.stdout + proc.stderr
         failed = [line for line in output.splitlines() if "FAIL" in line]

--- a/dots/.config/quickshell/imi/tests/test_widget_group_drag_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_widget_group_drag_runtime.py
@@ -50,7 +50,8 @@ def _stop(proc):
 
 
 def _runtime_available():
-    return shutil.which("qs") is not None and shutil.which("weston") is not None
+    return all(shutil.which(binary) is not None
+               for binary in ("qs", "weston", "dbus-run-session"))
 
 
 @unittest.skipUnless(_runtime_available(), "needs qs and weston on PATH")
@@ -83,7 +84,13 @@ class WidgetGroupDragRuntimeTest(unittest.TestCase):
         env["XDG_CONFIG_HOME"] = str(self.home / "config")
         env["XDG_STATE_HOME"] = str(self.home / "state")
 
-        proc = subprocess.run(["qs", "-p", str(HARNESS)], cwd=str(ROOT), env=env,
+        proc = subprocess.run(
+            # dbus-run-session, not the inherited DBUS_SESSION_BUS_ADDRESS: a
+            # shell reading MPRIS, UPower or a portal off the developer's bus
+            # measures their session rather than this tree, and a harness that
+            # passes everywhere except on the maintainer's machine is the
+            # failure this costs nothing to prevent.
+            ["dbus-run-session", "--", "qs", "-p", str(HARNESS)], cwd=str(ROOT), env=env,
                               capture_output=True, text=True, timeout=180)
         output = proc.stdout + proc.stderr
         failed = [line for line in output.splitlines() if "FAIL" in line]

--- a/dots/.config/quickshell/imi/tests/test_widget_interaction_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_widget_interaction_runtime.py
@@ -49,7 +49,8 @@ def _stop(proc):
 
 
 def _runtime_available():
-    return shutil.which("qs") is not None and shutil.which("weston") is not None
+    return all(shutil.which(binary) is not None
+               for binary in ("qs", "weston", "dbus-run-session"))
 
 
 @unittest.skipUnless(_runtime_available(), "needs qs and weston on PATH")
@@ -82,7 +83,13 @@ class WidgetInteractionRuntimeTest(unittest.TestCase):
         env["XDG_CONFIG_HOME"] = str(self.home / "config")
         env["XDG_STATE_HOME"] = str(self.home / "state")
 
-        proc = subprocess.run(["qs", "-p", str(HARNESS)], cwd=str(ROOT), env=env,
+        proc = subprocess.run(
+            # dbus-run-session, not the inherited DBUS_SESSION_BUS_ADDRESS: a
+            # shell reading MPRIS, UPower or a portal off the developer's bus
+            # measures their session rather than this tree, and a harness that
+            # passes everywhere except on the maintainer's machine is the
+            # failure this costs nothing to prevent.
+            ["dbus-run-session", "--", "qs", "-p", str(HARNESS)], cwd=str(ROOT), env=env,
                               capture_output=True, text=True, timeout=180)
         output = proc.stdout + proc.stderr
         failed = [line for line in output.splitlines() if "FAIL" in line]

--- a/dots/.config/quickshell/imi/tests/test_widget_parallax_optout.py
+++ b/dots/.config/quickshell/imi/tests/test_widget_parallax_optout.py
@@ -227,7 +227,8 @@ def _stop(proc):
 
 
 def _runtime_available():
-    return shutil.which("qs") is not None and shutil.which("weston") is not None
+    return all(shutil.which(binary) is not None
+               for binary in ("qs", "weston", "dbus-run-session"))
 
 
 @unittest.skipUnless(_runtime_available(), "needs qs and weston on PATH")
@@ -260,7 +261,13 @@ class WidgetParallaxOptOutRuntimeTest(unittest.TestCase):
         env["XDG_CONFIG_HOME"] = str(self.home / "config")
         env["XDG_STATE_HOME"] = str(self.home / "state")
 
-        proc = subprocess.run(["qs", "-p", str(HARNESS)], cwd=str(ROOT), env=env,
+        proc = subprocess.run(
+            # dbus-run-session, not the inherited DBUS_SESSION_BUS_ADDRESS: a
+            # shell reading MPRIS, UPower or a portal off the developer's bus
+            # measures their session rather than this tree, and a harness that
+            # passes everywhere except on the maintainer's machine is the
+            # failure this costs nothing to prevent.
+            ["dbus-run-session", "--", "qs", "-p", str(HARNESS)], cwd=str(ROOT), env=env,
                               capture_output=True, text=True, timeout=180)
         output = proc.stdout + proc.stderr
         failed = [line for line in output.splitlines() if "FAIL" in line]

--- a/dots/.config/quickshell/imi/tests/test_widget_resize_grip_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_widget_resize_grip_runtime.py
@@ -53,7 +53,8 @@ def _stop(proc):
 
 
 def _runtime_available():
-    return shutil.which("qs") is not None and shutil.which("weston") is not None
+    return all(shutil.which(binary) is not None
+               for binary in ("qs", "weston", "dbus-run-session"))
 
 
 @unittest.skipUnless(_runtime_available(), "needs qs and weston on PATH")
@@ -86,7 +87,13 @@ class WidgetResizeGripRuntimeTest(unittest.TestCase):
         env["XDG_CONFIG_HOME"] = str(self.home / "config")
         env["XDG_STATE_HOME"] = str(self.home / "state")
 
-        proc = subprocess.run(["qs", "-p", str(HARNESS)], cwd=str(ROOT), env=env,
+        proc = subprocess.run(
+            # dbus-run-session, not the inherited DBUS_SESSION_BUS_ADDRESS: a
+            # shell reading MPRIS, UPower or a portal off the developer's bus
+            # measures their session rather than this tree, and a harness that
+            # passes everywhere except on the maintainer's machine is the
+            # failure this costs nothing to prevent.
+            ["dbus-run-session", "--", "qs", "-p", str(HARNESS)], cwd=str(ROOT), env=env,
                               capture_output=True, text=True, timeout=180)
         output = proc.stdout + proc.stderr
         failed = [line for line in output.splitlines() if "FAIL" in line]

--- a/dots/.config/quickshell/imi/tests/test_widget_resize_motion_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_widget_resize_motion_runtime.py
@@ -52,7 +52,8 @@ def _stop(proc):
 
 
 def _runtime_available():
-    return shutil.which("qs") is not None and shutil.which("weston") is not None
+    return all(shutil.which(binary) is not None
+               for binary in ("qs", "weston", "dbus-run-session"))
 
 
 @unittest.skipUnless(_runtime_available(), "needs qs and weston on PATH")
@@ -85,7 +86,13 @@ class WidgetResizeMotionRuntimeTest(unittest.TestCase):
         env["XDG_CONFIG_HOME"] = str(self.home / "config")
         env["XDG_STATE_HOME"] = str(self.home / "state")
 
-        proc = subprocess.run(["qs", "-p", str(HARNESS)], cwd=str(ROOT), env=env,
+        proc = subprocess.run(
+            # dbus-run-session, not the inherited DBUS_SESSION_BUS_ADDRESS: a
+            # shell reading MPRIS, UPower or a portal off the developer's bus
+            # measures their session rather than this tree, and a harness that
+            # passes everywhere except on the maintainer's machine is the
+            # failure this costs nothing to prevent.
+            ["dbus-run-session", "--", "qs", "-p", str(HARNESS)], cwd=str(ROOT), env=env,
                               capture_output=True, text=True, timeout=180)
         output = proc.stdout + proc.stderr
         failed = [line for line in output.splitlines() if "FAIL" in line]


### PR DESCRIPTION
First tightening of the register `lint_runtime_bus_isolation.py` landed as a ratchet: **33 → 24**.

## Six harnesses converted
The desktop-widget family is the group with no D-Bus needs of its own — synthetic manifests over an inert node, driven with real mouse events — so the launch wrapping is one line per file with nothing to reconcile: edge snap, group drag, interaction, parallax opt-out, resize grip, resize motion. Each was **run against its own bus** before the register was shrunk; all six pass.

## Three were never fixable
`test_widget_grip_lock.py`, `test_widget_group_selection.py` and `test_widget_interaction_modes.py` are source-contract checks that start no process at all. They were registered because the pattern matched the sentence `builds the real thing under \`qs -p\`` **in their docstrings**. A register carrying files that cannot be fixed is a register nobody can finish, so the check now reads code rather than prose (`ast` + `tokenize`), and a registered file that starts no `qs` says exactly that instead of claiming it fixed itself.

## The check had a hole, found by planting
The first version searched the **whole file** for `dbus-run-session`. A converted harness names it twice — in the `shutil.which` availability gate and at the launch — so unwrapping the launch left the lint green. Two further attempts stayed green for a second reason worth recording: stripping the prose textually and parsing *that* yields a token stream that is no longer valid Python, the parse fails, and the fallback is the file-wide search the fix was replacing.

The bus question is now asked of the **raw** source through `ast` — a comment is not in the tree at all — and it is a question about the argv list carrying `qs`, not about the file. An explicit `DBUS_SESSION_BUS_ADDRESS` constant still counts as deciding (the `test_notification_cards_runtime.py` case), and a `bash -c` string launch falls back to the file-wide question rather than being reported.

**Plant-proofs** (clean tree, each reverted):
- unwrap `test_widget_edge_snap_runtime`'s launch → `test_widget_edge_snap_runtime.py: launches \`qs\` on the inherited session bus…`, exit 1 (this is the plant the first two versions passed)
- add a `qs -p` prose docstring to `test_bar_widget_parity.py` → still passes, 34 harnesses (prose is not a launch)
- register `test_bar_widget_parity.py` in EXISTING → `registered, and starts no \`qs\` at all. Drop it from EXISTING…`, exit 1

## Tests
Full `tests/run_tests.sh`: **all tests passed**, exit 0, including the six converted harnesses running under their own bus.

Changelog: not user-visible — test isolation and a lint's own correctness

Docs: not needed — the lint's header carries the reasoning, including why the whole-file search was wrong; AGENT.md already states the rule and points at this file
