### PR TITLE
A wedged CI step fails in minutes instead of holding the queue for hours

### DIFF
--- a/.github/workflows/auto-close-issue.yml
+++ b/.github/workflows/auto-close-issue.yml
@@ -10,6 +10,9 @@ permissions:
 jobs:
   detect-and-close:
     runs-on: ubuntu-latest
+    # One api call; a job with no ceiling holds a runner until
+    # GitHub's six-hour limit and queues every other PR behind it.
+    timeout-minutes: 5
     steps:
       - name: Detect checked "ticked without reading" checkbox, comment, close and lock
         env:

--- a/.github/workflows/changelog-receipt.yml
+++ b/.github/workflows/changelog-receipt.yml
@@ -30,6 +30,9 @@ permissions:
 jobs:
   receipt:
     runs-on: ubuntu-latest
+    # A body grep plus one api call; a job with no ceiling holds a runner until
+    # GitHub's six-hour limit and queues every other PR behind it.
+    timeout-minutes: 5
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/dist-update-notification.yml
+++ b/.github/workflows/dist-update-notification.yml
@@ -12,6 +12,9 @@ on:
 jobs:
   comment_on_discussion:
     runs-on: ubuntu-latest
+    # One api call; a job with no ceiling holds a runner until
+    # GitHub's six-hour limit and queues every other PR behind it.
+    timeout-minutes: 10
     if: github.ref == 'refs/heads/main' && github.repository == 'end-4/dots-hyprland'
     steps:
       - name: Create comment on discussion #2140

--- a/.github/workflows/docs-receipt.yml
+++ b/.github/workflows/docs-receipt.yml
@@ -12,6 +12,9 @@ on:
 jobs:
   receipt:
     runs-on: ubuntu-latest
+    # A body grep; a job with no ceiling holds a runner until
+    # GitHub's six-hour limit and queues every other PR behind it.
+    timeout-minutes: 5
     steps:
       - name: Require a Docs receipt in the PR body
         env:

--- a/.github/workflows/dump-github-context.yml
+++ b/.github/workflows/dump-github-context.yml
@@ -6,6 +6,9 @@ on:
 jobs:
   dump_github_context:
     runs-on: ubuntu-latest
+    # An echo; a job with no ceiling holds a runner until
+    # GitHub's six-hour limit and queues every other PR behind it.
+    timeout-minutes: 5
     steps:
       - name: Dump github context
         run: echo "$GITHUB_CONTEXT"

--- a/.github/workflows/moderator.yml
+++ b/.github/workflows/moderator.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   spam-detection:
     runs-on: ubuntu-latest
+    # One model call; a job with no ceiling holds a runner until
+    # GitHub's six-hour limit and queues every other PR behind it.
+    timeout-minutes: 10
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,13 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    # The suite runs in about two and a half minutes. Without a ceiling a job
+    # that wedges runs until GitHub's own six-hour limit kills it, and every
+    # other PR queues behind the runner it is holding - which is what happened
+    # to 2be6995c9 ("release: 0.27.0") and, on the same day, to most of an
+    # eighteen-PR series. Ten times the normal run is generous for a slow
+    # runner and still fails within the hour.
+    timeout-minutes: 25
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -19,14 +26,36 @@ jobs:
           fetch-depth: 0
 
       - name: Install Qt6 Dependencies
+        # Every observed wedge has been here rather than in the suite: apt
+        # hangs against a mirror and the step never returns. A step timeout
+        # turns that into a red run in minutes instead of a held runner, and
+        # the retry covers the transient case a rerun would otherwise be
+        # needed for.
+        timeout-minutes: 10
+        env:
+          DEBIAN_FRONTEND: noninteractive
         run: |
-          sudo apt-get update
+          set -euo pipefail
+          # Bounded per attempt as well as per step: a single apt call that
+          # hangs would otherwise consume the whole step budget and leave no
+          # room for the retry to be worth having.
+          apt_get() {
+            for attempt in 1 2 3; do
+              if timeout 150 sudo -E apt-get "$@"; then
+                return 0
+              fi
+              echo "apt-get $1 failed (attempt $attempt of 3), retrying"
+              sleep $((attempt * 10))
+            done
+            return 1
+          }
+          apt_get update
           # ffmpeg: test_tonemap_sdr.py builds a real HDR10 fixture (libx265)
           # and drives the actual tonemap script; without ffmpeg those tests
           # skip and the SDR delivery path ships unexercised.
           # qt5compat supplies FastBlur, which WallpaperBlurSurface imports; without
           # it that type is simply "unavailable" and its test fails to compile.
