### PR TITLE
The overview arrives and dissolves instead of snapping

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -4376,6 +4376,50 @@ the honest one — which is also what §"Expandable Content" of the guidelines
 already pairs with a spatial exit.
 (fix(wallpapers): the selector arrives and dissolves instead of flying.)
 
+**Two decisions that are each correct can add up to a surface that cannot animate at all, and neither
+one is where you would look.** The overview appeared and vanished on a single frame at both ends.
+`rules.lua` turns the compositor's own map animation off for `quickshell:overview` - which is right,
+because a map animation on a screen-sized surface animates the *surface*, and that reads as the
+desktop lurching rather than as a card opening - and the window's `visible` followed
+`GlobalStates.overviewOpen`, which is how nearly every panel here is written. Layer-shell forbids
+window reuse, so between the two the window was created on the frame the flag rose and destroyed on
+the frame it fell, and there was nothing left that *could* animate either end. The repair is the
+wallpaper selector's `reallyOpen` shape above; it is now written twice, so it is pinned rather than
+described - `tests/test_exit_owned_surface_contract.py` holds both sites to it.
+
+Four things from it worth not re-deriving:
+
+- **Everything else gated on the open flag has to move onto the lifetime flag too, or the exit is
+  half a panel leaving.** The overview grid's `Loader.active` read `GlobalStates.overviewOpen`, so
+  the grid was destroyed on frame one of the exit and the search bar dissolved on its own. Gating on
+  the gesture's flag inside the surface is invisible until the surface outlives the gesture.
+- **A blur region is not part of the card it sits behind.** The compositor frosts that rectangle
+  whether or not anything is drawn over it, so a region gated on the open flag arrives a whole
+  entrance before the card and stays a whole exit after it - a frosted ghost of a card that is not
+  there. A region is on or off and cannot be faded, so the step goes where the card is the least
+  transparent thing it can be while it happens: the half way point of the card's own opacity.
+- **The card does not travel, and that is geometry rather than taste.** The sibling fork drops this
+  card in from above the screen edge and pays for the room with a negative margin on all four sides
+  of its surface; ours is anchored to the top of a surface that stops at the bar's exclusive zone, so
+  a rise is drawn outside the window and clipped - the same constraint the selector's entry states
+  from the other end. `transformOrigin: Item.Top` says which edge the card comes out of without
+  needing the room. The entrance takes `elementMoveSmall` for its CURVE as well as its duration:
+  `expressiveFastSpatial` overshoots by construction (its second control point is 1.67), so the
+  bounce is the scale settling past 1 - and the overshoot is clamped off the opacity, where a card
+  fading past opaque and back is a flicker.
+- **The lifetime is measurable without looking at a single pixel, and it needs a control in the same
+  run.** `hyprctl layers` polled straight after a close: `quickshell:overview` survives **196-202ms**
+  across three runs, against `elementMoveFast`'s own 200ms, while `quickshell:sidebarRight` - whose
+  surface still follows its flag - is gone in **4-5ms**, which is the instrument's floor. On its own
+  200ms is a number that could be sampling lag; with the second one it is the exit animation.
+
+And the check's own first draft walked past the plant it exists for, which is the reusable half:
+it swept the whole file for a `visible:` line mentioning `reallyOpen`, and putting the *window* back
+on the gesture flag leaves the card inside it still matching. A gate is read at the declaration that
+maps the surface - located by the `WlrLayershell.namespace` under it - never anywhere in the file.
+c837f589e ("feat(overview): the overview arrives and dissolves instead of snapping"),
+3e2143eae ("fix(test): read the surface gate at the declaration that maps it").
+
 A delegate cannot see its siblings, so `Carousel`'s rank stays the model index — the clamp and the
 scaled step still come from the policy, which was the half that was wrong. And a wave is a
 **cancellable** list rather than loose animations: `expanded` flipping twice inside the first wave's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,13 @@ own repo; the installer pins which revision it builds.
   slide, the way it always did.
 
 ### Fixed
