### PR TITLE
fix(editmode): the chrome stops crowding the desktop it frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,19 @@ own repo; the installer pins which revision it builds.
 ## [Unreleased]
 
 ### Fixed
+- **Edit Mode's widget drawer no longer sits flush on the screen edge.** The
+  panel's rounded right corner met the edge of the display with nothing between
+  them, while its other side had a full margin against the desktop. It now
+  keeps a gap on the side it opens against.
+- **Edit Mode's desktop preview got bigger.** The toolbar and the tab bar each
+  reserved a full margin of air between themselves and the edge of the screen,
+  on the axis that decides how far the desktop shrinks — so both came straight
+  off the preview. The outer gap is now half the inner one, and on a 5120x1440
+  display the preview grows from 4380x1232 to 4466x1256.
+- **"Edit layout" no longer looks like a button you can press.** It was an icon
+  beside a label sitting flat in a row of controls, which is exactly how the
+  toolbar draws an unfilled button. It now reads as the title it is, with a
+  rule separating it from the buttons.
 - **Running the test suite no longer opens windows over what you are doing.**
   Five test harnesses started the shell on the session's own display, so a
   suite run flashed real windows across the screen — and a harness that draws a

--- a/dots/.config/quickshell/imi/EditModeDrawerLayoutProbe.qml
+++ b/dots/.config/quickshell/imi/EditModeDrawerLayoutProbe.qml
@@ -3,6 +3,7 @@ import Quickshell
 import qs
 import qs.modules.common
 import qs.modules.imi.editMode
