### PR TITLE
feat(weather): an hourly forecast in the bar's weather popup

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1147,6 +1147,21 @@ Two non-obvious behaviors have bitten this codebase before and are worth knowing
   height that is a literal rather than a measurement.
   cd607d416 ("feat(bar): the popup card runs on one driver, and unrolls from its first section"),
   d01879f4c ("test(lint): hold the popup card to one driver, and its unroll to a measured hero").
+- **A section added to a popup's content changes what the card opens at, and the hero is decided
+  by the BUILT tree rather than by source order.** `heroSectionHeight` walks the content root's
+  children and takes the first one that is drawn and taller than zero, so a row declared above the
+  hero card becomes the hero — the weather popup would open as a 99px strip with the temperature,
+  the city and the condition below the fold, which renders and looks deliberate. It also means a
+  section that comes and goes cannot be first: `Weather.hourly` is empty until a forecast parses,
+  and a hero that is a different section before and after the first fetch is a popup that opens two
+  different ways. The hourly row therefore sits between the hero card and the metrics grid, and the
+  measurement is checked on the built tree rather than in the source: hero 141 (the 125px hero card
+  at `contentPadding` 8) against an open height of 431, unchanged by the row's 99.
+  `tests/test_weather_popup_hero_runtime.py` parents the real popup's content into a window the way
+  the overlay parents it into the card and measures both;
+  `tests/test_weather_forecast_contract.py` holds the source order, which is the half a reviewer
+  can see. feat(bar): draw the weather popup's hourly row, growing from the axis,
+  test(weather): drive the popup's hero and the bars' growth in a real window.
 - **Moving content between windows is already how popups work here, and it has two traps.**
   `StyledPopup` reparented its content into its window at completion long before the overlay
   existed; the overlay does the same thing, one popup at a time, and never has more than two
@@ -1484,6 +1499,24 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   an engine context. Found by rendering the widget and reading the labels; the whole of it is
   invisible from the source. fix(weather): a forecast card is named for its weekday, not for its
   date.
+- **Both weather providers already return an hourly forecast in a response the shell has fetched,
+  and OpenWeatherMap's `dt_txt` is UTC while its `dt` is the instant.** The bar popup's hourly row
+  cost no new request: `/data/2.5/forecast`, fetched since the day cards landed, IS a three-hourly
+  list, and wttr.in's `weather[].hourly[]` arrives inside the one response the current conditions
+  come from. Before adding an endpoint for weather data, read what the existing responses carry —
+  `tests/test_weather_forecast_contract.py` pins the endpoint list and the fetcher count so a third
+  request has to be argued for rather than typed. The trap inside that data is the timestamp:
+  `dailyFromOwm` groups by the `dt_txt` DATE, which is fine a day at a time, but an hour label read
+  off the same field is the user's own clock wrong by their whole UTC offset — and right on a UTC
+  runner, which is CI and was also every fixture anyone would write. `weatherHourly.js` reads `dt`
+  and takes the local hour and the local date off it, and the contract test re-runs
+  `tst_weather_hourly.qml` at UTC+14 and UTC-11 for the same reason it already re-runs the daily
+  one. Planted: `getHours()` → `getUTCHours()` passes at UTC and fails at UTC+14.
+  A third thing about that module generalises past weather: `Number(null)` is 0 and `isFinite(0)`
+  is true, so the obvious "convert and test" guard reads an absent reading as a confident zero
+  degrees — a bar at the floor and a window range dragged down to it, with nothing in any log.
+  feat(weather): the hourly row's decisions, as arithmetic beside the daily ones,
+  feat(weather): publish the three-hourly slots both providers already return.
 - **`FileView` (`Quickshell.Io`) loads asynchronously - `.text()` right after calling `.reload()`
   is not guaranteed to return the new content.** The correct pattern (used throughout this codebase
   - `MaterialSymbolsSearch.qml`, `Notifications.qml`, `Emojis.qml`, `Profile.qml`) is to read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ own repo; the installer pins which revision it builds.
   panel it is on closes, its speed follows the motion speed setting, and with
   reduce motion on it holds each end for three seconds and switches between them
   rather than scrolling, so the whole name is still readable.
+- **The bar's weather popup has an hourly forecast.** Five three-hourly slots
+  under the current conditions, each a bar grown from the axis with its
+  temperature above it and its own condition glyph and hour below — night-aware
+  on the hour it describes rather than on the time you opened the popup, and
+  labelled with the weekday where the window crosses midnight. It follows the
+  clock format you already set, and it costs no extra request: both providers
+  were already returning this data in responses the shell fetches. A provider
+  that answers with nothing hourly leaves no empty row behind.
 - **Clock depth works on a live Wallpaper Engine scene.** The depth picker
   segments the still the shell already photographs of the active project, keyed
   on the project rather than on the still (which is re-grabbed every session),

--- a/dots/.config/quickshell/imi/WeatherPopupHeroRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/WeatherPopupHeroRuntimeTest.qml
@@ -74,6 +74,15 @@ ShellRoot {
         });
     }
 
+    function named(name) {
+        const children = popup.contentItem?.children ?? [];
+        for (let index = 0; index < children.length; index++) {
+            if (children[index].objectName === name)
+                return children[index];
+        }
+        return null;
+    }
+
     function chartItem() {
         const children = popup.contentItem?.children ?? [];
         for (let index = 0; index < children.length; index++) {
@@ -160,12 +169,21 @@ ShellRoot {
                               !!chart && chart.visible && chart.height > 0);
                 harness.check("the row is not the popup's first section",
                               harness.chartIndex() > 0);
+                // Against the hero card BY NAME, never against `children[0]`:
+                // a row that became the first child would satisfy that
+                // comparison by being what it measured.
                 harness.check("the card still unrolls from the hero card",
-                              hero === content.children[0].height + padding * 2);
+                              hero === harness.named("weatherHero").height + padding * 2);
                 harness.check("the hero is a fraction of the open height, so there is still an unroll",
                               hero > 0 && hero < openHeight);
-                harness.check("the row added its own height to what the card opens to",
-                              !!chart && openHeight > hero + chart.height);
+                // The feature's name, measured: every bar's bottom edge is the
+                // same line, so what moves is the top.
+                const feet = harness.bars(chart).map(function (bar) {
+                    return bar.mapToItem(chart, 0, bar.height).y;
+                });
+                harness.check("the bars stand on one axis, whatever their height",
+                              feet.length > 1
+                              && feet.every(function (foot) { return Math.abs(foot - feet[0]) < 0.5; }));
                 harness.check("the bars are flat while the popup is not showing",
                               harness.tallestBar() === 0);
 
@@ -212,7 +230,7 @@ ShellRoot {
                               !!chart && !chart.visible);
                 harness.check("and the card still opens at the hero card",
                               BarPopupUnroll.heroSectionHeight(content.children, padding)
-                              === content.children[0].height + padding * 2);
+                              === harness.named("weatherHero").height + padding * 2);
                 harness.finish();
                 break;
             }

