### PR TITLE
feat(phoneConnect): drive updates from the daemon's signals, not from the poll

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -560,7 +560,10 @@ services/                  Singletons wrapping external state/processes - one pe
                               `busctl --json=short` Process calls (the shell has no D-Bus
                               binding) - backend detection from the bus name list, one
                               normalized device/battery model for both daemons, ring/ping/
-                              clipboard actions. Its parser logic is kept byte-for-byte in
+                              clipboard actions. KDE Connect's changes arrive as SIGNALS
+                              (`busctl monitor`, see the streaming note below); Valent's
+                              still arrive on the poll, which stays on for both as the
+                              reconcile. Its parser logic is kept byte-for-byte in
                               sync with a logic-only test double
                               (tests/test_phone_connect_contract.py enforces it)
   SchemePreview.qml            Per-scheme swatches for the scheme pickers: one venv run of
@@ -3602,6 +3605,52 @@ therefore needs a one-shot migration with a marker (`migrateDeadParallaxSwitches
 test that seeds a real config directory. Reset only the switches - a tuned number is a plausible
 preference and usually cannot disable the feature by itself.
 (fix(config): revive the parallax switches every stored config turned off.)
+
+**`busctl monitor` is how a Process streams D-Bus signals here, and the sender filter has to live
+in the match rule because the output does not carry one you can use.** `services/PhoneConnect.qml`
+is the case (`services/Clight.qml` is the sibling that only calls). Measured against a live KDE
+Connect daemon on systemd 261: a monitored signal's `sender` is the **unique** name it arrived on
+(`:1.55`), never the well-known name, so a QML-side check for "is this the daemon" has nothing to
+compare against — `--match=type='signal',sender='org.kde.kdeconnect.daemon',path_namespace='…'` is
+the only place the daemon can be named, and dbus-daemon resolves that well-known name for you
+across daemon restarts. Four more things about that path, each of which cost a measurement:
+
+- **A `SERVICE` argument to `busctl monitor` does not narrow it the way it reads.** Run as
+  `busctl --user --json=short monitor org.kde.kdeconnect.daemon`, the capture came back full of
+  other clients' traffic (an unrelated `name.giacomofurlan.ArctisManager` call, portal `Get`s).
+  `--match=` did narrow it, to zero lines over ten seconds on the same bus. Filter with the match
+  rule, not the positional argument.
+- **The output is one JSON document per line and it is flushed per message**, so a `SplitParser` on
+  `stdout` sees a signal as it happens — checked by watching the redirect file grow while the
+  process was still running, not by reading it after the exit.
+- **An instant exit is the normal failure, which is why CONTRIBUTING.md's backoff rule bites
+  here specifically.** A match rule the bus rejects fails with `Call to
+  org.freedesktop.DBus.Monitoring.BecomeMonitor failed: Invalid match rule` and exit 1, in
+  milliseconds. A `running:` binding on that Process is a tight respawn loop. `PhoneConnect`
+  starts it imperatively, restarts only through `monitorExitPlan` (capped exponential backoff, a
+  ceiling of five per **daemon appearance**, and a healthy-run reset so one daemon restart in a
+  long session does not spend the ceiling) and falls back to the poll past the ceiling. The poll
+  is never removed: nothing announces a daemon *appearing* — there is no monitor running to hear
+  it on — and a daemon that dies without a parting signal would otherwise freeze the model.
+- **Signals arrive in bursts, so a signal drives a coalesced re-read rather than a sweep.** One
+  device leaving the network emitted **seven** signals within a millisecond
+  (`statusIconNameChanged`, `deviceRemoved`, `deviceListChanged`, `reachableChanged`,
+  `linksChanged`, `deviceAdded`, `deviceListChanged`), and each re-read is a chain of `busctl`
+  spawns. The settle timer also has to **re-arm** rather than fire while a sweep is in flight,
+  because the sweep declines then and firing would drop the change that asked for it.
+
+The gate deciding whether to start it was first written as a `readonly property bool` derived from
+`backend` and read from `onBackendChanged` — the change-handler trap under
+[State propagation is reactive](#state-propagation-is-reactive-or-it-is-a-bug-waiting) — so it
+answered with the *previous* backend, the monitor never started, and nothing showed it because the
+poll kept the model correct the whole time. Only `tests/test_phone_connect_monitor_runtime.py`
+could see it: a source contract reads a gate that is spelled correctly, and `qmltestrunner` cannot
+construct the `Process` the gate guards. That harness is also where the *lifetime* is pinned, and
+it asserts the spawn **timestamps** as well as the count — "it stopped after six spawns" is equally
+true of six spawns in six milliseconds, which is the bug.
+(feat(phoneConnect): drive updates from the daemon's signals, not from the poll,
+fix(phoneConnect): the monitor's gate is a function, because a handler cannot read its own binding,
+test(phoneConnect): drive the monitor's start, its stream, its backoff and its ceiling.)
 
 **A player on the MPRIS bus may be a proxy for another player, and every field you would match on
 is the borrowed one.** `playerctld` is `playerctl`'s daemon, not a player: it re-publishes whichever

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ own repo; the installer pins which revision it builds.
 
 ## [Unreleased]
 
+### Changed
+- **Your phone's battery and connection state update the moment they change.**
+  The phone panel and its quick toggle used to redraw on a timer, so a phone
+  going out of range, coming back, or charging showed up in the shell up to ten
+  seconds late. With KDE Connect the shell now listens to the daemon instead of
+  asking it, and the change appears as it happens. Valent still updates on the
+  timer, unchanged: its signals could not be checked against a running Valent
+  daemon, and guessing at them would have been worse than the wait. If the
+  listener cannot stay up, the shell quietly goes back to asking on a timer
+  rather than showing nothing.
+
 ### Fixed
 - **Spinners and pulses stop when nothing can see them.** Seven animations
   looped forever regardless of whether the thing they animate was on screen —

--- a/docs/proposals/phone-connect.md
+++ b/docs/proposals/phone-connect.md
@@ -1,6 +1,7 @@
 # Proposal: Phone Connect (KDE Connect / Valent integration)
 
-> Draft / tracking proposal. First slice implemented on this branch.
+> Draft / tracking proposal. The service, its sidebar surface and
+> signal-driven updates are implemented; the slices below are what remains.
 
 ## Goal
 
@@ -15,8 +16,7 @@ The first slice exists on this branch:
 - `services/PhoneConnect.qml` — `busctl --json=short` transport (the
   recommendation below), backend detection from the bus name list, one
   normalized device/battery model for both daemons, ring/ping/clipboard
-  actions, clean degraded state when neither daemon runs. Bounded polling for
-  now; `busctl monitor` streaming remains open (see below).
+  actions, clean degraded state when neither daemon runs.
 - Sidebar surface: a quick toggle (classic + android styles) and a device
   dialog, following the Tailscale surface pattern rather than a bundled
   plugin — the toggle hides when no daemon runs (classic) or is opt-in
@@ -26,6 +26,55 @@ The first slice exists on this branch:
 - Config (`networking.phoneConnect`) + settings rows, and a contract test
   keeping the service's parser logic byte-for-byte in sync with the QML
   suite's logic-only double.
+
+**Slice 1 (signal-driven updates) has landed.** KDE Connect's state now
+arrives when it changes rather than on the next tick:
+
+- One `busctl --user --json=short monitor --match=…` per daemon appearance,
+  subscribed to `type='signal',sender='org.kde.kdeconnect.daemon',
+  path_namespace='/modules/kdeconnect'`. The filter is at the BUS because it
+  has to be: `busctl monitor` reports a signal's sender as the unique name it
+  arrived on (`:1.55`, captured live), so nothing in QML can tell the daemon's
+  signals from anyone else's on the same path.
+- The event set came from introspecting a live daemon rather than from the
+  fork's source — `/modules/kdeconnect` emits `deviceAdded`, `deviceRemoved`,
+  `deviceListChanged`, `deviceVisibilityChanged`, `pairingRequestsChanged`; a
+  device path emits `reachableChanged`, `pairStateChanged`, `nameChanged`,
+  `typeChanged`, `pluginsChanged`; the battery leaf emits `refreshed`. It is an
+  allowlist because the SMS plugin's conversation signals share the device
+  path. A signal restarts a 120ms settle rather than sweeping: one device
+  leaving the network emitted **seven** signals within a millisecond of each
+  other on the live daemon.
+- Lifetime, which is what CONTRIBUTING.md forbids getting wrong: no `running`
+  binding, capped exponential backoff (1s…30s), a retry ceiling of five per
+  daemon appearance, and a healthy-run reset so one daemon restart in a long
+  session does not spend the ceiling. Past the ceiling the poll is the whole
+  update path again. Measured: `busctl` handed a match rule the bus rejects
+  exits in milliseconds (`Invalid match rule`, exit 1), which is exactly the
+  respawn loop the rule exists for.
+- The poll did **not** go away. Nothing announces a daemon *appearing* (there
+  is no monitor running to hear it on), and a daemon that dies without a
+  parting signal would freeze the model — so the timer stays on, gated exactly
+  as before, at a reconcile cadence while the stream is live.
+- **Valent still polls, explicitly.** No live Valent daemon was reachable to
+  verify its signal set, so `monitorMatchRule("valent")` is `""` and nothing
+  spawns a monitor for it. A signal path that only works for one backend is a
+  regression in the other. Verifying it is the prerequisite for changing this,
+  and the shape is already there: an ObjectManager `InterfacesAdded`/`Removed`
+  plus `PropertiesChanged` on the device paths and `org.gtk.Actions.Changed`
+  are the *plausible* rule, and plausible is not verified.
+- Covered by `tests/tst_phone_connect.qml` (the match rule, the monitor-line
+  parser against verbatim captured lines, the event allowlist, the backoff
+  ladder and the restart plan), `tests/test_phone_connect_contract.py` (the
+  lifetime as source shape) and `tests/test_phone_connect_monitor_runtime.py`
+  (a real shell against a fake `busctl` that streams in one case and exits
+  instantly in the other, with the spawn timestamps read back).
+
+One finding worth carrying into slice 2: the monitor's gate was first written
+as a `readonly property bool` read from `onBackendChanged`, which is AGENT.md's
+change-handler trap — it answered with the previous backend, the monitor never
+started, and nothing showed it because the poll kept the model correct. It is a
+function now.
 
 ## Prior art: P3DROVFX/ii-p3drovfx
 
@@ -141,17 +190,14 @@ Ordered by value. Each borrows the fork's shape and none of its transport:
 every read is a `busctl` argv, every write goes through `runAction`, and both
 backends stay behind the one model.
 
-1. **Signal-driven updates.** Replace the poll with `busctl --user
-   --json=short monitor` on the daemon's bus name, keyed on the same signals
-   the fork's `monitor.py` subscribes to (`PropertiesChanged`,
-   `battery.refreshed`, `deviceAdded`/`Removed`/`VisibilityChanged`,
-   `pairingRequestsChanged`, `pairStateChanged`, `notifications.*`,
-   `share.shareReceived`). Borrow the event set and the initial `GetAll` dump;
-   not the sidecar, not the 4 s restart with no backoff (CONTRIBUTING.md
-   already forbids a persistent `running` binding without backoff and a
-   ceiling). Valent's signal set has to be verified against a live daemon the
-   same way KDE Connect's is.
-2. **Notification mirroring.** Borrow: the leaf `notification.dismiss` (not
+**Slice 1 (signal-driven updates) is done** — see "Current state" above. The
+next slice is now notification mirroring, and it inherits the stream: its
+signals go in `signalChangesDevices`' allowlist and the match rule already
+covers the whole `/modules/kdeconnect` namespace, so nothing about the
+transport has to be rebuilt for it. What is still open from slice 1 is Valent:
+its signal set was not verifiable and it keeps the poll until it is.
+
+1. **Notification mirroring.** Borrow: the leaf `notification.dismiss` (not
    `sendAction("cancel")`), `sendReply` with a re-fetch, `internalId` →
    package, group-by-app, and the dedupe rule against kdeconnectd's own
    desktop notifications with its "only while we are showing them" gate. Not:
@@ -161,23 +207,23 @@ backends stay behind the one model.
    necessary. Not: the qdbus/`fetch_notifications.py` split; one `busctl`
    `GetAll` per leaf covers it. Not: "open on phone" — that is scrcpy+adb,
    out of scope.
-3. **`connectivity_report` and `reachableAddresses`.** One more `GetAll` on
+2. **`connectivity_report` and `reachableAddresses`.** One more `GetAll` on
    the device path and one more signal, both already in the fork's event set;
-   the model gains cellular type/strength. Cheap once (1) exists.
-4. **Pairing requests.** Accept/decline banners in the device dialog, fed by
+   the model gains cellular type/strength. Cheap now the stream exists.
+3. **Pairing requests.** Accept/decline banners in the device dialog, fed by
    `pairingRequestsChanged` and `pairStateChanged`; the calls are
    `acceptPairing`/`cancelPairing` on the device path. This closes the "Open
    questions" item — the fork shows it wraps cleanly. Not: interpolating
    `devId` into a shell string; the id is validated (`validDeviceId`) and
    passed as an argument.
-5. **Send and receive.** `share.shareUrl("file://…")` for file send, drop
+4. **Send and receive.** `share.shareUrl("file://…")` for file send, drop
    target on the drop shelf (`modules/imi/dropShelf/`) rather than a picker
    dialog, and `share.shareReceived` surfaced as a notification. Not: the
    kdialog/zenity picker chain.
-6. **SFTP mount/browse.** `sftp.mount`/`unmount` plus a file-manager open;
+5. **SFTP mount/browse.** `sftp.mount`/`unmount` plus a file-manager open;
    the fork's `3a7f653b4` records that the mount root is not the user's
    storage — open `<mount>/storage/emulated/0` when it exists.
-7. **Persisted active device, MRU, and low-battery hooks.** Small; take the
+6. **Persisted active device, MRU, and low-battery hooks.** Small; take the
    thresholds (<20% not charging, recover at ≥25% or charging) as they are.
 
 Still open regardless: media (`mprisremote`), clipboard *receive*, and Valent

--- a/dots/.config/quickshell/imi/PhoneConnectMonitorRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/PhoneConnectMonitorRuntimeTest.qml
@@ -1,0 +1,117 @@
+import QtQuick
+import Quickshell
+import qs.modules.common
+import qs.services
+
+/**
+ * The phone-connect stream's process lifetime, against the real
+ * services/PhoneConnect.qml singleton in a real Quickshell process.
+ *
+ * Driven once per case by tests/test_phone_connect_monitor_runtime.py, which
+ * puts a fake `busctl` at the front of PATH and reads the recorded
+ * invocations back afterwards. The fake is stateful: its `monitor` verb
+ * rewrites the battery charge its own `GetAll` will report NEXT, then prints
+ * one signal line, so "the change reached the shell" can only be true if the
+ * signal was heard and acted on.
+ *
+ * That is the whole oracle for the stream case, and it is why the poll
+ * interval is seeded at ten minutes there: with the timer that far out,
+ * nothing but the signal can deliver the new charge inside the harness's
+ * lifetime. A shorter interval would let a poll pass the check for a stream
+ * that never worked.
+ *
+ * What each case pins:
+ * - stream: the monitor comes up for KDE Connect and a battery change
+ *   arrives from the signal rather than from the timer.
+ * - crash: a busctl that exits immediately - the shape CONTRIBUTING.md
+ *   forbids answering with a `running` binding - is retried a bounded number
+ *   of times and then given up on, with the poll still populating the model.
+ *   The delays between spawns are asserted driver-side.
+ *  - valent: no monitor at all (its signal set is unverified), model still
+ *   populated by the poll.
+ * - none: no daemon, so nothing streams and nothing is spawned for it.
+ *
+ *   PHONE_EXPECT_BACKEND=kdeconnect PHONE_EXPECT_MONITOR=running ... \
+ *     qs -p PhoneConnectMonitorRuntimeTest.qml
+ */
+ShellRoot {
+    id: harness
+
+    property int failures: 0
+    property int checksRun: 0
+    property int elapsed: 0
+
+    readonly property string expectBackend: Quickshell.env("PHONE_EXPECT_BACKEND") ?? "none"
+    readonly property string expectMonitor: Quickshell.env("PHONE_EXPECT_MONITOR") ?? "idle"
+    readonly property int expectCharge: Number(Quickshell.env("PHONE_EXPECT_CHARGE") ?? "-1")
+    readonly property int settleMs: Number(Quickshell.env("PHONE_SETTLE_MS") ?? "6000")
+
+    function check(label, ok) {
+        harness.checksRun++;
+        console.log(`[PhoneConnectMonitor] ${label}: ${ok ? "ok" : "FAIL"}`);
+        if (!ok)
+            harness.failures++;
+    }
+
+    function finish() {
+        console.log(`[PhoneConnectMonitor] checks: ${harness.checksRun} failures: ${harness.failures}`);
+        Qt.exit(harness.failures === 0 ? 0 : 1);
+    }
+
+    Component.onCompleted: {
+        // A singleton is constructed on first use, so this read is what
+        // starts the presence probe at all.
+        console.log(`[PhoneConnectMonitor] service constructed, installed=${PhoneConnect.installed}`);
+    }
+
+    Timer {
+        id: waitForReady
+        interval: 250
+        repeat: true
+        running: true
+        onTriggered: {
+            harness.elapsed += waitForReady.interval;
+            if (!Config.ready || !PhoneConnect.installed) {
+                if (harness.elapsed >= 30000) {
+                    harness.check("Config becomes ready and busctl is detected", false);
+                    harness.finish();
+                }
+                return;
+            }
+            waitForReady.running = false;
+            settle.running = true;
+        }
+    }
+
+    Timer {
+        id: settle
+        // Long enough for the crash case to exhaust its ceiling
+        // (1+2+4+8+16s of backoff), set per case by the driver.
+        interval: harness.settleMs
+        onTriggered: {
+            harness.check(`backend is ${harness.expectBackend}, got ${PhoneConnect.backend}`,
+                          PhoneConnect.backend === harness.expectBackend);
+            harness.check(`monitor state is ${harness.expectMonitor}, got ${PhoneConnect.monitorState}`,
+                          PhoneConnect.monitorState === harness.expectMonitor);
+
+            if (harness.expectMonitor === "failed")
+                harness.check(`the ceiling was reached exactly, got ${PhoneConnect.monitorAttempts}`,
+                              PhoneConnect.monitorAttempts === PhoneConnect.monitorAttemptCeiling);
+
+            if (harness.expectBackend === "none") {
+                harness.check(`no daemon leaves no devices, got ${PhoneConnect.devices.length}`,
+                              PhoneConnect.devices.length === 0);
+                harness.finish();
+                return;
+            }
+
+            harness.check(`the model is populated, got ${PhoneConnect.devices.length} device(s)`,
+                          PhoneConnect.devices.length === 1);
+            const device = PhoneConnect.devices[0] ?? null;
+            harness.check("the device is reachable and paired", (device?.reachable ?? false) && (device?.paired ?? false));
+            harness.check(`battery charge is ${harness.expectCharge}, got ${device?.batteryCharge}`,
+                          (device?.batteryCharge ?? -99) === harness.expectCharge);
+            harness.finish();
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/services/PhoneConnect.qml
+++ b/dots/.config/quickshell/imi/services/PhoneConnect.qml
@@ -16,9 +16,20 @@ import qs.modules.common
  * both daemons double-pairs phones anyway). No daemon at all is a clean
  * degraded state: backend "none", no devices, UI hides.
  *
- * Updates are bounded polling like Tailscale.qml, not `busctl monitor`
- * streaming - a persistent streaming Process needs backoff and a retry
- * ceiling (see CONTRIBUTING.md) that this feature does not justify yet.
+ * Updates are signal-driven where the signal set has been verified against a
+ * live daemon, and polled where it has not. KDE Connect gets a
+ * `busctl --json=short monitor` subscribed to a match rule; Valent keeps the
+ * poll, because no Valent daemon was reachable to check its signals against
+ * and a stream that only works for one backend is a regression in the other.
+ * The poll stays on either way as the reconcile that notices a daemon
+ * disappearing - slower while the monitor is live.
+ *
+ * The monitor is a streaming Process, so it is started imperatively and
+ * never by a `running` binding: busctl exits in milliseconds on a rule the
+ * bus rejects, and a binding would answer that with a tight respawn loop
+ * (CONTRIBUTING.md). Restarts go through monitorExitPlan - capped exponential
+ * backoff, a per-daemon-appearance retry ceiling, and a healthy-run reset -
+ * after which polling is the whole update path again.
  *
  * Device ids and object paths get spliced into D-Bus object paths, so both
  * are validated first (validDeviceId / validValentObjectPath); anything that
@@ -257,6 +268,12 @@ Singleton {
         return ["busctl", "--user", "--json=short", "--timeout=5", "call", dest, path, iface, member, ...extra];
     }
 
+    // The match rule is one argv element. It carries quotes the D-Bus match
+    // grammar requires, which is exactly why it never goes near a shell.
+    function busctlMonitor(matchRule: string): var {
+        return ["busctl", "--user", "--json=short", "monitor", `--match=${matchRule}`];
+    }
+
     function refresh(): void {
         if (!root.enableService || !root.installed) return;
         if (busProc.running || root.callQueue.length > 0) return; // previous sweep still in flight
@@ -311,6 +328,107 @@ Singleton {
                 });
             }
         });
+    }
+
+    // ---- signal streaming ----
+
+    property string monitorState: "idle" // idle | running | backoff | failed
+    property int monitorAttempts: 0
+    property real monitorStartedAt: 0
+
+    readonly property int monitorAttemptCeiling: 5
+    // A monitor that held the bus this long was doing its job; anything
+    // shorter counts toward the ceiling (see monitorExitPlan).
+    readonly property int monitorHealthyMs: 30000
+
+    readonly property bool monitorLive: root.monitorState === "running"
+    readonly property bool wantMonitor: root.enableService && root.installed
+        && root.monitorState !== "failed" && root.monitorMatchRule(root.backend) !== ""
+
+    function startMonitor(): void {
+        if (monitorProc.running || !root.wantMonitor) return;
+        monitorRestart.stop();
+        root.monitorStartedAt = Date.now();
+        root.monitorState = "running";
+        monitorProc.exec(root.busctlMonitor(root.monitorMatchRule(root.backend)));
+    }
+
+    function stopMonitor(): void {
+        monitorRestart.stop();
+        root.monitorAttempts = 0;
+        root.monitorState = "idle";
+        monitorProc.running = false;
+    }
+
+    function handleMonitorLine(line: string): void {
+        if (!root.signalChangesDevices(root.parseMonitorLine(line))) return;
+        // Signals arrive in bursts - one device going out of range emitted
+        // seven within a millisecond of each other on a live daemon - and
+        // every re-read is a chain of busctl spawns, so they coalesce.
+        signalSettle.restart();
+    }
+
+    Timer {
+        id: signalSettle
+        interval: 120
+        onTriggered: {
+            // refresh() declines while a sweep is in flight; re-arm rather
+            // than drop the change that asked for it.
+            if (busProc.running || root.callQueue.length > 0) {
+                signalSettle.restart();
+                return;
+            }
+            root.refresh();
+        }
+    }
+
+    Timer {
+        id: monitorRestart
+        onTriggered: root.startMonitor()
+    }
+
+    Process {
+        id: monitorProc
+        // process-lifecycle: restart-safe -- capped exponential backoff; no running binding.
+        environment: ({
+            LANG: "C",
+            LC_ALL: "C"
+        })
+        stdout: SplitParser {
+            onRead: data => root.handleMonitorLine(data)
+        }
+        // busctl says nothing here on a rule the bus accepts, and exits
+        // non-zero with one line on a rule it does not; either way the exit
+        // is what the plan reads.
+        stderr: SplitParser {}
+        onExited: (exitCode, exitStatus) => {
+            const plan = root.monitorExitPlan(root.monitorAttempts, Date.now() - root.monitorStartedAt,
+                root.wantMonitor, root.monitorHealthyMs, root.monitorAttemptCeiling);
+            root.monitorAttempts = plan.attempts;
+            if (!plan.retry) {
+                if (root.wantMonitor) {
+                    root.monitorState = "failed";
+                    console.warn(`[PhoneConnect] busctl monitor gave up after ${root.monitorAttemptCeiling} restarts; falling back to polling`);
+                } else {
+                    root.monitorState = "idle";
+                }
+                return;
+            }
+            root.monitorState = "backoff";
+            monitorRestart.interval = plan.delay;
+            monitorRestart.restart();
+        }
+    }
+
+    onBackendChanged: {
+        // The ceiling is per daemon appearance, not per session: a daemon
+        // that has just come back is a new opportunity rather than the sixth
+        // rung of the loop that gave up on the old one. Nothing can reach
+        // this faster than a ListNames sweep, so it cannot itself become one.
+        root.monitorAttempts = 0;
+        if (root.monitorState === "failed") root.monitorState = "idle";
+        if (root.monitorMatchRule(root.backend) === "") root.stopMonitor();
+        else root.startMonitor();
     }
 
     // ---- actions ----
@@ -401,6 +519,7 @@ Singleton {
         if (!root.enableService) {
             root.callQueue = [];
             root.activeCallback = null;
+            root.stopMonitor();
             root.applyBackend("none");
         } else if (root.installed) {
             root.refresh();
@@ -418,8 +537,14 @@ Singleton {
         }
     }
 
+    // While the monitor is live this is no longer the update path - every
+    // change already arrives as a signal - but it stays on, slower, as the
+    // reconcile that notices a daemon which went away without saying so, and
+    // as the detector that notices one arriving in the first place.
+    readonly property int reconcileInterval: Math.max(root.pollInterval * 6, 60000)
+
     Timer {
-        interval: root.pollInterval
+        interval: root.monitorLive ? root.reconcileInterval : root.pollInterval
         running: root.enableService && root.installed
         repeat: true
         triggeredOnStart: true

--- a/dots/.config/quickshell/imi/services/PhoneConnect.qml
+++ b/dots/.config/quickshell/imi/services/PhoneConnect.qml
@@ -162,6 +162,80 @@ Singleton {
     function validDeviceId(id: var): bool {
         return typeof id === "string" && /^[A-Za-z0-9_-]+$/.test(id);
     }
+
+    // The monitor's subscription, as one D-Bus match rule. Narrowing it at
+    // the BUS is the only filter there is: `busctl monitor` reports a signal's
+    // sender as the unique name it arrived on (":1.55", captured live), so
+    // nothing downstream can tell the daemon's signals from anyone else's
+    // emitted on the same path. An empty rule means "this backend has no
+    // verified signal set" and leaves it on the poll - Valent's case.
+    function monitorMatchRule(backend: string): string {
+        if (backend === "kdeconnect")
+            return "type='signal',sender='org.kde.kdeconnect.daemon',path_namespace='/modules/kdeconnect'";
+        return "";
+    }
+
+    // One `busctl --json=short monitor` line as { path, iface, member, args },
+    // or null. A monitor sees method calls, returns and errors on the same
+    // stream; only a signal carries a change.
+    function parseMonitorLine(line: string): var {
+        const trimmed = (line ?? "").trim();
+        if (trimmed.length === 0) return null;
+        let doc;
+        try {
+            doc = JSON.parse(trimmed);
+        } catch (e) {
+            return null;
+        }
+        if (!doc || typeof doc !== "object" || doc.type !== "signal") return null;
+        return {
+            path: doc.path ?? "",
+            iface: doc.interface ?? "",
+            member: doc.member ?? "",
+            args: doc.payload?.data ?? []
+        };
+    }
+
+    // Which of the daemon's signals can move the device model. An allowlist
+    // rather than "anything under org.kde.kdeconnect": the SMS plugin's
+    // conversation signals share the device path, and re-reading every device
+    // per incoming message is a chain of busctl spawns for a change this
+    // service does not model. Members verified by introspecting a live
+    // daemon's /modules/kdeconnect and device paths.
+    function signalChangesDevices(signal: var): bool {
+        if (!signal) return false;
+        // PropertiesChanged names the interface it is about in its first arg.
+        if (signal.iface === "org.freedesktop.DBus.Properties")
+            return signal.member === "PropertiesChanged"
+                && String((signal.args ?? [])[0] ?? "").startsWith("org.kde.kdeconnect");
+        const members = {
+            "org.kde.kdeconnect.daemon": ["deviceAdded", "deviceRemoved", "deviceListChanged",
+                "deviceVisibilityChanged", "pairingRequestsChanged"],
+            "org.kde.kdeconnect.device": ["reachableChanged", "pairStateChanged", "nameChanged",
+                "typeChanged", "pluginsChanged"],
+            "org.kde.kdeconnect.device.battery": ["refreshed"]
+        }[signal.iface];
+        return Array.isArray(members) && members.includes(signal.member);
+    }
+
+    // Delay before the Nth consecutive fast monitor exit is retried: 1s, 2s,
+    // 4s, 8s, 16s, capped at 30s.
+    function monitorBackoffDelay(attempt: int): int {
+        return Math.min(30000, 1000 * Math.pow(2, Math.max(1, attempt) - 1));
+    }
+
+    // What a monitor exit means, as one decision: the attempt count it leaves
+    // behind, whether to restart, and after how long. A run that lasted at
+    // least `healthyMs` was working, so it clears the count rather than
+    // counting as the next rung of a respawn loop - without that, one daemon
+    // restart in a day-long session spends the ceiling and the shell never
+    // streams again.
+    function monitorExitPlan(attempts: int, ranForMs: int, wanted: bool, healthyMs: int, ceiling: int): var {
+        const settled = ranForMs >= healthyMs ? 0 : attempts;
+        if (!wanted || settled >= ceiling)
+            return { attempts: settled, retry: false, delay: 0 };
+        return { attempts: settled + 1, retry: true, delay: root.monitorBackoffDelay(settled + 1) };
+    }
     // END phone-connect parser logic
 
     function applyBackend(newBackend: string): void {

--- a/dots/.config/quickshell/imi/services/PhoneConnect.qml
+++ b/dots/.config/quickshell/imi/services/PhoneConnect.qml
@@ -342,11 +342,21 @@ Singleton {
     readonly property int monitorHealthyMs: 30000
 
     readonly property bool monitorLive: root.monitorState === "running"
-    readonly property bool wantMonitor: root.enableService && root.installed
-        && root.monitorState !== "failed" && root.monitorMatchRule(root.backend) !== ""
+
+    // A function rather than a binding, and that is not a style choice:
+    // onBackendChanged is the caller, and nothing orders a change handler
+    // against the re-evaluation of a binding derived from the same property,
+    // so a binding here answers with the PREVIOUS backend. Written as one it
+    // read false on the transition that arms the stream and the monitor
+    // never started - measured against the runtime harness, silently, with
+    // the model still updating from the poll.
+    function monitorWanted(): bool {
+        return root.enableService && root.installed
+            && root.monitorState !== "failed" && root.monitorMatchRule(root.backend) !== "";
+    }
 
     function startMonitor(): void {
-        if (monitorProc.running || !root.wantMonitor) return;
+        if (monitorProc.running || !root.monitorWanted()) return;
         monitorRestart.stop();
         root.monitorStartedAt = Date.now();
         root.monitorState = "running";
@@ -403,10 +413,10 @@ Singleton {
         stderr: SplitParser {}
         onExited: (exitCode, exitStatus) => {
             const plan = root.monitorExitPlan(root.monitorAttempts, Date.now() - root.monitorStartedAt,
-                root.wantMonitor, root.monitorHealthyMs, root.monitorAttemptCeiling);
+                root.monitorWanted(), root.monitorHealthyMs, root.monitorAttemptCeiling);
             root.monitorAttempts = plan.attempts;
             if (!plan.retry) {
-                if (root.wantMonitor) {
+                if (root.monitorWanted()) {
                     root.monitorState = "failed";
                     console.warn(`[PhoneConnect] busctl monitor gave up after ${root.monitorAttemptCeiling} restarts; falling back to polling`);
                 } else {

--- a/dots/.config/quickshell/imi/tests/imports/testservices/PhoneConnect.qml
+++ b/dots/.config/quickshell/imi/tests/imports/testservices/PhoneConnect.qml
@@ -133,6 +133,80 @@ Singleton {
     function validDeviceId(id: var): bool {
         return typeof id === "string" && /^[A-Za-z0-9_-]+$/.test(id);
     }
+
+    // The monitor's subscription, as one D-Bus match rule. Narrowing it at
+    // the BUS is the only filter there is: `busctl monitor` reports a signal's
+    // sender as the unique name it arrived on (":1.55", captured live), so
+    // nothing downstream can tell the daemon's signals from anyone else's
+    // emitted on the same path. An empty rule means "this backend has no
+    // verified signal set" and leaves it on the poll - Valent's case.
+    function monitorMatchRule(backend: string): string {
+        if (backend === "kdeconnect")
+            return "type='signal',sender='org.kde.kdeconnect.daemon',path_namespace='/modules/kdeconnect'";
+        return "";
+    }
+
+    // One `busctl --json=short monitor` line as { path, iface, member, args },
+    // or null. A monitor sees method calls, returns and errors on the same
+    // stream; only a signal carries a change.
+    function parseMonitorLine(line: string): var {
+        const trimmed = (line ?? "").trim();
+        if (trimmed.length === 0) return null;
+        let doc;
+        try {
+            doc = JSON.parse(trimmed);
+        } catch (e) {
+            return null;
+        }
+        if (!doc || typeof doc !== "object" || doc.type !== "signal") return null;
+        return {
+            path: doc.path ?? "",
+            iface: doc.interface ?? "",
+            member: doc.member ?? "",
+            args: doc.payload?.data ?? []
+        };
+    }
+
+    // Which of the daemon's signals can move the device model. An allowlist
+    // rather than "anything under org.kde.kdeconnect": the SMS plugin's
+    // conversation signals share the device path, and re-reading every device
+    // per incoming message is a chain of busctl spawns for a change this
+    // service does not model. Members verified by introspecting a live
+    // daemon's /modules/kdeconnect and device paths.
+    function signalChangesDevices(signal: var): bool {
+        if (!signal) return false;
+        // PropertiesChanged names the interface it is about in its first arg.
+        if (signal.iface === "org.freedesktop.DBus.Properties")
+            return signal.member === "PropertiesChanged"
+                && String((signal.args ?? [])[0] ?? "").startsWith("org.kde.kdeconnect");
+        const members = {
+            "org.kde.kdeconnect.daemon": ["deviceAdded", "deviceRemoved", "deviceListChanged",
+                "deviceVisibilityChanged", "pairingRequestsChanged"],
+            "org.kde.kdeconnect.device": ["reachableChanged", "pairStateChanged", "nameChanged",
+                "typeChanged", "pluginsChanged"],
+            "org.kde.kdeconnect.device.battery": ["refreshed"]
+        }[signal.iface];
+        return Array.isArray(members) && members.includes(signal.member);
+    }
+
+    // Delay before the Nth consecutive fast monitor exit is retried: 1s, 2s,
+    // 4s, 8s, 16s, capped at 30s.
+    function monitorBackoffDelay(attempt: int): int {
+        return Math.min(30000, 1000 * Math.pow(2, Math.max(1, attempt) - 1));
+    }
+
+    // What a monitor exit means, as one decision: the attempt count it leaves
+    // behind, whether to restart, and after how long. A run that lasted at
+    // least `healthyMs` was working, so it clears the count rather than
+    // counting as the next rung of a respawn loop - without that, one daemon
+    // restart in a day-long session spends the ceiling and the shell never
+    // streams again.
+    function monitorExitPlan(attempts: int, ranForMs: int, wanted: bool, healthyMs: int, ceiling: int): var {
+        const settled = ranForMs >= healthyMs ? 0 : attempts;
+        if (!wanted || settled >= ceiling)
+            return { attempts: settled, retry: false, delay: 0 };
+        return { attempts: settled + 1, retry: true, delay: root.monitorBackoffDelay(settled + 1) };
+    }
     // END phone-connect parser logic
 
     function applyBackend(newBackend: string): void {

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -1324,6 +1324,17 @@ if ! python3 "$SCRIPT_DIR/test_phone_connect_contract.py"; then
     exit 1
 fi
 
+# The stream's process lifetime, which no source check and no unit test can
+# reach: a real shell, a fake busctl whose monitor verb streams one signal in
+# one case and exits instantly in the other, and the spawn TIMESTAMPS read
+# back - because "it stopped after six spawns" is also true of six spawns in
+# six milliseconds, which is the starvation bug itself.
+echo "Running Phone Connect monitor runtime tests..."
+if ! python3 "$SCRIPT_DIR/test_phone_connect_monitor_runtime.py"; then
+    echo "Phone Connect monitor runtime tests failed."
+    exit 1
+fi
+
 echo "Running registry entry validator tests..."
 if ! python3 "$SCRIPT_DIR/test_registry_validate.py"; then
     echo "Registry entry validator tests failed."

--- a/dots/.config/quickshell/imi/tests/test_phone_connect_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_connect_contract.py
@@ -204,9 +204,28 @@ def test_the_ceiling_is_declared_and_the_stream_falls_back_to_polling():
         "the ceiling never lands the monitor in a terminal state"
     )
     assert 'root.monitorState !== "failed"' in source, (
-        "wantMonitor does not read the terminal state, so the ceiling is "
+        "monitorWanted() does not read the terminal state, so the ceiling is "
         "reachable again immediately"
     )
+
+
+def test_the_monitor_gate_is_a_function_not_a_binding():
+    """AGENT.md's change-handler rule, paid for here. onBackendChanged is
+    what arms the stream, and nothing orders a handler against the
+    re-evaluation of a binding derived from the same property - written as a
+    `readonly property bool` this answered with the PREVIOUS backend, read
+    false on the one transition that matters, and the monitor never started
+    while the model kept updating from the poll."""
+    source = SERVICE.read_text()
+    assert re.search(r"function monitorWanted\(\): bool \{", source), (
+        "the monitor's gate must be a function"
+    )
+    assert not re.search(r"property bool (wantMonitor|monitorWanted)", source), (
+        "the monitor's gate is a binding on the property its own handler hangs off"
+    )
+    handler = re.search(r"onBackendChanged: \{(.*?)\n    \}", source, re.S)
+    assert handler, "onBackendChanged missing"
+    assert "root.startMonitor()" in handler.group(1)
 
 
 def test_valent_keeps_the_poll_because_its_signals_are_unverified():

--- a/dots/.config/quickshell/imi/tests/test_phone_connect_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_connect_contract.py
@@ -14,8 +14,11 @@ The rest pins the busctl I/O the double deliberately omits:
 - device ids are filtered through validDeviceId before they are spliced
   into object paths, and Valent object paths pass validValentObjectPath
   before they are called into;
-- the poll survives the stream as the reconcile behind it, gated on
-  enableService && installed exactly as before.
+- the streaming monitor's lifetime, which is the half of this feature that
+  cannot be unit tested and the half CONTRIBUTING.md names outright: the
+  monitor Process must carry no `running` binding, every restart must go
+  through the backoff plan, and the poll must stay on (gated on
+  enableService && installed) as the reconcile behind it.
 """
 
 import re
@@ -92,6 +95,22 @@ def test_busctl_calls_are_argv_arrays_via_busctl_call():
     assert busctl_literals == [], f"busctl invoked outside the argv builders: {busctl_literals}"
 
 
+def test_the_match_rule_is_one_argv_element_and_never_a_shell_string():
+    """The D-Bus match grammar puts single quotes inside the rule
+    (`sender='org.kde.kdeconnect.daemon'`), which is exactly the string a
+    shell would re-interpret. It is one argv element, appended to
+    `--match=`, and the presence probe stays the only shell in the file
+    (pinned separately above)."""
+    source = SERVICE.read_text()
+    builder = re.search(r'function busctlMonitor\(.*?\{\n(.*?)\n    \}', source, re.S)
+    assert builder, "busctlMonitor builder missing"
+    body = builder.group(1)
+    assert '`--match=${matchRule}`' in body, (
+        f"the match rule must be one argv element: {body}"
+    )
+    assert '"monitor"' in body, "the monitor argv must name the monitor verb"
+
+
 def test_device_ids_are_validated_before_path_splicing():
     source = SERVICE.read_text()
     assert ".filter(id => root.validDeviceId(id))" in source, (
@@ -110,6 +129,100 @@ def test_device_ids_are_validated_before_path_splicing():
         )
 
 
+def _process_block(source: str, process_id: str) -> str:
+    """The `Process { ... }` block declaring `id: <process_id>`.
+
+    Brace-counted rather than regexed to a fixed indent: a check that bakes
+    in indentation passes vacuously after any reformat, and this one has to
+    be able to say a `running:` binding is absent.
+    """
+    for match in re.finditer(r"\bProcess\s*\{", source):
+        depth, index = 1, match.end()
+        while index < len(source) and depth:
+            if source[index] == "{":
+                depth += 1
+            elif source[index] == "}":
+                depth -= 1
+            index += 1
+        block = source[match.start():index]
+        if re.search(rf"\bid:\s*{process_id}\b", block):
+            return block
+    raise AssertionError(f"Process block for id {process_id} not found")
+
+
+def test_the_monitor_process_has_no_running_binding():
+    """The rule CONTRIBUTING.md states outright. `busctl monitor` handed a
+    match rule the bus rejects exits in milliseconds, so a `running:`
+    binding keeping it alive is a tight respawn loop that starves
+    Quickshell. It is started imperatively and the only assignment to
+    `running` is the deliberate stop."""
+    block = _process_block(SERVICE.read_text(), "monitorProc")
+    bindings = re.findall(r"^\s*running\s*:", block, re.M)
+    assert bindings == [], f"monitorProc declares a running binding: {bindings}"
+    assert "monitorProc.exec(" in SERVICE.read_text(), (
+        "the monitor must be started imperatively through exec()"
+    )
+    assert "process-lifecycle: restart-safe" in block, (
+        "the monitor block must carry the restart-safe marker the plugin "
+        "lifecycle lint recognises"
+    )
+
+
+def test_every_monitor_restart_goes_through_the_backoff_plan():
+    """No path may restart the monitor without a delay: the exit handler
+    consults monitorExitPlan, honours its refusal, and arms the restart
+    timer with the delay it returned."""
+    source = SERVICE.read_text()
+    block = _process_block(source, "monitorProc")
+    assert "root.monitorExitPlan(" in block, "the exit handler does not consult the plan"
+    assert "monitorRestart.interval = plan.delay" in block, (
+        "the restart timer is armed with something other than the plan's delay"
+    )
+    assert re.search(r"if\s*\(!plan\.retry\)", block), (
+        "the exit handler does not honour the plan's refusal"
+    )
+    # startMonitor is the only other way in, and it is reached either from a
+    # backend change or from that timer.
+    starts = [line.strip() for line in source.splitlines()
+              if "startMonitor()" in line and "function startMonitor" not in line]
+    assert starts, "nothing starts the monitor"
+    for line in starts:
+        assert ("root.startMonitor()" in line), f"unexpected monitor start path: {line}"
+
+
+def test_the_ceiling_is_declared_and_the_stream_falls_back_to_polling():
+    """A ceiling that is never reached is not a ceiling; a ceiling with no
+    fallback is a feature that silently stops working. Both halves."""
+    source = SERVICE.read_text()
+    assert re.search(r"readonly property int monitorAttemptCeiling:\s*\d+", source), (
+        "no declared retry ceiling"
+    )
+    assert re.search(r"readonly property int monitorHealthyMs:\s*\d+", source), (
+        "no declared healthy-run threshold"
+    )
+    assert 'root.monitorState = "failed"' in source, (
+        "the ceiling never lands the monitor in a terminal state"
+    )
+    assert 'root.monitorState !== "failed"' in source, (
+        "wantMonitor does not read the terminal state, so the ceiling is "
+        "reachable again immediately"
+    )
+
+
+def test_valent_keeps_the_poll_because_its_signals_are_unverified():
+    """A signal path that only works for one backend is a regression in the
+    other. Valent gets no match rule, so nothing ever spawns a monitor for
+    it, and its updates stay on the timer."""
+    source = SERVICE.read_text()
+    rule = re.search(r"function monitorMatchRule\(.*?\{\n(.*?)\n    \}", source, re.S)
+    assert rule, "monitorMatchRule missing"
+    body = rule.group(1)
+    assert "kdeconnect" in body
+    assert "andyholmes" not in body and "Valent" not in body, (
+        f"an unverified Valent rule has been added: {body}"
+    )
+
+
 def test_the_poll_survives_as_the_reconcile_and_stays_gated():
     """The stream is not allowed to replace the poll. Nothing announces a
     daemon appearing (there is no monitor to hear it on), and a daemon that
@@ -125,6 +238,25 @@ def test_the_poll_survives_as_the_reconcile_and_stays_gated():
     assert "triggeredOnStart: true" in body
     assert "root.monitorLive ? root.reconcileInterval : root.pollInterval" in body, (
         "the poll does not slow down behind a live stream"
+    )
+
+
+def test_signal_bursts_are_coalesced_and_never_dropped():
+    """One device going out of range emitted seven signals within a
+    millisecond on a live daemon, and each re-read is a chain of busctl
+    spawns - so they coalesce. The half that is easy to get wrong: refresh()
+    declines while a sweep is in flight, so the settle timer has to re-arm
+    rather than drop the change that asked for it."""
+    source = SERVICE.read_text()
+    settle = re.search(r"Timer \{\n\s*id: signalSettle(.*?)\n    \}", source, re.S)
+    assert settle, "signalSettle timer missing"
+    body = settle.group(1)
+    assert "root.callQueue.length > 0" in body and "signalSettle.restart()" in body, (
+        f"a signal arriving mid-sweep is dropped: {body}"
+    )
+    assert "signalSettle.restart()" in re.search(
+        r"function handleMonitorLine\(.*?\n    \}", source, re.S).group(0), (
+        "monitor lines do not go through the settle timer"
     )
 
 

--- a/dots/.config/quickshell/imi/tests/test_phone_connect_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_connect_contract.py
@@ -14,9 +14,8 @@ The rest pins the busctl I/O the double deliberately omits:
 - device ids are filtered through validDeviceId before they are spliced
   into object paths, and Valent object paths pass validValentObjectPath
   before they are called into;
-- no `busctl monitor`: updates are bounded polling (a persistent streaming
-  Process needs backoff and a retry ceiling per CONTRIBUTING.md), and the
-  poll timer is gated on enableService && installed.
+- the poll survives the stream as the reconcile behind it, gated on
+  enableService && installed exactly as before.
 """
 
 import re
@@ -74,20 +73,23 @@ def test_only_shell_string_is_the_static_presence_probe():
 
 def test_busctl_calls_are_argv_arrays_via_busctl_call():
     source = SERVICE.read_text()
-    builder = re.search(
-        r'function busctlCall\(.*?\{\n(.*?)\n    \}', source, re.S
-    )
-    assert builder, "busctlCall builder missing"
-    assert '["busctl", "--user", "--json=short"' in builder.group(1)
-    # Every exec goes through the queue or the action process, both fed by
-    # busctlCall argv arrays - no other busctl literal should exist.
+    for name in ("busctlCall", "busctlMonitor"):
+        builder = re.search(
+            rf'function {name}\(.*?\{{\n(.*?)\n    \}}', source, re.S
+        )
+        assert builder, f"{name} builder missing"
+        assert '["busctl", "--user", "--json=short"' in builder.group(1), (
+            f"{name} does not build a --json=short argv array"
+        )
+    # Every exec goes through the queue, the action process or the monitor,
+    # all fed by those two argv builders - no other busctl literal exists.
     busctl_literals = [
         line.strip() for line in source.splitlines()
         if '"busctl"' in line
         and not line.strip().startswith('return ["busctl"')
         and "command -v" not in line
     ]
-    assert busctl_literals == [], f"busctl invoked outside busctlCall: {busctl_literals}"
+    assert busctl_literals == [], f"busctl invoked outside the argv builders: {busctl_literals}"
 
 
 def test_device_ids_are_validated_before_path_splicing():
@@ -108,16 +110,22 @@ def test_device_ids_are_validated_before_path_splicing():
         )
 
 
-def test_no_streaming_monitor_and_poll_timer_is_gated():
+def test_the_poll_survives_as_the_reconcile_and_stays_gated():
+    """The stream is not allowed to replace the poll. Nothing announces a
+    daemon appearing (there is no monitor to hear it on), and a daemon that
+    dies without a signal would leave the model frozen - so the timer stays
+    on, gated exactly as before, and only slows down while the stream is
+    live."""
     source = SERVICE.read_text()
-    assert '"monitor"' not in source, (
-        "busctl monitor is a persistent streaming Process; bounded polling was "
-        "the reviewed decision (see the service header comment)"
+    timers = re.findall(r"Timer \{(.*?)\n    \}", source, re.S)
+    poll = [body for body in timers if "root.refresh()" in body and "repeat: true" in body]
+    assert len(poll) == 1, f"expected exactly one poll Timer, found {len(poll)}"
+    body = poll[0]
+    assert "running: root.enableService && root.installed" in body
+    assert "triggeredOnStart: true" in body
+    assert "root.monitorLive ? root.reconcileInterval : root.pollInterval" in body, (
+        "the poll does not slow down behind a live stream"
     )
-    timer = re.search(r"Timer \{(.*?)\n    \}", source, re.S)
-    assert timer, "poll Timer missing"
-    assert "running: root.enableService && root.installed" in timer.group(1)
-    assert "repeat: true" in timer.group(1)
 
 
 if __name__ == "__main__":

--- a/dots/.config/quickshell/imi/tests/test_phone_connect_monitor_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_connect_monitor_runtime.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""The phone-connect stream's process lifetime, against a real shell and a fake busctl.
+
+The parsing half of `busctl monitor` is covered by the QML suite through the
+logic-only double. The LIFETIME is not reachable from there at all -
+qmltestrunner cannot construct a Quickshell `Process` - and it is the half
+CONTRIBUTING.md names outright: an instant-exit streaming command kept alive
+by a `running` binding is a tight respawn loop that starves Quickshell.
+
+So this drives the real singleton in a real `qs` with a fake `busctl` on PATH
+and reads the spawns back:
+
+- stream: the monitor comes up for KDE Connect, and a battery change reaches
+  the shell from a SIGNAL. That is an oracle rather than an observation
+  because the poll interval is seeded at ten minutes for this case - the
+  timer cannot deliver the new charge inside the run, so a stream that never
+  worked reports the pre-signal value and reddens. (Seeded through
+  `config.json` rather than assigned in the harness: the stored value is the
+  one the JsonAdapter merges over the QML default, so it is also the one that
+  runs.)
+- crash: a `busctl monitor` that exits immediately. The retries are counted
+  and the GAPS between them measured, because "it stopped after six spawns"
+  is satisfied by six spawns in six milliseconds - which is the bug. The
+  model must still be populated afterwards, since giving up means falling
+  back to the poll rather than going dark.
+- valent: not one monitor spawn. Its signal set could not be verified
+  against a live daemon, and a stream that only works for one backend is a
+  regression in the other.
+- none: no daemon, so nothing streams and nothing is spawned for it.
+
+Brings its own headless weston and its own session bus (`dbus-run-session`,
+never the developer's - see lint_runtime_bus_isolation.py). Skips when
+weston, qs or dbus-run-session are missing, as in CI.
+"""
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HARNESS = ROOT / "PhoneConnectMonitorRuntimeTest.qml"
+SOCKET = "wayland-imi-phoneconnect-monitor"
+
+DEVICE_ID = "6131a746_571a_4176_a007_95625ff8e08e"
+CHARGE_BEFORE = 41
+CHARGE_AFTER = 87
+
+# The service's own declared ceiling. Read out of the source rather than
+# copied: a check that carries its own copy of the number passes when the
+# service's changes underneath it.
+CEILING = int(re.search(
+    r"readonly property int monitorAttemptCeiling:\s*(\d+)",
+    (ROOT / "services" / "PhoneConnect.qml").read_text()).group(1))
+
+# 1s, 2s, 4s, ... capped at 30s - monitorBackoffDelay, which the QML suite
+# pins as arithmetic. Here it is what the gaps between spawns must look like.
+EXPECTED_DELAYS = [min(30, 2 ** n) for n in range(CEILING)]
+
+RECORD = """#!/usr/bin/env bash
+printf '%s %s\\n' "$(date +%s.%N)" "$*" >> "$PHONE_EXEC_LOG"
+__BODY__
+"""
+
+# --json=short shapes lifted from a real busctl against a live KDE Connect
+# daemon. The battery charge comes out of a state file that the monitor verb
+# rewrites, so a poll after the signal reports something a poll before it
+# could not have.
+BUSCTL_BODY = """\
+state="$PHONE_STATE_DIR"
+charge=$(cat "$state/charge" 2>/dev/null || echo %(before)s)
+case "$*" in
+  *"org.freedesktop.DBus ListNames")
+    case "$PHONE_FAKE_BACKEND" in
+      kdeconnect) printf '{"type":"as","data":[[":1.5","org.freedesktop.DBus","org.kde.kdeconnect.daemon"]]}\\n' ;;
+      valent)     printf '{"type":"as","data":[[":1.5","org.freedesktop.DBus","ca.andyholmes.Valent"]]}\\n' ;;
+      *)          printf '{"type":"as","data":[[":1.5","org.freedesktop.DBus"]]}\\n' ;;
+    esac
+    ;;
+  *"org.kde.kdeconnect.daemon devices bb false false")
+    printf '{"type":"as","data":[["%(device)s"]]}\\n'
+    ;;
+  *"GetAll s org.kde.kdeconnect.device.battery")
+    printf '{"type":"a{sv}","data":[{"charge":{"type":"i","data":%%s},"isCharging":{"type":"b","data":false}}]}\\n' "$charge"
+    ;;
+  *"GetAll s org.kde.kdeconnect.device")
+    printf '{"type":"a{sv}","data":[{"name":{"type":"s","data":"Galaxy S23 Ultra"},"type":{"type":"s","data":"phone"},"isPaired":{"type":"b","data":true},"isReachable":{"type":"b","data":true}}]}\\n'
+    ;;
+  *"GetManagedObjects")
+    printf '{"type":"a{oa{sa{sv}}}","data":[{"/ca/andyholmes/Valent/Device/0":{"ca.andyholmes.Valent.Device":{"Id":{"type":"s","data":"abc123"},"Name":{"type":"s","data":"Pixel 9"},"Type":{"type":"s","data":"phone"},"State":{"type":"u","data":3}}}}]}\\n'
+    ;;
+  *"org.gtk.Actions DescribeAll")
+    printf '{"type":"a{s(bgav)}","data":[{"battery.state":[true,"",[{"type":"a{sv}","data":{"charging":{"type":"b","data":false},"percentage":{"type":"d","data":%(before)s.0},"is-present":{"type":"b","data":true}}}]]}]}\\n'
+    ;;
+  *monitor*)
+    case "$PHONE_FAKE_MONITOR" in
+      crash)
+        # busctl's own answer to a match rule the bus rejects, which is the
+        # instant-exit case the backoff exists for.
+        echo "Call to org.freedesktop.DBus.Monitoring.BecomeMonitor failed: Invalid match rule" >&2
+        exit 1
+        ;;
+      stream)
+        sleep 1
+        echo %(after)s > "$state/charge"
+        printf '{"type":"signal","endian":"l","flags":1,"version":1,"cookie":325,"timestamp-realtime":1787149977815500,"sender":":1.55","path":"/modules/kdeconnect/devices/%(device)s/battery","interface":"org.kde.kdeconnect.device.battery","member":"refreshed","payload":{"type":"bi","data":[false,%(after)s]}}\\n'
+        sleep 3600
+        ;;
+    esac
+    ;;
+esac
+exit 0
+""" % {"device": DEVICE_ID, "before": CHARGE_BEFORE, "after": CHARGE_AFTER}
+
+
+# How many checks the harness runs, per shape it is launched in. Literals
+# rather than anything read back out of the harness's own output: a harness
+# whose step list shrinks must redden here instead of reporting
+# `failures: 0` for a shorter run.
+EXPECTED_CHECKS_STREAMING = 5
+EXPECTED_CHECKS_GAVE_UP = 6
+EXPECTED_CHECKS_NO_DAEMON = 3
+
+
+def _stop(proc):
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+
+
+def _runtime_available():
+    return all(shutil.which(name) for name in ("qs", "weston", "dbus-run-session"))
+
+
+@unittest.skipUnless(_runtime_available(), "needs qs, weston and dbus-run-session on PATH")
+class PhoneConnectMonitorRuntimeTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.env = dict(os.environ)
+        cls.env.setdefault("XDG_RUNTIME_DIR", f"/run/user/{os.getuid()}")
+        cls.env["WAYLAND_DISPLAY"] = SOCKET
+        cls.env.pop("DISPLAY", None)
+        cls.weston = subprocess.Popen(
+            ["weston", "--backend=headless", "--renderer=pixman",
+             f"--socket={SOCKET}", "--width=800", "--height=600"],
+            env=cls.env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+        socket_path = Path(cls.env["XDG_RUNTIME_DIR"]) / SOCKET
+        deadline = time.monotonic() + 15
+        while not socket_path.exists() and time.monotonic() < deadline:
+            time.sleep(0.2)
+        if not socket_path.exists():
+            _stop(cls.weston)
+            raise AssertionError("headless weston never came up")
+
+        cls.env["LIBGL_ALWAYS_SOFTWARE"] = "1"
+        cls.env["QT_QUICK_BACKEND"] = "software"
+
+    @classmethod
+    def tearDownClass(cls):
+        _stop(cls.weston)
+
+    def setUp(self):
+        self.home = Path(tempfile.mkdtemp(prefix="imi-phoneconnect-runtime-"))
+        self.addCleanup(shutil.rmtree, self.home, ignore_errors=True)
+        self.config_home = self.home / "config"
+        self.exec_log = self.home / "exec.log"
+        self.state = self.home / "phone-state"
+        self.state.mkdir()
+        (self.state / "charge").write_text(f"{CHARGE_BEFORE}\n")
+        self.bin = self.home / "bin"
+        self.bin.mkdir(parents=True)
+        self.fake("busctl", BUSCTL_BODY)
+
+    def fake(self, name, body="exit 0"):
+        path = self.bin / name
+        path.write_text(RECORD.replace("__BODY__", body))
+        path.chmod(0o755)
+
+    def seed(self, poll_ms):
+        shell_config = self.config_home / "immaterial-impulse"
+        shell_config.mkdir(parents=True)
+        (shell_config / "config.json").write_text(json.dumps({
+            "networking": {"phoneConnect": {"enable": True, "pollInterval": poll_ms}},
+        }, indent=2))
+
+    def launch(self, *, backend, monitor_mode, expect_monitor, expect_charge,
+               checks, poll_ms, settle_ms):
+        self.seed(poll_ms)
+        env = dict(self.env)
+        env["XDG_CONFIG_HOME"] = str(self.config_home)
+        env["XDG_STATE_HOME"] = str(self.home / "state")
+        env["XDG_CACHE_HOME"] = str(self.home / "cache")
+        env["PATH"] = f"{self.bin}{os.pathsep}{env['PATH']}"
+        env["PHONE_EXEC_LOG"] = str(self.exec_log)
+        env["PHONE_STATE_DIR"] = str(self.state)
+        env["PHONE_FAKE_BACKEND"] = backend
+        env["PHONE_FAKE_MONITOR"] = monitor_mode
+        env["PHONE_EXPECT_BACKEND"] = backend
+        env["PHONE_EXPECT_MONITOR"] = expect_monitor
+        env["PHONE_EXPECT_CHARGE"] = str(expect_charge)
+        env["PHONE_SETTLE_MS"] = str(settle_ms)
+        # dbus-run-session, not the inherited DBUS_SESSION_BUS_ADDRESS: this
+        # harness must see the services it declares and no others.
+        proc = subprocess.run(
+            ["dbus-run-session", "--", "qs", "-p", str(HARNESS)],
+            cwd=str(ROOT), env=env, capture_output=True, text=True, timeout=300)
+        output = proc.stdout + proc.stderr
+        failed = [line for line in output.splitlines() if "FAIL" in line]
+        self.assertEqual(failed, [], f"harness reported failures:\n{output}")
+        self.assertIn(f"[PhoneConnectMonitor] checks: {checks} failures: 0", output,
+                      f"harness did not finish cleanly:\n{output}")
+        return output
+
+    def invocations(self):
+        if not self.exec_log.exists():
+            return []
+        out = []
+        for line in self.exec_log.read_text().splitlines():
+            if not line.strip():
+                continue
+            stamp, _, argv = line.partition(" ")
+            out.append((float(stamp), argv))
+        return out
+
+    def monitor_spawns(self):
+        return [entry for entry in self.invocations() if " monitor " in f" {entry[1]} "]
+
+    def test_a_signal_delivers_a_change_the_poll_could_not_have(self):
+        """The point of the slice. The poll is ten minutes out, so the new
+        charge can only have come from the monitor's signal."""
+        output = self.launch(backend="kdeconnect", monitor_mode="stream",
+                             expect_monitor="running", expect_charge=CHARGE_AFTER,
+                             checks=EXPECTED_CHECKS_STREAMING,
+                             poll_ms=600000, settle_ms=8000)
+        self.assertIn("[PhoneConnectMonitor] service constructed", output)
+
+        spawns = self.monitor_spawns()
+        self.assertEqual(len(spawns), 1, f"expected one monitor spawn, got {spawns}")
+        argv = spawns[0][1]
+        self.assertIn("--json=short", argv)
+        self.assertIn("--match=type='signal',sender='org.kde.kdeconnect.daemon'", argv)
+        self.assertIn("path_namespace='/modules/kdeconnect'", argv)
+
+        # Exactly one sweep per reason: the startup poll, then the one the
+        # signal asked for. A stream that re-swept per burst line, or a
+        # settle that fired while a sweep was in flight, would show more.
+        list_names = [entry for entry in self.invocations() if entry[1].endswith("ListNames")]
+        self.assertEqual(len(list_names), 2,
+                         f"expected a startup sweep and a signal-driven one, got {list_names}")
+
+    def test_an_instantly_exiting_monitor_is_backed_off_and_given_up_on(self):
+        """The shape CONTRIBUTING.md forbids answering with a `running`
+        binding. Both halves are asserted, because "it stopped after N
+        spawns" is satisfied by N spawns in N milliseconds - which is the
+        starvation bug itself."""
+        settle = int((sum(EXPECTED_DELAYS) + 10) * 1000)
+        self.launch(backend="kdeconnect", monitor_mode="crash",
+                    expect_monitor="failed", expect_charge=CHARGE_BEFORE,
+                    checks=EXPECTED_CHECKS_GAVE_UP,
+                    poll_ms=2000, settle_ms=settle)
+
+        spawns = self.monitor_spawns()
+        self.assertEqual(len(spawns), CEILING + 1,
+                         f"expected the first spawn plus {CEILING} retries, got {len(spawns)}")
+        gaps = [round(b[0] - a[0], 1) for a, b in zip(spawns, spawns[1:])]
+        self.assertEqual(len(gaps), len(EXPECTED_DELAYS))
+        for gap, expected in zip(gaps, EXPECTED_DELAYS):
+            self.assertGreaterEqual(
+                gap, expected * 0.8,
+                f"restart {gaps.index(gap) + 1} came back after {gap}s, not {expected}s: {gaps}")
+
+    def test_valent_is_never_streamed_because_its_signals_are_unverified(self):
+        self.launch(backend="valent", monitor_mode="crash",
+                    expect_monitor="idle", expect_charge=CHARGE_BEFORE,
+                    checks=EXPECTED_CHECKS_STREAMING,
+                    poll_ms=2000, settle_ms=6000)
+        self.assertEqual(self.monitor_spawns(), [],
+                         "a monitor was spawned for a backend with no verified signal set")
+
+    def test_no_daemon_spawns_no_monitor(self):
+        self.launch(backend="none", monitor_mode="crash",
+                    expect_monitor="idle", expect_charge=-1,
+                    checks=EXPECTED_CHECKS_NO_DAEMON,
+                    poll_ms=2000, settle_ms=6000)
+        self.assertEqual(self.monitor_spawns(), [],
+                         "a machine with no phone daemon spawned a monitor")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dots/.config/quickshell/imi/tests/tst_phone_connect.qml
+++ b/dots/.config/quickshell/imi/tests/tst_phone_connect.qml
@@ -255,6 +255,150 @@ TestCase {
         compare(PhoneConnect.materialSymbol, "mobile_off")
     }
 
+    // ---- monitor match rule ----
+
+    function test_monitor_match_rule_narrows_at_the_bus() {
+        // busctl reports a signal's sender as the unique name it arrived on
+        // (":1.55" in the capture these fixtures come from), so the rule is
+        // the only place the daemon can be named.
+        const rule = PhoneConnect.monitorMatchRule("kdeconnect")
+        verify(rule.includes("type='signal'"))
+        verify(rule.includes("sender='org.kde.kdeconnect.daemon'"))
+        verify(rule.includes("path_namespace='/modules/kdeconnect'"))
+    }
+
+    function test_monitor_match_rule_is_empty_for_unverified_backends() {
+        // Valent has no rule because no live Valent daemon was reachable to
+        // verify its signal set against; an empty rule keeps it on the poll.
+        compare(PhoneConnect.monitorMatchRule("valent"), "")
+        compare(PhoneConnect.monitorMatchRule("none"), "")
+        compare(PhoneConnect.monitorMatchRule(""), "")
+    }
+
+    // ---- parseMonitorLine ----
+    //
+    // Every fixture below is a line captured verbatim from
+    // `busctl --user --json=short monitor` against the live KDE Connect
+    // daemon on the development machine, with the device id left as it came.
+
+    readonly property string reachableLine: '{"type":"signal","endian":"l","flags":1,"version":1,"cookie":325,"timestamp-realtime":1787149977815500,"sender":":1.55","path":"/modules/kdeconnect/devices/3b767a2479954eceaf9f1e7fa212f48e","interface":"org.kde.kdeconnect.device","member":"reachableChanged","payload":{"type":"b","data":[false]}}'
+    readonly property string deviceAddedLine: '{"type":"signal","endian":"l","flags":1,"version":1,"cookie":326,"timestamp-realtime":1787149977815282,"sender":":1.55","path":"/modules/kdeconnect","interface":"org.kde.kdeconnect.daemon","member":"deviceAdded","payload":{"type":"s","data":["3b767a2479954eceaf9f1e7fa212f48e"]}}'
+    readonly property string methodCallLine: '{"type":"method_call","endian":"l","flags":0,"version":1,"cookie":2,"timestamp-realtime":1787149465537256,"sender":":1.18439","destination":"org.kde.kdeconnect.daemon","path":"/modules/kdeconnect","interface":"org.kde.kdeconnect.daemon","member":"devices","payload":{"type":"","data":[]}}'
+
+    function test_parse_monitor_line_reads_a_real_signal() {
+        const signal = PhoneConnect.parseMonitorLine(reachableLine)
+        compare(signal.path, "/modules/kdeconnect/devices/3b767a2479954eceaf9f1e7fa212f48e")
+        compare(signal.iface, "org.kde.kdeconnect.device")
+        compare(signal.member, "reachableChanged")
+        compare(signal.args[0], false)
+    }
+
+    function test_parse_monitor_line_rejects_everything_that_is_not_a_signal() {
+        // A monitor sees the whole conversation, calls and returns included.
+        compare(PhoneConnect.parseMonitorLine(methodCallLine), null)
+        compare(PhoneConnect.parseMonitorLine(""), null)
+        compare(PhoneConnect.parseMonitorLine("   \n"), null)
+        compare(PhoneConnect.parseMonitorLine(null), null)
+        compare(PhoneConnect.parseMonitorLine("Failed to become monitor: Invalid match rule"), null)
+        compare(PhoneConnect.parseMonitorLine('{"type":"signal"'), null)
+        compare(PhoneConnect.parseMonitorLine('"just a string"'), null)
+    }
+
+    // ---- signalChangesDevices ----
+
+    function test_signal_changes_devices_accepts_the_verified_event_set() {
+        verify(PhoneConnect.signalChangesDevices(PhoneConnect.parseMonitorLine(reachableLine)))
+        verify(PhoneConnect.signalChangesDevices(PhoneConnect.parseMonitorLine(deviceAddedLine)))
+        for (const member of ["deviceRemoved", "deviceListChanged", "deviceVisibilityChanged",
+                              "pairingRequestsChanged"])
+            verify(PhoneConnect.signalChangesDevices({ iface: "org.kde.kdeconnect.daemon", member: member, args: [] }),
+                   `daemon.${member} should re-read`)
+        for (const member of ["pairStateChanged", "nameChanged", "typeChanged", "pluginsChanged"])
+            verify(PhoneConnect.signalChangesDevices({ iface: "org.kde.kdeconnect.device", member: member, args: [] }),
+                   `device.${member} should re-read`)
+        verify(PhoneConnect.signalChangesDevices({ iface: "org.kde.kdeconnect.device.battery", member: "refreshed", args: [true, 87] }))
+    }
+
+    function test_signal_changes_devices_reads_the_interface_out_of_properties_changed() {
+        verify(PhoneConnect.signalChangesDevices({
+            iface: "org.freedesktop.DBus.Properties", member: "PropertiesChanged",
+            args: ["org.kde.kdeconnect.device.battery", { "charge": 41 }, []]
+        }))
+        verify(!PhoneConnect.signalChangesDevices({
+            iface: "org.freedesktop.DBus.Properties", member: "PropertiesChanged",
+            args: ["org.freedesktop.UPower.Device", {}, []]
+        }))
+        verify(!PhoneConnect.signalChangesDevices({
+            iface: "org.freedesktop.DBus.Properties", member: "PropertiesChanged", args: []
+        }))
+    }
+
+    function test_signal_changes_devices_ignores_traffic_the_model_does_not_hold() {
+        // Both fire in the same burst as reachableChanged on a real daemon,
+        // and the SMS plugin's are the reason this is an allowlist: they
+        // share the device path and would re-read every device per message.
+        verify(!PhoneConnect.signalChangesDevices({ iface: "org.kde.kdeconnect.device", member: "linksChanged", args: [] }))
+        verify(!PhoneConnect.signalChangesDevices({ iface: "org.kde.kdeconnect.device", member: "statusIconNameChanged", args: [] }))
+        verify(!PhoneConnect.signalChangesDevices({ iface: "org.kde.kdeconnect.device.conversations", member: "conversationUpdated", args: [] }))
+        verify(!PhoneConnect.signalChangesDevices({ iface: "org.freedesktop.DBus", member: "NameOwnerChanged", args: [] }))
+        verify(!PhoneConnect.signalChangesDevices(null))
+    }
+
+    // ---- restart plan ----
+
+    function test_monitor_backoff_delay_doubles_and_caps() {
+        compare(PhoneConnect.monitorBackoffDelay(1), 1000)
+        compare(PhoneConnect.monitorBackoffDelay(2), 2000)
+        compare(PhoneConnect.monitorBackoffDelay(3), 4000)
+        compare(PhoneConnect.monitorBackoffDelay(4), 8000)
+        compare(PhoneConnect.monitorBackoffDelay(5), 16000)
+        compare(PhoneConnect.monitorBackoffDelay(6), 30000)
+        compare(PhoneConnect.monitorBackoffDelay(40), 30000)
+        // A caller that has not counted yet still waits a full rung, never 0.
+        compare(PhoneConnect.monitorBackoffDelay(0), 1000)
+        compare(PhoneConnect.monitorBackoffDelay(-3), 1000)
+    }
+
+    function test_monitor_exit_plan_backs_off_a_fast_exit() {
+        // busctl handed a rule the bus rejects exits in milliseconds; this is
+        // the case an unguarded `running` binding turns into a respawn loop.
+        const first = PhoneConnect.monitorExitPlan(0, 40, true, 30000, 5)
+        compare(first.retry, true)
+        compare(first.attempts, 1)
+        compare(first.delay, 1000)
+        const second = PhoneConnect.monitorExitPlan(1, 40, true, 30000, 5)
+        compare(second.attempts, 2)
+        compare(second.delay, 2000)
+    }
+
+    function test_monitor_exit_plan_stops_at_the_ceiling() {
+        const capped = PhoneConnect.monitorExitPlan(5, 40, true, 30000, 5)
+        compare(capped.retry, false)
+        compare(capped.delay, 0)
+        compare(capped.attempts, 5)
+    }
+
+    function test_monitor_exit_plan_resets_after_a_healthy_run() {
+        // Otherwise one daemon restart in a day-long session spends the
+        // ceiling and the shell never streams again.
+        const healthy = PhoneConnect.monitorExitPlan(4, 30000, true, 30000, 5)
+        compare(healthy.retry, true)
+        compare(healthy.attempts, 1)
+        compare(healthy.delay, 1000)
+        // ...including from the ceiling itself.
+        const recovered = PhoneConnect.monitorExitPlan(5, 120000, true, 30000, 5)
+        compare(recovered.retry, true)
+        compare(recovered.attempts, 1)
+    }
+
+    function test_monitor_exit_plan_does_not_restart_what_nobody_wants() {
+        const unwanted = PhoneConnect.monitorExitPlan(0, 40, false, 30000, 5)
+        compare(unwanted.retry, false)
+        compare(unwanted.delay, 0)
+        // A deliberate stop after a healthy run leaves no debt behind.
+        compare(PhoneConnect.monitorExitPlan(3, 90000, false, 30000, 5).attempts, 0)
+    }
+
     // ---- device id guard ----
 
     function test_valid_device_id_accepts_kdeconnect_and_valent_ids() {


### PR DESCRIPTION
Slice 1 of `docs/proposals/phone-connect.md` — signal-driven updates.

Battery, reachability and pairing changes arrived up to a full poll interval
late (10s by default, and that interval was already set gently because every
sweep is a chain of `busctl` spawns). They now arrive when they happen.

The shape is borrowed from the surveyed fork's `monitor.py` — the event set,
and the `GetAll` dump behind it — and none of its transport: no sidecar, no
Python, no PyGObject, no `qdbus`, and no 4s restart with no backoff. Every
read is still a `busctl --json=short` argv array.

## What landed

- **One `busctl --user --json=short monitor --match=…` per daemon appearance**,
  subscribed to
  `type='signal',sender='org.kde.kdeconnect.daemon',path_namespace='/modules/kdeconnect'`.
  The filter has to be at the bus: measured against the live daemon, a
  monitored signal's `sender` is the **unique** name it arrived on (`:1.55`),
  never the well-known name, so nothing in QML can tell the daemon's signals
  from anyone else's on the same path. Also measured: a positional `SERVICE`
  argument to `busctl monitor` does **not** narrow the stream (the capture came
  back full of an unrelated `name.giacomofurlan.ArctisManager`'s traffic and
  portal `Get`s), while `--match=` narrowed it to zero lines on the same bus.
- **The event set came from introspecting the live daemon**, not from the
  fork's source: `/modules/kdeconnect` emits `deviceAdded`, `deviceRemoved`,
  `deviceListChanged`, `deviceVisibilityChanged`, `pairingRequestsChanged`; a
  device path emits `reachableChanged`, `pairStateChanged`, `nameChanged`,
  `typeChanged`, `pluginsChanged`; the battery leaf emits `refreshed`. It is an
  allowlist rather than a prefix match because the SMS plugin's conversation
  signals share the device path.
- **A signal restarts a 120ms settle rather than sweeping.** One device leaving
  the network emitted **seven** signals within a millisecond of each other on
  the live daemon. The settle re-arms rather than firing while a sweep is in
  flight, because `refresh()` declines then and firing would drop the change
  that asked for it.
- **Lifetime, which is the rule `CONTRIBUTING.md` states outright.** No
  `running` binding — `busctl` handed a rule the bus rejects exits in
  milliseconds (`Call to org.freedesktop.DBus.Monitoring.BecomeMonitor failed:
  Invalid match rule`, exit 1, measured). It is started imperatively from
  `onBackendChanged`, restarted only through `monitorExitPlan` (capped
  exponential backoff 1s→30s, a ceiling of five **per daemon appearance**, and
  a healthy-run reset so one daemon restart in a long session does not spend
  the ceiling), and past the ceiling the poll is the whole update path again.
- **Nothing starts before detection.** The only arming site is a backend
  change, which only a `ListNames` sweep can produce, so a machine with neither
  daemon spawns exactly what it spawned before.
- **The poll did not go away.** Nothing announces a daemon *appearing* (there
  is no monitor running to hear it on), and a daemon that dies without a
  parting signal would freeze the model — so the timer stays on, gated exactly
  as before, at a reconcile cadence while the stream is live.

## Valent still polls, deliberately

No Valent daemon was reachable from this machine, so its signal set could not
be verified. `monitorMatchRule("valent")` returns `""`, nothing spawns a
monitor for it, and its updates are byte-for-byte what they were. A signal path
that only works for one backend is a regression in the other. The plausible
rule (ObjectManager `InterfacesAdded`/`Removed` plus `PropertiesChanged` on the
device paths and `org.gtk.Actions.Changed`) is written down in the proposal as
the starting point — plausible is not verified, and the contract test fails the
suite on a Valent rule appearing without one.

## Tests

The parsing/decision half is in the logic-only double (the byte-for-byte synced
region), reachable from `qmltestrunner`. The **process lifetime** is reachable
from nothing else in the suite, so it gets both a source contract and a real
runtime harness — `tests/test_phone_connect_monitor_runtime.py`, a real `qs`
under headless weston on its own `dbus-run-session` bus, with a fake `busctl`
whose `monitor` verb streams one signal in one case and exits instantly in the
other.

The stream case's poll interval is seeded at **ten minutes**, so the battery
change it asserts cannot have come from the timer. The crash case asserts the
spawn **timestamps** as well as the count, because "it stopped after six
spawns" is equally true of six spawns in six milliseconds — which is the
starvation bug itself.

That harness earned its place immediately: `monitorWanted` was first written as
a `readonly property bool` derived from `backend` and read from
`onBackendChanged` — AGENT.md's change-handler trap — so it answered with the
*previous* backend, the monitor never started, and **nothing showed it**,
because the poll kept the model correct the whole time (fe7954193).

### Plant-proofs

Every new check planted in a clean tree and reverted. Contract checks
(`tests/test_phone_connect_contract.py`), mutating `services/PhoneConnect.qml`:

| Mutation | Reddens |
| --- | --- |
| `// process-lifecycle: restart-safe …` → `running: root.monitorWanted` | `test_the_monitor_process_has_no_running_binding` |
| `monitorRestart.interval = plan.delay;` → `= 4000;` | `test_every_monitor_restart_goes_through_the_backoff_plan` |
| `root.monitorState = "failed";` → `= "idle";` | `test_the_ceiling_is_declared_and_the_stream_falls_back_to_polling` |
| a Valent branch added to `monitorMatchRule` | `test_valent_keeps_the_poll_because_its_signals_are_unverified` (and `test_parser_region_is_byte_identical_between_service_and_double`) |
| poll `interval:` → `root.pollInterval` | `test_the_poll_survives_as_the_reconcile_and_stays_gated` |
| the `signalSettle.restart()` re-arm removed | `test_signal_bursts_are_coalesced_and_never_dropped` |
| `` `--match=${matchRule}` `` → `"--match=" + matchRule` | `test_the_match_rule_is_one_argv_element_and_never_a_shell_string` |
| `monitorWanted()` → `readonly property bool monitorWanted` | `test_the_monitor_gate_is_a_function_not_a_binding` |

QML checks (`tests/tst_phone_connect.qml`), mutating the double:

| Mutation | Reddens |
| --- | --- |
| `Math.min(30000, …)` cap removed | `test_monitor_backoff_delay_doubles_and_caps` |
| `ranForMs >= healthyMs ? 0 : attempts` → `attempts` | `test_monitor_exit_plan_resets_after_a_healthy_run`, `…_does_not_restart_what_nobody_wants` |
| `settled >= ceiling` → `settled > ceiling` | `test_monitor_exit_plan_stops_at_the_ceiling` |
| an `iface.startsWith("org.kde.kdeconnect")` prefix match added | `test_signal_changes_devices_ignores_traffic_the_model_does_not_hold` |
| `doc.type !== "signal"` guard removed | `test_parse_monitor_line_rejects_everything_that_is_not_a_signal` |
| `path_namespace='…'` removed from the rule | `test_monitor_match_rule_narrows_at_the_bus` |

Runtime harness (`tests/test_phone_connect_monitor_runtime.py`):

| Mutation | Reddens |
| --- | --- |
| the gate back to a binding | `test_a_signal_delivers_a_change_the_poll_could_not_have` — `monitor state is running, got idle: FAIL` |
| `monitorRestart.interval = 50` | `test_an_instantly_exiting_monitor_is_backed_off_and_given_up_on` — `0.1 not greater than or equal to 0.8 : restart 1 came back after 0.1s, not 1s: [0.1, 0.1, 0.1, 0.1, 0.1]` |
| the ceiling term dropped from `monitorExitPlan` | same test — `monitor state is failed, got backoff: FAIL` |
| a Valent branch added to `monitorMatchRule` | `test_valent_is_never_streamed_because_its_signals_are_unverified` |
| the rule made non-empty for every backend **and** `whichProc` arming the monitor | `test_no_daemon_spawns_no_monitor` — `monitor state is idle, got backoff: FAIL` |

That last row is worth stating: the single-point version of it does **not**
redden, because the no-daemon guarantee rests on two independent defences — the
arming site (only a backend change) and the empty rule. Both have to be broken
for a monitor to reach a machine with no daemon.

### Full suite

`dots/.config/quickshell/imi/tests/run_tests.sh`, all of it:

```
Running Phone Connect contract tests...
13/13 contract checks passed
Running Phone Connect monitor runtime tests...
....
----------------------------------------------------------------------
Ran 4 tests in 84.406s

OK
...
Totals: 1124 passed, 0 failed, 0 skipped, 0 blacklisted, 5197ms
********* Finished testing of qmltestrunner *********
All tests passed successfully!
```

## Not verified

- **Valent's signals**, as above — no daemon available. It keeps the poll.
- **`battery.refreshed` on the wire.** The battery object only exists for a
  paired *and* reachable device, and the phone paired to this machine was out
  of range for the whole session — so that leaf's path and interface come from
  introspection and the fork, and the signal itself was exercised only through
  the fake `busctl`. The other ten members in the allowlist were captured
  live.
- **The live shell.** The service was loaded and driven in a real `qs -p`
  process by the runtime harness, but the user's running `qs -c imi` was not
  restarted and nothing was deployed to `~/.config/quickshell/imi`.

Docs: updated AGENT.md §Dynamic/data-driven QML gotchas (the `busctl monitor` streaming point) and §Directory map (services/PhoneConnect.qml), plus docs/proposals/phone-connect.md
Changelog: updated