+- **The overview opens and closes with an animation instead of snapping.** It
+  appeared and vanished on a single frame at both ends. Now the search bar and
+  the workspace grid grow out of the top of the screen together and settle with
+  a small bounce, and on the way out they shrink and fade — the window stays on
+  screen for as long as that takes rather than being torn down the instant you
+  press the key, which is what left nothing to animate before. The frosted
+  backdrop behind the cards no longer appears before them or lingers after them.
 - **The password box in the authentication prompt draws the same animated
   characters as the lock screen.** Both are the shell asking for your password,
   and only one of them showed the shell's own masked characters — a Material

--- a/dots/.config/hypr/hyprland/rules.lua
+++ b/dots/.config/hypr/hyprland/rules.lua
@@ -177,6 +177,13 @@ hl.layer_rule({ match = { namespace = "quickshell:lockWindowPusher" }, no_anim =
 hl.layer_rule({ match = { namespace = "quickshell:notificationPopup" }, animation = "fade"})
 hl.layer_rule({ match = { namespace = "quickshell:overlay" }, no_anim = true})
 hl.layer_rule({ match = { namespace = "quickshell:overlay" }, ignore_alpha = 1})
+-- The overview owns its own entrance and exit in QML (Overview.qml: the
+-- card unfurls from its top edge on one scalar, and the window outlives
+-- the open flag by exactly that exit animation). A compositor map
+-- animation on top of it would animate the whole screen-sized surface
+-- underneath the card that is already animating, so the layerrule stays
+-- off. Removing this line does not give the overview an animation - it
+-- gives it two, one of them the desktop lurching.
 hl.layer_rule({ match = { namespace = "quickshell:overview" }, no_anim = true})
 hl.layer_rule({ match = { namespace = "quickshell:osk" }, animation = "slide bottom"})
 hl.layer_rule({ match = { namespace = "quickshell:polkit" }, no_anim = true})

--- a/dots/.config/quickshell/imi/modules/imi/overview/Overview.qml
+++ b/dots/.config/quickshell/imi/modules/imi/overview/Overview.qml
@@ -15,12 +15,28 @@ Scope {
     id: overviewScope
     property bool dontAutoCancelSearch: false
 
+    // The surface outlives the flag by exactly one exit animation, and it is
+    // the ANIMATION that says when - the same rule, and for the same reason, as
+    // `modules/imi/wallpaperSelector/WallpaperSelector.qml`'s `reallyOpen`
+    // records: a Behavior's animation starts a frame after the write that
+    // triggers it, and an accelerating exit carries most of its distance in its
+    // last frames, so a Timer at the exit tier's own duration tears the window
+    // down with the transition still on screen.
+    //
+    // Before this the window's `visible` followed `GlobalStates.overviewOpen`
+    // directly, and `rules.lua` turns the compositor's own map animation off for
+    // this namespace (`no_anim`, because a map animation on a screen-sized
+    // surface reads as the desktop lurching). Between the two there was nothing
+    // left to animate the overview at either end: it appeared and vanished on
+    // one frame.
+    property bool reallyOpen: false
+
     PanelWindow {
         id: panelWindow
         property string searchingText: ""
         readonly property HyprlandMonitor monitor: Hyprland.monitorFor(panelWindow.screen)
         property bool monitorIsFocused: (Hyprland.focusedMonitor?.id == monitor?.id)
-        visible: GlobalStates.overviewOpen
+        visible: overviewScope.reallyOpen
 
         WlrLayershell.namespace: "quickshell:overview"
         WlrLayershell.layer: WlrLayer.Top
@@ -37,15 +53,28 @@ Scope {
         // catch-all whole-surface blur frosted (#89, the deferred half of #82).
         // Pairs with rules.lua turning the layerrule blur off for this
         // namespace. The niri style contributes nothing (see NiriOverview.qml).
+        //
+        // The gate is the CARD's own progress rather than the open flag, and
+        // that only started mattering when the card got a transition. A blur
+        // region is a rectangle the compositor frosts whether or not anything is
+        // drawn over it: gated on the flag it arrives a full entrance before the
+        // card does and stays a full exit after it has gone, which is a frosted
+        // ghost of the card with no card in it. It cannot be faded - the region
+        // is on or off - so it switches at the half way point of the card's own
+        // opacity, where the card itself is the least transparent thing it can
+        // be while the switch happens. This is a choice about where to put an
+        // unavoidable step, not a measurement.
+        readonly property bool bodyFrosted: columnLayout.openProgress >= 0.5
+
         WindowBlurRegion {
             targetWindow: panelWindow
             region: Region {
                 Region {
-                    item: GlobalStates.overviewOpen ? searchWidget.backgroundItem : null
+                    item: panelWindow.bodyFrosted ? searchWidget.backgroundItem : null
                     radius: searchWidget.backgroundRadius
                 }
                 Region {
-                    item: (overviewLoader.item?.backgroundPainted ?? false) ? overviewLoader.item.backgroundItem : null
+                    item: (panelWindow.bodyFrosted && (overviewLoader.item?.backgroundPainted ?? false)) ? overviewLoader.item.backgroundItem : null
                     radius: overviewLoader.item?.backgroundRadius ?? 0
                 }
             }
@@ -65,11 +94,17 @@ Scope {
                     searchWidget.disableExpandAnimation();
                     overviewScope.dontAutoCancelSearch = false;
                     GlobalFocusGrab.dismiss();
+                    columnLayout.leave();
                 } else {
+                    // The surface is asked for before the card is asked to
+                    // arrive, in this order: an entrance started against an
+                    // unmapped window is an entrance nothing advances.
+                    overviewScope.reallyOpen = true;
                     if (!overviewScope.dontAutoCancelSearch) {
                         searchWidget.cancelSearch();
                     }
                     GlobalFocusGrab.addDismissable(panelWindow);
+                    columnLayout.arrive();
                 }
             }
         }
@@ -90,12 +125,86 @@ Scope {
 
         Column {
             id: columnLayout
-            visible: GlobalStates.overviewOpen
+            visible: overviewScope.reallyOpen
             anchors {
                 horizontalCenter: parent.horizontalCenter
                 top: parent.top
             }
             spacing: -Appearance.spacing.space100
+
+            // ONE scalar drives both channels, because docs/M3_GUIDELINES.md §2
+            // requires the opacity to finish on the same schedule as the scale -
+            // two Behaviors at two tiers is what makes a component reach full
+            // opacity while it is still growing, which reads as a hiccup.
+            //
+            // No translate, and that is a constraint rather than a preference.
+            // The sibling fork drops this card in from above the screen edge and
+            // pays for the room with a negative margin on all four sides of the
+            // surface; here the column is anchored to the top of a surface that
+            // stops at the bar's exclusive zone, so a rise would be drawn
+            // outside the window and clipped. `transformOrigin: Item.Top`
+            // already says which edge the card comes out of: it unfurls
+            // downwards from its own top edge, which is where it hangs from.
+            //
+            // The entrance takes `elementMoveSmall` for its CURVE, not only its
+            // duration. `expressiveFastSpatial` overshoots by construction (its
+            // second control point is 1.67), so the card settles with a bounce
+            // rather than easing flat into place - which is the half of the
+            // fork's "bounce" style that survives having no room to travel.
+            // The overshoot is left on the scale and clamped off the opacity: a
+            // card that fades past opaque and back is a flicker, a card that
+            // grows 2% past its size and settles is the bounce.
+            property real openProgress: 0
+            readonly property real entranceScaleFrom: 0.9
+
+            opacity: Math.min(1, columnLayout.openProgress)
+            scale: columnLayout.entranceScaleFrom
+                + (1 - columnLayout.entranceScaleFrom) * columnLayout.openProgress
+            transformOrigin: Item.Top
+
+            function arrive() {
+                exitAnim.stop();
+                enterAnim.start();
+            }
+            function leave() {
+                enterAnim.stop();
+                exitAnim.start();
+            }
+
+            // Started animations rather than a `Behavior`: a Behavior never
+            // raises `finished` at any duration (motion_policy.js records the
+            // probe), and this exit's `finished` is what owns the window.
+            // `openProgress` starts at 0 as its DECLARED value and is only ever
+            // written by these two - a start value written through the animated
+            // property is what lint_animated_start_write.py exists for.
+            NumberAnimation {
+                id: enterAnim
+                target: columnLayout
+                property: "openProgress"
+                to: 1
+                duration: Appearance.animation.elementMoveSmall.duration
+                easing.type: Appearance.animation.elementMoveSmall.type
+                easing.bezierCurve: Appearance.animation.elementMoveSmall.bezierCurve
+            }
+
+            NumberAnimation {
+                id: exitAnim
+                target: columnLayout
+                property: "openProgress"
+                to: 0
+                // The effects tier rather than `elementMoveExit`, for the
+                // reasoning WallpaperSelector.qml's exit animation writes out:
+                // this is an opacity transition with a scale nudge on it rather
+                // than a departure across the screen, and `emphasizedAccel` at
+                // its own 200ms spends 46% of the transition in its last two
+                // frames - on an opacity that is a card which sits there and
+                // then blinks out.
+                duration: Appearance.animation.elementMoveFast.duration
+                easing.type: Appearance.animation.elementMoveFast.type
+                easing.bezierCurve: Appearance.animation.elementMoveFast.bezierCurve
+                // The window's lifetime IS this animation's.
+                onFinished: overviewScope.reallyOpen = false
+            }
 
             Keys.onPressed: event => {
                 if (event.key === Qt.Key_Escape) {
@@ -119,7 +228,7 @@ Scope {
 
             Loader {
                 id: overviewLoader
-                active: GlobalStates.overviewOpen && (Config?.options.overview.enable ?? true)
+                active: overviewScope.reallyOpen && (Config?.options.overview.enable ?? true)
                 sourceComponent: (Config?.options.overview.style ?? "default") === "niri" ? niriComponent : defaultComponent
 
                 Component {

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -403,6 +403,17 @@ if ! python3 "$SCRIPT_DIR/test_marquee_text_contract.py"; then
     exit 1
 fi
 
+# A surface that animates on its way out is owned by that animation, not by the
+# flag the user's gesture sets: layer-shell forbids window reuse, so a window
+# whose `visible` follows the flag is destroyed on the frame the exit starts.
+# The shape is written twice now - the wallpaper selector and the overview - and
+# it is the adoption that decays.
+echo "Running exit-owned surface contract tests..."
+if ! python3 "$SCRIPT_DIR/test_exit_owned_surface_contract.py"; then
+    echo "Exit-owned surface contract tests failed."
+    exit 1
+fi
+
 # The shell has two password prompts - the lock screen and the polkit dialog -
 # and they were two different text fields, one of them Material's outlined
 # container with the prompt floating in a notch. The check derives the control

--- a/dots/.config/quickshell/imi/tests/test_exit_owned_surface_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_exit_owned_surface_contract.py
@@ -49,12 +49,19 @@ ROOT = Path(__file__).resolve().parent.parent
 OVERVIEW = ROOT / "modules/imi/overview/Overview.qml"
 SELECTOR = ROOT / "modules/imi/wallpaperSelector/WallpaperSelector.qml"
 
-# The surface and the property whose value maps it. The overview's window is
-# built unconditionally and toggles `visible`; the selector's is built by a
-# Loader and toggles `active`. Both are "the compositor has this surface", and
-# both must read the lifetime flag rather than the gesture's own.
+# The declaration that maps the surface, and the property on it that decides
+# whether the compositor has one. The overview's window is built unconditionally
+# and toggles its own `visible`; the selector's is built by a Loader and toggles
+# that Loader's `active`. Both mean "the surface exists", and both must read the
+# lifetime flag rather than the flag the gesture sets.
+#
+# The gate is read at the mapping declaration's OWN top level rather than
+# anywhere in the file. A sweep for "some `visible:` line mentions the lifetime
+# flag" passes on a tree where the window has been put back on the gesture's
+# flag and only the card inside it still reads the right one - which is the
+# exact regression this file exists to catch, and it survived the first draft.
 LIFETIME_FLAG = "reallyOpen"
-SURFACES = {OVERVIEW: "visible", SELECTOR: "active"}
+SURFACES = {OVERVIEW: ("PanelWindow", "visible"), SELECTOR: ("Loader", "active")}
 
 
 def read(path: Path) -> str:
@@ -112,8 +119,37 @@ def blocks(text: str, type_name: str):
     return found
 
 
+def mapping_block(text: str, type_name: str, name: str) -> str:
+    """The one declaration in the file that maps a layer surface.
+
+    Anchored on `WlrLayershell.namespace` rather than on being the first block
+    of its type: a file may declare several Loaders, and only one of them has a
+    window under it.
+    """
+    owning = [block for block in blocks(text, type_name)
+              if "WlrLayershell.namespace" in block]
+    assert len(owning) == 1, \
+        (f"{name} has {len(owning)} {type_name} declarations carrying a layer "
+         "surface - this rule is about the one that maps it")
+    return owning[0]
+
+
+def declared_at_top_level(block: str, prop: str):
+    """Values of `prop:` declared directly on `block`, not on anything nested
+    inside it."""
+    values = []
+    depth = 0
+    for line in logical_lines(block):
+        if depth == 1:
+            match = re.match(rf"\s*{prop}\s*:(.*)", line)
+            if match:
+                values.append(match.group(1).strip())
+        depth += line.count("{") - line.count("}")
+    return values
+
+
 def test_the_surface_outlives_the_gesture_by_one_exit_animation():
-    for path, gate in SURFACES.items():
+    for path, (declaration, gate) in SURFACES.items():
         text = code(path)
         name = path.relative_to(ROOT).as_posix()
 
@@ -122,12 +158,15 @@ def test_the_surface_outlives_the_gesture_by_one_exit_animation():
              "and dying with the flag the user's gesture sets, and its exit "
              "animation is drawing into a window that is already gone")
 
-        gates = [line.strip() for line in logical_lines(text)
-                 if re.match(rf"\s*{gate}\s*:", line)]
-        assert gates, f"{name} declares no `{gate}:` - nothing maps this surface"
-        assert any(LIFETIME_FLAG in line for line in gates), \
-            (f"{name}'s `{gate}:` reads {gates} - the surface must follow "
-             f"`{LIFETIME_FLAG}`, not the gesture's own flag")
+        gates = declared_at_top_level(
+            mapping_block(text, declaration, name), gate)
+        assert gates, \
+            (f"{name}'s {declaration} declares no `{gate}:` of its own - "
+             "nothing here says when the surface exists")
+        assert all(LIFETIME_FLAG in value for value in gates), \
+            (f"{name}'s {declaration} maps on `{gate}: {gates}` - the surface "
+             f"must follow `{LIFETIME_FLAG}`, not the gesture's own flag, or it "
+             "is destroyed on the frame the exit animation starts")
 
         clears = [line.strip() for line in logical_lines(text)
                   if re.search(rf"{LIFETIME_FLAG}\s*=\s*false", line)]

--- a/dots/.config/quickshell/imi/tests/test_exit_owned_surface_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_exit_owned_surface_contract.py
@@ -29,6 +29,13 @@ two tiers is what makes a component reach full opacity while it is still
 growing. The check reads the tier names out of each animation and refuses a
 duration taken from one tier with a curve taken from another - a mismatch that
 reads perfectly in review, since both halves name a real catalogued tier.
+(`lint_motion_tier_partial.py` is the tree-wide rule next door and catches the
+other half of this: a duration with no easing at all. The mismatch rule is NOT
+tree-wide, deliberately - four animations in the tree take their duration from
+the enter tier and their curve from the exit tier by design, branching on
+direction inside one declaration, and a tree-wide rule would need a register of
+them to say nothing new. These two surfaces animate in one direction per
+animation, so here the mismatch has no innocent reading.)
 
 **And a blur region is not part of the card it sits behind.** The compositor
 frosts the rectangle whether or not anything is drawn over it, so a region

--- a/dots/.config/quickshell/imi/tests/test_exit_owned_surface_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_exit_owned_surface_contract.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""A surface that animates on its way out is owned by that animation.
+
+Layer-shell forbids window reuse, so a panel whose `visible` follows the flag
+that asks for it is destroyed on the frame the flag drops - and anything the
+QML was drawing at that moment is simply not drawn. That is the whole reason
+the overview had no exit: `rules.lua` turns the compositor's own map animation
+off for `quickshell:overview` (a map animation on a screen-sized surface reads
+as the desktop lurching), the window went away with the flag, and between the
+two there was nothing left to animate at either end.
+
+The repair is one shape, and this file pins it at both of the surfaces that
+have it, because the shape is what decays:
+
+**The flag the window follows is NOT the flag the user's gesture sets.** A
+second flag stays true through the exit and is cleared by the exit animation's
+own `onFinished`. Never a `Timer` at the exit tier's duration:
+`modules/imi/wallpaperSelector/WallpaperSelector.qml` was written that way
+first, and measured on a 60fps capture the timer fired with a quarter of the
+travel left - the last frame drawn was 74.6% of the way out and the next one
+had no panel in it. A Behavior's animation starts a frame after the write that
+triggers it and an accelerating curve carries most of its distance in its last
+frames, so the two ends were never going to line up. An animation's own
+`finished` cannot be early or late.
+
+**One scalar drives every channel of the transition.** docs/M3_GUIDELINES.md §2
+asks the opacity to finish on the same schedule as the scale; two animations at
+two tiers is what makes a component reach full opacity while it is still
+growing. The check reads the tier names out of each animation and refuses a
+duration taken from one tier with a curve taken from another - a mismatch that
+reads perfectly in review, since both halves name a real catalogued tier.
+
+**And a blur region is not part of the card it sits behind.** The compositor
+frosts the rectangle whether or not anything is drawn over it, so a region
+gated on the open flag arrives an entrance before the card and stays an exit
+after it - a frosted ghost with no card in it. The overview's regions follow
+the card's own progress instead.
+
+Every sweep asserts it FOUND what it swept for. A regex over QML that matches
+nothing reads exactly like a regex over QML that found nothing wrong.
+"""
+
+import re
+from pathlib import Path
+
+from contract_runner import run
+
+ROOT = Path(__file__).resolve().parent.parent
+OVERVIEW = ROOT / "modules/imi/overview/Overview.qml"
+SELECTOR = ROOT / "modules/imi/wallpaperSelector/WallpaperSelector.qml"
+
+# The surface and the property whose value maps it. The overview's window is
+# built unconditionally and toggles `visible`; the selector's is built by a
+# Loader and toggles `active`. Both are "the compositor has this surface", and
+# both must read the lifetime flag rather than the gesture's own.
+LIFETIME_FLAG = "reallyOpen"
+SURFACES = {OVERVIEW: "visible", SELECTOR: "active"}
+
+
+def read(path: Path) -> str:
+    assert path.exists(), f"{path} is gone - the sweep has nothing to look at"
+    text = path.read_text()
+    assert text.strip(), f"{path} is empty"
+    return text
+
+
+def code(path: Path) -> str:
+    """The file with its comments stripped, so a rule cannot be satisfied by
+    prose about the rule."""
+    text = read(path)
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.S)
+    return re.sub(r"//[^\n]*", "", text)
+
+
+def logical_lines(text: str):
+    """Source lines with wrapped expressions joined back onto one.
+
+    A property whose value does not fit on a line is continued on the next one,
+    starting with the operator it is continued by. A line-scoped scan reads
+    those two halves as two lines, finds a `scale:` with nothing in it, and
+    reports a clean tree - which is exactly what this file's job is not.
+    """
+    joined = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if joined and stripped[:1] in {"+", "-", "*", "/", "?", ":", ".", "&", "|", ")", ","}:
+            joined[-1] = joined[-1] + " " + stripped
+        else:
+            joined.append(line)
+    return joined
+
+
+def blocks(text: str, type_name: str):
+    """Every `<type_name> { ... }` declaration in the file, brace-matched.
+
+    Brace matching rather than a line scan: every property these rules judge
+    sits on a continuation line, and a line-scoped check finds the opening
+    brace and reports a clean tree.
+    """
+    found = []
+    for opener in re.finditer(rf"(?<![\w.]){re.escape(type_name)}\s*\{{", text):
+        start = opener.end() - 1
+        depth = 0
+        for index in range(start, len(text)):
+            if text[index] == "{":
+                depth += 1
+            elif text[index] == "}":
+                depth -= 1
+                if depth == 0:
+                    found.append(text[start:index + 1])
+                    break
+    return found
+
+
+def test_the_surface_outlives_the_gesture_by_one_exit_animation():
+    for path, gate in SURFACES.items():
+        text = code(path)
+        name = path.relative_to(ROOT).as_posix()
+
+        assert re.search(rf"property\s+bool\s+{LIFETIME_FLAG}\b", text), \
+            (f"{name} has no `{LIFETIME_FLAG}` - its surface is back to living "
+             "and dying with the flag the user's gesture sets, and its exit "
+             "animation is drawing into a window that is already gone")
+
+        gates = [line.strip() for line in logical_lines(text)
+                 if re.match(rf"\s*{gate}\s*:", line)]
+        assert gates, f"{name} declares no `{gate}:` - nothing maps this surface"
+        assert any(LIFETIME_FLAG in line for line in gates), \
+            (f"{name}'s `{gate}:` reads {gates} - the surface must follow "
+             f"`{LIFETIME_FLAG}`, not the gesture's own flag")
+
+        clears = [line.strip() for line in logical_lines(text)
+                  if re.search(rf"{LIFETIME_FLAG}\s*=\s*false", line)]
+        assert clears, \
+            (f"{name} never clears `{LIFETIME_FLAG}` - the surface is now "
+             "mapped for the rest of the session")
+        for line in clears:
+            assert "onFinished" in line, \
+                (f"{name} clears `{LIFETIME_FLAG}` at `{line}` - the window's "
+                 "lifetime belongs to the exit animation's own `onFinished`. A "
+                 "Timer at the exit tier's duration tore the wallpaper selector "
+                 "down with 25% of its travel still to draw.")
+
+
+def test_one_scalar_and_one_tier_per_animation():
+    for path in SURFACES:
+        text = code(path)
+        name = path.relative_to(ROOT).as_posix()
+
+        scalars = set(re.findall(r'property\s*:\s*"(\w+)"', text))
+        assert len(scalars) == 1, \
+            (f"{name} animates {sorted(scalars)} - the entrance and the exit are "
+             "one scalar, or the opacity and the scale finish on two schedules "
+             "and the surface reads as hiccuping (docs/M3_GUIDELINES.md §2)")
+
+        animations = [block for block in blocks(text, "NumberAnimation")
+                      if "Appearance.animation." in block]
+        assert len(animations) == 2, \
+            (f"{name} has {len(animations)} catalogued animations, not the "
+             "entrance and exit pair this rule is about")
+        for block in animations:
+            tiers = set(re.findall(r"Appearance\.animation\.(\w+)\.", block))
+            assert len(tiers) == 1, \
+                (f"{name} builds one animation out of tiers {sorted(tiers)} - a "
+                 "duration from one tier with a curve from another names two "
+                 "real tiers and reads correctly, and is neither of them")
+
+
+def test_the_overview_card_arrives_rather_than_appears():
+    text = code(OVERVIEW)
+
+    assert "transformOrigin: Item.Top" in text, \
+        ("the overview card has no transform origin - it hangs from the top of "
+         "its surface, and scaling about its centre reads as a card growing in "
+         "mid-air rather than unfurling out of the edge it is fastened to")
+
+    driven = [line.strip() for line in logical_lines(text)
+              if re.match(r"\s*(opacity|scale)\s*:", line)
+              and "openProgress" in line]
+    assert len(driven) == 2, \
+        (f"only {driven} follow `openProgress` - both the opacity and the scale "
+         "take the one scalar, or the entrance is two transitions")
+
+
+def test_the_blur_region_follows_the_card_not_the_flag():
+    regions = blocks(code(OVERVIEW), "WindowBlurRegion")
+    assert len(regions) == 1, \
+        f"expected one WindowBlurRegion in the overview, found {len(regions)}"
+    assert "GlobalStates.overviewOpen" not in regions[0], \
+        ("the overview's blur regions are gated on the open flag again - the "
+         "compositor frosts that rectangle whether or not the card is drawn "
+         "over it, so the frost arrives a whole entrance early and leaves a "
+         "whole exit late, as a ghost of a card that is not there")
+
+
+if __name__ == "__main__":
+    raise SystemExit(run(globals()))


### PR DESCRIPTION
The overview appeared and vanished on a single frame at both ends. The reason was in two places that each look correct on their own.

`rules.lua` turns the compositor's own map animation off for `quickshell:overview` (`no_anim`), and that is right: a map animation on a screen-sized surface animates the *surface*, which reads as the desktop lurching rather than as a card opening. The window's `visible` then followed `GlobalStates.overviewOpen`, which is how nearly every panel here is written. Layer-shell forbids window reuse, so the surface was created on the frame the flag rose and destroyed on the frame it fell — and between the two there was nothing left that *could* animate.

## What changed

The surface now outlives the gesture by exactly one exit animation, which is the shape `WallpaperSelector.qml` already had: a second flag stays true through the exit and is cleared by the exit's own `onFinished`, never by a Timer at the exit tier's duration.

The card takes one scalar for both channels — opacity and a scale from 0.9, `transformOrigin: Item.Top`. There is no translate: the sibling fork drops this card in from above the screen edge and buys the room with a negative margin on all four sides of its surface, and here the column is anchored to the top of a surface that stops at the bar's exclusive zone, so a rise would be drawn outside the window and clipped. The origin already says which edge it comes from.

The entrance takes `elementMoveSmall` for its **curve** as well as its duration: `expressiveFastSpatial` overshoots by construction, so the card settles with a bounce rather than easing flat into place. The overshoot is left on the scale and clamped off the opacity, where a card fading past opaque and back is a flicker. The exit takes the effects tier, for the reasoning the selector's own exit writes out.

Two things had to move off the open flag with it, because gating on the flag only started mattering once the card had a transition:

- the overview grid's `Loader.active`, or the exit is the search bar leaving on its own;
- the blur regions, which are rectangles the compositor frosts whether or not a card is drawn over them — on the flag they arrive an entrance early and stay an exit late, as a frosted ghost of a card that is not there. A region is on or off and cannot be faded, so the step goes at the half way point of the card's own opacity.

## Measured

`hyprctl layers` polled straight after a close, on the live shell, with a control in the same run:

| namespace | run 1 | run 2 | run 3 |
| --- | --- | --- | --- |
| `quickshell:overview` | 202ms | 198ms | 196ms |
| `quickshell:sidebarRight` (control) | 4ms | 4ms | 5ms |

`elementMoveFast` is 200ms. The sidebar's surface still follows its own flag, so it gives the instrument's floor: without that second column, 200ms is a number that could be sampling lag.

That measures the **exit**. The entrance is the same construct started the same way, which is an inference and not a second measurement — no capture was taken.

## Checks

`tests/test_exit_owned_surface_contract.py`, wired into `run_tests.sh`, holds both sites — the wallpaper selector and the overview — to the shape, since it is the adoption that decays rather than the arithmetic. Eight plants, all caught:

- the overview window back on the gesture flag; the selector's Loader likewise
- the lifetime cleared outside an `onFinished`
- an animation built from two tiers' halves
- the card scaling about its centre; the scale no longer following the scalar
- a second scalar animated
- the blur region back on the open flag

The check's own first draft passed the first of those. It swept the whole file for a `visible:` line mentioning the lifetime flag, and putting the *window* back on the gesture flag leaves the card inside it still matching. It reads the gate at the declaration that maps the surface now — located by the `WlrLayershell.namespace` under it — never anywhere in the file. That repair is its own commit rather than folded away.

Suite: **1172 passed, 0 failed**, design-system compile `checked=185 failures=0`. Deployed and running; clean log across six open/close cycles.

## Known gaps

- The mismatched-tier rule is **not** tree-wide, deliberately: four animations in the tree take their duration from the enter tier and their curve from the exit tier by design, branching on direction inside one declaration. A tree-wide version would need a register of them and would say nothing new.
- `SessionScreen` rides the same PanelWindow shape — its window is created by the gesture that opens it — and is still unmeasured. Named in `AGENT.md`, not changed here.

Docs: updated AGENT.md §Design language (the no_anim + flag-bound window entry, the four things not to re-derive, the check's own blind spot); dots/.config/hypr/hyprland/rules.lua
Changelog: updated — Fixed entry under [Unreleased]