--- a/dots/.config/quickshell/imi/WeatherPopupHeroRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/WeatherPopupHeroRuntimeTest.qml
@@ -1,0 +1,222 @@
+import QtQuick
+import Quickshell
+import qs.modules.common
+import qs.modules.imi.bar
+import qs.services
+import "modules/imi/bar/bar_popup_unroll.js" as BarPopupUnroll
+import "modules/common/functions/weatherForecast.js" as WeatherForecast
+
+/**
+ * The weather popup with an hourly row in it, measured where the card can see
+ * it.
+ *
+ * Two separate things are checked, and neither is reachable from a unit test.
+ *
+ * The first is the HERO. `BarPopupOverlay` opens the card at the height of the
+ * content's first DRAWN section and unfurls from there, so adding a section to
+ * a popup changes what that measurement returns unless the section lands after
+ * the hero - and `heroSectionHeight` skips undrawn and zero-height children, so
+ * "after the hero" is a fact about the built tree rather than about the source.
+ * A row that became the hero would open the card as a 60px strip with the
+ * temperature and the city below the fold.
+ *
+ * The second is the GROWTH. The bars grow from the axis on `charted`, which is
+ * the popup's own visibility, so the motion plays on a refresh as well as on an
+ * open - the tree this was taken from writes the heights from a NumberAnimation
+ * that destroys the binding, so its chart animates on open and never on data
+ * (docs/p3drovfx-animation-research-2026-08-16.md §3.3). A settled height is
+ * the same number whether it animated or teleported, so every growth check
+ * samples the bars in flight.
+ *
+ * Driven by tests/test_weather_popup_hero_runtime.py under headless weston and
+ * its own bus. Nothing here needs a layer surface: the content is parented into
+ * an ordinary window, which is what the overlay does to it anyway.
+ */
+ShellRoot {
+    id: harness
+
+    property int failures: 0
+    property int checksRun: 0
+    property int step: 0
+
+    // Sampled in flight and compared later, because a settled bar is the same
+    // height whether it grew or snapped there.
+    property real growthSample: -1
+    property real settledFirstSeries: -1
+    property real refreshSample: -1
+
+    function check(label, ok) {
+        harness.checksRun++;
+        console.log(`[WeatherHero] ${label}: ${ok ? "ok" : "FAIL"}`);
+        if (!ok)
+            harness.failures++;
+    }
+
+    function finish() {
+        console.log(`[WeatherHero] checks: ${harness.checksRun} failures: ${harness.failures}`);
+        Qt.exit(harness.failures === 0 ? 0 : 1);
+    }
+
+    // Slots the row will actually show: the module keeps only what is still
+    // ahead of now, so a fixture with fixed timestamps would be empty by
+    // definition.
+    function seed(temps) {
+        const base = new Date();
+        return temps.map(function (temp, index) {
+            const when = new Date(base.getTime() + (index + 1) * 3600 * 1000);
+            return {
+                ms: when.getTime(),
+                date: WeatherForecast.localIsoDate(when),
+                hour: when.getHours(),
+                temp: temp,
+                wCode: 800
+            };
+        });
+    }
+
+    function chartItem() {
+        const children = popup.contentItem?.children ?? [];
+        for (let index = 0; index < children.length; index++) {
+            if (children[index].objectName === "hourlyChart")
+                return children[index];
+        }
+        return null;
+    }
+
+    function chartIndex() {
+        const children = popup.contentItem?.children ?? [];
+        for (let index = 0; index < children.length; index++) {
+            if (children[index].objectName === "hourlyChart")
+                return index;
+        }
+        return -1;
+    }
+
+    // Every bar in the row, found by name rather than by walking a fixed path
+    // through the layout - a delegate gains a label and the path moves.
+    function bars(node, found) {
+        const sink = found ?? [];
+        if (!node)
+            return sink;
+        if (node.objectName === "hourlyBar")
+            sink.push(node);
+        const children = node.children ?? [];
+        for (let index = 0; index < children.length; index++)
+            harness.bars(children[index], sink);
+        return sink;
+    }
+
+    function tallestBar() {
+        let tallest = 0;
+        harness.bars(harness.chartItem()).forEach(function (bar) {
+            tallest = Math.max(tallest, bar.height);
+        });
+        return tallest;
+    }
+
+    function schedule(ms) {
+        stepTimer.interval = ms;
+        stepTimer.restart();
+    }
+
+    FloatingWindow {
+        id: window
+        implicitWidth: 420
+        implicitHeight: 640
+        color: "black"
+
+        WeatherPopup {
+            id: popup
+        }
+
+        Component.onCompleted: {
+            // What the overlay does with a popup's content when it takes the
+            // card: an unparented tree never polishes, so nothing about it can
+            // be measured until it is in a window.
+            popup.contentItem.parent = window.contentItem;
+            Weather.hourly = harness.seed([9, 12, 17, 21, 14]);
+            harness.schedule(1500);
+        }
+    }
+
+    Timer {
+        id: stepTimer
+        repeat: false
+        onTriggered: {
+            harness.step++;
+            switch (harness.step) {
+            case 1: {
+                const content = popup.contentItem;
+                const chart = harness.chartItem();
+                const padding = popup.contentPadding;
+                const hero = BarPopupUnroll.heroSectionHeight(content.children, padding);
+                const openHeight = content.implicitHeight + padding * 2;
+
+                // Printed rather than only asserted: the numbers are what a
+                // reviewer needs when a later section moves the hero.
+                console.log(`[WeatherHero] geometry: hero=${hero} open=${openHeight} row=${chart ? chart.height : -1}`);
+
+                harness.check("the hourly row is drawn",
+                              !!chart && chart.visible && chart.height > 0);
+                harness.check("the row is not the popup's first section",
+                              harness.chartIndex() > 0);
+                harness.check("the card still unrolls from the hero card",
+                              hero === content.children[0].height + padding * 2);
+                harness.check("the hero is a fraction of the open height, so there is still an unroll",
+                              hero > 0 && hero < openHeight);
+                harness.check("the row added its own height to what the card opens to",
+                              !!chart && openHeight > hero + chart.height);
+                harness.check("the bars are flat while the popup is not showing",
+                              harness.tallestBar() === 0);
+
+                popup.pinnedOpen = true;
+                harness.schedule(80);
+                break;
+            }
+            case 2:
+                harness.growthSample = harness.tallestBar();
+                harness.schedule(1200);
+                break;
+            case 3:
+                harness.settledFirstSeries = harness.tallestBar();
+                harness.check("the bars settle at a height",
+                              harness.settledFirstSeries > 0);
+                harness.check("the bars grew from the axis rather than appearing at full height",
+                              harness.growthSample > 0
+                              && harness.growthSample < harness.settledFirstSeries - 1);
+
+                // The refresh case: a series whose coldest hour becomes the
+                // warmest, under a popup that is already open.
+                Weather.hourly = harness.seed([21, 17, 12, 9, 14]);
+                harness.schedule(80);
+                break;
+            case 4:
+                harness.refreshSample = harness.tallestBar();
+                harness.schedule(1200);
+                break;
+            case 5: {
+                const settled = harness.tallestBar();
+                harness.check("a refresh under an open popup animates rather than popping",
+                              harness.refreshSample > 0
+                              && Math.abs(harness.refreshSample - settled) > 0.5);
+
+                Weather.hourly = [];
+                harness.schedule(400);
+                break;
+            }
+            case 6: {
+                const content = popup.contentItem;
+                const padding = popup.contentPadding;
+                const chart = harness.chartItem();
+                harness.check("a provider with no hourly data leaves no empty row",
+                              !!chart && !chart.visible);
+                harness.check("and the card still opens at the hero card",
+                              BarPopupUnroll.heroSectionHeight(content.children, padding)
+                              === content.children[0].height + padding * 2);
+                harness.finish();
+                break;
+            }
+            }
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/WeatherPopupHeroRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/WeatherPopupHeroRuntimeTest.qml
@@ -176,14 +176,6 @@ ShellRoot {
                               hero === harness.named("weatherHero").height + padding * 2);
                 harness.check("the hero is a fraction of the open height, so there is still an unroll",
                               hero > 0 && hero < openHeight);
-                // The feature's name, measured: every bar's bottom edge is the
-                // same line, so what moves is the top.
-                const feet = harness.bars(chart).map(function (bar) {
-                    return bar.mapToItem(chart, 0, bar.height).y;
-                });
-                harness.check("the bars stand on one axis, whatever their height",
-                              feet.length > 1
-                              && feet.every(function (foot) { return Math.abs(foot - feet[0]) < 0.5; }));
                 harness.check("the bars are flat while the popup is not showing",
                               harness.tallestBar() === 0);
 
@@ -199,6 +191,19 @@ ShellRoot {
                 harness.settledFirstSeries = harness.tallestBar();
                 harness.check("the bars settle at a height",
                               harness.settledFirstSeries > 0);
+                // The feature's name, measured, and measured while the bars
+                // have height: at rest they are all zero tall and every
+                // arrangement of them shares a line.
+                const heights = harness.bars(harness.chartItem()).map(function (bar) {
+                    return bar.height;
+                });
+                const feet = harness.bars(harness.chartItem()).map(function (bar) {
+                    return bar.mapToItem(harness.chartItem(), 0, bar.height).y;
+                });
+                harness.check("the bars stand on one axis, whatever their height",
+                              feet.length > 1
+                              && Math.max.apply(null, heights) - Math.min.apply(null, heights) > 1
+                              && feet.every(function (foot) { return Math.abs(foot - feet[0]) < 0.5; }));
                 harness.check("the bars grew from the axis rather than appearing at full height",
                               harness.growthSample > 0
                               && harness.growthSample < harness.settledFirstSeries - 1);

--- a/dots/.config/quickshell/imi/modules/common/Icons.qml
+++ b/dots/.config/quickshell/imi/modules/common/Icons.qml
@@ -32,7 +32,15 @@ Singleton {
     }
 
     function isNight(): bool {
-        const hour = new Date().getHours();
+        return isNightAt(new Date().getHours());
+    }
+
+    // A forecast hour is not this hour: the weather popup's hourly row draws
+    // 21:00 at two in the afternoon, and asking isNight() there gives every bar
+    // the daytime glyph until eight in the evening and then all of them the
+    // night one. The threshold stays in one place rather than being restated
+    // wherever an hour is already known.
+    function isNightAt(hour: int): bool {
         return hour < 6 || hour >= 20;
     }
 

--- a/dots/.config/quickshell/imi/modules/common/functions/weatherHourly.js
+++ b/dots/.config/quickshell/imi/modules/common/functions/weatherHourly.js
@@ -1,0 +1,240 @@
+.pragma library
+.import "weatherForecast.js" as Daily
+
+// The hourly row in the bar's weather popup, as arithmetic.
+//
+// Neither provider is asked for anything new for this: OpenWeatherMap's
+// /data/2.5/forecast - already fetched for the day cards - IS a three-hourly
+// list, and wttr.in's `?format=j1` carries `weather[].hourly[]` inside the one
+// response the current conditions come from. The whole feature is a second
+// reading of two payloads the service already has.
+//
+// Everything here is a decision, which is why it is not in the QML: which
+// slots are shown, how a bar is scaled, where a day boundary falls, and when
+// there is not enough of a series to draw at all. Each of those is wrong in a
+// way that renders perfectly - a chart of yesterday morning, a row of bars all
+// the same height, a "00" label that belongs to tomorrow - so each has to be
+// somewhere `tst_weather_hourly.qml` can call it.
+//
+// A `.pragma library` has no QML engine context, so nothing here touches `Qt`
+// or a singleton (test_weather_forecast_contract.py holds both this file and
+// weatherForecast.js to that). The locale, the clock format and "now" are all
+// arguments; the caller has an engine context and passes them in.
+
+// Five bars is what 340px of popup holds at a legible label size, and it is
+// what the survey measured on the tree this is taken from
+// (docs/p3drovfx-animation-research-2026-08-16.md §5.2).
+var SLOT_COUNT = 5;
+
+// Two bars is the floor for a CHART. One bar is scaled against itself, which
+// makes it full height whatever the temperature is - a confident-looking
+// drawing of nothing. Below this the row is not drawn at all.
+var MIN_SLOTS = 2;
+
+// The coldest bar in the window still has to be visible as a bar, or the row
+// reads as four readings and a gap.
+var MIN_FRACTION = 0.18;
+
+// A window with no variation at all (five identical degrees, which a still
+// night really does produce) has no low and no high to place anything between.
+// Mid height says "flat"; full height would say "hot" and the floor would say
+// "cold", and both would be a claim the data does not make.
+var FLAT_FRACTION = 0.55;
+
+function _pad2(value) {
+    return value < 10 ? "0" + value : String(value);
+}
+
+// A temperature, or null if there isn't one.
+//
+// `Number(null)` is 0 and `isFinite(0)` is true, so the obvious guard - convert
+// and test - reads a missing reading as a confident zero degrees: a bar at the
+// floor, a "0°" label, and a window range dragged down to it. wttr.in hands
+// these over as strings ("21"), so the conversion cannot simply be dropped
+// either; the null-ish cases have to be refused before it.
+function _reading(value) {
+    if (value === null || value === undefined || value === "")
+        return null;
+    var number = Number(value);
+    return isFinite(number) ? number : null;
+}
+
+// OpenWeatherMap's three-hourly list, normalised.
+//
+// Keyed on `dt` - the instant - and NOT on `dt_txt`, which OWM documents as
+// UTC. `dailyFromOwm` groups by the `dt_txt` date because a day's card only
+// needs to be a day apart from its neighbours, but an HOUR label read off it
+// is the user's own clock wrong by their whole UTC offset, and it is right on
+// the CI runner and on any machine in London. So the local hour and the local
+// date both come from the timestamp.
+function slotsFromOwm(list) {
+    var slots = [];
+    (list || []).forEach(function (entry) {
+        var seconds = Number(entry && entry.dt);
+        if (!isFinite(seconds) || seconds <= 0)
+            return;
+        var when = new Date(seconds * 1000);
+        slots.push({
+            ms: when.getTime(),
+            date: Daily.localIsoDate(when),
+            hour: when.getHours(),
+            temp: _reading(entry && entry.main && entry.main.temp),
+            wCode: Number(entry && entry.weather && entry.weather[0] && entry.weather[0].id) || 0
+        });
+    });
+    return _sorted(slots);
+}
+
+// wttr.in's `weather[].hourly[]`, flattened across its three days.
+//
+// Both of its time fields are already local to the requested location: `date`
+// is "YYYY-MM-DD" and `time` is an hhmm string with no separator ("0", "300",
+// ... "2100"), which is why the hour is a division rather than a slice.
+//
+// The date is parsed field by field rather than through `new Date(string)`: a
+// bare "YYYY-MM-DD" is read as UTC midnight, which is the previous evening west
+// of UTC, and every slot of the day would be filed under the wrong date.
+function slotsFromWttr(weather, useUSCS) {
+    var slots = [];
+    (weather || []).forEach(function (day) {
+        var date = (day && day.date) || "";
+        var parts = date.split("-");
+        if (parts.length !== 3)
+            return;
+        var year = Number(parts[0]);
+        var month = Number(parts[1]);
+        var dayOfMonth = Number(parts[2]);
+        if (!isFinite(year) || !isFinite(month) || !isFinite(dayOfMonth))
+            return;
+        ((day && day.hourly) || []).forEach(function (entry) {
+            var raw = Number((entry && entry.time) || 0);
+            if (!isFinite(raw))
+                return;
+            var hour = Math.floor(raw / 100);
+            slots.push({
+                ms: new Date(year, month - 1, dayOfMonth, hour).getTime(),
+                date: date,
+                hour: hour,
+                temp: _reading(useUSCS ? (entry && entry.tempF) : (entry && entry.tempC)),
+                wCode: Number(entry && entry.weatherCode) || 0
+            });
+        });
+    });
+    return _sorted(slots);
+}
+
+// The slots the row shows: the next `limit` that have not started yet.
+//
+// Strictly ahead of `now`, because what it is doing at this minute is the hero
+// card's job and a bar labelled 15 while the clock says 16:30 reads as a stale
+// popup. This is also the whole of the day-boundary handling: wttr.in's first
+// day always begins at 00:00, so at any time after breakfast most of what it
+// returns is already spent, and a row that took the first five entries of the
+// payload would be a chart of this morning until midnight. The list is
+// flattened across days before it is cut, so the window rolls into tomorrow on
+// its own.
+//
+// `dayBreak` marks the first slot of a date the previous shown slot did not
+// have - never the first slot, whose day is the day the user is already in.
+// The caller labels it with the weekday instead of the hour: "00" on its own
+// is the one label that could belong to either side of the boundary.
+function upcoming(slots, nowMs, limit) {
+    var wanted = (limit === undefined || limit === null) ? SLOT_COUNT : limit;
+    var ahead = [];
+    (slots || []).forEach(function (slot) {
+        if (slot && isFinite(slot.ms) && slot.ms > nowMs)
+            ahead.push(slot);
+    });
+    return ahead.slice(0, Math.max(0, wanted)).map(function (slot, index, shown) {
+        return {
+            ms: slot.ms,
+            date: slot.date,
+            hour: slot.hour,
+            temp: slot.temp,
+            wCode: slot.wCode,
+            dayBreak: index > 0 && !!slot.date && slot.date !== shown[index - 1].date
+        };
+    });
+}
+
+// The temperature range the bars are drawn against: the shown window's own
+// extremes, not the day's and not the provider's. A five-slot window that
+// spans two degrees should show two degrees of shape, which is what makes the
+// row readable at a glance; scaling against a fixed range would draw every
+// mild day as a flat line.
+function chartRange(slots) {
+    var low = null;
+    var high = null;
+    (slots || []).forEach(function (slot) {
+        var temp = _reading(slot && slot.temp);
+        if (temp === null)
+            return;
+        low = (low === null) ? temp : Math.min(low, temp);
+        high = (high === null) ? temp : Math.max(high, temp);
+    });
+    return { low: low, high: high };
+}
+
+// A bar's height as a fraction of its track. `null` for a slot with no reading:
+// an absent temperature is not a zero-height bar, which would read as the
+// coldest hour of the window.
+function barFraction(temp, low, high) {
+    var value = _reading(temp);
+    var bottom = _reading(low);
+    var top = _reading(high);
+    if (value === null || bottom === null || top === null)
+        return null;
+    if (top === bottom)
+        return FLAT_FRACTION;
+    var scaled = MIN_FRACTION + (1 - MIN_FRACTION) * (value - bottom) / (top - bottom);
+    return Math.max(MIN_FRACTION, Math.min(1, scaled));
+}
+
+// Whether there is a chart here at all.
+//
+// Two conditions rather than one: a short payload, and a payload whose
+// temperatures are missing. Both end as a row of hour labels with nothing over
+// them, which looks like a rendering fault rather than like a provider that
+// answered thinly - so the caller hides the section instead.
+function isRenderable(slots) {
+    if (!slots || slots.length < MIN_SLOTS)
+        return false;
+    var withReadings = 0;
+    slots.forEach(function (slot) {
+        if (_reading(slot && slot.temp) !== null)
+            withReadings++;
+    });
+    return withReadings >= MIN_SLOTS;
+}
+
+// The shell has no 12/24-hour switch - it has `Config.options.time.format`, a
+// Qt time format string - so the row reads the clock the user already set
+// rather than growing a setting of its own. `ap`/`AP` is Qt's am/pm marker and
+// its presence is what makes a format twelve-hour.
+function usesTwelveHourClock(timeFormat) {
+    return /(^|[^a-zA-Z])(ap|AP)([^a-zA-Z]|$)/.test(String(timeFormat || ""));
+}
+
+// Built by hand rather than through a Date's locale methods, because this file
+// has no engine context to hand one a `Qt.locale()` - and because QtQml's
+// overload takes (locale, format) where ECMAScript takes an options object, so
+// the browser spelling silently returns a different string here.
+function hourLabel(hour, twelveHour) {
+    var value = Number(hour);
+    if (!isFinite(value))
+        return "";
+    var normalized = ((Math.floor(value) % 24) + 24) % 24;
+    if (!twelveHour)
+        return _pad2(normalized) + ":00";
+    var display = normalized % 12;
+    return (display === 0 ? 12 : display) + (normalized < 12 ? " AM" : " PM");
+}
+
+// Both providers return their entries in order, so this defends against a
+// malformed payload rather than against a normal one - but a single
+// out-of-order entry would put a bar out of sequence with no other symptom.
+function _sorted(slots) {
+    return slots.sort(function (left, right) {
+        return left.ms - right.ms;
+    });
+}

--- a/dots/.config/quickshell/imi/modules/common/functions/weatherHourly.js
+++ b/dots/.config/quickshell/imi/modules/common/functions/weatherHourly.js
@@ -99,11 +99,13 @@ function slotsFromWttr(weather, useUSCS) {
     (weather || []).forEach(function (day) {
         var date = (day && day.date) || "";
         var parts = date.split("-");
-        if (parts.length !== 3)
-            return;
         var year = Number(parts[0]);
         var month = Number(parts[1]);
         var dayOfMonth = Number(parts[2]);
+        // A day with no date, or one whose date is not a date, cannot be placed
+        // on a time axis at all. The NaN test is the whole of the check: a
+        // missing field is `undefined`, which converts to NaN, so a separate
+        // length test could never fire on its own.
         if (!isFinite(year) || !isFinite(month) || !isFinite(dayOfMonth))
             return;
         ((day && day.hourly) || []).forEach(function (entry) {
@@ -192,15 +194,16 @@ function barFraction(temp, low, high) {
 
 // Whether there is a chart here at all.
 //
-// Two conditions rather than one: a short payload, and a payload whose
+// Counted in READINGS rather than in slots, which answers both ways of having
+// too little at once: a payload that is nearly spent, and a payload whose
 // temperatures are missing. Both end as a row of hour labels with nothing over
 // them, which looks like a rendering fault rather than like a provider that
-// answered thinly - so the caller hides the section instead.
+// answered thinly - so the caller hides the section instead. A separate length
+// test would be a second condition that can never fire on its own, since a
+// reading needs a slot to sit in.
 function isRenderable(slots) {
-    if (!slots || slots.length < MIN_SLOTS)
-        return false;
     var withReadings = 0;
-    slots.forEach(function (slot) {
+    (slots || []).forEach(function (slot) {
         if (_reading(slot && slot.temp) !== null)
             withReadings++;
     });

--- a/dots/.config/quickshell/imi/modules/imi/bar/WeatherHourlyChart.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/WeatherHourlyChart.qml
@@ -1,0 +1,128 @@
+import QtQuick
+import QtQuick.Layouts
+import qs.services
+import qs.modules.common
+import qs.modules.common.widgets
+import "../../common/functions/weatherHourly.js" as WeatherHourly
+import "../../common/functions/weatherForecast.js" as WeatherForecast
+
+// The weather popup's hourly row: five three-hourly slots, each a bar grown
+// from the axis. Every decision behind it is in weatherHourly.js, which is
+// where the tests can reach them; this file owns the drawing and nothing else.
+Rectangle {
+    id: root
+    // The objectNames are how WeatherPopupHeroRuntimeTest.qml finds the row and
+    // its bars: it samples a bar mid-growth, and a settled bar is the same
+    // height whether it animated or teleported.
+    objectName: "hourlyChart"
+
+    // The popup holding the card. The bars grow whenever this goes true, so a
+    // card that is opened plays the growth and a card that is already open
+    // plays it again when a refresh moves the temperatures - the tree this was
+    // taken from animates on open only, by writing the heights from a
+    // NumberAnimation that destroys the binding, so a refresh under an open
+    // popup pops the bars with no motion at all
+    // (docs/p3drovfx-animation-research-2026-08-16.md §3.3).
+    required property bool charted
+
+    // Written once per fetch, so which of the slots are still ahead is a
+    // question about now rather than about the fetch. DateTime's clock is read
+    // to re-cut the window every minute; the shell has exactly one of those
+    // timers and this is how everything else borrows it.
+    readonly property real nowMs: {
+        DateTime.minutes;
+        return Date.now();
+    }
+    readonly property var slots: WeatherHourly.upcoming(Weather.hourly, root.nowMs, WeatherHourly.SLOT_COUNT)
+    readonly property var range: WeatherHourly.chartRange(root.slots)
+    readonly property bool twelveHour: WeatherHourly.usesTwelveHourClock(Config.options.time.format)
+
+    // A row of hour labels with nothing over them reads as a rendering fault
+    // rather than as a provider that answered thinly.
+    visible: WeatherHourly.isRenderable(root.slots)
+    Layout.fillWidth: true
+    implicitHeight: contentRow.implicitHeight + Appearance.spacing.space100 * 2
+
+    radius: Appearance.rounding.small
+    color: Appearance.colors.colSurfaceContainerHigh
+
+    RowLayout {
+        id: contentRow
+        anchors {
+            fill: parent
+            margins: Appearance.spacing.space100
+        }
+        spacing: Appearance.spacing.space50
+        uniformCellSizes: true
+
+        Repeater {
+            model: root.slots
+
+            ColumnLayout {
+                id: slotColumn
+                required property var modelData
+                Layout.fillWidth: true
+                spacing: Appearance.spacing.space25
+
+                readonly property var fraction: WeatherHourly.barFraction(slotColumn.modelData.temp,
+                                                                         root.range.low, root.range.high)
+
+                StyledText {
+                    Layout.alignment: Qt.AlignHCenter
+                    text: slotColumn.modelData.temp === null
+                        ? "–" : `${Math.round(slotColumn.modelData.temp)}°`
+                    font.pixelSize: Appearance.font.pixelSize.smallest
+                    font.weight: Font.DemiBold
+                    color: Appearance.colors.colOnSurfaceVariant
+                }
+
+                Item {
+                    id: track
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: 36
+
+                    Rectangle {
+                        id: bar
+                        objectName: "hourlyBar"
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        anchors.bottom: parent.bottom
+                        width: Math.min(12, track.width)
+                        radius: Appearance.rounding.verysmall
+                        color: Appearance.colors.colPrimary
+                        // A slot with no reading draws no bar; a zero-height one
+                        // would read as the coldest hour of the window.
+                        height: (root.charted && slotColumn.fraction !== null)
+                            ? slotColumn.fraction * track.height : 0
+
+                        Behavior on height {
+                            animation: Appearance.animation.elementMove.numberAnimation.createObject(this)
+                        }
+                    }
+                }
+
+                MaterialSymbol {
+                    Layout.alignment: Qt.AlignHCenter
+                    // Night-aware on the SLOT's own hour, not on the current
+                    // one: this row is drawn hours ahead of what it describes.
+                    text: Icons.getProviderWeatherIcon(Weather.provider, slotColumn.modelData.wCode,
+                                                       Icons.isNightAt(slotColumn.modelData.hour))
+                    iconSize: Appearance.font.pixelSize.smaller
+                    fill: 0
+                    color: Appearance.colors.colOnSurfaceVariant
+                }
+
+                StyledText {
+                    Layout.alignment: Qt.AlignHCenter
+                    // The weekday where the window crosses midnight: "00" alone
+                    // could belong to either side of the boundary.
+                    text: slotColumn.modelData.dayBreak
+                        ? WeatherForecast.shortDayName(slotColumn.modelData.date, Qt.locale())
+                        : WeatherHourly.hourLabel(slotColumn.modelData.hour, root.twelveHour)
+                    font.pixelSize: Appearance.font.pixelSize.smallest
+                    color: Appearance.colors.colOnSurfaceVariant
+                    opacity: 0.7
+                }
+            }
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/modules/imi/bar/WeatherPopup.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/WeatherPopup.qml
@@ -129,6 +129,17 @@ StyledPopup {
         }
 
 
+        // Deliberately not the first child: BarPopupOverlay unrolls the card
+        // from the height of the content's first DRAWN section, so a row that
+        // comes and goes would keep changing what the popup opens at - and a
+        // 60px strip is not the section this card should be legible at on
+        // frame one. The hero stays first.
+        WeatherHourlyChart {
+            charted: root.popupVisible
+            Layout.leftMargin: Appearance.spacing.space25
+            Layout.rightMargin: Appearance.spacing.space25
+        }
+
         GridLayout {
             id: gridLayout
             columns: 2

--- a/dots/.config/quickshell/imi/modules/imi/bar/WeatherPopup.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/WeatherPopup.qml
@@ -19,6 +19,10 @@ StyledPopup {
         Layout.rightMargin: -Appearance.spacing.space100
 
         Rectangle {
+            // Named so WeatherPopupHeroRuntimeTest.qml can ask whether this is
+            // still the section the card unrolls from, rather than asking
+            // whether the first child is the first child.
+            objectName: "weatherHero"
             Layout.fillWidth: true
             Layout.preferredHeight: 125
 

--- a/dots/.config/quickshell/imi/modules/imi/bar/WeatherPopup.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/WeatherPopup.qml
@@ -136,8 +136,8 @@ StyledPopup {
         // Deliberately not the first child: BarPopupOverlay unrolls the card
         // from the height of the content's first DRAWN section, so a row that
         // comes and goes would keep changing what the popup opens at - and a
-        // 60px strip is not the section this card should be legible at on
-        // frame one. The hero stays first.
+        // 99px strip is not the section this card should be legible at on
+        // frame one. The hero stays first, at 141 of the card's 431.
         WeatherHourlyChart {
             charted: root.popupVisible
             Layout.leftMargin: Appearance.spacing.space25

--- a/dots/.config/quickshell/imi/services/Weather.qml
+++ b/dots/.config/quickshell/imi/services/Weather.qml
@@ -8,6 +8,7 @@ import QtPositioning
 
 import qs.modules.common
 import "../modules/common/functions/weatherForecast.js" as WeatherForecast
+import "../modules/common/functions/weatherHourly.js" as WeatherHourly
 
 Singleton {
     id: root
@@ -62,6 +63,16 @@ Singleton {
     // the response the current conditions already come from, but OWM needs a
     // second request that can fail on its own.
     property var forecast: []
+
+    // The same two responses read a second way: every three-hourly entry they
+    // carry, normalised to `[{ ms, date, hour, temp, wCode }]`. NOT cut to the
+    // hours a chart shows - that window depends on the time of day, and this is
+    // written once per fetch while the popup reads it once a minute, so the
+    // caller does the cutting through WeatherHourly.upcoming(). Neither
+    // provider is asked for anything new: OpenWeatherMap's /data/2.5/forecast
+    // is already fetched for the day cards and IS a three-hourly list, and
+    // wttr.in's weather[].hourly[] arrives with the current conditions.
+    property var hourly: []
 
     function refineData(data) {
         let temp = {}
@@ -163,6 +174,7 @@ Singleton {
         // Already in the response the current conditions came from - wttr.in
         // returns three days of it whether or not anything asks.
         root.forecast = WeatherForecast.dailyFromWttr(data?.weather, root.useUSCS)
+        root.hourly = WeatherHourly.slotsFromWttr(data?.weather, root.useUSCS)
     }
 
     function getData() {
@@ -310,6 +322,7 @@ Singleton {
                         return
                     }
                     root.forecast = WeatherForecast.dailyFromOwm(parsedData.list)
+                    root.hourly = WeatherHourly.slotsFromOwm(parsedData.list)
                 } catch (e) {
                     console.error("[WeatherService] Forecast JSON parse error:", e.message)
                 }

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -1154,6 +1154,16 @@ if ! python3 "$SCRIPT_DIR/test_weather_forecast_contract.py"; then
     exit 1
 fi
 
+# Brings its own headless weston and its own bus. The card unrolls from the
+# content's first DRAWN section, so a section added to a popup silently changes
+# what that popup opens at - and a settled bar is the same height whether it
+# grew or teleported, so the bars are sampled in flight.
+echo "Running weather popup hero runtime tests..."
+if ! python3 "$SCRIPT_DIR/test_weather_popup_hero_runtime.py"; then
+    echo "Weather popup hero runtime tests failed."
+    exit 1
+fi
+
 echo "Running currency service safety tests..."
 if ! python3 "$SCRIPT_DIR/test_currency_service_contract.py"; then
     echo "Currency service safety tests failed."

--- a/dots/.config/quickshell/imi/tests/test_weather_forecast_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_weather_forecast_contract.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 """Weather forecast pins: the wiring the unit tests cannot see.
 
-`tst_weather_forecast.qml` proves the day-grouping arithmetic and
-`tst_weather_icons.qml` proves the provider-aware icon lookup, both against the
-real sources. Neither can see the service that has to call them or the second
-OpenWeatherMap request the forecast depends on, and each of those can break on
-its own without failing a single unit test.
+`tst_weather_forecast.qml` proves the day-grouping arithmetic,
+`tst_weather_hourly.qml` the hourly row's, and `tst_weather_icons.qml` the
+provider-aware icon lookup, all against the real sources. None of them can see
+the service that has to call them or the second OpenWeatherMap request the
+forecast depends on, and each of those can break on its own without failing a
+single unit test.
 
 The URL pins are the load-bearing ones. `city` comes from config and from
 shareable presets, and the existing calls carry a comment recording that they
@@ -23,9 +24,12 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 TESTS = ROOT / "tests"
 FORECAST_QML_TEST = TESTS / "tst_weather_forecast.qml"
+HOURLY_QML_TEST = TESTS / "tst_weather_hourly.qml"
 SERVICE = ROOT / "services/Weather.qml"
 ICONS = ROOT / "modules/common/Icons.qml"
+POPUP = ROOT / "modules/imi/bar/WeatherPopup.qml"
 FORECAST_JS = ROOT / "modules/common/functions/weatherForecast.js"
+HOURLY_JS = ROOT / "modules/common/functions/weatherHourly.js"
 
 
 def _function_body(source, name):
@@ -116,6 +120,60 @@ class WeatherServiceForecastTests(unittest.TestCase):
             self.service, r'"\s*curl[^"]*\$\{',
             "a URL is being interpolated into a shell command string.")
 
+    def test_the_service_publishes_the_hourly_slots(self):
+        """The popup's hourly row reads this and nothing else."""
+        self.assertRegex(self.service, r"property\s+var\s+hourly\s*:",
+                         "Weather no longer publishes the hourly slots the "
+                         "popup's row is drawn from.")
+
+    def test_both_providers_fill_the_hourly_row(self):
+        """Either half missing is a permanently empty row for that provider's
+        users, with nothing in the log - the same failure the daily row had."""
+        self.assertIn("slotsFromWttr", self.service)
+        self.assertIn("slotsFromOwm", self.service)
+
+    def test_the_hourly_row_costs_no_new_request(self):
+        """It is a second reading of two payloads the service already fetches.
+
+        OpenWeatherMap's /data/2.5/forecast, already fetched for the day cards,
+        IS a three-hourly list, and wttr.in's weather[].hourly[] arrives with
+        the current conditions. A third endpoint here would double a call rate
+        the OWM path has already doubled once, for data that was in the
+        response - so the pin is the endpoint list and the number of fetchers,
+        not the parsing.
+        """
+        endpoints = set(re.findall(r"https://[a-zA-Z0-9./-]+", self.service))
+        self.assertEqual(
+            endpoints,
+            {"https://api.openweathermap.org/data/2.5/weather",
+             "https://api.openweathermap.org/data/2.5/forecast",
+             "https://wttr.in/"},
+            "the weather service names an endpoint it did not before")
+        self.assertEqual(
+            self.service.count("Process {"), 2,
+            "a third Process in this service is a third request; the hourly "
+            "slots come out of the two responses already collected.")
+
+    def test_the_popup_draws_the_row_after_its_hero(self):
+        """The card unrolls from the content's FIRST drawn section.
+
+        `BarPopupOverlay` opens at that section's height, so a row declared
+        above the hero card would open the weather popup as a strip with the
+        temperature and the city below the fold - which renders, and looks
+        deliberate. This is the source half; the built tree is measured by
+        tests/test_weather_popup_hero_runtime.py, because `heroSectionHeight`
+        skips undrawn and zero-height children and source order alone cannot
+        answer that.
+        """
+        popup = POPUP.read_text(encoding="utf-8")
+        row = popup.find("WeatherHourlyChart {")
+        self.assertNotEqual(row, -1, "the popup no longer draws the hourly row at all")
+        hero = popup.find("Rectangle {")
+        self.assertNotEqual(hero, -1, "the popup's hero card is gone")
+        self.assertLess(hero, row,
+                        "the hourly row is declared above the hero card, so the "
+                        "card would unroll from the row instead of from the hero.")
+
     def test_the_forecast_endpoint_carries_the_key_and_the_unit_system(self):
         """A forecast in the wrong unit system next to a correct current
         temperature reads as the forecast being wrong, not the request."""
@@ -145,15 +203,18 @@ class WeatherIconLookupTests(unittest.TestCase):
         forecast would simply stop being populated, with a line in the log and
         a widget that looks like the provider returned nothing.
         """
-        source = FORECAST_JS.read_text(encoding="utf-8")
-        self.assertTrue(source.lstrip().startswith(".pragma library"))
-        code = _without_comments(source)
-        self.assertNotRegex(code, r"\bQt\.", "a library JS file cannot use `Qt`.")
-        for singleton in ("Appearance", "Config", "Translation", "Icons"):
-            self.assertNotIn(
-                singleton + ".", code,
-                f"weatherForecast.js reaches the {singleton} singleton, which a "
-                "`.pragma library` file has no engine context for.")
+        for path in (FORECAST_JS, HOURLY_JS):
+            with self.subTest(library=path.name):
+                source = path.read_text(encoding="utf-8")
+                self.assertTrue(source.lstrip().startswith(".pragma library"))
+                code = _without_comments(source)
+                self.assertNotRegex(code, r"\bQt\.", "a library JS file cannot use `Qt`.")
+                for singleton in ("Appearance", "Config", "Translation", "Icons",
+                                  "DateTime", "Weather"):
+                    self.assertNotIn(
+                        singleton + ".", code,
+                        f"{path.name} reaches the {singleton} singleton, which a "
+                        "`.pragma library` file has no engine context for.")
 
 
 class LocalDateAcrossTimezonesTests(unittest.TestCase):
@@ -173,31 +234,38 @@ class LocalDateAcrossTimezonesTests(unittest.TestCase):
     """
 
     ZONES = ("Pacific/Kiritimati", "Pacific/Niue")   # UTC+14 and UTC-11
+    # Both files decide something local. The hourly one is the sharper case:
+    # OpenWeatherMap's `dt_txt` is UTC and its `dt` is the instant, and a row
+    # that labels its bars from the first is correct on a UTC runner and wrong
+    # by the user's whole offset everywhere else.
+    QML_TESTS = (FORECAST_QML_TEST, HOURLY_QML_TEST)
 
-    def test_the_forecast_unit_test_passes_east_and_west_of_utc(self):
+    def test_the_weather_unit_tests_pass_east_and_west_of_utc(self):
         runner = _qmltestrunner()
         self.assertIsNotNone(
             runner,
             "qmltestrunner was not found, so this check cannot run - and it must "
             "not pass quietly. run_tests.sh needs the same binary.")
         for zone in self.ZONES:
-            with self.subTest(timezone=zone):
-                if not Path("/usr/share/zoneinfo", zone).exists():
-                    self.fail(f"tzdata has no {zone}; this check needs a real "
-                              "non-UTC zone to mean anything.")
-                env = dict(os.environ, TZ=zone,
-                           QT_QPA_PLATFORM=os.environ.get("QT_QPA_PLATFORM", "offscreen"))
-                proc = subprocess.run(
-                    [runner,
-                     "-import", str(TESTS / "mocks"),
-                     "-import", str(TESTS / "imports"),
-                     "-input", str(FORECAST_QML_TEST)],
-                    env=env, capture_output=True, text=True)
-                self.assertEqual(
-                    proc.returncode, 0,
-                    f"tst_weather_forecast.qml fails under TZ={zone}, so a "
-                    "forecast card is labelled with the wrong day for part of "
-                    f"every day there.\n{proc.stdout}\n{proc.stderr}")
+            for qml_test in self.QML_TESTS:
+                with self.subTest(timezone=zone, test=qml_test.name):
+                    if not Path("/usr/share/zoneinfo", zone).exists():
+                        self.fail(f"tzdata has no {zone}; this check needs a real "
+                                  "non-UTC zone to mean anything.")
+                    env = dict(os.environ, TZ=zone,
+                               QT_QPA_PLATFORM=os.environ.get("QT_QPA_PLATFORM", "offscreen"))
+                    proc = subprocess.run(
+                        [runner,
+                         "-import", str(TESTS / "mocks"),
+                         "-import", str(TESTS / "imports"),
+                         "-input", str(qml_test)],
+                        env=env, capture_output=True, text=True)
+                    self.assertEqual(
+                        proc.returncode, 0,
+                        f"{qml_test.name} fails under TZ={zone}, so a forecast "
+                        "card is labelled with the wrong day - or an hourly bar "
+                        "with the wrong hour - for part of every day there."
+                        f"\n{proc.stdout}\n{proc.stderr}")
 
 
 if __name__ == "__main__":

--- a/dots/.config/quickshell/imi/tests/test_weather_popup_hero_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_weather_popup_hero_runtime.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Drives the weather popup with its hourly row in it, in a real window.
+
+`WeatherPopupHeroRuntimeTest.qml` builds the real `WeatherPopup`, parents its
+content into a window the way `BarPopupOverlay` parents it into the card, seeds
+`Weather.hourly`, and measures two things nothing else can see.
+
+The card opens at the height of the content's FIRST DRAWN section and unfurls
+from there, so a section added to a popup silently changes what the popup opens
+at unless it lands after the hero - and `heroSectionHeight` skips undrawn and
+zero-height children, so which section that is, is a fact about the built tree
+rather than about the source order. A row that became the hero would open the
+weather card as a 60px strip with the temperature and the city below the fold.
+
+And the bars grow from the axis on the popup's own visibility, which is what
+makes the motion play on a REFRESH as well as on an open. The tree this was
+taken from writes its bar heights from a NumberAnimation that destroys the
+binding, so its chart animates on open and never on data
+(docs/p3drovfx-animation-research-2026-08-16.md §3.3). A settled height is the
+same number whether it animated or teleported, so the harness samples the bars
+in flight and compares the samples afterwards.
+
+Headless weston and a private bus, never the caller's session: this launches a
+`qs` and none of it may reach the user's compositor or their shell.
+
+Skips when weston, qs or dbus-run-session are missing, as in CI.
+"""
+
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HARNESS = ROOT / "WeatherPopupHeroRuntimeTest.qml"
+SOCKET = "wayland-imi-weather-hero"
+
+# The harness prints how many checks it ran. A literal rather than anything
+# read back out of its own output: a step that stops being reached must redden
+# here instead of reporting `failures: 0` for a shorter run.
+EXPECTED_CHECKS = 11
+
+
+def _stop(proc):
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+
+
+def _runtime_available():
+    return all(shutil.which(binary) is not None
+               for binary in ("qs", "weston", "dbus-run-session"))
+
+
+@unittest.skipUnless(_runtime_available(),
+                     "needs qs, weston and dbus-run-session on PATH")
+class WeatherPopupHeroRuntimeTest(unittest.TestCase):
+    def setUp(self):
+        self.home = Path(tempfile.mkdtemp(prefix="imi-weather-hero-"))
+        self.addCleanup(shutil.rmtree, self.home, ignore_errors=True)
+
+    def test_the_hourly_row_lands_after_the_hero_and_its_bars_grow(self):
+        env = dict(os.environ)
+        env.setdefault("XDG_RUNTIME_DIR", f"/run/user/{os.getuid()}")
+        env["WAYLAND_DISPLAY"] = SOCKET
+        env.pop("DISPLAY", None)
+        # Nothing here may reach the user's compositor; hyprctl and anything
+        # else keyed on the signature would, whatever the wayland socket says.
+        env.pop("HYPRLAND_INSTANCE_SIGNATURE", None)
+
+        weston = subprocess.Popen(
+            ["weston", "--backend=headless", "--renderer=pixman",
+             f"--socket={SOCKET}", "--width=900", "--height=900"],
+            env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        self.addCleanup(_stop, weston)
+
+        socket_path = Path(env["XDG_RUNTIME_DIR"]) / SOCKET
+        deadline = time.monotonic() + 15
+        while not socket_path.exists() and time.monotonic() < deadline:
+            time.sleep(0.2)
+        self.assertTrue(socket_path.exists(), "headless weston never came up")
+
+        env["LIBGL_ALWAYS_SOFTWARE"] = "1"
+        env["QT_QUICK_BACKEND"] = "software"
+        env["XDG_CONFIG_HOME"] = str(self.home / "config")
+        env["XDG_CACHE_HOME"] = str(self.home / "cache")
+        env["XDG_STATE_HOME"] = str(self.home / "state")
+        env["XDG_DATA_HOME"] = str(self.home / "data")
+        for key in ("XDG_CONFIG_HOME", "XDG_CACHE_HOME", "XDG_STATE_HOME", "XDG_DATA_HOME"):
+            Path(env[key]).mkdir(parents=True, exist_ok=True)
+
+        proc = subprocess.run(
+            ["dbus-run-session", "--", "qs", "-p", str(HARNESS)],
+            cwd=str(ROOT), env=env, capture_output=True, text=True, timeout=180)
+
+        output = proc.stdout + proc.stderr
+        failed = [line for line in output.splitlines() if "FAIL" in line]
+        self.assertEqual(failed, [], f"harness reported failures:\n{output}")
+        self.assertIn(f"[WeatherHero] checks: {EXPECTED_CHECKS} failures: 0", output,
+                      f"harness never reached a verdict:\n{output}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dots/.config/quickshell/imi/tests/tst_weather_hourly.qml
+++ b/dots/.config/quickshell/imi/tests/tst_weather_hourly.qml
@@ -90,6 +90,17 @@ TestCase {
         compare(slots.map(slot => slot.date), ["2026-08-04", "2026-08-05"]);
     }
 
+    // Both providers return their entries in order, so this is about a
+    // malformed payload rather than a normal one - and a single bar out of
+    // sequence has no other symptom.
+    function test_slotsComeBackInTimeOrder() {
+        const slots = WeatherHourly.slotsFromWttr([
+            wttrDay("2026-08-05", [{ time: "0", tempC: "10", tempF: "50", weatherCode: "113" }]),
+            wttrDay("2026-08-04", [{ time: "2100", tempC: "12", tempF: "54", weatherCode: "113" }])
+        ], false);
+        compare(slots.map(slot => slot.date), ["2026-08-04", "2026-08-05"]);
+    }
+
     function test_wttrSurvivesAJunkResponse() {
         compare(WeatherHourly.slotsFromWttr(undefined, false), []);
         compare(WeatherHourly.slotsFromWttr([{}], false), [],

--- a/dots/.config/quickshell/imi/tests/tst_weather_hourly.qml
+++ b/dots/.config/quickshell/imi/tests/tst_weather_hourly.qml
@@ -1,0 +1,242 @@
+import QtTest
+import "../modules/common/functions/weatherHourly.js" as WeatherHourly
+
+// The hourly row's decisions. Every one of them fails by drawing something
+// plausible rather than by erroring: a chart of this morning at nine in the
+// evening, five bars at the same height, a "00" that belongs to tomorrow, or a
+// single bar at full height because it was scaled against itself.
+TestCase {
+    name: "WeatherHourlyTest"
+
+    // Local, because that is what both a slot's hour and a slot's date mean.
+    // Building the fixtures this way also keeps the file honest under the
+    // far-east and far-west runs test_weather_forecast_contract.py drives it
+    // through: an assertion written against a UTC hour would be a timezone
+    // assumption wearing a fixture's clothes.
+    function at(year, month, day, hour) {
+        return new Date(year, month - 1, day, hour, 0, 0);
+    }
+
+    function owmEntry(when, temp, id) {
+        return {
+            dt: Math.floor(when.getTime() / 1000),
+            // Deliberately a DIFFERENT clock from `dt`, which is what OWM does:
+            // dt_txt is UTC. A reader that takes the hour from here is right
+            // only on a UTC machine.
+            dt_txt: "1999-01-01 00:00:00",
+            main: { temp: temp },
+            weather: [{ id: id }]
+        };
+    }
+
+    // OWM's own documentation calls dt_txt UTC, so the hour on screen has to
+    // come from the instant. On a UTC runner the two agree, which is exactly
+    // why this fixture makes them disagree by a century.
+    function test_owmSlotsTakeTheLocalHourFromTheInstantNotFromDtTxt() {
+        const when = at(2026, 8, 4, 15);
+        const slots = WeatherHourly.slotsFromOwm([owmEntry(when, 21.4, 500)]);
+        compare(slots.length, 1);
+        compare(slots[0].hour, 15, "the hour is the user's own clock");
+        compare(slots[0].date, "2026-08-04");
+        compare(slots[0].temp, 21.4, "the temperature is not rounded here; the label rounds it");
+        compare(slots[0].wCode, 500);
+        compare(slots[0].ms, when.getTime());
+    }
+
+    function test_owmSurvivesAJunkResponse() {
+        compare(WeatherHourly.slotsFromOwm(undefined), []);
+        compare(WeatherHourly.slotsFromOwm([]), []);
+        compare(WeatherHourly.slotsFromOwm([{}, { dt: "nonsense" }, { dt: 0 }]), [],
+                "an entry with no instant has no place on a time axis");
+    }
+
+    function test_owmKeepsASlotWhoseTemperatureIsMissing() {
+        const slots = WeatherHourly.slotsFromOwm([
+            { dt: Math.floor(at(2026, 8, 4, 15).getTime() / 1000), weather: [{ id: 800 }] }
+        ]);
+        compare(slots.length, 1, "the hour still exists");
+        compare(slots[0].temp, null, "an absent reading is null, never 0 degrees");
+    }
+
+    function wttrDay(date, hourly) {
+        return { date: date, hourly: hourly };
+    }
+
+    // "300" is 03:00, not three hundred.
+    function test_wttrSlotsParseTheHhmmTimeAndFollowTheUnitSetting() {
+        const day = wttrDay("2026-08-04", [
+            { time: "0", tempC: "9", tempF: "48", weatherCode: "113" },
+            { time: "300", tempC: "8", tempF: "46", weatherCode: "116" },
+            { time: "1500", tempC: "21", tempF: "70", weatherCode: "296" }
+        ]);
+        const metric = WeatherHourly.slotsFromWttr([day], false);
+        compare(metric.length, 3);
+        compare(metric.map(slot => slot.hour), [0, 3, 15]);
+        compare(metric[2].temp, 21);
+        compare(metric[2].wCode, 296);
+        compare(metric[2].ms, at(2026, 8, 4, 15).getTime(),
+                "the timestamp is local, because wttr's own date and time are");
+
+        const uscs = WeatherHourly.slotsFromWttr([day], true);
+        compare(uscs[2].temp, 70, "US customary");
+    }
+
+    function test_wttrFlattensItsDaysInOrder() {
+        const slots = WeatherHourly.slotsFromWttr([
+            wttrDay("2026-08-04", [{ time: "2100", tempC: "12", tempF: "54", weatherCode: "113" }]),
+            wttrDay("2026-08-05", [{ time: "0", tempC: "10", tempF: "50", weatherCode: "113" }])
+        ], false);
+        compare(slots.length, 2);
+        compare(slots.map(slot => slot.date), ["2026-08-04", "2026-08-05"]);
+    }
+
+    function test_wttrSurvivesAJunkResponse() {
+        compare(WeatherHourly.slotsFromWttr(undefined, false), []);
+        compare(WeatherHourly.slotsFromWttr([{}], false), [],
+                "a day with no date cannot be placed on a time axis");
+        compare(WeatherHourly.slotsFromWttr([wttrDay("2026-08-04", undefined)], false), []);
+    }
+
+    function series(hours) {
+        return hours.map(entry => ({
+            ms: at(entry[0], entry[1], entry[2], entry[3]).getTime(),
+            date: entry[0] + "-" + (entry[1] < 10 ? "0" + entry[1] : entry[1])
+                + "-" + (entry[2] < 10 ? "0" + entry[2] : entry[2]),
+            hour: entry[3],
+            temp: entry[4],
+            wCode: 800
+        }));
+    }
+
+    // wttr.in's first day always starts at 00:00, so most of what it returns is
+    // already spent by mid-afternoon. Taking the head of the payload would draw
+    // this morning's weather as a forecast for the rest of the day.
+    function test_upcomingSkipsWhatHasAlreadyHappened() {
+        const slots = series([
+            [2026, 8, 4, 0, 11], [2026, 8, 4, 3, 10], [2026, 8, 4, 6, 12],
+            [2026, 8, 4, 9, 16], [2026, 8, 4, 12, 20], [2026, 8, 4, 15, 21],
+            [2026, 8, 4, 18, 18], [2026, 8, 4, 21, 14]
+        ]);
+        const shown = WeatherHourly.upcoming(slots, at(2026, 8, 4, 13).getTime(), 5);
+        compare(shown.map(slot => slot.hour), [15, 18, 21],
+                "only the hours still ahead, and the payload runs out at 21");
+    }
+
+    function test_upcomingIsCappedAndExcludesTheSlotOnTheHour() {
+        const slots = series([
+            [2026, 8, 4, 15, 21], [2026, 8, 4, 18, 18], [2026, 8, 4, 21, 14],
+            [2026, 8, 5, 0, 12], [2026, 8, 5, 3, 11], [2026, 8, 5, 6, 13]
+        ]);
+        const shown = WeatherHourly.upcoming(slots, at(2026, 8, 4, 15).getTime(), 5);
+        compare(shown.length, 5, "the window is capped");
+        compare(shown[0].hour, 18,
+                "a slot that has just started is what it is doing NOW, which the hero says");
+    }
+
+    // Midnight is the one label that could belong to either side of the
+    // boundary, so the caller needs to be told where the day turns.
+    function test_upcomingMarksTheDayBoundaryButNeverTheFirstSlot() {
+        const slots = series([
+            [2026, 8, 4, 21, 14], [2026, 8, 5, 0, 12], [2026, 8, 5, 3, 11]
+        ]);
+        const shown = WeatherHourly.upcoming(slots, at(2026, 8, 4, 20).getTime(), 5);
+        compare(shown.map(slot => slot.dayBreak), [false, true, false]);
+
+        const fromMidnight = WeatherHourly.upcoming(slots, at(2026, 8, 4, 23).getTime(), 5);
+        compare(fromMidnight[0].hour, 0);
+        compare(fromMidnight[0].dayBreak, false,
+                "the first bar's day is the day the user is already in");
+    }
+
+    function test_upcomingReturnsNothingForAStalePayload() {
+        const slots = series([[2026, 8, 4, 15, 21], [2026, 8, 4, 18, 18]]);
+        compare(WeatherHourly.upcoming(slots, at(2026, 8, 9, 12).getTime(), 5), [],
+                "a payload that is entirely in the past has nothing to forecast");
+        compare(WeatherHourly.upcoming(undefined, 0, 5), []);
+    }
+
+    function test_theRangeIsTheShownWindowsOwn() {
+        const shown = series([[2026, 8, 4, 15, 21], [2026, 8, 4, 18, 18], [2026, 8, 4, 21, 14]]);
+        const range = WeatherHourly.chartRange(shown);
+        compare(range.low, 14);
+        compare(range.high, 21);
+    }
+
+    function test_theRangeIgnoresAbsentReadings() {
+        const shown = series([[2026, 8, 4, 15, null], [2026, 8, 4, 18, 18]]);
+        const range = WeatherHourly.chartRange(shown);
+        compare(range.low, 18);
+        compare(range.high, 18);
+        compare(WeatherHourly.chartRange([]).low, null);
+        compare(WeatherHourly.chartRange([]).high, null);
+    }
+
+    // The coldest hour of the window is still an hour, so its bar is still a
+    // bar - a zero-height one reads as a hole in the row.
+    function test_theColdestBarKeepsAVisibleFloorAndTheWarmestFillsTheTrack() {
+        compare(WeatherHourly.barFraction(14, 14, 21), WeatherHourly.MIN_FRACTION);
+        compare(WeatherHourly.barFraction(21, 14, 21), 1);
+        const middle = WeatherHourly.barFraction(17.5, 14, 21);
+        verify(middle > WeatherHourly.MIN_FRACTION && middle < 1,
+               `a middling hour lands between the two: ${middle}`);
+    }
+
+    // Five identical degrees is a real still night, and it leaves nothing to
+    // place anything between. Full height would claim heat and the floor would
+    // claim cold.
+    function test_aFlatWindowDrawsFlatBarsRatherThanDividingByZero() {
+        compare(WeatherHourly.barFraction(18, 18, 18), WeatherHourly.FLAT_FRACTION);
+    }
+
+    function test_anAbsentReadingHasNoBarRatherThanAZeroOne() {
+        compare(WeatherHourly.barFraction(null, 14, 21), null);
+        compare(WeatherHourly.barFraction(undefined, 14, 21), null);
+        compare(WeatherHourly.barFraction(18, null, null), null);
+    }
+
+    function test_aReadingOutsideTheRangeIsClampedIntoTheTrack() {
+        compare(WeatherHourly.barFraction(30, 14, 21), 1);
+        compare(WeatherHourly.barFraction(2, 14, 21), WeatherHourly.MIN_FRACTION);
+    }
+
+    // One bar is scaled against itself, so it is full height whatever the
+    // temperature is: a confident drawing of nothing.
+    function test_aSeriesTooShortToBeAChartIsNotDrawn() {
+        const one = series([[2026, 8, 4, 15, 21]]);
+        verify(!WeatherHourly.isRenderable(one));
+        verify(!WeatherHourly.isRenderable([]));
+        verify(!WeatherHourly.isRenderable(undefined));
+        verify(WeatherHourly.isRenderable(
+            series([[2026, 8, 4, 15, 21], [2026, 8, 4, 18, 18]])));
+    }
+
+    function test_aSeriesWithNoReadingsIsNotDrawnEither() {
+        const blank = series([[2026, 8, 4, 15, null], [2026, 8, 4, 18, null], [2026, 8, 4, 21, 14]]);
+        verify(!WeatherHourly.isRenderable(blank),
+               "hour labels with nothing over them read as a rendering fault");
+    }
+
+    // There is no 12/24-hour switch in this shell - there is a Qt time format
+    // string, and `ap` is its am/pm marker.
+    function test_theClockFormatDecidesTheLabelStyle() {
+        verify(!WeatherHourly.usesTwelveHourClock("hh:mm"));
+        verify(!WeatherHourly.usesTwelveHourClock("HH:mm:ss"));
+        verify(WeatherHourly.usesTwelveHourClock("h:mm ap"));
+        verify(WeatherHourly.usesTwelveHourClock("hh:mm AP"));
+        verify(!WeatherHourly.usesTwelveHourClock(""));
+        verify(!WeatherHourly.usesTwelveHourClock(undefined));
+        verify(!WeatherHourly.usesTwelveHourClock("dd/MMM"),
+               "the `a` in a month name is not an am/pm marker");
+    }
+
+    function test_hourLabels() {
+        compare(WeatherHourly.hourLabel(0, false), "00:00");
+        compare(WeatherHourly.hourLabel(9, false), "09:00");
+        compare(WeatherHourly.hourLabel(21, false), "21:00");
+        compare(WeatherHourly.hourLabel(0, true), "12 AM");
+        compare(WeatherHourly.hourLabel(9, true), "9 AM");
+        compare(WeatherHourly.hourLabel(12, true), "12 PM");
+        compare(WeatherHourly.hourLabel(21, true), "9 PM");
+        compare(WeatherHourly.hourLabel(undefined, false), "");
+    }
+}

--- a/dots/.config/quickshell/imi/tests/tst_weather_hourly.qml
+++ b/dots/.config/quickshell/imi/tests/tst_weather_hourly.qml
@@ -103,9 +103,13 @@ TestCase {
 
     function test_wttrSurvivesAJunkResponse() {
         compare(WeatherHourly.slotsFromWttr(undefined, false), []);
-        compare(WeatherHourly.slotsFromWttr([{}], false), [],
-                "a day with no date cannot be placed on a time axis");
         compare(WeatherHourly.slotsFromWttr([wttrDay("2026-08-04", undefined)], false), []);
+        // Hours WITH readings under a day with no date: the date is what places
+        // them on the axis, so dropping the guard has to be visible here rather
+        // than only where the day is empty anyway.
+        compare(WeatherHourly.slotsFromWttr(
+            [{ hourly: [{ time: "1200", tempC: "5", tempF: "41", weatherCode: "113" }] }], false), [],
+                "a day with no date cannot be placed on a time axis");
     }
 
     function series(hours) {
@@ -134,9 +138,12 @@ TestCase {
     }
 
     function test_upcomingIsCappedAndExcludesTheSlotOnTheHour() {
+        // Seven slots, of which six are ahead of the fixture's clock: a cap of
+        // five is only exercised while more than five remain.
         const slots = series([
             [2026, 8, 4, 15, 21], [2026, 8, 4, 18, 18], [2026, 8, 4, 21, 14],
-            [2026, 8, 5, 0, 12], [2026, 8, 5, 3, 11], [2026, 8, 5, 6, 13]
+            [2026, 8, 5, 0, 12], [2026, 8, 5, 3, 11], [2026, 8, 5, 6, 13],
+            [2026, 8, 5, 9, 17]
         ]);
         const shown = WeatherHourly.upcoming(slots, at(2026, 8, 4, 15).getTime(), 5);
         compare(shown.length, 5, "the window is capped");
@@ -185,10 +192,14 @@ TestCase {
     // The coldest hour of the window is still an hour, so its bar is still a
     // bar - a zero-height one reads as a hole in the row.
     function test_theColdestBarKeepsAVisibleFloorAndTheWarmestFillsTheTrack() {
-        compare(WeatherHourly.barFraction(14, 14, 21), WeatherHourly.MIN_FRACTION);
+        // The floor is a number the row was drawn around, so it is written out
+        // here rather than read back off the module: comparing the function
+        // against the constant the function used asserts only that it agrees
+        // with itself, and stays green with the floor set to zero.
+        compare(WeatherHourly.barFraction(14, 14, 21), 0.18);
         compare(WeatherHourly.barFraction(21, 14, 21), 1);
         const middle = WeatherHourly.barFraction(17.5, 14, 21);
-        verify(middle > WeatherHourly.MIN_FRACTION && middle < 1,
+        verify(middle > 0.18 && middle < 1,
                `a middling hour lands between the two: ${middle}`);
     }
 
@@ -196,7 +207,7 @@ TestCase {
     // place anything between. Full height would claim heat and the floor would
     // claim cold.
     function test_aFlatWindowDrawsFlatBarsRatherThanDividingByZero() {
-        compare(WeatherHourly.barFraction(18, 18, 18), WeatherHourly.FLAT_FRACTION);
+        compare(WeatherHourly.barFraction(18, 18, 18), 0.55);
     }
 
     function test_anAbsentReadingHasNoBarRatherThanAZeroOne() {
@@ -207,14 +218,15 @@ TestCase {
 
     function test_aReadingOutsideTheRangeIsClampedIntoTheTrack() {
         compare(WeatherHourly.barFraction(30, 14, 21), 1);
-        compare(WeatherHourly.barFraction(2, 14, 21), WeatherHourly.MIN_FRACTION);
+        compare(WeatherHourly.barFraction(2, 14, 21), 0.18);
     }
 
     // One bar is scaled against itself, so it is full height whatever the
     // temperature is: a confident drawing of nothing.
     function test_aSeriesTooShortToBeAChartIsNotDrawn() {
         const one = series([[2026, 8, 4, 15, 21]]);
-        verify(!WeatherHourly.isRenderable(one));
+        verify(!WeatherHourly.isRenderable(one),
+               "one bar is scaled against itself, so it is full height whatever it says");
         verify(!WeatherHourly.isRenderable([]));
         verify(!WeatherHourly.isRenderable(undefined));
         verify(WeatherHourly.isRenderable(


### PR DESCRIPTION
Item 12 of `docs/p3drovfx-animation-research-2026-08-16.md` (§5.2): the bar's
weather popup had no forecast of any kind. It has an hourly one now — five
three-hourly slots under the current conditions, each a bar grown from the axis.

**It costs no new request.** OpenWeatherMap's `/data/2.5/forecast` has been
fetched since the day cards landed and IS a three-hourly list; wttr.in's
`weather[].hourly[]` arrives inside the one response the current conditions come
from. The whole feature is a second reading of two payloads the service already
has, so no provider's call rate moves. `test_the_hourly_row_costs_no_new_request`
pins the endpoint list and the fetcher count so a third request has to be argued
for rather than typed.

## The split

`modules/common/functions/weatherHourly.js` (pure, `.pragma library`, no `Qt` and
no singleton) makes every decision: which slots the row shows, how a bar is
scaled, where a day boundary falls, and when there is not enough of a series to
draw. `modules/imi/bar/WeatherHourlyChart.qml` draws it and owns nothing else.
The locale, the clock format and "now" arrive as arguments, which is the rule
`weatherForecast.js` already lives under.

Four decisions worth stating, all of which fail by rendering something plausible:

- **The window is what is still AHEAD of now.** wttr.in's first day always begins
  at 00:00, so a row taking the head of the payload draws this morning's weather
  as a forecast for the rest of the day. The days are flattened before the cut,
  so the window rolls into tomorrow by itself — that is the whole of the
  day-boundary bucketing, and the slot where the date turns is marked so the
  caller labels it with the weekday: "00" alone belongs to either side of it.
- **A bar is scaled against the shown window's own extremes**, with a floor so
  the coldest hour is still a bar, and a flat mid-height for a window of
  identical degrees (a real still night) rather than a divide by zero.
- **A slot with no reading has no bar**, not a zero-height one — which would read
  as the coldest hour of the window.
- **Below two readings there is no chart**, and the row is not drawn: one bar is
  scaled against itself, so it is full height whatever it says.

## Traps paid for

- **OpenWeatherMap's `dt_txt` is UTC and its `dt` is the instant.** The daily
  grouping can live with the first; an hour LABEL cannot, and the difference is
  invisible on a UTC machine, which is CI. The row reads `dt`, and the contract
  check now re-runs `tst_weather_hourly.qml` at UTC+14 and UTC-11 as it already
  did for the daily one. Planted: `getHours()` → `getUTCHours()` passes at UTC and
  fails at UTC+14.
- **`Number(null)` is 0 and `isFinite(0)` is true**, so the obvious guard reads an
  absent reading as a confident zero degrees — a bar at the floor and a window
  range dragged down to it. Three of the module's functions route through one
  `_reading()` for that reason.
- **A section added to a bar popup becomes the hero the card unrolls from.** The
  row sits between the hero card and the metrics grid; declared above it, the
  popup would open as a 99px strip with the temperature and the city below the
  fold — and since the row disappears when a provider has nothing hourly, the
  popup would also open two different ways depending on whether a forecast had
  parsed. Both halves are checked (source order statically, the built tree in the
  harness, because `heroSectionHeight` skips undrawn and zero-height children).

## The popup still opens sensibly — measured

`WeatherPopupHeroRuntimeTest.qml` parents the real popup's content into a window
the way `BarPopupOverlay` parents it into the card, and measures what the overlay
would: **hero 141** (the 125px hero card at `contentPadding` 8 — the same number
as before this branch), **open height 431**, with the row's **99** in between, and
the same hero 141 again once the provider's hourly data is emptied. The unroll
therefore still starts on the city, the condition and the 48px temperature.

The bars grow on the popup's own visibility rather than from a one-shot
animation, so the motion plays on a **refresh** as well as on an open — the flaw
§3.3 records in the tree this is taken from, whose `NumberAnimation` destroys the
binding it writes. Both growth checks sample a bar 80ms in and compare
afterwards, because a settled bar is the same height whether it animated or
teleported.

## Tests, and the plant-proof for every new check

`tests/tst_weather_hourly.qml` (23 cases), `tests/test_weather_popup_hero_runtime.py`
+ its harness (11 checks, wired into `run_tests.sh`, headless weston and a private
bus), and five new cases plus a widened library rule in
`tests/test_weather_forecast_contract.py`.

Three checks could not fail when first written and were repaired rather than kept
(`test(weather): make three of the hourly checks able to fail`,
`test(weather): ask the harness which section the card opens at, by name`,
`test(weather): score the axis while the bars have height`): two module guards
that could never fire on their own, a cap fixture with fewer slots than the cap,
three assertions that read the module's own constants back (the tautology
`test_shortDayNameIsTheDatesOwnWeekday` records one file over), a hero comparison
against `children[0]` that the mutation satisfied by becoming `children[0]`, and a
baseline check sampled while every bar was zero tall.

<details><summary>Planted mutation → the check that reddened (unit module)</summary>

```
owm hour read from dt_txt's clock (UTC) [TZ=Pacific/Kiritimati]
  -> test_owmSlotsTakeTheLocalHourFromTheInstantNotFromDtTxt
owm temperature defaults to 0            -> test_owmKeepsASlotWhoseTemperatureIsMissing
owm accepts an entry with no instant     -> test_owmSurvivesAJunkResponse
wttr hhmm read as a number of hours      -> test_wttrSlotsParseTheHhmmTimeAndFollowTheUnitSetting,
                                            test_wttrFlattensItsDaysInOrder, test_slotsComeBackInTimeOrder
wttr reads only its first day            -> test_wttrFlattensItsDaysInOrder, test_slotsComeBackInTimeOrder
wttr accepts a day with no date          -> test_wttrSurvivesAJunkResponse
slots are left in payload order          -> test_slotsComeBackInTimeOrder
the window keeps what has already happened
  -> test_upcomingSkipsWhatHasAlreadyHappened, test_upcomingIsCappedAndExcludesTheSlotOnTheHour,
     test_upcomingMarksTheDayBoundaryButNeverTheFirstSlot, test_upcomingReturnsNothingForAStalePayload
the window includes the slot on the hour -> test_upcomingIsCappedAndExcludesTheSlotOnTheHour
the window is not capped                 -> test_upcomingIsCappedAndExcludesTheSlotOnTheHour
the first slot can be a day break        -> test_upcomingMarksTheDayBoundaryButNeverTheFirstSlot (+2)
the range counts absent readings         -> test_theRangeIgnoresAbsentReadings
the range is the first reading only      -> test_theRangeIsTheShownWindowsOwn
the coldest bar loses its floor          -> test_theColdestBarKeepsAVisibleFloorAndTheWarmestFillsTheTrack,
                                            test_aReadingOutsideTheRangeIsClampedIntoTheTrack
a flat window draws full-height bars     -> test_aFlatWindowDrawsFlatBarsRatherThanDividingByZero
an absent reading becomes a zero bar     -> test_anAbsentReadingHasNoBarRatherThanAZeroOne
a reading outside the range is not clamped -> test_aReadingOutsideTheRangeIsClampedIntoTheTrack
one reading is enough for a chart        -> test_aSeriesTooShortToBeAChartIsNotDrawn,
                                            test_aSeriesWithNoReadingsIsNotDrawnEither
a series with no readings is drawn       -> test_aSeriesTooShortToBeAChartIsNotDrawn,
                                            test_aSeriesWithNoReadingsIsNotDrawnEither
every clock format reads as twelve-hour  -> test_theClockFormatDecidesTheLabelStyle
the 24h label loses its padding          -> test_hourLabels
```
Every one of the 23 cases is reddened by at least one mutation; the sweep reports
"cases never reddened: []".
</details>

<details><summary>Planted mutation → the check that reddened (contract + harness)</summary>

```
service stops publishing the hourly slots -> test_the_service_publishes_the_hourly_slots
owm stops filling the row                 -> test_both_providers_fill_the_hourly_row
wttr stops filling the row                -> test_both_providers_fill_the_hourly_row
a third endpoint and a third fetcher      -> test_the_hourly_row_costs_no_new_request
the row is declared above the hero card   -> test_the_popup_draws_the_row_after_its_hero
the popup stops drawing the row at all    -> test_the_popup_draws_the_row_after_its_hero
the hourly library reaches for Qt         -> test_the_forecast_library_stays_free_of_qml [library=weatherHourly.js]
the hourly library reaches a singleton    -> test_the_forecast_library_stays_free_of_qml [library=weatherHourly.js]
the hour comes off a UTC clock            -> test_the_weather_unit_tests_pass_east_and_west_of_utc
                                             [timezone=Pacific/Kiritimati, test=tst_weather_hourly.qml]

[WeatherHero] harness, one mutation per line:
row never drawn (visible: false)      -> the hourly row is drawn
row takes no height of its own        -> the hourly row is drawn
row declared above the hero card      -> the row is not the popup's first section,
                                         the card still unrolls from the hero card
row above the hero AND always visible -> + a provider with no hourly data leaves no empty row,
                                           and the card still opens at the hero card
hero card is the only section         -> the hero is a fraction of the open height...,
                                         the hourly row is drawn
bars hang from the top of the track   -> the bars stand on one axis, whatever their height
bars ignore the popup's visibility    -> the bars are flat while the popup is not showing,
                                         the bars grew from the axis rather than appearing at full height
bars are never drawn                  -> the bars settle at a height, the bars grew..., a refresh... animates
the Behavior is removed (bars snap)   -> the bars grew from the axis..., a refresh under an open popup animates
row always visible                    -> a provider with no hourly data leaves no empty row
```
</details>

## Suite

`dots/.config/quickshell/imi/tests/run_tests.sh` in full, on this branch rebased
onto `gh/main`: `Totals: 1097 passed, 0 failed, 0 skipped, 0 blacklisted`,
`All tests passed successfully!`, exit 0. The design-system compile check ran
(`checked=185 failures=0`), the weather contract is `Ran 12 tests ... OK` and the
new runtime driver `Ran 1 test in 10.279s ... OK`.

## Not verified

- **Nothing was checked against the user's running shell.** Every measurement in
  this PR is from headless weston in its own runtime dir and on its own bus; the
  popup has never been drawn on the real compositor, and the card's actual unroll
  (a wlr-layer-shell surface, which weston does not implement) is inferred from
  `heroSectionHeight`'s inputs rather than watched.
- The **live provider payloads** are not exercised: the parsers are driven from
  fixtures, and the shapes come from each provider's documentation plus the
  existing daily parsers, not from a recorded response.
- The **12-hour label** path is unit-tested but has not been seen on screen; the
  render was taken with the default `hh:mm` format.

Docs: updated AGENT.md §Layer-shell (wlr-layer-shell) gotchas, §Dynamic/data-driven QML gotchas
Changelog: updated
