### PR TITLE
Test harnesses stop opening windows on the developer's screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ own repo; the installer pins which revision it builds.
 
 ## [Unreleased]
 
+### Fixed
+- **Running the test suite no longer opens windows over what you are doing.**
+  Five test harnesses started the shell on the session's own display, so a
+  suite run flashed real windows across the screen — and a harness that draws a
+  panel there covers it outright. They bring their own headless compositor now,
+  like the rest already did.
+
 ## [0.29.0] — 2026-08-20
 
 The on-screen keyboard becomes a real keyboard: every key a full-size board

--- a/dots/.config/quickshell/imi/tests/lint_display_isolation.py
+++ b/dots/.config/quickshell/imi/tests/lint_display_isolation.py
@@ -88,6 +88,26 @@ def delegates_to_nested_probe(text):
     return isolated
 
 
+def calls_nested_display(tree):
+    """Whether the harness actually CALLS the helper, not merely imports it.
+
+    A first version searched the text for the module's name, and a planted
+    mutation - the call replaced by `dict(os.environ)`, the import left in
+    place - sailed through it. An import is not isolation; the call is. Same
+    hole the bus-isolation lint had, found the same way.
+    """
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        function = node.func
+        if (isinstance(function, ast.Attribute)
+                and isinstance(function.value, ast.Name)
+                and function.value.id == NESTS
+                and function.attr in ("start", "session")):
+            return True
+    return False
+
+
 def starts_weston(tree):
     """Whether the file launches its own compositor rather than importing the
     helper that does. Both are isolation; only the spelling differs."""
@@ -118,7 +138,7 @@ def main() -> int:
                 f"{path.name}: listed as source-only and yet builds a `qs` argv "
                 f"list. Drop it from SOURCE_ONLY and nest a display.")
             continue
