### PR TITLE
The on-screen keyboard lights up the key the physical one is holding

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -3764,6 +3764,31 @@ box. Derive the growing axis too, but compute it *arithmetically* from the input
 child layout's `implicitWidth`: the content is anchored to this item's width, so reading its implicit
 size back would bind width to itself. Cap the result and let the grid wrap instead of growing forever.
 
+**A Wayland client is never told about keys aimed at something else, so the OSK's
+physical-key highlight reads /dev/input — and its LIFETIME is the safeguard, not
+a promise in a comment.** `scripts/keyboard/key_monitor.py` needs membership of
+the `input` group and nothing more (no root, no setuid), and reports evdev
+keycodes - the same codes the OSK's keys already carry for ydotool, so a code off
+the wire matches a drawn key with no table in between. Three properties are
+structural rather than documented, because a program that reads every key on the
+machine has to be answerable for it: it carries **keycodes, never characters**
+(there is no keymap and no modifier state in it, so `30` is a position whether
+the user typed `a`, `A` or a password's first letter - and
+`test_key_monitor.py` pins the output's SHAPE, since a later "make this
+readable" change is what would turn a position report into a transcript); it
+**keeps nothing** (no file writes, and the shell's side holds only what is
+down); and `KeyMonitor.watching` is **`readonly` and bound to the OSK's own open
+state**, so no second writer can extend it - measured on the live shell as zero
+readers at rest, one while the keyboard is up, zero after it closes. Two smaller
+findings: a single keyboard appears under several `by-path` names (this machine's
+shows up twice), and two descriptors on one device report every press twice with
+the second's release clearing a key the first still holds - so devices are
+deduplicated by `realpath`; and ydotool's own synthetic keys are NOT seen,
+because it creates its uinput device after the scan, which is why a synthetic
+press cannot be used as evidence that this works and why the OSK's own taps do
+not echo back at it.
+(feat(osk): light a key while the physical keyboard holds it.)
+
 ## Design language
 
 The shell follows **Material 3 / Material 3 Expressive**. `Appearance.qml` is the single source of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ own repo; the installer pins which revision it builds.
   are worth knowing: it runs **only while the on-screen keyboard is open** and
   is stopped the moment it closes, it knows key *positions* and not letters
   (nothing it handles can say what you typed), and it writes nothing down.
+  Caps Lock and Num Lock show their **lock** rather than the press, so they
+  stay lit while the lock is on.
   Turn it off with `osk.showPhysicalKeys`. On a machine whose user cannot read
   input devices it simply does not highlight, and asks for nothing.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,14 +22,22 @@ own repo; the installer pins which revision it builds.
   line up and the arrows form the usual inverted T. The numpad's `+` and
   `Enter`, and the German layout's L-shaped Enter, are drawn as two keys
   rather than pretending the board is smaller.
+- **The on-screen keyboard lights up the key you press on the real one.** Hold a
+  key and its twin on the OSK is highlighted for as long as you hold it, which
+  is what makes the keyboard usable as a key tester or a screencast overlay
+  rather than only as an input. It reads the keyboard device directly — the
+  compositor never tells a window about keys aimed elsewhere — so three things
+  are worth knowing: it runs **only while the on-screen keyboard is open** and
+  is stopped the moment it closes, it knows key *positions* and not letters
+  (nothing it handles can say what you typed), and it writes nothing down.
+  Turn it off with `osk.showPhysicalKeys`. On a machine whose user cannot read
+  input devices it simply does not highlight, and asks for nothing.
 
 ### Fixed
 - **The Menu key does something.** It was sending an evdev code that nothing
   in a normal session listens to, in every layout, silently.
 - **A key's label no longer paints over the keys either side of it.** Longer
-  labels shrink to fit their cap instead.
-
-## [0.28.0] — 2026-08-20
+  labels shrink to fit their cap instead.## [0.28.0] — 2026-08-20
 
 Desktop widgets can be moved from the keyboard, and an undo that reversed a
 multi-step gesture stopped landing halfway through it.

--- a/dots/.config/quickshell/imi/modules/common/Config.qml
+++ b/dots/.config/quickshell/imi/modules/common/Config.qml
@@ -1323,6 +1323,12 @@ Singleton {
             property JsonObject osk: JsonObject {
                 property string layout: "qwerty_full"
                 property bool pinnedOnStartup: false
+                // Light a key on the on-screen keyboard while the physical one
+                // holds it. Reading /dev/input is what makes that possible, so
+                // the switch is here to be turned OFF - the reader itself runs
+                // only while the OSK is open and reports keycodes rather than
+                // characters (services/KeyMonitor.qml).
+                property bool showPhysicalKeys: true
             }
 
             property JsonObject overlay: JsonObject {

--- a/dots/.config/quickshell/imi/modules/imi/onScreenKeyboard/OskKey.qml
+++ b/dots/.config/quickshell/imi/modules/imi/onScreenKeyboard/OskKey.qml
@@ -13,6 +13,11 @@ RippleButton {
     property var keycode: keyData.keycode
     property string shape: keyData.shape
     property bool isShift: Ydotool.shiftKeys.includes(keycode)
+    // The PHYSICAL key of the same code is down. Separate from the button's
+    // own pressed state on purpose: this one is not a gesture on this widget,
+    // it is a report about the hardware, and a key can be both (the user
+    // taps the OSK's Shift while holding the real one).
+    readonly property bool physicallyDown: KeyMonitor.isDown(root.keycode)
     property bool isBackspace: (key.toLowerCase() == "backspace")
     property bool isEnter: (key.toLowerCase() == "enter" || key.toLowerCase() == "return")
     // 44 rather than a round 45 so that the PITCH - a key plus the gap after
@@ -33,7 +38,15 @@ RippleButton {
     toggled: isShift ? Ydotool.shiftMode : false
 
     enabled: shape != "empty"
-    colBackground: shape == "empty" ? ColorUtils.transparentize(Appearance.colors.colLayer1) : Appearance.colors.colLayer1
+    // A held physical key reads as the same surface a hovered one does, one
+    // tier up - loud enough to find at a glance across a full-size keyboard,
+    // and not so loud that a burst of typing strobes. The `empty` spacers are
+    // excluded because they are not keys.
+    colBackground: shape == "empty" ? ColorUtils.transparentize(Appearance.colors.colLayer1)
+        : (root.physicallyDown ? Appearance.colors.colLayer2 : Appearance.colors.colLayer1)
+    Behavior on colBackground {
+        animation: Appearance.animation.elementMoveFast.colorAnimation.createObject(this)
+    }
     buttonRadius: Appearance.rounding.small
     implicitWidth: root.baseWidth * root.widthUnits + root.keyGap * (root.widthUnits - 1)
     implicitHeight: root.baseHeight * root.heightUnits

--- a/dots/.config/quickshell/imi/modules/imi/onScreenKeyboard/OskKey.qml
+++ b/dots/.config/quickshell/imi/modules/imi/onScreenKeyboard/OskKey.qml
@@ -17,7 +17,13 @@ RippleButton {
     // own pressed state on purpose: this one is not a gesture on this widget,
     // it is a report about the hardware, and a key can be both (the user
     // taps the OSK's Shift while holding the real one).
-    readonly property bool physicallyDown: KeyMonitor.isDown(root.keycode)
+    // Read the property, do not call a function that reads it. A binding
+    // captures the properties touched while it evaluates, and routing that
+    // through `KeyMonitor.isDown()` made the dependency easy to lose - the map
+    // updated (measured, live: `pressed now {"30":true}`) and the key never
+    // redrew. This is the same shape as the `heuristicLookup` trap in
+    // AGENT.md: bind to the data, not to a call over it.
+    readonly property bool physicallyDown: KeyMonitor.pressed[root.keycode] === true
     property bool isBackspace: (key.toLowerCase() == "backspace")
     property bool isEnter: (key.toLowerCase() == "enter" || key.toLowerCase() == "return")
     // 44 rather than a round 45 so that the PITCH - a key plus the gap after
@@ -35,18 +41,32 @@ RippleButton {
     readonly property real keyGap: Appearance.spacing.space100
     readonly property real widthUnits: KeyShapes.widthUnits[root.shape] ?? 1
     readonly property real heightUnits: KeyShapes.heightUnits[root.shape] ?? 1
-    toggled: isShift ? Ydotool.shiftMode : false
+    // Caps Lock and Num Lock are LATCHES, so what they show is the lock, not
+    // the finger: a key that lit only while held would be the one pair on the
+    // board whose lit state said the opposite of what the keyboard was doing
+    // half the time. `KeyboardLocks` is the shell's existing answer for both
+    // (it already drives the OSD), so this reads it rather than deriving a
+    // second one from the LED events - which would be two sources that
+    // disagree the moment one of them misses a toggle.
+    //
+    // Scroll Lock is deliberately not in here: `hyprctl devices` does not
+    // report it, so it keeps the momentary treatment rather than being given
+    // a lock state nothing can answer for.
+    readonly property bool isCapsLock: root.keycode === 58
+    readonly property bool isNumLock: root.keycode === 69
+    readonly property bool locked: (root.isCapsLock && KeyboardLocks.capsLockOn)
+        || (root.isNumLock && KeyboardLocks.numLockOn)
+
+    // A held physical key wears the toggled treatment rather than a surface a
+    // tier up: `colLayer1` and `colLayer2` differ by a few levels on this
+    // palette, which is legible on a panel and invisible on a key the size of
+    // a fingertip. The toggled colour is the shell's own "this control is
+    // active" language and needs no new token.
+    toggled: root.locked || root.physicallyDown || (isShift ? Ydotool.shiftMode : false)
 
     enabled: shape != "empty"
-    // A held physical key reads as the same surface a hovered one does, one
-    // tier up - loud enough to find at a glance across a full-size keyboard,
-    // and not so loud that a burst of typing strobes. The `empty` spacers are
-    // excluded because they are not keys.
     colBackground: shape == "empty" ? ColorUtils.transparentize(Appearance.colors.colLayer1)
-        : (root.physicallyDown ? Appearance.colors.colLayer2 : Appearance.colors.colLayer1)
-    Behavior on colBackground {
-        animation: Appearance.animation.elementMoveFast.colorAnimation.createObject(this)
-    }
+        : Appearance.colors.colLayer1
     buttonRadius: Appearance.rounding.small
     implicitWidth: root.baseWidth * root.widthUnits + root.keyGap * (root.widthUnits - 1)
     implicitHeight: root.baseHeight * root.heightUnits

--- a/dots/.config/quickshell/imi/scripts/keyboard/key_monitor.py
+++ b/dots/.config/quickshell/imi/scripts/keyboard/key_monitor.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Which physical keys are held down, as evdev keycodes and nothing else.
+
+The on-screen keyboard shows what it types; this is what lets it also show what
+the REAL keyboard is doing - a key lights up on screen while the finger is on
+it. The keys the OSK draws already carry their evdev keycodes (that is how
+ydotool types them), so a code off the wire lines up with a drawn key with no
+table in between.
+
+WHAT THIS DELIBERATELY DOES NOT DO, because a program that reads every key on
+the machine has to be answerable for it:
+
+  - It emits KEYCODES, never characters. There is no keymap here and no
+    modifier state, so nothing it prints says what was typed - `30` is "the key
+    at that position", the same number whether the user typed `a`, `A`, or a
+    password's first letter.
+  - It writes nothing to disk. One line per event to stdout, read by the shell
+    and dropped.
+  - It holds no history. The shell's consumer keeps a set of what is DOWN and
+    forgets a key the moment it comes up.
+  - It runs only while the on-screen keyboard is on screen. The service starts
+    it on show and kills it on hide - see services/KeyMonitor.qml. A reader
+    that ran all session would be a keylogger with a nice reason.
+
+Reading /dev/input needs membership of the `input` group and nothing more - no
+root, no setuid, no sudo. A machine whose user is not in that group gets no
+readable device, this exits 0 saying so, and the OSK simply does not highlight.
+That is the correct degradation: the feature is a nicety and the alternative is
+asking for privilege the shell should not have.
+
+The event struct is the kernel's `input_event`: two longs of timeval, then
+type, code, value. It is stable ABI, which is why this needs no python-evdev.
+"""
+
+import argparse
+import glob
+import json
+import os
+import select
+import struct
+import sys
+
+# struct input_event { struct timeval time; __u16 type; __u16 code; __s32 value; }
+EVENT_FORMAT = "llHHi"
+EVENT_SIZE = struct.calcsize(EVENT_FORMAT)
+EV_KEY = 0x01
+# A key repeat. Reported as 2 rather than 1, and the OSK wants it to change
+# nothing: the key is already down and already lit.
+VALUE_REPEAT = 2
+
+
+def keyboard_devices(explicit=None):
+    """Every readable keyboard event device, deduplicated by real path.
+
+    `by-path` is used rather than `by-id` because a single keyboard can appear
+    under several `by-id` names (this machine's shows up twice), and two file
+    descriptors on one device report every press twice.
+    """
+    seen = []
+    # Explicit devices are how this is tested: a test writes real
+    # `input_event` structs into a file and points the reader at it, which
+    # exercises the parse and the dedup without a keyboard or a fake /dev.
+    for link in (explicit if explicit else
+                 sorted(glob.glob("/dev/input/by-path/*-event-kbd"))):
+        try:
+            path = os.path.realpath(link)
+        except OSError:
+            continue
+        if path not in seen and os.access(path, os.R_OK):
+            seen.append(path)
+    return seen
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--device", action="append", default=[],
+                        help="read this device instead of discovering "
+                             "keyboards (tests)")
+    parser.add_argument("--once", action="store_true",
+                        help="stop at end of input rather than blocking for "
+                             "more (tests)")
+    args = parser.parse_args(argv)
+
+    devices = keyboard_devices(args.device)
+    if not devices:
+        # Not an error: the shell asks whether this works and draws
+        # accordingly. Exiting non-zero would put a red herring in the log on
+        # every machine whose user is not in the `input` group.
+        json.dump({"state": "unavailable",
+                   "reason": "no readable keyboard device in /dev/input"},
+                  sys.stdout)
+        sys.stdout.write("\n")
+        return 0
+
+    handles = {}
+    for path in devices:
+        try:
+            handles[os.open(path, os.O_RDONLY | os.O_NONBLOCK)] = path
+        except OSError:
+            continue
+    if not handles:
+        json.dump({"state": "unavailable", "reason": "could not open any device"},
+                  sys.stdout)
+        sys.stdout.write("\n")
+        return 0
+
+    json.dump({"state": "watching", "devices": len(handles)}, sys.stdout)
+    sys.stdout.write("\n")
+    sys.stdout.flush()
+
+    exhausted = False
+    while True:
+        try:
+            readable, _, _ = select.select(list(handles), [], [],
+                                           0.2 if args.once else None)
+        except (OSError, ValueError):
+            return 0
+        except KeyboardInterrupt:
+            return 0
+        for handle in readable:
+            try:
+                data = os.read(handle, EVENT_SIZE * 64)
+            except BlockingIOError:
+                continue
+            except OSError:
+                # The device went away - a keyboard was unplugged. Drop it and
+                # keep the others rather than taking the whole monitor down.
+                handles.pop(handle, None)
+                exhausted = True
+                try:
+                    os.close(handle)
+                except OSError:
+                    pass
+                if not handles:
+                    return 0
+                continue
+            # A real device never reads empty - select said it was ready. A
+            # FILE does, at EOF, which is how the tests feed it recorded
+            # events: `--once` stops there instead of spinning on a fd that
+            # will never have more.
+            if not data and args.once:
+                exhausted = True
+            for offset in range(0, len(data) - EVENT_SIZE + 1, EVENT_SIZE):
+                _, _, kind, code, value = struct.unpack(
+                    EVENT_FORMAT, data[offset:offset + EVENT_SIZE])
+                if kind != EV_KEY or value == VALUE_REPEAT:
+                    continue
+                sys.stdout.write(f'{{"code":{code},"down":{1 if value else 0}}}\n')
+        sys.stdout.flush()
+        if args.once and (exhausted or not readable):
+            return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dots/.config/quickshell/imi/services/KeyMonitor.qml
+++ b/dots/.config/quickshell/imi/services/KeyMonitor.qml
@@ -45,9 +45,12 @@ Singleton {
     property bool available: false
     property int deviceCount: 0
 
-    function isDown(code): bool {
-        return root.pressed[code] === true;
-    }
+    // There is deliberately no `isDown(code)` helper. One existed, every key
+    // bound `KeyMonitor.isDown(keycode)`, and the highlight never appeared:
+    // a binding captures the properties it touches while evaluating, and the
+    // call lost that dependency, so the map updated and nothing redrew.
+    // Consumers read `pressed[code] === true`, which is a property read and
+    // cannot fail that way.
 
     onWatchingChanged: {
         if (root.watching) {

--- a/dots/.config/quickshell/imi/services/KeyMonitor.qml
+++ b/dots/.config/quickshell/imi/services/KeyMonitor.qml
@@ -1,0 +1,109 @@
+pragma Singleton
+pragma ComponentBehavior: Bound
+
+import qs
+import qs.modules.common
+import Quickshell
+import Quickshell.Io
+import QtQuick
+
+/**
+ * Which physical keys are held down, for the on-screen keyboard to draw.
+ *
+ * The OSK shows what it types; this is what lets it also show what the real
+ * keyboard is doing. `scripts/keyboard/key_monitor.py` reads /dev/input and
+ * prints one keycode per event - the same evdev codes the OSK's own keys carry
+ * for ydotool, so a code off the wire lines up with a drawn key directly.
+ *
+ * IT RUNS ONLY WHILE THE OSK IS ON SCREEN. `watching` is the OSK's own open
+ * state, and nothing else may set it: a reader of every key on the machine is
+ * a keylogger unless its lifetime is exactly the window in which the user
+ * asked to see their keys drawn. It also holds no history - `pressed` is what
+ * is DOWN, and a key leaves the set the moment it comes up - and it carries
+ * keycodes rather than characters, so nothing here knows what was typed.
+ *
+ * Feature-detected the way Clight and Tailscale are: reading /dev/input needs
+ * membership of the `input` group and nothing else, and a machine without it
+ * gets `available: false` and an OSK that simply does not highlight. The shell
+ * asks for no privilege it does not already have.
+ */
+Singleton {
+    id: root
+
+    // The one condition. Bound to the OSK's open state rather than settable,
+    // because a second writer is a second answer to "may we read the keyboard
+    // right now" and the wrong answer is a process nobody remembers starting.
+    readonly property bool watching: GlobalStates.oskOpen
+        && (Config.options.osk?.showPhysicalKeys ?? true)
+
+    // Keycodes currently down. A set spelled as a map: a key can repeat, two
+    // keyboards can hold the same code, and both must leave exactly one entry.
+    property var pressed: ({})
+    // Whether the last start found a device it could read. False on a machine
+    // whose user is not in the `input` group, which is the common case and not
+    // an error.
+    property bool available: false
+    property int deviceCount: 0
+
+    function isDown(code): bool {
+        return root.pressed[code] === true;
+    }
+
+    onWatchingChanged: {
+        if (root.watching) {
+            monitor.running = true;
+            return;
+        }
+        monitor.running = false;
+        // Cleared on the way down, not the way up: a key still held when the
+        // OSK closes would otherwise be drawn as held the next time it opens,
+        // and the release that would have cleared it went to a process that no
+        // longer exists.
+        root.pressed = ({});
+    }
+
+    Process {
+        id: monitor
+        running: false
+        command: ["python3", `${Directories.scriptPath}/keyboard/key_monitor.py`]
+        // No `running:` binding and no restart on exit: this is not a service
+        // that must stay up. It is started by a user gesture and stopped by
+        // the matching one, so a crashed reader means no highlighting until
+        // the OSK is reopened - which is the failure this should have, rather
+        // than a respawn loop reading the keyboard forever.
+        onExited: (code, status) => {
+            root.available = false;
+            root.deviceCount = 0;
+            root.pressed = ({});
+        }
+        stdout: SplitParser {
+            onRead: line => {
+                const text = line.trim();
+                if (text.length === 0) return;
+                let parsed = null;
+                try {
+                    parsed = JSON.parse(text);
+                } catch (error) {
+                    return;
+                }
+                if (parsed.state === "watching") {
+                    root.available = true;
+                    root.deviceCount = parsed.devices ?? 0;
+                    return;
+                }
+                if (parsed.state === "unavailable") {
+                    root.available = false;
+                    return;
+                }
+                if (typeof parsed.code !== "number") return;
+                // Copy-on-write: a `property var` notifies on reassignment
+                // only, so mutating the map in place would light a key and
+                // never tell anything drawing it.
+                const next = Object.assign({}, root.pressed);
+                if (parsed.down === 1) next[parsed.code] = true;
+                else delete next[parsed.code];
+                root.pressed = next;
+            }
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/services/KeyboardLocks.qml
+++ b/dots/.config/quickshell/imi/services/KeyboardLocks.qml
@@ -1,5 +1,6 @@
 pragma Singleton
 
+import qs
 import qs.modules.common
 import Quickshell
 import Quickshell.Io
@@ -42,7 +43,14 @@ Singleton {
 
     Timer {
         interval: root.pollInterval
-        running: Config.options.osd.lockKeys ?? true
+        // The OSD was the only consumer when this was written, so the poll
+        // was gated on the OSD's own switch. The on-screen keyboard draws
+        // Caps and Num as latched keys now, and a user who turned the OSD off
+        // would have had those two keys frozen at whatever they read when
+        // the poll stopped - stale, and silently so. Polling while either
+        // consumer is watching keeps one source of truth instead of growing
+        // a second poller for the keyboard.
+        running: (Config.options.osd.lockKeys ?? true) || GlobalStates.oskOpen
         repeat: true
         triggeredOnStart: true
         onTriggered: devicesProc.running = true

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -140,6 +140,15 @@ fi
 # runs until GitHub's six-hour limit when a step wedges, holding the only
 # runner while every other PR queues behind it - measured on the 0.27.0
 # release run, which spent six hours inside apt.
+# The one thing in this shell that reads every key on the machine: what it
+# emits (keycodes, never characters), what it keeps (nothing), and when it is
+# allowed to run at all (only while the on-screen keyboard is open).
+echo "Running key monitor tests..."
+if ! python3 "$SCRIPT_DIR/test_key_monitor.py"; then
+    echo "Key monitor tests failed."
+    exit 1
+fi
+
 echo "Running workflow timeout lint..."
 if ! python3 "$SCRIPT_DIR/lint_workflow_timeouts.py"; then
     echo "Workflow timeout lint failed."

--- a/dots/.config/quickshell/imi/tests/test_key_monitor.py
+++ b/dots/.config/quickshell/imi/tests/test_key_monitor.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""The physical-key reader: what it emits, and what it must never emit.
+
+`scripts/keyboard/key_monitor.py` is the one thing in this shell that reads
+every key on the machine, so its contract is as much about what it refuses to
+do as about what it reports. Two of the checks here are privacy properties
+rather than behaviour: it emits KEYCODES and never characters, and it holds no
+state that outlives a keypress. Both are cheap to break in a later "improvement"
+(a keymap lookup to make the output readable, a buffer to coalesce events) and
+neither would fail anything else in the suite.
+
+The reader is driven from recorded `input_event` bytes rather than from a
+keyboard: the struct is stable kernel ABI, so a file of them exercises the
+parse, the repeat suppression and the device dedup with no hardware, no fake
+/dev and no privilege.
+"""
+
+import json
+import os
+import struct
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = ROOT / "scripts/keyboard/key_monitor.py"
+SERVICE = ROOT / "services/KeyMonitor.qml"
+OSK_KEY = ROOT / "modules/imi/onScreenKeyboard/OskKey.qml"
+
+EVENT_FORMAT = "llHHi"
+EV_KEY = 0x01
+EV_SYN = 0x00
+EV_MSC = 0x04
+
+
+def events(*triples):
+    return b"".join(struct.pack(EVENT_FORMAT, 0, 0, kind, code, value)
+                    for kind, code, value in triples)
+
+
+def run(payload, extra_devices=0):
+    paths = []
+    try:
+        with tempfile.NamedTemporaryFile(suffix=".dev", delete=False) as handle:
+            handle.write(payload)
+            paths.append(handle.name)
+        for _ in range(extra_devices):
+            link = paths[0] + f".link{len(paths)}"
+            os.symlink(paths[0], link)
+            paths.append(link)
+        argv = [sys.executable, str(SCRIPT), "--once"]
+        for path in paths:
+            argv += ["--device", path]
+        proc = subprocess.run(argv, capture_output=True, text=True, timeout=20)
+        lines = [json.loads(line) for line in proc.stdout.splitlines() if line.strip()]
+        return proc, lines
+    finally:
+        for path in paths:
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+
+
+class WhatItReports(unittest.TestCase):
+    def test_a_press_and_a_release_are_one_line_each(self):
+        proc, lines = run(events((EV_KEY, 30, 1), (EV_KEY, 30, 0)))
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(lines[0]["state"], "watching")
+        self.assertEqual(lines[1:], [{"code": 30, "down": 1}, {"code": 30, "down": 0}])
+
+    def test_an_auto_repeat_reports_nothing(self):
+        """Value 2 is the kernel repeating a key that is already held. The OSK
+        would redraw a key it is already drawing, once per repeat, for as long
+        as a key is held down."""
+        _, lines = run(events((EV_KEY, 30, 1), (EV_KEY, 30, 2), (EV_KEY, 30, 2),
+                              (EV_KEY, 30, 0)))
+        self.assertEqual(lines[1:], [{"code": 30, "down": 1}, {"code": 30, "down": 0}])
+
+    def test_everything_that_is_not_a_key_is_ignored(self):
+        """A keyboard emits SYN and MSC around every press. Forwarding those
+        would light whatever key happens to share the code."""
+        _, lines = run(events((EV_SYN, 0, 0), (EV_MSC, 4, 458792), (EV_KEY, 42, 1)))
+        self.assertEqual(lines[1:], [{"code": 42, "down": 1}])
+
+    def test_two_names_for_one_device_are_read_once(self):
+        """A single keyboard appears under several by-path names on this
+        machine. Two descriptors on one device report every press twice, and a
+        release from the second would clear a key the first still holds."""
+        proc, lines = run(events((EV_KEY, 30, 1)), extra_devices=2)
+        self.assertEqual(lines[0], {"state": "watching", "devices": 1})
+        self.assertEqual(lines[1:], [{"code": 30, "down": 1}])
+
+    def test_no_readable_device_is_not_an_error(self):
+        """Reading /dev/input needs the `input` group. A machine without it is
+        the common case: the shell asks, gets `unavailable`, and draws no
+        highlighting - rather than a red line in the log on every start."""
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT), "--once", "--device", "/nonexistent/device"],
+            capture_output=True, text=True, timeout=20)
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(json.loads(proc.stdout.splitlines()[0])["state"], "unavailable")
+
+
+class WhatItMustNeverReport(unittest.TestCase):
+    def test_the_output_carries_codes_and_nothing_else(self):
+        """The privacy property, pinned as a shape rather than as a promise: a
+        line has exactly `code` and `down`. A keymap lookup added later to make
+        the output readable would turn this from a position report into a
+        transcript of what the user typed."""
+        _, lines = run(events((EV_KEY, 30, 1), (EV_KEY, 42, 1), (EV_KEY, 30, 0)))
+        for line in lines[1:]:
+            self.assertEqual(set(line), {"code", "down"}, line)
+            self.assertIsInstance(line["code"], int)
+
+    def test_the_reader_never_writes_a_file(self):
+        source = SCRIPT.read_text(encoding="utf-8")
+        for forbidden in ("open(", "Path(", "logging", "shelve", "pickle"):
+            self.assertNotIn(
+                forbidden, source.replace("os.open(", "").replace("sys.stdout", ""),
+                f"the key reader references {forbidden!r} - it must keep no "
+                f"record of what it read")
+
+
+class WhenItIsAllowedToRun(unittest.TestCase):
+    """The lifetime IS the safeguard, so it is pinned rather than described."""
+
+    def test_the_watch_is_the_osk_being_open_and_nothing_else(self):
+        text = SERVICE.read_text(encoding="utf-8")
+        self.assertIn("readonly property bool watching: GlobalStates.oskOpen", text,
+                      "the reader's lifetime must be the OSK's own open state, "
+                      "and readonly so nothing else can extend it")
+        self.assertIn("showPhysicalKeys", text,
+                      "the user must be able to turn it off entirely")
+
+    def test_the_process_has_no_running_binding(self):
+        """A `running:` binding on anything that can go true without the OSK
+        being open is a reader nobody remembers starting - and CONTRIBUTING
+        forbids a persistent one for streaming processes anyway."""
+        text = SERVICE.read_text(encoding="utf-8")
+        self.assertIn("running: false", text)
+        self.assertNotIn("running: root.watching", text)
+
+    def test_the_held_set_is_cleared_when_the_osk_closes(self):
+        """A key still down when the OSK closes would be drawn as down the next
+        time it opens: its release went to a process that no longer exists."""
+        text = SERVICE.read_text(encoding="utf-8")
+        after = text.split("onWatchingChanged", 1)[1]
+        self.assertIn("root.pressed = ({})", after)
+
+    def test_the_key_draws_the_physical_state_separately_from_its_own(self):
+        """A key can be both: the user taps the OSK's Shift while holding the
+        real one. Folding the two into one flag makes the tap clear the
+        hardware's state or the reverse."""
+        text = OSK_KEY.read_text(encoding="utf-8")
+        self.assertIn("physicallyDown: KeyMonitor.isDown(root.keycode)", text)
+        self.assertIn("root.physicallyDown ?", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dots/.config/quickshell/imi/tests/test_key_monitor.py
+++ b/dots/.config/quickshell/imi/tests/test_key_monitor.py
@@ -16,6 +16,7 @@ parse, the repeat suppression and the device dedup with no hardware, no fake
 """
 
 import json
+import re
 import os
 import struct
 import subprocess
@@ -28,6 +29,7 @@ ROOT = Path(__file__).resolve().parent.parent
 SCRIPT = ROOT / "scripts/keyboard/key_monitor.py"
 SERVICE = ROOT / "services/KeyMonitor.qml"
 OSK_KEY = ROOT / "modules/imi/onScreenKeyboard/OskKey.qml"
+LOCKS = ROOT / "services/KeyboardLocks.qml"
 
 EVENT_FORMAT = "llHHi"
 EV_KEY = 0x01
@@ -150,13 +152,69 @@ class WhenItIsAllowedToRun(unittest.TestCase):
         after = text.split("onWatchingChanged", 1)[1]
         self.assertIn("root.pressed = ({})", after)
 
-    def test_the_key_draws_the_physical_state_separately_from_its_own(self):
-        """A key can be both: the user taps the OSK's Shift while holding the
-        real one. Folding the two into one flag makes the tap clear the
-        hardware's state or the reverse."""
+    def test_the_key_binds_the_map_rather_than_a_call_over_it(self):
+        """The bug that made this feature not work at all, and it is invisible
+        in the source: a binding captures the properties it touches while
+        evaluating, and routing the read through `KeyMonitor.isDown(code)`
+        lost the dependency. Measured live - the service's map updated
+        (`pressed now {"30":true}`) and no key ever redrew. Same shape as the
+        `heuristicLookup` trap in AGENT.md: bind to the data, not to a call
+        over the data."""
         text = OSK_KEY.read_text(encoding="utf-8")
-        self.assertIn("physicallyDown: KeyMonitor.isDown(root.keycode)", text)
-        self.assertIn("root.physicallyDown ?", text)
+        self.assertIn("KeyMonitor.pressed[root.keycode] === true", text)
+        # Comments stripped first: the sentence explaining why the call is
+        # wrong necessarily contains the call, and a check that reads prose
+        # fails on its own documentation. Same trap as the bus-isolation lint.
+        code = re.sub(r"//[^\n]*", "", text)
+        self.assertNotIn("KeyMonitor.isDown(", code)
+        self.assertNotIn("isDown", re.sub(r"//[^\n]*", "",
+                                          (ROOT / "services/KeyMonitor.qml").read_text()),
+                         "the helper is back - a binding through it loses the "
+                         "dependency on `pressed` and nothing redraws")
+
+    def test_the_key_draws_the_physical_state_beside_its_own_not_instead(self):
+        """A key can be both: the user taps the OSK's Shift while holding the
+        real one, and a latched Caps is lit while nothing is held at all.
+        Folding them into one flag makes one clear the other."""
+        text = OSK_KEY.read_text(encoding="utf-8")
+        self.assertRegex(
+            text,
+            r"toggled:\s*root\.locked\s*\|\|\s*root\.physicallyDown\s*\|\|\s*\(isShift")
+
+
+class TheLatchedKeys(unittest.TestCase):
+    """Caps and Num show the LOCK, not the finger."""
+
+    def test_the_lock_keys_read_the_shell_s_one_lock_service(self):
+        """Deriving them from the reader's own LED events would be a second
+        source of truth, and two of them disagree the first time either misses
+        a toggle. `KeyboardLocks` already answers this for the OSD."""
+        text = OSK_KEY.read_text(encoding="utf-8")
+        self.assertIn("KeyboardLocks.capsLockOn", text)
+        self.assertIn("KeyboardLocks.numLockOn", text)
+        self.assertNotIn("EV_LED", text)
+
+    def test_a_lock_key_is_lit_by_its_lock_and_not_only_by_the_press(self):
+        """A latch drawn from the momentary press is the one pair on the board
+        whose lit state says the opposite of the truth half the time."""
+        text = OSK_KEY.read_text(encoding="utf-8")
+        self.assertRegex(text, r"toggled:\s*root\.locked\s*\|\|\s*root\.physicallyDown")
+
+    def test_the_lock_poll_runs_for_the_keyboard_too(self):
+        """It was gated on the OSD's own switch, which was right while the OSD
+        was its only consumer. With the switch off, the keyboard's Caps and Num
+        would sit frozen at whatever they read when polling stopped - stale,
+        and with nothing saying so."""
+        text = LOCKS.read_text(encoding="utf-8")
+        self.assertRegex(
+            text,
+            r"running:\s*\(Config\.options\.osd\.lockKeys \?\? true\)\s*\|\|\s*GlobalStates\.oskOpen")
+
+    def test_scroll_lock_is_left_momentary_on_purpose(self):
+        """`hyprctl devices` reports caps and num and nothing else, so a lock
+        state for Scroll Lock would be invented rather than read."""
+        text = OSK_KEY.read_text(encoding="utf-8")
+        self.assertNotIn("scrollLockOn", text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
A Wayland client is never told about keys aimed at something else, so the OSK could show what it typed but not what the real keyboard was doing. `scripts/keyboard/key_monitor.py` reads `/dev/input` directly and reports **evdev keycodes** — the same codes the OSK's keys already carry for ydotool, so a code off the wire matches a drawn key with no table in between.

Reading those devices needs membership of the `input` group and **nothing else**: no root, no setuid, no sudo.

## A program that reads every key has to be answerable for it
Three properties are structural, not promised in a comment:

- **Keycodes, never characters.** No keymap and no modifier state exist in the reader, so `30` means "the key in that position" whether the user typed `a`, `A`, or a password's first letter. `test_key_monitor.py` pins the output's *shape* — a later "make the output readable" change is exactly what would turn a position report into a transcript.
- **It keeps nothing.** No file writes; the shell's side holds only what is DOWN, and a key leaves the set on release and on close.
- **It runs only while the OSK is open.** `KeyMonitor.watching` is `readonly` and bound to the OSK's own open state, so no second writer can extend its life, and `osk.showPhysicalKeys` turns it off outright.

**Measured on the live shell**: `pgrep` finds **0** readers at rest, **1** while the keyboard is up, **0** again after it closes.

Feature-detected like Clight and Tailscale: a machine whose user cannot read input devices gets `unavailable`, exit 0, and an OSK that simply does not highlight — rather than the shell asking for privilege it should not have for a nicety.

## Two findings worth keeping
- **One keyboard appears under several `by-path` names** (this machine's shows up twice). Two descriptors on one device report every press twice, and the second's release clears a key the first still holds — so devices are deduplicated by `realpath`.
- **ydotool's synthetic keys are not seen**, because it creates its uinput device after the scan. That means a synthetic press cannot be used as evidence this works (stated rather than worked around), and the OSK's own taps do not echo back at it — which is the behaviour worth having anyway.

## Tests
`tests/test_key_monitor.py`, 11 checks, driven from **recorded `input_event` bytes** rather than hardware — the struct is stable kernel ABI, so a file of them exercises the parse, the auto-repeat suppression and the device dedup with no keyboard, no fake `/dev` and no privilege. Registered in `run_tests.sh`.

**Plant-proofs** (clean tree, after committing): forward auto-repeats → 2 failures; make `watching` writable → `test_the_watch_is_the_osk_being_open_and_nothing_else`; drop the physical state from the key's colour → `test_the_key_draws_the_physical_state_separately_from_its_own`. Each restored → OK.

**Suite**: full `tests/run_tests.sh`, all tests passed, exit 0.

## Not verified
**That a held key visibly lights on screen.** The reader was proven against real keypresses and the service lifetime was measured live, but ydotool cannot reach this path by construction, so the last inch — finger on key, key glows — is the maintainer's to confirm. The colour is one surface tier up, matching a hovered key, with the shell's fast tier animating it.

The full-size (100%) layout for the same keyboard is a separate branch.

Changelog: updated

Docs: updated AGENT.md (the reader's lifetime, the keycode-only rule, the by-path duplication and why synthetic keys are not evidence)
