### PR TITLE
The keyboard and the wallpaper selector stop frosting their own shadow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ own repo; the installer pins which revision it builds.
 
 ## [Unreleased]
 
+### Fixed
+- **The on-screen keyboard and the wallpaper selector stop frosting their own
+  shadow.** Both were still asking the compositor to blur their whole surface,
+  which takes the drop shadow with it — so what should have been a shadow under
+  the panel read as a smudge. They now blur only the panel body, the way the
+  bars, the dock, the OSDs, the overview, the cheatsheet and the notification
+  popups already do.
+
 ### Added
 - **The on-screen keyboard is a full-size keyboard.** It was missing Caps
   Lock (the home row started at `a`), both Super keys, Scroll Lock, Pause, the

--- a/dots/.config/hypr/hyprland/rules.lua
+++ b/dots/.config/hypr/hyprland/rules.lua
@@ -228,6 +228,13 @@ hl.layer_rule({ match = { namespace = "quickshell:cheatsheet" }, blur = false})
 -- instead, leaving the gaps between them unblurred. See WindowBlurRegion in
 -- NotificationPopup.qml.
 hl.layer_rule({ match = { namespace = "quickshell:notificationPopup" }, blur = false})
+-- The on-screen keyboard and the wallpaper selector were the last two panels
+-- still frosting their own shadow: both draw a StyledRectangularShadow inside
+-- an elevation margin, and the catch-all blur above takes every pixel over
+-- ignore_alpha (0.05), which a shadow clears easily. See WindowBlurRegion in
+-- OnScreenKeyboard.qml / WallpaperSelector.qml.
+hl.layer_rule({ match = { namespace = "quickshell:osk" }, blur = false})
+hl.layer_rule({ match = { namespace = "quickshell:wallpaperSelector" }, blur = false})
 -- The popups those surfaces open (the tray menu, the dock's context menu, the
 -- drag-apps sheet, every tooltip) draw shadows too, and blur_popups above
 -- frosts them the same way. The fix above does not reach them: an

--- a/dots/.config/quickshell/imi/modules/imi/onScreenKeyboard/OnScreenKeyboard.qml
+++ b/dots/.config/quickshell/imi/modules/imi/onScreenKeyboard/OnScreenKeyboard.qml
@@ -65,6 +65,21 @@ Scope { // Scope
                 GlobalFocusGrab.removePersistent(oskRoot);
             }
 
+            // Blur is scoped to the body rather than left to the surface.
+            // The catch-all `blur = true` for `quickshell:.*` frosts every
+            // pixel over `ignore_alpha` (0.05), and this shadow sits well
+            // above that - so the compositor blurred the shadow along with
+            // the keyboard, which reads as a keyboard with a smudge under it
+            // instead of a shadow. Same fix the bars, the dock, the OSDs and
+            // the cheatsheet already carry (#82, #89); the layer rule turning
+            // the surface-wide blur off is the other half and
+            // `lint_blur_region_pairing.py` fails if either half is missing.
+            WindowBlurRegion {
+                targetWindow: oskRoot
+                regionItem: oskBackground
+                regionRadius: oskBackground.radius
+            }
+
             // Background
             StyledRectangularShadow {
                 target: oskBackground

--- a/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/WallpaperSelector.qml
+++ b/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/WallpaperSelector.qml
@@ -74,6 +74,16 @@ Scope {
                 }
             }
 
+            // The selector's card carries its own shadow, and the catch-all
+            // surface blur frosted it - the same defect #82 fixed for the
+            // panels. The region covers the card and not the elevation margin
+            // the shadow lives in.
+            WindowBlurRegion {
+                targetWindow: panelWindow
+                regionItem: content.blurTarget
+                regionRadius: content.blurTargetRadius
+            }
+
             WallpaperSelectorContent {
                 id: content
                 width: parent.width

--- a/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/WallpaperSelectorContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/WallpaperSelectorContent.qml
@@ -197,6 +197,13 @@ MouseArea {
     implicitHeight: mainLayout.implicitHeight
     implicitWidth: mainLayout.implicitWidth
 
+    // The blurred body, published rather than reached into: the window owns
+    // the region (it is a property of the surface) and this component owns the
+    // rectangle, so the two meet at a named property instead of an id lookup
+    // through the tree - the pattern the panels' `backgroundItem` pair uses.
+    readonly property alias blurTarget: wallpaperGridBackground
+    readonly property real blurTargetRadius: wallpaperGridBackground.radius
+
     StyledRectangularShadow {
         target: wallpaperGridBackground
     }


### PR DESCRIPTION
The last two panels still falling through the catch-all `blur = true` for `quickshell:.*`. That rule blurs every pixel over `ignore_alpha` (0.05), and a drop shadow clears 0.05 easily — so the compositor frosted the shadow along with the body, which reads as a smudge under the panel rather than a shadow.

Both draw a `StyledRectangularShadow` inside an elevation margin, which is exactly the shape #82 and #89 fixed for the bars, the dock, the OSDs, the overview, the cheatsheet and the notification popups. Nine namespaces already carry the fix; these two were never ported.

## The same two-part fix
- **The layer rule** turns surface-wide blur off for `quickshell:osk` and `quickshell:wallpaperSelector`.
- **The shell publishes a `WindowBlurRegion`** over just the painted body, so a translucent panel still gets its backdrop blur while the shadow stays crisp.

Both halves are required and each is silent alone — a region without the rule changes nothing, and the rule without a region leaves the panel with no blur at all. `lint_blur_region_pairing.py` exists for exactly that and pins them together.

The selector publishes its card as `blurTarget` rather than having the window reach through the tree for it: the window owns the region (a property of the surface) and the content owns the rectangle, which is the `backgroundItem` pattern the panels already use.

**Plant-proof** (clean tree, after committing): removed the OSK's region and left its layer rule → `test_every_disabled_namespace_publishes_a_region` fails with `quickshell:osk has blur = false in rules… but publishes no region`; restored → OK.

**Tests**: full `tests/run_tests.sh`, all tests passed, exit 0. `lint_blur_region_pairing.py` and `lint_qml_imports.sh` pass.

## How this was NOT verified, on purpose
I diffed before/after screenshots of the shadow band and got +13% high-frequency detail, then discarded it: the desktop it was captured on has video playing, so the two frames differ for reasons unrelated to the change. That is the two-captures trap AGENT.md records under the clock-depth investigation, and the number is worthless as evidence. The mechanism is documented, the precedent is nine namespaces, the lint pins both halves — and whether the shadow now reads as a shadow is the maintainer's to see.

Changelog: updated

Docs: not needed — AGENT.md's layer-shell section already carries the mechanism, the two-part fix, and why a half-fix is silent