-        if (NESTS not in text and not starts_weston(tree)
+        if (not calls_nested_display(tree) and not starts_weston(tree)
                 and not delegates_to_nested_probe(text)):
             failures.append(
                 f"{path.name}: launches `qs` without nesting a compositor, so "

--- a/dots/.config/quickshell/imi/tests/lint_display_isolation.py
+++ b/dots/.config/quickshell/imi/tests/lint_display_isolation.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+#
+# Regression guard: a harness that launches `qs` brings its own compositor.
+#
+# `qs -p` on the session's WAYLAND_DISPLAY maps its surfaces on the session's
+# compositor, so a suite run opened and closed real windows across whatever the
+# user was doing - reported as "tests spawn a lot of windows quickly". Every
+# `run_*_probe.sh` already nested its own headless weston; five Python
+# harnesses never did, and they are the ones that flashed.
+#
+# It is not only a nuisance. A harness mapping a LAYER surface on the live
+# display covers the user's screen, and the lock harness had to be nested
+# because a real WlSessionLock on this machine suspends the laptop. The
+# difference between "annoying" and "destructive" here is which surface the
+# harness happens to build.
+#
+# `tests/nested_display.py` is the one way to do it: three environment
+# variables and a process, each silent when wrong. Notably HYPRLAND_INSTANCE_
+# SIGNATURE, which `hyprctl` reads and nothing else - a harness that redirects
+# every other variable and leaves that one still talks to the user's
+# compositor (AGENT.md records it; run_notification_blur_probe.sh shipped it).
+#
+# So: a Python harness that launches `qs` must bring a compositor - either
+# through that module or by starting weston itself, which several harnesses did
+# before the module existed and which is equally correct. The check asks for
+# the PROPERTY (a compositor of its own), not for the helper: a first version
+# demanded the import and flagged twenty-four harnesses that were already
+# nesting perfectly well.
+#
+# Exits non-zero. Wired into run_tests.sh / CI.
+
+import ast
+import re
+import sys
+from pathlib import Path
+
+TESTS = Path(__file__).resolve().parent
+
+LAUNCHES_QS = re.compile(r'"qs"')
+NESTS = "nested_display"
+
+# Harnesses that name `qs` only in an assertion about the shell's own source,
+# and start nothing. Verified by hand; the check below also requires that they
+# contain no subprocess launch of qs, so a file that starts launching one
+# cannot hide here.
+SOURCE_ONLY = frozenset({
+    "test_conflict_killer_contract.py",
+})
+
+
+def launches_qs(tree):
+    """Whether any argv list literal in the file carries `qs` as argv[0].
+
+    A string assertion about the shell's source ('["qs", "-p", ...]' in text)
+    is not a launch, which is why this asks the syntax tree for a list whose
+    FIRST element is the binary rather than grepping for the name.
+    """
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.List, ast.Tuple)) or not node.elts:
+            continue
+        first = node.elts[0]
+        if isinstance(first, ast.Constant) and first.value == "qs":
+            return True
+        # `dbus-run-session -- qs ...`
+        strings = [e.value for e in node.elts
+                   if isinstance(e, ast.Constant) and isinstance(e.value, str)]
+        if "dbus-run-session" in strings and "qs" in strings:
+            return True
+    return False
+
+
+def delegates_to_nested_probe(text):
+    """Whether the harness hands off to a `run_*_probe.sh` that nests weston.
+
+    Five harnesses do exactly that - the Python side drives, the shell script
+    owns the compositor - and the isolation is real, one level down. Resolved
+    by READING the script it names rather than by allowlisting the harness, so
+    a probe that stops nesting takes its callers red with it.
+    """
+    isolated = False
+    for name in set(re.findall(r"run_[a-z0-9_]*probe\.sh", text)):
+        script = TESTS / name
+        if not script.exists():
+            return False
+        if "weston" not in script.read_text(encoding="utf-8"):
+            return False
+        isolated = True
+    return isolated
+
+
+def starts_weston(tree):
+    """Whether the file launches its own compositor rather than importing the
+    helper that does. Both are isolation; only the spelling differs."""
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.List, ast.Tuple)) or not node.elts:
+            continue
+        first = node.elts[0]
+        if isinstance(first, ast.Constant) and first.value == "weston":
+            return True
+    return False
+
+
+def main() -> int:
+    failures = []
+    scanned = 0
+
+    for path in sorted(TESTS.glob("test_*.py")):
+        text = path.read_text(encoding="utf-8")
+        try:
+            tree = ast.parse(text)
+        except SyntaxError:
+            continue
+        if not launches_qs(tree):
+            continue
+        scanned += 1
+        if path.name in SOURCE_ONLY:
+            failures.append(
+                f"{path.name}: listed as source-only and yet builds a `qs` argv "
+                f"list. Drop it from SOURCE_ONLY and nest a display.")
+            continue
+        if (NESTS not in text and not starts_weston(tree)
+                and not delegates_to_nested_probe(text)):
+            failures.append(
+                f"{path.name}: launches `qs` without nesting a compositor, so "
+                f"its windows open on the developer's screen - and a layer "
+                f"surface there covers it. Take the display from "
+                f"`nested_display.start(self, \"<name>\")`.")
+
+    for name in sorted(SOURCE_ONLY):
+        if not (TESTS / name).exists():
+            failures.append(f"{name}: in SOURCE_ONLY and no longer present.")
+
+    if not scanned:
+        failures.append("no qs-launching harness found - the sweep covers nothing")
+
+    for failure in failures:
+        print(f"display isolation: {failure}", file=sys.stderr)
+    if failures:
+        return 1
+    print(f"Display isolation lint passed: {scanned} qs harnesses, all nested")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dots/.config/quickshell/imi/tests/nested_display.py
+++ b/dots/.config/quickshell/imi/tests/nested_display.py
@@ -1,0 +1,92 @@
+"""A headless compositor of the harness's own, so a test never draws on the
+developer's screen.
+
+Every `run_*_probe.sh` already starts its own weston; the Python harnesses did
+not, so a suite run opened and closed a dozen real windows across whatever the
+user was doing - `qs -p` on the session's `WAYLAND_DISPLAY` maps its surfaces
+on the session's compositor. That is not only a nuisance: a harness that maps
+a layer surface on the live display is one keystroke away from covering the
+user's screen, and the lock-screen harness had to be nested for exactly that
+reason (a real `WlSessionLock` on this machine suspends the laptop).
+
+Isolation is three environment variables and a process, and getting any one of
+them wrong is silent:
+
+  - `XDG_RUNTIME_DIR` must be the harness's own, or the nested weston's socket
+    lands beside the session's and `qs` can pick either.
+  - `WAYLAND_DISPLAY` names the nested socket. libwayland prefixes the runtime
+    dir onto a relative name, which is why the two must move together.
+  - `HYPRLAND_INSTANCE_SIGNATURE` must go, because `hyprctl` reads it and
+    NOTHING else - a harness that leaves it set talks to the user's
+    compositor even with every other variable redirected (AGENT.md records
+    this one; `tests/run_notification_blur_probe.sh` shipped it as a bug).
+
+`DISPLAY` is dropped too, so nothing falls back to XWayland on the real X
+server.
+"""
+
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+BINARIES = ("qs", "weston", "dbus-run-session")
+
+
+def available():
+    """Whether a nested display can be started at all.
+
+    Deliberately NOT a check for `WAYLAND_DISPLAY`: a harness that nests its
+    own compositor does not need the caller to be in a graphical session, and
+    gating on one is what tied these tests to the developer's screen.
+    """
+    return all(shutil.which(binary) is not None for binary in BINARIES)
+
+
+def start(case, prefix, width=1500, height=900):
+    """Start a headless weston for `case` and return the env pointing at it.
+
+    `case` is the TestCase: the compositor and its runtime directory are
+    registered as its cleanups, so a failing assertion still takes them down.
+    """
+    base = Path(tempfile.mkdtemp(prefix=f"imi-{prefix}-display-"))
+    case.addCleanup(shutil.rmtree, base, ignore_errors=True)
+
+    runtime = base / "runtime"
+    runtime.mkdir(mode=0o700)
+    socket = f"wayland-imi-{prefix}"
+
+    env = dict(os.environ)
+    env["XDG_RUNTIME_DIR"] = str(runtime)
+    env["WAYLAND_DISPLAY"] = socket
+    env.pop("DISPLAY", None)
+    env.pop("HYPRLAND_INSTANCE_SIGNATURE", None)
+    # Software everywhere: a headless weston has no GPU context worth using,
+    # and the pixman renderer is what makes this run on a machine with no
+    # display at all (CI).
+    env["LIBGL_ALWAYS_SOFTWARE"] = "1"
+    env["QT_QUICK_BACKEND"] = "software"
+
+    weston = subprocess.Popen(
+        ["weston", "--backend=headless", "--renderer=pixman",
+         f"--socket={socket}", f"--width={width}", f"--height={height}"],
+        env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    case.addCleanup(_stop, weston)
+
+    socket_path = runtime / socket
+    deadline = time.monotonic() + 15
+    while not socket_path.exists() and time.monotonic() < deadline:
+        time.sleep(0.2)
+    if not socket_path.exists():
+        raise AssertionError("headless weston never came up")
+    return env
+
+
+def _stop(proc):
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -143,6 +143,16 @@ fi
 # The one thing in this shell that reads every key on the machine: what it
 # emits (keycodes, never characters), what it keeps (nothing), and when it is
 # allowed to run at all (only while the on-screen keyboard is open).
+# Static lint: a harness that launches qs brings its own compositor. Without
+# it, `qs -p` maps on the session's display and a suite run opens and closes
+# real windows over whatever the user is doing - and a layer surface there
+# covers their screen outright.
+echo "Running display isolation lint..."
+if ! python3 "$SCRIPT_DIR/lint_display_isolation.py"; then
+    echo "Display isolation lint failed."
+    exit 1
+fi
+
 echo "Running key monitor tests..."
 if ! python3 "$SCRIPT_DIR/test_key_monitor.py"; then
     echo "Key monitor tests failed."

--- a/dots/.config/quickshell/imi/tests/test_kboptions_migration_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_kboptions_migration_runtime.py
@@ -28,11 +28,15 @@ import json
 import os
 import shutil
 import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import nested_display  # noqa: E402
 HARNESS = ROOT / "KbOptionsRuntimeTest.qml"
 SHIPPED_DEFAULT = ROOT / "defaults/config.json"
 
@@ -53,12 +57,11 @@ EXPECTED_CHECKS = 1
 
 
 def _runtime_available():
-    return bool(os.environ.get("WAYLAND_DISPLAY")) and all(shutil.which(binary) is not None
-               for binary in ("qs", "dbus-run-session"))
+    return nested_display.available()
 
 
 @unittest.skipUnless(_runtime_available(),
-                     "needs a Wayland session and qs on PATH")
+                     "needs qs, weston and dbus-run-session on PATH")
 class KbOptionsMigrationRuntimeTest(unittest.TestCase):
     def setUp(self):
         self.home = Path(tempfile.mkdtemp(prefix="imi-kboptions-runtime-"))
