### PR TITLE
Persistent panel surfaces: sidebars, overview, and everything they broke

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -4587,12 +4587,21 @@ Three things a persistent surface costs that an unmapped one never did, and the 
 Two generalisations. A Top-layer surface is buried under a fullscreen window by Hyprland itself
 (the bar relies on it), so a persistent Top-layer panel needs no stand-down and does not hold the
 fullscreen fast path the way an Overlay one does — check `solitaryBlockedBy` rather than assuming
-either way. And the overview (`Overview.qml`) and `SessionScreen` still map per open and pay this
-same 61ms; the overview's exit-owned lifetime fixed what happens *after* the flag drops, not what
-happens when it rises.
+either way. The overview went persistent too — its window declares no `visible:` at all and
+`reallyOpen` gates the card instead (`tests/test_exit_owned_surface_contract.py` carries the
+per-surface mode). Persistence brought the two focus obligations with it, both taken from the
+sidebars: the grab is deferred two rendered frames past the flag flip, and the open names a focus
+target (`searchWidget.focusSearchInput()`), because a window created once at boot never gets a
+map-time keyboard grant. A third obligation lives in `services/GlobalFocusGrab.qml` and is global:
+the grab's whitelist must end with the dismissables — Hyprland hands the grab's keyboard focus to
+a surface picked from the END of the list, and with the bar/OSK after the panel, an opening panel
+never activates and every keypress is silently dropped (the persistent-sidebar contract pins the
+order; fix(sidebars): route the focus grab's keyboard to the opening panel). `SessionScreen` still
+maps per open and pays this same 61ms.
 (feat(widgets): EdgeSlide, the runner for a panel whose surface stays mapped;
 fix(sidebar): the right sidebar's surface outlives the gesture;
-fix(sidebar): the left sidebar's surface outlives the gesture.)
+fix(sidebar): the left sidebar's surface outlives the gesture;
+perf(overview): keep the surface mapped; only the card opens and closes.)
 
 **`Behavior on <non-animatable>` with a trailing bare `PropertyAction {}` defers a write instead of
 animating it.** A `Loader.source` is a `url`, which QML cannot interpolate, so the `Behavior` cannot

--- a/AGENT.md
+++ b/AGENT.md
@@ -4549,6 +4549,51 @@ the user is actually looking at — is inferred from the client's stall rather t
 7a7c1b794 ("revert(sidebar): the right sidebar's sections stop cascading"),
 1b8d4ac52 ("test(motion): the stagger ratchet runs in both directions").
 
+**...and that stall was then fixed, by the thing the measurement above pointed at and not by the
+three things that were bisected first.** After the wave was gone the user reported *"a momentary
+freeze right before they open"* and attributed it to the wave. Four trees were bisected on the live
+session — before the wave, the wave, the revert, main — and every one stalled; the recorder was
+turned off and it stalled; the machine was rebooted and it stalled. None of that was wasted, but all
+of it was the wrong instrument: `QSG_RENDER_TIMING` on the real session said it in one line,
+`blockedForSync=61 ms, polish=0` on the frame the sidebar's window was created. The shell has ONE
+GUI thread for every window it owns, and that thread waits while a new window gets its render
+thread, its GL context, its scene graph built from nothing and every glyph uploaded again — so the
+bar, the dock and the desktop all freeze for fifteen frames at 240Hz, right before the panel
+appears. The compositor's own main loop never stalled (probed at 2ms through its socket: max reply
+gap 1.3ms), which is why it read as the shell's freeze and not the screen's.
+
+The fix is the one the `visible: false` note under [Layer-shell gotchas](#layer-shell-wlr-layer-shell-gotchas)
+already prescribes for the background: **keep the surface mapped and move the panel.**
+`modules/common/widgets/EdgeSlide.qml` is the runner; both sidebars declare one; the compositor's
+`animation = slide` rules became `no_anim`; and the `sidebarSlideEnter`/`Exit` tiers were re-pinned
+to what those rules had been drawing (400ms on `pc_decel`/`pc_accel`, the first kept as
+`panelSlideDecel`) so the motion did not change, only who draws it. Measured live with the same
+instrument: 18ms on the first open after a restart (textures), 1–4ms after. Captured at 60fps with
+the user's permission and read per frame, the panel enters with its content already laid out and the
+frost under it, nothing ahead of it.
+
+Three things a persistent surface costs that an unmapped one never did, and the test that holds them
+(`tests/test_persistent_sidebar_contract.py`, read at the `PanelWindow` that carries the namespace):
+
+- **An ungated `mask` on a mapped surface eats every click on the screen edge it occupies**, and
+  the left sidebar had shipped with exactly that mask for as long as it existed — harmless only
+  because the window was unmapped when closed. Both masks read the open flag now.
+- **An unconditional `keyboardFocus: OnDemand` on a mapped surface holds the keyboard while
+  showing nothing.** Same file, same history, same gate.
+- **Content hides on the runner's `shown`, never on the open flag** — the flag drops on frame one
+  of a 400ms exit. And the slide is an `x`, not a transform: the blur region and the shadow both
+  follow the item's geometry, and a transform moves neither.
+
+Two generalisations. A Top-layer surface is buried under a fullscreen window by Hyprland itself
+(the bar relies on it), so a persistent Top-layer panel needs no stand-down and does not hold the
+fullscreen fast path the way an Overlay one does — check `solitaryBlockedBy` rather than assuming
+either way. And the overview (`Overview.qml`) and `SessionScreen` still map per open and pay this
+same 61ms; the overview's exit-owned lifetime fixed what happens *after* the flag drops, not what
+happens when it rises.
+(feat(widgets): EdgeSlide, the runner for a panel whose surface stays mapped;
+fix(sidebar): the right sidebar's surface outlives the gesture;
+fix(sidebar): the left sidebar's surface outlives the gesture.)
+
 **`Behavior on <non-animatable>` with a trailing bare `PropertyAction {}` defers a write instead of
 animating it.** A `Loader.source` is a `url`, which QML cannot interpolate, so the `Behavior` cannot
 animate it — and the *bare* `PropertyAction` (no `target`, no `property`, no `value`) means "apply

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,14 @@ own repo; the installer pins which revision it builds.
   slide, the way it always did.
 
 ### Fixed
+- **The clock settings filter actually filters now.** The per-style option
+  rows were annotated in the last cycle but Settings > Widgets kept showing
+  all of them regardless of the selected style: the rules survive as data,
+  but on their way to the settings page they cross a Qt type boundary that
+  turns JSON lists into list-like objects a strict `Array.isArray` check no
+  longer recognises, so every rule fell back to "just show the row". The
+  evaluator now accepts those objects, and switching Digital / Cookie / Pixel
+  swaps the visible rows immediately.
 - **Opening a sidebar no longer freezes the shell for a moment.** Every open
   rebuilt the sidebar's window from scratch, and while that happened every
   other thing the shell draws — the bar, the dock, the desktop — stopped for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,11 @@ own repo; the installer pins which revision it builds.
   slide, the way it always did.
 
 ### Fixed
+- **Wallpaper depth is reachable for Wallpaper Engine wallpapers.** The
+  depth service could already cut a subject from a live scene's still, but
+  the button that opens the picker only existed on the Local tab - from the
+  Wallpaper Engine grid the feature was unreachable. The same button now
+  sits in that tab's toolbar too.
 - **The overview's frost covers the whole card again.** Keeping the
   overview's window alive left its blur region stuck where the half-built
   grid had been on the very first open - a sharp unblurred band down the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@ own repo; the installer pins which revision it builds.
   Your presets carry the choice.
 
 ### Changed
+- **The clock widget's settings show only the options for the clock style you
+  picked.** Digital, Cookie and Pixel each have their own options, and all
+  three sets used to be listed together — eleven Cookie rows under a Digital
+  clock. Now a style's rows appear only while that style is selected for the
+  desktop or for the lock screen (the two can differ). Plugin authors get the
+  same: an option can declare `visibleWhen` against another option's value.
 - **The session screen and the settings pages now arrive in sequence instead of
   all at once.** The session screen's nine action buttons and a settings page's
   sections each fade in one after the other, a few hundredths of a second

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,10 @@ own repo; the installer pins which revision it builds.
   slide, the way it always did.
 
 ### Fixed
+- **The overview's frost covers the whole card again.** Keeping the
+  overview's window alive left its blur region stuck where the half-built
+  grid had been on the very first open - a sharp unblurred band down the
+  card's left edge. The region now follows the card through every rebuild.
 - **Typing works again the moment a sidebar opens.** Keeping the sidebar
   windows alive (the stutter fix below) quietly broke their keyboard: a
   window that is never re-created never gets the keyboard grant that used to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,15 @@ own repo; the installer pins which revision it builds.
   slide, the way it always did.
 
 ### Fixed
+- **Typing works again the moment a sidebar opens.** Keeping the sidebar
+  windows alive (the stutter fix below) quietly broke their keyboard: a
+  window that is never re-created never gets the keyboard grant that used to
+  arrive with its creation, so keys only reached a sidebar after the mouse
+  happened to touch it — the left sidebar's AI chat felt dead, and Escape
+  wouldn't close it. The focus system now hands the keyboard to whichever
+  panel just opened. Confirmed for both sidebars: typing lands immediately,
+  Escape closes, clicking outside closes, and clicking the bar while a
+  sidebar is open still leaves it open.
 - **The clock settings filter actually filters now.** The per-style option
   rows were annotated in the last cycle but Settings > Widgets kept showing
   all of them regardless of the selected style: the rules survive as data,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,12 @@ own repo; the installer pins which revision it builds.
   slide, the way it always did.
 
 ### Fixed
+- **Opening a sidebar no longer freezes the shell for a moment.** Every open
+  rebuilt the sidebar's window from scratch, and while that happened every
+  other thing the shell draws — the bar, the dock, the desktop — stopped for
+  about fifteen frames. The windows now stay alive and only the panel slides,
+  on the same motion as before, so the open is immediate. The left sidebar
+  also stops being able to hold the keyboard while it is closed.
 - **The overview opens and closes with an animation instead of snapping.** It
   appeared and vanished on a single frame at both ends. Now the search bar and
   the workspace grid grow out of the top of the screen together and settle with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,9 +38,8 @@ own repo; the installer pins which revision it builds.
   fixes, none of which changes how anything looks:
   - The overview's window now stays alive like the sidebars' do, so
     Super+Tab no longer pays a rebuild stall on every press.
-  - Boot builds its 28 panels between frames instead of all at once before
-    the first one, and the icon-search database (1.7MB) loads the first
-    time you search symbols instead of at startup.
+  - The icon-search database (1.7MB) loads the first time you search
+    symbols instead of at startup.
   - Caps/Num Lock state comes from the keyboard's own LEDs through one
     tiny watcher instead of asking Hyprland 3 times a second.
   - Network events feed the shell through a single monitor that cleans up

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,21 @@ own repo; the installer pins which revision it builds.
   Your presets carry the choice.
 
 ### Changed
+- **The shell idles lighter and boots smoother.** A round of performance
+  fixes, none of which changes how anything looks:
+  - The overview's window now stays alive like the sidebars' do, so
+    Super+Tab no longer pays a rebuild stall on every press.
+  - Boot builds its 28 panels between frames instead of all at once before
+    the first one, and the icon-search database (1.7MB) loads the first
+    time you search symbols instead of at startup.
+  - Caps/Num Lock state comes from the keyboard's own LEDs through one
+    tiny watcher instead of asking Hyprland 3 times a second.
+  - Network events feed the shell through a single monitor that cleans up
+    after itself - crashed shells used to leave silent nmcli processes
+    behind (30 were found on the dev machine).
+  - The dock's window previews stop being captured the moment the popup
+    hides, decorative cookie spins tick at 30Hz instead of every frame,
+    and icons share font engines instead of minting near-duplicates.
 - **The clock widget's settings show only the options for the clock style you
   picked.** Digital, Cookie and Pixel each have their own options, and all
   three sets used to be listed together — eleven Cookie rows under a Digital

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -183,6 +183,19 @@ enum names (`Cookie4Sided`, `Heart`, …); an unrecognised name falls back to `C
 whenever the value *is* a shape — a 31-entry name-chip row is unreadable, and `ConfigSelectionArray`'s
 chip `Flow` only wraps when the row has no label, so such a row cannot be labelled either.
 
+An option can be shown only while another option has a given value. `"visibleWhen"` takes a
+rule — `{ "key": "style", "in": ["cookie"] }`, `{ "key": "quoteEnable", "equals": true }`, a bare
+`{ "key": "flag" }` for truthiness, or `{ "anyOf": [...] }` / `{ "allOf": [...] }` over those —
+read against the plugin's current values with the manifest's own defaults filled in, so a rule
+against a default the user never changed still reads what the widget is using. A rule the evaluator
+cannot read (no `key`) shows the row: a wrongly hidden row is a setting the user cannot reach and
+nothing logs. The older `"enabledWhen": "<booleanKey>"` is the same thing for one boolean and, despite
+its name, hides rather than greys — both fields go through `option_visibility.js`, and when both are
+present both must pass. The clock is the worked example: every `digital*` / `cookie*` / `pixel*` row
+is gated on its style being chosen for the desktop **or** the lock screen, since the two can differ
+(`tests/test_clock_options_contract.py` holds that; `tests/tst_option_visibility.qml` holds the
+evaluator).
+
 `color` renders a row of palette swatches (`ColorSelectionArray`) instead of chips. Its `choices` are
 `Appearance.colors` role names without the `col` prefix (`primary`, `secondaryContainer`, `layer0`, …).
 The empty string is a legal choice and draws an "automatic" slot rather than a swatch — use it when

--- a/dots/.config/hypr/hyprland/rules.lua
+++ b/dots/.config/hypr/hyprland/rules.lua
@@ -203,8 +203,12 @@ hl.layer_rule({ match = { namespace = "quickshell:screenshot" }, no_anim = true}
 hl.layer_rule({ match = { namespace = "quickshell:session" }, blur = true})
 hl.layer_rule({ match = { namespace = "quickshell:session" }, no_anim = true})
 hl.layer_rule({ match = { namespace = "quickshell:session" }, ignore_alpha = 0})
-hl.layer_rule({ match = { namespace = "quickshell:sidebarRight" }, animation = "slide right"})
-hl.layer_rule({ match = { namespace = "quickshell:sidebarLeft" }, animation = "slide left"})
+-- The sidebars' surfaces stay mapped and the panels slide in QML (EdgeSlide,
+-- on tiers pinned to the layersIn/layersOut this used to draw), so there is
+-- no map to animate. The slide rules these replaced fired only on map, which
+-- on a persistent surface is once, at startup, on an empty window.
+hl.layer_rule({ match = { namespace = "quickshell:sidebarRight" }, no_anim = true})
+hl.layer_rule({ match = { namespace = "quickshell:sidebarLeft" }, no_anim = true})
 -- The sidebars draw a translucent drop shadow (StyledRectangularShadow) in
 -- their surface's elevation margin. The catch-all whole-surface blur above
 -- frosts that shadow into an ugly band along the panel's edge (#82). Turn the

--- a/dots/.config/quickshell/imi/defaults/config.json
+++ b/dots/.config/quickshell/imi/defaults/config.json
@@ -277,7 +277,7 @@
         "color": "",
         "cookie": {
           "aiStyling": false,
-          "constantlyRotate": true,
+          "constantlyRotate": false,
           "dateInClock": true,
           "dateStyle": "bubble",
           "dialNumberStyle": "full",

--- a/dots/.config/quickshell/imi/modules/common/Appearance.qml
+++ b/dots/.config/quickshell/imi/modules/common/Appearance.qml
@@ -398,6 +398,12 @@ Singleton {
         readonly property list<real> standard: [0.2, 0, 0, 1, 1, 1]
         readonly property list<real> standardAccel: [0.3, 0, 1, 1, 1, 1]
         readonly property list<real> standardDecel: [0, 0, 0, 1, 1, 1]
+        // What the compositor slid the sidebars on before the shell drew that
+        // slide itself (`pc_decel` in shellOverrides/animations.lua): a decel
+        // that settles through a 5% overshoot. Kept as its own curve rather
+        // than rounded to a Material one so the panels move exactly as they
+        // did when Hyprland moved them.
+        readonly property list<real> panelSlideDecel: [0.05, 0.9, 0.1, 1.05, 1, 1]
         readonly property real expressiveFastSpatialDuration: 350
         readonly property real expressiveDefaultSpatialDuration: 500
         readonly property real expressiveSlowSpatialDuration: 650
@@ -666,10 +672,15 @@ Singleton {
             property int type: Easing.OutExpo
         }
 
+        // The two sidebar tiers are pinned to the compositor's `layersIn` /
+        // `layersOut` (speed 4 = 400ms, on pc_decel / pc_accel), because that
+        // is the motion the sidebars have always had and EdgeSlide now draws
+        // it in QML instead. They were 300/250ms on the standard pair and
+        // nothing took them, so nothing else moved.
         property QtObject sidebarSlideEnter: QtObject {
-            property int duration: motion.scale(300)
+            property int duration: motion.scale(400)
             property int type: Easing.BezierSpline
-            property list<real> bezierCurve: animationCurves.standardDecel
+            property list<real> bezierCurve: animationCurves.panelSlideDecel
             property int velocity: motion.scaleVelocity(650)
             property Component numberAnimation: Component {
                 NumberAnimation {
@@ -682,9 +693,9 @@ Singleton {
         }
 
         property QtObject sidebarSlideExit: QtObject {
-            property int duration: motion.scale(250)
+            property int duration: motion.scale(400)
             property int type: Easing.BezierSpline
-            property list<real> bezierCurve: animationCurves.standardAccel
+            property list<real> bezierCurve: animationCurves.emphasizedAccel
             property int velocity: motion.scaleVelocity(650)
             property Component numberAnimation: Component {
                 NumberAnimation {

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginOptions.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginOptions.qml
@@ -6,6 +6,7 @@ import QtQuick.Layouts
 import qs.modules.common
 import qs.modules.common.widgets
 import "gridSizes.js" as GridSizes
+import "option_visibility.js" as OptionVisibility
 
 ColumnLayout {
     id: root
@@ -19,6 +20,20 @@ ColumnLayout {
     // settings, pushing them below the fold and reading as if the plugin had
     // declared them. They live in their own section below instead.
     readonly property var widgetOptions: manifest.options || []
+
+    // A visibility rule reads another option by key, and it has to read the
+    // value the WIDGET is using - which, for a key the user has never touched,
+    // is the manifest's default and not `undefined`. So the defaults are
+    // indexed once and every rule reads through them.
+    readonly property var optionDefaults: {
+        const defaults = {};
+        for (const option of root.widgetOptions)
+            defaults[option.key] = option.default;
+        return defaults;
+    }
+    function readOption(key) {
+        return PluginState.option(root.manifest.id, key, root.optionDefaults[key]);
+    }
 
     // Host blur is a desktop-widget mechanism (PluginWidget frost); bar/
     // overlay-only plugins were getting a dead "Blur background" toggle.
@@ -230,8 +245,9 @@ ColumnLayout {
             required property var modelData
             Layout.fillWidth: true
             property var optionData: modelData
-            visible: !optionData.enabledWhen
-                || PluginState.option(root.manifest.id, optionData.enabledWhen, false)
+            // `enabledWhen` and `visibleWhen`, one evaluator - see
+            // option_visibility.js for what each spells.
+            visible: OptionVisibility.visible(optionData, key => root.readOption(key))
             enabled: visible
             Layout.preferredHeight: visible ? implicitHeight : 0
 

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/clock/CookieClock.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/clock/CookieClock.qml
@@ -55,6 +55,24 @@ Item {
     readonly property int clockMinute: DateTime.clock.minutes
     readonly property int clockSecond: DateTime.clock.seconds
 
+    // Continuous motion - the body's spin and the second hand's sweep - is
+    // sampled from the wall clock at this rate rather than animated per
+    // vsync. See the body's `rotation` for the measurement behind the number.
+    readonly property int motionTickHz: 30
+    readonly property int spinPeriodMs: 30000
+    property real motionClockMs: 0
+
+    // Where the second hand is within the current second, shaped the way its
+    // old per-second Behavior shaped it (InOutQuad): it leaves one mark, eases
+    // across, and settles on the next. Zero when not sweeping, so the hand
+    // sits on the mark.
+    readonly property real secondSweep: {
+        if (!root.constantlyRotate)
+            return 0;
+        const f = (root.motionClockMs % 1000) / 1000;
+        return f < 0.5 ? 2 * f * f : 1 - Math.pow(-2 * f + 2, 2) / 2;
+    }
+
     implicitWidth: implicitSize
     implicitHeight: implicitSize
 
@@ -117,28 +135,31 @@ Item {
         anchors.fill: parent
         dragging: root.dragging
 
-        // Gated on the item being ON SCREEN, not just on the setting. An
-        // infinite animation dirties the scene every frame for as long as it
-        // runs, and a dirty scene makes the shell commit a frame, and a commit
-        // makes the compositor repaint the whole output - so this one kept a
-        // 5120x1440 240Hz screen redrawing continuously while the desktop was
-        // completely hidden behind a fullscreen game. Measured against FFXIV's
-        // own counter on a static scene: 52 fps with it spinning, 94 with this
-        // gate, 108 with the shell not running at all.
-        //
-        // `visible` is EFFECTIVE visibility in QML - it is false while any
-        // ancestor is hidden - so this covers the fullscreen suppression the
-        // canvas already does, a widget scrolled out of a hidden surface, and
-        // any future reason the desktop is not on screen, without any of them
-        // having to know this animation exists.
-        RotationAnimation on rotation {
+        Timer {
             running: root.constantlyRotate && cookieBody.visible
-            duration: 30000
-            easing.type: Easing.Linear
-            loops: Animation.Infinite
-            from: 360
-            to: 0
+            interval: Math.round(1000 / root.motionTickHz)
+            repeat: true
+            triggeredOnStart: true
+            onTriggered: root.motionClockMs = Date.now()
         }
+
+        // The spin is a function of the wall clock, advanced by the tick below
+        // - not a RotationAnimation. An animation advances every vsync, and on
+        // this surface every advance is a commit with whole-surface damage
+        // (Qt's GL path reports no less), which is the compositor re-rendering
+        // all 5120x1440 and re-blurring every surface over it, 240 times a
+        // second, for a rotation that takes 30 seconds. Measured at idle on
+        // the user's machine, GPU utilisation: 38% spinning at vsync, 28% at
+        // a 60Hz tick, 20% at 30Hz, 10-12% with the spin off. At 30Hz the rim
+        // of a 230px cookie moves 0.8px per tick, which is under where a step
+        // reads, so that is the rate.
+        //
+        // Still gated on the item being ON SCREEN, for the reason the old
+        // animation was: `visible` is EFFECTIVE visibility, false while any
+        // ancestor is hidden, so a desktop behind a fullscreen game spends
+        // nothing here. Measured against FFXIV's own counter: 52 fps with the
+        // spin ungated, 94 gated, 108 with the shell not running at all.
+        rotation: 360 - (root.motionClockMs % root.spinPeriodMs) / root.spinPeriodMs * 360
 
         Loader {
             id: sineCookieLoader
@@ -233,7 +254,9 @@ Item {
             id: secondHand
             clockSecond: root.clockSecond
             style: root.secondHandStyle
-            animateRotation: root.constantlyRotate
+            // Sampled, not animated: see `motionTickHz`.
+            animateRotation: false
+            sweep: root.secondSweep
             color: root.colSecondHand
         }
     }

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/clock/SecondHand.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/clock/SecondHand.qml
@@ -16,7 +16,11 @@ Item {
     property bool animateRotation: false
     property color color: Appearance.colors.colSecondary
     
-    rotation: (360 / 60 * clockSecond) + 90
+    // The fraction of the current second the hand has swept, for a host that
+    // samples time itself rather than animating each second (CookieClock). A
+    // host that does not drive it leaves it at 0 and the hand sits on the mark.
+    property real sweep: 0
+    rotation: (360 / 60 * (clockSecond + sweep)) + 90
 
     Behavior on rotation {
         enabled: root.animateRotation // Animating every second is expensive...

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/clock/manifest.json
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/clock/manifest.json
@@ -16,58 +16,58 @@
     ]},
     { "key": "showOnlyWhenLocked", "type": "boolean", "label": "Show only when locked", "icon": "lock_clock", "default": false },
 
-    { "key": "digitalVertical", "type": "boolean", "label": "Digital: vertical", "icon": "vertical_distribute", "default": false },
-    { "key": "digitalShowDate", "type": "boolean", "label": "Digital: show date", "icon": "date_range", "default": true },
-    { "key": "digitalAnimateChange", "type": "boolean", "label": "Digital: animate time change", "icon": "animation", "default": true },
-    { "key": "digitalAdaptiveAlignment", "type": "boolean", "label": "Digital: adaptive alignment", "icon": "activity_zone", "default": true },
-    { "key": "color", "type": "color", "label": "Digital: color", "icon": "palette", "default": "", "choices": [
+    { "key": "digitalVertical", "type": "boolean", "label": "Digital: vertical", "icon": "vertical_distribute", "default": false, "visibleWhen": { "anyOf": [ { "key": "style", "in": ["digital"] }, { "key": "styleLocked", "in": ["digital"] } ] } },
+    { "key": "digitalShowDate", "type": "boolean", "label": "Digital: show date", "icon": "date_range", "default": true, "visibleWhen": { "anyOf": [ { "key": "style", "in": ["digital"] }, { "key": "styleLocked", "in": ["digital"] } ] } },
+    { "key": "digitalAnimateChange", "type": "boolean", "label": "Digital: animate time change", "icon": "animation", "default": true, "visibleWhen": { "anyOf": [ { "key": "style", "in": ["digital"] }, { "key": "styleLocked", "in": ["digital"] } ] } },
+    { "key": "digitalAdaptiveAlignment", "type": "boolean", "label": "Digital: adaptive alignment", "icon": "activity_zone", "default": true, "visibleWhen": { "anyOf": [ { "key": "style", "in": ["digital"] }, { "key": "styleLocked", "in": ["digital"] } ] } },
+    { "key": "color", "type": "color", "label": "Digital: color", "icon": "palette", "default": "", "visibleWhen": { "anyOf": [ { "key": "style", "in": ["digital"] }, { "key": "styleLocked", "in": ["digital"] } ] }, "choices": [
       "", "primary", "secondary", "tertiary", "primaryContainer", "secondaryContainer", "tertiaryContainer", "layer1", "layer0"
     ]},
-    { "key": "digitalFontFamily", "type": "text", "label": "Digital: font family", "icon": "font_download", "default": "Google Sans Flex", "placeholder": "Google Sans Flex", "maxLength": 64 },
-    { "key": "digitalFontWeight", "type": "number", "label": "Digital: font weight", "icon": "format_bold", "default": 350, "from": 1, "to": 1000 },
-    { "key": "digitalFontSize", "type": "number", "label": "Digital: font size", "icon": "format_size", "default": 90, "from": 50, "to": 700 },
-    { "key": "digitalFontWidth", "type": "number", "label": "Digital: font width", "icon": "fit_width", "default": 100, "from": 25, "to": 125 },
-    { "key": "digitalFontRoundness", "type": "number", "label": "Digital: font roundness", "icon": "line_curve", "default": 0, "from": 0, "to": 100 },
+    { "key": "digitalFontFamily", "type": "text", "label": "Digital: font family", "icon": "font_download", "default": "Google Sans Flex", "placeholder": "Google Sans Flex", "maxLength": 64, "visibleWhen": { "anyOf": [ { "key": "style", "in": ["digital"] }, { "key": "styleLocked", "in": ["digital"] } ] } },
+    { "key": "digitalFontWeight", "type": "number", "label": "Digital: font weight", "icon": "format_bold", "default": 350, "from": 1, "to": 1000, "visibleWhen": { "anyOf": [ { "key": "style", "in": ["digital"] }, { "key": "styleLocked", "in": ["digital"] } ] } },
+    { "key": "digitalFontSize", "type": "number", "label": "Digital: font size", "icon": "format_size", "default": 90, "from": 50, "to": 700, "visibleWhen": { "anyOf": [ { "key": "style", "in": ["digital"] }, { "key": "styleLocked", "in": ["digital"] } ] } },
+    { "key": "digitalFontWidth", "type": "number", "label": "Digital: font width", "icon": "fit_width", "default": 100, "from": 25, "to": 125, "visibleWhen": { "anyOf": [ { "key": "style", "in": ["digital"] }, { "key": "styleLocked", "in": ["digital"] } ] } },
+    { "key": "digitalFontRoundness", "type": "number", "label": "Digital: font roundness", "icon": "line_curve", "default": 0, "from": 0, "to": 100, "visibleWhen": { "anyOf": [ { "key": "style", "in": ["digital"] }, { "key": "styleLocked", "in": ["digital"] } ] } },
 
-    { "key": "cookieUseSineCookie", "type": "boolean", "label": "Cookie: old sine wave shape", "icon": "airwave", "default": false },
-    { "key": "cookieAiStyling", "type": "boolean", "label": "Cookie: auto styling with Gemini", "icon": "wand_stars", "default": false },
-    { "key": "cookieSides", "type": "number", "label": "Cookie: sides", "icon": "add_triangle", "default": 14, "from": 0, "to": 40 },
-    { "key": "cookieConstantlyRotate", "type": "boolean", "label": "Cookie: constantly rotate", "icon": "autoplay", "default": false },
-    { "key": "cookieHourMarks", "type": "boolean", "label": "Cookie: hour marks", "icon": "brightness_7", "default": false },
-    { "key": "cookieTimeIndicators", "type": "boolean", "label": "Cookie: digits in the middle", "icon": "timer_10", "default": true },
-    { "key": "cookieDialNumberStyle", "type": "choice", "label": "Cookie: dial style", "icon": "graph_6", "default": "full", "choices": [
+    { "key": "cookieUseSineCookie", "type": "boolean", "label": "Cookie: old sine wave shape", "icon": "airwave", "default": false, "visibleWhen": { "anyOf": [ { "key": "style", "in": ["cookie"] }, { "key": "styleLocked", "in": ["cookie"] } ] } },
+    { "key": "cookieAiStyling", "type": "boolean", "label": "Cookie: auto styling with Gemini", "icon": "wand_stars", "default": false, "visibleWhen": { "anyOf": [ { "key": "style", "in": ["cookie"] }, { "key": "styleLocked", "in": ["cookie"] } ] } },
+    { "key": "cookieSides", "type": "number", "label": "Cookie: sides", "icon": "add_triangle", "default": 14, "from": 0, "to": 40, "visibleWhen": { "anyOf": [ { "key": "style", "in": ["cookie"] }, { "key": "styleLocked", "in": ["cookie"] } ] } },
+    { "key": "cookieConstantlyRotate", "type": "boolean", "label": "Cookie: constantly rotate", "icon": "autoplay", "default": false, "visibleWhen": { "anyOf": [ { "key": "style", "in": ["cookie"] }, { "key": "styleLocked", "in": ["cookie"] } ] } },
+    { "key": "cookieHourMarks", "type": "boolean", "label": "Cookie: hour marks", "icon": "brightness_7", "default": false, "visibleWhen": { "anyOf": [ { "key": "style", "in": ["cookie"] }, { "key": "styleLocked", "in": ["cookie"] } ] } },
+    { "key": "cookieTimeIndicators", "type": "boolean", "label": "Cookie: digits in the middle", "icon": "timer_10", "default": true, "visibleWhen": { "anyOf": [ { "key": "style", "in": ["cookie"] }, { "key": "styleLocked", "in": ["cookie"] } ] } },
+    { "key": "cookieDialNumberStyle", "type": "choice", "label": "Cookie: dial style", "icon": "graph_6", "default": "full", "visibleWhen": { "anyOf": [ { "key": "style", "in": ["cookie"] }, { "key": "styleLocked", "in": ["cookie"] } ] }, "choices": [
       { "displayName": "None", "icon": "block", "value": "none" },
       { "displayName": "Dots", "icon": "graph_6", "value": "dots" },
       { "displayName": "Full", "icon": "history_toggle_off", "value": "full" },
       { "displayName": "Numbers", "icon": "counter_1", "value": "numbers" }
     ]},
-    { "key": "cookieHourHandStyle", "type": "choice", "label": "Cookie: hour hand", "icon": "highlighter_size_2", "default": "fill", "choices": [
+    { "key": "cookieHourHandStyle", "type": "choice", "label": "Cookie: hour hand", "icon": "highlighter_size_2", "default": "fill", "visibleWhen": { "anyOf": [ { "key": "style", "in": ["cookie"] }, { "key": "styleLocked", "in": ["cookie"] } ] }, "choices": [
       { "displayName": "Hide", "icon": "block", "value": "hide" },
       { "displayName": "Classic", "icon": "radio", "value": "classic" },
       { "displayName": "Hollow", "icon": "circle", "value": "hollow" },
       { "displayName": "Fill", "icon": "eraser_size_5", "value": "fill" }
     ]},
-    { "key": "cookieMinuteHandStyle", "type": "choice", "label": "Cookie: minute hand", "icon": "eraser_size_1", "default": "medium", "choices": [
+    { "key": "cookieMinuteHandStyle", "type": "choice", "label": "Cookie: minute hand", "icon": "eraser_size_1", "default": "medium", "visibleWhen": { "anyOf": [ { "key": "style", "in": ["cookie"] }, { "key": "styleLocked", "in": ["cookie"] } ] }, "choices": [
       { "displayName": "Hide", "icon": "block", "value": "hide" },
       { "displayName": "Classic", "icon": "radio", "value": "classic" },
       { "displayName": "Thin", "icon": "line_end", "value": "thin" },
       { "displayName": "Medium", "icon": "eraser_size_2", "value": "medium" },
       { "displayName": "Bold", "icon": "eraser_size_4", "value": "bold" }
     ]},
-    { "key": "cookieSecondHandStyle", "type": "choice", "label": "Cookie: second hand", "icon": "pen_size_1", "default": "dot", "choices": [
+    { "key": "cookieSecondHandStyle", "type": "choice", "label": "Cookie: second hand", "icon": "pen_size_1", "default": "dot", "visibleWhen": { "anyOf": [ { "key": "style", "in": ["cookie"] }, { "key": "styleLocked", "in": ["cookie"] } ] }, "choices": [
       { "displayName": "Hide", "icon": "block", "value": "hide" },
       { "displayName": "Classic", "icon": "radio", "value": "classic" },
       { "displayName": "Line", "icon": "line_end", "value": "line" },
       { "displayName": "Dot", "icon": "adjust", "value": "dot" }
     ]},
-    { "key": "cookieDateStyle", "type": "choice", "label": "Cookie: date style", "icon": "date_range", "default": "bubble", "choices": [
+    { "key": "cookieDateStyle", "type": "choice", "label": "Cookie: date style", "icon": "date_range", "default": "bubble", "visibleWhen": { "anyOf": [ { "key": "style", "in": ["cookie"] }, { "key": "styleLocked", "in": ["cookie"] } ] }, "choices": [
       { "displayName": "Hide", "icon": "block", "value": "hide" },
       { "displayName": "Bubble", "icon": "bubble_chart", "value": "bubble" },
       { "displayName": "Border", "icon": "rotate_right", "value": "border" },
       { "displayName": "Rect", "icon": "rectangle", "value": "rect" }
     ]},
 
-    { "key": "pixelOrientation", "type": "choice", "label": "Pixel: orientation", "icon": "screen_rotation", "default": "vertical", "choices": [
+    { "key": "pixelOrientation", "type": "choice", "label": "Pixel: orientation", "icon": "screen_rotation", "default": "vertical", "visibleWhen": { "anyOf": [ { "key": "style", "in": ["pixel"] }, { "key": "styleLocked", "in": ["pixel"] } ] }, "choices": [
       { "displayName": "Horizontal", "icon": "swap_horiz", "value": "horizontal" },
       { "displayName": "Vertical", "icon": "swap_vert", "value": "vertical" }
     ]},

--- a/dots/.config/quickshell/imi/modules/common/plugins/option_visibility.js
+++ b/dots/.config/quickshell/imi/modules/common/plugins/option_visibility.js
@@ -1,0 +1,47 @@
+.pragma library
+
+// Whether a manifest option's row is shown, given the plugin's current values.
+//
+// Two fields on an option feed this. `enabledWhen: "<key>"` is the older one:
+// a boolean key that, while off, HIDES the row - the name says "enabled" and
+// the row is not greyed but gone, which is how it has always behaved and what
+// the two quote rows in the clock's manifest rely on. `visibleWhen` is the
+// honestly named one and can match a value, which a boolean gate cannot: the
+// clock has 28 options and a `style` choice, and the eleven `cookie*` rows have
+// nothing to say to someone whose clock is digital.
+//
+//   "visibleWhen": { "key": "style", "in": ["cookie"] }
+//   "visibleWhen": { "key": "quoteEnable", "equals": true }
+//   "visibleWhen": { "anyOf": [ {...}, {...} ] }      // or allOf
+//
+// `read(key)` returns the option's current value, resolved against the
+// manifest's own default for that key, so a rule written against a default
+// the user has never changed still reads the value the widget is using.
+//
+// A rule this cannot read - no key, or a key that is not a string - answers
+// VISIBLE. Hiding is the silent failure here: a row that is wrongly hidden is
+// a setting the user cannot reach and nothing logs, while a row that is
+// wrongly shown is a row.
+
+function visible(option, read) {
+    if (typeof option.enabledWhen === "string" && !read(option.enabledWhen))
+        return false;
+    return rule(option.visibleWhen, read);
+}
+
+function rule(r, read) {
+    if (r === undefined || r === null)
+        return true;
+    if (Array.isArray(r.anyOf))
+        return r.anyOf.some(inner => rule(inner, read));
+    if (Array.isArray(r.allOf))
+        return r.allOf.every(inner => rule(inner, read));
+    if (typeof r.key !== "string")
+        return true;
+    const value = read(r.key);
+    if (Array.isArray(r.in))
+        return r.in.indexOf(value) !== -1;
+    if (r.equals !== undefined)
+        return value === r.equals;
+    return !!value;
+}

--- a/dots/.config/quickshell/imi/modules/common/plugins/option_visibility.js
+++ b/dots/.config/quickshell/imi/modules/common/plugins/option_visibility.js
@@ -22,6 +22,23 @@
 // VISIBLE. Hiding is the silent failure here: a row that is wrongly hidden is
 // a setting the user cannot reach and nothing logs, while a row that is
 // wrongly shown is a row.
+//
+// The lists are duck-typed, NOT Array.isArray. The manifest is parsed as
+// plain JSON, but on the way to this evaluator it crosses a QVariant
+// boundary (it is carried through var properties and handed to the option
+// row as a Repeater's modelData), and a JS tree converted to
+// QVariantMap/QVariantList reads back as wrapper objects with `length` and
+// indexed access that fail Array.isArray. Measured live on the clock's
+// rules in Settings > Widgets: `Array.isArray(visibleWhen.anyOf)` was false
+// with `anyOf.length === 2`, so every rule fell through to the fail-open
+// answer and all 22 annotated rows stayed visible for every style. The
+// wrappers are also not guaranteed the Array prototype, so the walks below
+// use index loops rather than some/every/indexOf.
+
+function isList(value) {
+    return Array.isArray(value)
+        || (!!value && typeof value === "object" && typeof value.length === "number");
+}
 
 function visible(option, read) {
     if (typeof option.enabledWhen === "string" && !read(option.enabledWhen))
@@ -32,15 +49,27 @@ function visible(option, read) {
 function rule(r, read) {
     if (r === undefined || r === null)
         return true;
-    if (Array.isArray(r.anyOf))
-        return r.anyOf.some(inner => rule(inner, read));
-    if (Array.isArray(r.allOf))
-        return r.allOf.every(inner => rule(inner, read));
+    if (isList(r.anyOf)) {
+        for (let i = 0; i < r.anyOf.length; ++i)
+            if (rule(r.anyOf[i], read))
+                return true;
+        return false;
+    }
+    if (isList(r.allOf)) {
+        for (let i = 0; i < r.allOf.length; ++i)
+            if (!rule(r.allOf[i], read))
+                return false;
+        return true;
+    }
     if (typeof r.key !== "string")
         return true;
     const value = read(r.key);
-    if (Array.isArray(r.in))
-        return r.in.indexOf(value) !== -1;
+    if (isList(r.in)) {
+        for (let i = 0; i < r.in.length; ++i)
+            if (r.in[i] === value)
+                return true;
+        return false;
+    }
     if (r.equals !== undefined)
         return value === r.equals;
     return !!value;

--- a/dots/.config/quickshell/imi/modules/common/widgets/DragApps.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/DragApps.qml
@@ -674,7 +674,13 @@ Item {
                                         id: screencopyView
                                         anchors.centerIn: parent
                                         captureSource: windowButton.modelData
-                                        live: true
+                                        // Only while the popup is on screen. `appTopLevel`
+                                        // keeps the last hovered app after the popup hides,
+                                        // so these delegates outlive it - an unconditional
+                                        // `live: true` kept the compositor copying every one
+                                        // of that app's windows at their own frame rate,
+                                        // forever, into previews nobody could see.
+                                        live: previewPopup.visible
                                         paintCursor: true
                                         constraintSize: Qt.size(
                                             root.maxWindowPreviewWidth,

--- a/dots/.config/quickshell/imi/modules/common/widgets/EdgeSlide.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/EdgeSlide.qml
@@ -1,0 +1,110 @@
+import QtQuick
+import qs.modules.common
+
+/**
+ * The runner for a panel fastened to a screen edge: it slides in from that
+ * edge and back out, and the SURFACE it lives on stays mapped the whole time.
+ *
+ * That second half is the reason this exists. A layer surface cannot be
+ * reused, so a PanelWindow whose `visible` follows the flag that asks for it
+ * is destroyed on close and rebuilt on open - a new render thread, a new GL
+ * context, the whole scene graph built from nothing and every glyph uploaded
+ * again. The shell has ONE GUI thread for all of its windows, and measured
+ * with QSG_RENDER_TIMING on the real session that thread sat blocked for
+ * 61ms per open (`blockedForSync=61 ms, polish=0`) - every other window the
+ * shell draws frozen for fifteen frames at 240Hz, the "momentary freeze right
+ * before they open". The same open with the window kept mapped: 1-3ms.
+ *
+ * So the slide is QML's rather than the compositor's. The layerrule that
+ * used to animate the map (`animation = slide right`) is `no_anim` now, and
+ * the tiers here are pinned to what that rule drew: Hyprland's `layersIn` /
+ * `layersOut` at speed 4 on `pc_decel` / `pc_accel`. The look did not change;
+ * who draws it did.
+ *
+ * Three things the adopter has to do, because a persistent surface is a
+ * surface that can eat input and focus while showing nothing:
+ *
+ *  - gate the window's `mask` on the gesture's flag, so a closed panel is a
+ *    hole the pointer falls through;
+ *  - gate `WlrLayershell.keyboardFocus` on it, because an always-mapped
+ *    surface with OnDemand focus is a surface that takes the keyboard;
+ *  - hide the content on `shown`, not on the flag - `shown` stays true for
+ *    the length of the exit, which is the one reason the exit can be seen.
+ *
+ * A QtObject rather than an Item, for StaggerWave's reason: declared inside
+ * the window it drives, an Item would become a member of it. The animations
+ * are declared properties because a QtObject has no `data`.
+ */
+QtObject {
+    id: root
+
+    // The gesture's own flag. The runner reads it and never writes it.
+    required property bool open
+
+    // How far the panel travels: its own extent along the slide axis, so at
+    // progress 0 nothing of it is on screen.
+    required property real travel
+
+    // Which way "out" is. +1 for a panel on the right or bottom edge (it
+    // leaves toward +x / +y), -1 for one on the left or top.
+    property int direction: 1
+
+    // 0 = parked off its edge, 1 = at rest on screen. Declared at 0 and only
+    // ever written by the two animations below and by `Component.onCompleted`
+    // for a surface created with its panel already open - a start value
+    // written through the animated property is what
+    // lint_animated_start_write.py exists for.
+    property real progress: 0
+
+    // The displacement to apply to the panel, in px along the slide axis.
+    readonly property real offset: (1 - root.progress) * root.travel * root.direction
+
+    // Whether the panel has anything on screen. True through the whole exit,
+    // so content gated on it is not hidden under an animation still drawing
+    // it; false once the exit has finished, so a Loader gated on it may stand
+    // down.
+    readonly property bool shown: root.open || root.progress > 0
+
+    onOpenChanged: {
+        if (root.open)
+            root.arrive();
+        else
+            root.leave();
+    }
+
+    Component.onCompleted: {
+        if (root.open)
+            root.progress = 1;
+    }
+
+    function arrive() {
+        root.exitAnim.stop();
+        root.enterAnim.start();
+    }
+
+    function leave() {
+        root.enterAnim.stop();
+        root.exitAnim.start();
+    }
+
+    // Started animations rather than a Behavior: the gesture can be reversed
+    // mid-flight by toggling twice, and a Behavior branching on the flag is
+    // the tier race lint_behavior_tier_race.py exists for.
+    readonly property NumberAnimation enterAnim: NumberAnimation {
+        target: root
+        property: "progress"
+        to: 1
+        duration: Appearance.animation.sidebarSlideEnter.duration
+        easing.type: Appearance.animation.sidebarSlideEnter.type
+        easing.bezierCurve: Appearance.animation.sidebarSlideEnter.bezierCurve
+    }
+
+    readonly property NumberAnimation exitAnim: NumberAnimation {
+        target: root
+        property: "progress"
+        to: 0
+        duration: Appearance.animation.sidebarSlideExit.duration
+        easing.type: Appearance.animation.sidebarSlideExit.type
+        easing.bezierCurve: Appearance.animation.sidebarSlideExit.bezierCurve
+    }
+}

--- a/dots/.config/quickshell/imi/modules/common/widgets/MaterialSymbol.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/MaterialSymbol.qml
@@ -23,7 +23,13 @@ StyledText {
         weight: resolvedFill > 0.5 ? Font.DemiBold : Font.Normal
         variableAxes: {
             "FILL": resolvedFill,
-            "opsz": iconSize,
+            // Quantized to the axis' own integer range (Material Symbols
+            // defines opsz 20-48). Every distinct axis value mints a separate
+            // font engine, and icons sized by layout arithmetic produce
+            // near-duplicate fractional sizes - 62 engines were live for this
+            // one family. Clamping to whole numbers caps the set at 29, and
+            // an optical-size step of under 1pt is not a visible difference.
+            "opsz": Math.max(20, Math.min(48, Math.round(iconSize))),
         }
     }
 }

--- a/dots/.config/quickshell/imi/modules/common/widgets/SineCookie.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/SineCookie.qml
@@ -19,13 +19,23 @@ Item {
 
     property real shapeRotation: 0
 
+    // A 30Hz clock, not a FrameAnimation, and gated on visibility. The old
+    // FrameAnimation stepped 0.05°/frame, which redrew this decorative spin
+    // at the display's full refresh (240 damage events a second here) and
+    // made the speed itself a function of the refresh rate - 12°/s on a
+    // 240Hz panel, 3°/s on a 60Hz one. Time-based stepping at the cookie
+    // clock's own motionTickHz keeps the 240Hz look's speed everywhere at an
+    // eighth of the redraws, and an invisible cookie doesn't tick at all.
     Loader {
-        active: constantlyRotate
-        sourceComponent: FrameAnimation {
+        active: root.constantlyRotate && root.visible
+        sourceComponent: Timer {
+            readonly property int tickHz: 30
+            readonly property real degreesPerSecond: 12
             running: true
-            onTriggered: {
-                shapeRotation += 0.05
-            }
+            repeat: true
+            interval: Math.round(1000 / tickHz)
+            onTriggered: root.shapeRotation =
+                (root.shapeRotation + degreesPerSecond / tickHz) % 360
         }
     }
 

--- a/dots/.config/quickshell/imi/modules/imi/overview/Overview.qml
+++ b/dots/.config/quickshell/imi/modules/imi/overview/Overview.qml
@@ -15,20 +15,25 @@ Scope {
     id: overviewScope
     property bool dontAutoCancelSearch: false
 
-    // The surface outlives the flag by exactly one exit animation, and it is
+    // The CONTENT outlives the flag by exactly one exit animation, and it is
     // the ANIMATION that says when - the same rule, and for the same reason, as
     // `modules/imi/wallpaperSelector/WallpaperSelector.qml`'s `reallyOpen`
     // records: a Behavior's animation starts a frame after the write that
     // triggers it, and an accelerating exit carries most of its distance in its
-    // last frames, so a Timer at the exit tier's own duration tears the window
+    // last frames, so a Timer at the exit tier's own duration tears the card
     // down with the transition still on screen.
     //
-    // Before this the window's `visible` followed `GlobalStates.overviewOpen`
-    // directly, and `rules.lua` turns the compositor's own map animation off for
-    // this namespace (`no_anim`, because a map animation on a screen-sized
-    // surface reads as the desktop lurching). Between the two there was nothing
-    // left to animate the overview at either end: it appeared and vanished on
-    // one frame.
+    // This used to be the WINDOW's lifetime, and that was the overview's last
+    // per-open stall: a destroyed-and-rebuilt window blocks the shell's one
+    // GUI thread the way the sidebars' did before EdgeSlide.qml (61ms
+    // measured there, and this is the largest surface in the shell). The
+    // surface now stays mapped for the life of the shell - `rules.lua`
+    // already turns the compositor's map animation off for this namespace,
+    // and there is no map left to animate - while `reallyOpen` gates what it
+    // shows: the column's visibility, the grid loader, and (through
+    // `openProgress`) the blur regions. A closed overview is a full-screen
+    // surface with a null input mask, keyboardFocus None and nothing drawn,
+    // which is exactly what the bar's surface is under a fullscreen window.
     property bool reallyOpen: false
 
     PanelWindow {
@@ -36,7 +41,6 @@ Scope {
         property string searchingText: ""
         readonly property HyprlandMonitor monitor: Hyprland.monitorFor(panelWindow.screen)
         property bool monitorIsFocused: (Hyprland.focusedMonitor?.id == monitor?.id)
-        visible: overviewScope.reallyOpen
 
         WlrLayershell.namespace: "quickshell:overview"
         WlrLayershell.layer: WlrLayer.Top
@@ -87,23 +91,48 @@ Scope {
             right: true
         }
 
+        // The grab is taken after the surface has RENDERED two frames with the
+        // card open, not in the tick the flag flips - the sidebars' rule (see
+        // SidebarRight.qml): on a surface that is mapped all the time the new
+        // `keyboardFocus` value rides the next commit, and a grab that reaches
+        // Hyprland first lands on a surface it still knows as interactivity
+        // None, is cleared within milliseconds, and the clear is read as a
+        // click-outside that closes the overview it just opened.
+        FrameAnimation {
+            id: focusGrabAfterCommit
+            property int framesLeft: 0
+            running: framesLeft > 0
+            onTriggered: {
+                if (--framesLeft > 0)
+                    return;
+                if (GlobalStates.overviewOpen)
+                    GlobalFocusGrab.addDismissable(panelWindow);
+            }
+        }
+
         Connections {
             target: GlobalStates
             function onOverviewOpenChanged() {
                 if (!GlobalStates.overviewOpen) {
                     searchWidget.disableExpandAnimation();
                     overviewScope.dontAutoCancelSearch = false;
+                    focusGrabAfterCommit.framesLeft = 0;
                     GlobalFocusGrab.dismiss();
                     columnLayout.leave();
                 } else {
-                    // The surface is asked for before the card is asked to
+                    // The content is asked for before the card is asked to
                     // arrive, in this order: an entrance started against an
-                    // unmapped window is an entrance nothing advances.
+                    // unbuilt card is an entrance nothing advances.
                     overviewScope.reallyOpen = true;
                     if (!overviewScope.dontAutoCancelSearch) {
                         searchWidget.cancelSearch();
                     }
-                    GlobalFocusGrab.addDismissable(panelWindow);
+                    focusGrabAfterCommit.framesLeft = 2;
+                    // A persistent window is created once, at boot, without
+                    // keyboard focus - so an open has to say where keys go
+                    // (the sidebars' lesson, SidebarLeft.qml) or the window
+                    // activates with no focus item and every key is dropped.
+                    searchWidget.focusSearchInput();
                     columnLayout.arrive();
                 }
             }

--- a/dots/.config/quickshell/imi/modules/imi/overview/Overview.qml
+++ b/dots/.config/quickshell/imi/modules/imi/overview/Overview.qml
@@ -69,8 +69,20 @@ Scope {
         // be while the switch happens. This is a choice about where to put an
         // unavoidable step, not a measurement.
         readonly property bool bodyFrosted: columnLayout.openProgress >= 0.5
+        onBodyFrostedChanged: blurRegion.publishNow()
 
+        // The composed region's INNER items swap identity at runtime - the
+        // grid is rebuilt by its loader every open, and bodyFrosted flips
+        // both items in and out - and BackgroundEffect's live geometry
+        // tracking follows a given item, not a binding that replaces it.
+        // On the persistent surface nothing else republishes any more (the
+        // window never resizes and never remaps), so the first open showed
+        // the frost where the HALF-BUILT grid had been when the region was
+        // first pushed: a sharp unblurred band down the card's left edge,
+        // user-reported. Each identity flip republishes now; the settle
+        // timer inside publishNow covers the layout that follows it.
         WindowBlurRegion {
+            id: blurRegion
             targetWindow: panelWindow
             region: Region {
                 Region {
@@ -258,6 +270,7 @@ Scope {
             Loader {
                 id: overviewLoader
                 active: overviewScope.reallyOpen && (Config?.options.overview.enable ?? true)
+                onItemChanged: blurRegion.publishNow()
                 sourceComponent: (Config?.options.overview.style ?? "default") === "niri" ? niriComponent : defaultComponent
 
                 Component {

--- a/dots/.config/quickshell/imi/modules/imi/overview/Overview.qml
+++ b/dots/.config/quickshell/imi/modules/imi/overview/Overview.qml
@@ -47,8 +47,20 @@ Scope {
         WlrLayershell.keyboardFocus: GlobalStates.overviewOpen ? WlrKeyboardFocus.OnDemand : WlrKeyboardFocus.None
         color: "transparent"
 
+        // The proxy, not the column: the card scales during its entrance and
+        // a Region maps the item through its render transform, while
+        // Hyprland snapshots the input region when the focus grab lands -
+        // two frames into that entrance. The selector shipped the full
+        // failure (see WallpaperSelector.qml's mask note for the click-map);
+        // this one had the same scaled item under its mask and the same
+        // grab timing. Anchors track layout geometry and ignore render
+        // transforms, so the proxy is the settled rect at every instant.
+        Item {
+            id: inputRegionProxy
+            anchors.fill: columnLayout
+        }
         mask: Region {
-            item: GlobalStates.overviewOpen ? columnLayout : null
+            item: GlobalStates.overviewOpen ? inputRegionProxy : null
         }
 
         // Blur only the painted body cards. This one surface carries two of

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/SidebarLeft.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/SidebarLeft.qml
@@ -88,15 +88,23 @@ Scope { // Scope
         sourceComponent: PanelWindow { // Window
             id: panelWindow
 
-            property bool reallyVisible: false
-            visible: reallyVisible
-
-            Component.onCompleted: reallyVisible = GlobalStates.sidebarLeftOpen
+            // The surface stays mapped; the panel is what slides. See
+            // SidebarRight.qml and EdgeSlide.qml - the window following the
+            // open flag was a 61ms stall of the whole shell per open.
+            readonly property EdgeSlide slide: EdgeSlide {
+                open: GlobalStates.sidebarLeftOpen
+                travel: panelWindow.implicitWidth
+                direction: -1
+            }
 
             Connections {
                 target: GlobalStates
                 function onSidebarLeftOpenChanged() {
-                    panelWindow.reallyVisible = GlobalStates.sidebarLeftOpen;
+                    if (GlobalStates.sidebarLeftOpen) {
+                        GlobalFocusGrab.addDismissable(panelWindow);
+                    } else {
+                        GlobalFocusGrab.removeDismissable(panelWindow);
+                    }
                 }
             }
 
@@ -113,7 +121,9 @@ Scope { // Scope
             implicitWidth: Appearance.sizes.sidebarWidthExtended + Appearance.sizes.elevationMargin
             WlrLayershell.namespace: "quickshell:sidebarLeft"
             // Hyprland 0.49: OnDemand is Exclusive, Exclusive just breaks click-outside-to-close
-            WlrLayershell.keyboardFocus: WlrKeyboardFocus.OnDemand
+            // ...and on a surface that is mapped all the time, an unconditional
+            // OnDemand is a panel that holds the keyboard while showing nothing.
+            WlrLayershell.keyboardFocus: GlobalStates.sidebarLeftOpen ? WlrKeyboardFocus.OnDemand : WlrKeyboardFocus.None
             color: "transparent"
 
             anchors {
@@ -135,26 +145,21 @@ Scope { // Scope
                 }
             }
 
+            // Gated on the flag: a mapped surface with an unconditional mask
+            // takes every click on the left edge of the screen, panel or not.
             mask: Region {
-                item: sidebarLeftBackground
+                item: GlobalStates.sidebarLeftOpen ? sidebarLeftBackground : null
             }
 
             // Blur only the panel body. The drop shadow is drawn in the
             // surface's elevation margin, outside this region, so the
             // compositor's blur can't frost it (#82). Pairs with rules.lua
             // turning the whole-surface layerrule blur off for this namespace.
+            // Follows the body as it slides, withdrawn once it is off screen.
             WindowBlurRegion {
                 targetWindow: panelWindow
-                regionItem: sidebarLeftBackground
+                regionItem: panelWindow.slide.shown ? sidebarLeftBackground : null
                 regionRadius: sidebarLeftBackground.radius
-            }
-
-            onVisibleChanged: {
-                if (visible) {
-                    GlobalFocusGrab.addDismissable(panelWindow);
-                } else {
-                    GlobalFocusGrab.removeDismissable(panelWindow);
-                }
             }
             Connections {
                 target: GlobalFocusGrab
@@ -167,9 +172,11 @@ Scope { // Scope
             StyledRectangularShadow {
                 target: sidebarLeftBackground
                 radius: sidebarLeftBackground.radius
+                visible: sidebarLeftBackground.visible
             }
             Rectangle {
                 id: sidebarLeftBackground
+                visible: panelWindow.slide.shown
                 anchors.top: parent.top
                 anchors.topMargin: Appearance.sizes.hyprlandGapsOut
                 width: panelWindow.sidebarWidth - Appearance.sizes.hyprlandGapsOut - Appearance.sizes.elevationMargin
@@ -179,7 +186,9 @@ Scope { // Scope
                 border.color: Appearance.colors.colLayer0Border
                 radius: Appearance.rounding.screenRounding - Appearance.sizes.hyprlandGapsOut + 1
 
-                x: Appearance.sizes.hyprlandGapsOut
+                // An `x`, not a transform: the blur region and the shadow both
+                // follow the item's geometry, and a transform moves neither.
+                x: Appearance.sizes.hyprlandGapsOut + panelWindow.slide.offset
 
                 Behavior on width {
                     animation: Appearance.animation.elementMove.numberAnimation.createObject(this)

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/SidebarLeft.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/SidebarLeft.qml
@@ -97,12 +97,44 @@ Scope { // Scope
                 direction: -1
             }
 
+            // The grab is taken after the surface has RENDERED two frames with the
+            // panel open, not in the tick the flag flips. On a surface that is
+            // mapped all the time there is no map to carry the new
+            // `keyboardFocus` to the compositor - it goes out with the next commit,
+            // and a grab that reaches Hyprland before that commit is a grab on a
+            // surface it still knows as keyboard-interactivity None: Hyprland
+            // clears it within milliseconds, and `onDismissed` reads the clear as
+            // a click outside and closes the panel it just opened. A 1ms Timer
+            // lost that race on the left sidebar (grab at +10ms, cleared at +14ms)
+            // and won it on the right (+32ms) - so the wait is for frames, which
+            // is the thing the commit actually rides on.
+            FrameAnimation {
+                id: focusGrabAfterCommit
+                property int framesLeft: 0
+                running: framesLeft > 0
+                onTriggered: {
+                    if (--framesLeft > 0)
+                        return;
+                    if (GlobalStates.sidebarLeftOpen)
+                        GlobalFocusGrab.addDismissable(panelWindow);
+                }
+            }
             Connections {
                 target: GlobalStates
                 function onSidebarLeftOpenChanged() {
                     if (GlobalStates.sidebarLeftOpen) {
-                        GlobalFocusGrab.addDismissable(panelWindow);
+                        focusGrabAfterCommit.framesLeft = 2;
+                        // The window used to be rebuilt per open, and the tabs'
+                        // own creation-time focus grabs picked the focus item.
+                        // A persistent window is created once, at boot, without
+                        // keyboard focus - so an open has to say where keys go
+                        // or the window activates with NO focus item and every
+                        // key is dropped at the content item. (The right
+                        // sidebar's loader does this with a `focus:` binding on
+                        // the open flag.)
+                        root.sidebarContent?.focusActiveItem();
                     } else {
+                        focusGrabAfterCommit.framesLeft = 0;
                         GlobalFocusGrab.removeDismissable(panelWindow);
                     }
                 }

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/SidebarRight.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/SidebarRight.qml
@@ -39,12 +39,35 @@ Scope {
             GlobalStates.sidebarRightOpen = false;
         }
 
+        // The grab is taken after the surface has RENDERED two frames with the
+        // panel open, not in the tick the flag flips. On a surface that is
+        // mapped all the time there is no map to carry the new
+        // `keyboardFocus` to the compositor - it goes out with the next commit,
+        // and a grab that reaches Hyprland before that commit is a grab on a
+        // surface it still knows as keyboard-interactivity None: Hyprland
+        // clears it within milliseconds, and `onDismissed` reads the clear as
+        // a click outside and closes the panel it just opened. A 1ms Timer
+        // lost that race on the left sidebar (grab at +10ms, cleared at +14ms)
+        // and won it on the right (+32ms) - so the wait is for frames, which
+        // is the thing the commit actually rides on.
+        FrameAnimation {
+            id: focusGrabAfterCommit
+            property int framesLeft: 0
+            running: framesLeft > 0
+            onTriggered: {
+                if (--framesLeft > 0)
+                    return;
+                if (GlobalStates.sidebarRightOpen)
+                    GlobalFocusGrab.addDismissable(panelWindow);
+            }
+        }
         Connections {
             target: GlobalStates
             function onSidebarRightOpenChanged() {
                 if (GlobalStates.sidebarRightOpen) {
-                    GlobalFocusGrab.addDismissable(panelWindow);
+                    focusGrabAfterCommit.framesLeft = 2;
                 } else {
+                    focusGrabAfterCommit.framesLeft = 0;
                     GlobalFocusGrab.removeDismissable(panelWindow);
                 }
             }

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/SidebarRight.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/SidebarRight.qml
@@ -16,27 +16,37 @@ Scope {
     PanelWindow {
         id: panelWindow
 
-        property bool reallyVisible: false
-        visible: reallyVisible
+        // The surface stays mapped for the life of the shell; the PANEL is
+        // what opens and closes, and EdgeSlide draws that. `visible` used to
+        // follow the open flag, which destroyed and rebuilt this window on
+        // every gesture - see EdgeSlide.qml for what that cost, measured.
+        // (No `visible:` here at all: the default is true, and a persistent
+        // Top-layer surface is buried under a fullscreen window by Hyprland
+        // the same way the bar's is.)
+        readonly property EdgeSlide slide: EdgeSlide {
+            open: GlobalStates.sidebarRightOpen
+            travel: entranceWrapper.width
+            direction: 1
+        }
 
-        Component.onCompleted: reallyVisible = GlobalStates.sidebarRightOpen
-
-        Connections {
-            target: GlobalStates
-            function onSidebarRightOpenChanged() {
-                panelWindow.reallyVisible = GlobalStates.sidebarRightOpen;
-            }
+        // A mapped surface with no mask takes every click on its rectangle,
+        // and this one is a strip down the whole right edge of the screen.
+        mask: Region {
+            item: GlobalStates.sidebarRightOpen ? entranceWrapper : null
         }
 
         function hide() {
             GlobalStates.sidebarRightOpen = false;
         }
 
-        onVisibleChanged: {
-            if (visible) {
-                GlobalFocusGrab.addDismissable(panelWindow);
-            } else {
-                GlobalFocusGrab.removeDismissable(panelWindow);
+        Connections {
+            target: GlobalStates
+            function onSidebarRightOpenChanged() {
+                if (GlobalStates.sidebarRightOpen) {
+                    GlobalFocusGrab.addDismissable(panelWindow);
+                } else {
+                    GlobalFocusGrab.removeDismissable(panelWindow);
+                }
             }
         }
 
@@ -63,9 +73,14 @@ Scope {
         // shadow in the elevation margin stays outside the region, so the
         // compositor's blur can't frost it (#82). Pairs with rules.lua turning
         // the whole-surface layerrule blur off for this namespace.
+        //
+        // The region follows the body as it slides (a Region tracks its item's
+        // geometry, and the slide is an `x`, not a transform, for exactly that
+        // reason), and is withdrawn once the panel is off screen - a frosted
+        // rectangle with no panel over it is the overview's ghost, again.
         WindowBlurRegion {
             targetWindow: panelWindow
-            regionItem: sidebarContentLoader.item?.backgroundItem ?? null
+            regionItem: panelWindow.slide.shown ? (sidebarContentLoader.item?.backgroundItem ?? null) : null
             regionRadius: sidebarContentLoader.item?.backgroundItem?.radius ?? 0
         }
 
@@ -91,10 +106,13 @@ Scope {
                 anchors.bottom: parent.bottom
                 width: sidebarWidth
                 clip: true
+                // On `shown`, not on the open flag: the flag drops on frame
+                // one of the exit, and the exit is 400ms of this item moving.
+                visible: panelWindow.slide.shown
 
                 property real cachedParentWidth: sidebarWidth
                 readonly property real restX: cachedParentWidth - width
-                x: restX
+                x: restX + panelWindow.slide.offset
 
                 Connections {
                     target: entranceWrapper.parent
@@ -112,7 +130,7 @@ Scope {
 
                 Loader {
                     id: sidebarContentLoader
-                    active: panelWindow.reallyVisible || Config?.options.sidebar.keepRightSidebarLoaded
+                    active: panelWindow.slide.shown || Config?.options.sidebar.keepRightSidebarLoaded
                     anchors {
                         fill: parent
                         margins: Appearance.sizes.hyprlandGapsOut

--- a/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/WallpaperSelector.qml
+++ b/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/WallpaperSelector.qml
@@ -54,8 +54,26 @@ Scope {
                 top: Config?.options.bar.vertical ? Appearance.sizes.hyprlandGapsOut : Appearance.sizes.barHeight + Appearance.sizes.hyprlandGapsOut
             }
 
+            // The mask reads a proxy pinned to the card's LAYOUT rect, never
+            // the card itself: the card scales during its entrance
+            // (transformOrigin Top, 0.85 -> 1), a Region maps the item
+            // through its render transform, and Hyprland snapshots the input
+            // region when the focus grab is installed - which is
+            // mid-entrance. The snapshot kept the scaled rect forever: a
+            // ~60px band inside each side edge of the surface where hover
+            // and clicks still reached the card (the live input region had
+            // settled to full size) but the grab's stale copy said
+            // "outside", so any click there cleared the grab and dismissed
+            // the selector. Click-mapped live: x <= 2021 and >= 3099 closed
+            // on a 1960..3160 surface, which is the 0.9-scale rect exactly.
+            // Anchors track layout geometry and ignore render transforms, so
+            // the proxy is the full rect at every instant.
+            Item {
+                id: inputRegionProxy
+                anchors.fill: content
+            }
             mask: Region {
-                item: content
+                item: inputRegionProxy
             }
 
             implicitHeight: Appearance.sizes.wallpaperSelectorHeight

--- a/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/WallpaperSelectorContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/WallpaperSelectorContent.qml
@@ -681,6 +681,25 @@ MouseArea {
                                     onActiveFocusChanged: root.filterFieldFocused = activeFocus
                                 }
                                 IconToolbarButton {
+                                    implicitWidth: height
+                                    // The same way in as the local toolbar's -
+                                    // and the only one this tab had none of.
+                                    // The depth service has asked about live
+                                    // projects since spec §8 landed (it asks
+                                    // about the wallpaper ON SCREEN, which is
+                                    // the project's still whenever a project
+                                    // is live), but the picker's button only
+                                    // existed on the Local tab, so a user
+                                    // whose wallpaper came from THIS grid had
+                                    // no path into segmentation at all.
+                                    onClicked: root.depthPickerOpen = !root.depthPickerOpen
+                                    toggled: root.depthPickerOpen
+                                    text: "layers"
+                                    StyledToolTip {
+                                        text: Translation.tr("Put the widgets behind this wallpaper's subject")
+                                    }
+                                }
+                                IconToolbarButton {
                                     text: "refresh"
                                     enabled: !WallpaperEngine.loading
                                     onClicked: WallpaperEngine.refresh()

--- a/dots/.config/quickshell/imi/panelFamilies/PanelLoader.qml
+++ b/dots/.config/quickshell/imi/panelFamilies/PanelLoader.qml
@@ -5,11 +5,5 @@ import qs.modules.common
 
 LazyLoader {
     property bool extraCondition: true
-    // activeAsync, not active: `active` instantiates synchronously, and with
-    // ~28 of these firing on the same Config.ready flip, boot paid for every
-    // panel - lock screen, cheatsheet, session screen - before the first
-    // frame of the bar. activeAsync activates the same panels but builds
-    // them incrementally between frames; the ones nobody has opened yet stop
-    // gating the ones on screen.
-    activeAsync: Config.ready && extraCondition
+    active: Config.ready && extraCondition
 }

--- a/dots/.config/quickshell/imi/panelFamilies/PanelLoader.qml
+++ b/dots/.config/quickshell/imi/panelFamilies/PanelLoader.qml
@@ -5,5 +5,11 @@ import qs.modules.common
 
 LazyLoader {
     property bool extraCondition: true
-    active: Config.ready && extraCondition
+    // activeAsync, not active: `active` instantiates synchronously, and with
+    // ~28 of these firing on the same Config.ready flip, boot paid for every
+    // panel - lock screen, cheatsheet, session screen - before the first
+    // frame of the bar. activeAsync activates the same panels but builds
+    // them incrementally between frames; the ones nobody has opened yet stop
+    // gating the ones on screen.
+    activeAsync: Config.ready && extraCondition
 }

--- a/dots/.config/quickshell/imi/services/GlobalFocusGrab.qml
+++ b/dots/.config/quickshell/imi/services/GlobalFocusGrab.qml
@@ -54,14 +54,6 @@ Singleton {
         }
     }
 
-    function hasActive(element) {
-        return element?.activeFocus || Array.from(
-            element?.children ?? []
-        ).some(
-            (child) => hasActive(child)
-        );
-    }
-
     // Debounce transient clears. When a sidebar opens, Hyprland sends a
     // ToplevelHandle activation update ~20ms later for the previously-focused
     // window; HyprlandFocusGrab reads that as "a non-panel toplevel became
@@ -80,7 +72,27 @@ Singleton {
 
     HyprlandFocusGrab {
         id: grab
-        windows: root.dismissable.every(w => !w?.focusable) || root.dismissable.some(w => root.hasActive(w?.contentItem)) ? [...root.dismissable, ...root.persistent] : [...root.dismissable]
+        // Persistent windows first, dismissables LAST - the order is load-
+        // bearing. When the grab activates, Hyprland moves keyboard focus to
+        // a whitelisted surface, and it picks from the END of this list.
+        // Measured on the persistent sidebars (which never re-map, so the
+        // grab is the only thing that can hand them the keyboard): with the
+        // dismissable first and the bar/OSK after it, opening the left
+        // sidebar never activated its window - keys went to a persistent
+        // surface and every keypress was lost until the pointer happened to
+        // enter the panel. Same build, same open, with the dismissable moved
+        // to the end: Window.active flipped true immediately and typing
+        // landed in the AI chat's field with the cursor half a screen away.
+        //
+        // The old conditional (`every(!focusable) || some(hasActive(...))`)
+        // tried to solve the same problem by dropping the persistent windows
+        // from the list entirely in some states - which worked only by
+        // leaving nothing else for Hyprland to pick, and cost the protection
+        // those windows are listed for (a bar click would clear the grab and
+        // dismiss the panel). Ordering keeps both: the panel gets the
+        // keyboard, and clicking the bar or typing on the OSK stays inside
+        // the grab.
+        windows: [...root.persistent, ...root.dismissable]
         active: root.dismissable.length > 0
         onCleared: () => {
             dismissDebounce.restart();

--- a/dots/.config/quickshell/imi/services/KeyboardLocks.qml
+++ b/dots/.config/quickshell/imi/services/KeyboardLocks.qml
@@ -7,9 +7,19 @@ import Quickshell.Io
 import QtQuick
 
 /**
- * Exposes Caps Lock and Num Lock state by polling `hyprctl devices`.
+ * Exposes Caps Lock and Num Lock state.
  * `ready` stays false until the first successful read so consumers can
  * ignore the initial state and only react to real toggles.
+ *
+ * The state comes from the keyboard's own LEDs under /sys/class/leds - the
+ * kernel keeps those in sync with the seat's xkb state - read by ONE
+ * long-lived bash loop using only builtins, which emits a line when either
+ * value changes. This replaces forking `hyprctl devices -j` 3.3 times a
+ * second and parsing the full devices dump for two booleans (no Hyprland
+ * IPC event carries lock-key state, so some poll is unavoidable - but it
+ * can be a poll that costs two opens instead of a fork+exec+JSON). The
+ * hyprctl poll survives below as the fallback for a machine whose keyboard
+ * exposes no LED nodes, picked the moment the watcher exits.
  */
 Singleton {
     id: root
@@ -18,6 +28,54 @@ Singleton {
     property bool numLockOn: false
     property bool ready: false
     property int pollInterval: 300
+    property bool useFallback: false
+
+    // The OSD was the only consumer when this was written, so the poll
+    // was gated on the OSD's own switch. The on-screen keyboard draws
+    // Caps and Num as latched keys now, and a user who turned the OSD off
+    // would have had those two keys frozen at whatever they read when
+    // the poll stopped - stale, and silently so. Watching while either
+    // consumer is interested keeps one source of truth instead of growing
+    // a second poller for the keyboard.
+    readonly property bool watching: (Config.options.osd.lockKeys ?? true) || GlobalStates.oskOpen
+
+    Process {
+        id: ledWatcher
+        running: root.watching && !root.useFallback
+        // Globbing (not ls) and `read -t` on a self-held pipe (not sleep):
+        // after startup the loop is pure bash builtins - two file opens per
+        // tick, zero forks. `sleep` would have forked /usr/bin/sleep 3.3
+        // times a second, which is the cost this watcher exists to remove.
+        command: ["bash", "-c",
+            'shopt -s nullglob; caps=(/sys/class/leds/*::capslock/brightness); ' +
+            'num=(/sys/class/leds/*::numlock/brightness); ' +
+            '[ ${#caps[@]} -gt 0 ] && [ ${#num[@]} -gt 0 ] || exit 1; ' +
+            'CAPS=${caps[0]}; NUM=${num[0]}; ' +
+            'exec 3<> <(:); last=""; while :; do ' +
+            'read c < "$CAPS" 2>/dev/null || exit 1; ' +
+            'read n < "$NUM" 2>/dev/null || exit 1; ' +
+            'cur="$c $n"; if [ "$cur" != "$last" ]; then echo "$cur"; last="$cur"; fi; ' +
+            'read -t 0.3 -u 3 || :; done']
+        stdout: SplitParser {
+            onRead: line => {
+                const parts = line.trim().split(" ");
+                if (parts.length !== 2)
+                    return;
+                // Set the values before flagging readiness so the very first
+                // read never triggers an OSD on startup.
+                root.capsLockOn = parts[0] !== "0";
+                root.numLockOn = parts[1] !== "0";
+                root.ready = true;
+            }
+        }
+        // No LED nodes (exit 1 up front) or a keyboard unplug mid-watch:
+        // fall back to hyprctl for the rest of the session rather than
+        // respawning a loop that will just exit again.
+        onExited: (exitCode, exitStatus) => {
+            if (root.watching)
+                root.useFallback = true;
+        }
+    }
 
     Process {
         id: devicesProc
@@ -29,8 +87,7 @@ Singleton {
                     if (!data.keyboards || data.keyboards.length === 0)
                         return;
                     const keyboard = data.keyboards.find(k => k.main === true) ?? data.keyboards[0];
-                    // Set the values before flagging readiness so the very first
-                    // read never triggers an OSD on startup.
+                    // Same ordering rule as the LED path above.
                     root.capsLockOn = keyboard.capsLock;
                     root.numLockOn = keyboard.numLock;
                     root.ready = true;
@@ -43,14 +100,7 @@ Singleton {
 
     Timer {
         interval: root.pollInterval
-        // The OSD was the only consumer when this was written, so the poll
-        // was gated on the OSD's own switch. The on-screen keyboard draws
-        // Caps and Num as latched keys now, and a user who turned the OSD off
-        // would have had those two keys frozen at whatever they read when
-        // the poll stopped - stale, and silently so. Polling while either
-        // consumer is watching keeps one source of truth instead of growing
-        // a second poller for the keyboard.
-        running: (Config.options.osd.lockKeys ?? true) || GlobalStates.oskOpen
+        running: root.watching && root.useFallback
         repeat: true
         triggeredOnStart: true
         onTriggered: devicesProc.running = true

--- a/dots/.config/quickshell/imi/services/MaterialSymbolsSearch.qml
+++ b/dots/.config/quickshell/imi/services/MaterialSymbolsSearch.qml
@@ -12,10 +12,19 @@ Singleton {
     // Raw list loaded from JSON: [{name, tags, categories}]
     property var allSymbols: []
 
-    // ── Load JSON ─────────────────────────────────────────────────────────
+    // ── Load JSON, on demand ──────────────────────────────────────────────
+    // The tag database is 1.7MB of JSON, and LauncherSearch instantiates
+    // this singleton at boot (allSymbols is in its resultInputs list) - so
+    // an unconditional path here read and parsed all of it before the first
+    // frame, for a search prefix most sessions never type. The path is now
+    // withheld until the first symbols query. That first query answers from
+    // an empty list, and answers itself: allSymbols changing when the parse
+    // lands is exactly the resultInputs entry LauncherSearch rebuilds on.
+    property bool loadRequested: false
+
     FileView {
         id: symbolsFile
-        path: `${Directories.assetsPath}/material_symbols_rounded.json`
+        path: root.loadRequested ? `${Directories.assetsPath}/material_symbols_rounded.json` : ""
         watchChanges: false
         onLoaded: {
             try {
@@ -31,6 +40,8 @@ Singleton {
     // Returns a list of plain strings formatted as:
     //   "<name>  <tag1>, <tag2>, ..."
     function fuzzyQuery(query) {
+        if (!root.loadRequested)
+            root.loadRequested = true;
         if (!query || query.length === 0)
             return root.allSymbols.slice(0, 30).map(sym => _format(sym));
 

--- a/dots/.config/quickshell/imi/services/Network.qml
+++ b/dots/.config/quickshell/imi/services/Network.qml
@@ -175,12 +175,32 @@ Singleton {
         updatePublicIp.running = true;
     }
 
+    // One NetworkManager event feed for the whole shell. Vpn refreshes off
+    // this signal instead of running a second `nmcli monitor` of its own -
+    // measured before the change: two monitors per shell instance, and every
+    // dead instance left both behind (30 orphans reaped from 15 restarts,
+    // all reparented to init and sleeping until the next network event).
+    signal monitorEvent()
+
     Process {
         id: subscriber
         running: true
-        command: ["nmcli", "monitor"]
+        // `nmcli monitor` under a watchdog rather than bare. `nmcli monitor`
+        // only writes on network events, so when the shell dies without
+        // tearing its children down (SIGKILL, a crash) the orphan never hits
+        // SIGPIPE and sleeps forever. The loop costs one wakeup every 5s and
+        // ends when either side dies: quickshell gone -> the trap kills
+        // nmcli; nmcli gone -> the loop falls through and the Process exits.
+        // nmcli's stdout is inherited, not piped through bash, so the
+        // SplitParser reads it exactly as before.
+        command: ["bash", "-c",
+            "nmcli monitor & M=$!; trap 'kill $M 2>/dev/null' EXIT; " +
+            "while kill -0 $PPID 2>/dev/null && kill -0 $M 2>/dev/null; do sleep 5; done"]
         stdout: SplitParser {
-            onRead: root.update()
+            onRead: {
+                root.update();
+                root.monitorEvent();
+            }
         }
     }
 

--- a/dots/.config/quickshell/imi/services/Vpn.qml
+++ b/dots/.config/quickshell/imi/services/Vpn.qml
@@ -5,6 +5,7 @@ import Quickshell
 import Quickshell.Io
 import QtQuick
 import qs.modules.common
+import qs.services
 
 /**
  * VPN service backed by NetworkManager (nmcli).
@@ -73,13 +74,15 @@ Singleton {
         onTriggered: root.refresh()
     }
 
-    // Refresh immediately on any NetworkManager event, with the timer as a fallback.
-    Process {
-        id: monitor
-        running: root.enableService
-        command: ["nmcli", "monitor"]
-        stdout: SplitParser {
-            onRead: root.refresh()
+    // Refresh immediately on any NetworkManager event, with the timer as a
+    // fallback. The events come from Network's single watchdogged
+    // `nmcli monitor` - this service used to run a second one, which doubled
+    // the per-instance monitor count and the orphans each dead instance left.
+    Connections {
+        target: Network
+        enabled: root.enableService
+        function onMonitorEvent() {
+            root.refresh();
         }
     }
 

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -403,6 +403,16 @@ if ! python3 "$SCRIPT_DIR/test_marquee_text_contract.py"; then
     exit 1
 fi
 
+# The cookie clock's spin and sweep are sampled at 30Hz, not animated per vsync:
+# on the background surface every commit is a whole-screen re-render and a
+# re-blur of every surface over it, and the animated version was 38% of the GPU
+# at idle against 20% sampled and 10-12% off.
+echo "Running clock motion contract tests..."
+if ! python3 "$SCRIPT_DIR/test_clock_motion_contract.py"; then
+    echo "Clock motion contract tests failed."
+    exit 1
+fi
+
 # The clock's options page shows only the chosen style's rows. The predicate is
 # pinned by tst_option_visibility.qml; this is the adoption, which is what
 # decays - a 29th option added without a rule renders on every style again.

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -403,6 +403,15 @@ if ! python3 "$SCRIPT_DIR/test_marquee_text_contract.py"; then
     exit 1
 fi
 
+# The clock's options page shows only the chosen style's rows. The predicate is
+# pinned by tst_option_visibility.qml; this is the adoption, which is what
+# decays - a 29th option added without a rule renders on every style again.
+echo "Running clock options contract tests..."
+if ! python3 "$SCRIPT_DIR/test_clock_options_contract.py"; then
+    echo "Clock options contract tests failed."
+    exit 1
+fi
+
 # A sidebar's surface stays mapped and the panel slides; a window that followed
 # the open flag was rebuilt per gesture and blocked the shell's one GUI thread
 # for 61ms each time. The rule that matters most here is the silent one: a

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -403,6 +403,16 @@ if ! python3 "$SCRIPT_DIR/test_marquee_text_contract.py"; then
     exit 1
 fi
 
+# A sidebar's surface stays mapped and the panel slides; a window that followed
+# the open flag was rebuilt per gesture and blocked the shell's one GUI thread
+# for 61ms each time. The rule that matters most here is the silent one: a
+# mapped surface with an ungated mask eats every click on a screen edge.
+echo "Running persistent sidebar contract tests..."
+if ! python3 "$SCRIPT_DIR/test_persistent_sidebar_contract.py"; then
+    echo "Persistent sidebar contract tests failed."
+    exit 1
+fi
+
 # A surface that animates on its way out is owned by that animation, not by the
 # flag the user's gesture sets: layer-shell forbids window reuse, so a window
 # whose `visible` follows the flag is destroyed on the frame the exit starts.

--- a/dots/.config/quickshell/imi/tests/test_clock_motion_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_clock_motion_contract.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""The cookie clock's continuous motion is sampled, not animated per vsync.
+
+On the background surface every commit carries whole-surface damage - Qt's GL
+path reports no less - so a running animation there is the compositor
+re-rendering all of a 5120x1440 screen and re-blurring every surface over it,
+once per vsync. The cookie's 30-second spin and its per-second hand sweep did
+exactly that, and measured at idle on the reporter's machine it was 38% of the
+GPU against 10-12% with the spin off. Sampling the wall clock at 30Hz brought
+it to 20%, with the rim of a 230px cookie moving 0.8px per tick.
+
+Three things this pins, each of which is a one-line way back to the 38%:
+
+- no infinite `RotationAnimation` / `NumberAnimation` on the body's rotation;
+- the second hand is handed `animateRotation: false` and a `sweep` - its own
+  Behavior is a one-second animation that refires every second, which is a
+  continuous animation by another name;
+- the tick rate stays at or under 30Hz. It is a declared number, and a
+  declared number is the easiest thing in a file to nudge.
+"""
+
+import re
+from pathlib import Path
+
+from contract_runner import run
+
+ROOT = Path(__file__).resolve().parent.parent
+COOKIE = ROOT / "modules/common/plugins/bundled/clock/CookieClock.qml"
+SECOND_HAND = ROOT / "modules/common/plugins/bundled/clock/SecondHand.qml"
+MAX_TICK_HZ = 30
+
+
+def code(path: Path) -> str:
+    assert path.exists(), f"{path} is gone"
+    text = path.read_text()
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.S)
+    return re.sub(r"//[^\n]*", "", text)
+
+
+def test_the_body_spin_is_a_function_of_sampled_time():
+    text = code(COOKIE)
+    assert not re.search(r"(Rotation|Number|Property)Animation\s+on\s+rotation", text), \
+        "CookieClock animates its rotation per vsync again - that was 38% of the GPU at idle"
+    assert "loops: Animation.Infinite" not in text, \
+        "CookieClock carries an infinite animation again"
+    assert re.search(r"rotation:\s*360\s*-\s*\(root\.motionClockMs", text), \
+        "the body's rotation no longer derives from `motionClockMs` - what drives it now?"
+    assert re.search(r"onTriggered:\s*root\.motionClockMs\s*=\s*Date\.now\(\)", text), \
+        "nothing samples the wall clock into `motionClockMs`"
+
+
+def test_the_second_hand_is_handed_a_sweep_not_an_animation():
+    cookie = code(COOKIE)
+    hand = code(SECOND_HAND)
+    assert re.search(r"animateRotation:\s*false", cookie), \
+        "CookieClock lets SecondHand animate its own rotation - a one-second Behavior refiring every second is a continuous animation"
+    assert not re.search(r"animateRotation:\s*root\.constantlyRotate", cookie), \
+        "the sweep is back on SecondHand's per-second Behavior"
+    assert re.search(r"sweep:\s*root\.secondSweep", cookie), \
+        "CookieClock no longer hands SecondHand its sampled sweep"
+    assert re.search(r"property\s+real\s+sweep\b", hand) and re.search(r"clockSecond\s*\+\s*sweep", hand), \
+        "SecondHand no longer folds `sweep` into its rotation"
+
+
+def test_the_tick_rate_is_declared_and_capped():
+    text = code(COOKIE)
+    match = re.search(r"readonly\s+property\s+int\s+motionTickHz:\s*(\d+)", text)
+    assert match, "`motionTickHz` is not a declared integer literal any more"
+    hz = int(match.group(1))
+    assert hz <= MAX_TICK_HZ, \
+        (f"motionTickHz is {hz}; measured GPU at idle was 20% at 30Hz, 28% at 60Hz, 38% at vsync. "
+         "Raise MAX_TICK_HZ here only with a new measurement")
+    assert re.search(r"interval:\s*Math\.round\(1000\s*/\s*root\.motionTickHz\)", text), \
+        "the tick Timer's interval is not derived from `motionTickHz`"
+    assert re.search(r"running:\s*root\.constantlyRotate\s*&&\s*cookieBody\.visible", text), \
+        "the tick is not gated on the cookie being ON SCREEN - a desktop behind a fullscreen game would pay for it"
+
+
+if __name__ == "__main__":
+    raise SystemExit(run(globals()))

--- a/dots/.config/quickshell/imi/tests/test_clock_options_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_clock_options_contract.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""The clock's options page shows only the chosen style's rows.
+
+The clock declares 28 options for three styles, and every one of them rendered
+whether or not the style it belongs to was selected: eleven `cookie*` rows on
+a digital clock, five `digitalFont*` rows on a cookie. The manifest says which
+style each row belongs to in its own key prefix, so the rule is mechanical: a
+`digital*`, `cookie*` or `pixel*` option carries a `visibleWhen` that matches
+that style on `style` OR on `styleLocked` - the desktop and the lock screen can
+show different clocks, and a row has something to say if either of them is the
+style it configures.
+
+`color` is the one row whose key does not carry its style; its label does
+("Digital: color"), and Widget.qml reads it inside the digital block only.
+
+The predicate itself is pinned by tst_option_visibility.qml. This is the
+adoption, which is what decays: a 29th option added without a rule renders on
+every style again and nothing notices.
+"""
+
+import json
+from pathlib import Path
+
+from contract_runner import run
+
+ROOT = Path(__file__).resolve().parent.parent
+MANIFEST = ROOT / "modules/common/plugins/bundled/clock/manifest.json"
+STYLES = ("digital", "cookie", "pixel")
+# Rows every style shares. Anything else must name a style.
+SHARED = {"style", "styleLocked", "showOnlyWhenLocked", "quoteEnable", "quoteFollowClock", "quoteText"}
+# Rows whose key does not carry the style they belong to.
+STYLE_OF = {"color": "digital"}
+
+
+def options():
+    manifest = json.loads(MANIFEST.read_text())
+    opts = manifest.get("options") or []
+    assert len(opts) >= 20, f"the clock manifest has {len(opts)} options - this sweep expects the real one"
+    return opts
+
+
+def expected_style(key: str):
+    if key in STYLE_OF:
+        return STYLE_OF[key]
+    for style in STYLES:
+        if key.startswith(style):
+            return style
+    return None
+
+
+def matches(rule, style: str) -> bool:
+    """Whether `rule` is exactly 'style == S on either key'."""
+    branches = rule.get("anyOf") if isinstance(rule, dict) else None
+    if not isinstance(branches, list) or len(branches) != 2:
+        return False
+    keys = sorted(b.get("key") for b in branches if isinstance(b, dict))
+    return keys == ["style", "styleLocked"] and all(b.get("in") == [style] for b in branches)
+
+
+def test_every_style_bound_row_is_gated_on_its_style():
+    seen = 0
+    for option in options():
+        key = option["key"]
+        style = expected_style(key)
+        if style is None:
+            assert key in SHARED, \
+                (f"clock option `{key}` names no style and is not in the shared set - either "
+                 "prefix it with its style, add it to STYLE_OF, or say here that every style shows it")
+            assert "visibleWhen" not in option, \
+                f"shared clock option `{key}` carries a visibleWhen - it is shown on every style"
+            continue
+        seen += 1
+        assert "visibleWhen" in option, \
+            f"clock option `{key}` belongs to the {style} style and has no visibleWhen - it renders on every style"
+        assert matches(option["visibleWhen"], style), \
+            (f"clock option `{key}`'s rule is {option['visibleWhen']!r}; expected {style} on "
+             "`style` OR `styleLocked` - the desktop and the lock screen can show different clocks")
+    assert seen >= 20, f"only {seen} style-bound rows found - the sweep is looking at the wrong file"
+
+
+def test_no_style_is_left_without_rows():
+    by_style = {s: 0 for s in STYLES}
+    for option in options():
+        style = expected_style(option["key"])
+        if style:
+            by_style[style] += 1
+    for style, count in by_style.items():
+        assert count >= 1, f"the {style} style has no options of its own - did a prefix change?"
+
+
+if __name__ == "__main__":
+    raise SystemExit(run(globals()))

--- a/dots/.config/quickshell/imi/tests/test_exit_owned_surface_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_exit_owned_surface_contract.py
@@ -56,19 +56,25 @@ ROOT = Path(__file__).resolve().parent.parent
 OVERVIEW = ROOT / "modules/imi/overview/Overview.qml"
 SELECTOR = ROOT / "modules/imi/wallpaperSelector/WallpaperSelector.qml"
 
-# The declaration that maps the surface, and the property on it that decides
-# whether the compositor has one. The overview's window is built unconditionally
-# and toggles its own `visible`; the selector's is built by a Loader and toggles
-# that Loader's `active`. Both mean "the surface exists", and both must read the
-# lifetime flag rather than the flag the gesture sets.
+# What the lifetime flag owns differs between the two surfaces now, and the
+# mode records it. The selector's SURFACE is exit-owned: its window is built
+# by a Loader whose `active` reads the flag, torn down when the exit finishes.
+# The overview's surface went persistent (perf(overview): keep the surface
+# mapped) - it pays no per-open rebuild, so there the flag owns the CONTENT:
+# the window must declare no `visible:` of its own at all (a `visible:` that
+# reappears puts the 61ms rebuild back on every Super+Tab), and the card
+# inside it hides on the flag instead.
 #
-# The gate is read at the mapping declaration's OWN top level rather than
+# The gate is read at the owning declaration's OWN top level rather than
 # anywhere in the file. A sweep for "some `visible:` line mentions the lifetime
 # flag" passes on a tree where the window has been put back on the gesture's
 # flag and only the card inside it still reads the right one - which is the
 # exact regression this file exists to catch, and it survived the first draft.
 LIFETIME_FLAG = "reallyOpen"
-SURFACES = {OVERVIEW: ("PanelWindow", "visible"), SELECTOR: ("Loader", "active")}
+SURFACES = {
+    OVERVIEW: ("PanelWindow", "visible", "persistent-surface"),
+    SELECTOR: ("Loader", "active", "exit-owned-surface"),
+}
 
 
 def read(path: Path) -> str:
@@ -156,36 +162,52 @@ def declared_at_top_level(block: str, prop: str):
 
 
 def test_the_surface_outlives_the_gesture_by_one_exit_animation():
-    for path, (declaration, gate) in SURFACES.items():
+    for path, (declaration, gate, mode) in SURFACES.items():
         text = code(path)
         name = path.relative_to(ROOT).as_posix()
 
         assert re.search(rf"property\s+bool\s+{LIFETIME_FLAG}\b", text), \
-            (f"{name} has no `{LIFETIME_FLAG}` - its surface is back to living "
+            (f"{name} has no `{LIFETIME_FLAG}` - what it owns is back to living "
              "and dying with the flag the user's gesture sets, and its exit "
-             "animation is drawing into a window that is already gone")
+             "animation is drawing into something that is already gone")
 
         gates = declared_at_top_level(
             mapping_block(text, declaration, name), gate)
-        assert gates, \
-            (f"{name}'s {declaration} declares no `{gate}:` of its own - "
-             "nothing here says when the surface exists")
-        assert all(LIFETIME_FLAG in value for value in gates), \
-            (f"{name}'s {declaration} maps on `{gate}: {gates}` - the surface "
-             f"must follow `{LIFETIME_FLAG}`, not the gesture's own flag, or it "
-             "is destroyed on the frame the exit animation starts")
+        if mode == "persistent-surface":
+            # The overview's window stays mapped for the life of the shell -
+            # a `visible:` reappearing on it is the 61ms per-gesture rebuild
+            # coming back. The flag owns the CARD instead.
+            assert gates in ([], ["true"]), \
+                (f"{name}'s {declaration} declares `{gate}: {gates}` - this "
+                 "surface is persistent, and a gated `visible` puts the "
+                 "per-open window rebuild back on every gesture")
+            card_gates = [line.strip() for line in logical_lines(text)
+                          if re.match(r"\s*visible\s*:", line)
+                          and LIFETIME_FLAG in line]
+            assert card_gates, \
+                (f"{name} hides nothing on `{LIFETIME_FLAG}` - with the window "
+                 "persistent, the card must be what the exit animation owns, "
+                 "or a closed overview keeps drawing")
+        else:
+            assert gates, \
+                (f"{name}'s {declaration} declares no `{gate}:` of its own - "
+                 "nothing here says when the surface exists")
+            assert all(LIFETIME_FLAG in value for value in gates), \
+                (f"{name}'s {declaration} maps on `{gate}: {gates}` - the surface "
+                 f"must follow `{LIFETIME_FLAG}`, not the gesture's own flag, or it "
+                 "is destroyed on the frame the exit animation starts")
 
         clears = [line.strip() for line in logical_lines(text)
                   if re.search(rf"{LIFETIME_FLAG}\s*=\s*false", line)]
         assert clears, \
-            (f"{name} never clears `{LIFETIME_FLAG}` - the surface is now "
-             "mapped for the rest of the session")
+            (f"{name} never clears `{LIFETIME_FLAG}` - what it gates is now "
+             "on for the rest of the session")
         for line in clears:
             assert "onFinished" in line, \
-                (f"{name} clears `{LIFETIME_FLAG}` at `{line}` - the window's "
-                 "lifetime belongs to the exit animation's own `onFinished`. A "
-                 "Timer at the exit tier's duration tore the wallpaper selector "
-                 "down with 25% of its travel still to draw.")
+                (f"{name} clears `{LIFETIME_FLAG}` at `{line}` - the lifetime "
+                 "belongs to the exit animation's own `onFinished`. A Timer at "
+                 "the exit tier's duration tore the wallpaper selector down "
+                 "with 25% of its travel still to draw.")
 
 
 def test_one_scalar_and_one_tier_per_animation():

--- a/dots/.config/quickshell/imi/tests/test_key_monitor.py
+++ b/dots/.config/quickshell/imi/tests/test_key_monitor.py
@@ -204,11 +204,22 @@ class TheLatchedKeys(unittest.TestCase):
         """It was gated on the OSD's own switch, which was right while the OSD
         was its only consumer. With the switch off, the keyboard's Caps and Num
         would sit frozen at whatever they read when polling stopped - stale,
-        and with nothing saying so."""
+        and with nothing saying so.
+
+        The condition lives in one `watching` property now (the LED watcher
+        and the hyprctl fallback both gate on it), so the pin is in two
+        halves: the property carries both consumers, and every `running:` in
+        the file reads it."""
         text = LOCKS.read_text(encoding="utf-8")
         self.assertRegex(
             text,
-            r"running:\s*\(Config\.options\.osd\.lockKeys \?\? true\)\s*\|\|\s*GlobalStates\.oskOpen")
+            r"property bool watching:\s*\(Config\.options\.osd\.lockKeys \?\? true\)\s*\|\|\s*GlobalStates\.oskOpen")
+        running_lines = re.findall(r"running:\s*(.+)", text)
+        self.assertTrue(running_lines, "no watcher gates found in KeyboardLocks")
+        for condition in running_lines:
+            self.assertIn("root.watching", condition,
+                          f"a lock watcher runs on `{condition.strip()}` without root.watching - "
+                          "it will poll (or stay dead) regardless of who is listening")
 
     def test_scroll_lock_is_left_momentary_on_purpose(self):
         """`hyprctl devices` reports caps and num and nothing else, so a lock

--- a/dots/.config/quickshell/imi/tests/test_persistent_sidebar_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_persistent_sidebar_contract.py
@@ -184,5 +184,21 @@ def test_the_compositor_no_longer_animates_the_map():
             f"{namespace} still carries a compositor slide rule: {[l.strip() for l in lines]}"
 
 
+def test_the_grab_lists_dismissables_last():
+    # When the grab activates, Hyprland hands keyboard focus to a whitelisted
+    # surface picked from the END of the list. A persistent surface never
+    # re-maps, so this is the ONLY way an opening panel ever gets the
+    # keyboard: dismissables anywhere but last leave keys on the bar/OSK and
+    # every keypress is silently dropped (measured on the left sidebar -
+    # Window.active never flipped true until the pointer entered the panel).
+    grab = code(ROOT / "services/GlobalFocusGrab.qml")
+    windows = [l for l in grab.splitlines() if re.match(r"\s*windows\s*:", l)]
+    assert len(windows) == 1, f"GlobalFocusGrab declares {len(windows)} `windows:` lists"
+    assert re.search(r"windows\s*:\s*\[\s*\.\.\.root\.persistent\s*,\s*\.\.\.root\.dismissable\s*\]", windows[0]), \
+        (f"GlobalFocusGrab's whitelist reads `{windows[0].strip()}` - it must be exactly "
+         "`[...root.persistent, ...root.dismissable]`: dismissables LAST is what routes the "
+         "grab's keyboard focus to the panel that just opened")
+
+
 if __name__ == "__main__":
     raise SystemExit(run(globals()))

--- a/dots/.config/quickshell/imi/tests/test_persistent_sidebar_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_persistent_sidebar_contract.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""A sidebar's surface stays mapped; the panel is what opens.
+
+Layer-shell forbids window reuse, so a PanelWindow whose `visible` follows the
+flag that asks for it is destroyed on every close and rebuilt on every open: a
+new render thread, a new GL context, the scene graph built from nothing and
+every glyph uploaded again. The shell has ONE GUI thread for all of its
+windows. Measured with QSG_RENDER_TIMING on the real session, that thread sat
+blocked for 61ms per sidebar open (`blockedForSync=61 ms, polish=0`) - every
+window the shell draws frozen for fifteen frames at 240Hz, reported as "a
+momentary freeze right before they open". With the window kept mapped and the
+slide drawn by `EdgeSlide`, the same gesture blocks it for 1-3ms.
+
+A persistent surface is a surface that can take input and focus while showing
+nothing, and both sidebars had a property that was harmless only BECAUSE the
+window used to be unmapped when closed. So the shape is four rules, read at
+the declaration that maps the surface, and every one of them is a defect one
+of these two files has had:
+
+- the PanelWindow declares no `visible:` that reads the open flag (or any
+  lifetime flag derived from it); the surface is mapped for the life of the
+  shell;
+- its `mask:` reads the open flag, so a closed panel is a hole the pointer
+  falls through rather than a strip down the screen edge that eats clicks;
+- its `WlrLayershell.keyboardFocus:` reads the open flag - the left sidebar's
+  was an unconditional OnDemand, which on a mapped surface holds the keyboard;
+- it declares an `EdgeSlide`, and the content's `visible:` reads that
+  runner's `shown`, not the flag: the flag drops on frame one of the exit.
+
+And `rules.lua` carries `no_anim` for both namespaces, not the slide rules
+EdgeSlide replaced: a map animation fires once, at startup, on an empty
+surface, and would fire a second time on top of the QML slide whenever a
+remap happens.
+
+Every sweep asserts it FOUND what it swept for.
+"""
+
+import re
+from pathlib import Path
+
+from contract_runner import run
+
+ROOT = Path(__file__).resolve().parent.parent
+RULES = ROOT.parents[1] / "hypr/hyprland/rules.lua"
+RUNNER = ROOT / "modules/common/widgets/EdgeSlide.qml"
+
+SIDEBARS = {
+    ROOT / "modules/imi/sidebarRight/SidebarRight.qml": ("GlobalStates.sidebarRightOpen", "quickshell:sidebarRight"),
+    ROOT / "modules/imi/sidebarLeft/SidebarLeft.qml": ("GlobalStates.sidebarLeftOpen", "quickshell:sidebarLeft"),
+}
+
+
+def read(path: Path) -> str:
+    assert path.exists(), f"{path} is gone - the sweep has nothing to look at"
+    text = path.read_text()
+    assert text.strip(), f"{path} is empty"
+    return text
+
+
+def code(path: Path) -> str:
+    text = read(path)
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.S)
+    return re.sub(r"//[^\n]*", "", text)
+
+
+def logical_lines(text: str):
+    joined = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if joined and stripped[:1] in {"+", "-", "*", "/", "?", ":", ".", "&", "|", ")", ","}:
+            joined[-1] = joined[-1] + " " + stripped
+        else:
+            joined.append(line)
+    return joined
+
+
+def blocks(text: str, type_name: str):
+    found = []
+    for opener in re.finditer(rf"(?<![\w.]){re.escape(type_name)}\s*\{{", text):
+        start = opener.end() - 1
+        depth = 0
+        for index in range(start, len(text)):
+            if text[index] == "{":
+                depth += 1
+            elif text[index] == "}":
+                depth -= 1
+                if depth == 0:
+                    found.append(text[start:index + 1])
+                    break
+    return found
+
+
+def mapping_block(text: str, namespace: str, name: str) -> str:
+    owning = [b for b in blocks(text, "PanelWindow") if f'WlrLayershell.namespace: "{namespace}"' in b]
+    assert len(owning) == 1, \
+        f"{name} has {len(owning)} PanelWindow declarations carrying {namespace} - this rule is about the one that maps it"
+    return owning[0]
+
+
+def declared_at_top_level(block: str, prop: str):
+    """Values of `prop:` declared directly on `block`, not on anything nested
+    inside it. A `mask: Region { item: ... }` spans lines; the value returned
+    is the whole brace-matched declaration so the gate inside it is visible."""
+    values = []
+    depth = 0
+    lines = logical_lines(block)
+    for i, line in enumerate(lines):
+        if depth == 1:
+            match = re.match(rf"\s*{re.escape(prop)}\s*:(.*)", line)
+            if match:
+                value = match.group(1).strip()
+                if value.endswith("{"):
+                    inner = 1
+                    j = i + 1
+                    while j < len(lines) and inner > 0:
+                        value += " " + lines[j].strip()
+                        inner += lines[j].count("{") - lines[j].count("}")
+                        j += 1
+                values.append(value)
+        depth += line.count("{") - line.count("}")
+    return values
+
+
+def test_the_surface_is_mapped_for_the_life_of_the_shell():
+    for path, (flag, namespace) in SIDEBARS.items():
+        name = path.relative_to(ROOT).as_posix()
+        window = mapping_block(code(path), namespace, name)
+        visibles = declared_at_top_level(window, "visible")
+        assert visibles in ([], ["true"]), \
+            (f"{name}'s PanelWindow declares `visible: {visibles}` - a surface that follows the "
+             "open flag is destroyed on close and rebuilt on open, which blocked the shell's one GUI "
+             "thread for 61ms per gesture. The panel slides; the surface stays.")
+        assert "reallyVisible" not in window, \
+            f"{name} still carries a `reallyVisible` lifetime flag - the surface has no lifetime to track any more"
+
+
+def test_a_closed_panel_takes_neither_clicks_nor_the_keyboard():
+    for path, (flag, namespace) in SIDEBARS.items():
+        name = path.relative_to(ROOT).as_posix()
+        window = mapping_block(code(path), namespace, name)
+
+        masks = declared_at_top_level(window, "mask")
+        assert len(masks) == 1, f"{name}'s PanelWindow declares {len(masks)} `mask:` - exactly one gates its input"
+        assert flag in masks[0], \
+            (f"{name}'s mask reads `{masks[0]}` without `{flag}` - a mapped surface with an ungated mask "
+             "is a strip down the whole screen edge that eats every click while showing nothing")
+
+        focus = declared_at_top_level(window, "WlrLayershell.keyboardFocus")
+        assert len(focus) == 1, f"{name}'s PanelWindow declares {len(focus)} keyboardFocus values"
+        assert flag in focus[0], \
+            (f"{name}'s keyboardFocus reads `{focus[0]}` without `{flag}` - an always-mapped surface "
+             "with OnDemand focus holds the keyboard while closed")
+
+
+def test_the_panel_slides_on_the_shared_runner_and_hides_on_its_shown():
+    runner = code(RUNNER)
+    assert re.search(r"readonly\s+property\s+bool\s+shown\b", runner), \
+        "EdgeSlide no longer publishes `shown` - the one signal that outlives the flag by the exit"
+    for path, (flag, namespace) in SIDEBARS.items():
+        name = path.relative_to(ROOT).as_posix()
+        text = code(path)
+        window = mapping_block(text, namespace, name)
+        assert re.search(r"EdgeSlide\s*\{", window), \
+            f"{name} declares no EdgeSlide - its panel has no slide of its own and the compositor's is gone"
+        content_visibles = [l.strip() for l in logical_lines(window)
+                            if re.match(r"\s*visible\s*:", l) and "slide.shown" in l]
+        assert content_visibles, \
+            (f"{name} hides nothing on `slide.shown` - content gated on the flag vanishes on frame one "
+             "of a 400ms exit")
+        flag_visibles = [l.strip() for l in logical_lines(window)
+                         if re.match(r"\s*visible\s*:", l) and flag in l]
+        assert flag_visibles == [], \
+            f"{name} gates visibility on the open flag at {flag_visibles} - use the runner's `shown`"
+
+
+def test_the_compositor_no_longer_animates_the_map():
+    rules = code(RULES)
+    for _, (flag, namespace) in SIDEBARS.items():
+        lines = [l for l in rules.splitlines() if f'namespace = "{namespace}"' in l]
+        assert lines, f"rules.lua has no layer rule for {namespace} at all"
+        assert any("no_anim = true" in l for l in lines), \
+            f"{namespace} has no `no_anim` rule - the compositor animates the map on top of EdgeSlide's slide"
+        assert not any(re.search(r"animation\s*=", l) for l in lines), \
+            f"{namespace} still carries a compositor slide rule: {[l.strip() for l in lines]}"
+
+
+if __name__ == "__main__":
+    raise SystemExit(run(globals()))

--- a/dots/.config/quickshell/imi/tests/tst_option_visibility.qml
+++ b/dots/.config/quickshell/imi/tests/tst_option_visibility.qml
@@ -75,6 +75,41 @@ TestCase {
         verify(OptionVisibility.visible({ key: "x", visibleWhen: null }, reader({})));
     }
 
+    // The bug this pins: the manifest crosses a QVariant boundary on its way
+    // to the evaluator (var properties, Repeater modelData), and a JSON list
+    // read back from QVariantList has `length` and indexed access but fails
+    // Array.isArray and carries no Array prototype. On the live shell that
+    // sent every clock rule down the fail-open branch - 22 annotated rows all
+    // visible for every style. The stand-in here is a prototype-less object
+    // with the same surface: length, indices, and nothing else.
+    function wrapList(items) {
+        const wrapper = Object.create(null);
+        wrapper.length = items.length;
+        for (let i = 0; i < items.length; ++i)
+            wrapper[i] = items[i];
+        return wrapper;
+    }
+
+    function test_a_qvariant_wrapped_rule_still_filters() {
+        const option = { key: "digitalVertical", visibleWhen: {
+            anyOf: wrapList([
+                { key: "style", in: wrapList(["digital"]) },
+                { key: "styleLocked", in: wrapList(["digital"]) }
+            ])
+        } };
+        verify(!OptionVisibility.visible(option, reader({ style: "cookie", styleLocked: "cookie" })));
+        verify(OptionVisibility.visible(option, reader({ style: "digital", styleLocked: "cookie" })));
+        verify(OptionVisibility.visible(option, reader({ style: "cookie", styleLocked: "digital" })));
+    }
+
+    function test_a_qvariant_wrapped_all_of_still_filters() {
+        const option = { key: "x", visibleWhen: {
+            allOf: wrapList([{ key: "a", equals: true }, { key: "b", in: wrapList(["k"]) }])
+        } };
+        verify(OptionVisibility.visible(option, reader({ a: true, b: "k" })));
+        verify(!OptionVisibility.visible(option, reader({ a: true, b: "z" })));
+    }
+
     function test_the_reader_is_asked_for_the_value_not_guessed() {
         // A rule against a default the user never changed must read the
         // widget's value - which is the reader's job, not this file's.

--- a/dots/.config/quickshell/imi/tests/tst_option_visibility.qml
+++ b/dots/.config/quickshell/imi/tests/tst_option_visibility.qml
@@ -1,0 +1,86 @@
+import QtTest
+import "../modules/common/plugins/option_visibility.js" as OptionVisibility
+
+// Whether a manifest option's row is shown, as a pure function of the
+// plugin's current values. The rule worth pinning hardest is the fail-open
+// one: a rule this cannot read answers VISIBLE, because a row wrongly hidden
+// is a setting the user cannot reach and nothing logs.
+TestCase {
+    name: "OptionVisibilityTest"
+
+    function reader(values) {
+        return key => values[key];
+    }
+
+    function test_no_rule_is_visible() {
+        verify(OptionVisibility.visible({ key: "a" }, reader({})));
+    }
+
+    function test_in_matches_a_choice_value() {
+        const option = { key: "cookieSides", visibleWhen: { key: "style", in: ["cookie"] } };
+        verify(OptionVisibility.visible(option, reader({ style: "cookie" })));
+        verify(!OptionVisibility.visible(option, reader({ style: "digital" })));
+    }
+
+    function test_equals_matches_one_value_exactly() {
+        const option = { key: "x", visibleWhen: { key: "flag", equals: true } };
+        verify(OptionVisibility.visible(option, reader({ flag: true })));
+        verify(!OptionVisibility.visible(option, reader({ flag: 1 })));
+        verify(!OptionVisibility.visible(option, reader({ flag: false })));
+    }
+
+    function test_a_bare_key_is_truthiness() {
+        const option = { key: "x", visibleWhen: { key: "flag" } };
+        verify(OptionVisibility.visible(option, reader({ flag: "yes" })));
+        verify(!OptionVisibility.visible(option, reader({ flag: "" })));
+    }
+
+    function test_any_of_is_an_or_across_two_style_keys() {
+        // The clock: the desktop style and the lock-screen style can differ,
+        // and a cookie option has something to say if EITHER is a cookie.
+        const option = { key: "cookieSides", visibleWhen: { anyOf: [
+            { key: "style", in: ["cookie"] }, { key: "styleLocked", in: ["cookie"] }
+        ] } };
+        verify(OptionVisibility.visible(option, reader({ style: "digital", styleLocked: "cookie" })));
+        verify(OptionVisibility.visible(option, reader({ style: "cookie", styleLocked: "pixel" })));
+        verify(!OptionVisibility.visible(option, reader({ style: "digital", styleLocked: "pixel" })));
+    }
+
+    function test_all_of_is_an_and() {
+        const option = { key: "x", visibleWhen: { allOf: [
+            { key: "a", equals: true }, { key: "b", in: ["k"] }
+        ] } };
+        verify(OptionVisibility.visible(option, reader({ a: true, b: "k" })));
+        verify(!OptionVisibility.visible(option, reader({ a: true, b: "z" })));
+    }
+
+    function test_enabled_when_still_hides_on_a_false_boolean() {
+        // The older field, kept: the clock's two quote rows rely on it.
+        const option = { key: "quoteText", enabledWhen: "quoteEnable" };
+        verify(OptionVisibility.visible(option, reader({ quoteEnable: true })));
+        verify(!OptionVisibility.visible(option, reader({ quoteEnable: false })));
+    }
+
+    function test_both_fields_must_agree() {
+        const option = { key: "x", enabledWhen: "on", visibleWhen: { key: "style", in: ["a"] } };
+        verify(OptionVisibility.visible(option, reader({ on: true, style: "a" })));
+        verify(!OptionVisibility.visible(option, reader({ on: false, style: "a" })));
+        verify(!OptionVisibility.visible(option, reader({ on: true, style: "b" })));
+    }
+
+    function test_a_rule_that_cannot_be_read_fails_open() {
+        verify(OptionVisibility.visible({ key: "x", visibleWhen: {} }, reader({})));
+        verify(OptionVisibility.visible({ key: "x", visibleWhen: { in: ["a"] } }, reader({})));
+        verify(OptionVisibility.visible({ key: "x", visibleWhen: { key: 7 } }, reader({})));
+        verify(OptionVisibility.visible({ key: "x", visibleWhen: null }, reader({})));
+    }
+
+    function test_the_reader_is_asked_for_the_value_not_guessed() {
+        // A rule against a default the user never changed must read the
+        // widget's value - which is the reader's job, not this file's.
+        let asked = [];
+        const option = { key: "x", visibleWhen: { key: "style", in: ["cookie"] } };
+        OptionVisibility.visible(option, key => { asked.push(key); return "cookie"; });
+        compare(asked, ["style"]);
+    }
+}


### PR DESCRIPTION
## What this is

The sidebars and the overview keep their windows mapped for the life of the shell; only the panel slides (EdgeSlide) or the card scales. The per-gesture window rebuild blocked the shell's one GUI thread for ~61ms, measured with QSG_RENDER_TIMING; a persistent surface opens in 1-4ms.

Persistence has obligations, and most of this branch is paying them, each one found live:

- **Keyboard.** A window that never re-maps never gets Hyprland's map-time OnDemand grant. The focus grab is the only remaining path, and Hyprland hands the grab's keyboard to the surface picked from the END of the whitelist - with the bar/OSK listed after the panel, keys landed on the bar and every press was dropped. The grab now lists persistent windows first, dismissables last (contract-pinned), the grab is deferred two rendered frames past the flag flip (an in-tick grab lands on a surface the compositor still knows as interactivity None and clears as a phantom click-outside), and each opener names a QML focus target.
- **Input region.** A Region maps its item through the render transform, and Hyprland snapshots the input region when the grab is installed - mid-entrance, while the card is at 0.9 scale. The stale snapshot left a ~60px dead band inside each side edge where any click dismissed the panel (click-mapped live on the selector: x <= 2021 and >= 3099 dismissed on a 1960..3160 surface). Both masks now read a proxy Item anchored over the card; anchors ignore render transforms.
- **Blur.** BackgroundEffect's live geometry tracking follows a given item, not a binding that replaces it, and the overview's grid is rebuilt by its loader every open - the frost stayed where the half-built grid had been on the first open. The region republishes on every inner-item identity change.

Also on this branch:

- The clock widget's per-style settings filter actually filters: the manifest's `visibleWhen` rules cross a QVariant boundary on the way to the settings page, and the wrapped lists fail `Array.isArray`, so every rule fell into the fail-open branch. The evaluator duck-types lists now; two regression tests feed wrapped stand-ins and fail on the old code.
- The depth picker is reachable from the Wallpaper Engine tab. The service has segmented live projects' stills since spec §8 landed, but the layers button only existed on the Local toolbar. Verified end-to-end on a live scene: detector, candidate, accept, subject drawn over the widgets while the scene animates.
- A performance round, each item measured before and after: one watchdogged `nmcli monitor` for the whole shell instead of two leak-prone ones (30 orphans reaped from 15 dead instances; the watchdog makes orphaning impossible), Caps/Num from the keyboard LEDs via one zero-fork bash loop instead of `hyprctl devices -j` at 3.3/s (strace: 1 execve + 1 clone total), the 1.7MB symbols database loading on first query instead of at boot, dock previews stopping their captures when the popup hides, the decorative cookie spin at 30Hz time-based instead of per-frame refresh-rate-dependent, Material Symbols opsz quantized to its own 20-48 integer range (62 font engines -> <=29), and the shipped default for the desktop cookie's constant spin aligned to the manifest's false.
- One revert, kept honest in history: building the 28 boot panels with `activeAsync` froze Flow-based settings rows at incubation-time width (every chip on its own line, user-reported, bisected live). The win was not worth auditing every panel for polish-order sensitivity.

## Known gaps

- `SessionScreen` still maps per open and pays the 61ms; named in AGENT.md, not changed here.
- Weather's PositionSource runs whenever GPS is enabled even with no weather consumer visible; needs demand tracking, parked.

Suite: full runs green after every batch (final: 1186 QML tests passed, all contract/lint phases passed). Every fix verified on the live shell with real input before its commit; where a mid-suite file edit voided a run, the suite was rerun clean afterwards.

Docs: updated AGENT.md (persistent-surface obligations extended with the overview, the grab-order rule, the input-region snapshot trap); CHANGELOG.md carries user-facing entries for every fix
Changelog: updated — Fixed and Changed entries under [Unreleased]