-          sudo apt-get install -y qt6-declarative-dev qml6-module-qttest qml6-module-qtquick qml6-module-qtqml qml6-module-qtquick-controls qml6-module-qtquick-templates qml6-module-qtquick-layouts qml6-module-qtqml-workerscript qml6-module-qtquick-window qml6-module-qt5compat-graphicaleffects ffmpeg
+          apt_get install -y qt6-declarative-dev qml6-module-qttest qml6-module-qtquick qml6-module-qtqml qml6-module-qtquick-controls qml6-module-qtquick-templates qml6-module-qtquick-layouts qml6-module-qtqml-workerscript qml6-module-qtquick-window qml6-module-qt5compat-graphicaleffects ffmpeg
 
       # zstd builds the fixture release tarballs in
       # test_wallpaperengine_prebuilt.py and extracts them in the installer under

--- a/dots/.config/quickshell/imi/tests/lint_workflow_timeouts.py
+++ b/dots/.config/quickshell/imi/tests/lint_workflow_timeouts.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+#
+# Regression guard: every workflow job declares a `timeout-minutes`.
+#
+# A job without one runs until GitHub's own six-hour limit kills it. That is
+# not a slow test - the suite finishes in about two and a half minutes - it is
+# a runner held for six hours, and on a repository with one concurrent runner
+# every other PR queues behind it.
+#
+# Measured rather than supposed: run 32276396125 on 2be6995c9 ("release:
+# 0.27.0") sat on `Install Qt6 Dependencies` from 16:31 to 22:32 and was
+# cancelled by the limit, and most of an eighteen-PR series that same day spent
+# longer waiting for a runner than being tested. Every observed wedge was apt
+# against a mirror, never the suite itself, which is why the install step
+# carries its own tighter ceiling and a bounded retry.
+#
+# A ceiling is not a guess about how long the work takes - it is the answer to
+# "how long should this be allowed to hold the queue while broken". Ten times
+# the normal run is a generous ceiling and still fails within the hour.
+#
+# The check is deliberately textual rather than PyYAML: this suite runs with
+# whatever python3 the machine has, PyYAML is not a declared dependency of the
+# shell, and a check that silently skips when an import fails is the failure
+# mode `run_tests.sh` already had three of.
+#
+# Exits non-zero listing jobs with no ceiling. Wired into run_tests.sh / CI.
+
+import re
+import sys
+from pathlib import Path
+
+# tests/ sits five levels under the repo root.
+REPO = Path(__file__).resolve().parents[5]
+WORKFLOWS = REPO / ".github" / "workflows"
+
+JOB = re.compile(r"^  (?P<name>[A-Za-z0-9_-]+):\s*$")
+TIMEOUT = re.compile(r"^    timeout-minutes:\s*(\d+)\s*$")
+# A step's own ceiling is indented deeper and is not the job's.
+ANY_KEY_AT_JOB_LEVEL = re.compile(r"^  \S")
+
+
+def jobs_without_ceiling(text: str):
+    """(job, declared) for every job in one workflow file.
+
+    Read line by line against indentation rather than parsed: the shape being
+    checked is two levels deep and fixed by the schema, and this keeps the
+    check free of a dependency the rest of the suite does not have.
+    """
+    lines = text.splitlines()
+    try:
+        start = next(i for i, line in enumerate(lines) if line.rstrip() == "jobs:")
+    except StopIteration:
+        return []
+
+    found = []
+    current, ceiling = None, None
+    for line in lines[start + 1:]:
+        if line.strip() and not line.startswith(" "):
+            break  # a new top-level key: jobs: is over
+        match = JOB.match(line)
+        if match:
+            if current is not None:
+                found.append((current, ceiling))
+            current, ceiling = match.group("name"), None
+            continue
+        if current is not None and TIMEOUT.match(line):
+            ceiling = int(TIMEOUT.match(line).group(1))
+    if current is not None:
+        found.append((current, ceiling))
+    return found
+
+
+FIXTURE_UNCAPPED = """name: X
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+"""
+
+FIXTURE_CAPPED = """name: X
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: slow
+        timeout-minutes: 10
+        run: echo hi
+  second:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - run: echo hi
+"""
+
+
+def self_check():
+    """Prove the reader on fixtures, not on what the tree happens to hold.
+
+    The second fixture is the one that earns its place: a step's own
+    `timeout-minutes` is indented deeper than a job's, and a check that
+    matched it anywhere would read a capped step as a capped job and pass a
+    workflow that can still run for six hours.
+    """
+    problems = []
+    if jobs_without_ceiling(FIXTURE_UNCAPPED) != [("build", None)]:
+        problems.append("self-check: an uncapped job was not reported")
+    if jobs_without_ceiling(FIXTURE_CAPPED) != [("build", 25), ("second", 5)]:
+        problems.append("self-check: a capped job or its step ceiling was misread")
+    return problems
+
+
+def main() -> int:
+    failures = self_check()
+
+    if not WORKFLOWS.is_dir():
+        print(f"workflow timeouts: {WORKFLOWS} does not exist - the check is "
+              f"looking in the wrong place", file=sys.stderr)
+        return 1
+
+    files = sorted(WORKFLOWS.glob("*.yml")) + sorted(WORKFLOWS.glob("*.yaml"))
+    if not files:
+        failures.append("no workflow files found - the sweep covers nothing")
+
+    checked = 0
+    for path in files:
+        for job, ceiling in jobs_without_ceiling(path.read_text(encoding="utf-8")):
+            checked += 1
+            if ceiling is None:
+                failures.append(
+                    f"{path.name}: job `{job}` declares no timeout-minutes. A "
+                    f"wedged step then holds a runner until GitHub's six-hour "
+                    f"limit and every other PR queues behind it - which is how "
+                    f"the 0.27.0 release run spent six hours inside apt.")
+
+    for failure in failures:
+        print(f"workflow timeouts: {failure}", file=sys.stderr)
+    if failures:
+        return 1
+    print(f"Workflow timeout lint passed: {checked} jobs, all with a ceiling")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -136,6 +136,16 @@ if ! python3 "$SCRIPT_DIR/test_effective_scale_contract.py"; then
     exit 1
 fi
 
