### PR TITLE
Every infinite animation stops when nobody can see it — the register is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ own repo; the installer pins which revision it builds.
 
 ## [Unreleased]
 
+### Fixed
+- **Spinners and pulses stop when nothing can see them.** Seven animations
+  looped forever regardless of whether the thing they animate was on screen —
+  the bar's update spinner turned for the whole session whether or not it was
+  shown, and the world map's location ping ran on a settings page that spends
+  most of its life closed. Each one keeps the compositor repainting the whole
+  screen while it runs, which is what halved a fullscreen game's frame rate
+  once already.
+
 ### Added
 - **Long names scroll instead of being cut off.** Four places showed a name you
   did not write and cannot look up anywhere else on the row, and cut it off with

--- a/dots/.config/quickshell/imi/modules/common/widgets/DockIconMotion.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/DockIconMotion.qml
@@ -65,7 +65,7 @@ Item {
     property real bounceOffset: 0
     SequentialAnimation {
         id: bounceAnimation
-        running: root.launching && !root.dragging
+        running: root.launching && !root.dragging && root.visible
         loops: Animation.Infinite
         alwaysRunToEnd: true
         NumberAnimation {

--- a/dots/.config/quickshell/imi/modules/common/widgets/MaterialLoadingIndicator.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/MaterialLoadingIndicator.qml
@@ -40,7 +40,9 @@ Rectangle {
     rotation: pullRotation + continuousRotation + leapRotation
 
     RotationAnimation on continuousRotation {
-        running: root.loading
+        // `loading` says the work is in flight; `visible` says anyone can see
+        // it. Only the conjunction is worth a repaint of the whole output.
+        running: root.loading && root.visible
         duration: 12000
         easing.type: Easing.Linear
         loops: Animation.Infinite

--- a/dots/.config/quickshell/imi/modules/common/widgets/WorldMap.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/WorldMap.qml
@@ -117,11 +117,19 @@ Item {
             border.color: root.markerColor
             opacity: 0.8
 
+            // The marker's ping runs forever, so it is gated on the ring
+            // being drawn: this map lives on a settings page that spends most
+            // of its life closed, and an ungated pulse there is a repaint of
+            // the whole output for a widget nobody has open. `visible` is
+            // effective, so the marker's own `hasMarker` gate and the page's
+            // Loader both reach it without either being named here.
             SequentialAnimation on scale {
+                running: ring.visible
                 loops: Animation.Infinite
                 NumberAnimation { from: 0.5; to: 2.2; duration: 1400; easing.type: Easing.OutCubic }
             }
             SequentialAnimation on opacity {
+                running: ring.visible
                 loops: Animation.Infinite
                 NumberAnimation { from: 0.7; to: 0.0; duration: 1400; easing.type: Easing.OutCubic }
             }
@@ -136,6 +144,7 @@ Item {
             color: root.markerColor
 
             SequentialAnimation on opacity {
+                running: core.visible
                 loops: Animation.Infinite
                 NumberAnimation { from: 1.0; to: 0.4; duration: 900; easing.type: Easing.InOutSine }
                 NumberAnimation { from: 0.4; to: 1.0; duration: 900; easing.type: Easing.InOutSine }

--- a/dots/.config/quickshell/imi/modules/imi/bar/UpdatesCount.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/UpdatesCount.qml
@@ -86,16 +86,21 @@ MouseArea {
     Component {
         id: spinnerComp
         MaterialSymbol {
+            id: spinnerGlyph
             leftPadding: Appearance.spacing.space100
             rightPadding: Appearance.spacing.space50
             text: "progress_activity"
             iconSize: Appearance.font.pixelSize.normal
             color: root.isMaterial ? Appearance.colors.colPrimary : Appearance.colors.colOnLayer1
+            // Effective visibility, not `true`: a running infinite animation
+            // dirties the scene every frame, the shell commits, and the
+            // compositor repaints the whole output - including while this
+            // spinner's own Loader is inactive or the bar's surface is down.
             RotationAnimation on rotation {
                 from: 0; to: 360
                 duration: 1000
                 loops: Animation.Infinite
-                running: true
+                running: spinnerGlyph.visible
             }
         }
     }

--- a/dots/.config/quickshell/imi/modules/imi/overview/SearchBar.qml
+++ b/dots/.config/quickshell/imi/modules/imi/overview/SearchBar.qml
@@ -136,7 +136,7 @@ RowLayout {
         colText: toggled ? Appearance.colors.colOnPrimary : Appearance.colors.colOnSurfaceVariant
         background: MaterialShape {
             RotationAnimation on rotation {
-                running: songRecButton.toggled
+                running: songRecButton.toggled && songRecButton.visible
                 duration: 12000
                 easing.type: Easing.Linear
                 loops: Animation.Infinite

--- a/dots/.config/quickshell/imi/modules/imi/recordingRegion/RecordingRegionPanel.qml
+++ b/dots/.config/quickshell/imi/modules/imi/recordingRegion/RecordingRegionPanel.qml
@@ -141,7 +141,7 @@ Scope {
                     animateChange: true
 
                     SequentialAnimation on opacity {
-                        running: !ScreenRecord.recordPaused
+                        running: !ScreenRecord.recordPaused && root.visible
                         loops: Animation.Infinite
                         alwaysRunToEnd: true
                         NumberAnimation {

--- a/dots/.config/quickshell/imi/modules/imi/regionSelector/RectCornersSelectionDetails.qml
+++ b/dots/.config/quickshell/imi/modules/imi/regionSelector/RectCornersSelectionDetails.qml
@@ -55,7 +55,7 @@ Item {
         // Breathing
         opacity: 0.9
         SequentialAnimation on opacity {
-            running: root.breathingBorderOnly
+            running: root.breathingBorderOnly && root.visible
             loops: Animation.Infinite
             NumberAnimation { from: 0.9; to: 0.3; duration: 1200; easing.type: Easing.InOutQuad }
             NumberAnimation { from: 0.3; to: 0.9; duration: 1200; easing.type: Easing.InOutQuad }

--- a/dots/.config/quickshell/imi/tests/lint_infinite_animation_visibility.py
+++ b/dots/.config/quickshell/imi/tests/lint_infinite_animation_visibility.py
@@ -50,13 +50,6 @@ RUNNING = re.compile(r"running:\s*([^\n]+)")
 BOOL_PROPERTY = re.compile(r"property\s+bool\s+(\w+)\s*:\s*([^\n]+(?:\n\s+&&[^\n]+)*)")
 
 EXISTING = frozenset({
-    "common/widgets/DockIconMotion.qml",
-    "common/widgets/MaterialLoadingIndicator.qml",
-    "common/widgets/WorldMap.qml",
-    "imi/bar/UpdatesCount.qml",
-    "imi/overview/SearchBar.qml",
-    "imi/recordingRegion/RecordingRegionPanel.qml",
-    "imi/regionSelector/RectCornersSelectionDetails.qml",
 })
 
 


### PR DESCRIPTION
`lint_infinite_animation_visibility.py` landed with a **7-file register** as a ratchet, on the reasoning that those animations live on surfaces that are unmapped when idle. Rechecking them one at a time — prompted by `docs/p3drovfx-animation-research-2026-08-16.md`'s survey of this class — that reasoning holds for some and never held for others.

**The bar's update spinner ran `running: true` outright**, so its `RotationAnimation` turned at the display's refresh rate for the life of the session whether or not its own `Loader` was active. **`WorldMap`'s three marker pulses had no `running` term at all**, on a settings page that spends most of its life closed.

The chain is invisible from any of these files and is why the register exists: a running animation writes a property every frame → the scene is dirty → the shell commits → **the compositor repaints the whole output**. One 30-second cookie rotation behind a fullscreen game measured 52 fps against a 108 ceiling.

- Six take a `visible` conjunct beside the condition they already had (loading indicator, overview song-recognition spinner, region-selector breathe, recording pulse, dock launch bounce, update spinner — the last via an explicit id on the glyph rather than reaching through the animation's `target`).
- `WorldMap`'s ring and core pulses follow the items they animate.
- `visible` is *effective* visibility, so each gate reaches every ancestor's own gate without naming any of them.

**The register is now empty**, which is what a ratchet is for.

**Plant-proof**: removed `running: core.visible` from `WorldMap`'s core pulse → `common/widgets/WorldMap.qml:147: loops forever with no visibility term…`, exit 1; restored → passes, 23 infinite animations, 0 registered. Planted in a clean tree after committing.

**Tests**: full `tests/run_tests.sh` — all tests passed, exit 0.

**Not verified**: that each gated animation still *starts* when it should on a live shell. The gates are conjunctions with conditions that were already there, and `visible` is true whenever the item is drawn, so a false negative would mean the item was not drawn — but no one has watched the update spinner spin or the dock bounce since the change.

Changelog: updated

Docs: not needed — AGENT.md's design-language section already carries the entry this enforces, including the measurement, and the lint's own header carries the register's history
