### PR TITLE
Settings honesty and one bounded decode: EasyEffects, Screens, selector backdrop

### DIFF
--- a/dots/.config/quickshell/imi/EasyEffectsStateRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/EasyEffectsStateRuntimeTest.qml
@@ -1,0 +1,112 @@
+import QtQuick
+import Quickshell
+import qs.services
+
+/**
+ * EasyEffects toggle honesty, against the real singleton and fake binaries.
+ *
+ * Driven by tests/test_easyeffects_state_runtime.py, which puts fake
+ * `easyeffects`/`flatpak`/`pidof`/`pkill` executables at the front of PATH.
+ * The fakes keep a little state of their own in $EE_STATE_DIR: launching
+ * succeeds only while `launch_ok` exists (and then leaves a `running` marker
+ * pidof answers from; pkill removes it), so the harness can drive both a
+ * launch that fails and one that works.
+ *
+ * What it pins: enable() answers the click optimistically, and the verify
+ * pass corrects the lie - a failed launch reads as off again within
+ * verifyInterval, a real one stays on, and a kill stays off.
+ *
+ *   EE_STATE_DIR=... qs -p EasyEffectsStateRuntimeTest.qml
+ */
+ShellRoot {
+    id: harness
+
+    property int failures: 0
+    property int checksRun: 0
+    property int step: 0
+    readonly property string stateDir: Quickshell.env("EE_STATE_DIR") ?? ""
+
+    function check(label, ok) {
+        harness.checksRun++;
+        console.log(`[EasyEffectsState] ${label}: ${ok ? "ok" : "FAIL"}`);
+        if (!ok)
+            harness.failures++;
+    }
+
+    function finish() {
+        console.log(`[EasyEffectsState] checks: ${harness.checksRun} failures: ${harness.failures}`);
+        Qt.exit(harness.failures === 0 ? 0 : 1);
+    }
+
+    Component.onCompleted: {
+        // The suite cannot wait out the production 1.5s grace.
+        EasyEffects.verifyInterval = 300;
+    }
+
+    Timer {
+        id: waitForDetection
+        interval: 200
+        repeat: true
+        running: true
+        property int elapsed: 0
+        onTriggered: {
+            elapsed += interval;
+            if (!EasyEffects.available) {
+                if (elapsed >= 15000) {
+                    harness.check("the fake easyeffects was detected", false);
+                    harness.finish();
+                }
+                return;
+            }
+            running = false;
+            harness.check("the fake easyeffects was detected", true);
+            harness.check("nothing is running at startup", EasyEffects.active === false);
+            EasyEffects.enable();
+            harness.check("enable answers the click at once", EasyEffects.active === true);
+            afterFailedLaunch.start();
+        }
+    }
+
+    Timer {
+        // The fake launch failed (no launch_ok yet): the verify pass at 300ms
+        // must take the optimistic flag back down. This is the bug - without
+        // the verify, active stays true for the rest of the session.
+        id: afterFailedLaunch
+        interval: 900
+        onTriggered: {
+            harness.check("a failed launch is corrected to off", EasyEffects.active === false);
+            Quickshell.execDetached(["touch", `${harness.stateDir}/launch_ok`]);
+            allowLaunch.start();
+        }
+    }
+
+    Timer {
+        id: allowLaunch
+        interval: 300
+        onTriggered: {
+            EasyEffects.enable();
+            harness.check("the second enable is optimistic too", EasyEffects.active === true);
+            afterRealLaunch.start();
+        }
+    }
+
+    Timer {
+        id: afterRealLaunch
+        interval: 900
+        onTriggered: {
+            harness.check("a real launch survives the verify", EasyEffects.active === true);
+            EasyEffects.disable();
+            harness.check("disable answers the click at once", EasyEffects.active === false);
+            afterKill.start();
+        }
+    }
+
+    Timer {
+        id: afterKill
+        interval: 900
+        onTriggered: {
+            harness.check("a killed daemon stays off", EasyEffects.active === false);
+            harness.finish();
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/EasyEffectsStateRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/EasyEffectsStateRuntimeTest.qml
@@ -106,6 +106,54 @@ ShellRoot {
         interval: 900
         onTriggered: {
             harness.check("a killed daemon stays off", EasyEffects.active === false);
+            Quickshell.execDetached(["touch", `${harness.stateDir}/slow`]);
+            raceSetup.start();
+        }
+    }
+
+    // The stale-probe race, driven deterministically: with `slow` set, a probe
+    // reads its answer at spawn and reports it 300ms later. enable() at T0,
+    // verify starts a probe at T400 (reads: running), disable() at T550 (kills
+    // the daemon, restarts the timer to fire at T950) - so the probe's stale
+    // "running" lands at ~T700 while the newer toggle's verify is pending, and
+    // the guard must discard it or the toggle shows ON after an OFF click.
+    Timer {
+        id: raceSetup
+        interval: 300
+        onTriggered: {
+            EasyEffects.verifyInterval = 400;
+            EasyEffects.enable();
+            harness.check("race: enable is optimistic", EasyEffects.active === true);
+            raceClick.start();
+        }
+    }
+
+    Timer {
+        id: raceClick
+        interval: 550
+        onTriggered: {
+            EasyEffects.disable();
+            raceStaleLanding.start();
+        }
+    }
+
+    Timer {
+        // T780: after the stale probe's answer landed (~T700), before the
+        // fresh verify fires (T950).
+        id: raceStaleLanding
+        interval: 230
+        onTriggered: {
+            harness.check("race: a stale probe does not overrule a fresh click",
+                          EasyEffects.active === false);
+            raceSettled.start();
+        }
+    }
+
+    Timer {
+        id: raceSettled
+        interval: 900
+        onTriggered: {
+            harness.check("race: the click's own verify agrees", EasyEffects.active === false);
             harness.finish();
         }
     }

--- a/dots/.config/quickshell/imi/modules/imi/settings/pages/BarConfig.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/pages/BarConfig.qml
@@ -62,11 +62,25 @@ ContentPage {
         spacing: Appearance.spacing.space250
 
         ContentSection {
+            id: screensSection
             icon: "monitor"
             shape: MaterialShape.Shape.ClamShell
-            visible: Hyprland.monitors.values.length > 1
             title: Translation.tr("Screens")
+            // The section used to hide itself on a single-monitor machine
+            // (`visible: length > 1`), which broke it two ways. "Screens" is in
+            // this page's static `sections:` list, so settings search offered a
+            // section that did not exist - the Clight section's bug, one page
+            // over. And a laptop undocked with a stored screen filter hid the
+            // only control that can clear that filter, while the filter kept
+            // deciding where the bar shows. So the section stays; the chooser
+            // shows whenever it can mean something (several monitors, or a
+            // filter already stored); one screen with no filter gets a line
+            // saying why there is nothing to choose.
+            readonly property bool chooserMeaningful: Hyprland.monitors.values.length > 1
+                || Config.options.bar.screenList.length > 0
+
             ContentSubsection {
+                visible: screensSection.chooserMeaningful
                 title: Translation.tr("Show bar on")
 
                 ColumnLayout {
@@ -144,6 +158,13 @@ ContentPage {
                         }
                     }
                 }
+            }
+            StyledText {
+                visible: !screensSection.chooserMeaningful
+                Layout.fillWidth: true
+                wrapMode: Text.WordWrap
+                color: Appearance.colors.colSubtext
+                text: Translation.tr("Only one screen is connected. With more than one, you can choose which of them show the bar.")
             }
         }
 

--- a/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/WallpaperSelectorContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/WallpaperSelectorContent.qml
@@ -241,6 +241,15 @@ MouseArea {
                 fillMode: Image.PreserveAspectCrop
                 source: Config.options.background.wallpaperPath
                 cache: false
+                // Bound the decode to what is drawn: without a sourceSize this
+                // decoded the wallpaper at file resolution on every selector
+                // open, only to be blurred at radius 48. `cache: false` above
+                // means no other Image shares this request, so bounding it
+                // cannot un-share a decode (the trap 33139b688 records for the
+                // desktop frost, which is why Background's own request is not
+                // touched from here).
+                sourceSize.width: width
+                sourceSize.height: height
                 layer.enabled: true
                 layer.effect: OpacityMask {
                     maskSource: Rectangle {

--- a/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/WallpaperSelectorContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/WallpaperSelectorContent.qml
@@ -248,8 +248,18 @@ MouseArea {
                 // cannot un-share a decode (the trap 33139b688 records for the
                 // desktop frost, which is why Background's own request is not
                 // touched from here).
-                sourceSize.width: width
-                sourceSize.height: height
+                //
+                // The bound is the selector's size CONSTANTS, never the item's
+                // own live width/height: anchors resolve after the load starts,
+                // so a bound-to-geometry sourceSize begins at 0 (= unbounded,
+                // the decode this exists to remove) and then reloads once per
+                // axis as the geometry lands - measured as three decodes of the
+                // same file per open. The constants are known at creation and
+                // stable for the window's life; they run slightly larger than
+                // the item (which sits inside the card's margins), which
+                // PreserveAspectCrop absorbs.
+                sourceSize.width: Appearance.sizes.wallpaperSelectorWidth
+                sourceSize.height: Appearance.sizes.wallpaperSelectorHeight
                 layer.enabled: true
                 layer.effect: OpacityMask {
                     maskSource: Rectangle {

--- a/dots/.config/quickshell/imi/services/EasyEffects.qml
+++ b/dots/.config/quickshell/imi/services/EasyEffects.qml
@@ -14,6 +14,10 @@ Singleton {
 
     property bool available: false
     property bool active: false
+    // How long a spawned daemon gets to appear (or a killed one to exit)
+    // before the optimistic flip below is checked against reality. A test
+    // shortens it; nothing else should.
+    property int verifyInterval: 1500
 
     function fetchAvailability() {
         fetchAvailabilityProc.running = true
@@ -23,14 +27,27 @@ Singleton {
         fetchActiveStateProc.running = true
     }
 
+    // enable()/disable() flip `active` optimistically so the toggle answers
+    // the click, then verify against the real process list once the launch or
+    // kill has had time to happen - without that, a failed launch (easyeffects
+    // uninstalled between checks, or crashing at startup) left the toggle
+    // saying on for the rest of the session.
     function disable() {
         root.active = false
         Quickshell.execDetached(["bash", "-c", "pkill easyeffects || flatpak pkill com.github.wwmm.easyeffects"])
+        verifyTimer.restart()
     }
 
     function enable() {
         root.active = true
         Quickshell.execDetached(["bash", "-c", "easyeffects --hide-window --service-mode || flatpak run com.github.wwmm.easyeffects --hide-window --service-mode"])
+        verifyTimer.restart()
+    }
+
+    Timer {
+        id: verifyTimer
+        interval: root.verifyInterval
+        onTriggered: root.fetchActiveState()
     }
 
     function toggle() {

--- a/dots/.config/quickshell/imi/services/EasyEffects.qml
+++ b/dots/.config/quickshell/imi/services/EasyEffects.qml
@@ -24,6 +24,10 @@ Singleton {
     }
 
     function fetchActiveState() {
+        // Restart, never join: a probe already in flight was asked before the
+        // state it would report on, and `running = true` on a live Process is
+        // a no-op - the stale run would be the one whose answer lands.
+        fetchActiveStateProc.running = false
         fetchActiveStateProc.running = true
     }
 
@@ -72,6 +76,13 @@ Singleton {
         running: true
         command: ["bash", "-c", "pidof easyeffects || flatpak ps | grep com.github.wwmm.easyeffects > /dev/null 2>&1"]
         onExited: (exitCode, exitStatus) => {
+            // A pending verify means a toggle happened after this probe was
+            // asked: it read the world before that click's launch or kill
+            // landed, so its answer would overrule the fresher intent - the
+            // toggle showing ON for a grace period after an OFF click. The
+            // click's own verify is the one that gets to write.
+            if (verifyTimer.running)
+                return
             root.active = exitCode === 0
         }
     }

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -1268,6 +1268,14 @@ if ! python3 "$SCRIPT_DIR/test_clight_integration_runtime.py"; then
     exit 1
 fi
 
+# Brings its own headless weston and fake easyeffects/flatpak/pidof/pkill:
+# the toggle answers optimistically and the verify pass corrects a lie.
+echo "Running EasyEffects state runtime tests..."
+if ! python3 "$SCRIPT_DIR/test_easyeffects_state_runtime.py"; then
+    echo "EasyEffects state runtime tests failed."
+    exit 1
+fi
+
 echo "Running shared widget contract tests..."
 if ! python3 "$SCRIPT_DIR/test_shared_widget_contracts.py"; then
     echo "Shared widget contract tests failed."

--- a/dots/.config/quickshell/imi/tests/test_clight_integration_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_clight_integration_runtime.py
@@ -86,6 +86,20 @@ esac
 exit 0
 """
 
+# The not-installed flavour used to fake absence by simply not creating a fake
+# `clight` - which held only while the machine itself had none. PATH-prepending
+# cannot fake nonexistence (`command -v` walks past the fake dir to
+# /usr/bin/clight), so on a machine with clight genuinely installed the case
+# read installed=true and failed. Detection runs through `sh -c "command -v
+# clight"` (Clight.qml's whichProc), so a fake `sh` answers exactly that probe
+# with "not found" when asked to, and hands everything else to the real shell.
+SH_SHIM = """#!/usr/bin/env bash
+if [ "$CLIGHT_HIDE_REAL" = "1" ] && [ "$1" = "-c" ] && [ "$2" = "command -v clight" ]; then
+    exit 1
+fi
+exec /bin/sh "$@"
+"""
+
 
 # How many checks the harness runs, per shape it is launched in. Literals
 # rather than anything read back from the harness's own output: a harness
@@ -163,6 +177,10 @@ class ClightIntegrationRuntimeTest(unittest.TestCase):
         self.fake("pidof", "exit 1")
         if clight_installed:
             self.fake("clight")
+        else:
+            shim = self.bin / "sh"
+            shim.write_text(SH_SHIM)
+            shim.chmod(0o755)
 
     def seed(self):
         shell_config = self.config_home / "immaterial-impulse"
@@ -191,6 +209,7 @@ class ClightIntegrationRuntimeTest(unittest.TestCase):
         env["CLIGHT_EXEC_LOG"] = str(self.exec_log)
         env["CLIGHT_STATE_DIR"] = str(self.clight_state)
         env["CLIGHT_DBUS_UP"] = "1" if available else "0"
+        env["CLIGHT_HIDE_REAL"] = "0" if installed else "1"
         env["CLIGHT_EXPECT_INSTALLED"] = "true" if installed else "false"
         env["CLIGHT_EXPECT_AVAILABLE"] = "true" if available else "false"
         if temp_switch_after is not None:

--- a/dots/.config/quickshell/imi/tests/test_easyeffects_state_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_easyeffects_state_runtime.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""The EasyEffects toggle tells the truth, against a real shell and fake binaries.
+
+services/EasyEffects.qml flips `active` optimistically when the toggle is
+clicked - which is right for responsiveness and was the whole story: a launch
+that failed (easyeffects gone, or crashing at startup) left the toggle saying
+on for the rest of the session, with nothing ever re-checking. The fix
+verifies against the real process list one grace period after every
+enable()/disable(); this drives all three outcomes end to end:
+
+- a failed launch is corrected back to off;
+- a real launch survives the verify;
+- a kill stays off.
+
+The fake binaries keep state in a directory the harness controls: launching
+succeeds only while `launch_ok` exists, a successful launch leaves a `running`
+marker, `pidof` answers from it and `pkill` removes it.
+
+Brings its own headless weston and a private session bus. Skips when weston
+or qs is missing, as in CI.
+"""
+
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HARNESS = ROOT / "EasyEffectsStateRuntimeTest.qml"
+SOCKET = "wayland-imi-easyeffects-state"
+
+# The harness's check count, as a literal: a harness whose step list shrinks
+# must redden here instead of reporting `failures: 0` for a shorter run.
+EXPECTED_CHECKS = 8
+
+RECORD = """#!/usr/bin/env bash
+printf '%s\\n' "$(basename "$0") $*" >> "$EE_EXEC_LOG"
+__BODY__
+"""
+
+EASYEFFECTS_BODY = """\
+case "$1" in
+  --hide-window)
+    if [ -f "$EE_STATE_DIR/launch_ok" ]; then
+      touch "$EE_STATE_DIR/running"
+      exit 0
+    fi
+    exit 1
+    ;;
+esac
+exit 0
+"""
+
+FLATPAK_BODY = """\
+# `flatpak run` must fail like the native launch; `flatpak ps` and
+# `flatpak info` answer for the pipeline and the availability probe.
+case "$1" in
+  info) exit 1 ;;
+  ps) exit 1 ;;
+  run) exit 1 ;;
+  pkill) exit 1 ;;
+esac
+exit 1
+"""
+
+PIDOF_BODY = """\
+[ -f "$EE_STATE_DIR/running" ] && exit 0
+exit 1
+"""
+
+PKILL_BODY = """\
+rm -f "$EE_STATE_DIR/running"
+exit 0
+"""
+
+
+def _stop(proc):
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+
+
+def _runtime_available():
+    return all(shutil.which(binary) is not None
+               for binary in ("qs", "weston", "dbus-run-session"))
+
+
+@unittest.skipUnless(_runtime_available(), "needs qs, weston and dbus-run-session on PATH")
+class EasyEffectsStateRuntimeTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.env = dict(os.environ)
+        cls.env.setdefault("XDG_RUNTIME_DIR", f"/run/user/{os.getuid()}")
+        cls.env["WAYLAND_DISPLAY"] = SOCKET
+        cls.env.pop("DISPLAY", None)
+        cls.weston = subprocess.Popen(
+            ["weston", "--backend=headless", "--renderer=pixman",
+             f"--socket={SOCKET}", "--width=800", "--height=600"],
+            env=cls.env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+        socket_path = Path(cls.env["XDG_RUNTIME_DIR"]) / SOCKET
+        deadline = time.monotonic() + 15
+        while not socket_path.exists() and time.monotonic() < deadline:
+            time.sleep(0.2)
+        if not socket_path.exists():
+            _stop(cls.weston)
+            raise AssertionError("headless weston never came up")
+
+        cls.env["LIBGL_ALWAYS_SOFTWARE"] = "1"
+        cls.env["QT_QUICK_BACKEND"] = "software"
+
+    @classmethod
+    def tearDownClass(cls):
+        _stop(cls.weston)
+
+    def test_toggle_state_is_verified_against_reality(self):
+        with tempfile.TemporaryDirectory(prefix="imi-easyeffects-") as directory:
+            home = Path(directory)
+            state = home / "ee-state"
+            state.mkdir()
+            bin_dir = home / "bin"
+            bin_dir.mkdir()
+            for name, body in (("easyeffects", EASYEFFECTS_BODY),
+                               ("flatpak", FLATPAK_BODY),
+                               ("pidof", PIDOF_BODY),
+                               ("pkill", PKILL_BODY)):
+                path = bin_dir / name
+                path.write_text(RECORD.replace("__BODY__", body))
+                path.chmod(0o755)
+
+            env = dict(self.env)
+            env["XDG_CONFIG_HOME"] = str(home / "config")
+            env["XDG_STATE_HOME"] = str(home / "state")
+            env["XDG_CACHE_HOME"] = str(home / "cache")
+            env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+            env["EE_STATE_DIR"] = str(state)
+            env["EE_EXEC_LOG"] = str(home / "exec.log")
+
+            proc = subprocess.run(
+                ["dbus-run-session", "--", "qs", "-p", str(HARNESS)],
+                cwd=str(ROOT), env=env, capture_output=True, text=True, timeout=120)
+            output = proc.stdout + proc.stderr
+            failed = [line for line in output.splitlines() if "FAIL" in line]
+            self.assertEqual(failed, [], f"harness reported failures:\n{output}")
+            self.assertIn(f"[EasyEffectsState] checks: {EXPECTED_CHECKS} failures: 0",
+                          output, f"harness did not finish cleanly:\n{output}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dots/.config/quickshell/imi/tests/test_easyeffects_state_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_easyeffects_state_runtime.py
@@ -34,7 +34,7 @@ SOCKET = "wayland-imi-easyeffects-state"
 
 # The harness's check count, as a literal: a harness whose step list shrinks
 # must redden here instead of reporting `failures: 0` for a shorter run.
-EXPECTED_CHECKS = 8
+EXPECTED_CHECKS = 11
 
 RECORD = """#!/usr/bin/env bash
 printf '%s\\n' "$(basename "$0") $*" >> "$EE_EXEC_LOG"
@@ -66,9 +66,13 @@ esac
 exit 1
 """
 
+# Slow mode drives the stale-probe race: the answer is read BEFORE the sleep,
+# so a probe that started before a toggle reports the pre-toggle world after
+# the toggle has landed - exactly the answer the guard must discard.
 PIDOF_BODY = """\
-[ -f "$EE_STATE_DIR/running" ] && exit 0
-exit 1
+if [ -f "$EE_STATE_DIR/running" ]; then answer=0; else answer=1; fi
+[ -f "$EE_STATE_DIR/slow" ] && sleep 0.3
+exit "$answer"
 """
 
 PKILL_BODY = """\


### PR DESCRIPTION
Three items from the task list, plus one environmental test repair found on the way:

- **fix(easyeffects):** the quick toggle flipped `active` optimistically and nothing ever re-checked, so a failed launch left it saying on for the rest of the session. It still answers the click at once, and verifies against the real process list one grace period later. New weston harness (`EasyEffectsStateRuntimeTest`) drives all three outcomes against stateful fake binaries; proven red on the planted original bug.
- **fix(settings):** the Screens section hid itself on one monitor while staying in the search index — the Clight section's bug (f9311591) one page over, plus a sharper edge: a laptop undocked with a stored screen filter hid the only control that can clear it. The section stays; the chooser shows when it can mean something; one screen with no filter gets a caption. Verified on this machine's live shell (single monitor) — search lands on the section.
- **perf(wallpapers):** the selector's blurred backdrop decoded the wallpaper at file resolution on every open; now bounded to the item it draws into. The sweep found no other unbounded wallpaper decode; the frost's shared-request caveat (33139b688) is why Background's own request is untouched.
- **test(clight):** the not-installed harness flavour faked absence by omitting a fake binary, which broke the day clight got genuinely installed on this machine — an sh shim now answers the one detection probe.

Suite green end to end (1186 QML checks, DesignSystemCompile 185 files, all runtime harnesses including the new one).

Docs: not needed — no mechanism changed; the rowVisible/section pattern is already documented in AGENT.md from f9311591's series
Changelog: not user-visible — entries ride the next catch-all release PR, per the release workflow