@@ -92,7 +95,7 @@ class KbOptionsMigrationRuntimeTest(unittest.TestCase):
         self.lua_file.write_text(lua)
 
     def launch(self, expected):
-        env = dict(os.environ)
+        env = nested_display.start(self, "kboptions")
         env["XDG_CONFIG_HOME"] = str(self.config_home)
         env["XDG_STATE_HOME"] = str(self.home / "state")
         env["XDG_CACHE_HOME"] = str(self.home / "cache")

--- a/dots/.config/quickshell/imi/tests/test_motion_multiplier_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_motion_multiplier_runtime.py
@@ -29,11 +29,15 @@ import json
 import os
 import shutil
 import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import nested_display  # noqa: E402
 HARNESS = ROOT / "MotionMultiplierRuntimeTest.qml"
 SHIPPED_DEFAULT = ROOT / "defaults/config.json"
 
@@ -62,12 +66,11 @@ CASES = [
 
 
 def _runtime_available():
-    return bool(os.environ.get("WAYLAND_DISPLAY")) and all(shutil.which(binary) is not None
-               for binary in ("qs", "dbus-run-session"))
+    return nested_display.available()
 
 
 @unittest.skipUnless(_runtime_available(),
-                     "needs a Wayland session and qs on PATH")
+                     "needs qs, weston and dbus-run-session on PATH")
 class MotionMultiplierRuntimeTest(unittest.TestCase):
     def setUp(self):
         self.home = Path(tempfile.mkdtemp(prefix="imi-motion-runtime-"))
