### PR TITLE
fix(osk): the numpad's + and Enter become one key two rows tall

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1572,6 +1572,44 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   keyboard's rows agreed before there was anything to the right of the spacebar.
   afd3bf661 ("fix(osk): make the key pitch a multiple of four, so a quarter unit is whole pixels"),
   e119c7b1d ("refactor(osk): no key fills the row any more").
+- **A keyboard is a LATTICE, not a stack of rows, and a `GridLayout` does not
+  hand out equal columns on its own.** The numpad's `+` and its Enter are one
+  key two rows tall, which a `RowLayout` cannot say — so each of them shipped
+  as two keys carrying one keycode, and the pad drew two Enters. The tool for
+  it is `Layout.rowSpan`, and reaching it needs a column: every width in
+  `modules/imi/onScreenKeyboard/key_shapes.js` is a multiple of 0.25u, so the
+  quarter unit is the column, 1u is four of them and a row is 92.
+  `osk_lattice.js` is the walk that turns the row-major layout data into cells
+  — a key takes the next free columns in its row, a key taller than one unit
+  claims the cells beneath it, and the row below steps over the claim — kept
+  pure because nothing about a drawn key is reachable from `qmltestrunner`.
+  The **layouts carry no coordinates**, which is what keeps a new key a line of
+  data rather than a re-numbering.
+  Three things about the grid are not obvious and all three were measured
+  rather than reasoned about. **The engine spreads a multi-column item's width
+  over the columns it spans and arrives at columns of different widths**: on
+  the real component with nothing pinning them, the keyboard comes out 1197px
+  wide against the 1188 its units buy, with a 13px gap before Backspace where
+  every other gap is 8 — which is afd3bf661's drift arriving from the other
+  side, and it is visible in a screenshot and in nothing else. A **declared
+  lattice** fixes it: one zero-height item per column asking for exactly one
+  column's width (`Lattice.columnWidth`, the pitch's quarter minus the spacing
+  that follows it) puts every key back on a multiple of 13. It needs a **row of
+  its own** — `QGridLayoutEngine::addItem` refuses a second item in a cell that
+  is taken, so a ruler spanning the key rows is dropped with a console warning
+  — and that row costs one `rowSpacing` which `OskContent` reports off its
+  implicit height rather than resizing the grid to hide (a grid given less
+  height than it asked for takes the difference out of a row of keys; a
+  negative `Layout.bottomMargin` to cancel the spacing is clamped away).
+  The ISO Enter is the one key that stays two: 1.5u on the top row against
+  1.25u on the bottom, offset by the wider Caps, so it is an L and no cell of a
+  rectangular lattice has that shape. `tst_osk_layouts.qml` allows a repeated
+  keycode for that one alone, and counts a row's width off the lattice rather
+  than by summing the row's own keys — the row under a double-height key does
+  not declare the columns that key already took, so the old arithmetic reports
+  the home row four units short.
+  fix(osk): the numpad's + and its Enter become one key two rows tall,
+  feat(osk): draw the keyboard on one grid, with the lattice declared.
 - **Never `anchors.fill: parent` a `Loader` whose *own* size is meant to be derived from the loaded
   item's implicit size.** `Loader` forces the loaded item to match the Loader's size whenever the
   Loader itself has an explicit size (anchors count as explicit sizing) - but if the wrapping

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,9 @@ own repo; the installer pins which revision it builds.
   keyboard layout decides what the letters spell, not whether the board has a
   numpad — and laid out on real keycap proportions, so the numpad's columns
   line up and the arrows form the usual inverted T. The numpad's `+` and
-  `Enter`, and the German layout's L-shaped Enter, are drawn as two keys
-  rather than pretending the board is smaller.
+  `Enter` are one key two rows tall, as they are on the board beside you. The
+  German layout's Enter stays two keys, because an ISO Enter is an L rather
+  than a taller rectangle.
 - **The on-screen keyboard lights up the key you press on the real one.** Hold a
   key and its twin on the OSK is highlighted for as long as you hold it, which
   is what makes the keyboard usable as a key tester or a screencast overlay
@@ -47,7 +48,9 @@ own repo; the installer pins which revision it builds.
 - **The Menu key does something.** It was sending an evdev code that nothing
   in a normal session listens to, in every layout, silently.
 - **A key's label no longer paints over the keys either side of it.** Longer
-  labels shrink to fit their cap instead.## [0.28.0] — 2026-08-20
+  labels shrink to fit their cap instead.
+
+## [0.28.0] — 2026-08-20
 
 Desktop widgets can be moved from the keyboard, and an undo that reversed a
 multi-step gesture stopped landing halfway through it.

--- a/dots/.config/quickshell/imi/OskLayoutProbe.qml
+++ b/dots/.config/quickshell/imi/OskLayoutProbe.qml
@@ -1,4 +1,8 @@
 import QtQuick
+// For the attached Layout the rows are read back through - an attached type
+// is only resolvable where its module is imported, and without this every
+// key's `Layout` reads undefined.
+import QtQuick.Layouts
 import Quickshell
 import "modules/imi/onScreenKeyboard" as Osk
 import "modules/imi/onScreenKeyboard/layouts.js" as Layouts
