### PR TITLE
feat(bar): a bar widget slides to its new slot instead of teleporting

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1691,6 +1691,47 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   every mutation of the motion. fa1e2a8b5 ("feat(plugins): animate a resizable widget's size
   between its offered spans"), 4e33a332a ("test(widgets): score a span change as in flight, not
   as a snap").
+- **The third member of that family: where the layout writes the target, the motion is INVERTED
+  from a measurement rather than eased onto the value.** A bar widget sits in a `Repeater` of
+  `BarGroup`s inside a `RowLayout`, so its `x` is the layout's to write - a `Behavior` on it is
+  handed a target that moves on every reflow, which is b710ef731 again. `modules/imi/bar/
+  BarGroup.qml` therefore animates a `Translate` toward zero, set from the offset back to where
+  the slot was drawn, which is FLIP (First, Last, Invert, Play); the arithmetic is
+  `modules/imi/bar/bar_flip.js` because nothing about the rendered bar is reachable from
+  `qmltestrunner`. Four things about it are worth not re-deriving.
+  **The "First" cannot live on the slot.** Measured with a `qml6` probe: a `Repeater` whose model
+  is a JS array answers a reassignment by destroying EVERY delegate and building the replacements,
+  in one turn of the event loop - so the widget about to slide is not the object that was standing
+  there, and a naive `onXChanged` inverse would start it from `x: 0`.
+  `modules/imi/bar/BarFlipRegistry.qml` is one deposit-and-recall per bar, keyed on the widget id
+  and expiring at the end of that turn: one per content tree rather than a singleton, because the
+  ids are identical on every screen and the positions are not, and expiring because a widget
+  switched back on ten minutes later has no honest position to fly in from.
+  **What is measured is not what moves.** The survey's source watches the widget's own `x`. That is
+  right in a near-edge bucket and wrong in a far-edge one: the section is sized by its row and
+  anchored to the screen's edge, so removing a widget moves the SECTION and leaves the first slot
+  at row-local zero - it travels the whole width of what left while its own `x` never changes, and
+  the last slot's `x` changes while it does not move at all. Each slot sums its ancestors' x/y up
+  to the registry's frame and watches every one of them. Deliberately a sum and never `mapToItem`,
+  which composes transforms: measured through that, a slot part-way through its own reposition
+  reports where it is DRAWN and the next invert comes off a number that is still moving.
+  **It is inert outside a reflow**, because a bar widget's content changes width constantly - the
+  clock every minute - and a running animation is a repaint of the whole output.
+  **And it stands down for a reorder drag**, whose `layout_ops.dropTarget` centres are read through
+  a `mapToItem` that composes exactly this transform; the drop's own reflow still animates, because
+  `BarEditController` clears `editBarDragActive` before the layout pass that follows it. The popup
+  overlay's card is unaffected for a different reason - its target is read only by its own
+  `retarget()`, which a reposition never calls.
+  Checked from both sides, because a settled position passes identically on the teleport this
+  replaced: `tests/test_bar_flip_contract.py` holds the source shape (one registry per tree on the
+  tree's own root, six delegate wirings each, no `Behavior` on a layout-written coordinate, no
+  `mapToItem`) and `BarFlipRuntimeTest.qml` samples where each slot is DRAWN 40ms in. That sample
+  is early on purpose - the spatial tier is front-loaded, so by 80ms a correct reposition and one
+  started on the mirror side of its destination are both ~90% of the way there. Design taken from
+  `docs/p3drovfx-animation-research-2026-08-16.md` §3.5.
+  b155851422 ("feat(bar): a bar widget slides to its new slot instead of teleporting"),
+  2bc474d53a ("feat(bar): bar_flip.js, a slot's reposition as arithmetic"),
+  bd60b78a31 ("test(bar): the harness stops rescuing the idiom it exists to fail").
 - **A sweep over ordered PAIRS is not a walk, and a trail's floor is in the trail's own units.**
   Two ways a span-motion harness reports confidently about a transition it never ran.
   `WeatherTreeMotionProbe` drives a list of `[from, to]` pairs but only ever committed `to` — so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@ own repo; the installer pins which revision it builds.
   once already.
 
 ### Added
+- **Bar widgets slide to their new place instead of teleporting.** When the
+  system tray empties, a plugin's bar widget is switched off, or the layouts
+  are reordered, every widget after it used to be drawn somewhere else on the
+  very next frame. They now travel there. Both bars, every corner style, and
+  the widget that returns still appears where it belongs rather than flying in
+  from wherever it last sat; a reorder drag in Edit Mode is left alone while it
+  is in flight.
 - **Long names scroll instead of being cut off.** Four places showed a name you
   did not write and cannot look up anywhere else on the row, and cut it off with
   an ellipsis: the dock's window preview — where the title is the only thing

--- a/dots/.config/quickshell/imi/BarEditRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/BarEditRuntimeTest.qml
@@ -156,7 +156,7 @@ ShellRoot {
                         currentIndex: index
                         editController: controller
                         editBucket: bucketBox.bucketName
-                        editWidgetId: modelData
+                        widgetId: modelData
 
                         Rectangle {
                             implicitWidth: 30

--- a/dots/.config/quickshell/imi/BarFlipRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/BarFlipRuntimeTest.qml
@@ -1,0 +1,503 @@
+import QtQuick
+import QtQuick.Layouts
+import QtTest
+import Quickshell
+import qs
+import qs.modules.common
+import qs.modules.imi.bar
+
+/**
+ * Scores a bar reflow as motion rather than as a result.
+ *
+ * A settled check cannot tell the reposition from the teleport it replaces:
+ * both end with every slot in the right place, and the difference exists only
+ * in the frames in between. So this harness samples where each slot is DRAWN
+ * 80ms and 240ms into a reflow and fails if it was already at its destination
+ * - the same question `WidgetResizeMotionRuntimeTest.qml` asks of a span
+ * change, for the same reason.
+ *
+ * Three strips are built because a bar's buckets are anchored three ways and
+ * the interesting slot is a different one in each:
+ *
+ *   - a LEFT-anchored bucket is the plain case: take a widget out and the ones
+ *     after it move, in their row's coordinates and on screen alike;
+ *   - a RIGHT-anchored bucket is the case the idiom this was taken from cannot
+ *     see. Its section is sized by its row, so removing a widget moves the
+ *     SECTION and leaves the first slot at row-local zero: that slot travels
+ *     the whole width of what left while its own `x` never changes, and a
+ *     reposition watching only `onXChanged` animates every slot but that one.
+ *     The harness asserts the slot's own coordinate really did not move, or
+ *     the check above passes vacuously - and asserts the mirror image on the
+ *     last slot, whose own coordinate changes and which does not travel at all;
+ *   - the vertical bar's far-edge bucket is the same turn, down the strip.
+ *
+ * Three more things are scored, none of them visible from a settled position:
+ *
+ *   - a widget with no record snaps. That is the first layout of every shell
+ *     start - nothing has been drawn yet, so there is nothing to invert from,
+ *     and a reposition there would slide the whole bar in from the frame's
+ *     origin - and it is equally a widget switched back on minutes later,
+ *     whose record expired with the reflow that removed it. The second is what
+ *     is driven here, because it runs the same recall on a strip already on
+ *     screen;
+ *   - a reorder drag in flight suppresses the reposition, because the gesture
+ *     reads slot centres through a `mapToItem` that composes the transform
+ *     this animates;
+ *   - and the motion is along the bar only, at both orientations, which is the
+ *     axis-inert comparison the vertical dock's reorder shipped without.
+ *
+ * The slots are synthetic - real `BarGroup`s carrying a coloured rectangle -
+ * because the real bar widget files reach Hyprland, PipeWire and the tray,
+ * none of which a weston harness has. What IS real is everything the feature
+ * added: BarGroup's translate, its ancestor walk, BarFlipRegistry's deposit,
+ * recall and expiry, and bar_flip.js's arithmetic under all of it.
+ *
+ * Run it against a throwaway config:
+ *   XDG_CONFIG_HOME=$(mktemp -d) XDG_STATE_HOME=$(mktemp -d) qs -p BarFlipRuntimeTest.qml
+ */
+ShellRoot {
+    id: harness
+
+    property int failures: 0
+    property int checksRun: 0
+
+    function check(label, ok) {
+        harness.checksRun++;
+        console.log(`[BarFlip] ${label}: ${ok ? "ok" : "FAIL"}`);
+        if (!ok)
+            harness.failures++;
+    }
+
+    // Sizes that differ per widget, so a reflow moves every survivor by a
+    // different amount and no check can pass on a coincidence.
+    function sizeOf(id) {
+        return ({ alpha: 40, beta: 70, gamma: 100 })[id] ?? 40;
+    }
+
+    property var nearModel: ["alpha", "beta", "gamma"]
+    property var farModel: ["alpha", "beta", "gamma"]
+    property var colModel: ["alpha", "beta", "gamma"]
+
+    FloatingWindow {
+        visible: true
+        implicitWidth: 900
+        implicitHeight: 500
+        color: "black"
+
+        TestCase {
+            id: driver
+            when: false
+            name: "BarFlipDriver"
+        }
+
+        // The near-edge bucket: anchored where the row starts.
+        Item {
+            id: nearFrame
+            x: 0
+            y: 0
+            width: parent.width
+            height: 60
+
+            BarFlipRegistry { id: nearRegistry }
+
+            Item {
+                anchors.left: parent.left
+                anchors.top: parent.top
+                anchors.bottom: parent.bottom
+                width: nearRow.implicitWidth
+
+                RowLayout {
+                    id: nearRow
+                    anchors.fill: parent
+                    spacing: 4
+
+                    Repeater {
+                        id: nearRepeater
+                        model: harness.nearModel
+                        delegate: BarGroup {
+                            required property var modelData
+                            required property int index
+                            currentIndex: index
+                            totalCount: harness.nearModel.length
+                            widgetId: modelData
+                            flipRegistry: nearRegistry
+                            Rectangle {
+                                implicitWidth: harness.sizeOf(modelData)
+                                implicitHeight: 24
+                                color: "gray"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // The far-edge bucket: anchored to the other end of the bar, sized by
+        // its row, which is what makes the section itself move.
+        Item {
+            id: farFrame
+            x: 0
+            y: 70
+            width: parent.width
+            height: 60
+
+            BarFlipRegistry { id: farRegistry }
+
+            Item {
+                anchors.right: parent.right
+                anchors.top: parent.top
+                anchors.bottom: parent.bottom
+                width: farRow.implicitWidth
+
+                RowLayout {
+                    id: farRow
+                    anchors.fill: parent
+                    spacing: 4
+
+                    Repeater {
+                        id: farRepeater
+                        model: harness.farModel
+                        delegate: BarGroup {
+                            required property var modelData
+                            required property int index
+                            currentIndex: index
+                            totalCount: harness.farModel.length
+                            widgetId: modelData
+                            flipRegistry: farRegistry
+                            Rectangle {
+                                implicitWidth: harness.sizeOf(modelData)
+                                implicitHeight: 24
+                                color: "gray"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // The vertical bar's far-edge bucket, the same arrangement turned.
+        // Three frames rather than one that re-anchors: an item holding two
+        // orientations' anchors at once is the silent full-fill defect
+        // AGENT.md records for the dock's turn, and this harness has no reason
+        // to reproduce it.
+        Item {
+            id: colFrame
+            x: 0
+            y: 150
+            width: 60
+            height: parent.height - 150
+
+            BarFlipRegistry { id: colRegistry }
+
+            Item {
+                anchors.bottom: parent.bottom
+                anchors.left: parent.left
+                anchors.right: parent.right
+                height: col.implicitHeight
+
+                ColumnLayout {
+                    id: col
+                    anchors.fill: parent
+                    spacing: 4
+
+                    Repeater {
+                        id: colRepeater
+                        model: harness.colModel
+                        delegate: BarGroup {
+                            required property var modelData
+                            required property int index
+                            vertical: true
+                            currentIndex: index
+                            totalCount: harness.colModel.length
+                            widgetId: modelData
+                            flipRegistry: colRegistry
+                            Rectangle {
+                                implicitWidth: 24
+                                implicitHeight: harness.sizeOf(modelData)
+                                color: "gray"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // ---- reading a strip ---------------------------------------------------
+    //
+    // A reflow destroys every delegate and builds the replacements, so a slot
+    // is looked up by widget id at the moment it is read, never held.
+
+    function slotOf(repeater, id) {
+        for (let i = 0; i < repeater.count; i++) {
+            const item = repeater.itemAt(i);
+            if (item && item.widgetId === id) return item;
+        }
+        return null;
+    }
+
+    // Where the slot is DRAWN - the translate included - which is the only
+    // number the eye can check a reposition against.
+    function drawnAlong(repeater, id, vertical) {
+        const slot = harness.slotOf(repeater, id);
+        if (!slot) return NaN;
+        const origin = slot.flipDrawnOrigin();
+        return Math.round(vertical ? origin.y : origin.x);
+    }
+
+    function drawnAcross(repeater, id, vertical) {
+        const slot = harness.slotOf(repeater, id);
+        if (!slot) return NaN;
+        const origin = slot.flipDrawnOrigin();
+        return Math.round(vertical ? origin.x : origin.y);
+    }
+
+    // The slot's own coordinate, which is what the layout writes and what the
+    // idiom this replaces would have watched.
+    function ownAlong(repeater, id, vertical) {
+        const slot = harness.slotOf(repeater, id);
+        if (!slot) return NaN;
+        return Math.round(vertical ? slot.y : slot.x);
+    }
+
+    // ---- sampling ----------------------------------------------------------
+    //
+    // 80ms and 240ms are both well inside the 350ms tier the reposition takes,
+    // and the runner's own tick is past its end, so a settled read is settled.
+
+    property var samples: ({})
+    property var sampled: []
+    property var sampleRepeater: null
+    property bool sampleVertical: false
+
+    function sampleNow() {
+        const shot = ({});
+        for (const id of harness.sampled) {
+            shot[id] = {
+                along: harness.drawnAlong(harness.sampleRepeater, id, harness.sampleVertical),
+                across: harness.drawnAcross(harness.sampleRepeater, id, harness.sampleVertical)
+            };
+        }
+        return shot;
+    }
+
+    function startSampling(repeater, vertical, ids) {
+        harness.samples = ({});
+        harness.sampleRepeater = repeater;
+        harness.sampleVertical = vertical;
+        harness.sampled = ids;
+        earlySample.restart();
+        midSample.restart();
+    }
+
+    Timer {
+        id: earlySample
+        interval: 80
+        onTriggered: harness.samples.early = harness.sampleNow()
+    }
+    Timer {
+        id: midSample
+        interval: 240
+        onTriggered: harness.samples.mid = harness.sampleNow()
+    }
+
+    // The check that separates a reposition from a teleport. A slot already at
+    // its destination 80ms in is exactly what the Repeater does on its own.
+    function scoreInFlight(label, id, from, to) {
+        const early = harness.samples.early;
+        const mid = harness.samples.mid;
+        harness.check(`${label}: sampled at all`,
+                      !!early && !!mid && !!early[id] && !!mid[id]);
+        if (!early || !mid || !early[id] || !mid[id]) return;
+        harness.check(`${label}: the slot under test actually moves, `
+                      + `${from} to ${to}`, from !== to);
+        harness.check(`${label}: was not already at its new place, `
+                      + `got ${early[id].along} against ${to}`,
+                      early[id].along !== to);
+        harness.check(`${label}: had left its old one, `
+                      + `got ${early[id].along} against ${from}`,
+                      early[id].along !== from);
+        harness.check(`${label}: was still travelling, `
+                      + `got ${early[id].along} then ${mid[id].along}`,
+                      early[id].along !== mid[id].along);
+    }
+
+    function scoreSnapped(label, id, to) {
+        const early = harness.samples.early;
+        harness.check(`${label}: sampled at all`, !!early && !!early[id]);
+        if (!early || !early[id]) return;
+        harness.check(`${label}: was already where it belongs, `
+                      + `got ${early[id].along} against ${to}`,
+                      early[id].along === to);
+    }
+
+    // ---- the run -----------------------------------------------------------
+
+    property var before: ({})
+
+    readonly property var steps: [
+        // The strips built at all, and built along their own axes. Every
+        // "nothing moved" result below proves nothing if the harness never
+        // drew anything.
+        () => {
+            harness.check("a near-edge bucket stacks along the bar",
+                          harness.drawnAlong(nearRepeater, "alpha", false)
+                          < harness.drawnAlong(nearRepeater, "gamma", false));
+            harness.check("a far-edge bucket does too",
+                          harness.drawnAlong(farRepeater, "alpha", false)
+                          < harness.drawnAlong(farRepeater, "gamma", false));
+            harness.check("and a vertical bucket stacks down its strip",
+                          harness.drawnAlong(colRepeater, "alpha", true)
+                          < harness.drawnAlong(colRepeater, "gamma", true));
+        },
+        // The plain case: a widget disappears from a near-edge bucket - the
+        // tray emptying, a plugin switched off - and everything after it moves.
+        () => {
+            harness.before = ({
+                alpha: harness.drawnAlong(nearRepeater, "alpha", false),
+                gamma: harness.drawnAlong(nearRepeater, "gamma", false),
+                gammaOwn: harness.ownAlong(nearRepeater, "gamma", false)
+            });
+            harness.startSampling(nearRepeater, false, ["alpha", "gamma"]);
+            harness.nearModel = ["alpha", "gamma"];
+        },
+        () => {
+            scoreInFlight("a widget leaving a near-edge bucket", "gamma",
+                          harness.before.gamma,
+                          harness.drawnAlong(nearRepeater, "gamma", false));
+            harness.check("...its own coordinate moved too, "
+                          + `got ${harness.ownAlong(nearRepeater, "gamma", false)} `
+                          + `against ${harness.before.gammaOwn}`,
+                          harness.ownAlong(nearRepeater, "gamma", false)
+                          !== harness.before.gammaOwn);
+            harness.check("...and the slot before it stayed where it was",
+                          harness.drawnAlong(nearRepeater, "alpha", false)
+                          === harness.before.alpha);
+            harness.check("...with the reposition settled on the layout's own place",
+                          harness.slotOf(nearRepeater, "gamma").flipTravel === 0);
+        },
+        // The case a reposition watching the slot's own x cannot see: in a
+        // far-edge bucket the SECTION moves and the first slot does not.
+        () => {
+            harness.before = ({
+                alpha: harness.drawnAlong(farRepeater, "alpha", false),
+                alphaOwn: harness.ownAlong(farRepeater, "alpha", false),
+                alphaAcross: harness.drawnAcross(farRepeater, "alpha", false),
+                gamma: harness.drawnAlong(farRepeater, "gamma", false),
+                gammaOwn: harness.ownAlong(farRepeater, "gamma", false)
+            });
+            harness.startSampling(farRepeater, false, ["alpha", "gamma"]);
+            harness.farModel = ["alpha", "gamma"];
+        },
+        () => {
+            scoreInFlight("a widget leaving a far-edge bucket", "alpha",
+                          harness.before.alpha,
+                          harness.drawnAlong(farRepeater, "alpha", false));
+            // Without this the check above is satisfied by any implementation:
+            // it is only interesting because the slot's own coordinate is the
+            // one it always had and only its section moved under it.
+            harness.check("...while its own coordinate never changed, "
+                          + `got ${harness.ownAlong(farRepeater, "alpha", false)} `
+                          + `against ${harness.before.alphaOwn}`,
+                          harness.ownAlong(farRepeater, "alpha", false)
+                          === harness.before.alphaOwn);
+            // And the mirror image, so the pair cannot both be read off one
+            // property: the last slot's own coordinate moves and the slot does
+            // not travel, because the far edge is where it already was.
+            harness.check("...and the last slot's own coordinate moved without it travelling",
+                          harness.ownAlong(farRepeater, "gamma", false)
+                          !== harness.before.gammaOwn
+                          && harness.drawnAlong(farRepeater, "gamma", false)
+                          === harness.before.gamma);
+            const early = harness.samples.early;
+            harness.check("a horizontal bar's slots do not travel across it, "
+                          + `got ${early.alpha.across} against ${harness.before.alphaAcross}`,
+                          early.alpha.across === harness.before.alphaAcross);
+        },
+        // A record is worth one reflow. Switching the widget back on a second
+        // later finds nothing to invert from.
+        () => {
+            harness.before = ({
+                alpha: harness.drawnAlong(farRepeater, "alpha", false)
+            });
+            harness.startSampling(farRepeater, false, ["alpha", "beta"]);
+            harness.farModel = ["alpha", "beta", "gamma"];
+        },
+        () => {
+            scoreSnapped("a widget switched back on later", "beta",
+                         harness.drawnAlong(farRepeater, "beta", false));
+            scoreInFlight("...while its neighbour still makes room", "alpha",
+                          harness.before.alpha,
+                          harness.drawnAlong(farRepeater, "alpha", false));
+        },
+        // A reorder drag reads slot centres through mapToItem, which composes
+        // the transform, so the gesture and the reposition may not overlap.
+        () => {
+            GlobalStates.editBarDragActive = true;
+            harness.startSampling(farRepeater, false, ["alpha"]);
+            harness.farModel = ["alpha", "gamma"];
+        },
+        () => {
+            scoreSnapped("a reflow while a reorder drag is in flight", "alpha",
+                         harness.drawnAlong(farRepeater, "alpha", false));
+            GlobalStates.editBarDragActive = false;
+        },
+        // ---- the same reflow, down a vertical bar -------------------------
+        () => {
+            harness.before = ({
+                alpha: harness.drawnAlong(colRepeater, "alpha", true),
+                alphaOwn: harness.ownAlong(colRepeater, "alpha", true),
+                alphaAcross: harness.drawnAcross(colRepeater, "alpha", true)
+            });
+            harness.startSampling(colRepeater, true, ["alpha"]);
+            harness.colModel = ["alpha", "gamma"];
+        },
+        () => {
+            scoreInFlight("a widget leaving a vertical bar", "alpha",
+                          harness.before.alpha,
+                          harness.drawnAlong(colRepeater, "alpha", true));
+            harness.check("...while its own coordinate never changed, "
+                          + `got ${harness.ownAlong(colRepeater, "alpha", true)} `
+                          + `against ${harness.before.alphaOwn}`,
+                          harness.ownAlong(colRepeater, "alpha", true)
+                          === harness.before.alphaOwn);
+            const early = harness.samples.early;
+            harness.check("a vertical bar's slots do not travel across it, "
+                          + `got ${early.alpha.across} against ${harness.before.alphaAcross}`,
+                          early.alpha.across === harness.before.alphaAcross);
+        }
+    ]
+
+    property int stepIndex: 0
+
+    Timer {
+        id: setup
+        interval: 250
+        repeat: true
+        running: true
+        onTriggered: {
+            if (!Config.ready)
+                return;
+            setup.running = false;
+            runner.running = true;
+        }
+    }
+
+    // One step per tick, and the tick outlasts the reposition, so every
+    // settled read below is a settled read.
+    Timer {
+        id: runner
+        interval: 900
+        repeat: true
+        running: false
+        onTriggered: {
+            if (harness.stepIndex >= harness.steps.length) {
+                runner.running = false;
+                console.log(`[BarFlip] checks: ${harness.checksRun} failures: ${harness.failures}`);
+                Qt.exit(harness.failures === 0 ? 0 : 1);
+                return;
+            }
+            harness.steps[harness.stepIndex++]();
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/BarFlipRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/BarFlipRuntimeTest.qml
@@ -12,7 +12,7 @@ import qs.modules.imi.bar
  * A settled check cannot tell the reposition from the teleport it replaces:
  * both end with every slot in the right place, and the difference exists only
  * in the frames in between. So this harness samples where each slot is DRAWN
- * 80ms and 240ms into a reflow and fails if it was already at its destination
+ * 40ms and 240ms into a reflow and fails if it was already at its destination
  * - the same question `WidgetResizeMotionRuntimeTest.qml` asks of a span
  * change, for the same reason.
  *
@@ -117,6 +117,15 @@ ShellRoot {
                         delegate: BarGroup {
                             required property var modelData
                             required property int index
+                            // As the content trees declare them: a horizontal
+                            // slot fills the bar's height and a vertical one
+                            // its width, so the CROSS coordinate is zero and
+                            // stays there. Without that the harness rescues an
+                            // implementation watching only the slot's own
+                            // coordinate - the cross-axis centring writes it
+                            // once at creation and that write alone triggers a
+                            // measurement the real bar never gets.
+                            Layout.fillHeight: true
                             currentIndex: index
                             totalCount: harness.nearModel.length
                             widgetId: modelData
@@ -160,6 +169,15 @@ ShellRoot {
                         delegate: BarGroup {
                             required property var modelData
                             required property int index
+                            // As the content trees declare them: a horizontal
+                            // slot fills the bar's height and a vertical one
+                            // its width, so the CROSS coordinate is zero and
+                            // stays there. Without that the harness rescues an
+                            // implementation watching only the slot's own
+                            // coordinate - the cross-axis centring writes it
+                            // once at creation and that write alone triggers a
+                            // measurement the real bar never gets.
+                            Layout.fillHeight: true
                             currentIndex: index
                             totalCount: harness.farModel.length
                             widgetId: modelData
@@ -206,6 +224,7 @@ ShellRoot {
                         delegate: BarGroup {
                             required property var modelData
                             required property int index
+                            Layout.fillWidth: true
                             vertical: true
                             currentIndex: index
                             totalCount: harness.colModel.length
@@ -236,20 +255,27 @@ ShellRoot {
         return null;
     }
 
-    // Where the slot is DRAWN - the translate included - which is the only
-    // number the eye can check a reposition against.
-    function drawnAlong(repeater, id, vertical) {
+    // Where the slot is DRAWN, read through Qt's own transform chain rather
+    // than through the reposition's arithmetic. `mapToItem` composes the
+    // Translate - which is exactly why BarGroup may not measure with it, and
+    // exactly why this may: a harness that read the implementation's own
+    // accounting back would agree with it by construction, including about an
+    // axis it had stopped applying.
+    function scenePoint(repeater, id) {
         const slot = harness.slotOf(repeater, id);
-        if (!slot) return NaN;
-        const origin = slot.flipDrawnOrigin();
-        return Math.round(vertical ? origin.y : origin.x);
+        return slot ? slot.mapToItem(null, 0, 0) : null;
+    }
+
+    function drawnAlong(repeater, id, vertical) {
+        const point = harness.scenePoint(repeater, id);
+        if (!point) return NaN;
+        return Math.round(vertical ? point.y : point.x);
     }
 
     function drawnAcross(repeater, id, vertical) {
-        const slot = harness.slotOf(repeater, id);
-        if (!slot) return NaN;
-        const origin = slot.flipDrawnOrigin();
-        return Math.round(vertical ? origin.x : origin.y);
+        const point = harness.scenePoint(repeater, id);
+        if (!point) return NaN;
+        return Math.round(vertical ? point.x : point.y);
     }
 
     // The slot's own coordinate, which is what the layout writes and what the
@@ -262,8 +288,15 @@ ShellRoot {
 
     // ---- sampling ----------------------------------------------------------
     //
-    // 80ms and 240ms are both well inside the 350ms tier the reposition takes,
+    // 40ms and 240ms are both well inside the 350ms tier the reposition takes,
     // and the runner's own tick is past its end, so a settled read is settled.
+    //
+    // The early one is deliberately EARLY rather than merely in flight. The
+    // spatial tier is front-loaded, so by 80ms a reposition is already ~90%
+    // of the way there - and so is one that started on the mirror side of its
+    // destination, which is what an inverse applied with the wrong sign
+    // produces. Measured: 0.55 of the travel at 40ms against 0.90 at 80ms, so
+    // only the earlier sample leaves the two apart.
 
     property var samples: ({})
     property var sampled: []
@@ -292,7 +325,7 @@ ShellRoot {
 
     Timer {
         id: earlySample
-        interval: 80
+        interval: 40
         onTriggered: harness.samples.early = harness.sampleNow()
     }
     Timer {
@@ -320,6 +353,18 @@ ShellRoot {
         harness.check(`${label}: was still travelling, `
                       + `got ${early[id].along} then ${mid[id].along}`,
                       early[id].along !== mid[id].along);
+        // ...and travelling the right WAY, which every check above is
+        // satisfied by: an inverse applied with the wrong sign puts the slot
+        // on the mirror side of its destination and eases it back across, so
+        // it is never at either endpoint and never stops moving. Scored as
+        // progress from the old place to the new, with a quarter of the travel
+        // of headroom past the end because the spatial tier's control points
+        // leave the unit box and a sample is allowed to overshoot. A mirrored
+        // start reads as 2.
+        const progress = (early[id].along - from) / (to - from);
+        harness.check(`${label}: was on its way there, `
+                      + `got ${early[id].along} at progress ${progress.toFixed(2)}`,
+                      progress >= 0 && progress <= 1.25);
     }
 
     function scoreSnapped(label, id, to) {
@@ -415,13 +460,16 @@ ShellRoot {
                           early.alpha.across === harness.before.alphaAcross);
         },
         // A record is worth one reflow. Switching the widget back on a second
-        // later finds nothing to invert from.
+        // later finds nothing to invert from - and it comes back at the END
+        // of the bucket, somewhere it has never been drawn, because a widget
+        // returning to the slot it left would snap whether or not its record
+        // had expired.
         () => {
             harness.before = ({
                 alpha: harness.drawnAlong(farRepeater, "alpha", false)
             });
             harness.startSampling(farRepeater, false, ["alpha", "beta"]);
-            harness.farModel = ["alpha", "beta", "gamma"];
+            harness.farModel = ["alpha", "gamma", "beta"];
         },
         () => {
             scoreSnapped("a widget switched back on later", "beta",

--- a/dots/.config/quickshell/imi/modules/imi/bar/BarContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/BarContent.qml
@@ -222,7 +222,7 @@ Item {
                             totalCount: root.effectiveLeftLayout.length
                             editController: barEditController
                             editBucket: "left"
-                            editWidgetId: modelData
+                            widgetId: modelData
                             paintMaterialPill: root.shouldPaintMaterialPill(modelData)
                             bgColor: root.getMaterialPillColor(modelData)
                             Loader {
@@ -260,7 +260,7 @@ Item {
                         totalCount: root.effectiveLeftLayout.length
                         editController: barEditController
                         editBucket: "left"
-                        editWidgetId: modelData
+                        widgetId: modelData
                         Loader {
                             Layout.fillHeight: true
                             source: root.getWidgetUrl(modelData)
@@ -335,7 +335,7 @@ Item {
                             totalCount: root.effectiveMiddleLayout.length
                             editController: barEditController
                             editBucket: "middle"
-                            editWidgetId: modelData
+                            widgetId: modelData
                             paintMaterialPill: root.shouldPaintMaterialPill(modelData)
                             bgColor: root.getMaterialPillColor(modelData)
                             Loader {
@@ -373,7 +373,7 @@ Item {
                         totalCount: root.effectiveMiddleLayout.length
                         editController: barEditController
                         editBucket: "middle"
-                        editWidgetId: modelData
+                        widgetId: modelData
                         Loader {
                             Layout.fillHeight: true
                             source: root.getWidgetUrl(modelData)
@@ -449,7 +449,7 @@ Item {
                             totalCount: root.effectiveRightLayout.length
                             editController: barEditController
                             editBucket: "right"
-                            editWidgetId: modelData
+                            widgetId: modelData
                             paintMaterialPill: root.shouldPaintMaterialPill(modelData)
                             bgColor: root.getMaterialPillColor(modelData)
                             Loader {
@@ -487,7 +487,7 @@ Item {
                         totalCount: root.effectiveRightLayout.length
                         editController: barEditController
                         editBucket: "right"
-                        editWidgetId: modelData
+                        widgetId: modelData
                         Loader {
                             Layout.fillHeight: true
                             source: root.getWidgetUrl(modelData)

--- a/dots/.config/quickshell/imi/modules/imi/bar/BarContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/BarContent.qml
@@ -223,6 +223,7 @@ Item {
                             editController: barEditController
                             editBucket: "left"
                             widgetId: modelData
+                            flipRegistry: flipRegistry
                             paintMaterialPill: root.shouldPaintMaterialPill(modelData)
                             bgColor: root.getMaterialPillColor(modelData)
                             Loader {
@@ -261,6 +262,7 @@ Item {
                         editController: barEditController
                         editBucket: "left"
                         widgetId: modelData
+                        flipRegistry: flipRegistry
                         Loader {
                             Layout.fillHeight: true
                             source: root.getWidgetUrl(modelData)
@@ -336,6 +338,7 @@ Item {
                             editController: barEditController
                             editBucket: "middle"
                             widgetId: modelData
+                            flipRegistry: flipRegistry
                             paintMaterialPill: root.shouldPaintMaterialPill(modelData)
                             bgColor: root.getMaterialPillColor(modelData)
                             Loader {
@@ -374,6 +377,7 @@ Item {
                         editController: barEditController
                         editBucket: "middle"
                         widgetId: modelData
+                        flipRegistry: flipRegistry
                         Loader {
                             Layout.fillHeight: true
                             source: root.getWidgetUrl(modelData)
@@ -450,6 +454,7 @@ Item {
                             editController: barEditController
                             editBucket: "right"
                             widgetId: modelData
+                            flipRegistry: flipRegistry
                             paintMaterialPill: root.shouldPaintMaterialPill(modelData)
                             bgColor: root.getMaterialPillColor(modelData)
                             Loader {
@@ -488,6 +493,7 @@ Item {
                         editController: barEditController
                         editBucket: "right"
                         widgetId: modelData
+                        flipRegistry: flipRegistry
                         Loader {
                             Layout.fillHeight: true
                             source: root.getWidgetUrl(modelData)
@@ -530,5 +536,12 @@ Item {
         leftZone: leftBoundary
         middleZone: middleBoundary
         rightZone: rightBoundary
+    }
+
+    // Where each widget was drawn, so the slot that replaces it after a reflow
+    // has a First to invert from. Declared as a child of this root because
+    // that is the frame every position is measured in - see BarFlipRegistry.
+    BarFlipRegistry {
+        id: flipRegistry
     }
 }

--- a/dots/.config/quickshell/imi/modules/imi/bar/BarFlipRegistry.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/BarFlipRegistry.qml
@@ -1,0 +1,68 @@
+import QtQuick
+
+/**
+ * Where each of one bar's widgets was drawn, for exactly as long as a reflow
+ * takes.
+ *
+ * FLIP needs a "First" - where the thing being repositioned was before the
+ * layout changed - and a bar slot cannot keep it itself. Measured with a
+ * `qml6` probe: a `Repeater` whose model is a JS array answers a reassignment
+ * by destroying EVERY delegate and building the replacements, so the widget
+ * that is about to slide is not the object that was standing there. The
+ * outgoing slot deposits where it was drawn, the incoming one recalls it, and
+ * the identity that survives in between is the widget id.
+ *
+ * ---- why one of these per content tree, and not a singleton ---------------
+ *
+ * The ids are the same on every screen and the positions are not: a bar's
+ * right-hand bucket sits at the screen's width. A singleton would have each
+ * screen's bar overwriting the others' records during the one config change
+ * that reflows all of them at once, and every bar but the last would invert
+ * from a position on somebody else's monitor.
+ *
+ * ---- why the records expire ------------------------------------------------
+ *
+ * A record is worth exactly one reflow. The destroy-and-rebuild burst happens
+ * inside a single turn of the event loop, so a recall always beats the timer -
+ * while a widget the user switches back on from Settings ten minutes later
+ * finds nothing, and simply appears where it belongs instead of flying in from
+ * wherever it last sat. Keeping the record would be indistinguishable from a
+ * bug the moment the bar's layout had changed in between.
+ */
+Item {
+    id: root
+
+    // The frame every position is measured in: this item's own parent, which
+    // is the content tree's root. Deliberately NOT the window - the bar's body
+    // slides on its margins for auto-hide, and a frame that travelled with the
+    // screen would read the slide as every slot repositioning at once.
+    readonly property Item frame: root.parent
+
+    visible: false
+    width: 0
+    height: 0
+
+    // widgetId -> { x, y }, in `frame` coordinates.
+    property var positions: ({})
+
+    function deposit(widgetId, point) {
+        if (!widgetId || !point) return;
+        root.positions[widgetId] = point;
+        expiry.restart();
+    }
+
+    function recall(widgetId) {
+        if (!widgetId) return null;
+        const point = root.positions[widgetId];
+        return point === undefined ? null : point;
+    }
+
+    Timer {
+        id: expiry
+        // Zero, not a duration: "the rest of this turn of the event loop" is
+        // the whole life of a record, and a real interval would be a guess at
+        // how long a rebuild takes.
+        interval: 0
+        onTriggered: root.positions = ({})
+    }
+}

--- a/dots/.config/quickshell/imi/modules/imi/bar/BarGroup.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/BarGroup.qml
@@ -2,6 +2,7 @@ import qs
 import qs.modules.common
 import QtQuick
 import QtQuick.Layouts
+import "bar_flip.js" as BarFlip
 
 Item {
     id: root
@@ -22,6 +23,11 @@ Item {
     // controller (a test, a future preview) gets no overlay at all.
     property var editController: null
     property string editBucket: ""
+
+    // Where this bar's slots were drawn, handed in by the content tree. A tree
+    // that passes none (the edit harness, a preview) simply has no motion -
+    // the same opt-out shape as editController.
+    property BarFlipRegistry flipRegistry: null
     property bool isMaterial: Config.options.bar.cornerStyle === 3
     property bool paintMaterialPill: false
     // Islands is the only style where each group *is* the visible shape, with
@@ -112,6 +118,129 @@ Item {
     opacity: editLoader.item && editLoader.item.dragging ? 0.4 : 1
     Behavior on opacity {
         animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
+    }
+
+    // ---- the reposition -----------------------------------------------------
+    //
+    // FLIP, declared HERE for the reason the edit overlay is: every widget in
+    // both bars is wrapped in a BarGroup, so one file turns by the `vertical`
+    // flag where a per-delegate copy would be twelve and the two bars would
+    // drift the way they already did over widget files (a47462fcc).
+    //
+    // What moves is a Translate, never `x`/`y`: a slot's coordinates belong to
+    // the layout, and writing them would fight it. What is animated is that
+    // translate toward zero, which nothing else writes - the layout's own
+    // motion is inverted from a measurement rather than eased, precisely
+    // because a Behavior handed a target that moves every frame restarts every
+    // frame and never ticks (b710ef731).
+    property real flipTravel: 0
+    property var flipOrigin: null
+    property bool flipPending: false
+    property var flipChain: []
+
+    transform: Translate {
+        x: root.vertical ? 0 : root.flipTravel
+        y: root.vertical ? root.flipTravel : 0
+    }
+
+    // The tier taken WHOLE - duration, easing type and curve from the tier's
+    // own component - and named so the reposition can be retargeted rather
+    // than restarted from scratch when a second reflow lands mid-flight.
+    readonly property NumberAnimation flipAnim:
+        Appearance.animation.elementMoveSmall.numberAnimation.createObject(root)
+
+    // The ancestors between this slot and the registry's frame, each of which
+    // can move it without its own x/y changing: the right-hand bucket's
+    // section is anchored to the screen's edge and takes its width from its
+    // row, so removing a widget moves the section and leaves the slot at
+    // row-local 0 exactly where it was. That slot travels the whole width of
+    // what left, and nothing on it announces the move.
+    function flipWalk() {
+        const frame = root.flipRegistry ? root.flipRegistry.frame : null;
+        const chain = [];
+        let node = root;
+        while (node && node !== frame) {
+            chain.push(node);
+            node = node.parent;
+        }
+        return chain;
+    }
+
+    function flipOriginNow() {
+        return BarFlip.chainOrigin(root.flipWalk());
+    }
+
+    // What the next slot for this widget inverts from: where this one is
+    // DRAWN, translate included, so a reflow interrupting another is continuous
+    // rather than starting from the layout position nobody ever saw.
+    function flipDrawnOrigin() {
+        const origin = root.flipOriginNow();
+        return root.vertical
+            ? { x: origin.x, y: origin.y + root.flipTravel }
+            : { x: origin.x + root.flipTravel, y: origin.y };
+    }
+
+    function flipMeasure() {
+        // Outside a reposition this slot is inert. A bar widget's content
+        // changes width constantly - the clock every minute, the media title
+        // per track - and animating every one of those would keep the bar
+        // repainting the whole output for reasons the user never asked about.
+        if (!root.flipPending && !root.flipAnim.running) return;
+        const origin = root.flipOriginNow();
+        const step = BarFlip.repositionTravel(root.flipTravel, root.flipOrigin,
+                                              origin, root.vertical, BarFlip.MIN_TRAVEL);
+        root.flipOrigin = origin;
+        root.flipPending = false;
+        if (!step.play) return;
+        root.flipTravel = step.travel;
+        root.flipAnim.restart();
+    }
+
+    // A reorder drag is the one motion this must not join. The gesture reads
+    // slot centres through `mapToItem`, which composes transforms, so a slot
+    // part-way through a reposition would offer the drop arithmetic a centre
+    // that moves every frame - and the drag's own ghost and indicator are
+    // already the moving parts. The drop's reflow still animates: the
+    // controller clears this flag before the layout pass that follows it.
+    readonly property bool flipAllowed: !GlobalStates.editBarDragActive
+    onFlipAllowedChanged: if (!root.flipAllowed) {
+        root.flipAnim.stop();
+        root.flipTravel = 0;
+        root.flipPending = false;
+    }
+
+    Connections {
+        target: root.flipAnim
+        // `finished`, not `stopped`: a retarget stops the animation to restart
+        // it, and standing the reposition down there would end it half way.
+        function onFinished() {
+            root.flipTravel = 0;
+        }
+    }
+
+    Component.onCompleted: {
+        if (!root.flipRegistry) return;
+        root.flipAnim.target = root;
+        root.flipAnim.property = "flipTravel";
+        root.flipAnim.to = 0;
+        root.flipChain = root.flipWalk();
+        for (const node of root.flipChain) {
+            node.xChanged.connect(root, root.flipMeasure);
+            node.yChanged.connect(root, root.flipMeasure);
+        }
+        const recalled = root.flipAllowed ? root.flipRegistry.recall(root.widgetId) : null;
+        if (!recalled) return;
+        root.flipOrigin = recalled;
+        root.flipPending = true;
+    }
+
+    Component.onDestruction: {
+        if (!root.flipRegistry) return;
+        root.flipRegistry.deposit(root.widgetId, root.flipDrawnOrigin());
+        for (const node of root.flipChain) {
+            node.xChanged.disconnect(root, root.flipMeasure);
+            node.yChanged.disconnect(root, root.flipMeasure);
+        }
     }
 
     Loader {

--- a/dots/.config/quickshell/imi/modules/imi/bar/BarGroup.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/BarGroup.qml
@@ -9,15 +9,19 @@ Item {
     property int currentIndex: 0
     property int totalCount: 0
 
+    // Which widget this slot draws. Not the edit overlay's alone any more -
+    // the reposition at the bottom of this file keys its record on it too, and
+    // a slot cannot have two answers to which widget it is - so the name lost
+    // the `edit` prefix it carried while the overlay was its only reader.
+    property string widgetId: ""
+
     // Edit Mode's per-widget affordances, declared HERE because every widget
     // in both bars is wrapped in a BarGroup - one Loader in this file covers
     // both orientations, where a per-delegate copy would be twelve. The
-    // delegates pass which bucket this slot draws and which widget id it is;
-    // a tree that passes no controller (a test, a future preview) gets no
-    // overlay at all.
+    // delegates pass which bucket this slot draws; a tree that passes no
+    // controller (a test, a future preview) gets no overlay at all.
     property var editController: null
     property string editBucket: ""
-    property string editWidgetId: ""
     property bool isMaterial: Config.options.bar.cornerStyle === 3
     property bool paintMaterialPill: false
     // Islands is the only style where each group *is* the visible shape, with
@@ -122,7 +126,7 @@ Item {
         sourceComponent: BarWidgetEditItem {
             controller: root.editController
             bucket: root.editBucket
-            widgetId: root.editWidgetId
+            widgetId: root.widgetId
             visibleIndex: root.currentIndex
         }
     }

--- a/dots/.config/quickshell/imi/modules/imi/bar/bar_flip.js
+++ b/dots/.config/quickshell/imi/modules/imi/bar/bar_flip.js
@@ -1,0 +1,74 @@
+.pragma library
+
+// FLIP (First, Last, Invert, Play) for a bar slot, as arithmetic.
+//
+// The rendering half cannot be tested - qmltestrunner builds no bar - so the
+// decisions live here and BarGroup.qml owns only the transform and the parent
+// walk. Same split as dock_geometry.js and layout_ops.js.
+//
+// Two things about the shape are load-bearing.
+//
+// The offset is INVERTED from a position the caller measured, never from a
+// property that is being animated: a Behavior handed a target that moves every
+// frame restarts every frame and never ticks (AGENT.md, b710ef731). What the
+// caller animates is the translate this returns, toward zero, which nothing
+// else writes.
+//
+// And the travel ACCUMULATES onto whatever translate is already in force, so a
+// second reflow landing mid-flight retargets from where the slot is drawn
+// rather than from where the layout has already put it. Two writes inside one
+// layout pass telescope to `recorded - final` whatever order they arrive in,
+// which is what makes the caller free to re-measure as often as it likes.
+
+// Below this the reposition is not worth a frame of motion: a sub-pixel
+// settle, or a slot the layout put back where it already was.
+var MIN_TRAVEL = 1;
+
+// FIRST/LAST: where a chain of ancestors puts an item, in the frame the walk
+// stopped at.
+//
+// Deliberately a sum of x/y rather than `mapToItem`: that composes TRANSFORMS
+// too, so a slot part-way through its own FLIP would report the position it is
+// drawn at, and the next reposition would invert from a moving number - the
+// feedback loop this whole module is arranged to avoid.
+function chainOrigin(nodes) {
+    var x = 0;
+    var y = 0;
+    var count = nodes && typeof nodes.length === "number" ? nodes.length : 0;
+    for (var i = 0; i < count; i++) {
+        var node = nodes[i];
+        if (!node) continue;
+        x += node.x;
+        y += node.y;
+    }
+    return { x: x, y: y };
+}
+
+// INVERT: the offset that puts an item back where it was drawn.
+function invert(recorded, current) {
+    if (!recorded || !current) return { x: NaN, y: NaN };
+    return { x: recorded.x - current.x, y: recorded.y - current.y };
+}
+
+// A bar runs along ONE axis, and only that axis is a reorder. The cross-axis
+// term of a reposition is the bar changing thickness - every slot at once,
+// which reads as the bar resizing rather than as its contents rearranging -
+// so it is dropped rather than animated. (A comparison on the wrong axis of a
+// turned layout is inert rather than wrong, which is the trap the dock's
+// column reorder shipped with; naming the axis is how that is avoided.)
+function alongAxis(offset, vertical) {
+    if (!offset) return NaN;
+    return vertical ? offset.y : offset.x;
+}
+
+// PLAY: the translate to animate from, and whether this reposition earns one.
+//
+// The floor is written as `!(|delta| >= min)` rather than `|delta| < min` so
+// an absent record - which arrives as NaN, because a slot with nothing to
+// invert from has no first position - refuses instead of comparing false and
+// playing a jump from nowhere.
+function repositionTravel(held, recorded, current, vertical, minTravel) {
+    var delta = alongAxis(invert(recorded, current), vertical);
+    if (!(Math.abs(delta) >= minTravel)) return { travel: held, play: false };
+    return { travel: held + delta, play: true };
+}

--- a/dots/.config/quickshell/imi/modules/imi/verticalBar/VerticalBarContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/verticalBar/VerticalBarContent.qml
@@ -222,7 +222,7 @@ Item {
                             totalCount: root.effectiveLeftLayout.length
                             editController: barEditController
                             editBucket: "left"
-                            editWidgetId: modelData
+                            widgetId: modelData
                             paintMaterialPill: root.shouldPaintMaterialPill(modelData)
                             bgColor: root.getMaterialPillColor(modelData)
                             Loader {
@@ -256,7 +256,7 @@ Item {
                         totalCount: root.effectiveLeftLayout.length
                         editController: barEditController
                         editBucket: "left"
-                        editWidgetId: modelData
+                        widgetId: modelData
                         Loader {
                             Layout.fillWidth: true
                             source: root.getWidgetUrl(modelData)
@@ -317,7 +317,7 @@ Item {
                             totalCount: root.effectiveMiddleLayout.length
                             editController: barEditController
                             editBucket: "middle"
-                            editWidgetId: modelData
+                            widgetId: modelData
                             paintMaterialPill: root.shouldPaintMaterialPill(modelData)
                             bgColor: root.getMaterialPillColor(modelData)
                             Loader {
@@ -351,7 +351,7 @@ Item {
                         totalCount: root.effectiveMiddleLayout.length
                         editController: barEditController
                         editBucket: "middle"
-                        editWidgetId: modelData
+                        widgetId: modelData
                         Loader {
                             Layout.fillWidth: true
                             source: root.getWidgetUrl(modelData)
@@ -414,7 +414,7 @@ Item {
                             totalCount: root.effectiveRightLayout.length
                             editController: barEditController
                             editBucket: "right"
-                            editWidgetId: modelData
+                            widgetId: modelData
                             paintMaterialPill: root.shouldPaintMaterialPill(modelData)
                             bgColor: root.getMaterialPillColor(modelData)
                             Loader {
@@ -448,7 +448,7 @@ Item {
                         totalCount: root.effectiveRightLayout.length
                         editController: barEditController
                         editBucket: "right"
-                        editWidgetId: modelData
+                        widgetId: modelData
                         Loader {
                             Layout.fillWidth: true
                             source: root.getWidgetUrl(modelData)

--- a/dots/.config/quickshell/imi/modules/imi/verticalBar/VerticalBarContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/verticalBar/VerticalBarContent.qml
@@ -223,6 +223,7 @@ Item {
                             editController: barEditController
                             editBucket: "left"
                             widgetId: modelData
+                            flipRegistry: flipRegistry
                             paintMaterialPill: root.shouldPaintMaterialPill(modelData)
                             bgColor: root.getMaterialPillColor(modelData)
                             Loader {
@@ -257,6 +258,7 @@ Item {
                         editController: barEditController
                         editBucket: "left"
                         widgetId: modelData
+                        flipRegistry: flipRegistry
                         Loader {
                             Layout.fillWidth: true
                             source: root.getWidgetUrl(modelData)
@@ -318,6 +320,7 @@ Item {
                             editController: barEditController
                             editBucket: "middle"
                             widgetId: modelData
+                            flipRegistry: flipRegistry
                             paintMaterialPill: root.shouldPaintMaterialPill(modelData)
                             bgColor: root.getMaterialPillColor(modelData)
                             Loader {
@@ -352,6 +355,7 @@ Item {
                         editController: barEditController
                         editBucket: "middle"
                         widgetId: modelData
+                        flipRegistry: flipRegistry
                         Loader {
                             Layout.fillWidth: true
                             source: root.getWidgetUrl(modelData)
@@ -415,6 +419,7 @@ Item {
                             editController: barEditController
                             editBucket: "right"
                             widgetId: modelData
+                            flipRegistry: flipRegistry
                             paintMaterialPill: root.shouldPaintMaterialPill(modelData)
                             bgColor: root.getMaterialPillColor(modelData)
                             Loader {
@@ -449,6 +454,7 @@ Item {
                         editController: barEditController
                         editBucket: "right"
                         widgetId: modelData
+                        flipRegistry: flipRegistry
                         Loader {
                             Layout.fillWidth: true
                             source: root.getWidgetUrl(modelData)
@@ -478,5 +484,11 @@ Item {
         leftZone: leftBoundary
         middleZone: middleBoundary
         rightZone: rightBoundary
+    }
+
+    // The same registry, in the vertical bar's own frame: the ids are shared
+    // between the two bars and between screens, and the positions are not.
+    Bar.BarFlipRegistry {
+        id: flipRegistry
     }
 }

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -505,6 +505,15 @@ if ! python3 "$SCRIPT_DIR/test_bar_flip_contract.py"; then
     exit 1
 fi
 
+# ...and the half that can tell the reposition from the teleport it replaces:
+# it samples where each slot is DRAWN mid-reflow, at three bucket anchorings
+# and both orientations. Brings its own headless weston and its own session bus.
+echo "Running bar reposition runtime tests..."
+if ! python3 "$SCRIPT_DIR/test_bar_flip_runtime.py"; then
+    echo "Bar reposition runtime tests failed."
+    exit 1
+fi
+
 # Stage 9b: the lock islands' reorder, driven with real mouse events on the
 # real LockSurface with the preview context - the overlay's eater, the shared
 # gesture, move semantics, the storedOrder merge, and both cancel paths.

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -494,6 +494,17 @@ if ! python3 "$SCRIPT_DIR/test_bar_edit_runtime.py"; then
     exit 1
 fi
 
+# The bar's reposition: one registry per bar wired into every bucket delegate
+# of both trees, animating a transform rather than a coordinate the layout
+# writes. Source-only, because the runtime half below skips wherever weston is
+# missing - which is CI, which is where a divergence between the two bars would
+# go unseen.
+echo "Running bar reposition contract tests..."
+if ! python3 "$SCRIPT_DIR/test_bar_flip_contract.py"; then
+    echo "Bar reposition contract tests failed."
+    exit 1
+fi
+
 # Stage 9b: the lock islands' reorder, driven with real mouse events on the
 # real LockSurface with the preview context - the overlay's eater, the shared
 # gesture, move semantics, the storedOrder merge, and both cancel paths.

--- a/dots/.config/quickshell/imi/tests/test_bar_dock_edit_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_bar_dock_edit_contract.py
@@ -218,7 +218,7 @@ def test_every_bucket_delegate_in_both_trees_wires_the_edit_overlay():
             assert count == 2, (
                 f'{path.name} declares editBucket: "{bucket}" {count} times, '
                 f"not 2 (one per style)")
-        assert text.count("editWidgetId: modelData") == 6, (
+        assert text.count("widgetId: modelData") == 6, (
             f"{path.name} does not hand every delegate its widget id")
 
 

--- a/dots/.config/quickshell/imi/tests/test_bar_flip_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_bar_flip_contract.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""One reposition, wired into both bars, animating one thing.
+
+`BarFlipRuntimeTest.qml` scores the motion and is the check that earns its
+place - but it needs weston and a `qs`, which CI has neither of, so it skips
+exactly where a divergence between the two bars would go unnoticed. That is the
+failure a47462fcc records: a capability added to one bar and not the other is
+invisible on a default screen, because the vertical bar is opt-in. These are
+the source pins that run everywhere.
+
+The rules:
+
+  - every bucket delegate in BOTH content trees hands its BarGroup the frame's
+    registry. Six per tree - three buckets, two styles - the same count the
+    edit overlay's own contract asserts, and for the same reason: a delegate
+    that misses the wiring is a widget that teleports in one style and one
+    orientation only;
+  - each tree declares exactly one registry, as a child of its own root. The
+    root is the frame every position is measured in, and a registry declared
+    anywhere else measures in a frame that moves with the bar's auto-hide slide;
+  - the reposition is declared in BarGroup and nowhere else. Both bars wrap
+    every widget in one, so a second copy is the drift this file exists to
+    stop;
+  - and what is animated is the translate, never `x`/`y` or an anchor margin.
+    A slot's coordinates belong to its layout: animating those fights the
+    layout, and a `Behavior` on one of them is handed a target the layout moves
+    every frame, which restarts every frame and never ticks (AGENT.md,
+    b710ef731). Nor is a position measured with `mapToItem`, which composes
+    that same translate back into the next invert.
+"""
+import re
+from pathlib import Path
+
+from contract_runner import run
+from test_background_fullscreen_suppression import _qml_source
+
+ROOT = Path(__file__).resolve().parents[1]
+BAR_DIR = ROOT / "modules/imi/bar"
+BAR_CONTENT = BAR_DIR / "BarContent.qml"
+VERTICAL_CONTENT = ROOT / "modules/imi/verticalBar/VerticalBarContent.qml"
+BAR_GROUP = BAR_DIR / "BarGroup.qml"
+REGISTRY = BAR_DIR / "BarFlipRegistry.qml"
+MODULE = BAR_DIR / "bar_flip.js"
+
+TREES = (BAR_CONTENT, VERTICAL_CONTENT)
+
+# A Behavior on a coordinate the layout writes. `\s*` rather than a literal
+# space because the two spellings differ by whitespace nowhere that matters,
+# and a pattern with baked-in indentation passes vacuously after a reformat.
+_LAYOUT_BEHAVIOR = re.compile(r"Behavior\s+on\s+(x|y|anchors\.\w+Margin)\b")
+
+
+def code(path):
+    """QML source with comments blanked, so a comment cannot satisfy a pin."""
+    return _qml_source(path).code
+
+
+def test_every_bucket_delegate_in_both_trees_hands_over_the_registry():
+    for path in TREES:
+        text = code(path)
+        wired = text.count("flipRegistry: flipRegistry")
+        assert wired == 6, (
+            f"{path.name} wires flipRegistry into {wired} delegates, not 6 - a "
+            f"bucket or a style still teleports, in that orientation only")
+
+
+def test_each_tree_declares_exactly_one_registry_on_its_own_root():
+    for path in TREES:
+        text = code(path)
+        declared = len(re.findall(r"\bBarFlipRegistry\s*{", text))
+        assert declared == 1, (
+            f"{path.name} declares {declared} BarFlipRegistry instances, not 1 "
+            f"- the ids are shared between screens and the positions are not")
+        # The declaration is a direct child of the content root, which is the
+        # frame every position is measured in. One indent level, and after the
+        # root's opening brace.
+        assert re.search(r"\n    (?:Bar\.)?BarFlipRegistry\s*{", text), (
+            f"{path.name}'s registry is not a direct child of the content root "
+            f"- its frame would then be some inner item, and every recalled "
+            f"position would be measured against something that moves")
+
+
+def test_the_reposition_is_declared_in_one_file():
+    others = []
+    for path in sorted(ROOT.glob("modules/**/*.qml")):
+        if path == BAR_GROUP:
+            continue
+        if "flipTravel" in path.read_text(encoding="utf-8", errors="replace"):
+            others.append(str(path.relative_to(ROOT)))
+    assert not others, (
+        f"the slot reposition is spelled outside {BAR_GROUP.name}: {others}. "
+        f"Both bars wrap every widget in a BarGroup, so a second copy is a "
+        f"second answer that only one of them will get")
+
+
+def test_the_reposition_animates_a_transform_and_not_the_layouts_coordinates():
+    text = code(BAR_GROUP)
+    assert "Translate" in text, (
+        f"{BAR_GROUP.name} no longer moves the slot with a Translate - a "
+        f"coordinate written here is a coordinate taken off the layout")
+    found = _LAYOUT_BEHAVIOR.findall(text)
+    assert not found, (
+        f"{BAR_GROUP.name} declares Behavior on {found} - those are written by "
+        f"the layout on every reflow, so the Behavior restarts every frame and "
+        f"never ticks (b710ef731)")
+
+
+def test_the_reposition_takes_its_motion_tier_whole():
+    text = code(BAR_GROUP)
+    assert re.search(r"Appearance\.animation\.\w+\.numberAnimation\.createObject", text), (
+        f"{BAR_GROUP.name} does not build its reposition from a tier's own "
+        f"component - a duration without its curve is silently Easing.Linear")
+    assert "animationCurves" not in text, (
+        f"{BAR_GROUP.name} reads a duration out of animationCurves, which is a "
+        f"tier's BASE: the motion speed slider and reduce motion cannot reach it")
+
+
+def test_the_arithmetic_stays_out_of_the_qml():
+    text = code(BAR_GROUP)
+    assert 'import "bar_flip.js"' in text, (
+        f"{BAR_GROUP.name} does not import {MODULE.name} - the invert and the "
+        f"play offsets are the only part of this reachable from a test")
+    # mapToItem composes transforms, so measuring a slot's position with it
+    # would read the translate this animates back into the next invert.
+    assert "mapToItem" not in text, (
+        f"{BAR_GROUP.name} measures with mapToItem, which composes the "
+        f"Translate it animates - the next reposition would invert from a "
+        f"number that is still moving")
+
+
+def test_the_registry_measures_in_its_parents_frame():
+    text = code(REGISTRY)
+    assert re.search(r"property\s+Item\s+frame:\s*root\.parent", text), (
+        f"{REGISTRY.name} no longer names its parent as the frame - a frame "
+        f"further out travels with the bar's auto-hide slide, and every slot "
+        f"would read the slide as a reposition")
+
+
+if __name__ == "__main__":
+    raise SystemExit(run(globals()))

--- a/dots/.config/quickshell/imi/tests/test_bar_flip_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_bar_flip_runtime.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Scores a bar reflow as motion rather than as a result.
+
+`BarFlipRuntimeTest.qml` builds real `BarGroup`s in the three arrangements the
+bar's buckets use - near-edge, far-edge and a vertical strip - and takes a
+widget out of each model, which is what an emptying tray or a switched-off
+plugin does. It then samples where each surviving slot is DRAWN 80ms and 240ms
+into the reflow.
+
+That sampling is the whole point. Every settled check passes identically on the
+teleport this replaces: a `Repeater` puts every slot in the right place either
+way, and the difference is only ever visible in the frames in between. The
+sibling shape is `WidgetResizeMotionRuntimeTest.qml`, which exists for exactly
+the same reason on the desktop widgets' span change.
+
+Four further things are scored because none of them are visible from a settled
+position: a slot whose own coordinate never changed still travels (in a
+far-edge bucket the section moves under it, and the idiom this was taken from
+watches only the slot itself); a widget with no record snaps instead of flying
+in from wherever it used to sit; a reorder drag in flight suppresses the
+reposition, because the gesture reads slot centres through a `mapToItem` that
+composes the transform; and the motion is along the bar only, at both
+orientations.
+
+Headless weston because the harness opens a window; weston implements no
+wlr-layer-shell, so the bar's real surface and the real widget files are
+outside what this can say. On a private session bus, because a harness that
+inherits the developer's measures their session as well as this tree. Skips
+when weston, qs or dbus-run-session is missing, as in CI.
+"""
+
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HARNESS = ROOT / "BarFlipRuntimeTest.qml"
+SOCKET = "wayland-imi-bar-flip"
+
+# A literal, never read back out of the harness's own output: a step list that
+# shrinks must redden here instead of reporting `failures: 0` for a shorter
+# run.
+EXPECTED_CHECKS = 35
+
+
+def _stop(proc):
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+
+
+def _runtime_available():
+    return all(shutil.which(tool) is not None
+               for tool in ("qs", "weston", "dbus-run-session"))
+
+
+@unittest.skipUnless(_runtime_available(),
+                     "needs qs, weston and dbus-run-session on PATH")
+class BarFlipRuntimeTest(unittest.TestCase):
+    def setUp(self):
+        self.home = Path(tempfile.mkdtemp(prefix="imi-bar-flip-"))
+        self.addCleanup(shutil.rmtree, self.home, ignore_errors=True)
+
+    def test_a_bar_reflow_travels_instead_of_teleporting(self):
+        env = dict(os.environ)
+        env.setdefault("XDG_RUNTIME_DIR", f"/run/user/{os.getuid()}")
+        env["WAYLAND_DISPLAY"] = SOCKET
+        env.pop("DISPLAY", None)
+
+        weston = subprocess.Popen(
+            ["weston", "--backend=headless", "--renderer=pixman",
+             f"--socket={SOCKET}", "--width=1000", "--height=1000"],
+            env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        self.addCleanup(_stop, weston)
+
+        socket_path = Path(env["XDG_RUNTIME_DIR"]) / SOCKET
+        deadline = time.monotonic() + 15
+        while not socket_path.exists() and time.monotonic() < deadline:
+            time.sleep(0.2)
+        self.assertTrue(socket_path.exists(), "headless weston never came up")
+
+        env["LIBGL_ALWAYS_SOFTWARE"] = "1"
+        env["QT_QUICK_BACKEND"] = "software"
+        env["XDG_CONFIG_HOME"] = str(self.home / "config")
+        env["XDG_STATE_HOME"] = str(self.home / "state")
+
+        proc = subprocess.run(
+            ["dbus-run-session", "--", "qs", "-p", str(HARNESS)],
+            cwd=str(ROOT), env=env, capture_output=True, text=True, timeout=240)
+        output = proc.stdout + proc.stderr
+        failed = [line for line in output.splitlines() if "FAIL" in line]
+        self.assertEqual(failed, [], f"harness reported failures:\n{output}")
+        self.assertIn(f"[BarFlip] checks: {EXPECTED_CHECKS} failures: 0", output,
+                      f"harness did not finish cleanly:\n{output}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dots/.config/quickshell/imi/tests/test_bar_flip_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_bar_flip_runtime.py
@@ -4,7 +4,7 @@
 `BarFlipRuntimeTest.qml` builds real `BarGroup`s in the three arrangements the
 bar's buckets use - near-edge, far-edge and a vertical strip - and takes a
 widget out of each model, which is what an emptying tray or a switched-off
-plugin does. It then samples where each surviving slot is DRAWN 80ms and 240ms
+plugin does. It then samples where each surviving slot is DRAWN 40ms and 240ms
 into the reflow.
 
 That sampling is the whole point. Every settled check passes identically on the
@@ -44,7 +44,7 @@ SOCKET = "wayland-imi-bar-flip"
 # A literal, never read back out of the harness's own output: a step list that
 # shrinks must redden here instead of reporting `failures: 0` for a shorter
 # run.
-EXPECTED_CHECKS = 35
+EXPECTED_CHECKS = 39
 
 
 def _stop(proc):

--- a/dots/.config/quickshell/imi/tests/tst_bar_flip.qml
+++ b/dots/.config/quickshell/imi/tests/tst_bar_flip.qml
@@ -1,0 +1,114 @@
+import QtTest
+import "../modules/imi/bar/bar_flip.js" as BarFlip
+
+// The invert and the play offsets a bar slot's reposition is built out of.
+// Nothing about the rendered bar is reachable from qmltestrunner, so this is
+// the half that can be pinned; BarFlipRuntimeTest.qml is the one that can tell
+// the animation from the snap it replaces.
+TestCase {
+    name: "BarFlipTest"
+
+    function test_a_chain_of_ancestors_sums_to_one_origin() {
+        const origin = BarFlip.chainOrigin([{ x: 4, y: 5 }, { x: 100, y: 0 }, { x: 20, y: 3 }]);
+        compare(origin.x, 124);
+        compare(origin.y, 8);
+    }
+
+    function test_an_empty_or_absent_chain_is_the_frames_own_origin() {
+        compare(BarFlip.chainOrigin([]).x, 0);
+        compare(BarFlip.chainOrigin([]).y, 0);
+        compare(BarFlip.chainOrigin(undefined).x, 0);
+        compare(BarFlip.chainOrigin(null).y, 0);
+    }
+
+    // A slot destroyed mid-walk reads as null from JS; skipping it is right,
+    // because the alternative is NaN propagating into the translate, which is
+    // a legal double no boundary rejects.
+    function test_a_hole_in_the_chain_is_skipped_rather_than_poisoning_it() {
+        const origin = BarFlip.chainOrigin([{ x: 10, y: 1 }, null, { x: 5, y: 2 }]);
+        compare(origin.x, 15);
+        compare(origin.y, 3);
+    }
+
+    function test_the_invert_is_the_offset_back_to_where_the_slot_was_drawn() {
+        const offset = BarFlip.invert({ x: 600, y: 5 }, { x: 720, y: 5 });
+        compare(offset.x, -120);
+        compare(offset.y, 0);
+        const back = BarFlip.invert({ x: 720, y: 5 }, { x: 600, y: 5 });
+        compare(back.x, 120);
+    }
+
+    function test_a_missing_record_inverts_to_nothing_rather_than_to_zero() {
+        // Zero would be a legal offset - "it did not move" - and would let a
+        // slot with no first position play a zero-length animation. NaN is the
+        // honest answer and repositionTravel refuses it below.
+        verify(isNaN(BarFlip.invert(null, { x: 10, y: 0 }).x));
+        verify(isNaN(BarFlip.invert({ x: 10, y: 0 }, null).x));
+    }
+
+    function test_only_the_axis_the_bar_runs_along_travels() {
+        const offset = { x: -120, y: 7 };
+        compare(BarFlip.alongAxis(offset, false), -120);
+        compare(BarFlip.alongAxis(offset, true), 7);
+    }
+
+    function test_a_reposition_along_the_bar_plays_from_the_inverted_offset() {
+        const step = BarFlip.repositionTravel(0, { x: 600, y: 5 }, { x: 720, y: 5 },
+                                              false, BarFlip.MIN_TRAVEL);
+        verify(step.play);
+        compare(step.travel, -120);
+    }
+
+    function test_a_reposition_across_the_bar_alone_does_not_play() {
+        // A horizontal bar growing taller moves every slot down by the same
+        // amount; animating that reads as the bar resizing, not as its
+        // contents rearranging.
+        const step = BarFlip.repositionTravel(0, { x: 600, y: 5 }, { x: 600, y: 21 },
+                                              false, BarFlip.MIN_TRAVEL);
+        verify(!step.play);
+        compare(step.travel, 0);
+    }
+
+    function test_a_sub_pixel_settle_is_not_worth_a_frame_of_motion() {
+        const step = BarFlip.repositionTravel(0, { x: 600, y: 0 }, { x: 600.4, y: 0 },
+                                              false, BarFlip.MIN_TRAVEL);
+        verify(!step.play);
+        compare(step.travel, 0);
+    }
+
+    function test_a_slot_with_no_record_refuses_instead_of_jumping_from_nowhere() {
+        const step = BarFlip.repositionTravel(0, null, { x: 720, y: 5 },
+                                              false, BarFlip.MIN_TRAVEL);
+        verify(!step.play);
+        compare(step.travel, 0);
+    }
+
+    // The half a settled check cannot see: a second reflow arriving while the
+    // first is still running has to continue from where the slot is DRAWN.
+    function test_a_reposition_mid_flight_accumulates_onto_the_travel_in_force() {
+        const step = BarFlip.repositionTravel(-80, { x: 720, y: 0 }, { x: 760, y: 0 },
+                                              false, BarFlip.MIN_TRAVEL);
+        verify(step.play);
+        compare(step.travel, -120);
+    }
+
+    // Two writes inside one layout pass - the slot's own x, then its section's
+    // - must telescope to `recorded - final` whatever order they arrive in, or
+    // a caller would have to know how many times the layout touched it.
+    function test_two_writes_in_one_pass_telescope_to_the_same_travel() {
+        const recorded = { x: 800, y: 0 };
+        const first = BarFlip.repositionTravel(0, recorded, { x: 712, y: 0 },
+                                               false, BarFlip.MIN_TRAVEL);
+        const second = BarFlip.repositionTravel(first.travel, { x: 712, y: 0 },
+                                                { x: 820, y: 0 }, false, BarFlip.MIN_TRAVEL);
+        compare(second.travel, -20);
+        compare(second.travel, recorded.x - 820);
+    }
+
+    function test_a_vertical_bar_plays_the_same_reposition_down_its_strip() {
+        const step = BarFlip.repositionTravel(0, { x: 4, y: 300 }, { x: 4, y: 220 },
+                                              true, BarFlip.MIN_TRAVEL);
+        verify(step.play);
+        compare(step.travel, 80);
+    }
+}


### PR DESCRIPTION
Item 6 of `docs/p3drovfx-animation-research-2026-08-16.md` — §3.5, FLIP reposition for a bar widget.

Both bars draw their buckets as a `Repeater` of `Loader`s with no motion anywhere in the path, so the moment `filterLayout` drops `sysTray` because the tray emptied — or a plugin is switched off, or Settings reorders the layouts — every widget after it is simply drawn somewhere else on the next frame. Now it travels there.

## Where it lives, and why the vertical bar gets it too

In `BarGroup.qml`, for the reason the edit overlay is there: every widget in **both** bars is wrapped in one, so a single file turned by the existing `vertical` flag is the whole feature at both orientations, where a per-delegate copy would be twelve and the two bars would drift the way they already did over widget files (a47462fcc). The vertical bar getting it is a decision, not a side effect — it is opt-in, so anything it silently missed would stay green and unseen, which is exactly the hole `test_bar_widget_parity.py` exists for.

## Three things the idiom does not say

**What is measured is not what moves.** The survey's source watches a widget's own `onXChanged`. That is right in a near-edge bucket and wrong in a far-edge one: the section is sized by its row and anchored to the screen's edge, so removing a widget moves the *section* and leaves the first slot at row-local zero — it travels the whole width of what left while its own `x` never changes, and the last slot's `x` changes while it does not move at all. Each slot sums its ancestors' x/y up to the registry's frame and watches every one of them. Deliberately a sum and never `mapToItem`, which composes transforms: measured through that, a slot part-way through its own reposition reports where it is *drawn*, and the next invert comes off a number that is still moving.

**The "First" cannot live on the slot.** Measured with a `qml6` probe: a `Repeater` whose model is a JS array answers a reassignment by destroying **every** delegate and building the replacements, in one turn of the event loop — so the widget about to slide is not the object that was standing there, and a naive inverse would start it from `x: 0`. `BarFlipRegistry.qml` is one deposit-and-recall per bar, keyed on the widget id and expiring at the end of that turn. One per content tree rather than a singleton, because the ids are identical on every screen and the positions are not; expiring, because a widget switched back on ten minutes later has no honest position to fly in from.

**It animates a translate, never a coordinate.** A slot's `x`/`y` belong to its layout, and a `Behavior` on one of them is handed a target the layout rewrites on every reflow — which restarts every frame and never ticks (b710ef731). The translate is written by this animation and by nothing else. The reposition is also inert outside a reflow: a bar widget's content changes width constantly (the clock every minute), and a running animation is a repaint of the whole output.

## The constraints named in the brief

- **b710ef731** — the translate is not a `Behavior` on a moving value; it is inverted from a measurement and eased toward zero. `test_bar_flip_contract.py` fails on a `Behavior on x`/`y`/`anchors.*Margin` in that file.
- **Both bars / `test_bar_widget_parity.py`** — the feature is in the shared `BarGroup`, so neither bar decides anything; the contract asserts six delegate wirings and exactly one registry per tree. Parity is unchanged and still green.
- **Edit Mode / `test_bar_dock_edit_contract.py`** — a reorder drag reads slot centres through a `mapToItem` that composes this transform, so `GlobalStates.editBarDragActive` suppresses the reposition and zeroes it. The drop's own reflow still animates, because `BarEditController` clears the flag before the layout pass that follows. Driven in the harness; the edit contract is unchanged and green.
- **`lint_bar_popup_overlay_static.py`** — the card's target is read only by the overlay's own `retarget()`, which a reposition never calls, so a moving widget cannot move the card. The lint is unchanged and green.
- **Motion tiers whole** — `Appearance.animation.elementMoveSmall.numberAnimation.createObject(...)`; the contract fails on `animationCurves` appearing in the file at all, which is the `lint_motion_multiplier_bypass.py` rule stated locally.

## Tests, and what planting each one proved

Pure arithmetic in `modules/imi/bar/bar_flip.js` (`chainOrigin`, `invert`, `alongAxis`, `repositionTravel`), beside `bar_widget_source.js` and split the way `edit_mode.js` / `dock_geometry.js` / `layout_ops.js` are.

**`tests/tst_bar_flip.qml`** — 15 checks. Planted in a clean tree, by name:

```
floor `!(|d| >= min)` -> `|d| < min`   FAIL test_a_slot_with_no_record_refuses_instead_of_jumping_from_nowhere
travel `held + delta` -> `delta`       FAIL test_a_reposition_mid_flight_accumulates_onto_the_travel_in_force
                                       FAIL test_two_writes_in_one_pass_telescope_to_the_same_travel
alongAxis ignores `vertical`           FAIL test_only_the_axis_the_bar_runs_along_travels
                                       FAIL test_a_vertical_bar_plays_the_same_reposition_down_its_strip
chainOrigin drops its null guard       FAIL test_a_hole_in_the_chain_is_skipped_rather_than_poisoning_it
```

**`tests/test_bar_flip_contract.py`** — 7 checks, source-only because the runtime half skips wherever weston is missing, which is CI, which is where a divergence between the two bars would go unseen. Planted, by name:

```
one delegate loses `flipRegistry:`     FAIL test_every_bucket_delegate_in_both_trees_hands_over_the_registry
`Behavior on x` added to BarGroup      FAIL test_the_reposition_animates_a_transform_and_not_the_layouts_coordinates
the Translate becomes an `x:` binding  FAIL test_the_reposition_animates_a_transform_and_not_the_layouts_coordinates
measure with `mapToItem`               FAIL test_the_arithmetic_stays_out_of_the_qml
the `bar_flip.js` import removed       FAIL test_the_arithmetic_stays_out_of_the_qml
registry moved one level in            FAIL test_each_tree_declares_exactly_one_registry_on_its_own_root
a second copy of BarGroup.qml          FAIL test_the_reposition_is_declared_in_one_file
duration read from animationCurves     FAIL test_the_reposition_takes_its_motion_tier_whole
`frame: root.parent` -> `null`         FAIL test_the_registry_measures_in_its_parents_frame
```

**`BarFlipRuntimeTest.qml` + `tests/test_bar_flip_runtime.py`** — 39 checks (`EXPECTED_CHECKS` in the driver, the verdict line from the harness's own counter, `dbus-run-session` around the launch, headless weston). Three strips, because a bucket is anchored three ways and the interesting slot differs in each; real `BarGroup`s carrying a stand-in rectangle, since the real widget files reach Hyprland, PipeWire and the tray.

The check that earns its place is the mid-flight sample — a settled position passes identically on the teleport this replaces. Planted:

```
`flipTravel = 0` instead of playing        8 FAIL (every in-flight check, all three strips)
watch only the slot's own x                6 FAIL (both far-edge cases and the vertical one)
the registry never expires                 1 FAIL (a widget switched back on later)
the drag no longer suppresses it           1 FAIL (a reflow while a reorder drag is in flight)
the translate leaves the bar's axis        2 FAIL (both "do not travel across it")
the invert applied with the wrong sign     4 FAIL (was on its way there)
```

Two of those plants failed to redden on the first attempt and the harness was fixed rather than the plant dropped, which is the part worth reading (`test(bar): the harness stops rescuing the idiom it exists to fail`):

- the slots were declared without `Layout.fillHeight`/`fillWidth`, which both content trees set. Without them the layout centres each slot across the bar and writes that coordinate once at creation — and that single write triggered a measurement, so the naive own-`x` implementation passed the far-edge strip by being rescued by a write the real bar never makes;
- `drawnAlong` read the reposition's own `flipDrawnOrigin()`, which adds the translate on the bar's axis and nothing else — so a translate leaking across the bar was invisible to the check written to catch it. It reads `mapToItem` now, which is banned in `BarGroup` for the feedback reason above and is exactly right in a harness that must not agree with the implementation by construction;
- and the early sample moved 80ms → 40ms: the spatial tier is front-loaded, so at 80ms a correct reposition and one started on the mirror side of its destination are both ~90% of the way there (measured: 0.55 of the travel at 40ms against 0.90 at 80ms).

## Full suite

`dots/.config/quickshell/imi/tests/run_tests.sh`, exit 0:

```
Running bar reposition contract tests...
7/7 contract checks passed
Running bar reposition runtime tests...
Ran 1 test in 16.840s
OK
...
Totals: 1061 passed, 0 failed, 0 skipped, 0 blacklisted, 5250ms
All tests passed successfully!
```

## Not verified

- **The look on a real bar.** Everything here was measured under headless weston in a worktree, which does not hot-reload the running shell; the curve, the duration and whether a 350ms travel reads as too slow beside the popup card's 500ms are judgements only the screen can settle.
- **A popup open across a reflow.** The card's target is only re-read on the overlay's own `retarget()`, so a widget sliding under an open card leaves the card where it is. That is the intended behaviour and it has not been looked at.
- **The accumulation guard's second term.** `!flipPending && !flipAnim.running` — the `running` half exists because a layout pass writes a slot's own coordinate and its section's as two signals (demonstrated in a standalone `qml6` probe). Deleting it does not redden the runtime harness: no reflow the harness drives produces a visibly wrong intermediate. The telescoping arithmetic it feeds is covered by `tst_bar_flip.qml`.
- **A widget leaving does not animate out.** FLIP is about the neighbours; the departing widget is destroyed with its delegate, as before.

Docs: updated AGENT.md §Dynamic/data-driven QML gotchas
Changelog: updated