+# Static lint: every workflow job declares a timeout. A job with no ceiling
+# runs until GitHub's six-hour limit when a step wedges, holding the only
+# runner while every other PR queues behind it - measured on the 0.27.0
+# release run, which spent six hours inside apt.
+echo "Running workflow timeout lint..."
+if ! python3 "$SCRIPT_DIR/lint_workflow_timeouts.py"; then
+    echo "Workflow timeout lint failed."
+    exit 1
+fi
+
 echo "Running test import symlink lint..."
 if ! python3 "$SCRIPT_DIR/lint_test_import_symlinks.py"; then
     echo "Test import symlink lint failed."


### PR DESCRIPTION
## What happened
The `QML Tests` run on `2be6995c9` ("release: 0.27.0") — run [32276396125](https://github.com/XephyLon/immaterial-impulse/actions/runs/32276396125) — sat inside `Install Qt6 Dependencies` from **16:31 to 22:32** and was cancelled by GitHub's six-hour job limit. It read as a failed release. Re-running the same commit passed in the usual time, so nothing was wrong with the code.

The suite takes about two and a half minutes. What burned six hours was apt hanging against a mirror with nothing to stop it — and on a repository with one concurrent runner, that is not one slow run, it is **every other PR queued behind it**. Most of an eighteen-PR series that same day spent longer waiting for a runner than being tested.

**No workflow in this repository declared a timeout.**

## The ceilings
Each answers "how long should this be allowed to hold the queue while broken", not "how long does the work take":

| Job | Ceiling | Why |
|---|---|---|
| `tests.yml` → `test` | 25 min | ten times a normal run |
| `Install Qt6 Dependencies` step | 10 min | every wedge observed has been here, never in the suite |
| the six one-shot workflows | 5–10 min | a body grep cannot legitimately take longer |

The install step also gets a **bounded retry**: each apt call is capped at 150s and tried three times with a growing pause, so the transient case stops needing a human to press rerun. Per-attempt as well as per-step, because one hanging call would otherwise eat the whole step budget and leave no room for the retry to be worth having.

## The check
`tests/lint_workflow_timeouts.py` fails on any workflow job that declares no ceiling.

It reads the file rather than parsing YAML deliberately: PyYAML is not a declared dependency of this suite, and a check that silently skips when an import fails is the exact no-op shape `run_tests.sh` has already shipped three of. Its second fixture is the one that earns its place — a **step's** own `timeout-minutes` is indented deeper than a **job's**, and a check matching it anywhere would read a capped step as a capped job and pass a workflow that can still run for six hours.

**Plant-proof** (clean tree, after committing): removed `timeout-minutes: 5` from `docs-receipt.yml` → `workflow timeouts: docs-receipt.yml: job \`receipt\` declares no timeout-minutes…`, exit 1; restored → passes, 7 jobs all with a ceiling.

**Tests**: full `tests/run_tests.sh` — all tests passed, exit 0.

**Not verified**: that a real apt hang now reddens at ten minutes rather than six hours. That needs a wedge to happen again; the retry loop's shape is exercised only by reading it.

Changelog: not user-visible — CI runner behaviour only

Docs: not needed — the reasoning, the measurement and the run id are in the lint's header and the workflow comments, which is where the next person editing a ceiling is standing