@@ -87,7 +90,7 @@ class MotionMultiplierRuntimeTest(unittest.TestCase):
         (self.shell_config / "config.json").write_text(json.dumps(config, indent=2))
 
     def launch(self, move, faster, press, velocity, stagger):
-        env = dict(os.environ)
+        env = nested_display.start(self, "motion")
         env["XDG_CONFIG_HOME"] = str(self.config_home)
         env["XDG_STATE_HOME"] = str(self.home / "state")
         env["XDG_CACHE_HOME"] = str(self.home / "cache")

--- a/dots/.config/quickshell/imi/tests/test_notes_migration_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_notes_migration_runtime.py
@@ -21,11 +21,15 @@ import json
 import os
 import shutil
 import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import nested_display  # noqa: E402
 HARNESS = ROOT / "NotesMigrationRuntimeTest.qml"
 
 LEGACY_NOTES = json.dumps([
@@ -41,8 +45,7 @@ EXPECTED_CHECKS = 7
 
 
 def _runtime_available():
-    return bool(os.environ.get("WAYLAND_DISPLAY")) and all(shutil.which(binary) is not None
-               for binary in ("qs", "dbus-run-session"))
+    return nested_display.available()
 
 
 def _digest(path):
@@ -50,7 +53,7 @@ def _digest(path):
 
 
 @unittest.skipUnless(_runtime_available(),
-                     "needs a Wayland session and qs on PATH")
+                     "needs qs, weston and dbus-run-session on PATH")
 class NotesMigrationRuntimeTest(unittest.TestCase):
     def setUp(self):
         self.home = Path(tempfile.mkdtemp(prefix="imi-notes-runtime-"))
@@ -77,7 +80,7 @@ class NotesMigrationRuntimeTest(unittest.TestCase):
             self.legacy_file.write_text(legacy)
 
     def launch(self, expected):
-        env = dict(os.environ)
+        env = nested_display.start(self, "notes")
         env["XDG_STATE_HOME"] = str(self.home / "state")
         env["XDG_CONFIG_HOME"] = str(self.home / "config")
         env["NOTES_EXPECT"] = json.dumps(expected)

--- a/dots/.config/quickshell/imi/tests/test_parallax_migration_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_parallax_migration_runtime.py
@@ -21,11 +21,15 @@ import json
 import os
 import shutil
 import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import nested_display  # noqa: E402
 HARNESS = ROOT / "ParallaxMigrationRuntimeTest.qml"
 SHIPPED_DEFAULT = ROOT / "defaults/config.json"
 
@@ -40,12 +44,11 @@ EXPECTED_CHECKS = 6
 
 
 def _runtime_available():
-    return bool(os.environ.get("WAYLAND_DISPLAY")) and all(shutil.which(binary) is not None
-               for binary in ("qs", "dbus-run-session"))
+    return nested_display.available()
 
 
 @unittest.skipUnless(_runtime_available(),
-                     "needs a Wayland session and qs on PATH")
+                     "needs qs, weston and dbus-run-session on PATH")
 class ParallaxMigrationRuntimeTest(unittest.TestCase):
     def setUp(self):
         self.home = Path(tempfile.mkdtemp(prefix="imi-parallax-runtime-"))
@@ -66,7 +69,7 @@ class ParallaxMigrationRuntimeTest(unittest.TestCase):
         self.config_file.write_text(json.dumps(config, indent=2))
 
     def launch(self, expected):
-        env = dict(os.environ)
+        env = nested_display.start(self, "parallax")
         env["XDG_CONFIG_HOME"] = str(self.config_home)
         env["XDG_STATE_HOME"] = str(self.home / "state")
         env["XDG_CACHE_HOME"] = str(self.home / "cache")

