### PR TITLE
MarqueeText: a label that scrolls only when it overflows, and four places that needed one

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -461,7 +461,8 @@ modules/common/             Shared, feature-agnostic building blocks
                               PopupToolTip, StyledPopup, GroupedList, ConfigSwitch/ConfigSpinBox/
                               ConfigSelectionArray (settings-page form controls), DockIconMotion
                               (M3E feedback-motion wrapper for dock icons), SchemePaletteCircle
-                              (a colour scheme drawn as its own palette), etc.
+                              (a colour scheme drawn as its own palette), MarqueeText
+                              (a label that scrolls only while it overflows), etc.
   functions/, models/, utils/, panels/   Supporting JS logic, list models, window-panel base classes
 
 modules/imi/                 The "imi" (Immaterial Impulse) panel family - one directory per feature:
@@ -3838,7 +3839,64 @@ lift and the bounce are magnitudes travelling along `dock_geometry.js`'s inward 
 negative y),
 `SchemePaletteCircle` (an Android 12-style palette circle for a colour scheme, fed from
 `services/SchemePreview`, with the scheme's glyph as the fallback while the colour venv has not
-answered). All in `modules/common/widgets/`.
+answered),
+`MarqueeText` (a single-line label that scrolls only while it overflows its box, over the overflow
+and back, at a distance-proportional speed with a floor — see the entry below before adopting one).
+All in `modules/common/widgets/`.
+
+**A marquee is the answer for an IDENTITY, and where it may run is as much of the design as how it
+moves.** `MarqueeText` exists because every long label in this shell elides, which is honest about
+the truncation and useless about the content: a router that names its two bands and its guest
+network off one prefix produces list rows whose elided forms are byte-identical, so the list offers
+a choice it does not let the user make. It is *not* a general replacement for `elide`, and the four
+call sites it has (the dock's window-preview title, and the SSID, Bluetooth device name and audio
+stream name in the right sidebar) are a reviewed register in
+`tests/test_marquee_text_contract.py` rather than a starting point for a sweep. Two questions have
+to be answered before a fifth joins them, and neither is checkable from a pattern.
+
+- **Is the elided string something the user cannot recover from anything else on that row?** A
+  status line, a button label or a settings caption is a string this repo wrote; truncating one
+  loses nothing. A name a device or a network advertises for itself is the whole of what the row
+  is for.
+- **Is the surface hidden when idle?** This is an animation with `loops: Animation.Infinite` on a
+  label, i.e. exactly the class that took a fullscreen game from 94 fps to 52 — see the
+  infinite-animation entry above. Its `running` is `overflows && visible`, and `visible` is
+  effective visibility, which is the right question on the right sidebar (a `PanelWindow` whose
+  `visible` follows the sidebar's open state) and on the dock's preview (an xdg-popup that does not
+  exist while it is not shown). It is the *wrong* question on the bar, which sits on `WlrLayer.Top`
+  and stays `visible` while a fullscreen window covers it (53d1ff893 ("fix(bar): drop the cava
+  claim while a fullscreen window covers the bar")) — a marquee there is the performance bug
+  wearing the fix's clothes, so it is refused by the register rather than by a comment.
+
+Three things about its motion do not generalise from a tier and are pinned for that reason.
+
+- **The duration is distance-proportional rather than catalogued** (`modules/common/functions/
+  marquee.js`, 28ms per pixel of overflow with a 3500ms floor). What has to be held constant is the
+  speed the text passes the eye: one tier would run a three-word overrun and a whole sentence on
+  the same clock, so one of the two is unreadable. The floor is the same argument from the other
+  end — a six-pixel overflow twitches, and a movement that resolves before it can be looked at is
+  worse than the truncation.
+- **The travel goes through `Appearance.animation.scale()` and the dwell at each end deliberately
+  does not.** The travel is motion, so the speed slider retimes it and the reduce-motion floor
+  collapses it to zero — which is a *snap* between the two ends, and is how reduce motion still
+  leaves the whole string readable rather than permanently cut off. The dwell is reading time, and
+  it is the half that keeps that floor from being a strobe: with the traverse at zero the dwell is
+  the entire cycle, so a scaled dwell would swap a label's two ends every frame. `dwell()` takes
+  `reduceMotion` and gets **longer**; getting that direction backwards is invisible from either
+  constant on its own, which is why it is a test rather than a comment.
+- **The curve is `Easing.Linear`, spelled out.** An eased scroll reads at a speed that changes
+  under the eye, which is the whole thing a constant ms-per-pixel exists to hold still. This is a
+  curve somebody chose, not the one `lint_motion_tier_partial.py` exists to catch nobody choosing.
+
+Nothing about the rendered result is reachable from `qmltestrunner` — it can build neither a
+`StyledText` nor a laid-out box — so every decision lives in `marquee.js` and
+`tests/lint_infinite_animation_visibility.py`'s general gate rule is supplemented by the contract
+above, which checks the term that lint cannot see (`overflows`) and refuses to let the widget join
+that lint's ratchet.
+62da34c1b ("feat(widgets): marquee.js, what a label that does not fit costs to read"),
+d7e90dac8 ("feat(widgets): MarqueeText, a label that scrolls only when it overflows"),
+91d7f5fab ("feat(sidebar): three names the right sidebar used to cut in half now scroll"),
+281ca292c ("test(widgets): pin the marquee's gate, its two durations, and where it may run").
 
 **A colour scheme is shown as its colours, not as a glyph.** The desktop menu's nine scheme
 presets were nine abstract Material Symbols sitting directly above a list of transition

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ own repo; the installer pins which revision it builds.
 ## [Unreleased]
 
 ### Added
+- **Long names scroll instead of being cut off.** Four places showed a name you
+  did not write and cannot look up anywhere else on the row, and cut it off with
+  an ellipsis: the dock's window preview — where the title is the only thing
+  telling several windows of one application apart — and the Wi-Fi network,
+  Bluetooth device and audio stream lists in the right sidebar. Those now scroll
+  to the end of the text and back whenever it does not fit, so a router that
+  names its two bands and its guest network off one prefix stops producing rows
+  that read identically. Everything the shell wrote itself — status lines,
+  buttons, settings captions — still elides. The scroll stops the moment the
+  panel it is on closes, its speed follows the motion speed setting, and with
+  reduce motion on it holds each end for three seconds and switches between them
+  rather than scrolling, so the whole name is still readable.
 - **Clock depth works on a live Wallpaper Engine scene.** The depth picker
   segments the still the shell already photographs of the active project, keyed
   on the project rather than on the still (which is re-grabbed every session),

--- a/dots/.config/quickshell/imi/DesignSystemCompile.qml
+++ b/dots/.config/quickshell/imi/DesignSystemCompile.qml
@@ -57,6 +57,14 @@ ShellRoot {
                 Quickshell.shellPath("modules/common/plugins/PluginWidget.qml"),
                 Quickshell.shellPath("modules/common/widgets/AutostartApps.qml"),
                 Quickshell.shellPath("modules/common/widgets/WallpaperSubmenu.qml"),
+                // Every marquee call site is behind a surface that is unmapped
+                // when idle - the dock's window preview and three right-sidebar
+                // rows - which is deliberate (see MarqueeText.qml's gate) and
+                // means nothing else in this sweep compiles it.
+                Quickshell.shellPath("modules/common/widgets/MarqueeText.qml"),
+                Quickshell.shellPath("modules/imi/sidebarRight/wifiNetworks/WifiNetworkItem.qml"),
+                Quickshell.shellPath("modules/imi/sidebarRight/bluetoothDevices/BluetoothDeviceItem.qml"),
+                Quickshell.shellPath("modules/imi/sidebarRight/volumeMixer/VolumeMixerEntry.qml"),
                 // The clock depth picker sits behind an inactive Loader in the
                 // wallpaper selector, so it compiles for the first time when
                 // someone clicks its toolbar button - which on a shell where

--- a/dots/.config/quickshell/imi/modules/common/functions/marquee.js
+++ b/dots/.config/quickshell/imi/modules/common/functions/marquee.js
@@ -1,0 +1,109 @@
+.pragma library
+
+// A label that does not fit its box, and what it costs to read the rest of it.
+//
+// Every long label in this shell elides, which is honest about the truncation
+// and useless about the content: two networks called "BT-Hub6-KJXQ-guest" and
+// "BT-Hub6-KJXQ-5GHz" are the same three words and an ellipsis, and nothing on
+// screen will ever tell them apart. A marquee is the answer where the string
+// is an IDENTITY the user did not write and cannot look up elsewhere.
+//
+// The arithmetic lives here, apart from the widget, for the reason
+// placeholderFit.js does: what a marquee decides - whether the text overflows
+// at all, how far it has to travel, how long that should take and where the
+// bottom of that scale is - is answerable without a compositor, and the
+// rendered result is not. `qmltestrunner` cannot lay out a StyledText against
+// this tree's fonts (see tst_placeholder_fit.qml's own note), so a decision
+// left inside the QML is a decision no check can reach.
+//
+// A .pragma library has no engine context, so nothing in here may touch Qt,
+// Appearance or Config - every input arrives as an argument, and the one
+// output that is a DURATION is a base, scaled by the caller through
+// `Appearance.animation.scale()`.
+
+// How long one pixel of overflow takes to travel, in BASE milliseconds. About
+// 36 px/s at the default multiplier, which is a reading pace rather than a
+// ticker-tape one; taken from the surveyed implementation
+// (docs/p3drovfx-animation-research-2026-08-16.md §3.11) rather than picked.
+var MS_PER_PIXEL = 28;
+
+// The shortest a traverse may be, whatever the distance. Without it a label
+// overflowing by six pixels twitches: the eye is drawn to a movement that
+// resolves before it can be looked at, which is worse than the truncation.
+var MIN_TRAVEL_MS = 3500;
+
+// The hold at each end of the traverse. It is NOT a motion tier and is
+// deliberately not scaled by anything - see `dwell()`.
+var DWELL_MS = 1200;
+
+// The hold at each end when the user has asked for reduced motion. At the
+// motion floor the traverse itself has no duration at all, so the dwell is the
+// whole cycle: at 1200ms the label would swap ends roughly once a second for
+// as long as it is on screen, which is a flicker rather than a marquee. This
+// is what stops the accessibility state producing the most aggressive motion
+// in the shell.
+var REDUCED_DWELL_MS = 3000;
+
+// Sub-pixel slack on the overflow test. A text's implicit width and its box's
+// width are laid out by different passes and routinely disagree by a fraction
+// of a pixel on a settled layout; without slack that reads as a permanent
+// overflow and a label that fits scrolls by half a pixel forever.
+var OVERFLOW_SLACK = 1;
+
+function _finite(value) {
+    var number = Number(value);
+    return isFinite(number) ? number : 0;
+}
+
+// Does the text need a marquee at all?
+//
+// A box with no width yet has not been laid out - it is not "infinitely
+// overflowing". Reading it that way starts every marquee in the shell at its
+// full travel on the frame its surface is built, before the layout that will
+// usually make it unnecessary has run.
+function overflows(contentWidth, boxWidth) {
+    var box = _finite(boxWidth);
+    if (box <= 0)
+        return false;
+    return _finite(contentWidth) > box + OVERFLOW_SLACK;
+}
+
+// How far the text has to travel to bring its far end into the box. The
+// overflow, never the whole string: the marquee is a ping-pong over what is
+// hidden, not a wrap-around, so the first character is on screen at rest and
+// the label reads normally until it moves.
+function travelDistance(contentWidth, boxWidth) {
+    if (!overflows(contentWidth, boxWidth))
+        return 0;
+    return _finite(contentWidth) - _finite(boxWidth);
+}
+
+// How long that travel should take, in BASE milliseconds.
+//
+// Distance-proportional rather than a catalogued tier, because the thing being
+// held constant is the speed the text passes the eye - a tier would run a
+// three-word overrun and a whole sentence at the same clock, so one of the two
+// is unreadable. The floor is the same argument at the other end.
+//
+// The caller scales this through `Appearance.animation.scale()`: it is motion,
+// so the shell's speed slider retimes it like everything else, and the
+// reduce-motion floor collapses it to zero - which is a snap between the two
+// ends rather than a scroll, and the reason `dwell()` takes reduceMotion.
+function travelDuration(contentWidth, boxWidth) {
+    var distance = travelDistance(contentWidth, boxWidth);
+    if (distance <= 0)
+        return 0;
+    return Math.max(MIN_TRAVEL_MS, Math.round(distance * MS_PER_PIXEL));
+}
+
+// The hold at each end, in real milliseconds - not a base, because nothing
+// scales it.
+//
+// The multiplier does not, because a dwell is reading time rather than motion:
+// a user who set the shell to 0.5x asked for slower animation, not for half as
+// long to read a device name. Reduce motion does not either, and this is the
+// half that matters - at the motion floor every catalogued duration is 0, so a
+// scaled dwell would leave a label snapping between its two ends every frame.
+function dwell(reduceMotion) {
+    return reduceMotion ? REDUCED_DWELL_MS : DWELL_MS;
+}

--- a/dots/.config/quickshell/imi/modules/common/widgets/DragApps.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/DragApps.qml
@@ -632,12 +632,17 @@ Item {
                                 ButtonGroup {
                                     contentWidth: parent.width - anchors.margins * 2
 
-                                    StyledText {
+                                    // A marquee, not an ellipsis: this popup
+                                    // exists to tell several windows of the
+                                    // SAME application apart, and the title is
+                                    // the only thing that differs between
+                                    // them. Five browser windows elided at
+                                    // this width are five identical rows.
+                                    MarqueeText {
                                         Layout.margins: Appearance.spacing.space100
                                         Layout.fillWidth: true
                                         font.pixelSize: Appearance.font.pixelSize.small
-                                        text: windowButton.modelData?.title
-                                        elide: Text.ElideRight
+                                        text: windowButton.modelData?.title ?? ""
                                         color: Appearance.m3colors.m3onSurface
                                     }
 

--- a/dots/.config/quickshell/imi/modules/common/widgets/MarqueeText.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/MarqueeText.qml
@@ -1,0 +1,96 @@
+import qs.modules.common
+import "../functions/marquee.js" as Marquee
+import QtQuick
+
+// A single-line label that scrolls only while it does not fit, for a string
+// the user needs whole: a network's name, a paired device's name, the title
+// that tells one of five identical windows from the others. Everywhere the
+// truncation itself is the information - a status line, a label this repo
+// wrote - `StyledText { elide: ... }` is still the right widget.
+//
+// Every decision it makes lives in marquee.js, because nothing about the
+// rendered result is reachable from a test.
+Item {
+    id: root
+
+    property alias text: label.text
+    property alias color: label.color
+    property alias font: label.font
+    // Honoured only while the text fits. There is no such thing as centring
+    // something wider than its box: a centred overflow hangs off BOTH ends, so
+    // the marquee would start with the first character already off screen.
+    property int horizontalAlignment: Text.AlignLeft
+
+    readonly property bool overflows: Marquee.overflows(label.implicitWidth, root.width)
+    readonly property real travelDistance: Marquee.travelDistance(label.implicitWidth, root.width)
+
+    // The gate. An animation that loops forever must stop when what it
+    // animates is off screen: a running animation writes a property every
+    // frame, which dirties the scene, which commits a frame, which makes the
+    // compositor repaint the whole output - measured at half a fullscreen
+    // game's frame rate for one spinner nobody could see. `visible` is
+    // EFFECTIVE visibility, false while any ancestor is hidden, so this does
+    // not have to know why it is off screen.
+    //
+    // Note what it deliberately does NOT cover, and why this widget is adopted
+    // only on surfaces that are unmapped when idle: a surface the compositor
+    // COVERS is not a surface QML considers hidden (53d1ff893 ("fix(bar): drop
+    // the cava claim while a fullscreen window covers the bar")).
+    readonly property bool scrolling: root.overflows && root.visible
+
+    // The label's natural width, so a layout still sizes this the way it sized
+    // the StyledText it replaced. The label is sized FROM this item and never
+    // the other way round - its implicit width is a function of the string and
+    // the font alone, which is what keeps the pair off the Loader/implicit-size
+    // binding loop.
+    implicitWidth: label.implicitWidth
+    implicitHeight: label.implicitHeight
+    clip: true
+
+    // Parked at the first character whenever it is not travelling - a stopped
+    // marquee left mid-string is a label whose beginning is missing, which is
+    // worse than the elision this replaces.
+    onScrollingChanged: if (!root.scrolling) label.x = 0
+
+    StyledText {
+        id: label
+
+        width: root.width
+        height: root.height
+        x: 0
+        // The box clips; the label must not shorten itself, or there is
+        // nothing left to scroll to.
+        elide: Text.ElideNone
+        verticalAlignment: Text.AlignVCenter
+        horizontalAlignment: root.overflows ? Text.AlignLeft : root.horizontalAlignment
+    }
+
+    SequentialAnimation {
+        running: root.scrolling
+        loops: Animation.Infinite
+
+        PauseAnimation { duration: Marquee.dwell(Appearance.animation.reduceMotion) }
+        MarqueeTravel { to: -root.travelDistance }
+        PauseAnimation { duration: Marquee.dwell(Appearance.animation.reduceMotion) }
+        MarqueeTravel { to: 0 }
+    }
+
+    // Linear is the one curve this shell may take deliberately: an eased scroll
+    // reads at a speed that changes under the eye, which is the whole thing a
+    // constant ms-per-pixel exists to hold still. It is spelled out rather than
+    // left to Qt's default, which is the same value arrived at by nobody
+    // (docs/M3_GUIDELINES.md §2).
+    //
+    // The duration goes through the motion policy's own door, so the speed
+    // slider retimes the scroll like everything else and reduce motion collapses
+    // it to a snap between the two ends. That is the whole reason the dwell
+    // above is NOT scaled: at the floor the dwell is the entire cycle, and the
+    // accessibility state must not produce the fastest motion in the shell.
+    component MarqueeTravel: NumberAnimation {
+        target: label
+        property: "x"
+        duration: Appearance.animation.scale(
+            Marquee.travelDuration(label.implicitWidth, root.width))
+        easing.type: Easing.Linear
+    }
+}

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/bluetoothDevices/BluetoothDeviceItem.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/bluetoothDevices/BluetoothDeviceItem.qml
@@ -44,12 +44,15 @@ DialogListItem {
             ColumnLayout {
                 spacing: Appearance.spacing.space25
                 Layout.fillWidth: true
-                StyledText {
+                // The device's own advertised name is the only thing telling
+                // two of the same model apart, and a Bluetooth name is
+                // routinely long enough to reach this row's width - the
+                // sibling status line below is this repo's own short string
+                // and stays elided.
+                MarqueeText {
                     Layout.fillWidth: true
                     color: Appearance.colors.colOnSurfaceVariant
-                    elide: Text.ElideRight
                     text: root.device?.name || Translation.tr("Unknown device")
-                    textFormat: Text.PlainText
                 }
                 StyledText {
                     visible: (root.device?.connected || root.device?.paired) ?? false

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/volumeMixer/VolumeMixerEntry.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/volumeMixer/VolumeMixerEntry.qml
@@ -84,11 +84,15 @@ Item {
             Layout.fillWidth: true
             spacing: -Appearance.spacing.space50
 
-            StyledText {
+            // The half that identifies the stream is the media name, and it is
+            // the half on the far side of the separator - so elision here
+            // reliably removes exactly the part the user is looking for. Two
+            // browser tabs are one row apiece reading "Firefox • ..." with
+            // nothing after it.
+            MarqueeText {
                 Layout.fillWidth: true
                 font.pixelSize: Appearance.font.pixelSize.small
                 color: Appearance.colors.colSubtext
-                elide: Text.ElideRight
                 text: {
                     // application.name -> description -> name
                     const app = Audio.appNodeDisplayName(root.node);

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/wifiNetworks/WifiNetworkItem.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/wifiNetworks/WifiNetworkItem.qml
@@ -35,12 +35,15 @@ DialogListItem {
                 text: strength > 80 ? "signal_wifi_4_bar" : strength > 60 ? "network_wifi_3_bar" : strength > 40 ? "network_wifi_2_bar" : strength > 20 ? "network_wifi_1_bar" : "signal_wifi_0_bar"
                 color: Appearance.colors.colOnSurfaceVariant
             }
-            StyledText {
+            // An SSID is the whole of what identifies a network to connect to,
+            // and it is a name the user did not write and cannot look up from
+            // this row. A router that names its bands and its guest network
+            // off one prefix produces several entries whose elided forms are
+            // byte-identical.
+            MarqueeText {
                 Layout.fillWidth: true
                 color: Appearance.colors.colOnSurfaceVariant
-                elide: Text.ElideRight
                 text: root.wifiNetwork?.ssid ?? Translation.tr("Unknown")
-                textFormat: Text.PlainText
             }
             MaterialSymbol {
                 visible: (root.wifiNetwork?.isSecure || root.wifiNetwork?.active) ?? false

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -314,6 +314,17 @@ if ! python3 "$SCRIPT_DIR/lint_rich_text_optin.py"; then
     exit 1
 fi
 
+# The one marquee in the shell is an infinite animation sitting on a label, so
+# WHERE it may run is as much of the contract as how it runs: the gate has to
+# ask whether the text overflows as well as whether it is on screen, the travel
+# is scaled by the motion policy and the dwell deliberately is not, and every
+# adoption is reviewed against a surface that is hidden when idle.
+echo "Running marquee text contract tests..."
+if ! python3 "$SCRIPT_DIR/test_marquee_text_contract.py"; then
+    echo "Marquee text contract tests failed."
+    exit 1
+fi
+
 echo "Running expandable panel contract tests..."
 if ! python3 "$SCRIPT_DIR/test_expandable_panel.py"; then
     echo "Expandable panel contract tests failed."

--- a/dots/.config/quickshell/imi/tests/test_marquee_text_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_marquee_text_contract.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+#
+# Contract for the one marquee in this shell, and for where it is allowed to
+# run.
+#
+# A marquee is an animation with `loops: Animation.Infinite` sitting on a
+# label, which is the exact shape that cost a fullscreen game half its frames
+# (see tests/lint_infinite_animation_visibility.py, and AGENT.md's
+# design-language section). That lint holds the general rule and carries a
+# seven-file ratchet; this file holds the four things it cannot see:
+#
+#   1. The gate is `overflows && visible`, not `visible` alone. A marquee that
+#      runs whenever it is on screen runs on every label that already fits,
+#      writing `x` sixty times a second to move a string nobody asked to move.
+#      The generic lint passes that happily - it only asks whether the word
+#      `visible` is reachable from `running:`.
+#   2. MarqueeText is not in that lint's register. The register is for
+#      animations whose surface is unmapped when idle and whose gate would be a
+#      no-op; a marquee is adopted on such surfaces DELIBERATELY, so it must
+#      carry its gate anyway rather than lean on the surface.
+#   3. The travel is scaled and the dwell is not. Both halves fail silently and
+#      in opposite directions: an unscaled travel is an animation the speed
+#      slider and the reduce-motion switch cannot reach, and a scaled dwell is
+#      zero at the reduce-motion floor - where the travel is also zero - so the
+#      accessibility state would produce a label swapping its two ends every
+#      frame. That is a photosensitivity hazard reached by asking for less
+#      motion.
+#   4. The adoption set. Every call site is reviewed, because "this string is
+#      an identity the user cannot look up elsewhere" is a judgement no pattern
+#      can make, and because a marquee on a surface the compositor merely
+#      COVERS (the bar: WlrLayer.Top, `visible` stays true under a fullscreen
+#      window - 53d1ff893) is the perf bug wearing the fix's clothes.
+#
+# Exits non-zero listing offenders. Wired into run_tests.sh / CI.
+
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from contract_runner import run  # noqa: E402
+
+ROOT = Path(__file__).resolve().parent.parent
+WIDGET = ROOT / "modules/common/widgets/MarqueeText.qml"
+INFINITE_LINT = ROOT / "tests/lint_infinite_animation_visibility.py"
+
+# path (repo-relative, POSIX) -> why elision loses information there. Adding a
+# row is the review: name the string, and name the surface it sits on, which
+# must be one that is unmapped or hidden when idle.
+REVIEWED_ADOPTIONS = {
+    "modules/common/widgets/DragApps.qml":
+        "the dock's window-preview card - the title is the only thing telling "
+        "several windows of one application apart, and the popup is an "
+        "xdg-popup that does not exist while it is not shown",
+    "modules/imi/sidebarRight/wifiNetworks/WifiNetworkItem.qml":
+        "an SSID, on the right sidebar - a layer surface whose `visible` is "
+        "false whenever the sidebar is closed",
+    "modules/imi/sidebarRight/bluetoothDevices/BluetoothDeviceItem.qml":
+        "a paired device's advertised name, on the same surface",
+    "modules/imi/sidebarRight/volumeMixer/VolumeMixerEntry.qml":
+        "a stream's media name, on the same surface - elision here removes "
+        "exactly the half that identifies the stream",
+}
+
+USE = re.compile(r"(?:^|[^\w.])MarqueeText\s*\{")
+BOOL_PROPERTY = re.compile(r"property\s+bool\s+(\w+)\s*:\s*([^\n]+)")
+SCALE_CALL = r"Appearance\s*\??\s*\.\s*animation\s*\??\s*\.\s*scale\s*\(\s*"
+
+# Both duration declarations in this widget are written across two lines, and a
+# line-scoped check reads `duration: Appearance.animation.scale(` and finds no
+# travel duration at all - the same trap 189caa6ff's sweep records for a
+# block-bodied QML property. Whitespace is flattened first so a declaration is
+# matched whole, however it is wrapped.
+def flat(source: str) -> str:
+    return re.sub(r"\s+", " ", source)
+
+
+def widget_source() -> str:
+    return WIDGET.read_text(encoding="utf-8")
+
+
+def _running_expression(source: str) -> str:
+    for line in source.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("running:"):
+            return stripped.split(":", 1)[1].strip()
+    return ""
+
+
+def gate_terms(source: str) -> str:
+    """The full expression the infinite animation's `running:` resolves to."""
+    expression = _running_expression(source)
+    for name, value in BOOL_PROPERTY.findall(source):
+        if name in expression:
+            return value
+    return expression
+
+
+def test_the_widget_exists_and_loops_forever():
+    assert WIDGET.exists(), f"{WIDGET} is missing - the rest of this contract is vacuous"
+    source = widget_source()
+    assert "Animation.Infinite" in source, (
+        "MarqueeText no longer loops forever. If the scroll became a one-shot "
+        "this whole contract needs rewriting rather than deleting - say so.")
+
+
+def test_the_scroll_is_gated_on_visibility_and_on_overflowing():
+    gate = gate_terms(widget_source())
+    assert "visible" in gate, (
+        f"the marquee's `running:` resolves to `{gate}`, which carries no "
+        "visibility term. A running animation dirties the scene every frame "
+        "and the compositor repaints the whole output for it.")
+    assert "overflows" in gate, (
+        f"the marquee's `running:` resolves to `{gate}`, which does not ask "
+        "whether the text overflows. A marquee that runs on a label that "
+        "already fits animates a string nobody asked to move - and the "
+        "infinite-animation lint cannot see it, because the visibility term "
+        "is there.")
+
+
+def test_the_widget_does_not_join_the_infinite_animation_ratchet():
+    register = INFINITE_LINT.read_text(encoding="utf-8")
+    assert "MarqueeText.qml" not in register, (
+        "MarqueeText is registered as an ungated infinite animation in "
+        "lint_infinite_animation_visibility.py. That register is for "
+        "animations on surfaces that are unmapped when idle, where the gate "
+        "would be a no-op; a marquee is adopted on exactly those surfaces on "
+        "purpose, so it carries its own gate rather than leaning on them.")
+
+
+def test_the_travel_goes_through_the_motion_policy():
+    body = flat(widget_source())
+    assert "Marquee.travelDuration(" in body, (
+        "MarqueeText no longer reads a travel duration at all")
+    assert re.search(r"duration:\s*" + SCALE_CALL + r"Marquee\.travelDuration\(", body), (
+        "the travel duration does not go straight through "
+        "`Appearance.animation.scale()`, so the speed slider and the "
+        "reduce-motion switch never reach the one animation in the shell that "
+        "runs for as long as its label is on screen.")
+
+
+def test_the_dwell_is_not_scaled():
+    body = flat(widget_source())
+    assert "Marquee.dwell(" in body, (
+        "MarqueeText no longer takes its dwell from marquee.js, so the "
+        "reduce-motion hold is not decided anywhere a test can reach")
+    assert not re.search(SCALE_CALL + r"Marquee\.dwell\(", body), (
+        "the dwell is scaled. At the reduce-motion floor every catalogued "
+        "duration is 0 - including the traverse this dwell brackets - so a "
+        "scaled dwell makes the label swap its two ends every frame. Asking "
+        "for less motion would produce the most aggressive motion in the "
+        "shell.")
+    assert re.search(r"duration:\s*Marquee\.dwell\(", body), (
+        "the dwell no longer reaches its PauseAnimation directly. Anything "
+        "between the two is where a scaling gets reintroduced.")
+
+
+def test_the_label_does_not_elide():
+    source = widget_source()
+    assert "elide: Text.ElideNone" in source, (
+        "MarqueeText's label must declare `elide: Text.ElideNone`. An eliding "
+        "label shortens itself to its box, so the marquee scrolls a string "
+        "that already ends in an ellipsis - the motion is there and the "
+        "information is not, which is the failure this widget exists to fix "
+        "wearing its own fix's clothes.")
+
+
+def _adoptions() -> dict:
+    found = {}
+    for path in sorted(ROOT.rglob("*.qml")):
+        relative = path.relative_to(ROOT).as_posix()
+        if relative.startswith("tests/") or path == WIDGET:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+        uses = len(USE.findall(text))
+        if uses:
+            found[relative] = uses
+    return found
+
+
+def test_every_adoption_is_reviewed():
+    for relative in sorted(_adoptions()):
+        assert relative in REVIEWED_ADOPTIONS, (
+            f"{relative} adopts MarqueeText without a review. Add it to "
+            "REVIEWED_ADOPTIONS in tests/test_marquee_text_contract.py with "
+            "the string it shows and the surface it sits on. Two questions "
+            "have to be answered there and neither is checkable: is the "
+            "elided string an IDENTITY the user cannot recover elsewhere, and "
+            "is the surface one that is hidden when idle? The bar is not - it "
+            "is on WlrLayer.Top and stays `visible` under a fullscreen window "
+            "that covers it (53d1ff893).")
+
+
+def test_the_review_register_carries_no_dead_entries():
+    adopted = _adoptions()
+    for relative in sorted(REVIEWED_ADOPTIONS):
+        assert relative in adopted, (
+            f"{relative} is registered as a marquee call site and no longer "
+            "declares one. Drop it from REVIEWED_ADOPTIONS - a register with "
+            "slack in it stops being read.")
+
+
+def test_the_arithmetic_is_not_written_out_in_the_widget():
+    source = widget_source()
+    for number, line in enumerate(source.splitlines(), 1):
+        if line.lstrip().startswith("//"):
+            continue
+        assert "implicitWidth >" not in line and "implicitWidth -" not in line, (
+            f"MarqueeText.qml:{number}: the overflow test or the travel "
+            "distance is spelled out here. Both belong in marquee.js, which "
+            "is the only part of this widget a check can reach - "
+            "`qmltestrunner` can build neither a StyledText nor a laid-out "
+            "box.")
+
+
+if __name__ == "__main__":
+    sys.exit(run(globals()))

--- a/dots/.config/quickshell/imi/tests/tst_marquee.qml
+++ b/dots/.config/quickshell/imi/tests/tst_marquee.qml
@@ -1,0 +1,118 @@
+import QtTest
+import "../modules/common/functions/marquee.js" as Marquee
+
+// Everything MarqueeText decides: whether the text overflows at all, how far
+// it has to travel, how long that should take, and what the hold at each end
+// is. The widget itself cannot be built here - it is a StyledText in a box,
+// and `qmltestrunner` can lay out neither (see tst_placeholder_fit.qml) - so
+// the decisions live in the library and this is where they are exercised.
+TestCase {
+    name: "MarqueeTest"
+
+    // ---------------------------------------------------------------------
+    // Does it overflow?
+    // ---------------------------------------------------------------------
+
+    function test_textWiderThanItsBoxOverflows() {
+        verify(Marquee.overflows(300, 120));
+        verify(!Marquee.overflows(80, 120));
+    }
+
+    // A text and its box are measured by different layout passes and settle a
+    // fraction of a pixel apart routinely. Without slack that reads as a
+    // permanent overflow, and a label that fits scrolls half a pixel forever.
+    function test_aSubPixelOverrunIsNotAnOverflow() {
+        verify(!Marquee.overflows(120.4, 120), "0.4px is measurement noise");
+        verify(!Marquee.overflows(121, 120), "exactly the slack still fits");
+        verify(Marquee.overflows(121.5, 120), "past the slack is a real overflow");
+    }
+
+    // The case that decides whether every marquee in the shell starts at full
+    // travel on the frame its surface is built: a box with no width yet has
+    // not been laid out, and is not "overflowing by the whole string".
+    function test_anUnlaidOutBoxDoesNotOverflow() {
+        verify(!Marquee.overflows(300, 0));
+        verify(!Marquee.overflows(300, -1));
+        verify(!Marquee.overflows(300, NaN));
+        verify(!Marquee.overflows(300, undefined));
+    }
+
+    function test_anUnmeasuredTextDoesNotOverflow() {
+        verify(!Marquee.overflows(0, 120));
+        verify(!Marquee.overflows(NaN, 120));
+        verify(!Marquee.overflows(undefined, 120));
+    }
+
+    // ---------------------------------------------------------------------
+    // How far
+    // ---------------------------------------------------------------------
+
+    // The overflow, never the whole string: the marquee is a ping-pong over
+    // what is hidden, so the first character is on screen at rest.
+    function test_theTravelIsTheOverflowNotTheWholeString() {
+        compare(Marquee.travelDistance(300, 120), 180);
+        compare(Marquee.travelDistance(287.2, 120), 167.2);
+    }
+
+    function test_textThatFitsTravelsNowhere() {
+        compare(Marquee.travelDistance(80, 120), 0);
+        compare(Marquee.travelDistance(120.4, 120), 0, "inside the slack");
+        compare(Marquee.travelDistance(300, 0), 0, "not laid out yet");
+    }
+
+    // ---------------------------------------------------------------------
+    // How long
+    // ---------------------------------------------------------------------
+
+    // Proportional, because what has to be held constant is the speed the text
+    // passes the eye. A catalogued tier would run a three-word overrun and a
+    // whole sentence at the same clock, so one of the two is unreadable.
+    function test_theDurationIsProportionalToTheDistance() {
+        const near = Marquee.travelDuration(120 + 400, 120);
+        const far = Marquee.travelDuration(120 + 800, 120);
+        compare(near, 400 * Marquee.MS_PER_PIXEL);
+        compare(far, 800 * Marquee.MS_PER_PIXEL);
+        compare(far, near * 2, "twice the overflow is twice the time");
+    }
+
+    // The floor, from the other end: a label overflowing by six pixels would
+    // otherwise twitch - a movement that resolves before it can be looked at,
+    // which is worse than the truncation it replaces.
+    function test_aShortOverflowStillTakesTheFloor() {
+        compare(Marquee.travelDuration(126, 120), Marquee.MIN_TRAVEL_MS);
+        const atFloor = Marquee.MIN_TRAVEL_MS / Marquee.MS_PER_PIXEL;
+        compare(Marquee.travelDuration(120 + atFloor - 1, 120), Marquee.MIN_TRAVEL_MS,
+            "one pixel short of the crossover is still the floor");
+        verify(Marquee.travelDuration(120 + atFloor + 1, 120) > Marquee.MIN_TRAVEL_MS,
+            "one pixel past it is proportional again");
+    }
+
+    function test_textThatFitsHasNoDuration() {
+        compare(Marquee.travelDuration(80, 120), 0);
+        compare(Marquee.travelDuration(300, 0), 0);
+    }
+
+    // ---------------------------------------------------------------------
+    // The dwell
+    // ---------------------------------------------------------------------
+
+    // The whole reason this is a function of reduceMotion rather than one
+    // constant. At the motion floor the traverse has no duration at all, so
+    // the dwell IS the cycle: keeping the ordinary hold would swap the label's
+    // two ends roughly once a second, for as long as it is on screen. The
+    // accessibility state must not produce the fastest motion in the shell.
+    function test_reduceMotionLengthensTheHoldRatherThanShorteningIt() {
+        verify(Marquee.dwell(true) > Marquee.dwell(false));
+        compare(Marquee.dwell(false), Marquee.DWELL_MS);
+        compare(Marquee.dwell(true), Marquee.REDUCED_DWELL_MS);
+    }
+
+    // A dwell long enough to read a device name at. Measured against the
+    // traverse it brackets rather than asserted as a number, so retiming one
+    // without the other reddens.
+    function test_theHoldIsAReadableFractionOfTheTraverse() {
+        verify(Marquee.DWELL_MS >= 1000, "shorter than a second is a flash");
+        verify(Marquee.DWELL_MS < Marquee.MIN_TRAVEL_MS,
+            "a hold longer than the shortest traverse reads as a stall");
+    }
+}


### PR DESCRIPTION
Item 13 of `docs/p3drovfx-animation-research-2026-08-16.md` — §3.11, "Text motion, where we have none".

Every long label in this shell elides, which is honest about the truncation and useless about the content. `MarqueeText` is the answer where the truncated string is an **identity** the user did not write and cannot recover from anything else on the row.

## What landed

- `modules/common/functions/marquee.js` — the arithmetic: does it overflow (with a pixel of slack, and an unlaid-out box is *not* an infinite overflow), how far (the overflow, not the whole string — it is a ping-pong, so the first character is on screen at rest), how long (28ms per pixel of overflow, floored at 3500ms), and the dwell at each end.
- `modules/common/widgets/MarqueeText.qml` — an `Item` clipping a `StyledText`, built on `StyledText` so it keeps its `Text.PlainText` default; no `AutoText` anywhere.

## The three constraints, and the decisions

**The infinite-animation rule.** `running` is `overflows && visible`, `visible` being effective visibility. It does **not** join `lint_infinite_animation_visibility.py`'s ratchet, and the contract test refuses to let it: that register is for animations whose surface is unmapped when idle and whose gate would be a no-op, and a marquee is adopted on exactly those surfaces *on purpose*, so it carries its own gate rather than leaning on them. The `overflows` term is the half that lint cannot see — it only asks whether the word `visible` is reachable from `running:` — so a marquee animating labels that already fit would pass it.

**Motion multiplier and reduce motion.** Asymmetric, deliberately:

- The **travel** goes through `Appearance.animation.scale()`. It is motion, so the speed slider retimes it, and the reduce-motion floor collapses it to zero — which is a *snap* between the two ends, not a dead marquee. Reduce motion therefore never leaves the text permanently cut off: the whole string is still readable, in two positions.
- The **dwell** does not, and gets **longer** under reduce motion (1200ms → 3000ms). At the floor the traverse has no duration at all, so the dwell is the entire cycle — a scaled dwell would be zero too, and answering "less motion, please" with a label swapping its two ends every frame is a photosensitivity hazard, not an accessibility feature.
- The duration is **distance-proportional rather than a catalogued tier** because what has to be held constant is the speed the text passes the eye; one tier would run a three-word overrun and a whole sentence on the same clock. The curve is `Easing.Linear`, spelled out — a curve chosen, not the one `lint_motion_tier_partial.py` exists to catch nobody choosing.

**Sizing.** The label is sized *from* the item, never the reverse: its implicit width is a function of the string and the font alone, so a layout sizes a `MarqueeText` exactly the way it sized the `StyledText` it replaced, and the pair cannot close the `Loader`/implicit-size binding loop.

## Adopted call sites, and why these four

Found by sweeping all 113 `elide:` sites rather than by guessing. Adoption is a reviewed register in `tests/test_marquee_text_contract.py`; a fifth has to answer two questions there.

| Site | Why elision loses information |
|---|---|
| `modules/common/widgets/DragApps.qml` — the dock's window preview | The card exists to tell several windows of the *same* application apart. Thumbnail and icon are identical by construction; the title is the entire content, and the card is width-capped so it cannot be widened out of the problem. |
| `.../sidebarRight/wifiNetworks/WifiNetworkItem.qml` — the SSID | The whole identity of a network you are about to hand a password to. A router naming two bands and a guest network off one prefix produces rows whose elided forms are byte-identical. |
| `.../sidebarRight/bluetoothDevices/BluetoothDeviceItem.qml` — the device name | The device advertises its own name; it is what tells two of the same model apart. |
| `.../sidebarRight/volumeMixer/VolumeMixerEntry.qml` — the stream label | `<application> • <media name>`, and the identifying half is on the far side of the separator, so elision removes exactly the part being looked for. |

**Not adopted, with reasons.** The bar (`ActiveWindow`, `Media`) — it is on `WlrLayer.Top` and stays `visible` while a fullscreen window covers it (53d1ff893), so a marquee there is the perf bug wearing the fix's clothes; the bar media widget also already runs its own slide-on-text-change. The sibling status lines beside two of the adopted rows ("Connected", "Paired", a battery suffix) — this repo's own short strings. Settings rows, button labels, combo-box items, section headings, notification bodies — strings this repo wrote, or recoverable from the widget around them. `MonitorRect`/`DropShelfPanel`'s `ElideMiddle` paths — a path elided in the middle keeps both ends, which is the identity.

All four adopted surfaces are hidden or unmapped when idle: the right sidebar's `PanelWindow.visible` follows its open state, and the dock's preview is an xdg-popup that does not exist while it is not shown.

## Verification

Behaviour was driven rather than reasoned about, with a throwaway `qs -p` probe under **headless weston** on its own `XDG_RUNTIME_DIR` (never the live session):

- Default motion: 1200ms hold at 0, then linear travel of 167.2px at 14.29px per 400ms — 35.7px/s, i.e. the 28ms-per-pixel asked for.
- `reduceMotion: true` seeded into an isolated `config.json`: 3000ms at 0, one frame to −167.19, 3000ms there. No continuous motion; the whole string readable.
- Hiding the item mid-traverse stopped it and parked it back at x=0; showing it again restarted from the hold.
- A label that fits reported `overflows=false`, `scrolling=false` throughout.

**Plant-proved, in a clean tree, 20/20 — every new check reddened by name.** `tst_marquee.qml` (11 mutations of `marquee.js`) and `test_marquee_text_contract.py` (9 mutations of `MarqueeText.qml`, the adoption sites and the infinite-animation lint's register):

```
REDDENED  test_textWiderThanItsBoxOverflows
            FAIL!  : qmltestrunner::MarqueeTest::test_textWiderThanItsBoxOverflows() 'verify()' returned FALSE. ()
REDDENED  test_aSubPixelOverrunIsNotAnOverflow
            FAIL!  : qmltestrunner::MarqueeTest::test_aSubPixelOverrunIsNotAnOverflow() '0.4px is measurement noise' returned FALSE. ()
REDDENED  test_anUnlaidOutBoxDoesNotOverflow
            FAIL!  : qmltestrunner::MarqueeTest::test_anUnlaidOutBoxDoesNotOverflow() 'verify()' returned FALSE. ()
REDDENED  test_anUnmeasuredTextDoesNotOverflow
            FAIL!  : qmltestrunner::MarqueeTest::test_anUnmeasuredTextDoesNotOverflow() 'verify()' returned FALSE. ()
REDDENED  test_theTravelIsTheOverflowNotTheWholeString
            FAIL!  : qmltestrunner::MarqueeTest::test_theTravelIsTheOverflowNotTheWholeString() Compared values are not the same
REDDENED  test_textThatFitsTravelsNowhere
            FAIL!  : qmltestrunner::MarqueeTest::test_textThatFitsTravelsNowhere() Compared values are not the same
REDDENED  test_theDurationIsProportionalToTheDistance
            FAIL!  : qmltestrunner::MarqueeTest::test_theDurationIsProportionalToTheDistance() Compared values are not the same
REDDENED  test_aShortOverflowStillTakesTheFloor
            FAIL!  : qmltestrunner::MarqueeTest::test_aShortOverflowStillTakesTheFloor() Compared values are not the same
REDDENED  test_textThatFitsHasNoDuration
            FAIL!  : qmltestrunner::MarqueeTest::test_textThatFitsHasNoDuration() Compared values are not the same
REDDENED  test_reduceMotionLengthensTheHoldRatherThanShorteningIt
            FAIL!  : qmltestrunner::MarqueeTest::test_reduceMotionLengthensTheHoldRatherThanShorteningIt() 'verify()' returned FALSE. ()
REDDENED  test_theHoldIsAReadableFractionOfTheTraverse
            FAIL!  : qmltestrunner::MarqueeTest::test_theHoldIsAReadableFractionOfTheTraverse() 'shorter than a second is a flash' returned FALSE. ()
REDDENED  test_the_widget_exists_and_loops_forever
            AssertionError: MarqueeText no longer loops forever. ...
REDDENED  test_the_scroll_is_gated_on_visibility_and_on_overflowing
            AssertionError: the marquee's `running:` resolves to `root.visible`, which does not ask whether the text overflows. ...
REDDENED  test_the_widget_does_not_join_the_infinite_animation_ratchet
            AssertionError: MarqueeText is registered as an ungated infinite animation in lint_infinite_animation_visibility.py. ...
REDDENED  test_the_travel_goes_through_the_motion_policy
            AssertionError: the travel duration does not go straight through `Appearance.animation.scale()`, ...
REDDENED  test_the_dwell_is_not_scaled
            AssertionError: the dwell is scaled. At the reduce-motion floor every catalogued duration is 0 ...
REDDENED  test_the_label_does_not_elide
            AssertionError: MarqueeText's label must declare `elide: Text.ElideNone`. ...
REDDENED  test_every_adoption_is_reviewed
            AssertionError: modules/imi/bar/ActiveWindow.qml adopts MarqueeText without a review. ...
REDDENED  test_the_review_register_carries_no_dead_entries
            AssertionError: modules/imi/sidebarRight/wifiNetworks/WifiNetworkItem.qml is registered as a marquee call site and no longer declares one. ...
REDDENED  test_the_arithmetic_is_not_written_out_in_the_widget
            AssertionError: MarqueeText.qml:24: the overflow test or the travel distance is spelled out here. ...

20/20 planted mutations reddened their named check
```

**Full suite** (`dots/.config/quickshell/imi/tests/run_tests.sh`), exit 0:

```
Running marquee text contract tests...
9/9 contract checks passed
...
[DesignSystemCompile] checked=185 failures=0
...
PASS   : qmltestrunner::MarqueeTest::test_aShortOverflowStillTakesTheFloor()
PASS   : qmltestrunner::MarqueeTest::test_aSubPixelOverrunIsNotAnOverflow()
PASS   : qmltestrunner::MarqueeTest::test_anUnlaidOutBoxDoesNotOverflow()
PASS   : qmltestrunner::MarqueeTest::test_anUnmeasuredTextDoesNotOverflow()
PASS   : qmltestrunner::MarqueeTest::test_reduceMotionLengthensTheHoldRatherThanShorteningIt()
PASS   : qmltestrunner::MarqueeTest::test_textThatFitsHasNoDuration()
PASS   : qmltestrunner::MarqueeTest::test_textThatFitsTravelsNowhere()
PASS   : qmltestrunner::MarqueeTest::test_textWiderThanItsBoxOverflows()
PASS   : qmltestrunner::MarqueeTest::test_theDurationIsProportionalToTheDistance()
PASS   : qmltestrunner::MarqueeTest::test_theHoldIsAReadableFractionOfTheTraverse()
PASS   : qmltestrunner::MarqueeTest::test_theTravelIsTheOverflowNotTheWholeString()
Totals: 1059 passed, 0 failed, 0 skipped, 0 blacklisted, 5230ms
All tests passed successfully!
```

The four adopted call-site files and `MarqueeText.qml` joined `DesignSystemCompile.qml`'s sweep, because the gate's own adoption rule is exactly why nothing in that sweep reached them: every one is behind a surface that has to be opened.

## What I could not verify

- **Nothing was checked against the live shell.** Work stayed in the worktree; the running `qs -c imi` was never touched or restarted, so the "check the log for `Configuration Loaded`" loop was not run. The compile sweep proves the five files compile, and the probe proves the widget behaves — neither proves the adopted rows render correctly on the real sidebar/dock.
- **No pixels were scored.** There is no screenshot of a marquee mid-traverse; "the clip actually hides the overflow at rest and reveals it at the end" is inferred from `label.x` and the `clip: true`, not measured off a frame.
- **The reduce-motion snap was not judged by a human.** It is the design decision most likely to want a second opinion: it is a hard content swap every three seconds, chosen over "no motion, text stays cut off" because the brief forbids the latter.
- **RTL was not considered.** The overflowing case forces `Text.AlignLeft` and travels leftward; a right-to-left string in an overflowing box is untested and probably wrong.
- **No measurement of the marquee's own frame cost.** The gate is argued from the existing `CookieClock` measurement, not re-measured for a text item — though every adopted surface is hidden when idle, so the worst case is bounded by the sidebar being open.

Docs: updated AGENT.md §Directory map (shared widgets) and §Design language (a new entry on what a marquee is for, where it may not run, and its two durations)
Changelog: updated
