### PR TITLE
Eight more harnesses get their own session bus (24 → 16)

### DIFF
--- a/dots/.config/quickshell/imi/tests/lint_runtime_bus_isolation.py
+++ b/dots/.config/quickshell/imi/tests/lint_runtime_bus_isolation.py
@@ -116,7 +116,6 @@ def decides_at_the_launch(raw):
     return all(WRAPPER in strings for strings in lists)
 
 EXISTING = frozenset({
-    "test_app_usage_runtime.py",
     "test_bar_edit_runtime.py",
     "test_calendar_card.py",
     "test_card_shadow.py",
@@ -124,21 +123,14 @@ EXISTING = frozenset({
     "test_clock_depth_compositing.py",
     "test_clock_depth_noop.py",
     "test_config_control_write_back.py",
-    "test_config_dir_migration_runtime.py",
     "test_conflict_killer_contract.py",
     "test_dock_edge_runtime.py",
     "test_edit_mode_chrome.py",
-    "test_edit_mode_runtime.py",
     "test_get_keybinds.py",
-    "test_kboptions_migration_runtime.py",
     "test_keybind_overrides_runtime.py",
     "test_launcher_qalc_runtime.py",
-    "test_motion_multiplier_runtime.py",
     "test_nightlight_state_runtime.py",
-    "test_notes_migration_runtime.py",
     "test_notes_surfaces_runtime.py",
-    "test_parallax_migration_runtime.py",
-    "test_quick_toggles_layout_runtime.py",
     "test_widget_elevation.py",
 })
 

--- a/dots/.config/quickshell/imi/tests/test_app_usage_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_app_usage_runtime.py
@@ -56,7 +56,8 @@ def _stop(proc):
 
 
 def _runtime_available():
-    return shutil.which("qs") is not None and shutil.which("weston") is not None
+    return all(shutil.which(binary) is not None
+               for binary in ("qs", "weston", "dbus-run-session"))
 
 
 @unittest.skipUnless(_runtime_available(), "needs qs and weston on PATH")
@@ -96,7 +97,11 @@ class AppUsageRuntimeTest(unittest.TestCase):
         env = dict(self.env)
         env["APPUSAGE_CASE"] = case
         env.update(extra)
-        proc = subprocess.run(["qs", "-p", str(HARNESS)], cwd=str(ROOT), env=env,
+        proc = subprocess.run(
+            # dbus-run-session, not the inherited DBUS_SESSION_BUS_ADDRESS: a
+            # shell reading MPRIS, UPower or a portal off the developer's bus
+            # measures their session rather than this tree.
+            ["dbus-run-session", "--", "qs", "-p", str(HARNESS)], cwd=str(ROOT), env=env,
                               capture_output=True, text=True, timeout=180)
         output = proc.stdout + proc.stderr
         failed = [line for line in output.splitlines() if "FAIL" in line]

--- a/dots/.config/quickshell/imi/tests/test_config_dir_migration_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_config_dir_migration_runtime.py
@@ -81,7 +81,8 @@ def _stop(proc):
 
 
 def _runtime_available():
-    return shutil.which("qs") is not None and shutil.which("weston") is not None
+    return all(shutil.which(binary) is not None
+               for binary in ("qs", "weston", "dbus-run-session"))
 
 
 @unittest.skipUnless(_runtime_available(), "needs qs and weston on PATH")
@@ -138,7 +139,11 @@ class ConfigDirMigrationRuntimeTest(unittest.TestCase):
         env["CONFIGDIR_MODE"] = mode
         if delay is not None:
             env["IMI_MIGRATE_DELAY"] = delay
-        proc = subprocess.run(["qs", "-p", str(HARNESS)], cwd=str(ROOT), env=env,
+        proc = subprocess.run(
+            # dbus-run-session, not the inherited DBUS_SESSION_BUS_ADDRESS: a
+            # shell reading MPRIS, UPower or a portal off the developer's bus
+            # measures their session rather than this tree.
+            ["dbus-run-session", "--", "qs", "-p", str(HARNESS)], cwd=str(ROOT), env=env,
                               capture_output=True, text=True, timeout=240)
         output = proc.stdout + proc.stderr
         failed = [line for line in output.splitlines() if "FAIL" in line]

--- a/dots/.config/quickshell/imi/tests/test_edit_mode_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_edit_mode_runtime.py
@@ -53,7 +53,8 @@ def _stop(proc):
 
 
 def _runtime_available():
-    return shutil.which("qs") is not None and shutil.which("weston") is not None
+    return all(shutil.which(binary) is not None
+               for binary in ("qs", "weston", "dbus-run-session"))
 
 
 @unittest.skipUnless(_runtime_available(), "needs qs and weston on PATH")
@@ -86,7 +87,11 @@ class EditModeRuntimeTest(unittest.TestCase):
         env["XDG_CONFIG_HOME"] = str(self.home / "config")
         env["XDG_STATE_HOME"] = str(self.home / "state")
 
-        proc = subprocess.run(["qs", "-p", str(HARNESS)], cwd=str(ROOT), env=env,
+        proc = subprocess.run(
+            # dbus-run-session, not the inherited DBUS_SESSION_BUS_ADDRESS: a
+            # shell reading MPRIS, UPower or a portal off the developer's bus
+            # measures their session rather than this tree.
+            ["dbus-run-session", "--", "qs", "-p", str(HARNESS)], cwd=str(ROOT), env=env,
                               capture_output=True, text=True, timeout=240)
         output = proc.stdout + proc.stderr
         failed = [line for line in output.splitlines() if "FAIL" in line]

--- a/dots/.config/quickshell/imi/tests/test_kboptions_migration_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_kboptions_migration_runtime.py
@@ -53,7 +53,8 @@ EXPECTED_CHECKS = 1
 
 
 def _runtime_available():
-    return bool(os.environ.get("WAYLAND_DISPLAY")) and shutil.which("qs") is not None
+    return bool(os.environ.get("WAYLAND_DISPLAY")) and all(shutil.which(binary) is not None
+               for binary in ("qs", "dbus-run-session"))
 
 
 @unittest.skipUnless(_runtime_available(),
@@ -97,7 +98,11 @@ class KbOptionsMigrationRuntimeTest(unittest.TestCase):
         env["XDG_CACHE_HOME"] = str(self.home / "cache")
         env["XDG_DATA_HOME"] = str(self.home / "data")
         env["KBOPT_EXPECT"] = expected
-        proc = subprocess.run(["qs", "-p", str(HARNESS)], cwd=str(ROOT), env=env,
+        proc = subprocess.run(
+            # dbus-run-session, not the inherited DBUS_SESSION_BUS_ADDRESS: a
+            # shell reading MPRIS, UPower or a portal off the developer's bus
+            # measures their session rather than this tree.
+            ["dbus-run-session", "--", "qs", "-p", str(HARNESS)], cwd=str(ROOT), env=env,
                               capture_output=True, text=True, timeout=180)
         output = proc.stdout + proc.stderr
         failed = [line for line in output.splitlines() if "FAIL" in line]

--- a/dots/.config/quickshell/imi/tests/test_motion_multiplier_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_motion_multiplier_runtime.py
@@ -62,7 +62,8 @@ CASES = [
 
 
 def _runtime_available():
-    return bool(os.environ.get("WAYLAND_DISPLAY")) and shutil.which("qs") is not None
+    return bool(os.environ.get("WAYLAND_DISPLAY")) and all(shutil.which(binary) is not None
+               for binary in ("qs", "dbus-run-session"))
 
 
 @unittest.skipUnless(_runtime_available(),
@@ -96,7 +97,11 @@ class MotionMultiplierRuntimeTest(unittest.TestCase):
         env["MOTION_EXPECT_PRESS"] = str(press)
         env["MOTION_EXPECT_VELOCITY"] = str(velocity)
         env["MOTION_EXPECT_STAGGER"] = str(stagger)
-        proc = subprocess.run(["qs", "-p", str(HARNESS)], cwd=str(ROOT), env=env,
+        proc = subprocess.run(
+            # dbus-run-session, not the inherited DBUS_SESSION_BUS_ADDRESS: a
+            # shell reading MPRIS, UPower or a portal off the developer's bus
+            # measures their session rather than this tree.
+            ["dbus-run-session", "--", "qs", "-p", str(HARNESS)], cwd=str(ROOT), env=env,
                               capture_output=True, text=True, timeout=180)
         output = proc.stdout + proc.stderr
         failed = [line for line in output.splitlines() if "FAIL" in line]

--- a/dots/.config/quickshell/imi/tests/test_notes_migration_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_notes_migration_runtime.py
@@ -41,7 +41,8 @@ EXPECTED_CHECKS = 7
 
 
 def _runtime_available():
-    return bool(os.environ.get("WAYLAND_DISPLAY")) and shutil.which("qs") is not None
+    return bool(os.environ.get("WAYLAND_DISPLAY")) and all(shutil.which(binary) is not None
+               for binary in ("qs", "dbus-run-session"))
 
 
 def _digest(path):
@@ -80,7 +81,11 @@ class NotesMigrationRuntimeTest(unittest.TestCase):
         env["XDG_STATE_HOME"] = str(self.home / "state")
         env["XDG_CONFIG_HOME"] = str(self.home / "config")
         env["NOTES_EXPECT"] = json.dumps(expected)
-        proc = subprocess.run(["qs", "-p", str(HARNESS)], cwd=str(ROOT), env=env,
+        proc = subprocess.run(
+            # dbus-run-session, not the inherited DBUS_SESSION_BUS_ADDRESS: a
+            # shell reading MPRIS, UPower or a portal off the developer's bus
+            # measures their session rather than this tree.
+            ["dbus-run-session", "--", "qs", "-p", str(HARNESS)], cwd=str(ROOT), env=env,
                               capture_output=True, text=True, timeout=180)
         output = proc.stdout + proc.stderr
         failed = [line for line in output.splitlines() if "FAIL" in line]

--- a/dots/.config/quickshell/imi/tests/test_parallax_migration_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_parallax_migration_runtime.py
@@ -40,7 +40,8 @@ EXPECTED_CHECKS = 6
 
 
 def _runtime_available():
-    return bool(os.environ.get("WAYLAND_DISPLAY")) and shutil.which("qs") is not None
+    return bool(os.environ.get("WAYLAND_DISPLAY")) and all(shutil.which(binary) is not None
+               for binary in ("qs", "dbus-run-session"))
 
 
 @unittest.skipUnless(_runtime_available(),
@@ -71,7 +72,11 @@ class ParallaxMigrationRuntimeTest(unittest.TestCase):
         env["XDG_CACHE_HOME"] = str(self.home / "cache")
         env["XDG_DATA_HOME"] = str(self.home / "data")
         env["PARALLAX_EXPECT"] = expected
-        proc = subprocess.run(["qs", "-p", str(HARNESS)], cwd=str(ROOT), env=env,
+        proc = subprocess.run(
+            # dbus-run-session, not the inherited DBUS_SESSION_BUS_ADDRESS: a
+            # shell reading MPRIS, UPower or a portal off the developer's bus
+            # measures their session rather than this tree.
+            ["dbus-run-session", "--", "qs", "-p", str(HARNESS)], cwd=str(ROOT), env=env,
                               capture_output=True, text=True, timeout=180)
         output = proc.stdout + proc.stderr
         failed = [line for line in output.splitlines() if "FAIL" in line]

--- a/dots/.config/quickshell/imi/tests/test_quick_toggles_layout_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_quick_toggles_layout_runtime.py
@@ -50,7 +50,8 @@ EXPECTED_CHECKS = 11
 
 
 def _runtime_available():
-    return bool(os.environ.get("WAYLAND_DISPLAY")) and shutil.which("qs") is not None
+    return bool(os.environ.get("WAYLAND_DISPLAY")) and all(shutil.which(binary) is not None
+               for binary in ("qs", "dbus-run-session"))
 
 
 @unittest.skipUnless(_runtime_available(),
@@ -86,7 +87,11 @@ class QuickTogglesLayoutRuntimeTest(unittest.TestCase):
         env["XDG_CACHE_HOME"] = str(self.home / "cache")
         env["XDG_DATA_HOME"] = str(self.home / "data")
 
-        proc = subprocess.run(["qs", "-p", str(HARNESS)], cwd=str(ROOT), env=env,
+        proc = subprocess.run(
+            # dbus-run-session, not the inherited DBUS_SESSION_BUS_ADDRESS: a
+            # shell reading MPRIS, UPower or a portal off the developer's bus
+            # measures their session rather than this tree.
+            ["dbus-run-session", "--", "qs", "-p", str(HARNESS)], cwd=str(ROOT), env=env,
                               capture_output=True, text=True, timeout=180)
         output = proc.stdout + proc.stderr
         failed = [line for line in output.splitlines() if "FAIL" in line]


### PR DESCRIPTION
Second tightening of `lint_runtime_bus_isolation.py`'s register, after the first took it 33 → 24.

## The group
The config and migration harnesses plus the three UI ones with no D-Bus needs of their own: config-dir migration, kbOptions, notes, parallax switches, motion multiplier, app usage, quick toggles, Edit Mode.

Picked by **reading each one**, not by name — none mentions `busctl`, MPRIS, UPower or the notification server, so wrapping the launch is a one-line change with nothing to reconcile. Each was **run against its own bus before the register was shrunk**; all eight pass.

## What stays registered (16)
The group that genuinely interacts with a bus, or that launches `qs` from a shell probe rather than from Python: clight integration, conflict killer, night light, keybind overrides, `get_keybinds`, and the probe-driven pixel harnesses (calendar card, card shadow, widget elevation, both clock-depth ones, edit-mode chrome, bar edit, dock edge, launcher qalc, config control write-back). Those need the wrapper moved into the `.sh`, which is a different change and wants its own pass.

**Plant-proof** (clean tree, after committing): unwrapped `test_edit_mode_runtime.py`'s launch → `test_edit_mode_runtime.py: launches \`qs\` on the inherited session bus…`, exit 1; restored → passes, 36 harnesses, 16 registered.

**Tests**: full `tests/run_tests.sh` — all tests passed, exit 0, with the eight converted harnesses running under their own bus inside that run.

Changelog: not user-visible — test isolation only

Docs: not needed — AGENT.md already states the rule and points at the register; the lint's header carries its history