--- a/dots/.config/quickshell/imi/tests/test_quick_toggles_layout_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_quick_toggles_layout_runtime.py
@@ -34,11 +34,15 @@ import json
 import os
 import shutil
 import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import nested_display  # noqa: E402
 HARNESS = ROOT / "QuickTogglesLayoutRuntimeTest.qml"
 SHIPPED_DEFAULT = ROOT / "defaults/config.json"
 
@@ -50,12 +54,11 @@ EXPECTED_CHECKS = 11
 
 
 def _runtime_available():
-    return bool(os.environ.get("WAYLAND_DISPLAY")) and all(shutil.which(binary) is not None
-               for binary in ("qs", "dbus-run-session"))
+    return nested_display.available()
 
 
 @unittest.skipUnless(_runtime_available(),
-                     "needs a Wayland session and qs on PATH")
+                     "needs qs, weston and dbus-run-session on PATH")
 class QuickTogglesLayoutRuntimeTest(unittest.TestCase):
     def setUp(self):
         self.home = Path(tempfile.mkdtemp(prefix="imi-quicktoggles-runtime-"))
@@ -81,7 +84,7 @@ class QuickTogglesLayoutRuntimeTest(unittest.TestCase):
         (shell_config / "config.json").write_text(json.dumps(config, indent=2))
 
     def test_layout_edits_keep_every_toggle_on_its_own_button(self):
-        env = dict(os.environ)
+        env = nested_display.start(self, "quicktoggles")
         env["XDG_CONFIG_HOME"] = str(self.config_home)
         env["XDG_STATE_HOME"] = str(self.home / "state")
         env["XDG_CACHE_HOME"] = str(self.home / "cache")


### PR DESCRIPTION
Reported by the maintainer: a suite run "spawns a lot of windows quickly" across whatever they are doing.

`qs -p` on the session's `WAYLAND_DISPLAY` maps its surfaces on the session's compositor. Every `run_*_probe.sh` has nested its own headless weston for ages; **five Python harnesses never got ported** — the notes, kbOptions, parallax and quick-toggle migrations, and the motion multiplier.

It is not only a nuisance. A harness that maps a **layer** surface on the live display covers the screen, and the lock-screen harness was nested precisely because a real `WlSessionLock` on this machine suspends the laptop. Which of the two a harness is depends on the surface it happens to build.

## The recipe, once
`tests/nested_display.py` — three environment variables and a process, each silent when wrong:
- `XDG_RUNTIME_DIR` of its own, or the nested socket lands beside the session's and `qs` can pick either
- `WAYLAND_DISPLAY` naming the nested socket (libwayland prefixes the runtime dir onto a relative name, so the two must move together)
- **`HYPRLAND_INSTANCE_SIGNATURE` dropped** — `hyprctl` reads that and nothing else, so a harness redirecting every other variable still talks to the user's compositor. AGENT.md records it; `run_notification_blur_probe.sh` shipped it as a bug.

Their availability gate changed with them: it required the developer to be **in** a graphical session, which is exactly what tied these tests to the screen. They now need `qs`, `weston` and `dbus-run-session` and nothing about where they run — so they also work headless in CI.

All five run green against their own compositor.

## The check, and two wrong versions of it
`tests/lint_display_isolation.py` asks for the **property** — a compositor of its own — not for the helper: nesting via `nested_display`, starting weston inline (several harnesses did that before the module existed), or delegating to a `run_*_probe.sh` that nests, **resolved by reading the script it names**, so a probe that stops nesting takes its callers red with it.

Both earlier versions were wrong and both were found by planting, not by reading:
1. Demanding the import flagged **24 harnesses that were already nesting perfectly well**.
2. Searching the text for the module's name then **passed a mutation with the call removed and the import left behind**. An import is not isolation; the call is. That is the same hole `lint_runtime_bus_isolation.py` had, found the same way.

**Plant-proofs** (clean tree, after committing): call replaced by `dict(os.environ)` → `test_notes_migration_runtime.py: launches qs without nesting a compositor…`; `run_calendar_probe.sh` stripped of weston → `test_calendar_card.py` reddens through the delegation; both restored → 34 qs harnesses, all nested.

**Suite**: full `tests/run_tests.sh`, all tests passed, exit 0.

**Not verified**: that the screen stays quiet during a full run — the maintainer will see that on their next suite run, which is the only place it is observable.

Changelog: updated

Docs: not needed — the mechanism is in `nested_display.py`'s header and the lint's, where the next person writing a harness is standing