+import "modules/common/functions/edit_mode.js" as EditMode
 
 /*
  * What the drawer's column gives its list, in pixels.
@@ -39,6 +40,13 @@ ShellRoot {
             card: Qt.rect(120, 120, 900, 900)
             area: Qt.rect(0, 0, win.width, win.height)
             drawer: Qt.rect(1100, 120, 370, 960)
+            // This probe hands the chrome hand-written rects rather than a
+            // geometry, so it states the split from the same two tokens the
+            // geometry would have derived it from.
+            bandFraction: EditMode.chromeBandFraction({
+                margin: Appearance.sizes.editModeMargin,
+                edgeMargin: Appearance.sizes.editModeEdgeMargin
+            })
         }
 
         // The drawer's own column, found by shape rather than by id: the probe

--- a/dots/.config/quickshell/imi/EditModeLookProbe.qml
+++ b/dots/.config/quickshell/imi/EditModeLookProbe.qml
@@ -283,6 +283,7 @@ ShellRoot {
                 sourceComponent: EditModeChromeContent {
                     card: harness.card
                     area: harness.area
+                    bandFraction: EditMode.chromeBandFraction(harness.viewport)
                 }
             }
         }

--- a/dots/.config/quickshell/imi/EditModeLookProbe.qml
+++ b/dots/.config/quickshell/imi/EditModeLookProbe.qml
@@ -395,18 +395,25 @@ ShellRoot {
                 && harness.tabBar.y + harness.tabBar.height <= harness.screenHeight,
             `toolbar=${harness.toolbar?.y.toFixed(1)}+${harness.toolbar?.height.toFixed(1)}`
                 + ` band=${harness.card.y.toFixed(1)}`);
-        // ...and clear of the two edges the bar and the dock own, by a whole
+        // ...and clear of the two edges the bar and the dock own, by the edge
         // margin at each end. This is the check stage 4 did not have: its bands
         // were whatever the ceiling left over, so the toolbar started 22px into
         // a screen whose bar occupies the first 68 and the tab bar landed on the
         // dock. Asserted against the reserved insets rather than against the
         // area, so it cannot be satisfied by an area that forgot to subtract
         // them.
+        //
+        // The gap is `edgeMargin`, not `margin`: the band is asymmetric, with
+        // the tight gap on the outside against the panel and the generous one
+        // on the inside against the desktop. Clearing the panel is what this
+        // check is about, so it is the outer number that belongs here - and
+        // the inner one is asserted by the band check above.
         harness.check("...clear of the bar's and the dock's own edges",
             harness.toolbar !== null && harness.tabBar !== null
-                && harness.toolbar.y >= harness.insetTop + harness.margin - 0.5
+                && harness.toolbar.y >= harness.insetTop + harness.edgeMargin - 0.5
                 && harness.tabBar.y + harness.tabBar.height
-                    <= harness.screenHeight - harness.insetBottom - harness.margin + 0.5
+                    <= harness.screenHeight - harness.insetBottom
+                        - harness.edgeMargin + 0.5
                 && harness.card.y >= harness.insetTop
                 && harness.card.y + harness.card.height
                     <= harness.screenHeight - harness.insetBottom,
@@ -425,8 +432,13 @@ ShellRoot {
                     - (harness.card.x + harness.card.width / 2)) < 0.5
                 && Math.abs((harness.tabBar.x + harness.tabBar.width / 2)
                     - (harness.card.x + harness.card.width / 2)) < 0.5
-                && Math.abs(gapAbove - gapBelow) < 0.5,
-            `gaps=${gapAbove.toFixed(1)},${gapBelow.toFixed(1)}`);
+                && Math.abs(gapAbove - gapBelow) < 0.5
+                // ...and both are the EDGE margin. Equal to each other alone
+                // passes at any symmetric value, including the old one, so it
+                // could not see the band's split arrive or leave.
+                && Math.abs(gapAbove - harness.edgeMargin) < 0.5,
+            `gaps=${gapAbove.toFixed(1)},${gapBelow.toFixed(1)}`
+                + ` edgeMargin=${harness.edgeMargin.toFixed(1)}`);
         harness.check("in the mode at rest the lattice is down",
             !widgetCanvas.gridVisible && widgetCanvas.gridStrength === 0);
         harness.reportGeometry("geometry");

--- a/dots/.config/quickshell/imi/EditModeLookProbe.qml
+++ b/dots/.config/quickshell/imi/EditModeLookProbe.qml
@@ -78,6 +78,7 @@ ShellRoot {
 
     readonly property real drawerWidth: Appearance.sizes.editModeDrawerWidth
     readonly property real margin: Appearance.sizes.editModeMargin
+    readonly property real edgeMargin: Appearance.sizes.editModeEdgeMargin
     readonly property real chromeThickness: Appearance.sizes.toolbarHeight
 
     // What the bar and the dock occupy. `EditModeInsets` answers this on the
@@ -100,6 +101,7 @@ ShellRoot {
         screenHeight: harness.screenHeight,
         drawerWidth: harness.drawerWidth,
         margin: harness.margin,
+        edgeMargin: harness.edgeMargin,
         chromeThickness: harness.chromeThickness,
         insetTop: harness.insetTop,
         insetBottom: harness.insetBottom

--- a/dots/.config/quickshell/imi/EditModeRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/EditModeRuntimeTest.qml
@@ -59,7 +59,8 @@ ShellRoot {
         screenWidth: harness.screenWidth,
         screenHeight: harness.screenHeight,
         drawerWidth: Appearance.sizes.editModeDrawerWidth,
-        margin: Appearance.sizes.editModeMargin
+        margin: Appearance.sizes.editModeMargin,
+        edgeMargin: Appearance.sizes.editModeEdgeMargin
     })
     // The drawer's shift, from the REAL scalar: GlobalStates derives
     // editDrawerProgress from the mode and the open flag exactly as the shell

--- a/dots/.config/quickshell/imi/modules/common/Appearance.qml
+++ b/dots/.config/quickshell/imi/modules/common/Appearance.qml
@@ -826,6 +826,13 @@ Singleton {
         // The gap outside the shrunk desktop on its three free sides, and
         // between it and the drawer's slot on the fourth.
         property real editModeMargin: root.spacing.space300
+        // The gap between Edit Mode's own chrome - the toolbar, the tab bar and
+        // the drawer - and the edge of the usable area. Half the desktop's,
+        // because it is a floating surface's gap from the screen edge rather
+        // than a gap between two pieces of content, and because on the vertical
+        // axis it is the term that binds: every pixel here is one the shrunk
+        // desktop does not get.
+        property real editModeEdgeMargin: root.spacing.space150
         // M3's toolbar height (m3.material.io/components/toolbars). It is a
         // token rather than a literal inside Toolbar.qml because Edit Mode's
         // viewport reserves a band for the toolbar on the BACKGROUND surface,

--- a/dots/.config/quickshell/imi/modules/common/functions/edit_mode.js
+++ b/dots/.config/quickshell/imi/modules/common/functions/edit_mode.js
@@ -211,12 +211,18 @@ function viewportGeometry(input) {
     const area = usableArea(input);
     // Two margins horizontally (outside the desktop, and between the desktop
     // and the drawer). Vertically the desktop gives up a whole band on each
-    // side: a margin, the chrome, and another margin - so the toolbar centred
-    // in that band has `margin` above and below it by construction, whatever
-    // the screen is and wherever the bar happens to be. With no chrome the band
-    // collapses back to one margin, which is what the geometry was before the
-    // chrome existed.
-    const band = chromeThickness > 0 ? margin * 2 + chromeThickness : margin;
+    // side, and the band is ASYMMETRIC: an edge margin, the chrome, and a full
+    // margin - the tight gap on the outside where the toolbar floats against
+    // the screen, the generous one on the inside between it and the desktop.
+    //
+    // Symmetric was the wrong shape. This axis is the one that binds on a wide
+    // screen, so both outer margins come straight off the desktop the mode
+    // exists to show: at 5120x1440 the symmetric band cost 24px of desktop
+    // height and 85px of width to put air above a toolbar that already floats
+    // over the wallpaper. With no chrome the band collapses back to one margin,
+    // which is what the geometry was before the chrome existed.
+    const band = chromeThickness > 0
+        ? edgeMargin + chromeThickness + margin : margin;
     // Horizontally, left to right: a margin, the desktop, a margin, the
     // drawer, and the drawer's own edge gap. The last term is what stops the
     // open drawer sitting flush on the screen's edge - it was missing, so the
@@ -280,6 +286,29 @@ function drawerTravel(geometry) {
         ? geometry.edgeMargin : (geometry.margin || 0);
     return Math.max(0,
         (geometry.drawer || 0) + (geometry.margin || 0) + edge - free);
+}
+
+// Where a chrome piece sits in its band, as a FRACTION of the band's slack
+// rather than as a pixel offset from the edge.
+//
+// A fraction because the band has no height at progress 0 - it grows out of
+// nothing as the desktop shrinks away from it - and a piece placed at a fixed
+// `edgeMargin` from the area's edge would be sitting fully on screen before the
+// mode had started. At a fraction it is parked off the edge at 0 and lands at
+// exactly `edgeMargin` at 1, with no Behavior of its own; a piece whose target
+// moves every frame must not have one (b710ef731).
+//
+// The band is `edgeMargin + chrome + margin`, so its slack is
+// `edgeMargin + margin` and the piece starts `edgeMargin` into it. The BOTTOM
+// band is the mirror, which is `1 - this`: from the card's edge it is the
+// margin first and the edge gap last.
+function chromeBandFraction(geometry) {
+    if (!geometry)
+        return 0.5;
+    const margin = geometry.margin || 0;
+    const edge = geometry.edgeMargin !== undefined ? geometry.edgeMargin : margin;
+    const slack = edge + margin;
+    return slack > 0 ? edge / slack : 0.5;
 }
 
 // The entry and exit animation, expressed as one scalar the shell can put a

--- a/dots/.config/quickshell/imi/modules/common/functions/edit_mode.js
+++ b/dots/.config/quickshell/imi/modules/common/functions/edit_mode.js
@@ -181,6 +181,14 @@ function usableArea(input) {
 // `margin` is one token: the gap between the desktop and the screen's edge, and
 // the gap between the desktop and the drawer's slot once there is a drawer.
 //
+// `edgeMargin` is the OTHER gap - between the chrome and the usable area's own
+// edge - and it is a second token because the two are not the same distance.
+// The desktop's margin is a gap between two pieces of content and wants to be
+// generous; the chrome's is a gap between a floating toolbar and the edge of
+// the screen and wants to be tight, because every pixel of it is taken off the
+// desktop the mode exists to show. It defaults to `margin`, which is the
+// symmetric band the geometry had before the two were told apart.
+//
 // `chromeThickness` is the toolbar's own height, and it is passed rather than
 // measured for the same reason `drawerWidth` is: the desktop's transform is
 // built out of this function on the BACKGROUND surface, where neither the
@@ -191,6 +199,8 @@ function viewportGeometry(input) {
     const screenHeight = (input && input.screenHeight) || 0;
     const drawerWidth = (input && input.drawerWidth) || 0;
     const margin = (input && input.margin) || 0;
+    const edgeMargin = (input && input.edgeMargin !== undefined)
+        ? input.edgeMargin : margin;
     const chromeThickness = (input && input.chromeThickness) || 0;
     if (screenWidth <= 0 || screenHeight <= 0)
         return {
@@ -207,7 +217,12 @@ function viewportGeometry(input) {
     // collapses back to one margin, which is what the geometry was before the
     // chrome existed.
     const band = chromeThickness > 0 ? margin * 2 + chromeThickness : margin;
-    const roomX = area.width - drawerWidth - margin * 2;
+    // Horizontally, left to right: a margin, the desktop, a margin, the
+    // drawer, and the drawer's own edge gap. The last term is what stops the
+    // open drawer sitting flush on the screen's edge - it was missing, so the
+    // panel had a rounded right corner against nothing.
+    const roomX = area.width - drawerWidth - margin * 2
+        - (drawerWidth > 0 ? edgeMargin : 0);
     const roomY = area.height - band * 2;
     const scale = Math.max(MIN_SCALE,
         Math.min(MAX_SCALE, roomX / screenWidth, roomY / screenHeight));
@@ -237,18 +252,18 @@ function viewportGeometry(input) {
         // opens another into it, and only the machine where the two differ
         // ever sees it.
         drawer: drawerWidth,
-        margin: margin
+        margin: margin,
+        edgeMargin: edgeMargin
     };
 }
 
 // How far LEFT the desktop travels when the drawer is fully open: whatever the
 // centred desktop's free side cannot absorb of the drawer's slot.
 //
-// The slot is `drawer + margin` against the usable area's right edge - the
-// drawer sits flush on the edge and the margin is the gap between it and the
-// desktop, which is exactly the room `viewportGeometry` reserved in the SIZE
-// (`roomX = area.width - drawerWidth - margin * 2`: one margin outside the
-// desktop, one between it and the drawer). A centred desktop already has
+// The slot is `edgeMargin + drawer + margin` against the usable area's right
+// edge - the drawer's own gap from the screen edge, the drawer, and the gap
+// between it and the desktop, which is exactly the room `viewportGeometry`
+// reserved in the SIZE. A centred desktop already has
 // `(area.width - width) / 2` free on that side, so the travel is the
 // difference, floored at zero for the screens where the ceiling left more
 // room than the slot needs.
@@ -261,7 +276,10 @@ function drawerTravel(geometry) {
     if (!geometry || !(geometry.width > 0) || !geometry.area)
         return 0;
     const free = (geometry.area.width - geometry.width) / 2;
-    return Math.max(0, (geometry.drawer || 0) + (geometry.margin || 0) - free);
+    const edge = geometry.edgeMargin !== undefined
+        ? geometry.edgeMargin : (geometry.margin || 0);
+    return Math.max(0,
+        (geometry.drawer || 0) + (geometry.margin || 0) + edge - free);
 }
 
 // The entry and exit animation, expressed as one scalar the shell can put a
@@ -357,14 +375,21 @@ function areaRect(geometry, progress, screenWidth, screenHeight) {
 // It spans exactly the card's band (same y, same height), which needs no shift
 // term: the drawer's travel moves the desktop sideways and sideways does not
 // change y or height.
+//
+// It slides out from `edgeMargin` in from the area's right edge rather than
+// from the edge itself, so the panel keeps a gap on the side it opens against.
+// Expressed as an offset on the ORIGIN rather than a smaller width, because the
+// width is the reveal and the reveal must still reach the drawer's full size.
 function drawerRect(geometry, progress, drawerProgress, screenWidth, screenHeight) {
     const t = Math.max(0, Math.min(1, progress || 0));
     const p = Math.max(0, Math.min(1, drawerProgress || 0)) * t;
     const area = areaRect(geometry, progress, screenWidth, screenHeight);
     const card = cardRect(geometry, progress, screenWidth, screenHeight);
     const width = (geometry.drawer || 0) * p;
+    const edge = geometry.edgeMargin !== undefined
+        ? geometry.edgeMargin : (geometry.margin || 0);
     return {
-        x: area.x + area.width - width,
+        x: area.x + area.width - edge - width,
         y: card.y,
         width: width,
         height: card.height

--- a/dots/.config/quickshell/imi/modules/imi/background/Background.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/Background.qml
@@ -574,6 +574,7 @@ Variants {
             screenHeight: bgRoot.height,
             drawerWidth: Appearance.sizes.editModeDrawerWidth,
             margin: Appearance.sizes.editModeMargin,
+            edgeMargin: Appearance.sizes.editModeEdgeMargin,
             chromeThickness: Appearance.sizes.toolbarHeight,
             insetTop: bgRoot.editInsets.top,
             insetBottom: bgRoot.editInsets.bottom,

--- a/dots/.config/quickshell/imi/modules/imi/background/EditModeCard.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/EditModeCard.qml
@@ -52,6 +52,38 @@ Item {
     // interpolate from "the whole screen, square" so that at rest there is
     // nothing inset, nothing rounded and nothing to stand down.
     property rect card: Qt.rect(0, 0, root.width, root.height)
+
+    // How far the card's MASK is grown past the card itself: half a pixel, the
+    // standard cure for a compositing seam.
+    //
+    // `surround` is an OpacityMask taken from the card's shape and INVERTED, so
+    // what survives is the complement - the backdrop, everywhere the card is
+    // not. Where the card's edge falls between two pixels, that boundary pixel
+    // is partly inside both: the mask leaves it partly opaque, the backdrop
+    // keeps a fraction of its own alpha there, and the backdrop is brighter
+    // than the desktop. The seam renders as a bright rim down the flank - the
+    // difference between an object with an edge and an object with a border
+    // drawn round it.
+    //
+    // Fractional is the normal case, not the exception. The card is a screen
+    // scaled to fit a room measured in whole pixels, so its width is
+    // `screenWidth * (room / screenHeight)` and lands on an integer only by
+    // coincidence: at 5120x1440 the resting card is 4465.778 wide at x 327.111.
+    //
+    // The overlap is INWARD. Grown the other way it opens a gap instead of
+    // closing one: the desktop is a scaled screen and ends at its own edge, so
+    // a complement that starts half a pixel further out leaves half a pixel
+    // where neither the desktop nor the backdrop draws. Shrunk, the backdrop
+    // laps half a pixel over the desktop, the boundary pixel is fully covered
+    // by one layer, and there is no fraction of anything left to show.
+    //
+    // Adjusted rather than rounded, because the card is the arithmetic the
+    // transform interpolates and it has to stay continuous - and because
+    // rounding the mask alone is worse than the seam it fixes: a mask on a
+    // whole pixel and a desktop on a fractional one disagree by up to a whole
+    // pixel rather than by the fraction of one.
+    readonly property real maskBleed: -0.5
+
     property real cardRadius: 0
 
     // ---- the glass edge ---------------------------------------------------
@@ -175,10 +207,16 @@ Item {
         // as the corner, because it is the same mask that makes the corner.
         Rectangle {
             id: edgeSpecular
-            x: root.card.x - root.edgeSpecularWidth
-            y: root.card.y - root.edgeSpecularWidth
-            width: root.card.width + 2 * root.edgeSpecularWidth
-            height: root.card.height + 2 * root.edgeSpecularWidth
+            // The bleed too, or the catch loses it. This ring is drawn INSIDE
+            // `surround`, so what is seen of it is the annulus between the
+            // mask's edge and this rectangle's - and the mask's edge just moved
+            // out by `maskBleed`. Extending the outer bound by the same amount
+            // keeps the drawn width at `edgeSpecularWidth`, which is a single
+            // pixel and had half of itself masked away.
+            x: root.card.x - root.edgeSpecularWidth - root.maskBleed
+            y: root.card.y - root.edgeSpecularWidth - root.maskBleed
+            width: root.card.width + 2 * (root.edgeSpecularWidth + root.maskBleed)
+            height: root.card.height + 2 * (root.edgeSpecularWidth + root.maskBleed)
             radius: root.cardRadius > 0 ? root.cardRadius + root.edgeSpecularWidth : 0
             antialiasing: true
             // The non-uniformity is not a flourish on top of a rim, it IS the
@@ -220,10 +258,10 @@ Item {
         visible: false
 
         Rectangle {
-            x: root.card.x
-            y: root.card.y
-            width: root.card.width
-            height: root.card.height
+            x: root.card.x - root.maskBleed
+            y: root.card.y - root.maskBleed
+            width: root.card.width + root.maskBleed * 2
+            height: root.card.height + root.maskBleed * 2
             radius: root.cardRadius
             color: "white"
             antialiasing: true

--- a/dots/.config/quickshell/imi/modules/imi/editMode/EditModeChromeContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/editMode/EditModeChromeContent.qml
@@ -74,6 +74,13 @@ Item {
     signal lockIslandToggleRequested(string key)
     signal lockLayoutResetRequested()
 
+    // Where in its band each chrome piece sits, as a fraction of the band's
+    // slack - `edit_mode.js`'s `chromeBandFraction`, which is 0.5 exactly when
+    // the two margins that bound the band are equal. Defaults to 0.5 so an
+    // unconnected instance centres its chrome the way it did before the band
+    // was told apart into an outer gap and an inner one.
+    property real bandFraction: 0.5
+
     // The screen this chrome belongs to, for the drawer's fork question.
     property string screenName: ""
 
@@ -92,11 +99,14 @@ Item {
         // point today and stop being one the moment stage 5's drawer
         // translates the desktop, and the chrome belongs to the desktop.
         x: root.card.x + (root.card.width - width) / 2
-        // Centred in the band between the usable area's top edge and the card's
+        // Placed in the band between the usable area's top edge and the card's
         // - the screen's top edge only while nothing is on that edge. The
-        // viewport reserves `margin + toolbarHeight + margin` there, so this
-        // lands with a margin above and below it and cannot reach the bar.
-        y: root.area.y + (root.card.y - root.area.y - height) / 2
+        // viewport reserves `edgeMargin + toolbarHeight + margin` there, and
+        // `bandFraction` is the split, so this lands with the tight gap above
+        // it and the generous one below and cannot reach the bar. A fraction
+        // rather than `area.y + edgeMargin`, because the band has no height at
+        // progress 0 and the piece has to be parked off the edge there.
+        y: root.area.y + (root.card.y - root.area.y - height) * root.bandFraction
         spacing: Appearance.spacing.space150
 
         MaterialSymbol {
@@ -175,9 +185,13 @@ Item {
         // area's. The card is centred in that area, so the two bands are the
         // same height and the two pieces travel by the same amount - which is
         // true with a bar on one edge and a dock on the other, and was true
-        // before only because neither was accounted for.
+        // before only because neither was accounted for. Mirrored means
+        // `1 - bandFraction` as well as the other edge: measured from the
+        // card, the bottom band spends the generous margin first and the tight
+        // edge gap last.
         y: root.card.y + root.card.height
-            + (root.area.y + root.area.height - root.card.y - root.card.height - height) / 2
+            + (root.area.y + root.area.height - root.card.y - root.card.height - height)
+                * (1 - root.bandFraction)
 
         // The mode's two tabs (spec §1.4): the tab is a FILTER on what the
         // viewport draws, so the bar's index and `GlobalStates.editTab` must

--- a/dots/.config/quickshell/imi/modules/imi/editMode/EditModeChromeContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/editMode/EditModeChromeContent.qml
@@ -109,19 +109,41 @@ Item {
         y: root.area.y + (root.card.y - root.area.y - height) * root.bandFraction
         spacing: Appearance.spacing.space150
 
-        MaterialSymbol {
+        // The toolbar's title, and every part of this is about it NOT reading
+        // as a control.
+        //
+        // It used to be a `MaterialSymbol { text: "edit" }` followed by a
+        // `StyledText`, which is not merely similar to a button - it is the
+        // exact construction of `IconAndTextToolbarButton`, an icon and a label
+        // in a row. Sat flat between two real buttons it was an unfilled
+        // icon-and-text button with nothing behind it, so the one question the
+        // toolbar has to answer, "which of these can I press", had a wrong
+        // answer sitting first in the row. `doneButton` below records the
+        // mirror of this failure: Done rendered flat read as a second label.
+        //
+        // So the icon goes (an icon beside a word is the button shape here),
+        // the type drops to the label tier in the variant role, and a rule
+        // stands between the title and the controls - which is the structural
+        // half, and the half a restyle cannot undo by accident.
+        StyledText {
             Layout.alignment: Qt.AlignVCenter
-            Layout.leftMargin: Appearance.spacing.space75
-            text: "edit"
-            iconSize: 22
+            Layout.leftMargin: Appearance.spacing.space100
+            text: Translation.tr("Edit layout")
+            font.pixelSize: Appearance.font.pixelSize.small
+            font.weight: Font.Medium
             color: Appearance.colors.colOnSurfaceVariant
         }
 
-        StyledText {
+        Rectangle {
             Layout.alignment: Qt.AlignVCenter
-            text: Translation.tr("Edit layout")
-            font.pixelSize: Appearance.font.pixelSize.normal
-            color: Appearance.colors.colOnSurface
+            Layout.leftMargin: Appearance.spacing.space50
+            Layout.rightMargin: Appearance.spacing.space50
+            implicitWidth: 1
+            // Short of the toolbar's own height on purpose: a rule that ran the
+            // full height would read as the toolbar being split into two
+            // containers rather than as one container with a title on it.
+            implicitHeight: Math.round(Appearance.sizes.toolbarHeight * 0.4)
+            color: Appearance.colors.colOutlineVariant
         }
 
         // The drawer's toggle, drawn as state rather than as a verb: the

--- a/dots/.config/quickshell/imi/modules/imi/editMode/EditModeChromeSurface.qml
+++ b/dots/.config/quickshell/imi/modules/imi/editMode/EditModeChromeSurface.qml
@@ -93,6 +93,7 @@ PanelWindow {
         screenHeight: root.height,
         drawerWidth: Appearance.sizes.editModeDrawerWidth,
         margin: Appearance.sizes.editModeMargin,
+        edgeMargin: Appearance.sizes.editModeEdgeMargin,
         chromeThickness: Appearance.sizes.toolbarHeight,
         insetTop: root.insets.top,
         insetBottom: root.insets.bottom,

--- a/dots/.config/quickshell/imi/modules/imi/editMode/EditModeChromeSurface.qml
+++ b/dots/.config/quickshell/imi/modules/imi/editMode/EditModeChromeSurface.qml
@@ -313,6 +313,12 @@ PanelWindow {
         // rather than by a literal measured against one of them.
         area: EditMode.areaRect(root.viewport, GlobalStates.editProgress,
             root.width, root.height)
+        // The band's split, from the SAME geometry the band was reserved out
+        // of. Derived rather than restated out of the two Appearance tokens
+        // here: the reservation and the placement reading different numbers is
+        // exactly the "two fields that must agree" that puts the chrome in a
+        // band that is not its size.
+        bandFraction: EditMode.chromeBandFraction(root.viewport)
         // The second of the mode's two stand-down gates, the other being the
         // loader that creates this window at all. Either alone hides the
         // chrome, which is exactly why both are named in

--- a/dots/.config/quickshell/imi/tests/lint_edit_mode_band_fraction.py
+++ b/dots/.config/quickshell/imi/tests/lint_edit_mode_band_fraction.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Fail if Edit Mode's chrome centres itself in a band that is not symmetric.
+
+The band above and below the shrunk desktop is `edgeMargin + toolbarHeight +
+margin` - a tight gap on the outside where the toolbar floats against the
+screen edge, a generous one on the inside against the desktop. `edit_mode.js`'s
+`chromeBandFraction` is that split, and `EditModeChromeContent` places the
+toolbar at it and the tab bar at its mirror.
+
+Both halves are invisible when they disagree, which is why this is static:
+
+  - The band reserved asymmetrically but the piece still placed with `/ 2`
+    leaves the toolbar 6px off the gap it was given. `tst_edit_mode.qml` covers
+    the arithmetic and cannot see the placement, because the placement is a QML
+    binding on a rect the arithmetic never returns.
+  - A call site that instantiates the content and forgets `bandFraction` gets
+    the property's 0.5 default, which is silently the OLD behaviour on a band
+    that is no longer symmetric. Nothing errors; the chrome is just wrong by
+    the difference between the two margins, and only on a screen where the
+    vertical axis binds.
+
+Same shape as `lint_blur_region_pairing.py`: two files, either alone broken,
+neither announcing itself at runtime.
+"""
+import re
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+GEOMETRY = ROOT / "modules/common/functions/edit_mode.js"
+CONTENT = ROOT / "modules/imi/editMode/EditModeChromeContent.qml"
+
+# Every file that puts an `EditModeChromeContent { ... }` on screen. Found
+# rather than listed: a third surface is exactly the case that would be missed.
+INSTANTIATES = re.compile(r"\bEditModeChromeContent\s*\{")
+SETS_FRACTION = re.compile(r"^\s*bandFraction:\s*\S", re.M)
+
+# The two placements inside the content, matched on the property they place
+# rather than on their whole expression, so a reworded comment does not fail.
+TOOLBAR_Y = re.compile(
+    r"y:\s*root\.area\.y\s*\+\s*\(root\.card\.y[^\n]*\)\s*\*\s*root\.bandFraction")
+TAB_BAR_Y = re.compile(r"\*\s*\(1\s*-\s*root\.bandFraction\)")
+
+
+def qml_files():
+    return sorted(p for p in ROOT.rglob("*.qml") if ".git" not in p.parts)
+
+
+class EditModeBandFraction(unittest.TestCase):
+    def test_the_geometry_declares_the_split(self):
+        text = GEOMETRY.read_text()
+        self.assertIn("function chromeBandFraction(", text,
+                      "edit_mode.js no longer exports the band's split; the "
+                      "content's placement reads a function that is gone")
+        self.assertRegex(
+            text, r"\?\s*edgeMargin\s*\+\s*chromeThickness\s*\+\s*margin",
+            "the band is no longer reserved as edgeMargin + chrome + margin, "
+            "so the fraction the chrome is placed at is a split of nothing")
+
+    def test_the_content_places_both_pieces_on_the_fraction(self):
+        text = CONTENT.read_text()
+        self.assertRegex(
+            text, TOOLBAR_Y,
+            "the toolbar is not placed at `bandFraction` through its band")
+        self.assertRegex(
+            text, TAB_BAR_Y,
+            "the tab bar is not placed at the band's mirrored fraction")
+        # The specific regression: centring survives as `/ 2` on a band that is
+        # not symmetric, which renders as a toolbar off its gap by half the
+        # difference between the two margins.
+        for line in text.splitlines():
+            if "root.card.y - root.area.y - height" in line:
+                self.assertNotIn(
+                    "/ 2", line,
+                    "the toolbar is still centred in its band with `/ 2`")
+
+    def test_every_call_site_hands_the_fraction_down(self):
+        missing = []
+        for path in qml_files():
+            text = path.read_text()
+            if not INSTANTIATES.search(text):
+                continue
+            if not SETS_FRACTION.search(text):
+                missing.append(path.relative_to(ROOT).as_posix())
+        self.assertEqual(
+            [], missing,
+            "these instantiate EditModeChromeContent without setting "
+            "`bandFraction`, so they silently take the 0.5 default and centre "
+            "the chrome in a band that is not symmetric: " + ", ".join(missing))
+
+
+if __name__ == "__main__":
+    sys.exit(0 if unittest.main(exit=False).result.wasSuccessful() else 1)

--- a/dots/.config/quickshell/imi/tests/lint_toolbar_title_is_not_a_button.py
+++ b/dots/.config/quickshell/imi/tests/lint_toolbar_title_is_not_a_button.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Fail if a toolbar's title is built out of the shape a toolbar button uses.
+
+`IconAndTextToolbarButton` is a `MaterialSymbol` followed by a `StyledText` in a
+row. So is an icon-and-label title written directly into a toolbar - and sat
+flat between two real buttons, that is not merely similar to a control, it is
+the same construction with no container behind it. The one question a toolbar
+has to answer is which of its children can be pressed, and Edit Mode's answered
+it wrong at both ends: the title read as an unfilled button (#issue in review),
+and before that `Done` rendered flat read as a second label, which is why it is
+the one button in that toolbar carrying a filled primary container.
+
+Neither failure produces an error, a warning, or a wrong pixel anywhere a frame
+comparison looks - the toolbar renders exactly as written. It is only wrong to
+a person deciding what to click, so it is pinned here instead.
+
+The rule: inside a `Toolbar`, a non-interactive `StyledText` may not have a
+`MaterialSymbol` as its immediately preceding sibling, and must carry a colour
+role distinct from the one the toolbar's buttons put their labels in.
+"""
+import re
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# The toolbars whose titles are written inline rather than by a button widget.
+# Listed rather than discovered, because "a StyledText inside a Toolbar" is also
+# every button's own label, and those are reached through the widgets.
+TOOLBARS = [ROOT / "modules/imi/editMode/EditModeChromeContent.qml"]
+
+# The button widget whose construction a title must not borrow.
+BUTTON = ROOT / "modules/common/widgets/IconAndTextToolbarButton.qml"
+
+BLOCK = re.compile(r"\b(MaterialSymbol|StyledText|Rectangle)\s*\{")
+
+
+# Comments are stripped before any of this runs. A comment that NAMES the
+# construction - which the fix's own comment does, since saying why the title is
+# not a `MaterialSymbol` followed by a `StyledText` requires writing the pair
+# down - is otherwise indistinguishable from the construction itself.
+COMMENT = re.compile(r"//[^\n]*")
+
+
+def uncommented(text):
+    return COMMENT.sub("", text)
+
+
+def _block_end(text, open_brace):
+    """Index of the `}` closing the `{` at `open_brace`."""
+    depth, index = 0, open_brace
+    while index < len(text):
+        if text[index] == "{":
+            depth += 1
+        elif text[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return index
+        index += 1
+    return len(text)
+
+
+def toolbar_body(text):
+    """The `Toolbar { ... }` blocks of a file, brace-matched."""
+    text = uncommented(text)
+    for match in re.finditer(r"\bToolbar\s*\{", text):
+        yield text[match.end():_block_end(text, match.end() - 1)]
+
+
+def outside_the_buttons(body):
+    """`body` with every `*ToolbarButton { ... }` removed, brace-matched.
+
+    Brace-matched rather than pattern-matched on the closing line: a regex
+    anchored to an indentation level passes on any file that indents
+    differently, which is how the first version of this lint let the very
+    construction it names through.
+    """
+    while True:
+        match = re.search(r"\b\w*ToolbarButton\s*\{", body)
+        if not match:
+            return body
+        body = body[:match.start()] + body[_block_end(body, match.end() - 1) + 1:]
+
+
+class ToolbarTitleIsNotAButton(unittest.TestCase):
+    def test_the_button_widget_is_still_the_shape_this_guards_against(self):
+        # If the button stops being an icon beside a label, the rule below is
+        # guarding against a shape nothing uses any more and should be revised
+        # rather than left passing vacuously.
+        text = BUTTON.read_text()
+        self.assertRegex(text, r"MaterialSymbol\s*\{",
+                         "IconAndTextToolbarButton no longer draws an icon")
+        self.assertRegex(text, r"StyledText\s*\{",
+                         "IconAndTextToolbarButton no longer draws a label")
+
+    def test_no_title_borrows_the_buttons_construction(self):
+        for path in TOOLBARS:
+            for body in toolbar_body(path.read_text()):
+                outside = outside_the_buttons(body)
+                blocks = [m.group(1) for m in BLOCK.finditer(outside)]
+                for first, second in zip(blocks, blocks[1:]):
+                    self.assertFalse(
+                        first == "MaterialSymbol" and second == "StyledText",
+                        f"{path.name}: a MaterialSymbol immediately followed by "
+                        "a StyledText inside a Toolbar is exactly "
+                        "IconAndTextToolbarButton's construction, so the title "
+                        "reads as an unfilled button")
+
+    def test_the_title_is_in_a_role_the_buttons_labels_are_not(self):
+        for path in TOOLBARS:
+            for body in toolbar_body(path.read_text()):
+                outside = outside_the_buttons(body)
+                if "StyledText" not in outside:
+                    continue
+                self.assertIn(
+                    "colOnSurfaceVariant", outside,
+                    f"{path.name}: the toolbar's title is in the same colour "
+                    "role as a button's label, so nothing but its missing "
+                    "container tells them apart")
+
+
+if __name__ == "__main__":
+    sys.exit(0 if unittest.main(exit=False).result.wasSuccessful() else 1)

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -315,6 +315,15 @@ if ! python3 "$SCRIPT_DIR/lint_blur_region_pairing.py"; then
     exit 1
 fi
 
+# Static lint: Edit Mode's chrome band is asymmetric, so a piece still centred
+# in it with `/ 2`, or a call site that forgets `bandFraction` and takes the
+# 0.5 default, renders off its gap without erroring.
+echo "Running edit mode band fraction lint..."
+if ! python3 "$SCRIPT_DIR/lint_edit_mode_band_fraction.py"; then
+    echo "Edit mode band fraction lint failed."
+    exit 1
+fi
+
 # Static lint: a window's clear colour must be a literal. One that reaches alpha
 # 255 makes Qt declare the Wayland surface opaque, and nothing ever retracts
 # that, so the window loses its compositor blur for the rest of the process.

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -315,6 +315,16 @@ if ! python3 "$SCRIPT_DIR/lint_blur_region_pairing.py"; then
     exit 1
 fi
 
+# Static lint: a toolbar title written as an icon beside a label IS
+# IconAndTextToolbarButton's construction, so it renders as an unfilled button.
+# Nothing errors and no frame comparison can see it; it is only wrong to a
+# person deciding what to click.
+echo "Running toolbar title lint..."
+if ! python3 "$SCRIPT_DIR/lint_toolbar_title_is_not_a_button.py"; then
+    echo "Toolbar title lint failed."
+    exit 1
+fi
+
 # Static lint: Edit Mode's chrome band is asymmetric, so a piece still centred
 # in it with `/ 2`, or a call site that forgets `bandFraction` and takes the
 # 0.5 default, renders off its gap without erroring.

--- a/dots/.config/quickshell/imi/tests/tst_edit_mode.qml
+++ b/dots/.config/quickshell/imi/tests/tst_edit_mode.qml
@@ -310,20 +310,50 @@ TestCase {
     }
 
     function test_the_desktop_leaves_the_chrome_a_band_of_its_own() {
-        // The band above and below the card is a margin, the toolbar, and
-        // another margin - so the toolbar centred in it has a whole margin at
-        // each end BY CONSTRUCTION rather than by whatever the ceiling left
-        // over. That is the correction: the old band was 100.8px at this screen
-        // size and the toolbar is 56 centred in it, which starts 22.4px into a
-        // screen whose bar occupies the first 68.
+        // The band above and below the card is an edge margin, the toolbar, and
+        // a full margin - so the toolbar has a known gap at each end BY
+        // CONSTRUCTION rather than by whatever the ceiling left over. The two
+        // ends are deliberately UNEQUAL: the outer one is the chrome's gap from
+        // the screen edge and the inner one is its gap from the desktop, and on
+        // this axis every pixel of the outer one comes off the desktop.
         const bandTop = framed.y - barInset;
         const bandBottom = (1440 - dockInset) - (framed.y + framed.height);
-        fuzzyCompare(bandTop, 24 + chrome + 24, 0.5);
-        fuzzyCompare(bandBottom, 24 + chrome + 24, 0.5);
+        fuzzyCompare(bandTop, 12 + chrome + 24, 0.5);
+        fuzzyCompare(bandBottom, 12 + chrome + 24, 0.5);
+        // The two bands stay the same height as each other, which is what makes
+        // the toolbar and the tab bar travel by the same amount.
+        fuzzyCompare(bandTop, bandBottom, 1e-6);
         // ...and the vertical constraint is what decides the scale here, which
-        // is what makes the two numbers above a promise rather than a
-        // coincidence of the ceiling.
+        // is what makes the numbers above a promise rather than a coincidence
+        // of the ceiling.
         verify(framed.scale < EditMode.MAX_SCALE);
+    }
+
+    function test_the_chrome_sits_at_a_fraction_of_its_band_not_a_pixel_offset() {
+        // The split the two chrome pieces are placed on. It has to be a
+        // fraction: the band has no height at all at progress 0 - it grows out
+        // of nothing as the desktop shrinks away from it - so a piece placed at
+        // a fixed `edgeMargin` from the area's edge would already be sitting on
+        // screen before the mode started.
+        const fraction = EditMode.chromeBandFraction(framed);
+        fuzzyCompare(fraction, 12 / (12 + 24), 1e-9);
+        // At rest the fraction has to land the piece exactly `edgeMargin` in,
+        // or the reservation and the placement are two fields that disagree.
+        const slack = (framed.y - barInset) - chrome;
+        fuzzyCompare(slack * fraction, 12, 0.5);
+        fuzzyCompare(slack * (1 - fraction), 24, 0.5);
+        // At progress 0 the band is gone and the piece is off the edge, which
+        // is what makes the entrance need no Behavior of its own.
+        verify(0 - chrome * fraction < 0);
+        // Equal margins are still dead centre, which is what an unconnected
+        // instance and every caller passing no `edgeMargin` gets.
+        fuzzyCompare(EditMode.chromeBandFraction({ margin: 24 }), 0.5, 1e-9);
+        fuzzyCompare(EditMode.chromeBandFraction({ margin: 24, edgeMargin: 24 }),
+            0.5, 1e-9);
+        // ...and so are the degenerate inputs, rather than a divide by zero.
+        fuzzyCompare(EditMode.chromeBandFraction(null), 0.5, 1e-9);
+        fuzzyCompare(EditMode.chromeBandFraction({ margin: 0, edgeMargin: 0 }),
+            0.5, 1e-9);
     }
 
     function test_the_desktop_rests_dead_centre_of_the_usable_area() {

--- a/dots/.config/quickshell/imi/tests/tst_edit_mode.qml
+++ b/dots/.config/quickshell/imi/tests/tst_edit_mode.qml
@@ -89,21 +89,24 @@ TestCase {
     }
 
     readonly property var wide: EditMode.viewportGeometry({
-        screenWidth: 5120, screenHeight: 1440, drawerWidth: 400, margin: 24
+        screenWidth: 5120, screenHeight: 1440, drawerWidth: 400, margin: 24,
+        edgeMargin: 12
     })
     // A 16:10 laptop panel, where 400px of drawer is a quarter of the width and
     // the derivation is the tighter of the two constraints.
     readonly property var narrow: EditMode.viewportGeometry({
-        screenWidth: 1600, screenHeight: 1000, drawerWidth: 400, margin: 24
+        screenWidth: 1600, screenHeight: 1000, drawerWidth: 400, margin: 24,
+        edgeMargin: 12
     })
 
     function test_the_desktop_shrinks_by_exactly_what_the_drawer_will_need() {
-        // 1600 - 400 - 2*24 = 1152 of room, so the scale is the ratio of that
-        // to the screen and the drawn width is that room exactly. Asserted as
-        // the width rather than only as the scale: the scale is the mechanism,
-        // the width is the promise.
-        fuzzyCompare(narrow.width, 1152, 0.5);
-        fuzzyCompare(narrow.scale, 1152 / 1600, 1e-9);
+        // 1600 - 400 - 2*24 - 12 = 1140 of room - the drawer, a margin either
+        // side of the desktop, and the drawer's own gap from the screen edge -
+        // so the scale is the ratio of that to the screen and the drawn width
+        // is that room exactly. Asserted as the width rather than only as the
+        // scale: the scale is the mechanism, the width is the promise.
+        fuzzyCompare(narrow.width, 1140, 0.5);
+        fuzzyCompare(narrow.scale, 1140 / 1600, 1e-9);
     }
 
     function test_a_wide_screen_shrinks_by_the_ceiling_instead() {
@@ -166,7 +169,8 @@ TestCase {
         // drawer's WIDTH alone - so a caller that started passing 0 while the
         // drawer was shut would have to change this number.
         const closed = EditMode.viewportGeometry({
-            screenWidth: 1600, screenHeight: 1000, drawerWidth: 400, margin: 24
+            screenWidth: 1600, screenHeight: 1000, drawerWidth: 400, margin: 24,
+            edgeMargin: 12
         });
         compare(closed.width, narrow.width);
         compare(closed.x, narrow.x);
@@ -283,6 +287,7 @@ TestCase {
 
     readonly property var framed: EditMode.viewportGeometry({
         screenWidth: 5120, screenHeight: 1440, drawerWidth: 400, margin: 24,
+        edgeMargin: 12,
         chromeThickness: chrome, insetTop: barInset, insetBottom: dockInset
     })
 
@@ -343,9 +348,9 @@ TestCase {
         // horizontal constraint binds, or the ceiling answers for both.
         const sided = EditMode.viewportGeometry({
             screenWidth: 1600, screenHeight: 1000, drawerWidth: 400, margin: 24,
-            insetLeft: 60, insetRight: 40
+            edgeMargin: 12, insetLeft: 60, insetRight: 40
         });
-        fuzzyCompare(sided.width, 1600 - 60 - 40 - 400 - 48, 0.5);
+        fuzzyCompare(sided.width, 1600 - 60 - 40 - 400 - 48 - 12, 0.5);
         verify(sided.x >= 60);
         verify(sided.x + sided.width <= 1600 - 40);
     }
@@ -356,7 +361,8 @@ TestCase {
         // neither. If this ever needs updating, the mode's geometry changed for
         // a screen with no bar and no dock, which nothing here intends.
         const plain = EditMode.viewportGeometry({
-            screenWidth: 5120, screenHeight: 1440, drawerWidth: 400, margin: 24
+            screenWidth: 5120, screenHeight: 1440, drawerWidth: 400, margin: 24,
+            edgeMargin: 12
         });
         compare(plain.scale, wide.scale);
         compare(plain.x, wide.x);
@@ -375,15 +381,17 @@ TestCase {
     // exactly what the centred desktop's free side cannot absorb.
 
     function test_the_drawer_travel_is_what_the_free_side_cannot_absorb() {
-        // narrow: width 1152, so each side has (1600 - 1152) / 2 = 224 free.
-        // The drawer's slot is 400 + 24 = 424 against the area's right edge,
-        // so the desktop travels the 200 the free side is short.
-        fuzzyCompare(EditMode.drawerTravel(narrow), 424 - 224, 1e-9);
+        // narrow: width 1140, so each side has (1600 - 1140) / 2 = 230 free.
+        // The drawer's slot is 12 + 400 + 24 = 436 against the area's right
+        // edge - its own gap from that edge, itself, and the gap between it and
+        // the desktop - so the desktop travels the 206 the free side is short.
+        fuzzyCompare(EditMode.drawerTravel(narrow), 436 - 230, 1e-9);
         // A drawer small enough to fit in the ceiling's own leftover needs no
         // travel at all: at 5120 the ceiling leaves 358.4 a side, and a 120px
-        // drawer plus its margin is 144.
+        // drawer plus both its gaps is 156.
         const small = EditMode.viewportGeometry({
-            screenWidth: 5120, screenHeight: 1440, drawerWidth: 120, margin: 24
+            screenWidth: 5120, screenHeight: 1440, drawerWidth: 120, margin: 24,
+            edgeMargin: 12
         });
         compare(EditMode.drawerTravel(small), 0);
         // A geometry from a screen that reported no size travels nowhere.
@@ -428,6 +436,11 @@ TestCase {
         const drawer = EditMode.drawerRect(narrow, 1, 1, 1600, 1000);
         fuzzyCompare(drawer.x - (card.x + card.width), 24, 1e-6);
         verify(card.x - narrow.area.x >= 24 - 1e-6);
+        // ...and the drawer keeps its OWN gap on the side it opens against,
+        // which is the third term and the one that was missing: the panel used
+        // to sit flush, so its rounded right corner met the screen's edge.
+        fuzzyCompare((narrow.area.x + narrow.area.width) - (drawer.x + drawer.width),
+            12, 1e-6);
     }
 
     function test_the_drawer_rect_slides_in_from_the_areas_right_edge() {
@@ -436,15 +449,16 @@ TestCase {
         // is on that edge.
         const closed = EditMode.drawerRect(narrow, 1, 0, 1600, 1000);
         compare(closed.width, 0);
-        compare(closed.x, narrow.area.x + narrow.area.width);
+        compare(closed.x, narrow.area.x + narrow.area.width - 12);
 
-        // Open, it is the drawer's declared width flush against the usable
+        // Open, it is the drawer's declared width a gap in from the usable
         // area's right edge, spanning exactly the card's own band.
         const card = EditMode.cardRect(narrow, 1, 1600, 1000,
             EditMode.drawerTravel(narrow));
         const open = EditMode.drawerRect(narrow, 1, 1, 1600, 1000);
         compare(open.width, 400);
-        fuzzyCompare(open.x + open.width, narrow.area.x + narrow.area.width, 1e-9);
+        fuzzyCompare(open.x + open.width,
+            narrow.area.x + narrow.area.width - 12, 1e-9);
         fuzzyCompare(open.y, card.y, 1e-9);
         fuzzyCompare(open.height, card.height, 1e-9);
 


### PR DESCRIPTION
Three reported Edit Mode issues, plus one defect the second of them surfaced.

### The drawer sat flush on the screen edge

`drawerRect` was `area.x + area.width - width`, so an open panel's rounded right
corner met the edge of the display with nothing between them while its other
side had a full margin against the desktop. The reservation was honest about it
— it spent one margin outside the desktop and one between the desktop and the
drawer, and never reserved anything on the drawer's outer side.

The gap needs a term, and the term is not `margin`. `edgeMargin` is a second
token: the desktop's margin is a gap between two pieces of content and wants to
be generous, the chrome's is a floating surface's gap from the screen edge and
wants to be tight.

### The chrome's outer margins came off the desktop

The band was `margin + toolbar + margin` with the toolbar centred in it, so the
mode spent 24px of air between a floating toolbar and the edge of the screen —
twice, on the axis that binds. At 5120x1440 the vertical constraint decides the
scale (0.8556 against a horizontal 0.9164), so both outer margins came straight
off the preview.

The band becomes `edgeMargin + toolbar + margin`. The preview grows
**4380x1232 -> 4466x1256**.

Placement follows as a *fraction* of the band's slack rather than a pixel
offset from the area's edge: the band has no height at progress 0, so a fixed
offset would put the toolbar on screen before the mode started, and fixing that
with a `Behavior` is the frozen-target failure b710ef731 records.

### "Edit layout" read as a button

It was a `MaterialSymbol` followed by a `StyledText` — not merely button-like,
the exact construction of `IconAndTextToolbarButton`. `doneButton` already
carries a filled container and a comment recording the mirror of this failure
(rendered flat, it read as a second label). Same ambiguity, both directions, so
this one gets a check rather than a third comment.

### And a seam that was already on screen

The band change made the look probe's fixture fractional, which surfaced this:
the card's backdrop is an inverted `OpacityMask`, and at a fractional edge the
boundary pixel keeps part of the brighter backdrop's alpha — a bright rim down
the flank. The probe's 1600x900 fixture was integral by coincidence and could
not see it; at 5120x1440 the resting card is 4465.778 wide at x 327.111, so
this has been visible the whole time.

Fixed with a half-pixel *inward* mask overlap. Both wrong directions are
recorded in the commit: growing the mask opens a notch instead (the desktop
ends at its own edge), and rounding the mask to a whole pixel took the right
flank from 20/255 to 69/255.

### Checks

Two new lints, each plant-proven against every way its rule can be broken:

- `lint_edit_mode_band_fraction.py` — pins the asymmetric band, both placements,
  and every call site handing `bandFraction` down. It **found a third call site
  this change had missed** (`EditModeDrawerLayoutProbe.qml`, silently taking the
  0.5 default) on its first run.
- `lint_toolbar_title_is_not_a_button.py` — pins that a toolbar title is not
  built from the button's construction, *and* that the button still has that
  construction so the rule cannot pass vacuously. Its first draft was a regex
  anchored to an indentation level and passed on the very thing it names; its
  second matched the construction quoted in its own explanatory comment. Both
  are fixed.

`tst_edit_mode.qml` gains a test for the band fraction and updates the
fixtures to pass an `edgeMargin` deliberately different from `margin` — a test
where the two are equal cannot tell which one an assertion read.

Full suite green: 1150 QML assertions, every Python module, every lint.

Docs: not needed — no new gotcha; the two rules this adds are mechanised as
lints rather than as prose, which is what AGENT.md's "twice means a check"
point asks for.
Changelog: updated