@@ -68,14 +72,31 @@ ShellRoot {
             // Every row is drawn to the same width or the clusters on the
             // right drift; measured off the built tree rather than asserted
             // from the units, which is the half the contract test cannot see.
-            const column = keyboard.children[0];
-            const widths = [];
-            for (let i = 0; i < column.children.length; i++) {
-                const row = column.children[i];
-                if (row.children.length > 0)
-                    widths.push(Math.round(row.width * 100) / 100);
+            // A row is no longer an item - the keyboard is one grid, so a row
+            // is whatever covers it, tall keys from the row above included.
+            const grid = keyboard.children[0];
+            const rows = [];
+            const tall = [];
+            for (let i = 0; i < grid.children.length; i++) {
+                const key = grid.children[i];
+                if (key.keyData === undefined)
+                    continue;
+                const span = key.Layout.rowSpan;
+                for (let r = key.Layout.row; r < key.Layout.row + span; r++) {
+                    if (rows[r] === undefined)
+                        rows[r] = { left: key.x, right: key.x + key.width };
+                    rows[r].left = Math.min(rows[r].left, key.x);
+                    rows[r].right = Math.max(rows[r].right, key.x + key.width);
+                }
+                if (span > 1)
+                    tall.push(`${key.keyData.label}@${Math.round(key.x)},${Math.round(key.y)}`
+                        + ` ${Math.round(key.width)}x${Math.round(key.height)}`);
             }
+            const widths = rows.map(row => Math.round((row.right - row.left) * 100) / 100);
             console.log(`[OskLayout] rowWidths ${widths.join(" ")}`);
+            // A double-height key is ONE key of two rows. Printed because two
+            // keys stacked and one key spanning look identical in a total.
+            console.log(`[OskLayout] tallKeys ${tall.length} ${tall.join(" ")}`);
             field.grabToImage(result => {
                 result.saveToFile(shot);
                 console.log("[OskLayout] saved");

--- a/dots/.config/quickshell/imi/modules/imi/onScreenKeyboard/OskContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/onScreenKeyboard/OskContent.qml
@@ -1,40 +1,67 @@
 import qs.modules.common
 import "layouts.js" as Layouts
+import "key_shapes.js" as KeyShapes
+import "osk_lattice.js" as Lattice
 import QtQuick
 import QtQuick.Layouts
 
 Item {
-    id: root    
+    id: root
     property var layouts: Layouts.byName
-    property var activeLayoutName: (layouts.hasOwnProperty(Config.options?.osk.layout)) 
-        ? Config.options?.osk.layout 
+    property var activeLayoutName: (layouts.hasOwnProperty(Config.options?.osk.layout))
+        ? Config.options?.osk.layout
         : Layouts.defaultLayout
     property var currentLayout: layouts[activeLayoutName]
 
-    implicitWidth: keyRows.implicitWidth
-    implicitHeight: keyRows.implicitHeight
+    // The gap OskKey subtracts from every span it draws. One value read by
+    // both, or a key wider than one unit is drawn short by the difference.
+    readonly property real keyGap: Appearance.spacing.space100
+    readonly property var placements: Lattice.place(root.currentLayout.keys)
 
-    ColumnLayout {
-        id: keyRows
-        anchors.fill: parent
-        spacing: Appearance.spacing.space100
+    implicitWidth: keyGrid.implicitWidth
+    // The lattice row draws nothing and is one row tall, so the grid stands one
+    // rowSpacing taller than the keyboard. Reported off rather than absorbed by
+    // resizing the grid: a grid given less height than it asked for takes the
+    // difference out of a row of keys.
+    implicitHeight: keyGrid.implicitHeight - keyGrid.rowSpacing
+
+    // Deliberately not anchors.fill - see implicitHeight above.
+    GridLayout {
+        id: keyGrid
+        columns: Lattice.columnsIn(root.placements)
+        columnSpacing: root.keyGap
+        rowSpacing: root.keyGap
+
+        // The lattice, declared. A GridLayout does not land on a uniform column
+        // on its own: it spreads a multi-column item's width over the columns
+        // it spans, and measured over these three layouts that comes out 1197px
+        // wide against the 1188 the units buy, with a 13px gap before Backspace
+        // where every other gap is 8. One zero-height item per column, asking
+        // for exactly one column, is what pins it - and it is a row of its own
+        // because the engine refuses a second item in a cell already taken.
+        Repeater {
+            model: keyGrid.columns
+
+            delegate: Item {
+                required property int index
+                Layout.row: root.currentLayout.keys.length
+                Layout.column: index
+                Layout.preferredWidth: Lattice.columnWidth(KeyShapes.baseKeyWidth, root.keyGap)
+                Layout.preferredHeight: 0
+            }
+        }
 
         Repeater {
-            model: root.currentLayout.keys
+            model: root.placements
 
-            delegate: RowLayout {
-                id: keyRow
+            // A placement looks like this: {key: {...}, row: 3, column: 88, columnSpan: 4, rowSpan: 2}
+            delegate: OskKey {
                 required property var modelData
-                spacing: Appearance.spacing.space100
-                
-                Repeater {
-                    model: modelData
-                    // A normal key looks like this: {label: "a", labelShift: "A", shape: "normal", keycode: 30, type: "normal"}
-                    delegate: OskKey { 
-                        required property var modelData
-                        keyData: modelData
-                    }
-                }
+                keyData: modelData.key
+                Layout.row: modelData.row
+                Layout.column: modelData.column
+                Layout.columnSpan: modelData.columnSpan
+                Layout.rowSpan: modelData.rowSpan
             }
         }
     }

--- a/dots/.config/quickshell/imi/modules/imi/onScreenKeyboard/OskKey.qml
+++ b/dots/.config/quickshell/imi/modules/imi/onScreenKeyboard/OskKey.qml
@@ -28,9 +28,9 @@ RippleButton {
     property bool isEnter: (key.toLowerCase() == "enter" || key.toLowerCase() == "return")
     property real baseWidth: KeyShapes.baseKeyWidth
     property real baseHeight: KeyShapes.baseKeyHeight
-    // The gap a row leaves between two keys. A key spanning several units
+    // The gap the grid leaves between two cells. A key spanning several units
     // covers the gaps it swallows as well as the key bodies, so this has to be
-    // the same value OskContent gives its RowLayout or every wide key ends up
+    // the same value OskContent gives its GridLayout or every wide key ends up
     // shorter than the keys it is supposed to span.
     readonly property real keyGap: Appearance.spacing.space100
     readonly property real widthUnits: KeyShapes.widthUnits[root.shape] ?? 1

--- a/dots/.config/quickshell/imi/modules/imi/onScreenKeyboard/OskKey.qml
+++ b/dots/.config/quickshell/imi/modules/imi/onScreenKeyboard/OskKey.qml
@@ -63,7 +63,13 @@ RippleButton {
         : Appearance.colors.colLayer1
     buttonRadius: Appearance.rounding.small
     implicitWidth: root.baseWidth * root.widthUnits + root.keyGap * (root.widthUnits - 1)
+    // A key TALLER than one unit spans whole rows and covers the gaps between
+    // them, the same way a wide key covers the gaps along its row. A key
+    // shorter than one unit - the function row's cap, a spacer - covers no gap
+    // at all: it is drawn inside its own row rather than reaching into the
+    // next, so the term is clamped instead of going negative.
     implicitHeight: root.baseHeight * root.heightUnits
+        + root.keyGap * Math.max(0, root.heightUnits - 1)
 
     Connections {
         target: Ydotool

--- a/dots/.config/quickshell/imi/modules/imi/onScreenKeyboard/OskKey.qml
+++ b/dots/.config/quickshell/imi/modules/imi/onScreenKeyboard/OskKey.qml
@@ -26,14 +26,8 @@ RippleButton {
     readonly property bool physicallyDown: KeyMonitor.pressed[root.keycode] === true
     property bool isBackspace: (key.toLowerCase() == "backspace")
     property bool isEnter: (key.toLowerCase() == "enter" || key.toLowerCase() == "return")
-    // 44 rather than a round 45 so that the PITCH - a key plus the gap after
-    // it - is a multiple of four, and a quarter-unit span is therefore a whole
-    // number of pixels. QQuickLayout rounds every item's width UP, so a key
-    // whose span lands on a half pixel is drawn half a pixel wide of where its
-    // units put it, and fourteen spacers into the function row that is seven
-    // pixels of drift against the row below.
-    property real baseWidth: 44
-    property real baseHeight: 45
+    property real baseWidth: KeyShapes.baseKeyWidth
+    property real baseHeight: KeyShapes.baseKeyHeight
     // The gap a row leaves between two keys. A key spanning several units
     // covers the gaps it swallows as well as the key bodies, so this has to be
     // the same value OskContent gives its RowLayout or every wide key ends up

--- a/dots/.config/quickshell/imi/modules/imi/onScreenKeyboard/key_shapes.js
+++ b/dots/.config/quickshell/imi/modules/imi/onScreenKeyboard/key_shapes.js
@@ -42,6 +42,7 @@ const widthUnits = {
     "enterIsoTop": 1.5,
     "caps": 1.75,
     "backspace": 2,
+    "numpadTall": 1,
     "numpadZero": 2,
     "enter": 2.25,
     "shift": 2.25,
@@ -51,7 +52,9 @@ const widthUnits = {
 
 // Only two shapes are not a full key tall: the function row is a short key,
 // and a spacer has no height at all so it can pad any row without deciding
-// how tall that row is.
+// how tall that row is. One is TALLER than a key: the numpad's + and its
+// Enter are one key across two rows, which is a rowSpan of two on the lattice
+// osk_lattice.js places them on.
 const heightUnits = {
     "normal": 1,
     "fn": 0.7,
@@ -65,6 +68,7 @@ const heightUnits = {
     "enterIsoTop": 1,
     "caps": 1,
     "backspace": 1,
+    "numpadTall": 2,
     "numpadZero": 1,
     "enter": 1,
     "shift": 1,

--- a/dots/.config/quickshell/imi/modules/imi/onScreenKeyboard/key_shapes.js
+++ b/dots/.config/quickshell/imi/modules/imi/onScreenKeyboard/key_shapes.js
@@ -1,5 +1,18 @@
 .pragma library
 
+// A keycap's own box, in pixels. 44 rather than a round 45 so that the PITCH -
+// a key plus the gap after it - is a multiple of four, and a quarter unit is
+// therefore a whole number of pixels. QQuickLayout rounds every item's width
+// UP, so a key whose span lands on a half pixel is drawn half a pixel wide of
+// where its units put it, and fourteen spacers into the function row that is
+// seven pixels of drift against the row below.
+//
+// They live here rather than in OskKey because osk_lattice.js derives the
+// column the keys are placed on from the same two numbers, and two homes for a
+// pitch is two answers to where a column starts.
+const baseKeyWidth = 44;
+const baseKeyHeight = 45;
+
 // How wide and how tall every `shape` a layout in layouts.js may name is, in
 // KEYBOARD UNITS - the same unit a keycap is sold in, where a plain letter is
 // 1u and a US Enter is 2.25u.

--- a/dots/.config/quickshell/imi/modules/imi/onScreenKeyboard/layouts.js
+++ b/dots/.config/quickshell/imi/modules/imi/onScreenKeyboard/layouts.js
@@ -94,9 +94,7 @@ const byName = {
                 { keytype: "normal", label: "7", shape: "normal", keycode: 71 },
                 { keytype: "normal", label: "8", shape: "normal", keycode: 72 },
                 { keytype: "normal", label: "9", shape: "normal", keycode: 73 },
-                // The numpad's + is two rows tall on a real keyboard and a row
-                // cannot say so, so it is two keys on one keycode.
-                { keytype: "normal", label: "+", shape: "normal", keycode: 78 }
+                { keytype: "normal", label: "+", shape: "numpadTall", keycode: 78 }
             ],
             [
                 { keytype: "normal", label: "Caps", shape: "caps", keycode: 58 },
@@ -115,8 +113,7 @@ const byName = {
                 gap, gap, gap, gap, gap, gap, gap, gap,
                 { keytype: "normal", label: "4", shape: "normal", keycode: 75 },
                 { keytype: "normal", label: "5", shape: "normal", keycode: 76 },
-                { keytype: "normal", label: "6", shape: "normal", keycode: 77 },
-                { keytype: "normal", label: "+", shape: "normal", keycode: 78 }
+                { keytype: "normal", label: "6", shape: "normal", keycode: 77 }
             ],
             [
                 { keytype: "modkey", label: "Shift", labelShift: "Shift", labelCaps: "Caps", shape: "shift", keycode: 42 },
@@ -139,8 +136,7 @@ const byName = {
                 { keytype: "normal", label: "1", shape: "normal", keycode: 79 },
                 { keytype: "normal", label: "2", shape: "normal", keycode: 80 },
                 { keytype: "normal", label: "3", shape: "normal", keycode: 81 },
-                // The numpad's Enter, upper half - see the + two rows up.
-                { keytype: "normal", label: "Enter", shape: "normal", keycode: 96 }
+                { keytype: "normal", label: "Enter", shape: "numpadTall", keycode: 96 }
             ],
             [
                 { keytype: "modkey", label: "Ctrl", shape: "control", keycode: 29 },
@@ -157,8 +153,7 @@ const byName = {
                 { keytype: "normal", label: "→", shape: "normal", keycode: 106 },
                 gap,
                 { keytype: "normal", label: "0", shape: "numpadZero", keycode: 82 },
-                { keytype: "normal", label: ".", shape: "normal", keycode: 83 },
-                { keytype: "normal", label: "Enter", shape: "normal", keycode: 96 }
+                { keytype: "normal", label: ".", shape: "normal", keycode: 83 }
             ]
         ]
     },
@@ -229,8 +224,12 @@ const byName = {
                 { keytype: "normal", label: "p", labelShift: "P", labelAlt: "þ", shape: "normal", keycode: 25 },
                 { keytype: "normal", label: "ü", labelShift: "Ü", labelAlt: "¨", shape: "normal", keycode: 26 },
                 { keytype: "normal", label: "+", labelShift: "*", labelAlt: "~", shape: "normal", keycode: 27 },
-                // The ISO Enter is an L: this is its upper arm, and the lower
-                // one is the last key of the row below on the same keycode.
+                // The ISO Enter is an L, and stays two keys where the numpad's
+                // + and Enter became one: 1.5u on this row against 1.25u on
+                // the next, offset a quarter unit by the wider Caps below it,
+                // so no single rectangle on the lattice is that shape. This is
+                // its upper arm; the lower one is the last key of the row
+                // below, on the same keycode.
                 { keytype: "normal", label: "↵", shape: "enterIsoTop", keycode: 28 },
                 gap,
                 { keytype: "normal", label: "Entf", shape: "normal", keycode: 111 },
@@ -240,7 +239,7 @@ const byName = {
                 { keytype: "normal", label: "7", shape: "normal", keycode: 71 },
                 { keytype: "normal", label: "8", shape: "normal", keycode: 72 },
                 { keytype: "normal", label: "9", shape: "normal", keycode: 73 },
-                { keytype: "normal", label: "+", shape: "normal", keycode: 78 }
+                { keytype: "normal", label: "+", shape: "numpadTall", keycode: 78 }
             ],
             [
                 { keytype: "normal", label: "Feststell", shape: "caps", keycode: 58 },
@@ -260,8 +259,7 @@ const byName = {
                 gap, gap, gap, gap, gap, gap, gap, gap,
                 { keytype: "normal", label: "4", shape: "normal", keycode: 75 },
                 { keytype: "normal", label: "5", shape: "normal", keycode: 76 },
-                { keytype: "normal", label: "6", shape: "normal", keycode: 77 },
-                { keytype: "normal", label: "+", shape: "normal", keycode: 78 }
+                { keytype: "normal", label: "6", shape: "normal", keycode: 77 }
             ],
             [
                 { keytype: "modkey", label: "Shift", labelShift: "Shift ⇧", labelCaps: "Locked ⇩", shape: "shiftIso", keycode: 42 },
@@ -285,7 +283,7 @@ const byName = {
                 { keytype: "normal", label: "1", shape: "normal", keycode: 79 },
                 { keytype: "normal", label: "2", shape: "normal", keycode: 80 },
                 { keytype: "normal", label: "3", shape: "normal", keycode: 81 },
-                { keytype: "normal", label: "↵", shape: "normal", keycode: 96 }
+                { keytype: "normal", label: "↵", shape: "numpadTall", keycode: 96 }
             ],
             [
                 { keytype: "modkey", label: "Strg", shape: "control", keycode: 29 },
@@ -302,8 +300,7 @@ const byName = {
                 { keytype: "normal", label: "→", shape: "normal", keycode: 106 },
                 gap,
                 { keytype: "normal", label: "0", shape: "numpadZero", keycode: 82 },
-                { keytype: "normal", label: ",", shape: "normal", keycode: 83 },
-                { keytype: "normal", label: "↵", shape: "normal", keycode: 96 }
+                { keytype: "normal", label: ",", shape: "normal", keycode: 83 }
             ]
         ]
     },
@@ -383,7 +380,7 @@ const byName = {
                 { keytype: "normal", label: "7", shape: "normal", keycode: 71 },
                 { keytype: "normal", label: "8", shape: "normal", keycode: 72 },
                 { keytype: "normal", label: "9", shape: "normal", keycode: 73 },
-                { keytype: "normal", label: "+", shape: "normal", keycode: 78 }
+                { keytype: "normal", label: "+", shape: "numpadTall", keycode: 78 }
             ],
             [
                 { keytype: "normal", label: "Caps", shape: "caps", keycode: 58 },
@@ -402,8 +399,7 @@ const byName = {
                 gap, gap, gap, gap, gap, gap, gap, gap,
                 { keytype: "normal", label: "4", shape: "normal", keycode: 75 },
                 { keytype: "normal", label: "5", shape: "normal", keycode: 76 },
-                { keytype: "normal", label: "6", shape: "normal", keycode: 77 },
-                { keytype: "normal", label: "+", shape: "normal", keycode: 78 }
+                { keytype: "normal", label: "6", shape: "normal", keycode: 77 }
             ],
             [
                 { keytype: "modkey", label: "Shift", labelShift: "Shift", labelCaps: "Caps", shape: "shift", keycode: 42 },
@@ -426,7 +422,7 @@ const byName = {
                 { keytype: "normal", label: "1", shape: "normal", keycode: 79 },
                 { keytype: "normal", label: "2", shape: "normal", keycode: 80 },
                 { keytype: "normal", label: "3", shape: "normal", keycode: 81 },
-                { keytype: "normal", label: "Enter", shape: "normal", keycode: 96 }
+                { keytype: "normal", label: "Enter", shape: "numpadTall", keycode: 96 }
             ],
             [
                 { keytype: "modkey", label: "Ctrl", shape: "control", keycode: 29 },
@@ -443,8 +439,7 @@ const byName = {
                 { keytype: "normal", label: "→", shape: "normal", keycode: 106 },
                 gap,
                 { keytype: "normal", label: "0", shape: "numpadZero", keycode: 82 },
-                { keytype: "normal", label: ".", shape: "normal", keycode: 83 },
-                { keytype: "normal", label: "Enter", shape: "normal", keycode: 96 }
+                { keytype: "normal", label: ".", shape: "normal", keycode: 83 }
             ]
         ]
     }

--- a/dots/.config/quickshell/imi/modules/imi/onScreenKeyboard/osk_lattice.js
+++ b/dots/.config/quickshell/imi/modules/imi/onScreenKeyboard/osk_lattice.js
@@ -1,0 +1,113 @@
+.pragma library
+.import "key_shapes.js" as KeyShapes
+
+// Where every key of a layout sits, as GRID CELLS.
+//
+// A keyboard is a lattice rather than a stack of rows: the numpad's + and its
+// Enter are one key two rows tall, and a row of keys cannot say so - which is
+// why they used to be two keys carrying one keycode each. Saying it needs a
+// GridLayout, and a GridLayout spans whole columns, so the lattice's column is
+// the QUARTER UNIT: every width in key_shapes.js is a multiple of 0.25u, so 1u
+// is four columns, 1.25u is five and the 6.25u spacebar is twenty-five.
+// `widthsAreWholeColumns()` is what says that assumption still holds, and
+// tst_osk_layouts.qml fails on a shape that breaks it.
+//
+// The layouts stay row-major and carry no coordinates. This is the walk: a key
+// takes the next free cells in its row, a key taller than one unit CLAIMS the
+// cells under it as well, and the row below steps over whatever was claimed.
+// That claim is the whole of the bookkeeping the data does not carry.
+const COLUMNS_PER_UNIT = 4;
+
+function columnSpan(shape) {
+    return Math.round((KeyShapes.widthUnits[shape] ?? 1) * COLUMNS_PER_UNIT);
+}
+
+// Only a key at least a whole unit tall claims rows. The two shapes shorter
+// than a unit - the function row's short cap and the spacer with no height at
+// all - are a cap drawn inside its own row, not a span.
+function rowSpan(shape) {
+    const units = KeyShapes.heightUnits[shape] ?? 1;
+    return units > 1 ? Math.round(units) : 1;
+}
+
+// The lattice rests on every width being a whole number of columns. A shape
+// that is not - a 1.1u key, say - would be drawn at a rounded span and put
+// every column after it somewhere the row above does not have one.
+function widthsAreWholeColumns() {
+    const offenders = [];
+    for (const shape of Object.keys(KeyShapes.widthUnits)) {
+        const columns = KeyShapes.widthUnits[shape] * COLUMNS_PER_UNIT;
+        if (columns !== Math.round(columns))
+            offenders.push(shape);
+    }
+    return offenders;
+}
+
+function place(rows) {
+    const claimed = ({});
+    const placements = [];
+    for (let row = 0; row < rows.length; row++) {
+        let column = 0;
+        for (const key of rows[row]) {
+            const columns = columnSpan(key.shape);
+            const height = rowSpan(key.shape);
+            column = nextFreeColumn(claimed, row, column, columns);
+            for (let r = 0; r < height; r++)
+                for (let c = 0; c < columns; c++)
+                    claimed[(row + r) + "," + (column + c)] = true;
+            placements.push({
+                key: key,
+                row: row,
+                column: column,
+                columnSpan: columns,
+                rowSpan: height
+            });
+            column += columns;
+        }
+    }
+    return placements;
+}
+
+// Terminates because `claimed` holds finitely many cells: past the last one
+// every column is free.
+function nextFreeColumn(claimed, row, from, span) {
+    let column = from;
+    for (;;) {
+        let free = true;
+        for (let c = 0; c < span; c++) {
+            if (claimed[row + "," + (column + c)]) {
+                free = false;
+                break;
+            }
+        }
+        if (free)
+            return column;
+        column++;
+    }
+}
+
+function columnsIn(placements) {
+    let columns = 0;
+    for (const placed of placements)
+        columns = Math.max(columns, placed.column + placed.columnSpan);
+    return columns;
+}
+
+// How many of a row's columns are covered, counting the ones a taller key in
+// an earlier row claimed. Every row of a full-size keyboard covers all of
+// them; a row that does not is a row whose nav cluster and numpad sit
+// somewhere the rows above and below do not.
+function columnsCovered(placements, row) {
+    let covered = 0;
+    for (const placed of placements)
+        if (row >= placed.row && row < placed.row + placed.rowSpan)
+            covered += placed.columnSpan;
+    return covered;
+}
+
+// A GridLayout column is the pitch's quarter minus the spacing that follows
+// it, so that a key spanning n columns - which covers the n-1 gaps inside its
+// span - comes out at exactly the width its units buy.
+function columnWidth(baseWidth, keyGap) {
+    return (baseWidth + keyGap) / COLUMNS_PER_UNIT - keyGap;
+}

--- a/dots/.config/quickshell/imi/tests/test_osk_key_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_osk_key_contract.py
@@ -12,14 +12,20 @@ the data:
     testing a transcription; a table growing back there is a second answer to
     how wide a key is, and the layouts - and the lattice the keys are placed
     on - are written against the other one.
-  - a key gap that is not the row's gap. A key spanning several units swallows
-    the gaps it covers, so OskKey subtracts exactly what OskContent's RowLayout
-    puts between two keys. Two different tokens leave every wide key short by a
-    few pixels per unit and every column after it displaced.
+  - a key gap that is not the grid's gap. A key spanning several units swallows
+    the gaps it covers, so OskKey subtracts exactly what OskContent's grid puts
+    between two cells. Two different tokens leave every wide key short by a few
+    pixels per unit and every column after it displaced.
   - a key that fills the row. `Layout.fillWidth` is how the rows used to come
     out the same width, and it works only while the fill key is the last thing
     in the row. Behind a nav cluster and a numpad it hands every key after it a
     position that depends on that row's own leftover.
+  - a lattice that is not declared. A GridLayout spreads a multi-column item's
+    width over the columns it spans and does NOT arrive at equal columns:
+    measured over these three layouts, 92 columns come out 1197px wide instead
+    of 1188, with a 13px gap before Backspace where every other gap is 8. The
+    zero-height item per column is what pins it, and dropping it is silent -
+    the keyboard still lays out, one column at a time out of true.
 
 Run: python3 tests/test_osk_key_contract.py
 """
@@ -82,17 +88,69 @@ class OskKeyContractTests(unittest.TestCase):
                 self.key, rf"property real {prop}:\s*KeyShapes\.{metric}\b",
                 f"OskKey does not take {prop} from KeyShapes.{metric}")
 
-    def test_a_key_subtracts_the_gap_its_row_puts_between_keys(self):
+    def test_a_key_subtracts_the_gap_the_grid_puts_between_cells(self):
         gap = re.search(r"property real keyGap:\s*(Appearance\.spacing\.\w+)", self.key)
         self.assertIsNotNone(gap, "OskKey declares no keyGap")
-        spacing = re.findall(r"spacing:\s*(Appearance\.spacing\.\w+)", self.content)
-        self.assertTrue(spacing, "OskContent declares no row spacing")
-        for token in spacing:
-            self.assertEqual(
-                token, gap.group(1),
-                "OskContent lays its keys out on a different gap from the one "
-                "OskKey subtracts, so every key wider than one unit is drawn "
-                "short by the difference and every column after it moves.")
+        content_gap = re.search(
+            r"property real keyGap:\s*(Appearance\.spacing\.\w+)", self.content)
+        self.assertIsNotNone(content_gap, "OskContent declares no keyGap")
+        self.assertEqual(
+            content_gap.group(1), gap.group(1),
+            "OskContent lays its keys out on a different gap from the one "
+            "OskKey subtracts, so every key wider than one unit is drawn "
+            "short by the difference and every column after it moves.")
+        # Both axes, from that one property. A rowSpacing that is not the gap a
+        # tall key covers leaves the numpad's + and Enter short or overlapping
+        # the row beneath them.
+        for axis in ("columnSpacing", "rowSpacing"):
+            self.assertRegex(
+                self.content, rf"{axis}:\s*root\.keyGap\b",
+                f"OskContent's {axis} is not the gap OskKey subtracts")
+
+    def test_a_key_covers_the_row_gaps_its_height_spans(self):
+        # The numpad's + and Enter are two units tall, so each covers the one
+        # row gap inside its span. Clamped rather than signed, because the
+        # function row's cap and the spacer are SHORTER than a unit and reach
+        # into no row at all - the unclamped term would make a spacer 8px tall
+        # and shrink every fn key by 2.4.
+        self.assertRegex(
+            self.key,
+            r"implicitHeight:\s*root\.baseHeight \* root\.heightUnits\s*"
+            r"\+ root\.keyGap \* Math\.max\(0, root\.heightUnits - 1\)",
+            "a key's height no longer covers the row gaps its span swallows")
+
+    def test_the_keyboard_is_one_grid_with_its_lattice_declared(self):
+        # A row layout cannot span rows, which is why a double-height key used
+        # to be two keys on one keycode.
+        self.assertNotRegex(
+            self.content, r"\bRowLayout\b",
+            "OskContent draws its keys in rows again, and a row cannot hold a "
+            "key that reaches into the next one")
+        self.assertRegex(self.content, r"\bGridLayout\b",
+                         "OskContent no longer draws its keys on a grid")
+        for prop in ("Layout.row", "Layout.column", "Layout.columnSpan", "Layout.rowSpan"):
+            self.assertIn(prop, self.content,
+                          f"OskContent places no key by {prop}")
+        # The declared lattice. Without it the grid's own distribution decides
+        # where a column starts, and it does not decide the same thing twice.
+        self.assertRegex(
+            self.content, r"Layout\.preferredWidth:\s*Lattice\.columnWidth\(",
+            "OskContent does not pin its columns to the lattice's own width, "
+            "so a multi-column key's span is spread by the grid instead")
+        self.assertRegex(
+            self.content, r"model:\s*keyGrid\.columns\b",
+            "OskContent declares fewer ruler items than the grid has columns, "
+            "and an unpinned column is one the grid sizes for itself")
+
+    def test_the_walk_that_places_a_key_has_one_home(self):
+        self.assertIn('import "osk_lattice.js" as Lattice', self.content,
+                      "OskContent no longer places its keys through the lattice")
+        # Cells worked out in the QML are cells tst_osk_layouts.qml cannot
+        # check, and the row-span bookkeeping is the whole of what the data
+        # does not carry.
+        self.assertRegex(
+            self.content, r"placements:\s*Lattice\.place\(",
+            "OskContent does not take its placements from the lattice module")
 
     def test_a_key_computes_its_width_from_units_and_that_gap(self):
         self.assertRegex(

--- a/dots/.config/quickshell/imi/tests/test_osk_key_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_osk_key_contract.py
@@ -7,10 +7,11 @@ see is the conversion from a unit to a pixel, which lives in OskKey.qml - and
 all three of the ways that conversion has already gone wrong are invisible from
 the data:
 
-  - a second copy of the shape tables. They used to be declared inside
-    OskKey.qml, which is why the QML test would have been testing a
-    transcription; a table growing back there is a second answer to how wide a
-    key is, and the layouts are written against the other one.
+  - a second copy of the shape tables or of the cap's own metrics. Both used to
+    be declared inside OskKey.qml, which is why the QML test would have been
+    testing a transcription; a table growing back there is a second answer to
+    how wide a key is, and the layouts - and the lattice the keys are placed
+    on - are written against the other one.
   - a key gap that is not the row's gap. A key spanning several units swallows
     the gaps it covers, so OskKey subtracts exactly what OskContent's RowLayout
     puts between two keys. Two different tokens leave every wide key short by a
@@ -34,6 +35,13 @@ OSK_KEY = OSK_DIR / "OskKey.qml"
 OSK_CONTENT = OSK_DIR / "OskContent.qml"
 KEY_SHAPES = OSK_DIR / "key_shapes.js"
 APPEARANCE = ROOT / "modules/common/Appearance.qml"
+
+
+def _shape_metric(name):
+    """The pixel value behind a key_shapes.js cap metric."""
+    match = re.search(rf"(?m)^const {name} = (\d+);", KEY_SHAPES.read_text())
+    assert match is not None, f"key_shapes.js declares no {name}"
+    return int(match.group(1))
 
 
 def _spacing_token(name):
@@ -65,6 +73,14 @@ class OskKeyContractTests(unittest.TestCase):
         self.assertNotRegex(
             self.key, r"property\s+var\s+\w*(?:Multiplier|Units)\s*:\s*\(?\{",
             "OskKey declares a shape table of its own")
+        # The cap's own box lives there too, because osk_lattice.js derives the
+        # grid column from it. A literal here is a second answer to the pitch,
+        # and the lattice would keep placing keys on the old one.
+        for prop, metric in (("baseWidth", "baseKeyWidth"),
+                             ("baseHeight", "baseKeyHeight")):
+            self.assertRegex(
+                self.key, rf"property real {prop}:\s*KeyShapes\.{metric}\b",
+                f"OskKey does not take {prop} from KeyShapes.{metric}")
 
     def test_a_key_subtracts_the_gap_its_row_puts_between_keys(self):
         gap = re.search(r"property real keyGap:\s*(Appearance\.spacing\.\w+)", self.key)
@@ -87,11 +103,9 @@ class OskKeyContractTests(unittest.TestCase):
         # The pitch has to stay a multiple of four or a quarter-unit span lands
         # on a half pixel, which QQuickLayout rounds up - seven pixels of drift
         # across the function row's fourteen spacers.
-        base = re.search(r"property real baseWidth:\s*(\d+)", self.key)
-        self.assertIsNotNone(base, "OskKey declares no baseWidth")
         gap = re.search(r"property real keyGap:\s*Appearance\.spacing\.(\w+)", self.key)
         self.assertIsNotNone(gap, "OskKey declares no keyGap")
-        pitch = int(base.group(1)) + _spacing_token(gap.group(1))
+        pitch = _shape_metric("baseKeyWidth") + _spacing_token(gap.group(1))
         self.assertEqual(pitch % 4, 0,
                          f"the key pitch is {pitch}, which cannot draw a "
                          f"quarter unit in whole pixels")

--- a/dots/.config/quickshell/imi/tests/tst_osk_layouts.qml
+++ b/dots/.config/quickshell/imi/tests/tst_osk_layouts.qml
@@ -1,20 +1,23 @@
 import QtTest
 import "../modules/imi/onScreenKeyboard/layouts.js" as Layouts
 import "../modules/imi/onScreenKeyboard/key_shapes.js" as KeyShapes
+import "../modules/imi/onScreenKeyboard/osk_lattice.js" as Lattice
 
-// The on-screen keyboard's layouts are plain data, which makes them the one
-// part of that module a test can reach: nothing about a rendered key is
-// reachable from qmltestrunner, and OskLayoutProbe.qml exists for the half
-// that is a picture.
+// The on-screen keyboard's layouts are plain data and osk_lattice.js turns
+// them into cells without touching a pixel, which makes the pair the one part
+// of that module a test can reach: nothing about a rendered key is reachable
+// from qmltestrunner, and OskLayoutProbe.qml exists for the half that is a
+// picture.
 //
 // What is worth pinning here is what breaks silently. A key with the wrong
 // evdev keycode types the wrong character and nothing anywhere reports it. A
-// row that spans anything other than the full width puts that row's nav
-// cluster and numpad somewhere the rows above and below do not, and the row is
-// still a perfectly good row. A shape in one multiplier table and not the
-// other falls back to one unit, which is a plausible size for most keys. And a
-// keycode that appears twice is a typo everywhere except the three places a
-// real keyboard draws one key across two rows.
+// row that does not cover the whole lattice puts that row's nav cluster and
+// numpad somewhere the rows above and below do not, and the row is still a
+// perfectly good row. A shape in one multiplier table and not the other falls
+// back to one unit, which is a plausible size for most keys. A width that is
+// not a whole number of columns is drawn at a rounded span, which moves every
+// column after it. And a keycode that appears twice is a typo everywhere
+// except the one place a keyboard draws a key that is not a rectangle.
 TestCase {
     name: "OskLayoutsTest"
 
@@ -26,13 +29,17 @@ TestCase {
     readonly property real rowUnits: mainBlock + clusterGap + navCluster + clusterGap + numpad
     readonly property real numpadStart: mainBlock + clusterGap + navCluster + clusterGap
 
-    // The keys a real keyboard draws as ONE key spanning two rows, which a row
-    // of keys cannot say - each is two keys carrying the one keycode.
-    readonly property var splitKeys: ({
+    // The numpad's + and its Enter are ONE key two rows tall.
+    readonly property var tallKeys: ({
         78: "numpad +",
-        96: "numpad Enter",
-        28: "ISO Enter"
+        96: "numpad Enter"
     })
+
+    // The only key that is still two keys, because it is the only one that is
+    // not a rectangle: an ISO Enter is 1.5u on the top row and 1.25u on the
+    // bottom, so no cell of the lattice has that shape.
+    readonly property int isoEnter: 28
+    readonly property var isoEnterShapes: ["enterIsoBottom", "enterIsoTop"]
 
     // Everything outside a layout's own alphabet: the function row, the nav
     // cluster, the arrows, the numpad and the modifiers. A keyboard layout
@@ -55,17 +62,19 @@ TestCase {
         return Object.keys(Layouts.byName);
     }
 
+    // Every key of a layout, where the lattice puts it. The offset is in
+    // keyboard units, which is what the clusters are described in; the lattice
+    // counts in quarters of one.
     function keysOf(name) {
-        const rows = Layouts.byName[name].keys;
         const out = [];
-        for (let r = 0; r < rows.length; r++) {
-            let offset = 0;
-            for (let c = 0; c < rows[r].length; c++) {
-                const key = rows[r][c];
-                const units = KeyShapes.widthUnits[key.shape];
-                out.push({ key: key, row: r, offset: offset, units: units });
-                offset += units;
-            }
+        for (const placed of Lattice.place(Layouts.byName[name].keys)) {
+            out.push({
+                key: placed.key,
+                row: placed.row,
+                offset: placed.column / Lattice.COLUMNS_PER_UNIT,
+                units: placed.columnSpan / Lattice.COLUMNS_PER_UNIT,
+                rows: placed.rowSpan
+            });
         }
         return out;
     }
@@ -94,7 +103,7 @@ TestCase {
         }
     }
 
-    function test_a_keycode_repeats_only_where_one_key_spans_two_rows() {
+    function test_a_keycode_repeats_only_where_the_key_is_not_a_rectangle() {
         for (const name of layoutNames()) {
             const rowsFor = ({});
             for (const entry of keysOf(name)) {
@@ -107,19 +116,50 @@ TestCase {
                 const rows = rowsFor[code];
                 if (rows.length === 1)
                     continue;
-                verify(splitKeys.hasOwnProperty(code),
+                // A key that spans rows is ONE key now. The ISO Enter is the
+                // only thing left that two keys is the honest spelling of.
+                compare(Number(code), isoEnter,
                     `${name} sends keycode ${code} from ${rows.length} keys`);
-                compare(rows.length, 2, `${name}: ${splitKeys[code]} is not two keys`);
-                // The halves of a key that is two rows tall are in those two
-                // rows. Two halves anywhere else is a keycode typed twice.
+                compare(rows.length, 2, `${name}: the ISO Enter is not two keys`);
                 compare(rows[1] - rows[0], 1,
-                    `${name}: ${splitKeys[code]}'s halves are not in adjacent rows`);
+                    `${name}: the ISO Enter's arms are not in adjacent rows`);
+                const shapes = placed(name, isoEnter).map(entry => entry.key.shape).sort();
+                compare(shapes.join(","), isoEnterShapes.join(","),
+                    `${name}: the ISO Enter's arms are not the two ISO shapes`);
             }
-            // ...and the two the numpad always has are always there: a half
-            // deleted by hand leaves a keyboard that still lays out.
-            compare(placed(name, 78).length, 2, `${name} numpad + is not two keys`);
-            compare(placed(name, 96).length, 2, `${name} numpad Enter is not two keys`);
+            // ...and the two the numpad draws across two rows are ONE key
+            // each, which is what stops the pad showing two Enters.
+            for (const code of Object.keys(tallKeys))
+                compare(placed(name, Number(code)).length, 1,
+                    `${name}: ${tallKeys[code]} is more than one key`);
         }
+    }
+
+    function test_a_double_height_key_is_one_key_of_two_units() {
+        for (const name of layoutNames()) {
+            for (const code of Object.keys(tallKeys)) {
+                const entries = placed(name, Number(code));
+                compare(entries.length, 1, `${name}: ${tallKeys[code]} is not one key`);
+                const entry = entries[0];
+                // Two units tall AND reaching two rows, because a height table
+                // saying 2 while the lattice hands out one row is a key drawn
+                // over the row below it, and a rowSpan of 2 on a one-unit-tall
+                // key is a key half the height of its own cell.
+                compare(KeyShapes.heightUnits[entry.key.shape], 2,
+                    `${name}: ${tallKeys[code]} is not two units tall`);
+                compare(entry.rows, 2, `${name}: ${tallKeys[code]} does not span two rows`);
+                compare(entry.units, 1, `${name}: ${tallKeys[code]} is not one unit wide`);
+            }
+        }
+    }
+
+    function test_every_width_is_a_whole_number_of_columns() {
+        // The lattice's column is a quarter unit, so a shape whose width is
+        // not a multiple of 0.25u is drawn at a rounded span - every column
+        // after it moves, and nothing reports it.
+        const offenders = Lattice.widthsAreWholeColumns();
+        compare(offenders.join(","), "",
+            `these shapes are not a whole number of quarter units: ${offenders.join(", ")}`);
     }
 
     function test_every_shape_a_layout_names_is_in_both_tables() {
@@ -145,15 +185,19 @@ TestCase {
             verify(used[shape] === true, `shape "${shape}" is declared and never used`);
     }
 
-    function test_every_row_spans_the_whole_keyboard() {
+    function test_every_row_covers_the_whole_keyboard() {
         for (const name of layoutNames()) {
             const rows = Layouts.byName[name].keys;
             compare(rows.length, 6, `${name} does not have six rows`);
+            const placements = Lattice.place(rows);
+            compare(Lattice.columnsIn(placements) / Lattice.COLUMNS_PER_UNIT, rowUnits,
+                `${name} is not ${rowUnits} units wide`);
             for (let r = 0; r < rows.length; r++) {
-                let units = 0;
-                for (const key of rows[r])
-                    units += KeyShapes.widthUnits[key.shape];
-                compare(units, rowUnits, `${name} row ${r} spans ${units} units`);
+                // Counted off the lattice rather than by summing the row's own
+                // keys, because a row under a double-height key does not
+                // declare the columns that key already took.
+                const units = Lattice.columnsCovered(placements, r) / Lattice.COLUMNS_PER_UNIT;
+                compare(units, rowUnits, `${name} row ${r} covers ${units} units`);
             }
         }
     }


### PR DESCRIPTION
The numpad drew two Enter keys and two `+` keys. Each of them was two keys
carrying one keycode, because the keyboard was a `ColumnLayout` of
`RowLayout`s and a row cannot hold a key that reaches into the next one.

Both are one key two rows tall now, in all three layouts.

## How

`Layout.rowSpan` is the tool, and reaching it needs a column. Measured
against the real width table: every width in `key_shapes.js` — 0.5, 1,
1.25, 1.5, 1.75, 2, 2.25, 2.75, 6.25 — is a multiple of a quarter unit, so
the quarter unit is the column, 1u is four of them and a row is 92.
`osk_lattice.js` is the walk that turns the row-major layout data into
cells: a key takes the next free columns in its row, a key taller than one
unit claims the cells beneath it, and the row below steps over the claim.
The layouts gain no coordinates, and the walk is pure so
`tst_osk_layouts.qml` can read it — nothing about a drawn key is reachable
from `qmltestrunner`.

**The lattice has to be declared, and that is the part worth knowing.** A
`GridLayout` spreads a multi-column item's width over the columns it spans
and does not arrive at equal columns. Measured on the real component with
nothing pinning them, the keyboard comes out **1197px** wide against the
1188 its units buy, with a **13px gap before Backspace** where every other
gap is 8 — afd3bf661's drift arriving from the other side, visible in a
screenshot and in nothing else. One zero-height item per column, asking for
exactly one column's width, puts every key back on a multiple of 13. It
needs a row of its own (the engine refuses a second item in a taken cell)
and that row costs one `rowSpacing`, which `OskContent` reports off its
implicit height rather than resizing the grid to hide — a grid given less
height than it asked for takes the difference out of a row of keys, and a
negative `Layout.bottomMargin` to cancel the spacing is clamped away.

The cap's own metrics moved to `key_shapes.js`, because the lattice's
column is a quarter of the pitch and two homes for a pitch is two answers
to where a column starts. `OskKey` is otherwise touched in one place: a key
taller than one unit now covers the row gaps its span swallows, clamped
rather than signed because the function row's cap and the spacer are
*shorter* than a unit and reach into no row at all.

## The German ISO Enter stays two keys

Deliberately, and it is the one thing here that was asked for and not done.
An ISO Enter is 1.5u on the top row against 1.25u on the bottom, offset a
quarter unit by the wider Caps beside it: it is an **L**, and no cell of a
rectangular lattice has that shape. Making it one key would mean changing a
real keyboard's geometry to suit the renderer (Caps would have to shrink to
1.5u). The comment beside it says so, and the test's repeat allowance now
permits that one keycode alone — and only as two arms, in adjacent rows,
carrying the two ISO shapes.

## Rendered

`tests/run_osk_layout_probe.sh`, all three layouts. Each reports every row
at **1188px**, the keyboard at **1188x297** (unchanged), and exactly **two**
keys taller than one row — `44x98` at `x=1144`, the numpad's last column,
which is where the two halves used to sit. The pictures show one tall `+`
beside `7 8 9 / 4 5 6` and one tall Enter beside `1 2 3 / 0 .`, columns
aligned, nothing overlapping.

## Tests

Tightened, because the old allowance was written when three keycodes were
each two keys and would have kept passing on the defect:

- `test_a_keycode_repeats_only_where_the_key_is_not_a_rectangle` — permits
  keycode 28 alone, as the ISO L; the numpad's two must be one key each.
- `test_a_double_height_key_is_one_key_of_two_units` — one key, one unit
  wide, two units tall in the shape table **and** two rows on the lattice.
  Both halves: a height of 2 the lattice hands one row to is a key drawn
  over the row below, and a rowSpan of 2 under a one-unit height is a key
  half the height of its own cell.
- `test_every_row_covers_the_whole_keyboard` — counts columns off the
  lattice. Summing a row's own keys cannot work any more: the row under a
  double-height key does not declare the columns that key already took.
- `test_every_width_is_a_whole_number_of_columns` — the assumption the
  lattice rests on, as a check rather than a comment.
- `test_the_keyboard_is_one_grid_with_its_lattice_declared`,
  `test_the_walk_that_places_a_key_has_one_home`,
  `test_a_key_covers_the_row_gaps_its_height_spans`,
  `test_a_key_subtracts_the_gap_the_grid_puts_between_cells` — the source
  half, including that the ruler is there at all: dropping it is silent.

Every one of them was planted against and observed to fail by name, in a
clean tree.

Docs: updated AGENT.md §Dynamic/data-driven QML gotchas
Changelog: updated
