### PR TITLE
fix(bar): the flip registry is bound by a name a delegate cannot shadow

### DIFF
--- a/dots/.config/quickshell/imi/modules/imi/bar/BarContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/BarContent.qml
@@ -223,7 +223,7 @@ Item {
                             editController: barEditController
                             editBucket: "left"
                             widgetId: modelData
-                            flipRegistry: flipRegistry
+                            flipRegistry: barFlipRegistry
                             paintMaterialPill: root.shouldPaintMaterialPill(modelData)
                             bgColor: root.getMaterialPillColor(modelData)
                             Loader {
@@ -262,7 +262,7 @@ Item {
                         editController: barEditController
                         editBucket: "left"
                         widgetId: modelData
-                        flipRegistry: flipRegistry
+                        flipRegistry: barFlipRegistry
                         Loader {
                             Layout.fillHeight: true
                             source: root.getWidgetUrl(modelData)
@@ -338,7 +338,7 @@ Item {
                             editController: barEditController
                             editBucket: "middle"
                             widgetId: modelData
-                            flipRegistry: flipRegistry
+                            flipRegistry: barFlipRegistry
                             paintMaterialPill: root.shouldPaintMaterialPill(modelData)
                             bgColor: root.getMaterialPillColor(modelData)
                             Loader {
@@ -377,7 +377,7 @@ Item {
                         editController: barEditController
                         editBucket: "middle"
                         widgetId: modelData
-                        flipRegistry: flipRegistry
+                        flipRegistry: barFlipRegistry
                         Loader {
                             Layout.fillHeight: true
                             source: root.getWidgetUrl(modelData)
@@ -454,7 +454,7 @@ Item {
                             editController: barEditController
                             editBucket: "right"
                             widgetId: modelData
-                            flipRegistry: flipRegistry
+                            flipRegistry: barFlipRegistry
                             paintMaterialPill: root.shouldPaintMaterialPill(modelData)
                             bgColor: root.getMaterialPillColor(modelData)
                             Loader {
@@ -493,7 +493,7 @@ Item {
                         editController: barEditController
                         editBucket: "right"
                         widgetId: modelData
-                        flipRegistry: flipRegistry
+                        flipRegistry: barFlipRegistry
                         Loader {
                             Layout.fillHeight: true
                             source: root.getWidgetUrl(modelData)
@@ -542,6 +542,6 @@ Item {
     // has a First to invert from. Declared as a child of this root because
     // that is the frame every position is measured in - see BarFlipRegistry.
     BarFlipRegistry {
-        id: flipRegistry
+        id: barFlipRegistry
     }
 }

--- a/dots/.config/quickshell/imi/modules/imi/verticalBar/VerticalBarContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/verticalBar/VerticalBarContent.qml
@@ -223,7 +223,7 @@ Item {
                             editController: barEditController
                             editBucket: "left"
                             widgetId: modelData
-                            flipRegistry: flipRegistry
+                            flipRegistry: barFlipRegistry
                             paintMaterialPill: root.shouldPaintMaterialPill(modelData)
                             bgColor: root.getMaterialPillColor(modelData)
                             Loader {
@@ -258,7 +258,7 @@ Item {
                         editController: barEditController
                         editBucket: "left"
                         widgetId: modelData
-                        flipRegistry: flipRegistry
+                        flipRegistry: barFlipRegistry
                         Loader {
                             Layout.fillWidth: true
                             source: root.getWidgetUrl(modelData)
@@ -320,7 +320,7 @@ Item {
                             editController: barEditController
                             editBucket: "middle"
                             widgetId: modelData
-                            flipRegistry: flipRegistry
+                            flipRegistry: barFlipRegistry
                             paintMaterialPill: root.shouldPaintMaterialPill(modelData)
                             bgColor: root.getMaterialPillColor(modelData)
                             Loader {
@@ -355,7 +355,7 @@ Item {
                         editController: barEditController
                         editBucket: "middle"
                         widgetId: modelData
-                        flipRegistry: flipRegistry
+                        flipRegistry: barFlipRegistry
                         Loader {
                             Layout.fillWidth: true
                             source: root.getWidgetUrl(modelData)
@@ -419,7 +419,7 @@ Item {
                             editController: barEditController
                             editBucket: "right"
                             widgetId: modelData
-                            flipRegistry: flipRegistry
+                            flipRegistry: barFlipRegistry
                             paintMaterialPill: root.shouldPaintMaterialPill(modelData)
                             bgColor: root.getMaterialPillColor(modelData)
                             Loader {
@@ -454,7 +454,7 @@ Item {
                         editController: barEditController
                         editBucket: "right"
                         widgetId: modelData
-                        flipRegistry: flipRegistry
+                        flipRegistry: barFlipRegistry
                         Loader {
                             Layout.fillWidth: true
                             source: root.getWidgetUrl(modelData)
@@ -489,6 +489,6 @@ Item {
     // The same registry, in the vertical bar's own frame: the ids are shared
     // between the two bars and between screens, and the positions are not.
     Bar.BarFlipRegistry {
-        id: flipRegistry
+        id: barFlipRegistry
     }
 }

--- a/dots/.config/quickshell/imi/tests/test_bar_flip_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_bar_flip_contract.py
@@ -58,10 +58,23 @@ def code(path):
 def test_every_bucket_delegate_in_both_trees_hands_over_the_registry():
     for path in TREES:
         text = code(path)
-        wired = text.count("flipRegistry: flipRegistry")
+        # `flipRegistry: flipRegistry` is what this used to pin, and it is the
+        # one spelling that cannot work: inside a BarGroup the bare name
+        # resolves to the delegate's OWN property before it reaches the id in
+        # the enclosing scope, so the binding is the property bound to itself.
+        # QML reports it as `Binding loop detected for property
+        # "flipRegistry"` on every delegate and hands each group a null
+        # registry, which is a bar with no reposition at all - and neither the
+        # QML suite nor the runtime harness sees it, because the harness
+        # declares its own groups and wires them by a distinct id.
+        wired = text.count("flipRegistry: barFlipRegistry")
         assert wired == 6, (
             f"{path.name} wires flipRegistry into {wired} delegates, not 6 - a "
             f"bucket or a style still teleports, in that orientation only")
+        assert "flipRegistry: flipRegistry" not in text, (
+            f"{path.name} binds the registry to a name that resolves to the "
+            f"delegate's own property first - a binding loop, and a null "
+            f"registry in every group")
 
 
 def test_each_tree_declares_exactly_one_registry_on_its_own_root():


### PR DESCRIPTION
The bar-widget reposition landed in #276 and did nothing on a real shell. Caught on the first live deploy after the merge.

## What was wrong
`flipRegistry: flipRegistry` is the one spelling of that wiring that cannot work. Inside a `BarGroup` the bare name on the right resolves to the delegate's OWN `property BarFlipRegistry flipRegistry` before it reaches the id in the enclosing content root, so all twelve delegates bound the property **to itself**:

```
WARN scene: QML BarGroup at @modules/imi/bar/BarContent.qml[489:21]:
  Binding loop detected for property "flipRegistry"
```

QML drops the re-evaluation and each group keeps a **null** registry — a bar with no reposition at all. The feature is present in the source, absent on screen, and every check is green.

## Why nothing caught it
- The QML suite never builds these delegates.
- `test_bar_flip_contract.py` pinned `"flipRegistry: flipRegistry"` as the *correct* spelling, so the check asserted the bug.
- `BarFlipRuntimeTest.qml` declares its own groups and wires them by a distinct id, so the harness exercised a path the shell does not take.

That combination is exactly what CONTRIBUTING's "a green suite does not mean the shell loads" describes, and it is the second time in this file's history that a harness passed by not sharing the shell's own wiring.

## The fix
The registry is `barFlipRegistry` in both content trees — a name no property shadows. The contract pins both halves now: six delegates wired to it in each tree, **and** the shadowing spelling refused outright, with the reason and the log line in the comment.

**Plant-proof**: restored one `flipRegistry: flipRegistry` in `BarContent.qml` → `AssertionError: BarContent.qml wires flipRegistry into 5 delegates, not 6…` and `FAIL test_every_bucket_delegate_in_both_trees_hands_over_the_registry`; reverted → 7/7 pass. Planted in a clean tree after committing.

**Live verification** (the only thing that can see this class of bug): deployed to `~/.config/quickshell/imi`, restarted `qs -c imi` — `Configuration Loaded` once, **zero** `flipRegistry` lines in the log, no new warnings.

**Tests**: full `tests/run_tests.sh` — all tests passed, exit 0.

**Not verified**: that the slide now *looks* right on a real reflow. The registry is non-null and the arithmetic is unchanged and covered, but nobody has watched a tray empty on screen.

Changelog: not user-visible — #276's entry describes the behaviour this restores; it was never released broken

Docs: not needed — AGENT.md's dynamic-QML section already carries the shadowing rule this instance follows, and the contract test now carries the specific trap
