### PR TITLE
Arrow keys move a selected desktop widget one lattice cell

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -3199,6 +3199,29 @@ mode is built out of are worth not re-deriving:
   feat(editMode): Ctrl+Z reverses the last committed mutation, on the surface the keyboard reaches;
   test(editMode): drive undo's record, reverse and gate, and pin its shape;
   fix(editMode): a group release is one undo entry, and undoing a first commit leaves no null behind.)
+- **An undo BATCH replays backwards, and a keyboard step moves the PLACEMENT
+  coordinate rather than the drawn one.** Both were found building the arrow-key
+  nudge, and both are traps the mouse could never spring. A batch is one
+  gesture's commits, so reversing it means walking from the end: three arrow
+  steps on one widget push "back to 36", "back to 48", "back to 60", and
+  replaying those in order leaves the widget where the second press left it —
+  Ctrl+Z appearing to move it *forward*. The group drag that introduced batches
+  could not show it, because its entries are one per widget and independent, so
+  any order looks right. And `x` is the DRAWN coordinate, carrying a position
+  Behavior: a step that assigned to it and committed in the same turn read the
+  value the animation had not reached yet and stored that back, so the widget
+  returned to where it started — measured as three presses with `x` unchanged at
+  36, the keys reading as completely inert. `AbstractWidget.moveTargetBy` moves
+  `targetX`/`targetY` and `PluginWidget.commitPlacement` — the tail of
+  `commitPosition`, shared rather than copied — writes the store from them, so a
+  translation needs no conversion (the parallax cancellation is constant across
+  the step) and the two ways of moving a widget cannot disagree about what is
+  persisted. The lattice for the step comes from the CANVAS: `PluginWidget`
+  shadows `gridSize` with its component-grid span, so one read off a widget from
+  the canvas is an object and every step is silently NaN (8a534a7da).
+  (feat(widgetCanvas): widget_nudge.js, a keyboard step as arithmetic;
+  feat(widgetCanvas): arrow keys move a selected widget one lattice cell;
+  fix(editMode): an undo batch replays its entries backwards.)
 (feat(editMode): shrink the desktop into a viewport on the background surface,
 feat(editMode): stand the per-widget frost down for the mode,
 feat(editMode): draw the shrunk desktop as a card, not as a cropped screenshot,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ own repo; the installer pins which revision it builds.
 
 ## [Unreleased]
 
+### Added
+- **Arrow keys move a selected desktop widget.** Click a widget — or drag a
+  marquee over several — and each arrow press moves the selection one grid
+  cell, on the plain desktop as well as in Edit Mode. A widget sitting off the
+  grid is put back on it by the first press, so a widget placed by keyboard
+  ends up on the same lattice as one placed by mouse, and a group travels as a
+  block, stopping when its first member reaches the screen edge rather than
+  spreading out against it. Holding a key down is one undo, not fifty.
+
+### Fixed
+- **Undoing a multi-step gesture no longer stops halfway.** A gesture that
+  moved one widget several times in a row undid to the second-to-last step
+  instead of the start, because the steps were replayed in the order they were
+  made. Group drags were never affected.
+
 ## [0.27.0] — 2026-08-19
 
 The shell's motion catches up with itself: bar widgets travel instead of

--- a/dots/.config/quickshell/imi/EditModeRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/EditModeRuntimeTest.qml
@@ -452,6 +452,98 @@ ShellRoot {
             canvas.clearSelection();
         },
 
+        // ---- arrow-key nudge: one lattice cell, the group rigid -----------
+        //
+        // The keys themselves are not driven here. A key event has no explicit
+        // target - TestCase sends it to the focused item of ITS OWN window -
+        // and the canvas takes its focus from the background LAYER surface,
+        // which weston does not implement. What a harness can hold is
+        // everything after the key: the step, the group's rigidity, the clamp
+        // at the wall, the store write and the undo grain. That the surface
+        // receives real compositor keys at all was measured once, in a nested
+        // Hyprland, for the undo that shares this handler (spec §11.4 probe 4).
+        () => { canvas.clearSelection(); harness.placeWidgets(); },
+        () => {
+            canvas.applySelection([movableWidget]);
+            harness.before = { x: movableWidget.x, y: movableWidget.y };
+            canvas.nudgeSelection(1, 0);
+        },
+        () => {
+            harness.check("an arrow moves the widget one lattice cell",
+                          movableWidget.x - harness.before.x === canvas.gridSize);
+            harness.check("...and the move is in the store, not only on screen",
+                          Math.round(harness.storedPosition("edit-move-probe").x)
+                              === Math.round(harness.before.x + canvas.gridSize));
+        },
+        () => {
+            // Off the lattice on purpose: the edge snap parks a widget one gap
+            // off a neighbour's edge, and a stored position can predate a
+            // lattice change. The first press is the one that gets it back on.
+            movableWidget.x = harness.before.x + 5;
+            movableWidget.commitPosition();
+            harness.before = { x: movableWidget.x, y: movableWidget.y };
+            canvas.nudgeSelection(1, 0);
+        },
+        () => harness.check("a press from off the lattice lands back on it",
+                            movableWidget.x % canvas.gridSize === 0),
+        () => {
+            // Both widgets, and the follower is the one against the wall.
+            canvas.clearSelection();
+            harness.placeWidgets();
+            canvas.applySelection([movableWidget, resizableWidget]);
+            resizableWidget.moveTargetBy(
+                resizableWidget.clampX(Infinity) - resizableWidget.targetX, 0);
+            resizableWidget.commitPlacement(0, resizableWidget.targetY);
+            harness.before = {
+                leader: movableWidget.targetX, follower: resizableWidget.targetX
+            };
+            canvas.nudgeSelection(1, 0);
+        },
+        () => {
+            harness.check("a member already at the wall does not pass it",
+                          resizableWidget.targetX === harness.before.follower);
+            // The cluster is rigid: the one with room does not travel on
+            // alone, which is the answer a group drag gives at an edge and
+            // the reason the delta is shrunk once for every member rather
+            // than clamped per widget.
+            harness.check("...and the member with room stays with it",
+                          movableWidget.targetX === harness.before.leader);
+            canvas.clearSelection();
+        },
+        () => {
+            // One burst, one undo entry: a held arrow key delivers a press
+            // every ~30ms, and an entry each would fill a fifty-deep stack in
+            // under two seconds.
+            harness.placeWidgets();
+            GlobalStates.editUndoStack = [];
+            canvas.applySelection([movableWidget]);
+            harness.before = { x: movableWidget.targetX, y: movableWidget.targetY };
+            canvas.nudgeSelection(1, 0);
+            canvas.nudgeSelection(1, 0);
+            canvas.nudgeSelection(1, 0);
+            harness.check("three presses travel three cells",
+                          movableWidget.targetX - harness.before.x === canvas.gridSize * 3);
+            // Asserted in THIS step rather than the next: the batch closes on
+            // a 400ms timer (a key repeat has no release to hang it on) and
+            // the harness ticks at 700, so by the next step it is already
+            // closed and the check would be vacuous.
+            harness.check("...a burst mid-flight has not pushed its entry yet",
+                          GlobalStates.editUndoStack.length === 0);
+        },
+        () => {
+            harness.check("a settled burst is exactly one undo entry",
+                          GlobalStates.editUndoStack.length === 1);
+            GlobalStates.editUndo();
+        },
+        () => {
+            harness.check("undoing the burst returns the widget to where it started",
+                          Math.round(harness.storedPosition("edit-move-probe").x)
+                              === Math.round(harness.before.x));
+            harness.check("...all three cells at once, not one press at a time",
+                          GlobalStates.editUndoStack.length === 0);
+            canvas.clearSelection();
+        },
+
         // ---- leaving mid-drag cancels, it does not commit ------------------
         () => { harness.placeWidgets(); },
         () => {

--- a/dots/.config/quickshell/imi/GlobalStates.qml
+++ b/dots/.config/quickshell/imi/GlobalStates.qml
@@ -227,8 +227,15 @@ Singleton {
             root.editUndoStack = EditMode.undoPush(root.editUndoStack, entries[0]);
             return;
         }
+        // BACKWARDS. A batch of one gesture's commits is a sequence, and
+        // reversing a sequence means walking it from the end: three arrow-key
+        // steps on one widget push "back to 36", "back to 48", "back to 60",
+        // and replaying those in order leaves it at 60 - the last entry wins
+        // and the undo appears to move the widget forward. The group drag that
+        // introduced batches never showed it, because its entries are one per
+        // widget and independent, so any order looks right.
         root.editUndoStack = EditMode.undoPush(root.editUndoStack, () => {
-            for (const entry of entries) entry();
+            for (let index = entries.length - 1; index >= 0; index--) entries[index]();
         });
     }
     function editUndoPush(entry) {

--- a/dots/.config/quickshell/imi/modules/common/functions/widget_nudge.js
+++ b/dots/.config/quickshell/imi/modules/common/functions/widget_nudge.js
@@ -1,0 +1,99 @@
+.pragma library
+
+// Moving a selected widget with the arrow keys, as arithmetic.
+//
+// Pure for the reason every other decision on this canvas is: nothing about a
+// rendered widget is reachable from qmltestrunner, so the part worth checking
+// - where a press lands, and what a group does when one member reaches a wall
+// - has to live somewhere a test can call.
+//
+// One press is one lattice cell. There is deliberately no fine mode: a widget
+// placed by keyboard lands on the same grid as one placed by mouse, which is
+// what makes the two ways of moving a widget agree about where things sit.
+
+// The lattice step for a key, or null for a key this does not answer. Returned
+// as a direction rather than a distance so the caller supplies the lattice -
+// the canvas scales it, and a module that read a token would be a second place
+// that has to agree about the cell size.
+function direction(key, keys) {
+    const k = keys || {};
+    if (key === k.left) return { dx: -1, dy: 0 };
+    if (key === k.right) return { dx: 1, dy: 0 };
+    if (key === k.up) return { dx: 0, dy: -1 };
+    if (key === k.down) return { dx: 0, dy: 1 };
+    return null;
+}
+
+// Where one press lands: a whole cell along, snapped back onto the lattice.
+//
+// The snap is not redundant. A widget can sit OFF the lattice - the edge snap
+// parks it one gap from a neighbour's edge (measured: 465 on a 12px lattice),
+// and a stored position predating a lattice change is off it too. Adding a
+// cell to 465 gives 477, which is still off; rounding the sum lands 480 and
+// every press after it is a clean cell. The first press of such a burst
+// therefore moves 15px rather than 12, which is the whole point: it is the
+// press that gets the widget onto the grid.
+//
+// `origin` is the lattice's own offset in this axis (AbstractWidget's
+// snapOffsetX/Y), because a subclass whose coordinate is not the one it stores
+// moves the lattice into the frame it means something in.
+function step(current, delta, lattice, origin) {
+    const cell = positive(lattice);
+    if (cell === 0) return current + delta;
+    const base = origin || 0;
+    return Math.round((current + delta - base) / cell) * cell + base;
+}
+
+// The delta a whole selection may travel, given what each member can take.
+//
+// A group moves rigidly - the same answer the group drag gives, where the
+// cluster stops when its FIRST member reaches an edge rather than deforming
+// as members clamp individually. So the shared delta is shrunk to the
+// smallest headroom in the direction of travel, and a selection already
+// against the wall does not move at all (which is what makes a nudge into a
+// wall commit nothing, rather than writing every member's unchanged position
+// back and filling the undo stack).
+//
+// Members are { x, y, minX, maxX, minY, maxY }; the bounds are each member's
+// own clamp, since widgets differ in size.
+function groupDelta(members, dx, dy) {
+    const list = asList(members);
+    if (list.length === 0) return { dx: 0, dy: 0 };
+    let allowedX = dx;
+    let allowedY = dy;
+    for (const member of list) {
+        allowedX = shrink(allowedX, member.x, member.minX, member.maxX);
+        allowedY = shrink(allowedY, member.y, member.minY, member.maxY);
+    }
+    return { dx: allowedX, dy: allowedY };
+}
+
+// How far one member may travel before its own clamp bites, capped by what the
+// group has already agreed to.
+function shrink(delta, value, minimum, maximum) {
+    if (delta === 0) return 0;
+    const low = isNumber(minimum) ? minimum : -Infinity;
+    const high = isNumber(maximum) ? maximum : Infinity;
+    if (delta > 0) return Math.max(0, Math.min(delta, high - value));
+    return Math.min(0, Math.max(delta, low - value));
+}
+
+function isNumber(value) {
+    return typeof value === "number" && isFinite(value);
+}
+
+function positive(value) {
+    return isNumber(value) && value > 0 ? value : 0;
+}
+
+// Array-LIKENESS, not Array.isArray: a list that has crossed a QML property
+// boundary keeps its indices and its length and loses the brand.
+function asList(value) {
+    if (value === null || value === undefined) return [];
+    if (typeof value.length !== "number") return [];
+    const out = [];
+    for (let index = 0; index < value.length; index++) {
+        if (value[index]) out.push(value[index]);
+    }
+    return out;
+}

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
@@ -631,6 +631,16 @@ AbstractBackgroundWidget {
         rootWidget.targetY = rootWidget.clampY(ParallaxMath.placementFromDrawn(
             rootWidget.y, rootWidget.parallaxCancelY));
         rootWidget.restoreXYBinding();
+        rootWidget.commitPlacement(beforeX, beforeY);
+    }
+
+    // The store write, from targetX/targetY rather than from the drawn
+    // coordinate. Split out because a nudge has no drawn coordinate to read:
+    // `x` carries a position Behavior, so a keyboard step that assigned to it
+    // and committed in the same turn read the value the animation had not left
+    // yet, wrote it back as the target, and the widget snapped home - a move
+    // that looked like the keys doing nothing at all.
+    function commitPlacement(beforeX, beforeY) {
         if (!manifest) return;
         // A drag's release is a committed mutation (spec §7.3), and this is
         // its one commit path - the leader's release and every group-drag

--- a/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/AbstractWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/AbstractWidget.qml
@@ -223,6 +223,22 @@ MouseArea {
     // object from out there. Nothing warns.
     property real snapOffsetX: 0
     property real snapOffsetY: 0
+    // Move by a delta without a gesture: the keyboard's step.
+    //
+    // It writes targetX/targetY - the coordinate the widget is PLACED at -
+    // rather than `x`, which is the drawn one and carries a position Behavior.
+    // Assigning the drawn coordinate and committing in the same turn reads the
+    // value the animation has not reached yet and stores it back, so the widget
+    // returns to where it started and the keys look inert (measured: three
+    // presses, x unchanged at 36). A translation is the same delta in both
+    // frames, so nothing has to be converted here - the parallax cancellation
+    // is a constant across the step.
+    function moveTargetBy(dx, dy) {
+        root.targetX = root.clampX(root.targetX + dx)
+        root.targetY = root.clampY(root.targetY + dy)
+        root.restoreXYBinding()
+    }
+
     function snapX(value) { return root.snap(value - root.snapOffsetX) + root.snapOffsetX }
     function snapY(value) { return root.snap(value - root.snapOffsetY) + root.snapOffsetY }
 

--- a/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/WidgetCanvas.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/widgetCanvas/WidgetCanvas.qml
@@ -2,6 +2,7 @@ import QtQuick
 import qs
 import qs.modules.common
 import "../../functions/edit_mode.js" as EditMode
+import "../../functions/widget_nudge.js" as Nudge
 
 MouseArea {
     id: root
@@ -109,6 +110,21 @@ MouseArea {
     // COMMITTED mutation, Escape cancels the gesture still in flight, and
     // the two never answer the same moment.
     Keys.onPressed: (event) => {
+        // The arrows come first and are NOT gated on the mode. Selecting a
+        // widget is what takes this surface's keyboard focus (see
+        // keyboardFocusHeld), in the mode and out of it, so a selection the
+        // user can make is a selection they can move. Outside the mode the
+        // move still commits - it goes through the same commitPosition the
+        // drag does - and simply records no undo entry, because
+        // GlobalStates.editUndoPush is a no-op there. That is the existing
+        // grain rather than a new rule: a drag outside the mode is already
+        // unrecorded.
+        const nudge = Nudge.direction(event.key, root.arrowKeys)
+        if (nudge && root.selectedWidgets.length > 0) {
+            root.nudgeSelection(nudge.dx, nudge.dy)
+            event.accepted = true
+            return
+        }
         if (!root.editMode) return
         // Exactly Control, not "Control among others": Ctrl+Shift+Z is
         // convention's redo, and a redo stack is deliberately not built -
@@ -146,6 +162,86 @@ MouseArea {
         else if (action === "desktopTab") GlobalStates.editTab = EditMode.DESKTOP_TAB
         else if (root.editMode) GlobalStates.editMode = false
     }
+    // The four keys, named once. The module takes them as an argument rather
+    // than reaching for Qt itself, because a `.pragma library` has no engine
+    // context - the same reason the weather forecast's locale is passed in.
+    readonly property var arrowKeys: ({
+        left: Qt.Key_Left, right: Qt.Key_Right,
+        up: Qt.Key_Up, down: Qt.Key_Down
+    })
+
+    // A burst of presses is ONE undo entry, the way a group drag's release is.
+    // Auto-repeat delivers presses every ~30ms, and an entry each would fill a
+    // fifty-deep stack in a second and a half - so Ctrl+Z would answer a held
+    // arrow key with fifty presses of its own. The batch closes a beat after
+    // the last press rather than on release: a key repeat has no release to
+    // hang it on.
+    Timer {
+        id: nudgeBatch
+        interval: 400
+        onTriggered: GlobalStates.editUndoEndBatch()
+    }
+
+    // Move every selected widget one lattice cell. The delta is decided by the
+    // FIRST selected widget - the group translates rigidly, which is the same
+    // answer widgetDragStarted gives its followers - and then shrunk to what
+    // every member's own clamp allows, so a cluster stops at the first wall
+    // instead of deforming against it.
+    function nudgeSelection(dirX, dirY) {
+        const members = []
+        for (const widget of root.selectedWidgets) {
+            if (!widget || !widget.draggable) continue
+            members.push(widget)
+        }
+        if (members.length === 0) return
+        const leader = members[0]
+        // The canvas's own lattice, never the widget's. `AbstractWidget.gridSize`
+        // IS this number, but `PluginWidget` shadows the name with its
+        // component-grid span, so a lattice read off a widget from out here is
+        // `{"cols":2,"rows":1}` and every step silently becomes NaN. Same
+        // number, and the one the grid is drawn at (8a534a7da).
+        const lattice = root.gridSize
+        // Where the LEADER would land: a whole cell along, snapped back onto
+        // the lattice in its own frame. Every member then travels by that
+        // difference, so the cluster keeps its shape.
+        // Measured against the PLACEMENT coordinate, which is what the step
+        // moves and what the store holds - `x` is the drawn one and lags it
+        // through the position animation.
+        const wantX = dirX === 0 ? leader.targetX
+            : Nudge.step(leader.targetX, dirX * lattice, lattice, leader.snapOffsetX)
+        const wantY = dirY === 0 ? leader.targetY
+            : Nudge.step(leader.targetY, dirY * lattice, lattice, leader.snapOffsetY)
+        // Each member's own bounds, asked of its own clamp rather than
+        // recomputed here: the widgets differ in size, and a second derivation
+        // of "how far may this go" is the disagreement 705e9006d fixed between
+        // the two sides of the store.
+        const bounded = Nudge.groupDelta(members.map(widget => ({
+            x: widget.targetX,
+            y: widget.targetY,
+            minX: widget.clampX(-Infinity),
+            maxX: widget.clampX(Infinity),
+            minY: widget.clampY(-Infinity),
+            maxY: widget.clampY(Infinity)
+        })), wantX - leader.targetX, wantY - leader.targetY)
+        if (bounded.dx === 0 && bounded.dy === 0) return
+
+        // One entry for the burst, opened on the first press of it. Opening it
+        // per press would be one entry each; opening it once and never closing
+        // it would swallow every later mutation into the same undo.
+        if (!nudgeBatch.running) GlobalStates.editUndoBeginBatch()
+        nudgeBatch.restart()
+
+        for (const widget of members) {
+            const beforeX = widget.targetX
+            const beforeY = widget.targetY
+            widget.moveTargetBy(bounded.dx, bounded.dy)
+            // The same store write the drag's release performs, from the same
+            // place, so the two ways of moving a widget cannot disagree about
+            // what gets persisted or what an undo reverses.
+            if (widget.commitPlacement) widget.commitPlacement(beforeX, beforeY)
+        }
+    }
+
     readonly property bool keyboardFocusHeld: root.selectedWidgets.length > 0 || root.editMode
     onKeyboardFocusHeldChanged: {
         root.setKeyboardFocusRequest(root, root.keyboardFocusHeld)

--- a/dots/.config/quickshell/imi/tests/test_edit_mode_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_edit_mode_runtime.py
@@ -40,7 +40,7 @@ SOCKET = "wayland-imi-edit-mode"
 # The harness prints how many checks it ran. A literal rather than anything read
 # back out of that output: a harness whose step list shrinks must redden here
 # instead of reporting `failures: 0` for a shorter run.
-EXPECTED_CHECKS = 77
+EXPECTED_CHECKS = 87
 
 
 def _stop(proc):

--- a/dots/.config/quickshell/imi/tests/test_widget_group_selection.py
+++ b/dots/.config/quickshell/imi/tests/test_widget_group_selection.py
@@ -194,15 +194,36 @@ class GroupDragIsRigid(unittest.TestCase):
     def test_the_plugin_commit_still_restores_the_binding_and_persists(self):
         """Dropping `restoreXYBinding()` leaves every group member frozen at
         its last dragged position for the session (forceCenter dies with it);
-        dropping `setPosition` makes a group move revert on restart. Both
+        dropping the store write makes a group move revert on restart. Both
         halves read fine on their own.
+
+        The write lives in `commitPlacement` now, which the keyboard step
+        also calls - it takes the placement coordinate the caller already
+        knows, because `x` lags it through the position Behavior and a step
+        that read `x` stored a value the animation had not reached. So the
+        guarantee is the same and spread over two functions: the drag's
+        commit must still restore the binding AND still reach the write,
+        and the write must still be a `setPosition`. Checking only
+        `commitPosition` for the call would pass on a `commitPlacement`
+        that had quietly stopped persisting anything.
         """
+        source = uncommented(HOST)
         match = re.search(r"function commitPosition\(\)\s*\{(.*?)\n    \}",
-                          uncommented(HOST), re.S)
+                          source, re.S)
         self.assertIsNotNone(match)
         body = match.group(1)
         self.assertIn("restoreXYBinding()", body)
-        self.assertIn("PluginState.setPosition", body)
+        self.assertIn("commitPlacement(", body)
+
+        placement = re.search(
+            r"function commitPlacement\(beforeX, beforeY\)\s*\{(.*?)\n    \}",
+            source, re.S)
+        self.assertIsNotNone(
+            placement,
+            "commitPlacement is gone - the drag and the keyboard step share it, "
+            "so both stop persisting together")
+        self.assertIn("PluginState.setPosition", placement.group(1))
+        self.assertIn("GlobalStates.editUndoPush", placement.group(1))
 
 
 class TheSelectionIsVisible(unittest.TestCase):

--- a/dots/.config/quickshell/imi/tests/tst_widget_nudge.qml
+++ b/dots/.config/quickshell/imi/tests/tst_widget_nudge.qml
@@ -1,0 +1,107 @@
+import QtTest
+import QtQuick
+import "../modules/common/functions/widget_nudge.js" as Nudge
+
+// Arrow-key nudging of a selected desktop widget. Three decisions live in the
+// module: which keys are a direction at all, where one press lands (a whole
+// lattice cell along, snapped back ONTO the lattice, because a widget can sit
+// off it), and what a multi-widget selection does when one member reaches a
+// wall. Nothing about the rendered canvas or the key delivery is reachable
+// from qmltestrunner, so the arithmetic is the half a test can hold.
+TestCase {
+    name: "WidgetNudge"
+
+    readonly property var keys: ({
+        left: Qt.Key_Left, right: Qt.Key_Right,
+        up: Qt.Key_Up, down: Qt.Key_Down
+    })
+
+    function test_each_arrow_is_one_direction() {
+        compare(Nudge.direction(Qt.Key_Left, keys), { dx: -1, dy: 0 });
+        compare(Nudge.direction(Qt.Key_Right, keys), { dx: 1, dy: 0 });
+        compare(Nudge.direction(Qt.Key_Up, keys), { dx: 0, dy: -1 });
+        compare(Nudge.direction(Qt.Key_Down, keys), { dx: 0, dy: 1 });
+    }
+
+    function test_a_key_that_is_not_an_arrow_is_not_a_direction() {
+        // The handler leaves such a key unaccepted, so Escape still reaches
+        // the ladder and Ctrl+Z still reaches undo.
+        compare(Nudge.direction(Qt.Key_Escape, keys), null);
+        compare(Nudge.direction(Qt.Key_Z, keys), null);
+        compare(Nudge.direction(Qt.Key_Left, {}), null);
+    }
+
+    function test_a_press_from_the_lattice_moves_exactly_one_cell() {
+        compare(Nudge.step(96, 12, 12, 0), 108);
+        compare(Nudge.step(96, -12, 12, 0), 84);
+    }
+
+    function test_a_press_from_off_the_lattice_lands_on_it() {
+        // 465 is a measured edge-snap landing: one gap off a neighbour's edge,
+        // which the lattice cannot produce. The first press gets it onto the
+        // grid, so it travels 15 rather than 12 - and the next one is clean.
+        compare(Nudge.step(465, 12, 12, 0), 480);
+        compare(Nudge.step(480, 12, 12, 0), 492);
+    }
+
+    function test_the_lattice_can_be_offset() {
+        // A subclass whose coordinate is not the one it stores moves the
+        // lattice into its own frame (AbstractWidget's snapOffsetX/Y).
+        compare(Nudge.step(101, 12, 12, 5), 113);
+        compare(Nudge.step(100, 12, 12, 4), 112);
+    }
+
+    function test_a_lattice_of_zero_still_moves_by_the_delta() {
+        // Rather than dividing by it and answering NaN, which is a legal
+        // double nothing downstream rejects.
+        compare(Nudge.step(50, 12, 0, 0), 62);
+        compare(Nudge.step(50, 12, -12, 0), 62);
+    }
+
+    function test_a_lone_widget_travels_the_whole_delta() {
+        const members = [{ x: 96, y: 96, minX: 0, maxX: 500, minY: 0, maxY: 500 }];
+        compare(Nudge.groupDelta(members, 12, 0), { dx: 12, dy: 0 });
+    }
+
+    function test_the_group_stops_when_its_first_member_reaches_the_wall() {
+        // The group-drag rule: the cluster stops rather than deforming, so
+        // the member with the least headroom decides for all of them.
+        const members = [
+            { x: 96, y: 0, minX: 0, maxX: 500, minY: 0, maxY: 500 },
+            { x: 494, y: 0, minX: 0, maxX: 500, minY: 0, maxY: 500 }
+        ];
+        compare(Nudge.groupDelta(members, 12, 0), { dx: 6, dy: 0 });
+    }
+
+    function test_a_selection_already_against_the_wall_does_not_move() {
+        // Which is what keeps a nudge into a wall from committing every
+        // member's unchanged position and filling the undo stack.
+        const members = [{ x: 500, y: 0, minX: 0, maxX: 500, minY: 0, maxY: 500 }];
+        compare(Nudge.groupDelta(members, 12, 0), { dx: 0, dy: 0 });
+        compare(Nudge.groupDelta(members, -12, 0), { dx: -12, dy: 0 });
+    }
+
+    function test_each_axis_is_shrunk_on_its_own() {
+        const members = [
+            { x: 500, y: 96, minX: 0, maxX: 500, minY: 0, maxY: 500 },
+            { x: 96, y: 96, minX: 0, maxX: 500, minY: 0, maxY: 500 }
+        ];
+        // Blocked rightward, free downward: a diagonal is not a thing the
+        // keys produce, but the shrink must not leak between axes.
+        compare(Nudge.groupDelta(members, 12, 12), { dx: 0, dy: 12 });
+    }
+
+    function test_an_empty_or_unbranded_selection_answers_zero() {
+        // A list that has crossed a QML property boundary keeps its length
+        // and loses Array.isArray, so the module tests for likeness.
+        compare(Nudge.groupDelta([], 12, 0), { dx: 0, dy: 0 });
+        compare(Nudge.groupDelta(null, 12, 0), { dx: 0, dy: 0 });
+        compare(Nudge.groupDelta({ length: 1, 0: { x: 0, y: 0, minX: 0, maxX: 96, minY: 0, maxY: 96 } },
+                                 12, 0), { dx: 12, dy: 0 });
+    }
+
+    function test_a_member_with_no_bounds_is_unclamped_rather_than_frozen() {
+        const members = [{ x: 96, y: 96 }];
+        compare(Nudge.groupDelta(members, 12, 0), { dx: 12, dy: 0 });
+    }
+}


### PR DESCRIPTION
Selecting a widget already takes the canvas's keyboard focus — that is how Escape clears a selection and how Ctrl+Z reaches undo — so the keys were arriving and only the arrows were unanswered.

**One press is one 12px cell**, the same lattice a drag snaps to, with no fine mode: a widget placed by keyboard lands on the grid a widget placed by mouse lands on. A press from OFF the lattice snaps back onto it rather than adding a cell to an off-grid value, so the first press after an edge-snap detent (measured at 465) travels 15 and every one after is clean.

**Not gated on Edit Mode.** A selection the user can make on the desktop is one they can move. Outside the mode the write goes through the same commit path and records no undo entry, because `editUndoPush` is already a no-op there — the grain a drag outside the mode always had.

**A multi-widget selection travels rigidly** and stops at the first member's wall rather than deforming against it, which is the answer the group drag gives.

`modules/common/functions/widget_nudge.js` owns the step, the snap-back and the shared clamp, because nothing about a rendered canvas is reachable from qmltestrunner.

## Two defects found building it, both invisible to the mouse

**The keys read as completely inert.** `x` is the DRAWN coordinate and carries a position Behavior, so a first version that assigned to it and committed in the same turn read the value the animation had not reached yet and stored *that* back — measured as three presses with `x` unchanged at 36. `AbstractWidget.moveTargetBy` moves the placement coordinate and `PluginWidget.commitPlacement` — the tail of `commitPosition`, shared rather than copied — writes the store from it. A translation is the same delta in both frames, so nothing is converted.

**Undo batches replayed forwards.** Three steps on one widget push "back to 36", "back to 48", "back to 60"; in order, the last wins and Ctrl+Z appears to move the widget *forward*. The group drag that introduced batches could not show this — its entries are one per widget and independent, so any order looks right. The keyboard is the first gesture whose batch touches one widget more than once.

## Tests
- `tests/tst_widget_nudge.qml` — 14 checks on the arithmetic (direction, the cell step, the snap-back, lattice offset, a zero lattice, the group's shrink per axis, an unbranded list).
- `EditModeRuntimeTest.qml` +10 (77 → 87), on real widgets on a real canvas: the step, the snap-back from off-grid, a member at the wall stopping the rigid selection, and a three-press burst that is one undo entry — asserted **mid-burst in the same step**, because the batch closes on a 400ms timer and the harness ticks at 700ms, so the next step would find it closed and the check would be vacuous.
- `test_widget_group_selection.py`'s commit contract updated to follow the split rather than the spelling: the drag's commit must still restore the binding **and** reach the shared write, and that write must still be a `setPosition` with an `editUndoPush` beside it. Pinning only the first half would pass on a `commitPlacement` that had quietly stopped persisting — the failure the original check exists for.

**Plant-proofs** (clean tree): drop the delegation → 2 failures; break `setPosition` inside `commitPlacement` → `test_the_plugin_commit_still_restores_the_binding_and_persists` fails; break `editUndoPush` → same check fails; each restored → OK.

**Suite**: full `tests/run_tests.sh`, all tests passed, exit 0.

**Verified live** on the real compositor by the maintainer: arrows move a selected widget, which is the half no harness here can reach — a key event has no explicit target, `TestCase` sends it to the focused item of its own window, and this canvas takes focus from the background layer surface weston does not implement.

Changelog: updated

Docs: updated AGENT.md §Edit Mode (the batch-replay order and the drawn-versus-placement coordinate)
