### PR TITLE
The motion language's missing half: container-then-fill, one entrance spelling, text and list motion — plus the AI upgrade proposal

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -4478,6 +4478,43 @@ arrived.
 ("feat(widgets): StaggerWave, the one runner for a group's arrival";
 "feat(editMode): the drawer arrives as a surface and then fills").
 
+**What a member's ARRIVAL looks like is one spelling too — `StaggerEntrance`, beside the wave.**
+The three-channel entrance (opacity, a scale from a derived near-1 start, and a small rise, all on
+the one `appear` scalar the wave animates) lived only as Edit Mode's drawer's local dressing,
+spelled out per member nine times — the template the next adopter would copy, and a hand-copied
+dressing is how a member arrives on two channels out of three. `modules/common/widgets/
+StaggerEntrance.qml` is the promotion: declared beside the `StaggerWave`, aimed at the same
+container, it installs the three channels once on every child declaring `appear` — a member's whole
+opt-in is the property the runner already requires. The scale's START is derived, not picked:
+`motion_policy.js`'s `entranceScaleFrom(rise, reference)` matches the scale's excursion to the rise
+(the survey's raw 0.85 is a popup number that reads as a zoom on a full-width row) with the
+measured 0.85 as the floor, and `Appearance.animation.entranceRise` is the rise
+(`spacing.space250` — a distance on the shell's rhythm, not a duration). Two refusals are
+load-bearing: a child without `appear` is not a member, and a child owning an `interactionMotion`
+is skipped whole — a `RippleButton` already folds `appear` into the opacity binding that carries
+its disabled dim and owns `scale` through the model, so a writer here would REPLACE those bindings
+rather than compose with them. The runtime skip cannot see an ANCESTOR, so both composition lints
+learned the spelling: `lint_interaction_motion_double.py` fails a `StaggerEntrance` inside a
+scale-channel control and `lint_disabled_opacity.py` fails one anywhere in a file whose root dims —
+at ANY indent, because the realistic placement is a direct child at one level, which the ≥5-space
+nested-dim convention never sees (the plant proving the rule landed exactly there and the first
+version stayed green over it). A wave whose members are not one container's children — GroupedList
+reparents each row into its own plate — hands the runner the declared list via `StaggerWave.items`,
+which REPLACES the children walk. The desktop menu's rows adopted the entrance on the drawer's
+argument (its card's opacity IS a QML-readable container progress, so the wave gates with no
+`leadIn`; enter-only, since the close destroys the window); dialog content was assessed beside it
+and REFUSED — a dialog's content is the question the user was interrupted to read, and the polkit
+prompt focuses a password field the cascade would leave parked invisible under real keystrokes —
+with the full argument in `STAGGER_DECLINED`'s entry.
+("feat(motion): a wave member's entrance scale is derived, in the policy",
+"feat(widgets): StaggerEntrance, one spelling of a wave member's arrival",
+"refactor(editMode): the drawer's entrance dressing becomes the shared spelling",
+"test(lint): the two composition lints see the shared entrance dressing",
+"fix(lint): a dresser one indent deep is inside the control too",
+"feat(widgets): a StaggerWave can take its members as a list",
+"feat(desktopMenu): the menu's rows arrive in sequence, gated on the card",
+"test(motion): dialogs decline the group entrance, in the register".)
+
 **A wave asked for while its container is off screen writes nothing, and leaves the surface blank
 for ever.** Ranking asks each member whether it is on screen, and `visible` is EFFECTIVE visibility
 (see the `GroupedList` entry under

--- a/AGENT.md
+++ b/AGENT.md
@@ -4531,6 +4531,25 @@ A surface whose trigger is already the container's own `visible` (`ContentPage`,
 settings window's page switch) never showed it.
 ("fix(widgets): a wave waits for its container to be on screen").
 
+**A wave member must not carry a `Behavior on opacity`, because the member's opacity IS the wave's
+channel.** The wave assigns `appear = 0` to park a member — a snap, deliberately — and animates
+`appear` to bring it in, with opacity riding that scalar through a binding. A root-level
+`Behavior on opacity` in the member's file intercepts every write that binding makes: the park
+becomes a 200ms **on-stage fade-out** (measured live: `appear=0` with drawn opacity still 1.000 at
+the open), and the wave's own per-frame animation retargets the Behavior every frame — b710ef731's
+frozen-Behavior shape — pinning drawn opacity at 0.147 while `appear` was already at 0.955, so the
+member lands a whole fade-length after its slot. The android quick toggles shipped exactly that:
+their old `opacity: 0` + `onCompleted` self-fade was retired in favour of the wave and the Behavior
+that had animated it was left behind, which on every right-sidebar open drew the first-ranked tiles
+fully lit as the panel edge appeared, dimmed them on stage, held a blank beat as the slide landed,
+and then ran the cascade — read by the maintainer as "three quick toggles visible at all times,
+then the animation begins", through several attempted fixes aimed elsewhere.
+`tests/lint_wave_member_opacity_behavior.py` fails the suite on a root-level `appear`/`Behavior on
+opacity` pair; nested Behaviors (a ripple overlay, a scroll shadow) animate a child's own opacity
+and stay free.
+15688f7c ("fix(quickToggles): drop the tile's leftover opacity Behavior that swallowed the wave"),
+a5ef0c29 ("test(lint): fail on a wave member carrying a Behavior on opacity").
+
 **The adoption is the thing that decays, so the adoption is what is pinned.**
 `docs/p3drovfx-motion-measured-2026-08-22.md` §4.2 measured the sibling fork's motion off screen and
 found our arithmetic correct, our guideline written, and the wiring at **three** files against their

--- a/AGENT.md
+++ b/AGENT.md
@@ -4574,11 +4574,19 @@ the moment it opens and the moment it closes."* It is off that surface again, an
 **It since came back, the register's way — argued, at the maintainer's request, after both
 refusal facts had been repaired by unrelated work**: the persistent EdgeSlide surface removed the
 per-gesture teardown that was the measured frame drop, and the slide's in-client `progress`
-scalar is exactly the container progress whose absence forced the guessed leadIn. The re-adopted
-wave gates on it through `contentsArrived`, carries no leadIn, and is enter-only (sections ride
-the slide out rigid). The register entry moved from `STAGGER_DECLINED` to `STAGGER_ADOPTERS` with
+scalar gave the wave something real to coordinate with. The first re-adoption gated on that
+scalar through `contentsArrived` — correct-sounding, and measured on screen as ruined: parked
+content plus a gate puts the whole construction ON STAGE, the panel arriving empty and visibly
+building itself. The design that stuck is the opposite, read object-by-object off the fork's
+re-recorded sidebars: the wave runs UNGATED, park-and-enter on the open's rising edge, UNDER the
+slide — whose `reveal` curtain (EdgeSlide's 15%-plateau opacity ramp) masks the early frames, so
+the panel materializes already composed and only the last-ranked members visibly land after it —
+and the tile wave carries a small leadIn so no member is mid-fade as the panel edge arrives
+(1f254a158b ("fix(motion): the entrance runs under the slide - the panel materializes
+composed"); a0035941 ("fix(motion): the first tiles wait their turn - lead-in restored, curtain
+dimmed")). The register entry moved from `STAGGER_DECLINED` to `STAGGER_ADOPTERS` with
 the history kept in place — the round trip is the register doing its job, not the refusal being
-overridden. (feat(sidebar): the sections cascade again, gated on the slide the surface now owns.) Take the
+overridden. Take the
 reasoning rather than the removal, because both halves of the complaint were right and only one of
 them was the wave's:
 

--- a/AGENT.md
+++ b/AGENT.md
@@ -4551,7 +4551,15 @@ REFUSED — and a register that only grows is a target.** 9e10b8a9c ("feat(sideb
 sidebar's sections arrive in sequence") gave the right sidebar a wave; the user's verdict was *"I
 don't like the cascading animation effect in the sidebar… This one feels slow. There's a frame drop
 the moment it opens and the moment it closes."* It is off that surface again, and
-`STAGGER_DECLINED` in `tests/test_motion_policy_contract.py` reddens if it comes back. Take the
+`STAGGER_DECLINED` in `tests/test_motion_policy_contract.py` reddens if it comes back.
+**It since came back, the register's way — argued, at the maintainer's request, after both
+refusal facts had been repaired by unrelated work**: the persistent EdgeSlide surface removed the
+per-gesture teardown that was the measured frame drop, and the slide's in-client `progress`
+scalar is exactly the container progress whose absence forced the guessed leadIn. The re-adopted
+wave gates on it through `contentsArrived`, carries no leadIn, and is enter-only (sections ride
+the slide out rigid). The register entry moved from `STAGGER_DECLINED` to `STAGGER_ADOPTERS` with
+the history kept in place — the round trip is the register doing its job, not the refusal being
+overridden. (feat(sidebar): the sections cascade again, gated on the slide the surface now owns.) Take the
 reasoning rather than the removal, because both halves of the complaint were right and only one of
 them was the wave's:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,32 @@ own repo; the installer pins which revision it builds.
 
 ## [Unreleased]
 
+### Changed
+- **The panels arrive composed instead of snapping into place.** The bar's
+  popups open at their full height first and then let the sections below the
+  first fold cascade in — the top section is there on frame one, so a popup is
+  readable the instant it opens, and switching popups by hovering along the
+  bar never blinks content. The desktop menu's rows arrive in sequence the
+  same way. The sidebars got the fuller treatment: sections cascade behind the
+  panel's own slide, the quick-toggle tiles converge from their side of the
+  grid, the slider fills sweep up from zero with their icons turning with the
+  fill, the calendar ripples in diagonally, and the notification status row
+  converges into place. The left sidebar and the AI pane materialize the same
+  way. Exits stay rigid — everything rides out with the panel, nothing
+  cascades on the way out. Dialogs deliberately do not do any of this: a
+  cascade on a question you were interrupted to answer is latency.
+- **Text that changes now moves.** The bar's media label and the weather
+  temperature slide to their new value instead of swapping, and adding or
+  finishing a task in the to-do list animates the row in or out.
+
+### Fixed
+- **The to-do list's buttons no longer aim at the wrong row after a delete.**
+  Each row resolved its task by an index taken when the row was built, so
+  deleting a task left every row below it one off. Rows now find their task
+  at click time — by identity, and by content on older Quickshell builds where
+  the model hands each row a copy (the Gentoo package pins one), where every
+  done/delete click had been a silent no-op.
+
 ## [0.30.2] — 2026-08-26
 
 Two more "silently wrong" settings fixes and one decode the selector never

--- a/docs/proposals/ai-assistant-upgrade.md
+++ b/docs/proposals/ai-assistant-upgrade.md
@@ -1,0 +1,385 @@
+# Proposal: AI assistant upgrade — catalog, permissions, reviewed mutation
+
+> Stage 1 (the provider/model catalog as a pure module) is implemented on the
+> branch that carries this document: `services/ai_catalog.js`,
+> `tests/tst_ai_catalog.qml`, and `tests/test_ai_catalog_contract.py`, which
+> pins the catalog and `services/Ai.qml`'s literals to each other until stage 2
+> deletes the second copy. Nothing is wired into the UI yet, deliberately —
+> see stage 2 for why.
+
+## Goal
+
+Take the three transferable *shapes* from the `P3DROVFX/ii-p3drovfx` AI
+assistant rebuild — a provider/model **catalog** ("describe providers and
+models in one place"), a per-tool **permission vocabulary**, and a
+**reviewed-mutation** pattern (every shell-touching tool goes through one
+validated, approvable road) — and land them on our architecture, without
+taking the parts the surveys already rejected and without moving a single
+credential out of the keyring.
+
+This is the "own proposal" that
+[`docs/p3drovfx-feature-delta-2026-08-24.md`](../p3drovfx-feature-delta-2026-08-24.md)
+§2.2 and §3 call for: *"if ever, take the catalog + permission shapes, and no
+`.env`"*.
+
+## Current state (ours)
+
+- `services/Ai.qml` (984 lines) is the whole chat service: three built-in
+  models declared as inline `aiModelComponent.createObject` literals
+  (Gemini 2.5 Flash, Gemini 3 Flash, Mistral Medium 3), Ollama models
+  discovered at runtime, custom OpenAI-compatible providers fetched from
+  `Config.options.ai.customProviders` with keys in the keyring, and
+  `Config.options.ai.extraModels` for hand-written entries.
+- Three API dialects, each a strategy under `services/ai/`
+  (`GeminiApiStrategy`, `OpenAiApiStrategy`, `MistralApiStrategy`), selected
+  by the model's `api_format`.
+- The tool table (`Ai.qml`'s `property var tools`, ~150 lines) declares the
+  same four tools **three times over**, once per dialect —
+  `switch_to_search_mode`, `get_shell_config`, `set_shell_config`,
+  `run_shell_command` — as near-identical JSON blocks that have to be kept in
+  step by hand. This is the two-copies drift shape `BarWidgets` and
+  `MprisController` each grew a check against, here as three copies.
+- Approval exists for exactly one tool: `run_shell_command` sets
+  `functionPending` and waits for `approveCommand`/`rejectCommand`.
+  `set_shell_config` writes `Config.setNestedValue(key, value)` **immediately,
+  with no approval** — and its branch in `handleFunctionCall`
+  (`Ai.qml:881-888`) sends no function-output message back and never calls
+  `makeRequest()`, so after a config write the model is left waiting for a
+  result that never comes. The mutation path is both ungated and half-built.
+- Credentials are right already: every API key lives in the keyring
+  (`KeyringStorage.keyringData.apiKeys`, keyed by `key_id`), reaches `curl`
+  through an environment variable, and the one place a secret meets a shell
+  string passes it as a positional argument with a comment naming the
+  injection hole that shape closed (`Ai.qml:366-370`). The 2026-08-16 survey
+  (§3.1, §5) judged this layer *equal or better* than the fork's — this
+  proposal must not regress it.
+- One latent defect found while surveying our side: custom-provider keys are
+  keyring entries keyed **by list index** (`custom_provider_${i}`). Removing
+  provider *i* clears key *i* and splices the list, so every later provider
+  shifts down one slot while its key stays put — provider and key silently
+  disagree from then on (`ServicesConfig.qml` remove button + `Ai.qml`'s
+  `fetchCustomModels`).
+- Chats persist as JSON under `Directories.aiChats` (`saveChat`/`loadChat`,
+  plus an automatic `lastSession`). Serviceable; per-conversation permission
+  state has an obvious home there.
+- Tests: `tst_ai_custom_models.qml` covers `AiModelsParser.js`. Nothing else
+  in the AI stack is reachable from a test, because almost none of it is pure.
+
+## The evidence (theirs)
+
+The fork rebuilt its AI stack across ~60 commits, merged as their PR #98
+(`40df34f9`, "Merge pull request #98 from P3DROVFX/feat/ai-rebuild",
+2026-08-22, author P3DROVFX / Pedro Lucas). Read at their tip `81a5f57`
+(2026-08-24), the pieces this proposal draws on:
+
+- `dots/.config/quickshell/ii/services/ai/ModelCatalog.qml` (597 lines) —
+  "the single source of truth for which AI providers and models exist":
+  provider definitions with per-model capability overrides (thinking, tools,
+  vision, attachments, context window, max output, prices), models keyed
+  `provider:value`, endpoint templates with a `{model}` slot, a
+  key-whitelisted sanitiser for user-declared models, and a loopback-endpoint
+  predicate backing the local-only policy. Claude (`anthropic` dialect,
+  `AnthropicApiStrategy.qml`, 329 lines) and current Gemini are catalog
+  entries like any other.
+- `services/ai/AiToolRegistry.qml` (1,963 lines) — "everything that is true
+  about a tool before anyone runs it": one declaration per tool, read by the
+  schema sent to the model, the Tools settings page, the approval card and
+  the dispatcher, with a small closed vocabulary — `kind` (localRead /
+  explicitContextRead / navigation / externalRead / localWrite /
+  externalWrite / dangerous), `network` (never / optional / required),
+  `sensitivity` (none / device / personal / secret), approvals
+  (allow / ask / deny) — and risk *derived* from `kind` "so there is one
+  classification". Permissions are grouped by domain (`c4f7c64`) and scoped
+  **per conversation** (`04a2614`, "feat(ai-tools): scope permissions per
+  conversation").
+- `services/ai/AiToolBroker.qml` (512 lines) — "the one place a tool call
+  actually happens": schema-check the arguments (coerce the fixable, drop
+  unknown keys), ask the policy **at call time** rather than trusting the
+  answer from when the tool was offered, run with a deadline, truncate the
+  result to what the model can hold, journal what happened. What replaced it
+  is exactly what we still have: "a chain of `if (name === ...)` inside the
+  chat service".
+- `services/ai/AiConversationRepository.qml` (139 lines) and the usage/RAG/
+  integration cluster around it — read for context, not taken (see Out of
+  scope).
+
+Both repositories are GPL-3.0, so taking code is licence-compatible; anything
+taken **substantially as written** gets a credit line in the commit body
+naming the repo, the commit and the author, per the 2026-08-16 survey §6.
+This proposal mostly takes shapes and rewrites against our architecture; the
+few candidates for near-verbatim porting are flagged in their stages.
+
+The same survey's hard blockers stand and bound every stage below: the
+fork's plaintext `<shellconfig>/.env` credential pattern (which their
+2026-08-19 work *expanded* — Google OAuth was unified into it) does **not**
+come over in any form, and their `bash -c` bearer-token interpolation
+(`TickTickService.qml:48-80`, visible in `ps` to any local process) is a
+named anti-pattern, not a style choice. Our rule is already better: keys
+live in `services/KeyringStorage.qml`, travel as environment variables or
+positional arguments, and are never spliced into script text.
+
+## Why
+
+- **The catalog** removes the three-way scatter our model knowledge lives in
+  today (Ai.qml literals, `AiModelsParser.js`, `extraModels` conventions
+  documented only in a Config comment), gives capability flags one home so a
+  UI can honestly say "this model cannot see images" instead of failing
+  downstream, and is the precondition for adding a dialect (Claude) without
+  growing a fourth hand-kept copy of everything. It is also the shape this
+  repo already trusts: `WallpaperTransitions`, `BarWidgets`, `MprisSelection`
+  — one catalogue, pure where possible, with a check against a second copy.
+- **The permission vocabulary** replaces the triplicated tool table with one
+  declaration per tool, and gives "what may this conversation do" a data
+  model. Today the only knob is `Config.options.ai.tool` (search / functions
+  / none) — all tools or nothing.
+- **The reviewed mutation** closes a real hole: a model can rewrite any key in
+  the user's `config.json` today with no approval, no feedback to the model,
+  and no record. The approval card exists (for `run_shell_command`); the
+  pattern just never generalised.
+
+## Approach
+
+### 1. The catalog (`services/ai_catalog.js`) — stage 1, implemented
+
+A pure `.pragma library` beside `services/frecency.js` and
+`services/sound_theme.js` — data plus lookups, no Qt, no Config, no
+processes — so every rule is reachable from `qmltestrunner`. Deliberately a
+JS module rather than the fork's `QtObject` singleton: their catalog binds
+`Config` and `Translation` directly, which is what makes it untestable
+outside a shell.
+
+What it declares, per the fork's shape reduced to what our shell can honestly
+do today:
+
+- **Dialects** (`gemini`, `openai`, `mistral` — exactly the strategies under
+  `services/ai/`): endpoint shape (`model-in-path` vs `chat-completions`),
+  auth transport (`query-key` vs `bearer-header`), streaming framing
+  (`json-array` vs `sse`).
+- **Providers** (`google`, `mistral`, `ollama`): endpoint template with a
+  `{model}` slot, dialect, key *metadata* (`keyId`, `keyGetLink` — never
+  material), capability defaults, and the built-in model list with per-model
+  overrides. Ollama is a `discovered` provider whose models arrive at
+  runtime.
+- **Models**: id `provider:value`, plus a `legacyId` recording the flat key
+  today's `Ai.qml` (and every stored `Persistent.states.ai.model`) uses;
+  `resolve()` answers both, so stage 2 needs no migration for a saved model
+  choice. Capabilities are merged provider-default ⊕ model-override
+  (`buildModel`, exposed so the merge is testable and stage 2's custom-model
+  path can reuse it).
+
+What deliberately stays out: translated descriptions (they are
+`Translation.tr(...)` literals and the extractor only sees that form — same
+reasoning as `BarWidgets`' names), and anything key-shaped
+(`test_the_catalog_stays_pure` refuses the key plumbing's names in code).
+
+Until something reads it, the catalog and `Ai.qml` are two copies of one
+truth, so `tests/test_ai_catalog_contract.py` pins them equal field by field
+in both directions and pins the dialect vocabulary to the strategy files.
+Stage 2 inverts that check rather than deleting it.
+
+**Why nothing is wired yet**: `Ai.qml`'s `models` map is one monolithic
+translated literal; there is no *small* read that could adopt the catalog
+without rebuilding that map, and rebuilding it is a behaviour-bearing change
+to a live service that this round cannot verify against the running shell
+(no live-session contact). A drift pin now, one reviewed rewiring in stage 2.
+
+### 2. `Ai.qml` reads the catalog — stage 2
+
+One commit series, all in `services/`:
+
+- `Ai.qml.models` is built from `AiCatalog.builtinModels()`, with
+  descriptions supplied as a `Translation.tr` map keyed by catalog id.
+  `modelList`, `setModel`, `currentModelHasApiKey` and the strategy pick
+  (`apiStrategies[dialect]`) read catalog records. Stored legacy model ids
+  keep resolving via `resolve()`.
+- Ollama discovery (`getOllamaModels`) builds catalog-shaped records through
+  `buildModel(provider("ollama"), …)`; `guessModelName`/`guessModelLogo` move
+  into the catalog (they are duplicated today between `Ai.qml` and
+  `AiModelsParser.js` — a drift already in the tree).
+- Custom providers and `extraModels` go through one catalog sanitiser (the
+  fork's key-whitelist `sanitizeCustomModel` idea), folding
+  `AiModelsParser.js` in; `tst_ai_custom_models.qml` moves with it.
+- The local-only policy (`policies.ai === 2`) stops being
+  `endpoint.includes("localhost")` and becomes a loopback-endpoint predicate
+  in the catalog — the fork's `isLoopbackEndpoint` (127.0.0.0/8, `::1`,
+  `unix://`, userinfo/bracket handling) is small enough to port near-verbatim
+  **with the credit line** (ModelCatalog.qml, PR #98, author P3DROVFX).
+- Fix the index-keyed custom-provider keyring ids: give each provider a
+  stable generated id, key the keyring entry by it, and migrate existing
+  `custom_provider_<i>` entries once (the keyring already has a lazy re-key
+  precedent in `KeyringStorage`).
+- `test_ai_catalog_contract.py` inverts: `Ai.qml` may declare **no** model
+  literals.
+
+No Config schema change is required for the core rewiring. The custom-provider
+stable id wants one addition (an `id` field inside each `ai.customProviders`
+entry — a `list<var>`, so no new declared property; written here per this
+round's Config freeze).
+
+### 3. New dialects the catalog can name: Anthropic — stage 3
+
+- New `services/ai/AnthropicApiStrategy.qml`: `POST /v1/messages`, model in
+  body, `x-api-key` + `anthropic-version` headers (both via the existing
+  env-var route — the key never enters the script text), SSE parsing,
+  `max_tokens` required, temperature capped at 1.0, thinking blocks parsed
+  into the existing `thinking` message state. Their strategy (329 lines) is
+  the reference; ours is written against our `ApiStrategy` base and message
+  model, with credit if any parsing survives as written.
+- Catalog: `anthropic` dialect record + provider (keyId `anthropic`, key link
+  `https://console.anthropic.com/settings/keys`) + a small model list;
+  capability flags per model (tools, vision, thinking).
+- The contract test's dialect map gains the pair; the tool table (or, once
+  stage 4 lands first, the registry's per-dialect projection) gains the
+  anthropic tool schema.
+- Verification limit, stated now: streaming against the real API needs a key
+  and a network call, which agent rounds here do not make — the strategy's
+  parser is pinned against recorded fixture lines, and the first live run is
+  the maintainer's.
+
+### 4. The permission vocabulary (`services/ai_tool_policy.js`) — stage 4
+
+A second pure module, same pattern:
+
+- One declaration per tool — our four to start — carrying the fork's
+  vocabulary trimmed to what we enforce: `kind` (their seven-value scale,
+  with risk *derived*, never declared beside it), `network`, `sensitivity`,
+  `defaultApproval` (allow/ask/deny), `timeoutMs`, `maxResultTokens`, and the
+  parameter schema **once**, with per-dialect projection functions replacing
+  the three hand-kept copies in `Ai.qml.tools`. Our tools classify as:
+  `get_shell_config` = localRead/device, `switch_to_search_mode` =
+  navigation/network-required, `set_shell_config` = localWrite,
+  `run_shell_command` = dangerous.
+- Per-conversation grants: a plain `{toolId: "allow"|"ask"|"deny"}` object
+  resolved as grant ?? per-tool default ?? `kind`-derived fallback (a write
+  is never silently `allow`). The fork scoped grants per conversation
+  (`04a2614`); ours ride the existing chat JSON (`chatToJson`/`loadChat`
+  gain one field), so a restored conversation keeps its answers and a new
+  one starts from defaults.
+- Config keys this needs (written here, **not** into `Config.qml` this
+  round — the schema is a hotspot owned elsewhere): per-tool default
+  approvals. Note the trap for whoever lands it: a `JsonAdapter` cannot hold
+  a dynamic map (AGENT.md), and tool ids are known at compile time, so this
+  is a fixed `JsonObject` — e.g. `ai.tools.approvals` with one declared
+  `property string` per tool — not a `property var` keyed by tool id.
+
+### 5. The reviewed mutation — stage 5
+
+`handleFunctionCall`'s if-chain becomes one road, the fork's broker shape
+sized to four tools (ours will be well under their 512 lines):
+
+- **Validate**: arguments checked against the registry's schema — coerce the
+  fixable, drop unknown keys so a handler never sees a key it did not ask
+  for.
+- **Ask the policy at call time**, not at offer time: `allow` runs, `deny`
+  answers the model with a refusal, `ask` raises the approval card —
+  `set_shell_config` moves behind the same card `run_shell_command` already
+  has (its `ask` default is the recommendation below), and the card gains
+  the registry's title/summary so it can say *what* is being approved.
+- **Run bounded**: `timeoutMs` from the registry; a result cut to
+  `maxResultTokens` before it goes back on the wire.
+- **Always answer**: every outcome — success, denial, timeout, rejection —
+  produces a function-output message and continues the request, which fixes
+  the stalled-turn hole in today's `set_shell_config` branch as a
+  side effect of the shape rather than as a patch.
+
+Files: `services/Ai.qml` (the dispatch), `services/ai_tool_policy.js` (the
+pure halves: validation, resolution, truncation arithmetic), the approval
+card in `modules/imi/sidebarLeft/aiChat/` generalised from
+command-specific to registry-driven.
+
+### Staged plan
+
+| Stage | What | Files | Size | Status |
+|---|---|---|---|---|
+| 1 | Catalog as a pure module + drift pin | `services/ai_catalog.js`, `tests/tst_ai_catalog.qml`, `tests/test_ai_catalog_contract.py`, `tests/run_tests.sh` | Small (~800 lines, most of it tests) | **This branch** |
+| 2 | `Ai.qml` reads the catalog; custom models through one sanitiser; loopback policy; stable custom-provider key ids | `services/Ai.qml`, `services/ai_catalog.js`, retire `services/AiModelsParser.js`, tests | Medium (~200-line service diff + tests) | Proposed |
+| 3 | Anthropic dialect + Claude catalog entries | new `services/ai/AnthropicApiStrategy.qml`, `services/ai_catalog.js`, tests | Medium (~300 lines; live verification maintainer-run) | Proposed |
+| 4 | Tool registry + permission vocabulary, per-conversation grants | new `services/ai_tool_policy.js`, `services/Ai.qml` (tool tables deleted), chat JSON field, tests | Small–medium (~250 lines + tests); Config keys deferred to schema owner | Proposed |
+| 5 | Reviewed mutation: one validated, approvable, bounded, always-answering tool road | `services/Ai.qml`, `services/ai_tool_policy.js`, `modules/imi/sidebarLeft/aiChat/` approval card, tests | Medium (~300–400 lines) | Proposed |
+
+Stages 2 and 3 are independent of 4 and 5; 5 depends on 4. Every stage keeps
+the suite's shape: pure modules carry the decisions, `qmltestrunner` covers
+them, a contract check pins whatever must not drift, and anything only a live
+shell can show is verified per CONTRIBUTING's live loop by whoever deploys.
+
+### How credentials stay keyring-only
+
+Restated as a rule each stage is reviewed against, because the fork's stack
+fails it wholesale:
+
+- `services/KeyringStorage.qml` is the **only** credential store. The catalog
+  carries key metadata (`keyId`, `keyGetLink`) and its purity check refuses
+  the key plumbing's names in code.
+- A key reaches a process as an environment variable or a positional
+  argument — never interpolated into `bash -c` text, never written into the
+  request script, never into `config.json`, presets, or any `.env`.
+- No stage adds a file that could hold a secret. Per-conversation permission
+  grants are approvals, not credentials, and live in chat JSON.
+
+## Open questions (maintainer decisions, all flagged)
+
+1. **Id scheme going forward.** The catalog's canonical ids are
+   `provider:value` with legacy flat ids resolving. Should stage 2 keep
+   *writing* legacy ids into `Persistent.states.ai.model` (safest, forever
+   dual) or start writing canonical ids (needs `setModel` to accept both,
+   which `resolve()` already gives, and a one-line read-side migration)?
+2. **Ship Anthropic in the default catalog at all**, and if so which models —
+   a named model list is a maintenance commitment (the fork tracks theirs by
+   hand). Alternative: ship the dialect only, and let users add Claude models
+   as catalog-shaped custom entries.
+3. **Ollama tool default.** Today every local model is offered the function
+   table; the fork defaults local models to `tools: false` because the daemon
+   does not say which can. The catalog currently records the status quo so
+   wiring it in changes nothing — flipping the default is a behaviour change
+   that needs your call (and a per-model override either way).
+4. **Custom-provider keyring migration** (stage 2): re-keying
+   `custom_provider_<i>` entries to stable ids touches the user keyring; the
+   index-drift defect argues for it, but it is a migration and those get
+   review here.
+5. **`set_shell_config` behind the approval card** (stage 5): recommended
+   `ask` by default — it is a write to the user's config by a language model —
+   but it is a behaviour change to a shipped feature.
+6. **Where per-conversation grants persist**: chat JSON (proposed — survives
+   reload with the conversation) vs session-only (stricter: every session
+   re-asks).
+7. **The settings surface.** ServicesConfig's AI section eventually renders
+   the catalog (provider rows from `providers()` instead of hand-built
+   controls) and stage 4's defaults want a Tools section. Settings pages are
+   owned elsewhere this round, so both are listed as follow-ups for whoever
+   owns that surface, with the data model ready.
+8. **Local-only policy strictness** (stage 2): adopting the loopback
+   predicate makes `policies.ai === 2` *stricter* (a custom model pointing a
+   `localhost` path at a remote host via DNS tricks still passes today's
+   substring check; a non-loopback "local" daemon on a LAN host stops
+   passing). Confirm the boundary is "loopback", not "user says local".
+
+## Out of scope
+
+Each of these is in the fork's rebuild and deliberately not in this proposal:
+
+- **RAG** (`scripts/ai/ai_rag.py`, `AiRagService.qml`): an embeddings
+  pipeline, an on-disk vector store, and a background indexer over the user's
+  files — a separate subsystem with its own privacy surface and its own
+  failure modes, orthogonal to all three shapes here. If ever wanted, it is
+  its own proposal with its own data-retention answers.
+- **Gmail / Google integrations** (~11,500 lines, `gmail.modify` +
+  `gmail.send` scopes): excluded categorically by survey §6 — the OAuth
+  client secrets and tokens live in their plaintext `.env` (their 2026-08-19
+  work moved *more* credentials into it), and their `oauth_server.py` prints
+  the refresh token to stdout, which the shell captures into its log. There
+  is no version of this that comes over by accident; it would need its own
+  proposal and a ground-up keyring OAuth story.
+- **Sports scores** (ESPN): an undocumented third-party endpoint scraped
+  without a contract — churn we would own forever for a widget with no
+  relation to the assistant's job. No.
+- **OpenRouter / Ollama catalog browsing with model pulls**: a store-like
+  network browsing surface (search remote catalogs, download models) with its
+  own review needs. Our custom-provider `/models` fetch already answers "what
+  can my key reach"; the catalog shape does not preclude adding browsing
+  later, and nothing here depends on it.
+- **Also not here**, for the record: the conversation-repository rebuild (our
+  chat JSON gains one field in stage 4 and is otherwise sufficient), the
+  usage/cost dashboard (wants per-model price data the catalog could carry
+  someday, but the dashboard is its own surface), personas/memory/attention
+  hooks, and dictation (delta §2.3 — a separate feature with its own entry on
+  the shortlist).

--- a/dots/.config/quickshell/imi/DesignSystemCompile.qml
+++ b/dots/.config/quickshell/imi/DesignSystemCompile.qml
@@ -83,6 +83,11 @@ ShellRoot {
                 Quickshell.shellPath("modules/imi/editMode/EditModeChromeContent.qml"),
                 Quickshell.shellPath("modules/imi/editMode/EditWidgetMenu.qml"),
                 Quickshell.shellPath("modules/imi/editMode/EditWidgetMenuContent.qml"),
+                // The desktop menu builds its window behind a Loader gated on
+                // the right-click, so a shell that is merely running has never
+                // compiled it - and it now carries the rows' group entrance,
+                // which nothing else in the suite reaches.
+                Quickshell.shellPath("modules/imi/desktopMenu/DesktopMenu.qml"),
                 // Stage 9's Lockscreen tab: the preview context compiles for
                 // the first time when somebody opens that tab, and the lock
                 // surface itself only when the screen actually locks - so a

--- a/dots/.config/quickshell/imi/modules/common/Appearance.qml
+++ b/dots/.config/quickshell/imi/modules/common/Appearance.qml
@@ -538,6 +538,17 @@ Singleton {
         function staggerDelay(rank: int, step: int, leadIn: int): int {
             return MotionPolicy.staggerDelay(rank, step, leadIn);
         }
+        // The three-channel member entrance's two terms, read by
+        // StaggerEntrance (the one spelling of how a wave member arrives:
+        // opacity, a scale and a small rise, all on one `appear` scalar).
+        // The rise is a spacing token because it is a distance on the shell's
+        // rhythm, not a duration; the scale START is derived from it by the
+        // policy, floored at the survey's measured 0.85, so the scale's
+        // excursion stays the rise's size at any member width.
+        readonly property real entranceRise: root.spacing.space250
+        function entranceScaleFrom(reference: real): real {
+            return MotionPolicy.entranceScaleFrom(motion.entranceRise, reference);
+        }
 
         property QtObject elementMove: QtObject {
             property int duration: motion.scale(animationCurves.expressiveDefaultSpatialDuration)

--- a/dots/.config/quickshell/imi/modules/common/Appearance.qml
+++ b/dots/.config/quickshell/imi/modules/common/Appearance.qml
@@ -550,6 +550,22 @@ Singleton {
             return MotionPolicy.entranceScaleFrom(motion.entranceRise, reference);
         }
 
+        // Convergent arrival: an object starts a short reach away from its
+        // place on its own side of the container and settles with a slight
+        // overshoot (motion_policy.js's converge block carries the measured
+        // provenance). The reaches are DISTANCES, so they come off the
+        // spacing ladder, not the duration policy; the settle shape is
+        // unitless and rides whatever tier animates `appear`.
+        readonly property real convergeReachX: root.spacing.space250
+        readonly property real convergeReachY: root.spacing.space150
+        readonly property real convergeScaleFrom: 0.92
+        function convergeFrom(normX: real, rankParity: int): var {
+            return MotionPolicy.convergeFrom(normX, rankParity);
+        }
+        function convergeSettle(appear: real): real {
+            return MotionPolicy.convergeSettle(appear);
+        }
+
         property QtObject elementMove: QtObject {
             property int duration: motion.scale(animationCurves.expressiveDefaultSpatialDuration)
             property int type: Easing.BezierSpline

--- a/dots/.config/quickshell/imi/modules/common/motion_policy.js
+++ b/dots/.config/quickshell/imi/modules/common/motion_policy.js
@@ -117,6 +117,40 @@ function staggerDelay(rank, step, leadIn) {
 }
 
 // ---------------------------------------------------------------------------
+// The three-channel member entrance
+// ---------------------------------------------------------------------------
+//
+// A wave member arrives on three properties moving together - opacity, a scale
+// and a small rise - driven by one `appear` scalar so they cannot land on
+// different schedules (docs/M3_GUIDELINES.md §2, "Component Entrance and
+// Exit"; measured off the sibling fork in
+// docs/p3drovfx-motion-measured-2026-08-22.md §3 as opacity 0->1, scale from
+// 0.85 and +25px->0). The rendering is `StaggerEntrance.qml`; the one decision
+// in it is here, because it is the one a test can hold still: where the scale
+// STARTS.
+//
+// The scale is derived from the rise and the width it plays on, never picked.
+// The survey's 0.85 is a popup's compact cards; on a full-width row the same
+// factor is a horizontal swing wider than the rise it accompanies - a zoom,
+// not a settle. Matching the scale's excursion to the rise keeps the two
+// terms one motion at any width, and the measured 0.85 stays as the floor so
+// a narrow member cannot invert the proportion. (Promoted verbatim from Edit
+// Mode's drawer, which derived exactly this locally; the derivation moving
+// here must not move a pixel of that panel.)
+var ENTRANCE_SCALE_FLOOR = 0.85;
+
+function entranceScaleFrom(rise, reference) {
+    var span = Math.max(1, Number(reference) || 0);
+    var derived = 1 - Number(rise) / span;
+    // Comparisons, not Math.max: `Math.max(floor, NaN)` is NaN, which is a
+    // legal double no render boundary rejects - the Appearance-token lesson.
+    if (!(derived > ENTRANCE_SCALE_FLOOR)) return ENTRANCE_SCALE_FLOOR;
+    // A rise of zero (or nonsense) is no scale excursion at all - a member
+    // must never arrive LARGER than it rests.
+    return Math.min(1, derived);
+}
+
+// ---------------------------------------------------------------------------
 // The container-progress gate
 // ---------------------------------------------------------------------------
 //

--- a/dots/.config/quickshell/imi/modules/common/motion_policy.js
+++ b/dots/.config/quickshell/imi/modules/common/motion_policy.js
@@ -151,6 +151,52 @@ function entranceScaleFrom(rise, reference) {
 }
 
 // ---------------------------------------------------------------------------
+// Convergent arrival
+// ---------------------------------------------------------------------------
+//
+// How an object COMES INTO PLACE, measured off the sibling fork's sidebars
+// (recorded at 60fps and read frame by frame, then matched to their source -
+// SidebarDashboardContent's header enters from x -30/+30 per side, each
+// quick-toggle tile from its own third of the grid at +-18/+-12, scale 0.92
+// with a slight overshoot). The grammar: an object starts a short reach AWAY
+// from its place, on its own side of the container - leftmost members from
+// further left, rightmost from further right, alternating rows from above and
+// below - and settles in with a small pop past 1. Uniform rise-and-fade reads
+// as one sheet of content; convergence reads as objects each finding their
+// own seat.
+//
+// `convergeFrom` answers with a UNIT direction pair the caller multiplies by
+// its reach tokens; the thirds rule is deliberate (their `index % 3` grid
+// rule, generalised to a normalized position so it serves a column of
+// full-width sections - all middle-third, so pure vertical alternation - as
+// well as a grid of tiles).
+function convergeFrom(normX, rankParity) {
+    var x = Number(normX);
+    var dx = 0;
+    if (x < -1 / 3) dx = -1;
+    else if (x > 1 / 3) dx = 1;
+    var dy = (Number(rankParity) % 2 === 0) ? -1 : 1;
+    return { dx: dx, dy: dy };
+}
+
+// The settle that makes an arrival a landing rather than a fade: an
+// OutBack-shaped remap of the wave's own `appear` scalar, so the spatial
+// channels overshoot their place by a hair and come back while the opacity
+// tracks `appear` directly. One scalar stays the only driver - the desync the
+// fork buys with four hand-timed NumberAnimations per section falls out of
+// shaping the channels differently on the way to the same 1.
+var CONVERGE_OVERSHOOT = 1.1;
+
+function convergeSettle(appear, overshoot) {
+    var a = Number(appear);
+    if (!(a > 0)) return 0;
+    if (a >= 1) return 1;
+    var s = (overshoot === undefined) ? CONVERGE_OVERSHOOT : Number(overshoot);
+    var t = a - 1;
+    return 1 + t * t * ((s + 1) * t + s);
+}
+
+// ---------------------------------------------------------------------------
 // The container-progress gate
 // ---------------------------------------------------------------------------
 //

--- a/dots/.config/quickshell/imi/modules/common/widgets/EdgeSlide.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/EdgeSlide.qml
@@ -59,6 +59,22 @@ QtObject {
     // The displacement to apply to the panel, in px along the slide axis.
     readonly property real offset: (1 - root.progress) * root.travel * root.direction
 
+    // The curtain: an opacity for the panel's content that holds low early
+    // in the slide and ramps to full late - the sibling fork's `stall`
+    // fade-layer curve, derived from the same progress so it cannot drift.
+    // This is what makes a composed-under-construction panel possible: the
+    // per-widget entrances run while the content is still translucent, so a
+    // member not yet arrived is a dim nothing rather than an opaque HOLE in
+    // a fully-lit panel - which is exactly what the right sidebar showed
+    // (full-res frames: a black void where the toggle grid's later rows
+    // were still parked, for ~300ms, reading as an ugly pause). Piecewise
+    // rather than a bezier so the endpoints are exact: 30% alpha up to 40%
+    // travel, then a linear ramp home.
+    readonly property real reveal: root.progress >= 1 ? 1
+        : root.progress <= 0 ? 0
+        : root.progress < 0.4 ? 0.3 * (root.progress / 0.4)
+        : 0.3 + 0.7 * ((root.progress - 0.4) / 0.6)
+
     // Whether the panel has anything on screen. True through the whole exit,
     // so content gated on it is not hidden under an animation still drawing
     // it; false once the exit has finished, so a Loader gated on it may stand

--- a/dots/.config/quickshell/imi/modules/common/widgets/EdgeSlide.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/EdgeSlide.qml
@@ -68,12 +68,15 @@ QtObject {
     // a fully-lit panel - which is exactly what the right sidebar showed
     // (full-res frames: a black void where the toggle grid's later rows
     // were still parked, for ~300ms, reading as an ugly pause). Piecewise
-    // rather than a bezier so the endpoints are exact: 30% alpha up to 40%
-    // travel, then a linear ramp home.
+    // rather than a bezier so the endpoints are exact: a dim plateau up to
+    // 40% travel, then a linear ramp home. The plateau is 15%, measured
+    // against the fork's stall curve (alpha still near 0.1 at 40% travel) -
+    // a brighter early curtain let the first-ranked tiles read as
+    // already-lit before the panel had arrived.
     readonly property real reveal: root.progress >= 1 ? 1
         : root.progress <= 0 ? 0
-        : root.progress < 0.4 ? 0.3 * (root.progress / 0.4)
-        : 0.3 + 0.7 * ((root.progress - 0.4) / 0.6)
+        : root.progress < 0.4 ? 0.15 * (root.progress / 0.4)
+        : 0.15 + 0.85 * ((root.progress - 0.4) / 0.6)
 
     // Whether the panel has anything on screen. True through the whole exit,
     // so content gated on it is not hidden under an animation still drawing

--- a/dots/.config/quickshell/imi/modules/common/widgets/StaggerEntrance.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/StaggerEntrance.qml
@@ -52,15 +52,61 @@ QtObject {
     property real reference: 0
 
     readonly property real rise: Appearance.animation.entranceRise
-    readonly property real scaleFrom: Appearance.animation.entranceScaleFrom(
-        root.reference > 0 ? root.reference : (root.target?.width ?? 0))
+    readonly property real scaleFrom: root.convergent
+        ? Appearance.animation.convergeScaleFrom
+        : Appearance.animation.entranceScaleFrom(
+              root.reference > 0 ? root.reference : (root.target?.width ?? 0))
+
+    // Convergent mode: instead of one uniform rise, each member starts a
+    // short reach away from its place ON ITS OWN SIDE - leftmost members from
+    // further left, rightmost from further right, alternating members from
+    // above and below - and the spatial channels settle through an OutBack
+    // shape while opacity tracks `appear` directly, so an arrival lands with
+    // a hair of overshoot instead of fading into position. Measured off the
+    // sibling fork's sidebars; arithmetic and provenance in motion_policy.js.
+    // The direction reads the member's LIVE position (a binding on child.x),
+    // so a reflow re-aims it and nothing is captured stale.
+    property bool convergent: false
 
     property Component lift: Component {
         Translate {
             objectName: "staggerEntranceLift"
             property Item item
-            y: (1 - (item?.appear ?? 1)) * root.rise
+            readonly property real settle: root.convergent
+                ? Appearance.animation.convergeSettle(item?.appear ?? 1)
+                : (item?.appear ?? 1)
+            readonly property var direction: {
+                if (!root.convergent || !item || !root.target || root.target.width <= 0)
+                    return { dx: 0, dy: -1 };
+                const centre = (item.x + item.width / 2) / root.target.width * 2 - 1;
+                return Appearance.animation.convergeFrom(centre, root.memberParity(item));
+            }
+            x: root.convergent
+                ? (1 - settle) * direction.dx * Appearance.animation.convergeReachX
+                : 0
+            y: root.convergent
+                ? (1 - settle) * direction.dy * Appearance.animation.convergeReachY
+                : (1 - settle) * root.rise
         }
+    }
+
+    // A member's vertical alternation is its position among the members that
+    // are actually drawn - the wave's own visible-rank rule, reused so a
+    // hidden member does not flip every later member's direction.
+    function memberParity(child: Item): int {
+        const kids = members();
+        let rank = 0;
+        for (let i = 0; i < kids.length; i++) {
+            if (kids[i] === child)
+                return rank;
+            if (kids[i]?.appear !== undefined && kids[i].visible)
+                rank++;
+        }
+        return rank;
+    }
+
+    function members(): var {
+        return root.target ? root.target.children : [];
     }
 
     // Whether a member already carries this dressing, read off the member
@@ -79,13 +125,24 @@ QtObject {
             const child = kids[i];
             if (child.appear === undefined)
                 continue;
-            if (child.interactionMotion !== undefined)
-                continue;
             if (root.dressed(child))
                 continue;
+            if (child.interactionMotion !== undefined) {
+                // A control that applies the interaction model owns its scale
+                // (the model's) and folds `appear` into its own opacity (the
+                // binding that carries the disabled dim) - writing either here
+                // REPLACES those bindings, the doubling the composition lints
+                // exist to fail. Its POSITION belongs to nobody, so in
+                // convergent mode a control still travels into place; in
+                // uniform mode it keeps its own 6px fold untouched.
+                if (root.convergent)
+                    child.transform.push(root.lift.createObject(child, { item: child }));
+                continue;
+            }
             child.opacity = Qt.binding(() => child.appear);
             child.scale = Qt.binding(() =>
-                root.scaleFrom + (1 - root.scaleFrom) * child.appear);
+                root.scaleFrom + (1 - root.scaleFrom) *
+                (root.convergent ? Appearance.animation.convergeSettle(child.appear) : child.appear));
             child.transform.push(root.lift.createObject(child, { item: child }));
         }
     }

--- a/dots/.config/quickshell/imi/modules/common/widgets/StaggerEntrance.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/StaggerEntrance.qml
@@ -1,0 +1,104 @@
+import QtQuick
+import qs.modules.common
+
+/**
+ * The one spelling of how a wave member ARRIVES: opacity, a scale from a
+ * derived near-1 start, and a small rise, all riding the same `appear` scalar
+ * a `StaggerWave` animates. The wave decides WHEN a member moves; this decides
+ * what moving looks like - three channels on one scalar, so they cannot land
+ * on different schedules (docs/M3_GUIDELINES.md §2, "Component Entrance and
+ * Exit"; measured off the sibling fork in
+ * docs/p3drovfx-motion-measured-2026-08-22.md §3).
+ *
+ * Declared beside the wave, aimed at the same container, and it dresses every
+ * child that declares `appear` - which is what keeps the tenth row added next
+ * year from being the fourth hand-copied dressing that drifts by a channel,
+ * the way Edit Mode's drawer spelled these three bindings out nine times
+ * before this existed.
+ *
+ * Two refusals are as load-bearing as the dressing:
+ *
+ *  - A child without `appear` is not a wave member and is left alone.
+ *  - A child that owns an `interactionMotion` (RippleButton and its kin)
+ *    already folds `appear` into the opacity binding that carries its
+ *    disabled dim, and owns `scale` through the model - so it rides the wave
+ *    through the property the runner writes, and a second writer of either
+ *    channel here would REPLACE the control's binding rather than compose
+ *    with it: a press that stops squishing, and a disabled row drawn as
+ *    enabled. `lint_interaction_motion_double.py` and
+ *    `lint_disabled_opacity.py` fail the suite on a StaggerEntrance declared
+ *    inside such a control for the same reason.
+ *
+ * The scale START is `Appearance.animation.entranceScaleFrom(reference)` -
+ * derived from the rise and the width the member plays on, floored at the
+ * survey's measured 0.85, so the scale's excursion stays the rise's size at
+ * any width (see motion_policy.js for the derivation's reasoning).
+ *
+ * The channels are installed as bindings once per member rather than asked
+ * for per call site, because "from one place" is the entire point: the member
+ * declares `property real appear: 1` and nothing else. A QtObject rather than
+ * an Item for the StaggerWave reason - a dresser declared inside the
+ * container it dresses must not become a member of it.
+ */
+QtObject {
+    id: root
+
+    // The container whose `appear`-declaring children are dressed.
+    property Item target: null
+
+    // The width the scale's excursion is matched to. Defaults to the
+    // container's own; a caller whose panel is wider than the dressed column
+    // (the drawer's margins) passes the panel's width instead.
+    property real reference: 0
+
+    readonly property real rise: Appearance.animation.entranceRise
+    readonly property real scaleFrom: Appearance.animation.entranceScaleFrom(
+        root.reference > 0 ? root.reference : (root.target?.width ?? 0))
+
+    property Component lift: Component {
+        Translate {
+            objectName: "staggerEntranceLift"
+            property Item item
+            y: (1 - (item?.appear ?? 1)) * root.rise
+        }
+    }
+
+    // Whether a member already carries this dressing, read off the member
+    // itself rather than off a list of references: a Repeater destroys and
+    // rebuilds delegates, and a bookkeeping list would hold the dead.
+    function dressed(child: Item): bool {
+        for (let i = 0; i < child.transform.length; i++)
+            if (child.transform[i]?.objectName === "staggerEntranceLift")
+                return true;
+        return false;
+    }
+
+    function dress() {
+        const kids = root.target ? root.target.children : [];
+        for (let i = 0; i < kids.length; i++) {
+            const child = kids[i];
+            if (child.appear === undefined)
+                continue;
+            if (child.interactionMotion !== undefined)
+                continue;
+            if (root.dressed(child))
+                continue;
+            child.opacity = Qt.binding(() => child.appear);
+            child.scale = Qt.binding(() =>
+                root.scaleFrom + (1 - root.scaleFrom) * child.appear);
+            child.transform.push(root.lift.createObject(child, { item: child }));
+        }
+    }
+
+    // Members that arrive after completion - a Repeater filling the container
+    // - are dressed on arrival; `dressed()` keeps the residents from being
+    // dressed twice.
+    property Connections arrivals: Connections {
+        target: root.target
+        function onChildrenChanged() {
+            root.dress();
+        }
+    }
+
+    Component.onCompleted: root.dress()
+}

--- a/dots/.config/quickshell/imi/modules/common/widgets/StaggerWave.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/StaggerWave.qml
@@ -159,8 +159,20 @@ QtObject {
         const leadIn = Appearance.animation.scale(root.leadIn);
 
         for (let i = 0; i < kids.length; i++) {
-            if (ranks[i] < 0)
+            if (ranks[i] < 0) {
+                // A member that is not on screen takes no slot - but it must
+                // not be LEFT at the 0 the park wrote, either. It is invisible
+                // right now, so nothing shows; when whatever hides it lets it
+                // back on screen it arrives at rest, which is what it did
+                // before the wave existed. Leaving it parked is a member that
+                // never comes back: the AI pane's suggestion row is hidden at
+                // every open (the composer starts empty) and becomes visible
+                // when the user types "/" - at the opacity the last park
+                // wrote, for the rest of the open.
+                if (kids[i].appear !== undefined)
+                    kids[i].appear = 1;
                 continue;
+            }
             kids[i].appear = 0;
             wave.push(root.fade.createObject(root, {
                 item: kids[i],

--- a/dots/.config/quickshell/imi/modules/common/widgets/StaggerWave.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/StaggerWave.qml
@@ -68,7 +68,17 @@ QtObject {
         }
     }
 
+    // The members, when they are not one container's children. `GroupedList`
+    // reparents each declared row into its own plate, so a wave over its rows
+    // has no Item whose `children` are the group - the rows' shared origin is
+    // the declared list, and the caller hands it in. The list REPLACES the
+    // children walk; `target` stays what it is either way, the thing whose
+    // being on screen the deferral below waits for.
+    property list<Item> items
+
     function members(): var {
+        if (root.items.length > 0)
+            return root.items;
         return root.target ? root.target.children : [];
     }
 

--- a/dots/.config/quickshell/imi/modules/common/widgets/StyledPopup.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/StyledPopup.qml
@@ -13,6 +13,16 @@ QtObject {
     // Inset between the card's body and this popup's content. Denser popups keep
     // the default; content-heavy ones raise it.
     property real contentPadding: Appearance.spacing.space100
+    // The section entrance's rise, one token for every popup. A below-the-fold
+    // section opts into the overlay's gated cascade by declaring
+    // `property real appear: 1` and folding it into its opacity, a scale
+    // (bar_popup_unroll.js entranceScale, which derives its excursion from
+    // this rise over the section's own width) and a Translate of
+    // entranceOffset(appear, root.entranceRise). The HERO section never opts
+    // in - the card opens at its height so it is legible on frame one. See
+    // BarPopupOverlay's wave for the gate, and
+    // tests/test_bar_popup_section_entrance.py for the register.
+    readonly property real entranceRise: Appearance.spacing.space250
     // Interactive popups can remain open after the pointer leaves the bar.
     // Passive users retain the original hover-only behavior.
     property bool pinnedOpen: false

--- a/dots/.config/quickshell/imi/modules/common/widgets/StyledSlider.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/StyledSlider.qml
@@ -64,9 +64,13 @@ Slider {
     from: 0
     to: 1
 
+    // Named so a call site can slow one slider's glide (the sidebar's
+    // entrance sweeps the fill from zero) without spelling a second Behavior
+    // on a property this one already owns.
+    property real valueVelocity: Appearance.animation.elementMoveFast.velocity
     Behavior on value { // This makes the adjusted value (like volume) shift smoothly
         SmoothedAnimation {
-            velocity: Appearance.animation.elementMoveFast.velocity
+            velocity: root.valueVelocity
         }
     }
 

--- a/dots/.config/quickshell/imi/modules/common/widgets/StyledSlider.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/StyledSlider.qml
@@ -68,7 +68,12 @@ Slider {
     // entrance sweeps the fill from zero) without spelling a second Behavior
     // on a property this one already owns.
     property real valueVelocity: Appearance.animation.elementMoveFast.velocity
+    // Off only for a write that must land in the same frame - the sidebar's
+    // entrance parks the fill at zero before its sweep, and a park that rides
+    // the glide is a visible dip whenever the panel reopens mid-sweep.
+    property bool valueGlide: true
     Behavior on value { // This makes the adjusted value (like volume) shift smoothly
+        enabled: root.valueGlide
         SmoothedAnimation {
             velocity: root.valueVelocity
         }

--- a/dots/.config/quickshell/imi/modules/imi/bar/BarPopupOverlay.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/BarPopupOverlay.qml
@@ -208,7 +208,17 @@ Scope {
                 // partial `appear`, and a popup returning later by cross-fade
                 // - where nothing parks or re-enters - would keep it dimmed
                 // for the rest of the session.
-                if (previous && previous !== popup) sectionWave.settle();
+                if (previous && previous !== popup) {
+                    sectionWave.settle();
+                    // A flag armed for the PREVIOUS tree must not survive the
+                    // slot changing hands: hover A from idle, slide to B
+                    // before the gate answers, and the gate would fire
+                    // against B's never-parked sections - snapping them to
+                    // zero to cascade content that was already at full
+                    // strength, which is the opposite of what a cross-fade
+                    // promises. A takeover from idle re-arms below.
+                    overlayWindow.wavePending = false;
+                }
                 overlayWindow.current = popup;
 
                 if (previous && previous !== popup && previous.contentItem) {

--- a/dots/.config/quickshell/imi/modules/imi/bar/BarPopupOverlay.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/BarPopupOverlay.qml
@@ -125,6 +125,50 @@ Scope {
                 return popup;
             }
 
+            // ---- the content wave's gate --------------------------------
+            //
+            // The popup's below-the-fold sections hold their entrance until
+            // the card itself has arrived, then cascade
+            // (docs/p3drovfx-motion-measured-2026-08-22.md §2.1: container,
+            // then fill). The card's driver IS a container progress, so like
+            // Edit Mode's drawer this adopter asks the real question through
+            // Appearance.animation.contentsArrived and carries no leadIn - a
+            // lead-in as well would be two waits in front of one wave, only
+            // one of them answerable.
+            //
+            // `opening` is the overlay's own intent - the slot is claimed and
+            // the card is not leaving - never a direction inferred from the
+            // progress: the intent flips at the claim and the progress
+            // follows, so the gate's two branches are entered by different
+            // events and there is no ordering to get wrong.
+            readonly property bool opening: overlayWindow.current !== null
+                && !overlayWindow.exiting
+            readonly property bool contentsIn: Appearance.animation.contentsArrived(
+                card.openProgress, overlayWindow.opening)
+            // Armed by a FRESH open only, in takeOver's from-idle branch. A
+            // cross-fade takeover finds the card already there, so there is
+            // no container to wait for and the arriving sections stay at full
+            // strength; a re-hover that reverses an exit must not blink out
+            // sections the user is looking at. Both are exactly the states
+            // this flag is false in - which is what spares this surface the
+            // drawer's park-on-every-intent blink without a second notion of
+            // "current".
+            property bool wavePending: false
+
+            onContentsInChanged: {
+                // `opening` is a conjunct deliberately: a hover-out BEFORE
+                // the gate answered flips contentsIn true through the exit
+                // branch (any progress > 0 rides out), and a cascade started
+                // into a collapsing card is the race the gate exists to
+                // close. The armed flag survives that flip, so an exit
+                // reversed by a re-hover still gets the cascade it never had.
+                if (overlayWindow.contentsIn && overlayWindow.wavePending
+                        && overlayWindow.opening) {
+                    overlayWindow.wavePending = false;
+                    sectionWave.enter();
+                }
+            }
+
             onRequestedChanged: {
                 if (requested) takeOver(requested);
                 else beginExit();
@@ -158,6 +202,13 @@ Scope {
 
                 const previous = overlayWindow.current;
                 if (previous) previous.popupHovered = false;
+                // The wave follows whichever popup holds the card, so settle
+                // it against the outgoing tree BEFORE the slot changes hands:
+                // stopping alone would strand a mid-cascade section at
+                // partial `appear`, and a popup returning later by cross-fade
+                // - where nothing parks or re-enters - would keep it dimmed
+                // for the rest of the session.
+                if (previous && previous !== popup) sectionWave.settle();
                 overlayWindow.current = popup;
 
                 if (previous && previous !== popup && previous.contentItem) {
@@ -185,7 +236,18 @@ Scope {
 
                 // Coming from idle there is no geometry to morph from, so put
                 // the card at the widget it belongs to before anything animates.
-                if (card.width <= 0 || card.openHeight <= 0) overlayWindow.park();
+                if (card.width <= 0 || card.openHeight <= 0) {
+                    overlayWindow.park();
+                    // A fresh open arms the wave: the sections below the fold
+                    // are put away before the card is on screen, and the gate
+                    // releases them. Arming and running are two events -
+                    // parking inside enter() would draw the sections at full
+                    // strength for the whole run up to the gate and then
+                    // blink them out to cascade back in, which is the drawer's
+                    // measured mistake restated.
+                    sectionWave.park();
+                    overlayWindow.wavePending = true;
+                }
                 retargetTimer.restart();
             }
 
@@ -288,6 +350,16 @@ Scope {
                 exitTimer.stop();
                 contentEnter.stop();
                 contentExit.stop();
+                // The reset the next entrance starts from, made off screen -
+                // the card collapses in this same call. The exit itself never
+                // touches the sections: they ride the container out at full
+                // strength as one rigid piece (measured doc §2.2), so
+                // settle() here is assignment to values they already hold
+                // unless a cascade was interrupted mid-flight, which is
+                // exactly the state it exists to repair. While the leaving
+                // popup still holds the slot, the wave's target is its tree.
+                sectionWave.settle();
+                overlayWindow.wavePending = false;
 
                 const leaving = overlayWindow.current;
                 overlayWindow.release(overlayWindow.outgoing);
@@ -336,6 +408,31 @@ Scope {
                 id: retargetTimer
                 interval: 0
                 onTriggered: overlayWindow.retarget()
+            }
+
+            // One wave for whichever popup holds the card, never one per
+            // popup - a per-popup runner is ten copies of the drive, one door
+            // over from the per-popup watcher trap (#140). Members are the
+            // content root's children: a popup opts a section in by declaring
+            // `property real appear: 1` and folding it into its own opacity,
+            // scale and rise (bar_popup_unroll.js's entrance helpers). The
+            // HERO section - the first drawn one, whose height the card opens
+            // at - deliberately declares none: the unroll exists so that
+            // section is legible on frame one, and only the sections below
+            // the fold cascade. A popup declaring no `appear` at all (the
+            // tray grid, the privacy card's one-tree morph) yields an empty
+            // wave and keeps today's behaviour.
+            //
+            // The handover trap is answered by WHEN enter() runs: the gate
+            // holds it until the driver crosses contentGate, several frames
+            // after the zero-interval retarget, so the wave never ranks the
+            // reparented tree during the one frame its implicit size is
+            // stale - and StaggerWave itself defers an enter() until its
+            // target is effectively visible, which covers the window's own
+            // map on a fresh open.
+            StaggerWave {
+                id: sectionWave
+                target: overlayWindow.current?.contentItem ?? null
             }
 
             // One timer where there were two chained ones. The shrink and the

--- a/dots/.config/quickshell/imi/modules/imi/bar/BatteryPopup.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/BatteryPopup.qml
@@ -3,6 +3,7 @@ import qs.modules.common.widgets
 import qs.services
 import QtQuick
 import QtQuick.Layouts
+import "bar_popup_unroll.js" as BarPopupUnroll
 
 StyledPopup {
     id: root
@@ -21,7 +22,12 @@ StyledPopup {
     ColumnLayout {
         spacing: Appearance.spacing.space150
 
+        // The header row is this popup's HERO - the first drawn section,
+        // whose height the card opens at - so it never declares `appear`.
+        // The cards below the fold cascade in on BarPopupOverlay's gated
+        // wave.
         RowLayout {
+            id: batteryHeaderRow
             Layout.fillWidth: true
             Layout.leftMargin: Appearance.spacing.space50
             spacing: Appearance.spacing.space100
@@ -74,6 +80,11 @@ StyledPopup {
         }
 
         RowLayout {
+            id: batteryCards
+            property real appear: 1
+            opacity: batteryCards.appear
+            scale: BarPopupUnroll.entranceScale(batteryCards.appear, root.entranceRise, batteryCards.width)
+            transform: Translate { y: BarPopupUnroll.entranceOffset(batteryCards.appear, root.entranceRise) }
             Layout.fillWidth: true
             spacing: Appearance.spacing.space100
 

--- a/dots/.config/quickshell/imi/modules/imi/bar/ClockWidgetPopup.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/ClockWidgetPopup.qml
@@ -2,6 +2,7 @@ import qs.modules.common
 import qs.modules.common.widgets
 import qs.services
 import QtQuick
+import "bar_popup_unroll.js" as BarPopupUnroll
 
 StyledPopup {
     id: root
@@ -18,6 +19,12 @@ StyledPopup {
         // downwards from the top, so nothing here feeds back into this height.
         implicitHeight: pendingLabel.y + pendingLabel.height
 
+        // The month is this popup's HERO - the first drawn child, so the card
+        // opens at exactly its height - and the year rides in its band
+        // (baseline-anchored to it), so neither declares `appear`: parking
+        // the hero would have the card open at the height of a section that
+        // is not drawn. Everything below the two cascades in once the card
+        // has arrived, on BarPopupOverlay's gated wave.
         StyledText {
             id: monthLabel
             anchors {
@@ -31,6 +38,7 @@ StyledPopup {
         }
 
         StyledText {
+            id: yearLabel
             anchors {
                 left: monthLabel.right
                 leftMargin: Appearance.spacing.space100
@@ -43,6 +51,10 @@ StyledPopup {
 
         Row {
             id: weekRow
+            property real appear: 1
+            opacity: weekRow.appear
+            scale: BarPopupUnroll.entranceScale(weekRow.appear, root.entranceRise, weekRow.width)
+            transform: Translate { y: BarPopupUnroll.entranceOffset(weekRow.appear, root.entranceRise) }
             anchors {
                 left: parent.left
                 right: parent.right
@@ -104,6 +116,10 @@ StyledPopup {
 
         Item {
             id: taskSection
+            property real appear: 1
+            opacity: taskSection.appear
+            scale: BarPopupUnroll.entranceScale(taskSection.appear, root.entranceRise, taskSection.width)
+            transform: Translate { y: BarPopupUnroll.entranceOffset(taskSection.appear, root.entranceRise) }
             anchors {
                 left: parent.left
                 right: parent.right
@@ -201,6 +217,10 @@ StyledPopup {
 
         StyledText {
             id: pendingLabel
+            property real appear: 1
+            opacity: pendingLabel.appear
+            scale: BarPopupUnroll.entranceScale(pendingLabel.appear, root.entranceRise, pendingLabel.width)
+            transform: Translate { y: BarPopupUnroll.entranceOffset(pendingLabel.appear, root.entranceRise) }
             anchors {
                 left: parent.left
                 top: taskSection.bottom
@@ -212,6 +232,11 @@ StyledPopup {
         }
 
         StyledText {
+            id: uptimeLabel
+            property real appear: 1
+            opacity: uptimeLabel.appear
+            scale: BarPopupUnroll.entranceScale(uptimeLabel.appear, root.entranceRise, uptimeLabel.width)
+            transform: Translate { y: BarPopupUnroll.entranceOffset(uptimeLabel.appear, root.entranceRise) }
             anchors {
                 right: parent.right
                 baseline: pendingLabel.baseline

--- a/dots/.config/quickshell/imi/modules/imi/bar/Media.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/Media.qml
@@ -178,6 +178,9 @@ Item {
                 horizontalAlignment: Text.AlignHCenter
                 elide: Text.ElideRight
                 color: Appearance.colors.colOnLayer1
+                // A track change is an event the eye follows, not a tick - the
+                // material row's two labels already animate their swaps.
+                animateChange: true
                 text: Config.options.bar.media.onlyTitle ? root.cleanedTitle : `${root.cleanedTitle}${root.activePlayer?.trackArtist ? ' • ' + root.activePlayer.trackArtist : ''}`
             }
         }

--- a/dots/.config/quickshell/imi/modules/imi/bar/NetworkSpeedPopup.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/NetworkSpeedPopup.qml
@@ -3,6 +3,7 @@ import QtQuick.Layouts
 import qs.modules.common
 import qs.modules.common.widgets
 import qs.services
+import "bar_popup_unroll.js" as BarPopupUnroll
 
 StyledPopup {
     id: root
@@ -123,7 +124,12 @@ StyledPopup {
         implicitWidth: 300
         spacing: Appearance.spacing.space75
 
+        // The connection row is this popup's HERO - the first drawn section,
+        // whose height the card opens at, legible on frame one - so it never
+        // declares `appear`. The speed cards and the details list below the
+        // fold cascade in on BarPopupOverlay's gated wave.
         RowLayout {
+            id: connectionRow
             Layout.fillWidth: true
             Layout.leftMargin: Appearance.spacing.space50
             Layout.rightMargin: Appearance.spacing.space50
@@ -161,6 +167,11 @@ StyledPopup {
         }
 
         RowLayout {
+            id: speedRow
+            property real appear: 1
+            opacity: speedRow.appear
+            scale: BarPopupUnroll.entranceScale(speedRow.appear, root.entranceRise, speedRow.width)
+            transform: Translate { y: BarPopupUnroll.entranceOffset(speedRow.appear, root.entranceRise) }
             Layout.fillWidth: true
             spacing: Appearance.spacing.space75
 
@@ -182,6 +193,11 @@ StyledPopup {
         }
 
         GroupedList {
+            id: detailsList
+            property real appear: 1
+            opacity: detailsList.appear
+            scale: BarPopupUnroll.entranceScale(detailsList.appear, root.entranceRise, detailsList.width)
+            transform: Translate { y: BarPopupUnroll.entranceOffset(detailsList.appear, root.entranceRise) }
             visible: Network.networkInterface !== ""
                 || Network.ipAddress !== ""
                 || Network.publicIpAddress !== ""

--- a/dots/.config/quickshell/imi/modules/imi/bar/ResourcesPopup.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/ResourcesPopup.qml
@@ -3,6 +3,7 @@ import qs.modules.common.widgets
 import qs.services
 import QtQuick
 import Quickshell.Io
+import "bar_popup_unroll.js" as BarPopupUnroll
 
 StyledPopup {
     id: root
@@ -14,7 +15,14 @@ StyledPopup {
     Row {
         spacing: Appearance.spacing.space100
 
+        // The first column is this popup's HERO: the card opens at its
+        // height, so RAM and CPU are legible on frame one and it never
+        // declares `appear`. The other two columns are the below-the-fold
+        // sections that cascade in on BarPopupOverlay's gated wave -
+        // rightward here rather than downward, because this popup's sections
+        // run across the card.
         Column {
+            id: ramCpuColumn
             spacing: Appearance.spacing.space100
 
             ResourceCard {
@@ -38,6 +46,11 @@ StyledPopup {
         }
 
         Column {
+            id: swapDiskColumn
+            property real appear: 1
+            opacity: swapDiskColumn.appear
+            scale: BarPopupUnroll.entranceScale(swapDiskColumn.appear, root.entranceRise, swapDiskColumn.width)
+            transform: Translate { y: BarPopupUnroll.entranceOffset(swapDiskColumn.appear, root.entranceRise) }
             spacing: Appearance.spacing.space100
 
             ResourceCard {
@@ -58,6 +71,11 @@ StyledPopup {
         }
 
         Column {
+            id: gpuColumn
+            property real appear: 1
+            opacity: gpuColumn.appear
+            scale: BarPopupUnroll.entranceScale(gpuColumn.appear, root.entranceRise, gpuColumn.width)
+            transform: Translate { y: BarPopupUnroll.entranceOffset(gpuColumn.appear, root.entranceRise) }
             spacing: Appearance.spacing.space100
 
             ResourceCard {

--- a/dots/.config/quickshell/imi/modules/imi/bar/WeatherBar.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/WeatherBar.qml
@@ -55,6 +55,7 @@ MouseArea {
                 visible: !root.isMaterial
                 font.pixelSize: Appearance.font.pixelSize.small
                 color: Appearance.colors.colOnLayer1
+                animateChange: true
                 text: Weather.data?.temp ?? "--°"
                 Layout.alignment: Qt.AlignVCenter
             }
@@ -63,6 +64,7 @@ MouseArea {
                 visible: root.isMaterial
                 font.pixelSize: Appearance.font.pixelSize.small
                 color: Appearance.colors.colPrimary
+                animateChange: true
                 text: Weather.data?.temp ?? "--°"
                 Layout.alignment: Qt.AlignVCenter
                 leftPadding: Appearance.spacing.space100
@@ -104,6 +106,7 @@ MouseArea {
                 visible: !root.isMaterial
                 font.pixelSize: Appearance.font.pixelSize.small
                 color: Appearance.colors.colOnLayer1
+                animateChange: true
                 text: (Weather.data?.temp ?? "--°").replace(/[CF]$/, "")
                 Layout.alignment: Qt.AlignHCenter
             }
@@ -112,6 +115,7 @@ MouseArea {
                 visible: root.isMaterial
                 font.pixelSize: Appearance.font.pixelSize.small
                 color: Appearance.colors.colPrimary
+                animateChange: true
                 text: (Weather.data?.temp ?? "--°").replace(/[CF]$/, "")
                 Layout.alignment: Qt.AlignHCenter
                 Layout.topMargin: Appearance.spacing.space50

--- a/dots/.config/quickshell/imi/modules/imi/bar/WeatherPopup.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/WeatherPopup.qml
@@ -4,6 +4,7 @@ import qs.modules.common.widgets
 import QtQuick
 import QtQuick.Layouts
 import qs.modules.imi.bar
+import "bar_popup_unroll.js" as BarPopupUnroll
 
 StyledPopup {
     id: root
@@ -138,7 +139,19 @@ StyledPopup {
         // comes and goes would keep changing what the popup opens at - and a
         // 99px strip is not the section this card should be legible at on
         // frame one. The hero stays first, at 141 of the card's 431.
+        //
+        // The hero is also why IT carries no `appear` while the two sections
+        // below it do: the card opens at the hero's own height so the hero is
+        // readable from the first frame, and the below-the-fold sections
+        // cascade in once the card has arrived (BarPopupOverlay's gated
+        // wave). One scalar drives all three entrance channels so opacity,
+        // scale and rise cannot land on different schedules.
         WeatherHourlyChart {
+            id: hourlyChart
+            property real appear: 1
+            opacity: hourlyChart.appear
+            scale: BarPopupUnroll.entranceScale(hourlyChart.appear, root.entranceRise, hourlyChart.width)
+            transform: Translate { y: BarPopupUnroll.entranceOffset(hourlyChart.appear, root.entranceRise) }
             charted: root.popupVisible
             Layout.leftMargin: Appearance.spacing.space25
             Layout.rightMargin: Appearance.spacing.space25
@@ -146,6 +159,10 @@ StyledPopup {
 
         GridLayout {
             id: gridLayout
+            property real appear: 1
+            opacity: gridLayout.appear
+            scale: BarPopupUnroll.entranceScale(gridLayout.appear, root.entranceRise, gridLayout.width)
+            transform: Translate { y: BarPopupUnroll.entranceOffset(gridLayout.appear, root.entranceRise) }
             columns: 2
             rowSpacing: Appearance.spacing.space50
             columnSpacing: Appearance.spacing.space50

--- a/dots/.config/quickshell/imi/modules/imi/bar/bar_popup_unroll.js
+++ b/dots/.config/quickshell/imi/modules/imi/bar/bar_popup_unroll.js
@@ -74,3 +74,29 @@ function cardHeight(openHeight, heroHeight, parkedSize, exiting, progress) {
     const travelled = progress > 0 ? progress : 0;
     return rest + (openHeight - rest) * travelled;
 }
+
+// The three-channel section entrance, shared by every popup whose
+// below-the-fold sections cascade in once the card has arrived
+// (docs/p3drovfx-motion-measured-2026-08-22.md §3: opacity, a scale from
+// ~0.85, and a small rise - not a fade). One `appear` scalar drives all three
+// so they cannot land on different schedules; opacity IS that scalar and needs
+// no helper, these two are the other channels.
+//
+// The scale's excursion is DERIVED from the rise over the section's own width
+// rather than fixed - EditModeDrawer.qml derives its rows' the same way and
+// says why: the measured 0.85 is a compact popup card's, and the same factor
+// on a wide row is a horizontal swing that reads as a zoom, not a settle. The
+// measured 0.85 stays as the floor so a narrow section cannot invert the
+// derivation, and a section asked before its first layout pass (width 0, or
+// no width at all) takes the floor rather than dividing into nothing.
+var ENTRANCE_SCALE_FLOOR = 0.85;
+
+function entranceScale(appear, rise, width) {
+    const span = width > 0 ? width : 1;
+    const from = Math.max(ENTRANCE_SCALE_FLOOR, 1 - rise / span);
+    return from + (1 - from) * appear;
+}
+
+function entranceOffset(appear, rise) {
+    return (1 - appear) * rise;
+}

--- a/dots/.config/quickshell/imi/modules/imi/desktopMenu/DesktopMenu.qml
+++ b/dots/.config/quickshell/imi/modules/imi/desktopMenu/DesktopMenu.qml
@@ -167,7 +167,30 @@ Scope {
                 opacity: 0
                 transformOrigin: Item.Center
 
+                // Container, then fill: the card's own entrance is the scale
+                // and opacity above, and its ROWS arrive as a group once the
+                // card has mostly landed. This is the drawer's adoption shape,
+                // not the sidebar's refused one: the card's opacity IS a
+                // QML-readable progress for its entrance (the Behavior
+                // animates the property itself), so the wave gates on the
+                // real container rather than on a guessed leadIn - the exact
+                // scalar whose absence is half of why the right sidebar's
+                // wave came back off. Enter-only, because the close destroys
+                // this window on the frame the flag drops: there is no exit
+                // for a wave to animate, so nothing here calls leave().
+                readonly property bool contentsIn:
+                    Appearance.animation.contentsArrived(menuCard.opacity, true)
+                onContentsInChanged: {
+                    if (menuCard.contentsIn)
+                        rowsEntrance.enter()
+                }
+
                 Component.onCompleted: {
+                    // Park before the entrance starts, or the rows are drawn
+                    // at full strength for the run up to the gate and then
+                    // blink out to cascade back in - the arming-vs-running
+                    // lesson the drawer already paid for.
+                    rowsEntrance.park()
                     scale = 1.0
                     opacity = 1.0
                 }
@@ -177,6 +200,20 @@ Scope {
                 }
                 Behavior on opacity {
                     animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
+                }
+
+                // The rows are RippleButtons, so each already declares
+                // `appear` and folds it into its own opacity and 6px rise -
+                // the wave reaches them through the property the runner
+                // writes, and no dressing is declared here (a StaggerEntrance
+                // aimed at controls would be the doubling the composition
+                // lints fail on). `items`, not a container walk: GroupedList
+                // reparents each row into its own plate, so the declared list
+                // is the rows' only shared origin.
+                StaggerWave {
+                    id: rowsEntrance
+                    target: menuGroup
+                    items: menuGroup.items
                 }
 
                 MouseArea {
@@ -223,6 +260,7 @@ Scope {
                     }
 
                     GroupedList {
+                        id: menuGroup
                         Layout.fillWidth: true
                         itemVerticalPadding: Appearance.spacing.space200
                         bgcolor: Appearance.colors.colLayer0

--- a/dots/.config/quickshell/imi/modules/imi/editMode/EditModeDrawer.qml
+++ b/dots/.config/quickshell/imi/modules/imi/editMode/EditModeDrawer.qml
@@ -208,26 +208,14 @@ Item {
         GlobalStates.editDrawerProgress, root.opening)
 
     // A member arrives with three properties moving together, not as a fade:
-    // opacity, a scale, and a small rise. One `appear` scalar drives all three
-    // so they cannot finish on different schedules, which is what
-    // docs/M3_GUIDELINES.md §2 ("Component Entrance and Exit") requires and what
-    // reads as a hiccup when it is missed.
-    //
-    // The rise is a spacing token. The scale is DERIVED from it rather than
-    // picked: the survey measured 0.85, but that is a popup's compact cards, and
-    // on this panel's full-width rows the same factor is a 52px horizontal swing
-    // inside a 380px drawer - a zoom, not a settle. Matching the scale's own
-    // excursion to the rise keeps the two terms one motion at any drawer width,
-    // with the measured 0.85 as the floor so a narrow panel cannot invert it.
-    readonly property real entranceRise: Appearance.spacing.space250
-    readonly property real entranceScaleFrom: Math.max(0.85,
-        1 - root.entranceRise / Math.max(1, root.panelWidth))
-    function entranceScale(appear) {
-        return root.entranceScaleFrom + (1 - root.entranceScaleFrom) * appear;
-    }
-    function entranceOffset(appear) {
-        return (1 - appear) * root.entranceRise;
-    }
+    // opacity, a scale, and a small rise, all on one `appear` scalar so they
+    // cannot finish on different schedules (docs/M3_GUIDELINES.md §2,
+    // "Component Entrance and Exit"). That dressing used to be spelled out
+    // here once per member; it is the shared `StaggerEntrance` beside the wave
+    // now, and the derivation this file carried - the scale's excursion
+    // matched to the rise, floored at the survey's 0.85 - lives in
+    // motion_policy.js where a test can hold it still. A member's whole opt-in
+    // is `property real appear: 1`.
 
     // Arming and running are two events, not one, and measuring showed why.
     // Setting the members to zero inside the wave meant they were drawn at full
@@ -302,12 +290,23 @@ Item {
                 target: drawerColumn
             }
 
+            // ...and what arriving looks like: the shared three-channel
+            // dressing, walking the same column. The reference is the PANEL's
+            // width, not the column's - the column is inset by its margins and
+            // the derivation's input has been the panel since the drawer first
+            // dressed its members. The lock section's two re-link rows are
+            // `RippleButton`s and are skipped by the dresser itself: a control
+            // owns `scale` through the interaction model and folds `appear`
+            // into the opacity binding that carries its disabled dim, so it
+            // rides the wave through the property the runner writes.
+            StaggerEntrance {
+                target: drawerColumn
+                reference: root.panelWidth
+            }
+
             RowLayout {
                 id: addHeaderRow
                 property real appear: 1
-                opacity: addHeaderRow.appear
-                scale: root.entranceScale(addHeaderRow.appear)
-                transform: Translate { y: root.entranceOffset(addHeaderRow.appear) }
                 Layout.fillWidth: true
                 // A Layout nested in a Layout defaults to fillHeight TRUE, and
                 // a row of chrome that fills is a row that competes with the
@@ -335,9 +334,6 @@ Item {
             RowLayout {
                 id: sectionChipRow
                 property real appear: 1
-                opacity: sectionChipRow.appear
-                scale: root.entranceScale(sectionChipRow.appear)
-                transform: Translate { y: root.entranceOffset(sectionChipRow.appear) }
                 Layout.fillWidth: true
                 Layout.fillHeight: false
                 Layout.leftMargin: Appearance.spacing.space75
@@ -370,9 +366,6 @@ Item {
             StyledText {
                 id: sectionHint
                 property real appear: 1
-                opacity: sectionHint.appear
-                scale: root.entranceScale(sectionHint.appear)
-                transform: Translate { y: root.entranceOffset(sectionHint.appear) }
                 Layout.fillWidth: true
                 Layout.fillHeight: false
                 Layout.leftMargin: Appearance.spacing.space75
@@ -393,9 +386,6 @@ Item {
             ListView {
                 id: list
                 property real appear: 1
-                opacity: list.appear
-                scale: root.entranceScale(list.appear)
-                transform: Translate { y: root.entranceOffset(list.appear) }
                 visible: root.section === "widgets"
                 Layout.fillWidth: true
                 Layout.fillHeight: true
@@ -514,9 +504,6 @@ Item {
             RowLayout {
                 id: barBucketRow
                 property real appear: 1
-                opacity: barBucketRow.appear
-                scale: root.entranceScale(barBucketRow.appear)
-                transform: Translate { y: root.entranceOffset(barBucketRow.appear) }
                 visible: root.section === "bar"
                 Layout.fillWidth: true
                 Layout.fillHeight: false
@@ -545,9 +532,6 @@ Item {
             ListView {
                 id: barList
                 property real appear: 1
-                opacity: barList.appear
-                scale: root.entranceScale(barList.appear)
-                transform: Translate { y: root.entranceOffset(barList.appear) }
                 visible: root.section === "bar"
                 Layout.fillWidth: true
                 Layout.fillHeight: true
@@ -597,9 +581,6 @@ Item {
             MaterialTextField {
                 id: appSearchField
                 property real appear: 1
-                opacity: appSearchField.appear
-                scale: root.entranceScale(appSearchField.appear)
-                transform: Translate { y: root.entranceOffset(appSearchField.appear) }
                 visible: root.section === "dock"
                 Layout.fillWidth: true
                 placeholderText: Translation.tr("Search apps")
@@ -608,9 +589,6 @@ Item {
             ListView {
                 id: appList
                 property real appear: 1
-                opacity: appList.appear
-                scale: root.entranceScale(appList.appear)
-                transform: Translate { y: root.entranceOffset(appList.appear) }
                 visible: root.section === "dock"
                 Layout.fillWidth: true
                 Layout.fillHeight: true
@@ -686,9 +664,6 @@ Item {
             ListView {
                 id: lockList
                 property real appear: 1
-                opacity: lockList.appear
-                scale: root.entranceScale(lockList.appear)
-                transform: Translate { y: root.entranceOffset(lockList.appear) }
                 visible: root.section === "lock"
                 Layout.fillWidth: true
                 Layout.fillHeight: true
@@ -779,17 +754,18 @@ Item {
             // with the lock showing no widgets at all, "follows the desktop"
             // is a claim about a set nobody can see.
             //
-            // Neither this row nor the layout re-link below it is DRESSED with
-            // the three channels above, and both still arrive with the wave.
-            // A `RippleButton` declares `appear` itself and folds it into its
-            // own opacity and a 6px rise, so the runner reaches it like any
-            // other member - measured, these two land one and two steps behind
-            // the list. What it must not be handed is a second writer of
-            // either channel: `scale` is `interactionMotion`'s (a scale here
-            // replaces the control's rather than composing with it -
-            // lint_interaction_motion_double.py) and that same opacity binding
-            // carries the disabled dim (a second one draws this row as enabled
-            // while it is not - lint_disabled_opacity.py, and the bug
+            // Neither this row nor the layout re-link below it is dressed by
+            // the StaggerEntrance above - the dresser itself skips a member
+            // that owns an `interactionMotion` - and both still arrive with
+            // the wave. A `RippleButton` declares `appear` itself and folds it
+            // into its own opacity and a 6px rise, so the runner reaches it
+            // like any other member - measured, these two land one and two
+            // steps behind the list. What it must not be handed is a second
+            // writer of either channel: `scale` is `interactionMotion`'s (a
+            // scale here replaces the control's rather than composing with it
+            // - lint_interaction_motion_double.py) and that same opacity
+            // binding carries the disabled dim (a second one draws this row as
+            // enabled while it is not - lint_disabled_opacity.py, and the bug
             // ExpandablePanel's `appear` indirection exists for).
             RippleButton {
                 id: lockPresenceRow
@@ -847,9 +823,9 @@ Item {
             // in, and while forked offers the way back - the drawer never
             // forks by itself; a drag does that.
             //
-            // Undressed, for the reason stated on the widget-choice row above:
-            // this is a `RippleButton` and it rides the wave through its own
-            // `appear`.
+            // Undressed (the StaggerEntrance skips it), for the reason stated
+            // on the widget-choice row above: this is a `RippleButton` and it
+            // rides the wave through its own `appear`.
             RippleButton {
                 id: lockLayoutRow
                 visible: root.section === "lock"

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/AiChat.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/AiChat.qml
@@ -273,25 +273,18 @@ Inline w/ backslash and round brackets \\(e^{i\\pi} + 1 = 0\\)
         color: Appearance.colors.colOutlineVariant
     }
 
-    // The pane's own members cascade once the sidebar's gate opens - the
-    // fork's left-pane grammar (tab strip, content, hint, suggestions,
-    // composer, each individually). `sidebarLeftPaneIn` resolves through the
-    // creation context to SidebarLeftContent's gate (this pane is created
-    // from an inline Component there); the typeof guard keeps a pane built
-    // anywhere else - a test - drawn rather than throwing per evaluation.
-    // Same dynamic-scope pattern as dockRow.padding, with AGENT.md's warning
-    // attached: restructure above this and nothing warns.
-    readonly property bool paneGateOpen:
-        (typeof sidebarLeftPaneIn !== "undefined") ? sidebarLeftPaneIn : true
-    onPaneGateOpenChanged: {
-        if (root.paneGateOpen && GlobalStates.sidebarLeftOpen)
-            paneEntrance.enter();
-    }
+    // The pane's members run their entrance UNDER the slide, ungated (see
+    // the right sidebar's comment for the twice-learned reason): content,
+    // hint, suggestions, composer, each individually, with the composer -
+    // last rank - as the visible tail after the panel lands, which is the
+    // fork's own left-pane look.
     Connections {
         target: GlobalStates
         function onSidebarLeftOpenChanged() {
-            if (GlobalStates.sidebarLeftOpen && !root.paneGateOpen)
+            if (GlobalStates.sidebarLeftOpen) {
                 paneEntrance.park();
+                paneEntrance.enter();
+            }
         }
     }
 

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/AiChat.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/AiChat.qml
@@ -284,7 +284,31 @@ Inline w/ backslash and round brackets \\(e^{i\\pi} + 1 = 0\\)
             if (GlobalStates.sidebarLeftOpen) {
                 paneEntrance.park();
                 paneEntrance.enter();
+                if (emptyStatePlaceholder.shown) {
+                    glyphGrow.stop();
+                    emptyStatePlaceholder.scale = 0.85;
+                    glyphGrow.start();
+                }
             }
+        }
+    }
+
+    // The empty state's glyph GROWS into place while the pane's members
+    // fade - the fork's left-pane look, where the brain mark visibly
+    // arrives rather than being faded in as furniture. Scale only, on its
+    // own item: the fade is the wave member's (the messages area above it)
+    // and the placeholder's own opacity Behavior belongs to its shown
+    // fade - three channels, three owners, no doubling.
+    SequentialAnimation {
+        id: glyphGrow
+        PauseAnimation { duration: Appearance.animation.scale(120) }
+        NumberAnimation {
+            target: emptyStatePlaceholder
+            property: "scale"
+            to: 1
+            duration: Appearance.animation.scale(380)
+            easing.type: Easing.OutBack
+            easing.overshoot: 1.2
         }
     }
 
@@ -299,6 +323,13 @@ Inline w/ backslash and round brackets \\(e^{i\\pi} + 1 = 0\\)
         StaggerWave {
             id: paneEntrance
             target: columnLayout
+            // The right sidebar's twice-learned cadence: a modest head start
+            // so no member is mid-fade while the panel edge is arriving,
+            // then the fork's tight per-member step. The composer is the
+            // last rank - the visible tail after the landing, which is the
+            // fork's own left-pane signature.
+            leadIn: 80
+            step: 25
         }
         StaggerEntrance {
             target: columnLayout
@@ -419,6 +450,7 @@ Inline w/ backslash and round brackets \\(e^{i\\pi} + 1 = 0\\)
             }
 
             PagePlaceholder {
+                id: emptyStatePlaceholder
                 z: 2
                 shown: Ai.messageIDs.length === 0
                 icon: "neurology"

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/AiChat.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/AiChat.qml
@@ -273,6 +273,28 @@ Inline w/ backslash and round brackets \\(e^{i\\pi} + 1 = 0\\)
         color: Appearance.colors.colOutlineVariant
     }
 
+    // The pane's own members cascade once the sidebar's gate opens - the
+    // fork's left-pane grammar (tab strip, content, hint, suggestions,
+    // composer, each individually). `sidebarLeftPaneIn` resolves through the
+    // creation context to SidebarLeftContent's gate (this pane is created
+    // from an inline Component there); the typeof guard keeps a pane built
+    // anywhere else - a test - drawn rather than throwing per evaluation.
+    // Same dynamic-scope pattern as dockRow.padding, with AGENT.md's warning
+    // attached: restructure above this and nothing warns.
+    readonly property bool paneGateOpen:
+        (typeof sidebarLeftPaneIn !== "undefined") ? sidebarLeftPaneIn : true
+    onPaneGateOpenChanged: {
+        if (root.paneGateOpen && GlobalStates.sidebarLeftOpen)
+            paneEntrance.enter();
+    }
+    Connections {
+        target: GlobalStates
+        function onSidebarLeftOpenChanged() {
+            if (GlobalStates.sidebarLeftOpen && !root.paneGateOpen)
+                paneEntrance.park();
+        }
+    }
+
     ColumnLayout {
         id: columnLayout
         anchors {
@@ -281,7 +303,17 @@ Inline w/ backslash and round brackets \\(e^{i\\pi} + 1 = 0\\)
         }
         spacing: root.padding
 
+        StaggerWave {
+            id: paneEntrance
+            target: columnLayout
+        }
+        StaggerEntrance {
+            target: columnLayout
+            reference: root.width
+        }
+
         Item {
+            property real appear: 1
             // Messages
             Layout.fillWidth: true
             Layout.fillHeight: true
@@ -409,11 +441,13 @@ Inline w/ backslash and round brackets \\(e^{i\\pi} + 1 = 0\\)
         }
 
         DescriptionBox {
+            property real appear: 1
             text: root.suggestionList[suggestions.selectedIndex]?.description ?? ""
             showArrows: root.suggestionList.length > 1
         }
 
         FlowButtonGroup { // Suggestions
+            property real appear: 1
             id: suggestions
             visible: root.suggestionList.length > 0 && messageInputField.text.length > 0
             property int selectedIndex: 0
@@ -470,6 +504,7 @@ Inline w/ backslash and round brackets \\(e^{i\\pi} + 1 = 0\\)
         }
 
         Rectangle { // Input area
+            property real appear: 1
             id: inputWrapper
             property real spacing: Appearance.spacing.space100
             Layout.fillWidth: true

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/SidebarLeft.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/SidebarLeft.qml
@@ -64,6 +64,12 @@ Scope { // Scope
             "scopeRoot": root,
         });
         sidebarLoader.item.contentParent.children = [root.sidebarContent];
+        // The content is created detached and reparented on dock/undock, so
+        // the slide's progress reaches it by assignment rather than by an id
+        // it could see. Null-safe: while the attached window is unloaded
+        // (detached mode) there is no slide, and 1 means "no gate to wait on".
+        root.sidebarContent.containerProgress = Qt.binding(() =>
+            sidebarLoader.item ? sidebarLoader.item.slide.progress : 1);
     }
 
     onDetachChanged: {

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/SidebarLeft.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/SidebarLeft.qml
@@ -64,12 +64,6 @@ Scope { // Scope
             "scopeRoot": root,
         });
         sidebarLoader.item.contentParent.children = [root.sidebarContent];
-        // The content is created detached and reparented on dock/undock, so
-        // the slide's progress reaches it by assignment rather than by an id
-        // it could see. Null-safe: while the attached window is unloaded
-        // (detached mode) there is no slide, and 1 means "no gate to wait on".
-        root.sidebarContent.containerProgress = Qt.binding(() =>
-            sidebarLoader.item ? sidebarLoader.item.slide.progress : 1);
     }
 
     onDetachChanged: {

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/SidebarLeft.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/SidebarLeft.qml
@@ -221,6 +221,9 @@ Scope { // Scope
                 // An `x`, not a transform: the blur region and the shadow both
                 // follow the item's geometry, and a transform moves neither.
                 x: Appearance.sizes.hyprlandGapsOut + panelWindow.slide.offset
+                // The slide's curtain (see EdgeSlide.reveal): entrances run
+                // under it, so a member still parked is dimness, not a hole.
+                opacity: panelWindow.slide.reveal
 
                 Behavior on width {
                     animation: Appearance.animation.elementMove.numberAnimation.createObject(this)

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/SidebarLeftContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/SidebarLeftContent.qml
@@ -43,35 +43,19 @@ Item {
         }
     }
 
-    // The container's slide progress, assigned by SidebarLeft.qml AFTER the
-    // content is created - this tree is built detached and reparented between
-    // the attached panel and the detached window, so the binding arrives from
-    // outside rather than from an id this file could see. Defaults to 1: a
-    // detached window (or a test) has no slide to wait on.
-    property real containerProgress: 1
-
-    // Container-then-fill, the right sidebar's shape. The gate is keyed to
-    // the OPEN flag, which a detach does not flip - so undocking the chat to
-    // keep reading never re-runs the entrance (the hazard that first kept
-    // this surface in STAGGER_DECLINED).
-    // Resolved by the tab panes through dynamic scope (see AiChat.qml).
-    readonly property bool sidebarLeftPaneIn: root.contentsIn
-
-    readonly property bool contentsIn: Appearance.animation.contentsArrived(
-        root.containerProgress, GlobalStates.sidebarLeftOpen)
-    onContentsInChanged: {
-        if (root.contentsIn && GlobalStates.sidebarLeftOpen)
-            leftEntrance.enter();
-    }
-    Component.onCompleted: {
-        if (!root.contentsIn)
-            leftEntrance.park();
-    }
+    // The entrance runs UNDER the slide, ungated - the fork's grammar, read
+    // off its re-recorded sidebars: the surface carries the panel already
+    // composed and only the last-ranked members visibly land after (see the
+    // right sidebar's fuller comment). Keyed to the OPEN flag, which a
+    // detach does not flip, so undocking the chat to keep reading never
+    // re-runs the entrance.
     Connections {
         target: GlobalStates
         function onSidebarLeftOpenChanged() {
-            if (GlobalStates.sidebarLeftOpen && !root.contentsIn)
+            if (GlobalStates.sidebarLeftOpen) {
                 leftEntrance.park();
+                leftEntrance.enter();
+            }
         }
     }
 

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/SidebarLeftContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/SidebarLeftContent.qml
@@ -1,3 +1,4 @@
+import qs
 import qs.services
 import qs.modules.common
 import qs.modules.common.widgets
@@ -42,15 +43,58 @@ Item {
         }
     }
 
+    // The container's slide progress, assigned by SidebarLeft.qml AFTER the
+    // content is created - this tree is built detached and reparented between
+    // the attached panel and the detached window, so the binding arrives from
+    // outside rather than from an id this file could see. Defaults to 1: a
+    // detached window (or a test) has no slide to wait on.
+    property real containerProgress: 1
+
+    // Container-then-fill, the right sidebar's shape. The gate is keyed to
+    // the OPEN flag, which a detach does not flip - so undocking the chat to
+    // keep reading never re-runs the entrance (the hazard that first kept
+    // this surface in STAGGER_DECLINED).
+    // Resolved by the tab panes through dynamic scope (see AiChat.qml).
+    readonly property bool sidebarLeftPaneIn: root.contentsIn
+
+    readonly property bool contentsIn: Appearance.animation.contentsArrived(
+        root.containerProgress, GlobalStates.sidebarLeftOpen)
+    onContentsInChanged: {
+        if (root.contentsIn && GlobalStates.sidebarLeftOpen)
+            leftEntrance.enter();
+    }
+    Component.onCompleted: {
+        if (!root.contentsIn)
+            leftEntrance.park();
+    }
+    Connections {
+        target: GlobalStates
+        function onSidebarLeftOpenChanged() {
+            if (GlobalStates.sidebarLeftOpen && !root.contentsIn)
+                leftEntrance.park();
+        }
+    }
+
     ColumnLayout {
+        id: leftColumn
         anchors {
             fill: parent
             margins: sidebarPadding
         }
         spacing: verticalTabBar.expanded ? -Appearance.spacing.space25 : 0
 
+        StaggerWave {
+            id: leftEntrance
+            target: leftColumn
+        }
+        StaggerEntrance {
+            target: leftColumn
+            reference: root.width
+        }
+
         VerticalTabBar {
             id: verticalTabBar
+            property real appear: 1
             visible: tabButtonList.length > 0
             Layout.fillWidth: true
             tabButtonList: root.tabButtonList
@@ -59,6 +103,7 @@ Item {
         }
 
         Rectangle {
+            property real appear: 1
             Layout.fillWidth: true
             Layout.fillHeight: true
             implicitWidth: swipeView.implicitWidth

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/SidebarLeftContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/SidebarLeftContent.qml
@@ -87,7 +87,9 @@ Item {
         }
 
         Rectangle {
-            property real appear: 1
+            // Not a wave member: the AI pane's members animate inside this
+            // card, and a fading card over fading members is the compound
+            // the right sidebar's toggle section already paid for.
             Layout.fillWidth: true
             Layout.fillHeight: true
             implicitWidth: swipeView.implicitWidth

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/BottomWidgetGroup.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/BottomWidgetGroup.qml
@@ -10,6 +10,7 @@ import QtQuick.Layouts
 
 Rectangle {
     id: root
+    property int entranceTrigger: -1
     radius: Appearance.rounding.normal
     color: Appearance.colors.colLayer1
     clip: true
@@ -202,6 +203,15 @@ Rectangle {
                 id: tabStack
                 anchors.fill: parent
                 anchors.bottomMargin: -anchors.topMargin
+
+                // Duck-typed hand-down of the sidebar's entrance counter: a
+                // tab widget that owns a bespoke entrance (the calendar's
+                // diagonal ripple) declares `entranceTrigger`; the others are
+                // left alone.
+                onLoaded: {
+                    if (item && item.entranceTrigger !== undefined)
+                        item.entranceTrigger = Qt.binding(() => root.entranceTrigger);
+                }
 
                 Component.onCompleted: {
                     tabStack.source = root.tabs[root.selectedTab].widget;

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/CenterWidgetGroup.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/CenterWidgetGroup.qml
@@ -9,11 +9,13 @@ import QtQuick.Layouts
 
 Rectangle {
     id: root
+    property int entranceTrigger: -1
     radius: Appearance.rounding.normal
     color: Appearance.colors.colLayer1
 
     NotificationList {
         anchors.fill: parent
         anchors.margins: Appearance.spacing.space100
+        entranceTrigger: root.entranceTrigger
     }
 }

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/QuickSliders.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/QuickSliders.qml
@@ -126,8 +126,9 @@ Rectangle {
         }
         Timer {
             id: sweepTimer
-            // The fork's cadence: 180ms head start, 70ms per slider.
-            interval: Appearance.animation.scale(180 + quickSlider.sliderIndex * 70)
+            // Tightened from the fork's 180+70ms on the maintainer's call -
+            // the sweep starts almost with the slide and the stagger stays.
+            interval: Appearance.animation.scale(80 + quickSlider.sliderIndex * 50)
             onTriggered: {
                 // The named glide velocity turns the release into the fork's
                 // ~650ms sweep; restored (as a binding) once the sweep lands.

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/QuickSliders.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/QuickSliders.qml
@@ -121,8 +121,29 @@ Rectangle {
         property bool entranceParked: false
         value: entranceParked ? 0 : shownValue
         onEntranceTriggerChanged: {
+            // The park must LAND, not glide: a reopen inside the previous
+            // sweep's window otherwise rides the slow sweep velocity down -
+            // a visible dip the second sweep then has to reverse.
+            quickSlider.endSweep();
+            quickSlider.valueGlide = false;
             quickSlider.entranceParked = true;
+            quickSlider.valueGlide = true;
             sweepTimer.restart();
+        }
+        // Puts the glide back to the house velocity, whichever way the
+        // sweep ends - by landing, or by the reading changing under it.
+        function endSweep() {
+            sweepRestore.stop();
+            quickSlider.valueVelocity =
+                Qt.binding(() => Appearance.animation.elementMoveFast.velocity);
+        }
+        // A reading that changes while the sweep owns the velocity is the
+        // user (or another client) acting - choreography yields. Without
+        // this, a volume key pressed inside the ~730ms window moved the
+        // fill at the sweep's crawl and then snapped on the restore.
+        onShownValueChanged: {
+            if (sweepRestore.running)
+                quickSlider.endSweep();
         }
         Timer {
             id: sweepTimer
@@ -132,17 +153,21 @@ Rectangle {
             onTriggered: {
                 // The named glide velocity turns the release into the fork's
                 // ~650ms sweep; restored (as a binding) once the sweep lands.
+                // A near-zero reading gets no override: there is nothing to
+                // sweep, and the floor this used to install (0.05 u/s) left
+                // the fill nearly frozen against any input in the window.
                 const sweepMs = Appearance.animation.scale(650);
-                quickSlider.valueVelocity = Math.max(0.05, quickSlider.shownValue / (sweepMs / 1000));
+                if (quickSlider.shownValue > 0.01) {
+                    quickSlider.valueVelocity = quickSlider.shownValue / (sweepMs / 1000);
+                    sweepRestore.interval = sweepMs + 80;
+                    sweepRestore.restart();
+                }
                 quickSlider.entranceParked = false;
-                sweepRestore.interval = sweepMs + 80;
-                sweepRestore.restart();
             }
         }
         Timer {
             id: sweepRestore
-            onTriggered: quickSlider.valueVelocity =
-                Qt.binding(() => Appearance.animation.elementMoveFast.velocity)
+            onTriggered: quickSlider.endSweep()
         }
         configuration: StyledSlider.Configuration.M
         stopIndicatorValues: []

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/QuickSliders.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/QuickSliders.qml
@@ -11,6 +11,7 @@ import Quickshell.Services.UPower
 Rectangle {
     id: root
 
+    property int entranceTrigger: -1
     property var screen: root.QsWindow.window?.screen
     property var brightnessMonitor: Brightness.getMonitorForScreen(screen)
 
@@ -39,10 +40,12 @@ Rectangle {
             visible: active
             active: Config.options.sidebar.quickSliders.showBrightness
             sourceComponent: QuickSlider {
+                entranceTrigger: root.entranceTrigger
+                sliderIndex: 0
                 materialSymbol: "brightness_medium"
                 secondaryMaterialSymbol: "wb_twilight"
                 stopIndicatorValues: Hyprsunset.gamma !== 100 && root.brightnessMonitor?.brightness !== 0 ? [0.3 + root.brightnessMonitor?.brightness * 0.7] : []
-                value: Hyprsunset.gamma === 100? 0.3 + root.brightnessMonitor?.brightness * 0.7 : (Hyprsunset.gamma - Hyprsunset.gammaLowerLimit) / (100 - Hyprsunset.gammaLowerLimit) * 0.3
+                shownValue: Hyprsunset.gamma === 100? 0.3 + root.brightnessMonitor?.brightness * 0.7 : (Hyprsunset.gamma - Hyprsunset.gammaLowerLimit) / (100 - Hyprsunset.gammaLowerLimit) * 0.3
                 tooltipContent: Hyprsunset.gamma === 100 ? `${Math.round(root.brightnessMonitor?.brightness * 100)}%` : `${Translation.tr("Gamma")} ${Hyprsunset.gamma}%`
                 onMoved: {
                     if (value >= 0.3) {
@@ -73,8 +76,10 @@ Rectangle {
                 visible: active
                 active: Config.options.sidebar.quickSliders.showVolume
                 sourceComponent: QuickSlider {
+                    entranceTrigger: root.entranceTrigger
+                    sliderIndex: 1
                     materialSymbol: "volume_up"
-                    value: Audio.sink?.audio?.volume ?? 0
+                    shownValue: Audio.sink?.audio?.volume ?? 0
                     onMoved: {
                         if (Audio.sink?.audio)
                             Audio.sink.audio.volume = value
@@ -88,8 +93,10 @@ Rectangle {
                 visible: active
                 active: Config.options.sidebar.quickSliders.showMic
                 sourceComponent: QuickSlider {
+                    entranceTrigger: root.entranceTrigger
+                    sliderIndex: 2
                     materialSymbol: "mic"
-                    value: Audio.source?.audio?.volume ?? 0
+                    shownValue: Audio.source?.audio?.volume ?? 0
                     onMoved: {
                         if (Audio.source?.audio)
                             Audio.source.audio.volume = value
@@ -103,6 +110,39 @@ Rectangle {
         id: quickSlider
         required property string materialSymbol
         property string secondaryMaterialSymbol
+        // The entrance is a FILL SWEEP, the sibling fork's slider grammar:
+        // the value holds at zero while the panel is away and glides up to
+        // the real reading when the open's trigger fires, staggered per
+        // slider - no fade anywhere. Call sites bind `shownValue`; `value`
+        // stays this component's own so the hold cannot destroy a binding.
+        property int entranceTrigger: -1
+        property int sliderIndex: 0
+        property real shownValue: 0
+        property bool entranceParked: false
+        value: entranceParked ? 0 : shownValue
+        onEntranceTriggerChanged: {
+            quickSlider.entranceParked = true;
+            sweepTimer.restart();
+        }
+        Timer {
+            id: sweepTimer
+            // The fork's cadence: 180ms head start, 70ms per slider.
+            interval: Appearance.animation.scale(180 + quickSlider.sliderIndex * 70)
+            onTriggered: {
+                // The named glide velocity turns the release into the fork's
+                // ~650ms sweep; restored (as a binding) once the sweep lands.
+                const sweepMs = Appearance.animation.scale(650);
+                quickSlider.valueVelocity = Math.max(0.05, quickSlider.shownValue / (sweepMs / 1000));
+                quickSlider.entranceParked = false;
+                sweepRestore.interval = sweepMs + 80;
+                sweepRestore.restart();
+            }
+        }
+        Timer {
+            id: sweepRestore
+            onTriggered: quickSlider.valueVelocity =
+                Qt.binding(() => Appearance.animation.elementMoveFast.velocity)
+        }
         configuration: StyledSlider.Configuration.M
         stopIndicatorValues: []
         dividerValues: secondaryMaterialSymbol.length > 0 ? [secondaryIcon.iconLocation] : []
@@ -118,6 +158,16 @@ Rectangle {
             iconSize: 20
             color: nearFull ? Appearance.colors.colOnPrimary : Appearance.colors.colOnSecondaryContainer
             text: quickSlider.materialSymbol
+            // The fork's slider icon spins with the fill - one turn across
+            // the whole range, settling with the same slight overshoot.
+            rotation: quickSlider.value * 360
+            Behavior on rotation {
+                NumberAnimation {
+                    duration: Appearance.animation.scale(350)
+                    easing.type: Easing.OutBack
+                    easing.overshoot: 1.5
+                }
+            }
 
             Behavior on color {
                 animation: Appearance.animation.elementMoveFast.colorAnimation.createObject(this)

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/QuickSliders.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/QuickSliders.qml
@@ -160,15 +160,12 @@ Rectangle {
             color: nearFull ? Appearance.colors.colOnPrimary : Appearance.colors.colOnSecondaryContainer
             text: quickSlider.materialSymbol
             // The fork's slider icon spins with the fill - one turn across
-            // the whole range, settling with the same slight overshoot.
+            // the whole range. No Behavior here: `value` already glides
+            // through the slider's own animation, so the binding is smooth
+            // by construction, and a Behavior stacked on an animated source
+            // is retargeted every frame of the sweep - the icon sat still
+            // for the whole fill and then whipped the turn in one beat.
             rotation: quickSlider.value * 360
-            Behavior on rotation {
-                NumberAnimation {
-                    duration: Appearance.animation.scale(350)
-                    easing.type: Easing.OutBack
-                    easing.overshoot: 1.5
-                }
-            }
 
             Behavior on color {
                 animation: Appearance.animation.elementMoveFast.colorAnimation.createObject(this)

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/SidebarRight.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/SidebarRight.qml
@@ -169,12 +169,7 @@ Scope {
                         }
                     }
 
-                    sourceComponent: SidebarRightContent {
-                        // The slide's own scalar, so the section cascade
-                        // gates on the real container progress instead of a
-                        // guessed lead-in.
-                        containerProgress: panelWindow.slide.progress
-                    }
+                    sourceComponent: SidebarRightContent {}
                 }
             }
         }

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/SidebarRight.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/SidebarRight.qml
@@ -169,7 +169,12 @@ Scope {
                         }
                     }
 
-                    sourceComponent: SidebarRightContent {}
+                    sourceComponent: SidebarRightContent {
+                        // The slide's own scalar, so the section cascade
+                        // gates on the real container progress instead of a
+                        // guessed lead-in.
+                        containerProgress: panelWindow.slide.progress
+                    }
                 }
             }
         }

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/SidebarRight.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/SidebarRight.qml
@@ -136,6 +136,9 @@ Scope {
                 property real cachedParentWidth: sidebarWidth
                 readonly property real restX: cachedParentWidth - width
                 x: restX + panelWindow.slide.offset
+                // The slide's curtain (see EdgeSlide.reveal): entrances run
+                // under it, so a member still parked is dimness, not a hole.
+                opacity: panelWindow.slide.reveal
 
                 Connections {
                     target: entranceWrapper.parent

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/SidebarRightContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/SidebarRightContent.qml
@@ -48,9 +48,47 @@ Item {
     readonly property MprisPlayer activePlayer: MprisController.activePlayer
     readonly property var meaningfulPlayers: MprisController.meaningfulPlayers
 
+    // The container's slide progress, handed in by SidebarRight.qml (the
+    // EdgeSlide's own scalar). Defaults to 1 so a tree built outside the
+    // panel - a test harness - has no gate it can never cross.
+    property real containerProgress: 1
+
+    // Container-then-fill, the popup card's grammar. This surface's first
+    // cascade was removed on the maintainer's on-screen verdict (00efe588
+    // ("revert(sidebar): the right sidebar's sections stop cascading")), and
+    // both facts behind that verdict are gone: the frame drop was the
+    // per-open surface teardown, which the persistent EdgeSlide surface
+    // removed - and the guessed three-step leadIn that landed the last member
+    // ~200ms after the slide is replaced by a gate on the slide's own
+    // progress, the exact scalar whose absence forced the guess. Re-adopted
+    // at the maintainer's request with both repairs in place.
+    readonly property bool contentsIn: Appearance.animation.contentsArrived(
+        root.containerProgress, GlobalStates.sidebarRightOpen)
+    onContentsInChanged: {
+        if (root.contentsIn && GlobalStates.sidebarRightOpen)
+            sectionEntrance.enter();
+    }
+
+    Component.onCompleted: {
+        // Park before the entrance starts - the arming-vs-running lesson the
+        // drawer paid for. A tree built mid-open past the gate (or outside
+        // the panel) parks nothing and stays drawn.
+        if (!root.contentsIn)
+            sectionEntrance.park();
+    }
+
     Connections {
         target: GlobalStates
         function onSidebarRightOpenChanged() {
+            if (GlobalStates.sidebarRightOpen) {
+                // A kept-loaded tree re-parks on the open's rising edge so the
+                // wave has something to reveal; a reopen caught past the gate
+                // (an exit reversed by a quick re-toggle) skips the park so
+                // drawn sections never blink out.
+                if (!root.contentsIn)
+                    sectionEntrance.park();
+                return;
+            }
             if (!GlobalStates.sidebarRightOpen) {
                 root.showWifiDialog = false;
                 root.showTailscaleDialog = false;
@@ -98,12 +136,29 @@ Item {
         radius: Appearance.rounding.screenRounding - Appearance.sizes.hyprlandGapsOut + 5
 
         ColumnLayout {
+            id: sidebarColumn
             anchors.fill: parent
             anchors.margins: sidebarPadding
             spacing: sidebarPadding
 
+            // The sections arrive in sequence once the slide has essentially
+            // landed. Ranking by VISIBLE position earns its place here: only
+            // one quick-panel style is ever active and the media player is
+            // absent with nothing playing, so unranked slots would leave
+            // holes mid-wave. No exit wave - the sections ride the slide out
+            // rigid, the same asymmetry the popup card keeps.
+            StaggerWave {
+                id: sectionEntrance
+                target: sidebarColumn
+            }
+            StaggerEntrance {
+                target: sidebarColumn
+                reference: root.sidebarWidth
+            }
+
             // Banner
             Loader {
+                property real appear: 1
                 Layout.fillWidth: true
                 Layout.fillHeight: false
                 sourceComponent: Config.options.sidebar.banner ? bannerComponent : normalComponent
@@ -303,6 +358,7 @@ Item {
 
             Loader {
                 id: slidersLoader
+                property real appear: 1
                 Layout.fillWidth: true
                 visible: active
                 active: {
@@ -316,6 +372,7 @@ Item {
 
             Loader {
                 id: mediaPlayerLoader
+                property real appear: 1
                 active: root.activePlayer !== null && GlobalStates.sidebarRightOpen && Config.options.sidebar.mediaPlayer
                 visible: active
                 Layout.fillWidth: true
@@ -341,6 +398,7 @@ Item {
             }
 
             CenterWidgetGroup {
+                property real appear: 1
                 Layout.alignment: Qt.AlignHCenter
                 Layout.fillHeight: true
                 Layout.fillWidth: true
@@ -348,6 +406,7 @@ Item {
 
             BottomWidgetGroup {
                 id: bottomWidgetGroup
+                property real appear: 1
                 Layout.alignment: Qt.AlignHCenter
                 Layout.fillHeight: false
                 Layout.fillWidth: true
@@ -448,6 +507,7 @@ Item {
 
     component LoaderedQuickPanelImplementation: Loader {
         id: quickPanelImplLoader
+        property real appear: 1
         required property string styleName
         Layout.alignment: item?.Layout.alignment ?? Qt.AlignHCenter
         Layout.fillWidth: item?.Layout.fillWidth ?? false

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/SidebarRightContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/SidebarRightContent.qml
@@ -68,13 +68,33 @@ Item {
     // last-ranked one or two elements visibly pop after the panel lands.
     // So: park and enter on the open's rising edge, with no gate - the slide
     // masks the wave's early frames, and the tail is the grammar.
+    // With keepRightSidebarLoaded off, this whole tree is created INSIDE the
+    // sidebarRightOpenChanged emission (the loader's `active` follows
+    // `slide.shown` synchronously) - and a connection made during an
+    // emission does not receive that emission. The Connections below then
+    // misses every open, because the tree is torn down on close: no wave, no
+    // trigger, ever. So a tree born with the panel already open runs the
+    // entrance itself, one turn later - after the children (and the
+    // calendar's own creation-edge arming) have finished coming up.
+    Component.onCompleted: {
+        if (GlobalStates.sidebarRightOpen)
+            Qt.callLater(() => {
+                if (GlobalStates.sidebarRightOpen)
+                    root.runEntrance();
+            });
+    }
+
+    function runEntrance() {
+        sectionEntrance.park();
+        sectionEntrance.enter();
+        root.entranceTrigger++;
+    }
+
     Connections {
         target: GlobalStates
         function onSidebarRightOpenChanged() {
             if (GlobalStates.sidebarRightOpen) {
-                sectionEntrance.park();
-                sectionEntrance.enter();
-                root.entranceTrigger++;
+                root.runEntrance();
                 return;
             }
             if (!GlobalStates.sidebarRightOpen) {

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/SidebarRightContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/SidebarRightContent.qml
@@ -45,6 +45,13 @@ Item {
     // compositor blur region to it (see WindowBlurRegion in SidebarRight.qml).
     readonly property Item backgroundItem: sidebarRightBackground
 
+    // One counter drives every bespoke widget entrance, the fork's own
+    // architecture: sliders sweep their fill, the calendar ripples
+    // diagonally, the notification bar's halves converge - each widget owns
+    // its choreography and this only says "an open happened". The generic
+    // wave stays for the sections with no character of their own.
+    property int entranceTrigger: -1
+
     readonly property MprisPlayer activePlayer: MprisController.activePlayer
     readonly property var meaningfulPlayers: MprisController.meaningfulPlayers
 
@@ -67,6 +74,7 @@ Item {
             if (GlobalStates.sidebarRightOpen) {
                 sectionEntrance.park();
                 sectionEntrance.enter();
+                root.entranceTrigger++;
                 return;
             }
             if (!GlobalStates.sidebarRightOpen) {
@@ -346,7 +354,9 @@ Item {
 
             Loader {
                 id: slidersLoader
-                property real appear: 1
+                // Not a wave member: the sliders own their entrance (the
+                // fill sweep) - a fading section over sweeping sliders is
+                // the compound the toggle grid already paid for.
                 Layout.fillWidth: true
                 visible: active
                 active: {
@@ -355,7 +365,7 @@ Item {
                     if (!configQuickSliders.showMic && !configQuickSliders.showVolume && !configQuickSliders.showBrightness) return false;
                     return true;
                 }
-                sourceComponent: QuickSliders {}
+                sourceComponent: QuickSliders { entranceTrigger: root.entranceTrigger }
             }
 
             Loader {
@@ -386,7 +396,7 @@ Item {
             }
 
             CenterWidgetGroup {
-                property real appear: 1
+                entranceTrigger: root.entranceTrigger
                 Layout.alignment: Qt.AlignHCenter
                 Layout.fillHeight: true
                 Layout.fillWidth: true
@@ -394,7 +404,7 @@ Item {
 
             BottomWidgetGroup {
                 id: bottomWidgetGroup
-                property real appear: 1
+                entranceTrigger: root.entranceTrigger
                 Layout.alignment: Qt.AlignHCenter
                 Layout.fillHeight: false
                 Layout.fillWidth: true

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/SidebarRightContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/SidebarRightContent.qml
@@ -495,7 +495,12 @@ Item {
 
     component LoaderedQuickPanelImplementation: Loader {
         id: quickPanelImplLoader
-        property real appear: 1
+        // Deliberately NOT a wave member (no `appear`): the android panel's
+        // tiles run their own entrance, and a fading section times a fading
+        // tile is two opacities MULTIPLIED - measured at full resolution as
+        // a ~250ms mushy tail of half-visible tiles, which is what read as
+        // broken. One fade per pixel: the section stands still, the pieces
+        // move - the fork's own rule, finally applied where it bites.
         required property string styleName
         Layout.alignment: item?.Layout.alignment ?? Qt.AlignHCenter
         Layout.fillWidth: item?.Layout.fillWidth ?? false

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/SidebarRightContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/SidebarRightContent.qml
@@ -48,45 +48,25 @@ Item {
     readonly property MprisPlayer activePlayer: MprisController.activePlayer
     readonly property var meaningfulPlayers: MprisController.meaningfulPlayers
 
-    // The container's slide progress, handed in by SidebarRight.qml (the
-    // EdgeSlide's own scalar). Defaults to 1 so a tree built outside the
-    // panel - a test harness - has no gate it can never cross.
-    property real containerProgress: 1
-
-    // Container-then-fill, the popup card's grammar. This surface's first
-    // cascade was removed on the maintainer's on-screen verdict (00efe588
-    // ("revert(sidebar): the right sidebar's sections stop cascading")), and
-    // both facts behind that verdict are gone: the frame drop was the
-    // per-open surface teardown, which the persistent EdgeSlide surface
-    // removed - and the guessed three-step leadIn that landed the last member
-    // ~200ms after the slide is replaced by a gate on the slide's own
-    // progress, the exact scalar whose absence forced the guess. Re-adopted
-    // at the maintainer's request with both repairs in place.
-    readonly property bool contentsIn: Appearance.animation.contentsArrived(
-        root.containerProgress, GlobalStates.sidebarRightOpen)
-    onContentsInChanged: {
-        if (root.contentsIn && GlobalStates.sidebarRightOpen)
-            sectionEntrance.enter();
-    }
-
-    Component.onCompleted: {
-        // Park before the entrance starts - the arming-vs-running lesson the
-        // drawer paid for. A tree built mid-open past the gate (or outside
-        // the panel) parks nothing and stays drawn.
-        if (!root.contentsIn)
-            sectionEntrance.park();
-    }
-
+    // The entrance runs UNDER the slide, not after it. This surface's wave
+    // shipped twice wrong before landing here, and both wrong versions are
+    // worth naming. The original (00efe588's revert) guessed a leadIn and
+    // landed content ~200ms after the slide. The second gated on the slide's
+    // progress like the popup card - correct-sounding, and measured as
+    // ruined: the panel arrived EMPTY and then visibly built itself, because
+    // parked-at-zero content plus a 60% gate puts the whole construction ON
+    // STAGE. The fork's sidebars, re-recorded and read object by object, do
+    // the opposite: the surface's own fade carries the panel already
+    // composed - the per-element entrances run underneath it, and only the
+    // last-ranked one or two elements visibly pop after the panel lands.
+    // So: park and enter on the open's rising edge, with no gate - the slide
+    // masks the wave's early frames, and the tail is the grammar.
     Connections {
         target: GlobalStates
         function onSidebarRightOpenChanged() {
             if (GlobalStates.sidebarRightOpen) {
-                // A kept-loaded tree re-parks on the open's rising edge so the
-                // wave has something to reveal; a reopen caught past the gate
-                // (an exit reversed by a quick re-toggle) skips the park so
-                // drawn sections never blink out.
-                if (!root.contentsIn)
-                    sectionEntrance.park();
+                sectionEntrance.park();
+                sectionEntrance.enter();
                 return;
             }
             if (!GlobalStates.sidebarRightOpen) {
@@ -517,13 +497,6 @@ Item {
         id: quickPanelImplLoader
         property real appear: 1
         required property string styleName
-        // Hand the section's appear down so a panel that nests its own tile
-        // wave can gate it on this section's arrival. Duck-typed: the classic
-        // panel declares no sectionAppear and takes no wave.
-        onLoaded: {
-            if (item && item.sectionAppear !== undefined)
-                item.sectionAppear = Qt.binding(() => quickPanelImplLoader.appear);
-        }
         Layout.alignment: item?.Layout.alignment ?? Qt.AlignHCenter
         Layout.fillWidth: item?.Layout.fillWidth ?? false
         visible: active

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/SidebarRightContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/SidebarRightContent.qml
@@ -154,6 +154,11 @@ Item {
             StaggerEntrance {
                 target: sidebarColumn
                 reference: root.sidebarWidth
+                // Sections are full-width, so convergence degenerates to the
+                // vertical alternation - consecutive sections arrive from
+                // above and below their places rather than as one rising
+                // sheet - with the overshoot settle on top.
+                convergent: true
             }
 
             // Banner
@@ -509,6 +514,13 @@ Item {
         id: quickPanelImplLoader
         property real appear: 1
         required property string styleName
+        // Hand the section's appear down so a panel that nests its own tile
+        // wave can gate it on this section's arrival. Duck-typed: the classic
+        // panel declares no sectionAppear and takes no wave.
+        onLoaded: {
+            if (item && item.sectionAppear !== undefined)
+                item.sectionAppear = Qt.binding(() => quickPanelImplLoader.appear);
+        }
         Layout.alignment: item?.Layout.alignment ?? Qt.AlignHCenter
         Layout.fillWidth: item?.Layout.fillWidth ?? false
         visible: active

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/SidebarRightContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/SidebarRightContent.qml
@@ -154,11 +154,14 @@ Item {
             StaggerEntrance {
                 target: sidebarColumn
                 reference: root.sidebarWidth
-                // Sections are full-width, so convergence degenerates to the
-                // vertical alternation - consecutive sections arrive from
-                // above and below their places rather than as one rising
-                // sheet - with the overshoot settle on top.
-                convergent: true
+                // Deliberately UNIFORM at the section level. The convergent
+                // mode was tried here and read as ruined on screen: a section
+                // translating in from above or below WHILE its own interior
+                // converges (the toggle grid's tiles) is two directional
+                // motions stacked, and the fork this grammar was measured off
+                // never does that - its sections hold still and their PIECES
+                // converge. Sections keep the calm fade-scale-rise; the
+                // directional language lives one level down.
             }
 
             // Banner

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/calendar/CalendarDayButton.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/calendar/CalendarDayButton.qml
@@ -9,6 +9,37 @@ RippleButton {
     property int isToday
     property bool bold
     property bool hasEvent: false
+    // The diagonal ripple, the sibling fork's calendar entrance: each cell
+    // arrives (row + col) * 28ms after the trigger, so the month sweeps in
+    // from the top-left corner. Channel discipline: the cell is a
+    // RippleButton, so the entrance is spoken entirely through `appear` -
+    // the one seam the control folds into its own opacity and rise - never
+    // through opacity or scale, which the interaction model owns. Header
+    // cells pass no grid position and stay inert.
+    property int gridRow: -1
+    property int gridCol: -1
+    property int entranceKey: 0
+    onEntranceKeyChanged: {
+        if (gridRow < 0 || gridCol < 0)
+            return;
+        cellRipple.stop();
+        button.appear = 0;
+        cellRipple.start();
+    }
+    SequentialAnimation {
+        id: cellRipple
+        PauseAnimation {
+            duration: Appearance.animation.scale((Math.max(0, button.gridRow) + Math.max(0, button.gridCol)) * 28)
+        }
+        NumberAnimation {
+            target: button
+            property: "appear"
+            from: 0
+            to: 1
+            duration: Appearance.animation.scale(220)
+            easing.type: Easing.OutCubic
+        }
+    }
 
     Layout.fillWidth: false
     Layout.fillHeight: false

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/calendar/CalendarWidget.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/calendar/CalendarWidget.qml
@@ -12,7 +12,18 @@ Item {
     // navigation, which is the fork's own behavior.
     property int entranceTrigger: -1
     property int _entranceKey: 0
-    onEntranceTriggerChanged: _entranceKey++
+    // The counter arrives as a late Qt.binding from the tab Loader's
+    // onLoaded, so a widget created mid-open sees one jump from -1 to the
+    // current count in its creation turn - that is the binding catching up,
+    // not the sidebar opening, and it replayed the ripple over every
+    // Todo-to-Calendar switch. The handler arms one turn after creation:
+    // a real open is always a later turn.
+    property bool _entranceArmed: false
+    Component.onCompleted: Qt.callLater(() => root._entranceArmed = true)
+    onEntranceTriggerChanged: {
+        if (root._entranceArmed)
+            root._entranceKey++;
+    }
     onMonthShiftChanged: _entranceKey++
     // One grid column, on the 4dp grid. Seven rows of this plus the 32px header,
     // the gaps and the padding have to fit BottomWidgetGroup's fixed height, or

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/calendar/CalendarWidget.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/calendar/CalendarWidget.qml
@@ -8,6 +8,12 @@ import QtQuick.Layouts
 Item {
     id: root
     property int monthShift: 0
+    // The sidebar's open counter; the ripple also re-runs on month
+    // navigation, which is the fork's own behavior.
+    property int entranceTrigger: -1
+    property int _entranceKey: 0
+    onEntranceTriggerChanged: _entranceKey++
+    onMonthShiftChanged: _entranceKey++
     // One grid column, on the 4dp grid. Seven rows of this plus the 32px header,
     // the gaps and the padding have to fit BottomWidgetGroup's fixed height, or
     // the group grows and takes it straight out of the notification list below.
@@ -139,6 +145,9 @@ Item {
                     delegate: CalendarDayButton {
                         implicitWidth: root.dayCellSize
                         implicitHeight: root.dayCellSize
+                        gridRow: modelData
+                        gridCol: index
+                        entranceKey: root._entranceKey
                         day: calendarLayout[modelData][index].day
                         isToday: calendarLayout[modelData][index].today
                         // Only in-viewing-month cells (today !== -1) map cleanly

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/notifications/NotificationList.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/notifications/NotificationList.qml
@@ -51,6 +51,33 @@ Item {
         }
     }
 
+    // The status bar's entrance is the fork's converging halves: the snooze
+    // icon slides in from the left, the clear icon from the right, the count
+    // fading between them, after the fork's own deliberate 250ms beat. The
+    // buttons are GroupButtons, whose opacity and transform are free
+    // channels (no interaction model, no dim) - the same reading that lets
+    // the toggle tiles be dressed.
+    property int entranceTrigger: -1
+    property real _convergeLeft: 0
+    property real _convergeRight: 0
+    property real _statusOpacity: 1
+    onEntranceTriggerChanged: {
+        statusConverge.stop();
+        root._convergeLeft = -40;
+        root._convergeRight = 40;
+        root._statusOpacity = 0;
+        statusConverge.start();
+    }
+    SequentialAnimation {
+        id: statusConverge
+        PauseAnimation { duration: Appearance.animation.scale(250) }
+        ParallelAnimation {
+            NumberAnimation { target: root; property: "_statusOpacity"; from: 0; to: 1; duration: Appearance.animation.scale(320); easing.type: Easing.OutCubic }
+            NumberAnimation { target: root; property: "_convergeLeft"; from: -40; to: 0; duration: Appearance.animation.scale(350); easing.type: Easing.OutCubic }
+            NumberAnimation { target: root; property: "_convergeRight"; from: 40; to: 0; duration: Appearance.animation.scale(350); easing.type: Easing.OutCubic }
+        }
+    }
+
     ButtonGroup {
         id: statusRow
         anchors {
@@ -63,6 +90,8 @@ Item {
             Layout.fillWidth: false
             buttonIcon: "notifications_paused"
             toggled: Notifications.silent
+            opacity: root._statusOpacity
+            transform: Translate { x: root._convergeLeft }
             onClicked: () => {
                 Notifications.silent = !Notifications.silent;
             }
@@ -70,11 +99,14 @@ Item {
         NotificationStatusButton {
             enabled: false
             Layout.fillWidth: true
+            opacity: root._statusOpacity
             buttonText: Translation.tr("%1 notifications").arg(Notifications.list.length)
         }
         NotificationStatusButton {
             Layout.fillWidth: false
             buttonIcon: "delete_sweep"
+            opacity: root._statusOpacity
+            transform: Translate { x: root._convergeRight }
             onClicked: () => {
                 Notifications.discardAllNotifications()
             }

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/quickToggles/AndroidQuickPanel.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/quickToggles/AndroidQuickPanel.qml
@@ -47,14 +47,7 @@ AbstractQuickPanel {
     readonly property string unusedSignature: QuickToggleLayout.signatureOf(root.unusedToggles, root.columns)
     onUsedSignatureChanged: root.requestSync()
     onUnusedSignatureChanged: root.requestSync()
-    Component.onCompleted: {
-        root.requestSync();
-        // Park the tile wave when the tree is built before its section has
-        // arrived, so the first open reveals the tiles instead of finding
-        // them already drawn.
-        if (!root.tilesIn)
-            tileWave.park();
-    }
+    Component.onCompleted: root.requestSync()
 
     // ...and the sync itself waits for the turn to finish, because a live
     // `list<var>` notifies per ELEMENT written. Measured: one
@@ -77,23 +70,18 @@ AbstractQuickPanel {
         });
     }
 
-    // The section's own `appear`, handed in by the sidebar's loader: the
-    // tiles run a second, nested container-then-fill on it - the section
-    // arrives on the panel wave, and once it has essentially landed
-    // (contentsArrived on ITS appear, the same gate arithmetic one level
-    // down), the tiles converge into the grid from their own sides.
-    property real sectionAppear: 1
-    readonly property bool tilesIn: Appearance.animation.contentsArrived(
-        root.sectionAppear, GlobalStates.sidebarRightOpen)
-    onTilesInChanged: {
-        if (root.tilesIn && GlobalStates.sidebarRightOpen)
-            tileWave.enter();
-    }
+    // The tiles' wave starts WITH the open, ungated: it runs under the
+    // panel's slide, so the grid is composed as the edge reveals it and only
+    // the last-ranked tiles visibly land after - the fork's grammar, read
+    // off its re-recorded sidebars (the gated version put the whole build on
+    // stage and was judged ruined twice).
     Connections {
         target: GlobalStates
         function onSidebarRightOpenChanged() {
-            if (GlobalStates.sidebarRightOpen && !root.tilesIn)
+            if (GlobalStates.sidebarRightOpen) {
                 tileWave.park();
+                tileWave.enter();
+            }
         }
     }
 

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/quickToggles/AndroidQuickPanel.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/quickToggles/AndroidQuickPanel.qml
@@ -119,6 +119,9 @@ AbstractQuickPanel {
             StaggerWave {
                 id: tileWave
                 target: usedGrid
+                // The fork's tile cadence (80 + 25ms per tile); our default
+                // 40ms step reads sluggish across a 15-tile grid.
+                step: 25
             }
             StaggerEntrance {
                 target: usedGrid

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/quickToggles/AndroidQuickPanel.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/quickToggles/AndroidQuickPanel.qml
@@ -1,3 +1,4 @@
+import qs
 import qs.services
 import qs.modules.common
 import qs.modules.common.widgets
@@ -46,7 +47,14 @@ AbstractQuickPanel {
     readonly property string unusedSignature: QuickToggleLayout.signatureOf(root.unusedToggles, root.columns)
     onUsedSignatureChanged: root.requestSync()
     onUnusedSignatureChanged: root.requestSync()
-    Component.onCompleted: root.requestSync()
+    Component.onCompleted: {
+        root.requestSync();
+        // Park the tile wave when the tree is built before its section has
+        // arrived, so the first open reveals the tiles instead of finding
+        // them already drawn.
+        if (!root.tilesIn)
+            tileWave.park();
+    }
 
     // ...and the sync itself waits for the turn to finish, because a live
     // `list<var>` notifies per ELEMENT written. Measured: one
@@ -67,6 +75,26 @@ AbstractQuickPanel {
             usedModel.sync(root.toggles, root.columns);
             unusedModel.sync(root.unusedToggles, root.columns);
         });
+    }
+
+    // The section's own `appear`, handed in by the sidebar's loader: the
+    // tiles run a second, nested container-then-fill on it - the section
+    // arrives on the panel wave, and once it has essentially landed
+    // (contentsArrived on ITS appear, the same gate arithmetic one level
+    // down), the tiles converge into the grid from their own sides.
+    property real sectionAppear: 1
+    readonly property bool tilesIn: Appearance.animation.contentsArrived(
+        root.sectionAppear, GlobalStates.sidebarRightOpen)
+    onTilesInChanged: {
+        if (root.tilesIn && GlobalStates.sidebarRightOpen)
+            tileWave.enter();
+    }
+    Connections {
+        target: GlobalStates
+        function onSidebarRightOpenChanged() {
+            if (GlobalStates.sidebarRightOpen && !root.tilesIn)
+                tileWave.park();
+        }
     }
 
     StableQuickToggleModel { id: usedModel }
@@ -93,6 +121,21 @@ AbstractQuickPanel {
             id: usedGrid
             width: contentItem.width
             implicitHeight: root.gridHeight(usedModel)
+
+            // The tiles' own wave: convergent, so each tile arrives from its
+            // side of the grid - the leftmost third from the left, the
+            // rightmost from the right, alternating from above and below -
+            // with the overshoot settle. Delegates rooted on
+            // AndroidQuickToggleButton declare `appear`; the few widget-type
+            // toggles that do not are simply not members and arrive drawn.
+            StaggerWave {
+                id: tileWave
+                target: usedGrid
+            }
+            StaggerEntrance {
+                target: usedGrid
+                convergent: true
+            }
 
             Repeater {
                 model: usedModel

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/quickToggles/AndroidQuickPanel.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/quickToggles/AndroidQuickPanel.qml
@@ -119,8 +119,15 @@ AbstractQuickPanel {
             StaggerWave {
                 id: tileWave
                 target: usedGrid
-                // The fork's tile cadence (80 + 25ms per tile); our default
-                // 40ms step reads sluggish across a 15-tile grid.
+                // The fork's tile cadence: an 80ms head start before ANY
+                // tile, then 25ms per tile. The head start is load-bearing:
+                // without it ranks 0-2 begin fading the instant the panel
+                // edge appears and are well-lit before anything else has
+                // started - three tiles reading as "always there, then the
+                // animation begins", which is exactly the pause the
+                // maintainer kept seeing. With it the whole grid rises as
+                // one shimmering field behind the slide's curtain.
+                leadIn: 80
                 step: 25
             }
             StaggerEntrance {

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/quickToggles/AndroidQuickPanel.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/quickToggles/AndroidQuickPanel.qml
@@ -123,6 +123,11 @@ AbstractQuickPanel {
             id: usedGrid
             width: contentItem.width
             implicitHeight: root.gridHeight(usedModel)
+            // Read by a tile deciding whether its arrival is its own to
+            // animate: while this wave is running (or armed), the wave owns
+            // every arrival, and a tile fading itself under it would be a
+            // second writer on `appear`.
+            property StaggerWave entranceWave: tileWave
 
             // The tiles' own wave: convergent, so each tile arrives from its
             // side of the grid - the leftmost third from the left, the

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/quickToggles/AndroidQuickPanel.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/quickToggles/AndroidQuickPanel.qml
@@ -47,7 +47,21 @@ AbstractQuickPanel {
     readonly property string unusedSignature: QuickToggleLayout.signatureOf(root.unusedToggles, root.columns)
     onUsedSignatureChanged: root.requestSync()
     onUnusedSignatureChanged: root.requestSync()
-    Component.onCompleted: root.requestSync()
+    // The second arm mirrors SidebarRightContent's: with the keep-loaded
+    // toggle off this panel is created inside the open's own emission, and a
+    // connection made mid-emission never hears it - so a panel born open
+    // runs its wave itself, one turn later, after the sync scheduled above
+    // has built the tiles the wave walks.
+    Component.onCompleted: {
+        root.requestSync();
+        if (GlobalStates.sidebarRightOpen)
+            Qt.callLater(() => {
+                if (GlobalStates.sidebarRightOpen) {
+                    tileWave.park();
+                    tileWave.enter();
+                }
+            });
+    }
 
     // ...and the sync itself waits for the turn to finish, because a live
     // `list<var>` notifies per ELEMENT written. Measured: one

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/quickToggles/androidStyle/AndroidQuickToggleButton.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/quickToggles/androidStyle/AndroidQuickToggleButton.qml
@@ -49,10 +49,16 @@ GroupButton {
     // StaggerEntrance owns opacity/scale/translate through this): a tile
     // added mid-session simply appears in place, which is what the old
     // opacity: 0 + onCompleted self-fade approximated one tile at a time.
+    // No Behavior on opacity: the wave animates `appear` and opacity is a
+    // binding on it, so a Behavior here is a second animation on the same
+    // channel. The one left behind by the self-fade's retirement turned
+    // park()'s snap-to-invisible into a 200ms on-stage fade-out (measured:
+    // appear=0 with drawn opacity still 1.000 at the open, dimmest at
+    // ~140ms, and pinned at 0.15 by per-frame retargets while `appear`
+    // animated - b710ef731's frozen-Behavior shape - so the tile landed
+    // ~200ms after its own wave slot). That was the "toggles visible, then
+    // the animation begins" pause.
     property real appear: 1
-    Behavior on opacity {
-        animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
-    }
 
     // The grid is one flat container and a tile places itself in it, so a
     // reorder is a delegate travelling to another slot rather than a row of

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/quickToggles/androidStyle/AndroidQuickToggleButton.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/quickToggles/androidStyle/AndroidQuickToggleButton.qml
@@ -45,8 +45,11 @@ GroupButton {
     Behavior on baseHeight {
         animation: Appearance.animation.elementMove.numberAnimation.createObject(this)
     }
-    opacity: 0
-    Component.onCompleted: { opacity = 1 }
+    // The tile's arrival is the panel's convergent wave now (the panel's
+    // StaggerEntrance owns opacity/scale/translate through this): a tile
+    // added mid-session simply appears in place, which is what the old
+    // opacity: 0 + onCompleted self-fade approximated one tile at a time.
+    property real appear: 1
     Behavior on opacity {
         animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
     }

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/quickToggles/androidStyle/AndroidQuickToggleButton.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/quickToggles/androidStyle/AndroidQuickToggleButton.qml
@@ -1,3 +1,4 @@
+import qs
 import QtQuick
 import QtQuick.Layouts
 import qs.services
@@ -59,6 +60,39 @@ GroupButton {
     // ~200ms after its own wave slot). That was the "toggles visible, then
     // the animation begins" pause.
     property real appear: 1
+
+    // A tile born mid-session - edit mode adding it, a config change - used
+    // to pop in at full strength in one frame: the dresser dresses arrivals,
+    // but only an enter() animates them, and none is running. So a tile
+    // created while the panel is on screen parks itself and runs the one
+    // fade the retired self-fade used to be. The check is deferred a turn
+    // because of the one case where every tile is "late": a tree built with
+    // the panel already open (keepRightSidebarLoaded off). There the panel's
+    // wave enters right after the model sync, so by the time this looks, the
+    // wave is running (or armed) and the tile stands down - one writer on
+    // `appear`, always.
+    Component.onCompleted: {
+        root.appear = 0;
+        Qt.callLater(() => {
+            const wave = root.gridRef?.entranceWave ?? null;
+            if (wave && (wave.active.length > 0 || wave.pendingEnter))
+                return;
+            if (!GlobalStates.sidebarRightOpen) {
+                root.appear = 1;
+                return;
+            }
+            lateArrival.restart();
+        });
+    }
+    NumberAnimation {
+        id: lateArrival
+        target: root
+        property: "appear"
+        to: 1
+        duration: Appearance.animation.elementMoveFast.duration
+        easing.type: Appearance.animation.elementMoveFast.type
+        easing.bezierCurve: Appearance.animation.elementMoveFast.bezierCurve
+    }
 
     // The grid is one flat container and a tile places itself in it, so a
     // reorder is a delegate travelling to another slot rather than a row of

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/todo/TaskList.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/todo/TaskList.qml
@@ -20,7 +20,12 @@ Item {
         id: listView
         anchors.fill: parent
         spacing: root.todoListItemSpacing
-        animateAppearance: false
+        // animateAppearance stays at the view's default (on): a task marked done
+        // slides out and the rows below close the gap, instead of the list
+        // hard-cutting to its new shape. That only works because taskList holds
+        // the same objects Todo.list does - ScriptModel diffs by identity, so a
+        // per-update wrapper would read as remove-all + add-all and fly the
+        // whole list in on every change.
         model: ScriptModel {
             values: root.taskList
         }
@@ -77,10 +82,14 @@ Item {
                         TodoItemActionButton {
                             Layout.fillWidth: false
                             onClicked: {
+                                // Resolved at click time: modelData IS the item in
+                                // Todo.list (identity preserved for the model diff),
+                                // and a stored index goes stale across deletes.
+                                const index = Todo.list.indexOf(todoItem.modelData);
                                 if (!todoItem.modelData.done)
-                                    Todo.markDone(todoItem.modelData.originalIndex);
+                                    Todo.markDone(index);
                                 else
-                                    Todo.markUnfinished(todoItem.modelData.originalIndex);
+                                    Todo.markUnfinished(index);
                             }
                             contentItem: MaterialSymbol {
                                 anchors.centerIn: parent
@@ -93,7 +102,7 @@ Item {
                         TodoItemActionButton {
                             Layout.fillWidth: false
                             onClicked: {
-                                Todo.deleteItem(todoItem.modelData.originalIndex);
+                                Todo.deleteItem(Todo.list.indexOf(todoItem.modelData));
                             }
                             contentItem: MaterialSymbol {
                                 anchors.centerIn: parent

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/todo/TaskList.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/todo/TaskList.qml
@@ -36,6 +36,26 @@ Item {
             property bool pendingDelete: false
             property bool enableHeightAnimation: false
 
+            // Resolved at click time - a stored index goes stale across
+            // deletes. Identity first: on current quickshell, ScriptModel
+            // hands the delegate the very object Todo.list holds. But that
+            // is a property of the PIN, not of QML - before quickshell
+            // a611932 ("core/scriptmodel: represent members as a
+            // QJSValueList") the model stored QVariants and every delegate
+            // saw a fresh copy, so indexOf answered -1 and each done/delete
+            // click was a silent no-op (the Gentoo ebuild pins exactly such
+            // a commit). The content fallback covers those installs; equal
+            // payloads are interchangeable, so a duplicate task resolving to
+            // its twin commits the same edit.
+            function resolveIndex(): int {
+                const md = todoItem.modelData;
+                const idx = Todo.list.indexOf(md);
+                if (idx !== -1)
+                    return idx;
+                return Todo.list.findIndex(task =>
+                    task.content === md.content && task.done === md.done);
+            }
+
             implicitHeight: todoItemRectangle.implicitHeight
             width: ListView.view.width
             clip: true
@@ -82,10 +102,9 @@ Item {
                         TodoItemActionButton {
                             Layout.fillWidth: false
                             onClicked: {
-                                // Resolved at click time: modelData IS the item in
-                                // Todo.list (identity preserved for the model diff),
-                                // and a stored index goes stale across deletes.
-                                const index = Todo.list.indexOf(todoItem.modelData);
+                                const index = todoItem.resolveIndex();
+                                if (index === -1)
+                                    return;
                                 if (!todoItem.modelData.done)
                                     Todo.markDone(index);
                                 else
@@ -102,7 +121,9 @@ Item {
                         TodoItemActionButton {
                             Layout.fillWidth: false
                             onClicked: {
-                                Todo.deleteItem(Todo.list.indexOf(todoItem.modelData));
+                                const index = todoItem.resolveIndex();
+                                if (index !== -1)
+                                    Todo.deleteItem(index);
                             }
                             contentItem: MaterialSymbol {
                                 anchors.centerIn: parent

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/todo/TodoWidget.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/todo/TodoWidget.qml
@@ -61,21 +61,23 @@ Item {
             currentIndex: tabBar.currentIndex
 
             // To Do tab
+            // The filters pass Todo.list's own objects through untouched:
+            // TaskList's ScriptModel diffs by identity, so wrapping each item in
+            // a fresh object per update (the old Object.assign originalIndex
+            // annotation) made every change read as remove-all + add-all and no
+            // list transition could ever fire. Indices are resolved at click
+            // time in TaskList instead.
             TaskList {
                 listBottomPadding: root.fabSize + root.fabMargins * 2
                 emptyPlaceholderIcon: "check_circle"
                 emptyPlaceholderText: Translation.tr("Nothing here!")
-                taskList: Todo.list
-                    .map(function(item, i) { return Object.assign({}, item, {originalIndex: i}); })
-                    .filter(function(item) { return !item.done; })
+                taskList: Todo.list.filter(function(item) { return !item.done; })
             }
             TaskList {
                 listBottomPadding: root.fabSize + root.fabMargins * 2
                 emptyPlaceholderIcon: "checklist"
                 emptyPlaceholderText: Translation.tr("Finished tasks will go here")
-                taskList: Todo.list
-                    .map(function(item, i) { return Object.assign({}, item, {originalIndex: i}); })
-                    .filter(function(item) { return item.done; })
+                taskList: Todo.list.filter(function(item) { return item.done; })
             }
 
         }

--- a/dots/.config/quickshell/imi/services/ai_catalog.js
+++ b/dots/.config/quickshell/imi/services/ai_catalog.js
@@ -170,7 +170,10 @@ function buildModel(providerDef, entry) {
     }
     return {
         "id": providerDef.id + ":" + value,
-        "legacyId": entry.legacyId !== undefined ? entry.legacyId : "",
+        // Normalized to a string here so resolve() may ask .length without
+        // ceremony: stage 2's extraModels feed is user-authored JSON, where
+        // a null legacyId is one typo away.
+        "legacyId": typeof entry.legacyId === "string" ? entry.legacyId : "",
         "providerId": providerDef.id,
         "value": value,
         "name": entry.name !== undefined ? entry.name : value,
@@ -272,7 +275,8 @@ function resolve(id) {
             return models[i];
     }
     for (var j = 0; j < models.length; j++) {
-        if (models[j].legacyId.length > 0 && models[j].legacyId === wanted)
+        if (typeof models[j].legacyId === "string" && models[j].legacyId.length > 0
+                && models[j].legacyId === wanted)
             return models[j];
     }
     return null;

--- a/dots/.config/quickshell/imi/services/ai_catalog.js
+++ b/dots/.config/quickshell/imi/services/ai_catalog.js
@@ -1,0 +1,279 @@
+.pragma library
+
+// The AI provider/model catalog: every provider and built-in model the shell
+// knows, described in one place - id, display name, API dialect, endpoint
+// shape, capability flags, key metadata - so the chat service, the settings
+// page and the tests read one answer instead of each keeping a copy.
+//
+// Pure on purpose, like services/frecency.js and services/sound_theme.js:
+// no Qt, no Config, no Translation, no processes. services/Ai.qml owns the
+// processes, the keyring reads and the request lifecycle; this owns the data
+// and the lookups, which is what makes them reachable from qmltestrunner.
+//
+// Two things deliberately stay OUT of this file:
+// - Translated strings. Model descriptions are Translation.tr(...) literals,
+//   and the translation extractor only sees that form (see AGENT.md on
+//   BarWidgets), so they stay in QML, keyed by the ids declared here.
+// - Key MATERIAL. The catalog carries key metadata (keyId, keyGetLink);
+//   the keys themselves live in the keyring, read only by services/Ai.qml
+//   through services/KeyringStorage.qml. Nothing here may ever hold one.
+//
+// Until services/Ai.qml reads this catalog (stage 2 of
+// docs/proposals/ai-assistant-upgrade.md), the built-in model literals exist
+// twice - here and in Ai.qml's `models` map - and
+// tests/test_ai_catalog_contract.py pins the two copies equal so neither can
+// drift while the wiring waits.
+//
+// Ids are "provider:value" (stable across renames of either display name).
+// Today's Ai.qml keys its models by hand-chosen flat names; each model
+// records that name as `legacyId`, and resolve() answers both, so stage 2
+// needs no Persistent migration for a saved model choice.
+
+// How a dialect's requests are shaped. `id` must match a strategy in
+// services/ai/ (Ai.qml's `apiStrategies` keys); the contract test pins that.
+// - endpointShape: where the model name goes. "model-in-path" bakes it into
+//   the URL (the {model} slot in the provider's endpoint template);
+//   "chat-completions" posts it in the request body to a fixed URL.
+// - auth: how the key travels. "query-key" appends ?key=..., "bearer-header"
+//   sends Authorization: Bearer. Either way the key reaches curl through an
+//   environment variable, never spliced into the script text.
+// - streaming: "json-array" is Gemini's streamed JSON array;
+//   "sse" is data:-prefixed server-sent events with a [DONE] terminator.
+var DIALECTS = {
+    "gemini": {
+        "id": "gemini",
+        "endpointShape": "model-in-path",
+        "auth": "query-key",
+        "streaming": "json-array"
+    },
+    "openai": {
+        "id": "openai",
+        "endpointShape": "chat-completions",
+        "auth": "bearer-header",
+        "streaming": "sse"
+    },
+    // Same wire shape as "openai"; a separate dialect because the
+    // function-call/tool-response message turns differ enough to need their
+    // own strategy (see services/ai/MistralApiStrategy.qml).
+    "mistral": {
+        "id": "mistral",
+        "endpointShape": "chat-completions",
+        "auth": "bearer-header",
+        "streaming": "sse"
+    }
+};
+
+// Capability flags describe what the shell can DO with the model today, not
+// the vendor's brochure: `tools` = this dialect's function-calling table is
+// offered, `vision` = a file can be attached and sent (only the gemini
+// strategy builds a file-upload step), `thinking` = the model emits a
+// reasoning phase the strategy already parses. Provider-level defaults,
+// overridden per model; buildModel() does the merge.
+var PROVIDERS = [
+    {
+        "id": "google",
+        "name": "Google",
+        "icon": "google-gemini-symbolic",
+        "dialect": "gemini",
+        "endpoint": "https://generativelanguage.googleapis.com/v1beta/models/{model}:streamGenerateContent",
+        "requiresKey": true,
+        "keyId": "gemini",
+        "keyGetLink": "https://aistudio.google.com/app/apikey",
+        "homepage": "https://aistudio.google.com",
+        "capabilities": { "tools": true, "vision": true, "thinking": true },
+        "models": [
+            {
+                "value": "gemini-3-flash-preview",
+                "name": "Gemini 3 Flash",
+                "legacyId": "gemini-3-flash"
+            },
+            {
+                "value": "gemini-2.5-flash",
+                "name": "Gemini 2.5 Flash",
+                "legacyId": "gemini-2.5-flash"
+            }
+        ]
+    },
+    {
+        "id": "mistral",
+        "name": "Mistral",
+        "icon": "mistral-symbolic",
+        "dialect": "mistral",
+        "endpoint": "https://api.mistral.ai/v1/chat/completions",
+        "requiresKey": true,
+        "keyId": "mistral",
+        "keyGetLink": "https://console.mistral.ai/api-keys",
+        "homepage": "https://mistral.ai/news/mistral-medium-3",
+        "capabilities": { "tools": true, "vision": false, "thinking": false },
+        "models": [
+            {
+                "value": "mistral-medium-2505",
+                "name": "Mistral Medium 3",
+                "legacyId": "mistral-medium-3"
+            }
+        ]
+    },
+    // Models are discovered from the local daemon at runtime (Ai.qml's
+    // show-installed-ollama-models.sh); the provider record is here so the
+    // discovery path builds catalog-shaped records instead of its own.
+    // `tools: true` is the status quo - the shell currently offers the openai
+    // function table to every local model - kept so wiring the catalog in
+    // changes nothing; whether local models should default to no tools (the
+    // sibling fork's choice) is an open question in the proposal.
+    {
+        "id": "ollama",
+        "name": "Ollama",
+        "icon": "ollama-symbolic",
+        "dialect": "openai",
+        "endpoint": "http://localhost:11434/v1/chat/completions",
+        "requiresKey": false,
+        "keyId": "",
+        "keyGetLink": "",
+        "homepage": "https://ollama.com",
+        "local": true,
+        "discovered": true,
+        "capabilities": { "tools": true, "vision": false, "thinking": false },
+        "models": []
+    }
+];
+
+function _copyCapabilities(caps) {
+    return {
+        "tools": caps.tools === true,
+        "vision": caps.vision === true,
+        "thinking": caps.thinking === true
+    };
+}
+
+/** The endpoint template with its {model} slot filled. A template without
+ *  the slot (chat-completions dialects) is returned as-is. */
+function resolveEndpoint(template, modelValue) {
+    return String(template).split("{model}").join(modelValue);
+}
+
+/**
+ * One model record from a provider definition and a model entry: the
+ * provider supplies the defaults, the entry overrides field by field.
+ * Exposed (rather than folded into builtinModels) so the merge rules are
+ * testable with synthetic inputs, and so stage 2's custom-model path can
+ * build records the same way.
+ */
+function buildModel(providerDef, entry) {
+    if (!entry || entry.value === undefined || String(entry.value).length === 0)
+        return null;
+    var value = String(entry.value);
+    var caps = _copyCapabilities(providerDef.capabilities || {});
+    var overrides = entry.capabilities || {};
+    for (var key in caps) {
+        if (overrides[key] !== undefined)
+            caps[key] = overrides[key] === true;
+    }
+    return {
+        "id": providerDef.id + ":" + value,
+        "legacyId": entry.legacyId !== undefined ? entry.legacyId : "",
+        "providerId": providerDef.id,
+        "value": value,
+        "name": entry.name !== undefined ? entry.name : value,
+        "icon": entry.icon !== undefined ? entry.icon : (providerDef.icon || ""),
+        "dialect": entry.dialect !== undefined ? entry.dialect : providerDef.dialect,
+        "endpoint": resolveEndpoint(
+            entry.endpoint !== undefined ? entry.endpoint : providerDef.endpoint, value),
+        "requiresKey": entry.requiresKey !== undefined
+            ? entry.requiresKey === true : providerDef.requiresKey === true,
+        "keyId": entry.keyId !== undefined ? entry.keyId : (providerDef.keyId || ""),
+        "keyGetLink": entry.keyGetLink !== undefined
+            ? entry.keyGetLink : (providerDef.keyGetLink || ""),
+        "homepage": entry.homepage !== undefined
+            ? entry.homepage : (providerDef.homepage || ""),
+        "capabilities": caps
+    };
+}
+
+function _providerRecord(def) {
+    var models = [];
+    for (var i = 0; i < def.models.length; i++) {
+        var model = buildModel(def, def.models[i]);
+        if (model !== null)
+            models.push(model);
+    }
+    return {
+        "id": def.id,
+        "name": def.name,
+        "icon": def.icon || "",
+        "dialect": def.dialect,
+        "endpoint": def.endpoint,
+        "requiresKey": def.requiresKey === true,
+        "keyId": def.keyId || "",
+        "keyGetLink": def.keyGetLink || "",
+        "homepage": def.homepage || "",
+        "local": def.local === true,
+        "discovered": def.discovered === true,
+        "capabilities": _copyCapabilities(def.capabilities || {}),
+        "models": models
+    };
+}
+
+/** Dialect records, keyed by id. Fresh objects per call. */
+function dialects() {
+    var result = {};
+    for (var id in DIALECTS) {
+        var d = DIALECTS[id];
+        result[id] = {
+            "id": d.id,
+            "endpointShape": d.endpointShape,
+            "auth": d.auth,
+            "streaming": d.streaming
+        };
+    }
+    return result;
+}
+
+/** Provider records with their built-in models resolved, in catalog order. */
+function providers() {
+    var result = [];
+    for (var i = 0; i < PROVIDERS.length; i++)
+        result.push(_providerRecord(PROVIDERS[i]));
+    return result;
+}
+
+/** Every built-in model, flat, in catalog order. */
+function builtinModels() {
+    var result = [];
+    var provs = providers();
+    for (var i = 0; i < provs.length; i++) {
+        for (var j = 0; j < provs[i].models.length; j++)
+            result.push(provs[i].models[j]);
+    }
+    return result;
+}
+
+/** The provider record for an id, or null. */
+function provider(id) {
+    for (var i = 0; i < PROVIDERS.length; i++) {
+        if (PROVIDERS[i].id === id)
+            return _providerRecord(PROVIDERS[i]);
+    }
+    return null;
+}
+
+/**
+ * The model for an id, or null. Answers the canonical "provider:value" id
+ * and the legacy flat id today's Ai.qml (and every stored
+ * Persistent.states.ai.model) uses, so a saved model choice keeps resolving
+ * when the catalog takes over.
+ */
+function resolve(id) {
+    if (id === undefined || id === null || String(id).length === 0)
+        return null;
+    var wanted = String(id);
+    var models = builtinModels();
+    for (var i = 0; i < models.length; i++) {
+        if (models[i].id === wanted)
+            return models[i];
+    }
+    for (var j = 0; j < models.length; j++) {
+        if (models[j].legacyId.length > 0 && models[j].legacyId === wanted)
+            return models[j];
+    }
+    return null;
+}

--- a/dots/.config/quickshell/imi/tests/imports/qs/modules/common/widgets/StaggerEntrance.qml
+++ b/dots/.config/quickshell/imi/tests/imports/qs/modules/common/widgets/StaggerEntrance.qml
@@ -1,0 +1,1 @@
+../../../../../../modules/common/widgets/StaggerEntrance.qml

--- a/dots/.config/quickshell/imi/tests/imports/qs/modules/common/widgets/StaggerWave.qml
+++ b/dots/.config/quickshell/imi/tests/imports/qs/modules/common/widgets/StaggerWave.qml
@@ -1,0 +1,1 @@
+../../../../../../modules/common/widgets/StaggerWave.qml

--- a/dots/.config/quickshell/imi/tests/imports/qs/modules/common/widgets/qmldir
+++ b/dots/.config/quickshell/imi/tests/imports/qs/modules/common/widgets/qmldir
@@ -2,3 +2,4 @@ module qs.modules.common.widgets
 GroupedList 1.0 GroupedList.qml
 LiveDesktopEntry 1.0 LiveDesktopEntry.qml
 WallpaperBlurSurface 1.0 WallpaperBlurSurface.qml
+StaggerEntrance 1.0 StaggerEntrance.qml

--- a/dots/.config/quickshell/imi/tests/imports/qs/modules/common/widgets/qmldir
+++ b/dots/.config/quickshell/imi/tests/imports/qs/modules/common/widgets/qmldir
@@ -3,3 +3,4 @@ GroupedList 1.0 GroupedList.qml
 LiveDesktopEntry 1.0 LiveDesktopEntry.qml
 WallpaperBlurSurface 1.0 WallpaperBlurSurface.qml
 StaggerEntrance 1.0 StaggerEntrance.qml
+StaggerWave 1.0 StaggerWave.qml

--- a/dots/.config/quickshell/imi/tests/lint_bar_popup_overlay_static.py
+++ b/dots/.config/quickshell/imi/tests/lint_bar_popup_overlay_static.py
@@ -249,6 +249,71 @@ if not re.search(r"interval:\s*0\b[\s\S]{0,120}?onTriggered:[^\n]*retarget\(\)",
         "implicit size - and its first section's height - are stale until the turn after "
         "the takeover")
 
+# --- the content wave, and the gate it waits behind ---------------------------
+#
+# The popup contents arrive container-then-fill (the measured survey's §2.1):
+# the sections below the fold hold their entrance until the card's own driver
+# answers `Appearance.animation.contentsArrived`, then cascade as a StaggerWave.
+# This surface is the one bar adopter whose container HAS a progress scalar, so
+# the checks here are the drawer's rules restated for the overlay - and each one
+# guards a silent regression, because a wave that starts early, or from the
+# wrong event, still renders and reads as mushy rather than as broken.
+
+if "StaggerWave {" not in code:
+    failures.append(
+        "declares no StaggerWave; the popup sections' cascade must come from the one shared "
+        "runner, or the ranking, the clamp and the cancellation drift from every other "
+        "surface's")
+
+if re.search(r"^\s*leadIn\s*:", code, re.MULTILINE):
+    failures.append(
+        "gives the wave a leadIn as well as the gate; two waits in front of one wave, and "
+        "only the container's own progress is answerable")
+
+contents_in = declaration(code, "readonly property bool contentsIn")
+if "Appearance.animation.contentsArrived(" not in contents_in \
+        or f"card.{DRIVER}" not in contents_in:
+    failures.append(
+        f"contentsIn is not Appearance.animation.contentsArrived(card.{DRIVER}, ...); the "
+        "gate must read the card's own driver, which is the container progress the whole "
+        "design exists to gate on")
+
+opening = declaration(code, "readonly property bool opening")
+if not opening:
+    failures.append(
+        "declares no `readonly property bool opening`; the gate's second argument is the "
+        "overlay's own intent flag")
+elif DRIVER in opening:
+    failures.append(
+        f"derives `opening` from {DRIVER}; the intent flips at the claim and the progress "
+        "follows, so a direction inferred from the progress is entered by the wrong event")
+
+enter_calls = re.findall(r"\bsectionWave\.enter\(\)", code)
+if len(enter_calls) != 1:
+    failures.append(
+        f"calls sectionWave.enter() {len(enter_calls)} times; the wave starts from exactly "
+        "one place, the gate's own handler, or it races the reveal it is meant to land in")
+elif "sectionWave.enter()" not in declaration(code, "onContentsInChanged"):
+    failures.append(
+        "starts the wave outside the onContentsInChanged handler; an enter anywhere else "
+        "runs before the container has arrived, which is the race the gate exists to close")
+
+if re.search(r"\bsectionWave\.leave\(\)", code):
+    failures.append(
+        "calls sectionWave.leave(); the exit is one rigid transform - contents ride the "
+        "container out at full strength (measured doc §2.2), and the reset is settle(), "
+        "off screen")
+
+if "sectionWave.park()" not in code:
+    failures.append(
+        "never parks the wave; without an arm on the fresh open the sections are drawn at "
+        "full strength for the whole run up to the gate and then blink out to cascade in")
+
+if "sectionWave.settle()" not in code:
+    failures.append(
+        "never settles the wave; the released tree must get its `appear` back off screen, "
+        "or a popup whose cascade was interrupted returns with sections stuck part-dimmed")
+
 if failures:
     for failure in failures:
         print(f"modules/imi/bar/BarPopupOverlay.qml: {failure}", file=sys.stderr)

--- a/dots/.config/quickshell/imi/tests/lint_disabled_opacity.py
+++ b/dots/.config/quickshell/imi/tests/lint_disabled_opacity.py
@@ -43,6 +43,17 @@ NESTED_DIM = re.compile(r"^ {5,}opacity:.*" + DIM_SOURCE)
 ROOT_TYPE = re.compile(r"^([A-Z]\w*)\s*\{")
 NESTED_TYPE = re.compile(r"^ {5,}([A-Z]\w*)\s*\{")
 
+# The group entrance's shared dressing installs an `opacity` binding on every
+# `appear`-declaring member of its target, so a `StaggerEntrance` nested inside
+# a component whose root already dims is this lint's bug with the writer one
+# component away: the member's dressed opacity multiplies with the root's dim,
+# 0.4 becomes 0.16, and the members disagree with anything the dresser skipped.
+# (The component's own guard skips a member that OWNS an `interactionMotion`,
+# but the members inside a dimming control are ordinarily plain rows - the
+# control is their ancestor, which is exactly what that guard cannot see.)
+DRESSER_TYPES = ("StaggerEntrance",)
+NESTED_DRESSER = re.compile(r"^ {5,}(" + "|".join(DRESSER_TYPES) + r")\s*\{")
+
 
 def qml_files():
     return sorted(MODULES.rglob("*.qml"))
@@ -56,17 +67,95 @@ def root_type(lines):
     return None
 
 
+def dimming(sources):
+    """Files whose root object binds opacity to `enabled`."""
+    return {
+        path
+        for path, lines in sources.items()
+        if any(ROOT_DIM.match(line) for line in lines)
+    }
+
+
+def scan(sources, self_dimming):
+    violations = []
+    for path, lines in sources.items():
+        if root_type(lines) not in self_dimming:
+            continue
+        for number, line in enumerate(lines, 1):
+            if NESTED_DIM.match(line):
+                violations.append((path, number, line.strip()))
+                continue
+            dresser = NESTED_DRESSER.match(line)
+            if dresser:
+                violations.append((path, number,
+                                   f"{dresser.group(1)} installs an opacity "
+                                   f"on every member it dresses"))
+                continue
+            nested = NESTED_TYPE.match(line)
+            if nested and nested.group(1) in self_dimming:
+                violations.append((path, number,
+                                   f"nested self-dimming {nested.group(1)}"))
+    return violations
+
+
+# The dresser rule matches source text, so it is proven against a fixture that
+# cannot drift: a dimming root type, a component rooted on it holding a nested
+# StaggerEntrance (must redden), and the same dresser under a plain root (must
+# not). The original nested-dim rule is proven the other way, by the pinned
+# real-tree findings in main().
+SELF_CHECK = {
+    "Dimmer.qml": """
+Button {
+    opacity: enabled ? 1 : 0.4
+}
+""",
+    "DimmedHost.qml": """
+Dimmer {
+    Column {
+        StaggerEntrance {
+            target: rows
+        }
+    }
+}
+""",
+    "FreeHost.qml": """
+Item {
+    Column {
+        StaggerEntrance {
+            target: rows
+        }
+    }
+}
+""",
+}
+
+
+def self_check():
+    sources = {Path(name): text.splitlines() for name, text in SELF_CHECK.items()}
+    self_dimming = {path.stem for path in dimming(sources)}
+    if self_dimming != {"Dimmer"}:
+        return f"the fixture's dimming root resolved to {self_dimming or 'nothing'}"
+    found = {(path.name, number) for path, number, _ in scan(sources, self_dimming)}
+    if found != {("DimmedHost.qml", 4)}:
+        return (f"the dresser scan resolved {sorted(found) or 'nothing'} on a "
+                "fixture holding one nested StaggerEntrance inside a dimming "
+                "root and one under a plain one")
+    return None
+
+
 def main():
+    broken = self_check()
+    if broken:
+        print("Disabled-opacity lint FAILED its own self-check: "
+              f"{broken}. The check below cannot be trusted.", file=sys.stderr)
+        return 1
+
     files = qml_files()
     sources = {path: path.read_text(encoding="utf-8").splitlines() for path in files}
 
     # A type dims itself if its own declaration file binds opacity to `enabled`
     # on the root object. The type name is the file's basename.
-    dimming_files = {
-        path
-        for path, lines in sources.items()
-        if any(ROOT_DIM.match(line) for line in lines)
-    }
+    dimming_files = dimming(sources)
     self_dimming = {path.stem for path in dimming_files}
 
     # The check matches source text, so it would pass vacuously after a reformat
@@ -89,19 +178,8 @@ def main():
               "vacuous.", file=sys.stderr)
         return 1
 
-    violations = []
-    for path, lines in sources.items():
-        if root_type(lines) not in self_dimming:
-            continue
-        rel = path.relative_to(MODULES)
-        for number, line in enumerate(lines, 1):
-            if NESTED_DIM.match(line):
-                violations.append((rel, number, line.strip()))
-                continue
-            nested = NESTED_TYPE.match(line)
-            if nested and nested.group(1) in self_dimming:
-                violations.append((rel, number,
-                                   f"nested self-dimming {nested.group(1)}"))
+    violations = [(path.relative_to(MODULES), number, detail)
+                  for path, number, detail in scan(sources, self_dimming)]
 
     if violations:
         print("Disabled-opacity lint FAILED: opacity composites, so a second "

--- a/dots/.config/quickshell/imi/tests/lint_disabled_opacity.py
+++ b/dots/.config/quickshell/imi/tests/lint_disabled_opacity.py
@@ -52,7 +52,11 @@ NESTED_TYPE = re.compile(r"^ {5,}([A-Z]\w*)\s*\{")
 # but the members inside a dimming control are ordinarily plain rows - the
 # control is their ancestor, which is exactly what that guard cannot see.)
 DRESSER_TYPES = ("StaggerEntrance",)
-NESTED_DRESSER = re.compile(r"^ {5,}(" + "|".join(DRESSER_TYPES) + r")\s*\{")
+# Any indent at all, not the >=5 the nested-dim rule uses: a dresser declared
+# as a DIRECT child of the dimming root sits at one level - the realistic
+# placement, and the one the first version of this rule missed when the plant
+# proving it was put exactly there.
+NESTED_DRESSER = re.compile(r"^ +(" + "|".join(DRESSER_TYPES) + r")\s*\{")
 
 
 def qml_files():
@@ -118,6 +122,16 @@ Dimmer {
     }
 }
 """,
+    # The realistic placement: the dresser as a DIRECT child of the dimming
+    # root, at one indent level - which the >=5-space nested-dim convention
+    # never sees, and where the first plant proving this rule landed.
+    "DimmedDirect.qml": """
+Dimmer {
+    StaggerEntrance {
+        target: contentRow
+    }
+}
+""",
     "FreeHost.qml": """
 Item {
     Column {
@@ -136,10 +150,10 @@ def self_check():
     if self_dimming != {"Dimmer"}:
         return f"the fixture's dimming root resolved to {self_dimming or 'nothing'}"
     found = {(path.name, number) for path, number, _ in scan(sources, self_dimming)}
-    if found != {("DimmedHost.qml", 4)}:
+    if found != {("DimmedHost.qml", 4), ("DimmedDirect.qml", 3)}:
         return (f"the dresser scan resolved {sorted(found) or 'nothing'} on a "
-                "fixture holding one nested StaggerEntrance inside a dimming "
-                "root and one under a plain one")
+                "fixture holding a nested and a direct-child StaggerEntrance "
+                "inside dimming roots and one under a plain one")
     return None
 
 

--- a/dots/.config/quickshell/imi/tests/lint_interaction_motion_double.py
+++ b/dots/.config/quickshell/imi/tests/lint_interaction_motion_double.py
@@ -200,15 +200,32 @@ def declaration_value(lines, index, first_fragment):
     return value
 
 
+# The group entrance's shared dressing writes the scale (and opacity) channel
+# onto every `appear`-declaring member of its target, so a `StaggerEntrance`
+# declared inside a control that applies the model is the same doubling with
+# the writer one component away: the entrance scale composites with the
+# control's `interactionMotion.scale` down the scene graph, and the opacity it
+# installs multiplies with the dim the control's root already carries. (The
+# component itself SKIPS a direct child owning an `interactionMotion`, but a
+# dresser aimed at a container INSIDE the control reaches members that guard
+# cannot see - the members are plain items, the control is their ancestor.)
+DRESSER_TYPES = ("StaggerEntrance",)
+DRESSER = re.compile(r"^\s*(" + "|".join(DRESSER_TYPES) + r")\s*\{")
+
+
 class Channel:
     """One visual channel the model drives, and how to recognise both sides."""
 
-    def __init__(self, name, offending, applier, applies, doubling):
+    def __init__(self, name, offending, applier, applies, doubling,
+                 dressers=False):
         self.name = name
         self.offending = prop_matcher(offending)
         self.applier = prop_matcher(applier)
         self.applies = applies
         self.doubling = doubling
+        # Whether the shared entrance dressing writes this channel too. Scale
+        # only: the dresser installs no radius.
+        self.dressers = dressers
 
 
 CHANNELS = [
@@ -217,6 +234,7 @@ CHANNELS = [
         "a transform composites down the scene graph, so a hover/press scale "
         "written inside a control that already applies `interactionMotion.scale` "
         "MULTIPLIES with the model instead of replacing it",
+        dressers=True,
     ),
     Channel(
         "radius", RADIUS_NAMES, RADIUS_APPLIER_NAMES, APPLIES_RADIUS,
@@ -259,6 +277,13 @@ def scan(sources, channel, controls):
             inside = enclosing & controls
             if inside:
                 hosts.add(path)
+            if channel.dressers and inside:
+                dresser = DRESSER.match(line)
+                if dresser:
+                    violations.append((path, number, sorted(inside)[0],
+                                       f"{dresser.group(1)} dresses members "
+                                       f"with a scale of its own here"))
+                    continue
             match = channel.offending.match(line)
             if not match or not inside:
                 continue
@@ -304,9 +329,15 @@ Item {
         Icon {
             scale: root.motion.scale
         }
+        StaggerEntrance {
+            target: glyphColumn
+        }
     }
     Loose {
         scale: hoverArea.containsMouse ? 1.1 : 1
+    }
+    StaggerEntrance {
+        target: looseColumn
     }
 }
 """,
@@ -358,7 +389,9 @@ def self_check():
     sources = {Path(name): text.splitlines()
                for name, text in SELF_CHECK.items()}
     expected = {
-        "scale": ({"Control"}, {("CallSite.qml", 5), ("CallSite.qml", 8)},
+        "scale": ({"Control"},
+                  {("CallSite.qml", 5), ("CallSite.qml", 8),
+                   ("CallSite.qml", 17)},
                   "CallSite.qml", None),
         "radius": ({"Tightening"},
                    {("TighteningCallSite.qml", 3), ("TighteningCallSite.qml", 5), ("TighteningCallSite.qml", 8)},

--- a/dots/.config/quickshell/imi/tests/lint_suite_registration.py
+++ b/dots/.config/quickshell/imi/tests/lint_suite_registration.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Every register in tests/ must be named by run_tests.sh.
+
+A test file that exists but is not wired into the suite passes every hand
+run and protects nothing: test_bar_popup_section_entrance.py sat unwired
+with its "mutations all caught" receipt earned only ever by hand. This is
+the one failure mode the suite cannot see about itself, so it is checked
+from outside the registers.
+"""
+
+import pathlib
+import sys
+
+TESTS_DIR = pathlib.Path(__file__).resolve().parent
+RUNNER = (TESTS_DIR / "run_tests.sh").read_text()
+
+missing = [
+    p.name
+    for pattern in ("test_*.py", "lint_*.py")
+    for p in sorted(TESTS_DIR.glob(pattern))
+    if p.name not in RUNNER
+]
+
+if missing:
+    for name in missing:
+        print(f"UNREGISTERED: tests/{name} is not named in run_tests.sh")
+    sys.exit(1)
+
+print(f"Suite registration lint passed (every test_*.py and lint_*.py is wired in)")

--- a/dots/.config/quickshell/imi/tests/lint_wave_member_opacity_behavior.py
+++ b/dots/.config/quickshell/imi/tests/lint_wave_member_opacity_behavior.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+#
+# Regression guard: a wave member's opacity is the wave's channel, and a
+# `Behavior on opacity` on the member is a second animation on it.
+#
+# A component whose root declares `property real appear` is a StaggerWave
+# member: the wave assigns `appear = 0` to park it (a snap, deliberately -
+# see StaggerWave.park()'s comment) and animates `appear` to 1 to bring it
+# in, with the member's opacity riding `appear` - either through the
+# member's own fold (RippleButton) or through the binding StaggerEntrance
+# installs. A root-level `Behavior on opacity` in the same file intercepts
+# every write that binding makes:
+#
+#  - park()'s snap-to-invisible becomes an on-stage fade-out, so the member
+#    is drawn at full strength on the frames the park exists to clear;
+#  - the wave's own animation retargets the Behavior every frame, which
+#    restarts it every frame (b710ef731's frozen-Behavior shape), so the
+#    drawn opacity is pinned near wherever the fade-out left it until
+#    `appear` STOPS, and the member lands a whole fade-length after its
+#    slot.
+#
+# That is exactly what the android quick toggles shipped: the tiles' old
+# `opacity: 0` + `onCompleted` self-fade was retired in favour of the wave
+# (8a0120c2) and the Behavior that had animated it was left behind - so on
+# every sidebar open the first-ranked tiles read as "visible at all times,
+# then the animation begins", measured on the live shell as appear=0 with
+# drawn opacity still 1.000 at the open and 0.147 while appear was at 0.955.
+#
+# Nested `Behavior on opacity` declarations (a ripple overlay, a scroll
+# shadow) animate a child's own opacity, not the member's channel, and stay
+# free.
+#
+# Exits non-zero listing offenders. Wired into run_tests.sh / CI.
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+MODULES = ROOT / "modules"
+
+# Root-level: the repo indents QML with four spaces, so a property of the
+# root object sits at one level and anything nested sits deeper - the same
+# assumption lint_disabled_opacity.py rests on.
+ROOT_APPEAR = re.compile(r"^ {1,4}property real appear\b")
+ROOT_OPACITY_BEHAVIOR = re.compile(r"^ {1,4}Behavior on opacity\b")
+
+
+def scan(text):
+    appear_line = None
+    behavior_line = None
+    for number, line in enumerate(text.splitlines(), start=1):
+        if appear_line is None and ROOT_APPEAR.match(line):
+            appear_line = number
+        if behavior_line is None and ROOT_OPACITY_BEHAVIOR.match(line):
+            behavior_line = number
+    if appear_line is not None and behavior_line is not None:
+        return behavior_line
+    return None
+
+
+def self_check():
+    offender = (
+        "GroupButton {\n"
+        "    id: root\n"
+        "    property real appear: 1\n"
+        "    Behavior on opacity {\n"
+        "        animation: Appearance.animation.elementMoveFast"
+        ".numberAnimation.createObject(this)\n"
+        "    }\n"
+        "}\n"
+    )
+    nested_only = (
+        "Button {\n"
+        "    id: root\n"
+        "    property real appear: 1\n"
+        "    Rectangle {\n"
+        "        Behavior on opacity {\n"
+        "            animation: a\n"
+        "        }\n"
+        "    }\n"
+        "}\n"
+    )
+    no_member = (
+        "Item {\n"
+        "    Behavior on opacity {\n"
+        "        animation: a\n"
+        "    }\n"
+        "}\n"
+    )
+    if scan(offender) is None:
+        return "the detector passes the planted root-level pair"
+    if scan(nested_only) is not None:
+        return "the detector flags a Behavior nested inside a child"
+    if scan(no_member) is not None:
+        return "the detector flags a file that declares no member"
+    return None
+
+
+def main():
+    failure = self_check()
+    if failure:
+        print(f"Wave-member opacity-Behavior lint FAILED its self-check: "
+              f"{failure}.", file=sys.stderr)
+        return 1
+
+    files = sorted(MODULES.rglob("*.qml"))
+    members = []
+    violations = []
+    for path in files:
+        text = path.read_text(encoding="utf-8")
+        has_member = any(ROOT_APPEAR.match(line)
+                         for line in text.splitlines())
+        if has_member:
+            members.append(path)
+        line = scan(text)
+        if line is not None:
+            violations.append((path.relative_to(MODULES), line))
+
+    # The scan is only meaningful while the membership convention is what it
+    # matches: RippleButton is the canonical root-level `appear` and must be
+    # found, or the indentation assumption has rotted and everything below is
+    # vacuous.
+    expected = "common/widgets/RippleButton.qml"
+    if expected not in {str(p.relative_to(MODULES)) for p in members}:
+        print("Wave-member opacity-Behavior lint FAILED: the scan found no "
+              f"root-level `property real appear` in {expected} - the "
+              "indentation assumption or that file's shape changed, and the "
+              "check below is now vacuous.", file=sys.stderr)
+        return 1
+
+    if violations:
+        print("Wave-member opacity-Behavior lint FAILED: a wave member's "
+              "opacity rides `appear`, so a root-level Behavior on opacity "
+              "turns park()'s snap into an on-stage fade-out and freezes the "
+              "entrance while `appear` animates. Delete the Behavior - the "
+              "wave's own animation carries the curve:", file=sys.stderr)
+        for rel, number in violations:
+            print(f"  {rel}:{number}", file=sys.stderr)
+        return 1
+
+    print(f"Wave-member opacity-Behavior lint passed ({len(files)} QML "
+          f"files, {len(members)} root-level wave members)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dots/.config/quickshell/imi/tests/lint_wave_member_opacity_behavior.py
+++ b/dots/.config/quickshell/imi/tests/lint_wave_member_opacity_behavior.py
@@ -21,7 +21,10 @@
 #
 # That is exactly what the android quick toggles shipped: the tiles' old
 # `opacity: 0` + `onCompleted` self-fade was retired in favour of the wave
-# (8a0120c2) and the Behavior that had animated it was left behind - so on
+# (8a0120c2, "feat(motion): objects converge into place from their own
+# side, with a landing" - subject kept beside the sha so the pointer
+# survives a rebase renumbering it) and the Behavior that had animated it
+# was left behind - so on
 # every sidebar open the first-ranked tiles read as "visible at all times,
 # then the animation begins", measured on the live shell as appear=0 with
 # drawn opacity still 1.000 at the open and 0.147 while appear was at 0.955.

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -959,6 +959,26 @@ if ! python3 "$SCRIPT_DIR/test_parallax_migration_runtime.py"; then
     exit 1
 fi
 
+# A register that exists but is not named in this file protects nothing;
+# checked before anything else so the report is not buried under a long run.
+echo "Running suite registration lint..."
+if ! python3 "$SCRIPT_DIR/lint_suite_registration.py"; then
+    echo "Suite registration lint failed."
+    exit 1
+fi
+
+# The bar popup's section wave: armed on a takeover from idle, released by
+# the gate, and never fired against a tree that was not parked. This register
+# existed for a while without being wired in here - the mutations it plants
+# were only ever caught by hand runs, which is the one failure mode a suite
+# cannot see about itself. The meta-check at the end of this file exists so
+# the next unwired register goes red instead.
+echo "Running bar popup section entrance tests..."
+if ! python3 "$SCRIPT_DIR/test_bar_popup_section_entrance.py"; then
+    echo "Bar popup section entrance tests failed."
+    exit 1
+fi
+
 # One motion policy: that every tier still routes through it, and that the
 # reduce-motion floor stays a named state rather than the far end of a slider.
 echo "Running motion policy contract tests..."

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -433,6 +433,16 @@ if ! python3 "$SCRIPT_DIR/test_bar_text_change_motion.py"; then
     exit 1
 fi
 
+# The todo lists ride StyledListView's own add/remove transitions, which only
+# works while the model's values keep their identity across updates: ScriptModel
+# diffs by strict equality, so a per-update wrapper reads as remove-all+add-all
+# and flies the whole list in on every change.
+echo "Running todo list transition tests..."
+if ! python3 "$SCRIPT_DIR/test_todo_list_transitions.py"; then
+    echo "Todo list transition tests failed."
+    exit 1
+fi
+
 # The clock's options page shows only the chosen style's rows. The predicate is
 # pinned by tst_option_visibility.qml; this is the adoption, which is what
 # decays - a 29th option added without a rule renders on every style again.

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -1509,6 +1509,17 @@ if ! python3 "$SCRIPT_DIR/test_media_layouts_contract.py"; then
     exit 1
 fi
 
+# The AI provider/model catalog (services/ai_catalog.js) and Ai.qml's built-in
+# model literals are two copies of one truth until the proposal's stage 2 wires
+# Ai.qml to the catalog; this pins them equal field by field so neither can
+# drift in the meantime, and pins the catalog's dialect vocabulary to the
+# strategy files that implement it. See docs/proposals/ai-assistant-upgrade.md.
+echo "Running AI catalog contract tests..."
+if ! python3 "$SCRIPT_DIR/test_ai_catalog_contract.py"; then
+    echo "AI catalog contract tests failed."
+    exit 1
+fi
+
 # Contract: what turns an on-screen keyboard key's span into pixels. The
 # layouts themselves are data and are checked by tst_osk_layouts.qml; this is
 # the conversion, which the data cannot see - a second shape table, a key gap

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -128,6 +128,17 @@ if ! python3 "$SCRIPT_DIR/lint_interaction_motion_double.py"; then
     exit 1
 fi
 
+# Static lint: the third member of the doubled-channel family. A wave member's
+# opacity rides `appear`, so a root-level `Behavior on opacity` in the same
+# file turns StaggerWave.park()'s snap into an on-stage fade-out and freezes
+# the entrance while `appear` animates - the android quick toggles' "visible,
+# then the animation begins" pause.
+echo "Running wave-member opacity-Behavior lint..."
+if ! python3 "$SCRIPT_DIR/lint_wave_member_opacity_behavior.py"; then
+    echo "Wave-member opacity-Behavior lint failed."
+    exit 1
+fi
+
 # Static lint: an animation that names a motion tier's duration must take that
 # tier's easing with it. Leaving the curve behind hands the animation Qt's
 # default, Easing.Linear - the generic curve M3_GUIDELINES §2 forbids - and

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -423,6 +423,16 @@ if ! python3 "$SCRIPT_DIR/test_clock_motion_contract.py"; then
     exit 1
 fi
 
+# Bar texts whose change is an event (a track change, a weather refresh) take
+# StyledText's animateChange swap; the clock's tick is pinned as a refusal - a
+# configurable time format makes it up to once per second, on a bar that stays
+# `visible` under a fullscreen window.
+echo "Running bar text change motion tests..."
+if ! python3 "$SCRIPT_DIR/test_bar_text_change_motion.py"; then
+    echo "Bar text change motion tests failed."
+    exit 1
+fi
+
 # The clock's options page shows only the chosen style's rows. The predicate is
 # pinned by tst_option_visibility.qml; this is the adoption, which is what
 # decays - a 29th option added without a rule renders on every style again.

--- a/dots/.config/quickshell/imi/tests/test_ai_catalog_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_ai_catalog_contract.py
@@ -1,0 +1,344 @@
+"""The AI catalog and Ai.qml cannot drift while the wiring waits.
+
+services/ai_catalog.js declares every built-in provider and model in one
+place; services/Ai.qml still carries its own literals until stage 2 of
+docs/proposals/ai-assistant-upgrade.md wires it to the catalog. Two copies of
+one truth is exactly the shape this repo keeps paying for (BarWidgets,
+MprisController), so until the second copy is deleted this module pins them
+equal, field by field:
+
+- every built-in model Ai.qml declares exists in the catalog under the same
+  legacy id, with the same resolved endpoint, model value, dialect
+  (api_format), key id, key link and requires_key;
+- every non-discovered catalog model is declared in Ai.qml - a model added to
+  only one side fails in either direction;
+- the catalog's dialect vocabulary matches Ai.qml's apiStrategies keys and
+  the strategy files under services/ai/;
+- the Ollama discovery endpoint Ai.qml hands discovered models matches the
+  catalog's ollama provider record;
+- ai_catalog.js stays pure: `.pragma library`, no imports, no Qt.
+
+The parsers are proven against in-memory fixtures first (asserted counts),
+so a reformat that makes them match nothing is loud rather than green.
+
+When stage 2 lands, most of this module inverts: Ai.qml stops declaring
+model literals and the pin becomes "Ai.qml declares none".
+"""
+
+import re
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+AI_QML = ROOT / "services" / "Ai.qml"
+CATALOG_JS = ROOT / "services" / "ai_catalog.js"
+STRATEGY_DIR = ROOT / "services" / "ai"
+
+# dialect id -> the strategy file that implements it
+DIALECT_STRATEGY_FILES = {
+    "gemini": "GeminiApiStrategy.qml",
+    "openai": "OpenAiApiStrategy.qml",
+    "mistral": "MistralApiStrategy.qml",
+}
+
+
+def _matching_brace(text, start, open_ch, close_ch):
+    """Index just past the brace matching text[start], skipping strings."""
+    assert text[start] == open_ch, f"expected {open_ch!r} at {start}"
+    depth = 0
+    i = start
+    in_string = None
+    while i < len(text):
+        ch = text[i]
+        if in_string:
+            if ch == "\\":
+                i += 2
+                continue
+            if ch == in_string:
+                in_string = None
+        elif ch in "\"'`":
+            in_string = ch
+        elif ch == open_ch:
+            depth += 1
+        elif ch == close_ch:
+            depth -= 1
+            if depth == 0:
+                return i + 1
+        i += 1
+    raise AssertionError(f"unbalanced {open_ch} starting at {start}")
+
+
+def _string_field(block, name):
+    m = re.search(r'"%s"\s*:\s*"((?:[^"\\]|\\.)*)"' % re.escape(name), block)
+    return m.group(1) if m else None
+
+
+def _bool_field(block, name):
+    m = re.search(r'"%s"\s*:\s*(true|false)' % re.escape(name), block)
+    return m.group(1) == "true" if m else None
+
+
+def parse_ai_qml_builtins(text):
+    """Ai.qml's built-in models: {legacy_id: {field: value}}."""
+    result = {}
+    for m in re.finditer(
+            r'"([\w.\-]+)"\s*:\s*aiModelComponent\.createObject\(this,\s*\{',
+            text):
+        key = m.group(1)
+        start = m.end() - 1
+        end = _matching_brace(text, start, "{", "}")
+        block = text[start:end]
+        result[key] = {
+            "endpoint": _string_field(block, "endpoint"),
+            "model": _string_field(block, "model"),
+            "api_format": _string_field(block, "api_format") or "openai",
+            "key_id": _string_field(block, "key_id"),
+            "key_get_link": _string_field(block, "key_get_link"),
+            "requires_key": _bool_field(block, "requires_key"),
+        }
+    return result
+
+
+def parse_catalog_providers(text):
+    """ai_catalog.js's PROVIDERS: [{...provider fields, models: [...]}]."""
+    m = re.search(r"var PROVIDERS\s*=\s*\[", text)
+    assert m, "PROVIDERS declaration not found in ai_catalog.js"
+    list_start = m.end() - 1
+    list_end = _matching_brace(text, list_start, "[", "]")
+    body = text[list_start + 1:list_end - 1]
+
+    providers = []
+    i = 0
+    while True:
+        brace = body.find("{", i)
+        if brace < 0:
+            break
+        end = _matching_brace(body, brace, "{", "}")
+        block = body[brace:end]
+        i = end
+
+        models_match = re.search(r'"models"\s*:\s*\[', block)
+        assert models_match, "provider block without a models list"
+        models_start = models_match.end() - 1
+        models_end = _matching_brace(block, models_start, "[", "]")
+        models_body = block[models_start + 1:models_end - 1]
+        head = block[:models_start]
+
+        models = []
+        j = 0
+        while True:
+            mb = models_body.find("{", j)
+            if mb < 0:
+                break
+            me = _matching_brace(models_body, mb, "{", "}")
+            entry = models_body[mb:me]
+            j = me
+            models.append({
+                "value": _string_field(entry, "value"),
+                "legacyId": _string_field(entry, "legacyId"),
+                "endpoint": _string_field(entry, "endpoint"),
+            })
+
+        providers.append({
+            "id": _string_field(head, "id"),
+            "dialect": _string_field(head, "dialect"),
+            "endpoint": _string_field(head, "endpoint"),
+            "keyId": _string_field(head, "keyId"),
+            "keyGetLink": _string_field(head, "keyGetLink"),
+            "requiresKey": _bool_field(head, "requiresKey"),
+            "discovered": _bool_field(head, "discovered") or False,
+            "models": models,
+        })
+    return providers
+
+
+def parse_catalog_dialects(text):
+    m = re.search(r"var DIALECTS\s*=\s*\{", text)
+    assert m, "DIALECTS declaration not found in ai_catalog.js"
+    start = m.end() - 1
+    end = _matching_brace(text, start, "{", "}")
+    body = text[start:end]
+    return sorted(set(re.findall(r'"id"\s*:\s*"(\w+)"', body)))
+
+
+def parse_ai_qml_strategy_keys(text):
+    m = re.search(r"property var apiStrategies\s*:\s*\{", text)
+    assert m, "apiStrategies declaration not found in Ai.qml"
+    start = m.end() - 1
+    end = _matching_brace(text, start, "{", "}")
+    body = text[start:end]
+    return sorted(set(re.findall(r'"(\w+)"\s*:\s*\w+ApiStrategy\.createObject', body)))
+
+
+# ── Parser self-checks against in-memory fixtures ────────────────────────────
+
+_QML_FIXTURE = """
+    property var models: cond ? {} : {
+        "fixture-model": aiModelComponent.createObject(this, {
+            "name": "Fixture {braces} in string",
+            "endpoint": "https://example.test/v1beta/models/fixture-1:streamGenerateContent",
+            "model": "fixture-1",
+            "requires_key": true,
+            "key_id": "fixture",
+            "key_get_link": "https://example.test/keys",
+            "api_format": "gemini",
+        }),
+        "fixture-openai": aiModelComponent.createObject(this, {
+            "endpoint": "https://example.test/v1/chat/completions",
+            "model": "fixture-2",
+            "requires_key": false,
+        }),
+    }
+    property var apiStrategies: {
+        "openai": openaiApiStrategy.createObject(this),
+        "gemini": geminiApiStrategy.createObject(this),
+    }
+"""
+
+_JS_FIXTURE = """
+var DIALECTS = {
+    "gemini": { "id": "gemini", "endpointShape": "model-in-path", "auth": "query-key", "streaming": "json-array" },
+    "openai": { "id": "openai", "endpointShape": "chat-completions", "auth": "bearer-header", "streaming": "sse" }
+};
+var PROVIDERS = [
+    {
+        "id": "fixture",
+        "dialect": "gemini",
+        "endpoint": "https://example.test/v1beta/models/{model}:streamGenerateContent",
+        "requiresKey": true,
+        "keyId": "fixture",
+        "keyGetLink": "https://example.test/keys",
+        "models": [
+            { "value": "fixture-1", "name": "Fixture", "legacyId": "fixture-model" }
+        ]
+    },
+    {
+        "id": "disc",
+        "dialect": "openai",
+        "endpoint": "https://example.test/v1/chat/completions",
+        "requiresKey": false,
+        "discovered": true,
+        "models": []
+    }
+];
+"""
+
+
+def test_the_parsers_find_what_the_fixtures_hold():
+    qml = parse_ai_qml_builtins(_QML_FIXTURE)
+    assert len(qml) == 2, f"fixture parse found {sorted(qml)}"
+    assert qml["fixture-model"]["endpoint"] == \
+        "https://example.test/v1beta/models/fixture-1:streamGenerateContent"
+    assert qml["fixture-model"]["requires_key"] is True
+    assert qml["fixture-openai"]["api_format"] == "openai"  # the default
+    assert qml["fixture-openai"]["requires_key"] is False
+
+    provs = parse_catalog_providers(_JS_FIXTURE)
+    assert len(provs) == 2, f"fixture parse found {len(provs)} providers"
+    assert provs[0]["id"] == "fixture"
+    assert provs[0]["models"][0]["legacyId"] == "fixture-model"
+    assert provs[1]["discovered"] is True
+
+    assert parse_catalog_dialects(_JS_FIXTURE) == ["gemini", "openai"]
+    assert parse_ai_qml_strategy_keys(_QML_FIXTURE) == ["gemini", "openai"]
+
+
+# ── The contract ─────────────────────────────────────────────────────────────
+
+def _catalog_models_by_legacy_id():
+    providers = parse_catalog_providers(CATALOG_JS.read_text())
+    result = {}
+    for provider in providers:
+        if provider["discovered"]:
+            continue
+        for model in provider["models"]:
+            legacy = model["legacyId"]
+            assert legacy, (
+                f"catalog model {provider['id']}:{model['value']} carries no "
+                f"legacyId; every non-discovered built-in needs the Ai.qml key "
+                f"it mirrors until stage 2 removes the second copy")
+            template = model["endpoint"] or provider["endpoint"]
+            result[legacy] = {
+                "endpoint": template.replace("{model}", model["value"]),
+                "model": model["value"],
+                "api_format": provider["dialect"],
+                "key_id": provider["keyId"],
+                "key_get_link": provider["keyGetLink"],
+                "requires_key": provider["requiresKey"],
+            }
+    return result
+
+
+def test_every_ai_qml_builtin_is_in_the_catalog_and_vice_versa():
+    ai_models = parse_ai_qml_builtins(AI_QML.read_text())
+    assert len(ai_models) >= 3, (
+        f"parsed only {sorted(ai_models)} from Ai.qml - the parser lost the "
+        f"models block")
+    catalog = _catalog_models_by_legacy_id()
+
+    missing = sorted(set(ai_models) - set(catalog))
+    assert not missing, (
+        f"Ai.qml declares built-in models the catalog does not: {missing}. "
+        f"Add them to services/ai_catalog.js.")
+    extra = sorted(set(catalog) - set(ai_models))
+    assert not extra, (
+        f"the catalog declares built-in models Ai.qml does not: {extra}. "
+        f"Until stage 2 wires Ai.qml to the catalog, a model ships in both.")
+
+    for legacy_id, ai_fields in sorted(ai_models.items()):
+        cat_fields = catalog[legacy_id]
+        for field in ("endpoint", "model", "api_format", "key_id",
+                      "key_get_link", "requires_key"):
+            assert ai_fields[field] == cat_fields[field], (
+                f"{legacy_id}.{field} disagrees: Ai.qml has "
+                f"{ai_fields[field]!r}, the catalog resolves "
+                f"{cat_fields[field]!r}")
+
+
+def test_the_dialect_vocabulary_matches_the_strategies():
+    dialects = parse_catalog_dialects(CATALOG_JS.read_text())
+    strategy_keys = parse_ai_qml_strategy_keys(AI_QML.read_text())
+    assert dialects == strategy_keys, (
+        f"catalog dialects {dialects} != Ai.qml apiStrategies {strategy_keys}")
+    assert dialects == sorted(DIALECT_STRATEGY_FILES), (
+        f"catalog dialects {dialects} do not match this module's "
+        f"dialect-to-strategy-file map; update DIALECT_STRATEGY_FILES with "
+        f"the new strategy")
+    for dialect, filename in DIALECT_STRATEGY_FILES.items():
+        assert (STRATEGY_DIR / filename).is_file(), (
+            f"dialect {dialect!r} names {filename}, which does not exist "
+            f"under services/ai/")
+
+
+def test_the_ollama_discovery_endpoint_matches_the_catalog():
+    catalog_providers = parse_catalog_providers(CATALOG_JS.read_text())
+    ollama = next((p for p in catalog_providers if p["id"] == "ollama"), None)
+    assert ollama is not None, "the catalog lost its ollama provider record"
+    assert ollama["discovered"], "ollama must stay a discovered provider"
+    assert ollama["endpoint"] in AI_QML.read_text(), (
+        f"Ai.qml's Ollama discovery no longer hands out the endpoint the "
+        f"catalog records ({ollama['endpoint']})")
+
+
+def test_the_catalog_stays_pure():
+    text = CATALOG_JS.read_text()
+    assert text.startswith(".pragma library"), (
+        "ai_catalog.js must stay a .pragma library")
+    assert not re.search(r"^\s*\.import\b", text, re.M), (
+        "ai_catalog.js must not import anything - inputs arrive as arguments")
+    assert not re.search(r"\bQt\.\w+", text), (
+        "ai_catalog.js must not reach Qt; it has no engine context to assume")
+    # Describing HOW a key travels (auth: "bearer-header") is catalog data;
+    # holding or fetching one is not, so the names the key plumbing uses may
+    # not appear in the CODE at all. Comments are free to state the rule.
+    code = re.sub(r"//[^\n]*", "", text)
+    for secret_shape in ("apiKey", "api_key", "KeyringStorage", "keyringData"):
+        assert secret_shape not in code, (
+            f"ai_catalog.js code mentions {secret_shape!r}: the catalog "
+            f"carries key metadata, never key material or key plumbing")
+
+
+if __name__ == "__main__":
+    import sys
+    from contract_runner import run
+    sys.exit(run(globals()))

--- a/dots/.config/quickshell/imi/tests/test_bar_popup_section_entrance.py
+++ b/dots/.config/quickshell/imi/tests/test_bar_popup_section_entrance.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""The bar popups' sections cascade below the fold, and the hero never does.
+
+BarPopupOverlay unrolls the card from the height of the content's FIRST drawn
+section so that section is legible on frame one - that is the hero unroll's
+whole point. The section wave (gated on the card's own progress, see
+tests/lint_bar_popup_overlay_static.py) therefore must not park or dim the
+hero: only the sections below the fold cascade, and a popup opts each of those
+in by declaring `property real appear: 1` and folding it into the measured
+three-channel entrance (docs/p3drovfx-motion-measured-2026-08-22.md §3 -
+opacity, a slight scale, a small rise, all driven by the one scalar).
+
+What decays here, and what this file pins:
+
+  - A hero that grows an `appear` is parked at zero for the run up to the
+    gate, so the card opens at the height of a section that is not drawn -
+    the unroll rendered meaningless, with nothing in any log.
+  - A section that declares `appear` but binds only its opacity is the plain
+    fade the survey found lacking; the three channels are one scalar so they
+    cannot land on different schedules, and dropping two of them is silent.
+  - A section that quietly stops opting in arrives in a single frame again,
+    which reads on screen as the shell being flat rather than as a bug - the
+    same decay STAGGER_ADOPTERS exists for, one level down.
+
+The registers are RATCHETS: a new cascading section is a line here, and one
+that disappears reddens instead of going quiet. Popups deliberately absent
+(the tray overflow's homogeneous icon grid, the privacy card's one-tree depth
+morph whose entrance channels would composite with its own morph) simply
+declare no `appear` and keep today's behaviour - the wave is opt-in by
+construction.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from contract_runner import run  # noqa: E402
+
+ROOT = Path(__file__).resolve().parents[1]
+BAR = "modules/imi/bar"
+STYLED_POPUP = ROOT / "modules/common/widgets/StyledPopup.qml"
+
+# Per popup: the hero band's markers (ids or objectNames that must NOT declare
+# `appear` - the card opens at the first drawn section's height, and anything
+# sharing that band rides with it), and the ids of the sections that cascade.
+SECTION_WAVES = {
+    f"{BAR}/WeatherPopup.qml": {
+        "hero_band": ["weatherHero"],
+        "cascades": ["hourlyChart", "gridLayout"],
+    },
+    f"{BAR}/ClockWidgetPopup.qml": {
+        # The year label anchors its baseline to the month's, so the two are
+        # one visual band and neither may cascade out from under the other.
+        "hero_band": ["monthLabel", "yearLabel"],
+        "cascades": ["weekRow", "taskSection", "pendingLabel", "uptimeLabel"],
+    },
+    f"{BAR}/NetworkSpeedPopup.qml": {
+        "hero_band": ["connectionRow"],
+        "cascades": ["speedRow", "detailsList"],
+    },
+    f"{BAR}/BatteryPopup.qml": {
+        "hero_band": ["batteryHeaderRow"],
+        "cascades": ["batteryCards"],
+    },
+    f"{BAR}/ResourcesPopup.qml": {
+        "hero_band": ["ramCpuColumn"],
+        "cascades": ["swapDiskColumn", "gpuColumn"],
+    },
+}
+
+
+def block_declaring(text, ident):
+    """The body of the object declaring `id: <ident>` or objectName <ident>."""
+    marker = re.search(rf'\bid:\s*{ident}\b|\bobjectName:\s*"{ident}"', text)
+    if not marker:
+        return None
+    brace = text.rfind("{", 0, marker.start())
+    if brace < 0:
+        return None
+    depth = 0
+    for index in range(brace, len(text)):
+        if text[index] == "{":
+            depth += 1
+        elif text[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[brace + 1:index]
+    return None
+
+
+def stripped(path):
+    return re.sub(r"//.*", "", (ROOT / path).read_text(encoding="utf-8"))
+
+
+def test_every_registered_popup_is_on_disk_and_reaches_the_helpers():
+    for relative in SECTION_WAVES:
+        assert (ROOT / relative).is_file(), (
+            f"{relative} is registered and not on disk. Point the entry at "
+            f"wherever the popup moved to - a register naming nothing passes.")
+        text = stripped(relative)
+        assert re.search(r'import\s+"bar_popup_unroll\.js"', text), (
+            f"{relative} no longer imports bar_popup_unroll.js; the entrance "
+            f"channels live there so ten popups cannot each derive their own "
+            f"scale floor.")
+
+
+def test_the_hero_band_never_declares_appear():
+    for relative, spec in SECTION_WAVES.items():
+        text = stripped(relative)
+        for ident in spec["hero_band"]:
+            block = block_declaring(text, ident)
+            assert block is not None, (
+                f"{relative} no longer declares `{ident}`; the register names "
+                f"the hero band so a renamed hero is a line here, not a hole.")
+            assert "appear" not in block, (
+                f"{relative}: `{ident}` is in the hero band and declares or "
+                f"reads `appear`. The card opens at the first drawn section's "
+                f"height precisely so it is legible on frame one; a parked "
+                f"hero is a card opening at the height of nothing, and the "
+                f"failure renders - it looks deliberate and is wrong.")
+
+
+def test_each_cascading_section_takes_all_three_channels():
+    for relative, spec in SECTION_WAVES.items():
+        text = stripped(relative)
+        for ident in spec["cascades"]:
+            block = block_declaring(text, ident)
+            assert block is not None, (
+                f"{relative} no longer declares `{ident}`; it is registered "
+                f"as a cascading section.")
+            assert re.search(r"\bproperty real appear:\s*1\b", block), (
+                f"{relative}: `{ident}` no longer opts into the wave with "
+                f"`property real appear: 1`. Without it the section arrives "
+                f"in a single frame again, which is invisible in the source.")
+            assert re.search(rf"\bopacity:\s*{ident}\.appear\b", block), (
+                f"{relative}: `{ident}`'s opacity is not its own `appear`; "
+                f"the wave animates appear, never opacity, so a section that "
+                f"does not fold it in simply never dims or arrives.")
+            assert "BarPopupUnroll.entranceScale(" in block \
+                and "root.entranceRise" in block, (
+                f"{relative}: `{ident}` does not take its scale from "
+                f"BarPopupUnroll.entranceScale(..., root.entranceRise, ...); "
+                f"a section with opacity alone is the plain fade the survey "
+                f"found lacking, and a hand-spelled factor is the drift the "
+                f"helper exists to stop.")
+            assert "BarPopupUnroll.entranceOffset(" in block, (
+                f"{relative}: `{ident}` does not rise through "
+                f"BarPopupUnroll.entranceOffset; the three channels are one "
+                f"scalar so they cannot land on different schedules.")
+
+
+def test_no_unregistered_section_opts_in():
+    """Every `appear` in a popup file is a registered id, so review sees it."""
+    for relative, spec in SECTION_WAVES.items():
+        text = stripped(relative)
+        declared = len(re.findall(r"\bproperty real appear:", text))
+        assert declared == len(spec["cascades"]), (
+            f"{relative} declares {declared} `appear` sections against "
+            f"{len(spec['cascades'])} registered. A new cascading section is "
+            f"a line in SECTION_WAVES - the register is what lets the hero "
+            f"rule be checked against a named band rather than a guess.")
+
+
+def test_no_appear_section_sits_above_the_hero():
+    """The hero is decided by the BUILT tree - the first drawn section - and
+    this repo keeps source order agreeing with it (the weather popup's hourly
+    row sits below the hero for exactly that reason, pinned by
+    test_weather_forecast_contract). So a cascading section declared above
+    the hero band is a section that will BECOME the hero the moment it has
+    height, parked at appear 0 - the card opening at the height of a section
+    that is not drawn."""
+    for relative, spec in SECTION_WAVES.items():
+        text = stripped(relative)
+        first_hero = min(
+            m.start() for ident in spec["hero_band"]
+            for m in [re.search(rf'\bid:\s*{ident}\b|\bobjectName:\s*"{ident}"', text)]
+            if m)
+        first_appear = re.search(r"\bproperty real appear:", text)
+        assert first_appear and first_appear.start() > first_hero, (
+            f"{relative}: an `appear` section is declared above the hero "
+            f"band. The card unrolls from the first drawn section, so a "
+            f"cascading section above the hero is one gate-length of opening "
+            f"at the height of nothing.")
+
+
+def test_the_rise_is_one_token_on_styled_popup():
+    text = STYLED_POPUP.read_text(encoding="utf-8")
+    assert re.search(
+        r"readonly property real entranceRise:\s*Appearance\.spacing\.\w+", text), (
+        "StyledPopup no longer declares `entranceRise` from a spacing token. "
+        "Every popup's sections read it as root.entranceRise; five hand-spelled "
+        "rises are five entrances that drift apart by a token nobody chose.")
+
+
+if __name__ == "__main__":
+    sys.exit(run(globals()))

--- a/dots/.config/quickshell/imi/tests/test_bar_text_change_motion.py
+++ b/dots/.config/quickshell/imi/tests/test_bar_text_change_motion.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Bar texts whose change is an EVENT slide-swap; the clock's tick stays a tick.
+
+`StyledText.animateChange` is the shell's one spelling of a text swap (slide
+out, bare-PropertyAction swap, slide in - see `tests/tst_deferred_property_swap.qml`
+for the construct's semantics). docs/p3drovfx-animation-research-2026-08-16.md
+§3.11 found the sibling fork shipped the same mode and never turned it on
+anywhere, so its bar temperature hard-cut on every refresh - and ours did too,
+because the flag was only wired at ~20 call sites elsewhere.
+
+What this pins, and why each direction:
+
+- The media widget's verbose bar label (default horizontal style) animates its
+  change: a track change is an event the user notices and often caused.
+- Every WeatherBar temperature label animates its change: a refresh lands a new
+  number a few times an hour, an event rather than a tick.
+- The two material media labels keep their hand-rolled split-flap `Behavior on
+  text` and must NOT also set `animateChange`: StyledText's inner Behavior and
+  a call-site Behavior on the same property would both arm, which is the
+  doubled-motion family `lint_interaction_motion_double.py` exists for on
+  another channel. One transition per property.
+- ClockWidget carries no `animateChange` at all, and the refusal is pinned
+  rather than left as an omission someone "fixes":
+  - `DateTime.time`'s format is user-configurable (`Config.options.time.format`)
+    down to seconds, so the swap would run once per second, forever, on a bar
+    that stays `visible` while a fullscreen window covers it (53d1ff893
+    ("fix(bar): drop the cava claim while a fullscreen window covers the bar") -
+    occlusion happens below Qt, so no visibility gate can stand it down).
+  - In the vertical styles the time is a Repeater over `time.split(...)` - a
+    plain JS array model, which destroys and rebuilds every delegate per tick,
+    so `animateChange` never fires there anyway: enabling it would animate one
+    orientation and not the other.
+  A per-minute tick is not an event the eye is on; the desktop DigitalClock
+  animates its digits behind its own config switch, and that is where the
+  ambient-motion argument lives.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from contract_runner import run  # noqa: E402
+
+ROOT = Path(__file__).resolve().parents[1]
+MEDIA = ROOT / "modules/imi/bar/Media.qml"
+WEATHER = ROOT / "modules/imi/bar/WeatherBar.qml"
+CLOCK = ROOT / "modules/imi/bar/ClockWidget.qml"
+
+
+def code(path: Path) -> str:
+    assert path.exists(), f"{path} is gone"
+    text = path.read_text()
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.S)
+    return re.sub(r"//[^\n]*", "", text)
+
+
+def styled_text_blocks(text: str) -> list[str]:
+    blocks = []
+    for match in re.finditer(r"\bStyledText\s*\{", text):
+        depth = 0
+        start = match.end() - 1
+        for i in range(start, len(text)):
+            if text[i] == "{":
+                depth += 1
+            elif text[i] == "}":
+                depth -= 1
+                if depth == 0:
+                    blocks.append(text[match.start():i + 1])
+                    break
+    assert blocks, "no StyledText blocks found - did the sweep break?"
+    return blocks
+
+
+def test_the_media_bar_label_animates_a_track_change():
+    blocks = [b for b in styled_text_blocks(code(MEDIA))
+              if "bar.media.onlyTitle" in b]
+    assert len(blocks) == 1, \
+        f"expected exactly one verbose bar label in Media.qml, found {len(blocks)}"
+    assert re.search(r"animateChange:\s*true", blocks[0]), \
+        "the media widget's bar label hard-cuts on a track change again"
+
+
+def test_the_media_material_labels_do_not_double_their_transition():
+    for block in styled_text_blocks(code(MEDIA)):
+        if re.search(r"Behavior\s+on\s+text", block):
+            assert "animateChange" not in block, \
+                ("a StyledText with its own `Behavior on text` also arms "
+                 "animateChange - two transitions on one property")
+
+
+def test_every_weather_temperature_animates_its_refresh():
+    temp_blocks = [b for b in styled_text_blocks(code(WEATHER))
+                   if "Weather.data?.temp" in b]
+    assert len(temp_blocks) == 4, \
+        (f"expected 4 temperature labels in WeatherBar.qml (row/col x "
+         f"default/material), found {len(temp_blocks)}")
+    for block in temp_blocks:
+        assert re.search(r"animateChange:\s*true", block), \
+            "a WeatherBar temperature hard-cuts on refresh again"
+
+
+def test_the_clock_does_not_animate_its_tick():
+    assert "animateChange" not in code(CLOCK), \
+        ("ClockWidget arms animateChange - a per-minute (or, with seconds in "
+         "Config.options.time.format, per-second) animation on a bar that "
+         "stays `visible` under a fullscreen window, and one the vertical "
+         "styles' split-digit Repeaters cannot fire anyway. Read this test's "
+         "docstring before enabling it.")
+
+
+if __name__ == "__main__":
+    raise SystemExit(run(globals()))

--- a/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
@@ -1754,30 +1754,58 @@ def test_every_committed_mutation_records_exactly_its_entries():
 
 
 def test_every_staggered_drawer_member_arrives_on_all_three_channels():
-    """The drawer's entrance is one scalar driving three properties.
+    """The drawer's entrance dressing is the shared spelling, declared once.
 
     A member arriving on opacity alone is a fade, which is what
     `docs/M3_GUIDELINES.md` §2 ("Component Entrance and Exit") says a component
-    entrance is not - and a member that folds `appear` into two of the three
+    entrance is not - and a member dressed by copying half of a neighbour
     finishes its scale on a different schedule from its opacity, which reads as
-    a hiccup rather than as one motion. The realistic regression is a fifth
-    section added to the column and dressed by copying half of a neighbour, so
-    the sweep finds the members rather than naming them.
+    a hiccup rather than as one motion. This file used to spell the three
+    channels out once per member, nine times, and this test used to sweep all
+    twenty-seven bindings; the dressing is `StaggerEntrance` now, so what is
+    held instead is that the ONE dresser exists, walks the same column the
+    wave walks, and that no member spells a channel locally beside it - a
+    local copy would silently override or double what the dresser installs,
+    which is exactly the drift the promotion exists to end.
     """
     text = code(DRAWER)
+    assert text.count("StaggerEntrance {") == 1, (
+        "the drawer declares no (or more than one) StaggerEntrance - the "
+        "members' three-channel dressing comes from that one component, so "
+        "without it the wave animates an `appear` nothing renders")
+    dresser = text[text.index("StaggerEntrance {"):]
+    dresser = dresser[:dresser.index("}")]
+    assert "target: drawerColumn" in dresser, (
+        "the dresser is not aimed at drawerColumn - the wave and the dressing "
+        "must walk the same container or a member can be waved and undressed")
+    assert "reference: root.panelWidth" in dresser, (
+        "the dresser's scale reference is not the panel's width. The column "
+        "is inset by its margins, and the derivation's input has been the "
+        "panel since the drawer first dressed its members - changing the "
+        "reference changes the drawn scale of every row")
+
     ids = re.findall(r"id: (\w+)\n\s*property real appear: 1", text)
     assert len(ids) >= 9, (
         f"only {len(ids)} drawer members declare an `appear` - the column has "
         f"nine that should, so either a member lost its entrance or this sweep "
         f"stopped finding them")
-    for name in ids:
-        for channel in (f"opacity: {name}.appear",
-                        f"scale: root.entranceScale({name}.appear)",
-                        f"transform: Translate {{ y: root.entranceOffset({name}.appear) }}"):
-            assert channel in text, (
-                f"{name} does not fold `appear` into `{channel.split(':')[0]}`. "
-                f"All three channels ride one scalar so they cannot land on "
-                f"different schedules.")
+
+    # The old local spelling may not grow back beside the shared one. Any of
+    # these three is a second writer of a channel the dresser installs.
+    for banned, why in (
+            (r"\.appear\b(?!\s*[!=]== undefined)", None),
+            (r"entranceScale", "the drawer re-derives the scale locally"),
+            (r"entranceOffset", "the drawer re-derives the rise locally"),
+            (r"transform: Translate", "a member carries a hand-spelled rise")):
+        if banned == r"\.appear\b(?!\s*[!=]== undefined)":
+            hits = [m for m in re.finditer(r"(opacity|scale):[^\n]*\.appear\b", text)]
+            assert not hits, (
+                f"a drawer member folds `appear` into a channel by hand again "
+                f"({hits[0].group(0)!r}) - the dressing is StaggerEntrance's, "
+                f"and a local binding beside it doubles or replaces what the "
+                f"dresser installed")
+            continue
+        assert not re.search(banned, text), why
 
     # ...and the members that must NOT be dressed this way are the column's own
     # RippleButtons - the lock section's two re-link rows. A `RippleButton`

--- a/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
@@ -1827,14 +1827,10 @@ def test_every_staggered_drawer_member_arrives_on_all_three_channels():
             f"{name} redeclares `appear`. It is a RippleButton, which already "
             f"has one and already folds it into the opacity that carries its "
             f"disabled dim - a second declaration here shadows the control's "
-            f"own and draws the row as enabled while it is not.")
-        for channel in (f"opacity: {name}.appear",
-                        f"scale: root.entranceScale({name}.appear)"):
-            assert channel not in text, (
-                f"{name} writes `{channel.split(':')[0]}` itself. On a control "
-                f"that already writes it, that replaces the binding rather "
-                f"than composing with it - lint_interaction_motion_double.py "
-                f"and lint_disabled_opacity.py exist for the same doubling.")
+            f"own and draws the row as enabled while it is not. (A channel "
+            f"written out by hand beside it is caught by the local-spelling "
+            f"ban above, and a StaggerEntrance re-aimed at a control by "
+            f"lint_interaction_motion_double.py / lint_disabled_opacity.py.)")
 
 
 def test_the_drawer_arms_its_entrance_before_the_reveal_draws():

--- a/dots/.config/quickshell/imi/tests/test_motion_policy_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_motion_policy_contract.py
@@ -69,8 +69,22 @@ STAGGER_ADOPTERS = {
     # The right sidebar, re-adopted - the register's one round trip so far;
     # the STAGGER_DECLINED preamble below carries the full history and the
     # two repairs that made re-adoption arguable. Gate on the EdgeSlide's
-    # progress via containerProgress, no leadIn, enter-only.
+    # progress via containerProgress, no leadIn, enter-only. Its sections are
+    # deliberately UNIFORM while the toggle grid's tiles converge: section
+    # translate stacked on tile convergence was tried and judged ruined on
+    # screen - the fork's sections hold still and their PIECES move.
     "modules/imi/sidebarRight/SidebarRightContent.qml",
+    # The android toggle grid's nested tile wave (convergent - tiles from
+    # their own third of the grid), gated on the section's own appear.
+    "modules/imi/sidebarRight/quickToggles/AndroidQuickPanel.qml",
+    # The left sidebar, adopted after its refusal's hazard was answered
+    # rather than waved off: the gate keys on the OPEN flag, which a detach
+    # does not flip, so undocking the chat to keep reading cannot re-run the
+    # entrance. The slide progress reaches the reparented tree by assignment
+    # (SidebarLeft.qml), and the AI pane's members cascade through the
+    # dynamic-scope gate documented in AiChat.qml.
+    "modules/imi/sidebarLeft/SidebarLeftContent.qml",
+    "modules/imi/sidebarLeft/AiChat.qml",
 }
 
 # The other half of that ratchet: a surface that adopted a wave, was judged on
@@ -98,14 +112,9 @@ STAGGER_ADOPTERS = {
 # It is in STAGGER_ADOPTERS above; this note stays because the register's
 # job is exactly this round trip.
 STAGGER_DECLINED = {
-    # The LEFT sidebar. Its content is a live conversation (the AI chat) the
-    # user is mid-exchange with - the launcher refusal's argument - and the
-    # tree REPARENTS between the attached panel and the detached window
-    # (`contentParent.children = [sidebarContent]`), so an entrance keyed to
-    # the panel's lifecycle would re-run on a detach the user performs
-    # precisely to keep reading. Adopting there means solving the handover
-    # first.
-    "modules/imi/sidebarLeft/SidebarLeft.qml",
+    # (The LEFT sidebar sat here briefly for its detach-reparenting hazard;
+    # it moved to STAGGER_ADOPTERS once the gate was keyed to the open flag,
+    # which a detach does not flip - the hazard answered, not waved off.)
     # Dialog content. Assessed for the group entrance when the desktop menu
     # adopted it and refused on the surface's own facts, all of them readable
     # in the tree rather than guessed:

--- a/dots/.config/quickshell/imi/tests/test_motion_policy_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_motion_policy_contract.py
@@ -66,6 +66,11 @@ STAGGER_ADOPTERS = {
     # per-close cost cannot arise), and the per-open surface build is a cost
     # the menu already paid before the wave.
     "modules/imi/desktopMenu/DesktopMenu.qml",
+    # The right sidebar, re-adopted - the register's one round trip so far;
+    # the STAGGER_DECLINED preamble below carries the full history and the
+    # two repairs that made re-adoption arguable. Gate on the EdgeSlide's
+    # progress via containerProgress, no leadIn, enter-only.
+    "modules/imi/sidebarRight/SidebarRightContent.qml",
 }
 
 # The other half of that ratchet: a surface that adopted a wave, was judged on
@@ -75,25 +80,32 @@ STAGGER_ADOPTERS = {
 # tried and refused. A refusal is invisible in the source, exactly like the
 # adoption it mirrors.
 #
-# The right sidebar is the entry. 9e10b8a9c ("feat(sidebar): the right
-# sidebar's sections arrive in sequence") gave it one and the user rejected it:
-# "I don't like the cascading animation effect in the sidebar... This one feels
-# slow. There's a frame drop the moment it opens and the moment it closes."
-# Two properties of THIS surface are why, and neither is a tuning. Its
-# container is a layer surface the compositor slides, so there is no progress
-# to gate on and the head start can only be a guessed `leadIn` - which put the
-# last member's landing 180ms past the end of `sidebarSlideEnter`. And the
-# surface is DESTROYED by the gesture the wave rides: `PanelWindow.visible`
-# follows the open state, layer-shell forbids window reuse, so the wave's
-# frames land on a surface the compositor is still bringing up and its exit
-# animates a window that has already been asked to leave - measured at a median
-# of 30 rendered frames per open against 5 without it, and 13 per close against
-# zero. The frame drop the report names is that teardown-and-rebuild and NOT
-# the wave; see AGENT.md's design-language section, which carries the numbers
-# and the two suspects they eliminate. Re-adopting is a decision to be argued,
-# not a line to be copied.
+# The right sidebar is the worked example of the register running in BOTH
+# directions, and its history is the argument for keeping refusals written
+# down. 9e10b8a9c ("feat(sidebar): the right sidebar's sections arrive in
+# sequence") gave it a wave; the maintainer rejected it on screen ("feels
+# slow", a frame drop at both ends) and 00efe588 took it off, with two
+# measured facts recorded here: the container was a compositor-slid surface
+# with no progress to gate on (so the head start was a guessed leadIn landing
+# the last member ~200ms after the slide), and the surface was destroyed per
+# gesture, which was the frame drop. BOTH facts were later repaired for
+# unrelated reasons - the sidebar became a persistent surface whose EdgeSlide
+# owns the slide in-client - so when the maintainer asked for the cascade
+# again (2026-08-24), re-adoption was argued on the repairs, not copied:
+# the wave now gates on `containerProgress` (the EdgeSlide's own scalar,
+# handed in by SidebarRight.qml) through `contentsArrived`, carries NO
+# leadIn, and runs enter-only - the sections ride the slide out rigid.
+# It is in STAGGER_ADOPTERS above; this note stays because the register's
+# job is exactly this round trip.
 STAGGER_DECLINED = {
-    "modules/imi/sidebarRight/SidebarRightContent.qml",
+    # The LEFT sidebar. Its content is a live conversation (the AI chat) the
+    # user is mid-exchange with - the launcher refusal's argument - and the
+    # tree REPARENTS between the attached panel and the detached window
+    # (`contentParent.children = [sidebarContent]`), so an entrance keyed to
+    # the panel's lifecycle would re-run on a detach the user performs
+    # precisely to keep reading. Adopting there means solving the handover
+    # first.
+    "modules/imi/sidebarLeft/SidebarLeft.qml",
     # Dialog content. Assessed for the group entrance when the desktop menu
     # adopted it and refused on the surface's own facts, all of them readable
     # in the tree rather than guessed:

--- a/dots/.config/quickshell/imi/tests/test_motion_policy_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_motion_policy_contract.py
@@ -54,6 +54,18 @@ STAGGER_ADOPTERS = {
     # the hero's own height precisely so it is legible on frame one.
     # tests/lint_bar_popup_overlay_static.py holds the gate's shape.
     "modules/imi/bar/BarPopupOverlay.qml",
+    # The desktop menu's rows. Adopted on the drawer's argument, not the
+    # sidebar's counter-argument: the card's own entrance is a QML-readable
+    # scalar (its opacity Behavior), so the wave gates on the real container
+    # progress with no guessed leadIn - the exact property whose absence
+    # refused the right sidebar. Its rows are RippleButtons, so they ride the
+    # wave through the `appear` the control already folds; the card enters via
+    # scale/opacity itself, so only the rows cascade. Enter-only by
+    # construction: the window is destroyed with the close, so there is no
+    # exit for a wave to waste frames on (the sidebar's measured 13-frames-
+    # per-close cost cannot arise), and the per-open surface build is a cost
+    # the menu already paid before the wave.
+    "modules/imi/desktopMenu/DesktopMenu.qml",
 }
 
 # The other half of that ratchet: a surface that adopted a wave, was judged on

--- a/dots/.config/quickshell/imi/tests/test_motion_policy_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_motion_policy_contract.py
@@ -94,6 +94,42 @@ STAGGER_ADOPTERS = {
 # not a line to be copied.
 STAGGER_DECLINED = {
     "modules/imi/sidebarRight/SidebarRightContent.qml",
+    # Dialog content. Assessed for the group entrance when the desktop menu
+    # adopted it and refused on the surface's own facts, all of them readable
+    # in the tree rather than guessed:
+    #
+    #  - A dialog's content is the question being asked. Every WindowDialog
+    #    here is an interruption offering a decision (the polkit auth prompt,
+    #    the uninstall confirm, the Wi-Fi/Bluetooth/Tailscale/volume/phone
+    #    dialogs), and a clamped five-rank wave puts the last member's landing
+    #    ~400ms after the gate - latency on exactly the thing the user was
+    #    interrupted to read. This is the launcher refusal's argument on a
+    #    modal surface: a wave is wrong where the content IS what is being
+    #    waited for.
+    #  - The polkit prompt `forceActiveFocus()`es its field the moment it
+    #    opens (PolkitContent.qml) and users answer immediately; a cascade
+    #    puts keystrokes into a password field still parked at `appear: 0`,
+    #    invisible, on an authentication surface.
+    #  - The card already has an entrance of its own that members would fight:
+    #    `onShowChanged` freezes the card's height at the show flip (the
+    #    binding-destroying assignment AGENT.md documents as load-bearing) and
+    #    the card unfolds 0 -> that height while the content column fades AS
+    #    ONE - a per-member cascade inside an unfolding card is two entrances
+    #    stacked on one surface.
+    #  - Six of the dialog content files bleed children to the card's edge
+    #    with negative `contentPadding` margins (separators, lists); a
+    #    scale-and-rise dressing on those members swings edge-to-edge chrome
+    #    onto the scrim mid-entrance, and separators would spend wave slots.
+    #  - The dialog surfaces are created by the gesture that opens them (the
+    #    sidebar's `toggleDialogLoader.active` flips on `shown`;
+    #    FullscreenPolkitWindow is gated on `PolkitService.active`), which is
+    #    the measured half of the sidebar refusal above: wave frames landing
+    #    on a surface the compositor is still bringing up.
+    #
+    # A dialog that someday earns a group entrance argues these down first -
+    # in particular the first two, which are properties of what a dialog IS
+    # rather than of how this one is built.
+    "modules/common/widgets/WindowDialog.qml",
 }
 
 # A cascade whose rank is bounded by the shape of its own model rather than by

--- a/dots/.config/quickshell/imi/tests/test_motion_policy_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_motion_policy_contract.py
@@ -45,6 +45,15 @@ STAGGER_ADOPTERS = {
     "modules/common/widgets/ContentPage.qml",
     "modules/imi/sessionScreen/SessionScreen.qml",
     "modules/imi/editMode/EditModeDrawer.qml",
+    # The bar popups' shared card: the second adopter whose container has a
+    # real progress to gate on (card.openProgress through
+    # Appearance.animation.contentsArrived), so like the drawer it carries no
+    # leadIn. One wave on the overlay, never one per popup - the per-popup
+    # content files only opt their below-the-fold sections in with `appear`;
+    # the hero section deliberately declares none, because the card opens at
+    # the hero's own height precisely so it is legible on frame one.
+    # tests/lint_bar_popup_overlay_static.py holds the gate's shape.
+    "modules/imi/bar/BarPopupOverlay.qml",
 }
 
 # The other half of that ratchet: a surface that adopted a wave, was judged on

--- a/dots/.config/quickshell/imi/tests/test_motion_policy_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_motion_policy_contract.py
@@ -71,7 +71,7 @@ STAGGER_ADOPTERS = {
     # two repairs that made re-adoption arguable. UNGATED: park-and-enter on
     # the open's rising edge, running under the slide, whose `reveal` curtain
     # masks the early frames (the gated version put the whole construction on
-    # stage and was measured as ruined - 1f254a158b). Its sections are
+    # stage and was measured as ruined - d59440244 ("fix(motion): the entrance runs under the slide - the panel materializes composed")). Its sections are
     # deliberately UNIFORM while the toggle grid's tiles converge: section
     # translate stacked on tile convergence was tried and judged ruined on
     # screen - the fork's sections hold still and their PIECES move.
@@ -111,7 +111,7 @@ STAGGER_ADOPTERS = {
 # the wave first gated on the EdgeSlide's scalar - and that version was
 # measured as ruined (the panel arrived empty and built itself on stage).
 # The design that stuck runs UNGATED under the slide, park-and-enter on the
-# open's rising edge, behind EdgeSlide's `reveal` curtain (1f254a158b).
+# open's rising edge, behind EdgeSlide's `reveal` curtain (d59440244, "fix(motion): the entrance runs under the slide - the panel materializes composed").
 # It is in STAGGER_ADOPTERS above; this note stays because the register's
 # job is exactly this round trip.
 STAGGER_DECLINED = {

--- a/dots/.config/quickshell/imi/tests/test_motion_policy_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_motion_policy_contract.py
@@ -68,8 +68,10 @@ STAGGER_ADOPTERS = {
     "modules/imi/desktopMenu/DesktopMenu.qml",
     # The right sidebar, re-adopted - the register's one round trip so far;
     # the STAGGER_DECLINED preamble below carries the full history and the
-    # two repairs that made re-adoption arguable. Gate on the EdgeSlide's
-    # progress via containerProgress, no leadIn, enter-only. Its sections are
+    # two repairs that made re-adoption arguable. UNGATED: park-and-enter on
+    # the open's rising edge, running under the slide, whose `reveal` curtain
+    # masks the early frames (the gated version put the whole construction on
+    # stage and was measured as ruined - 1f254a158b). Its sections are
     # deliberately UNIFORM while the toggle grid's tiles converge: section
     # translate stacked on tile convergence was tried and judged ruined on
     # screen - the fork's sections hold still and their PIECES move.
@@ -106,9 +108,10 @@ STAGGER_ADOPTERS = {
 # unrelated reasons - the sidebar became a persistent surface whose EdgeSlide
 # owns the slide in-client - so when the maintainer asked for the cascade
 # again (2026-08-24), re-adoption was argued on the repairs, not copied:
-# the wave now gates on `containerProgress` (the EdgeSlide's own scalar,
-# handed in by SidebarRight.qml) through `contentsArrived`, carries NO
-# leadIn, and runs enter-only - the sections ride the slide out rigid.
+# the wave first gated on the EdgeSlide's scalar - and that version was
+# measured as ruined (the panel arrived empty and built itself on stage).
+# The design that stuck runs UNGATED under the slide, park-and-enter on the
+# open's rising edge, behind EdgeSlide's `reveal` curtain (1f254a158b).
 # It is in STAGGER_ADOPTERS above; this note stays because the register's
 # job is exactly this round trip.
 STAGGER_DECLINED = {

--- a/dots/.config/quickshell/imi/tests/test_todo_list_transitions.py
+++ b/dots/.config/quickshell/imi/tests/test_todo_list_transitions.py
@@ -74,11 +74,21 @@ def test_the_model_is_fed_identity_stable_values():
 
 
 def test_the_delegate_resolves_indices_at_click_time():
+    # One resolver, called by both handlers at click time. Identity first
+    # (modelData IS the list's object on the current quickshell pin), and a
+    # content+done fallback for pins where ScriptModel stored copies and
+    # indexOf answered -1 - the Gentoo ebuild's pinned commit predates
+    # quickshell a611932's QJSValueList members, and every click there was
+    # a silent no-op.
     text = code(TASK_LIST)
-    calls = re.findall(r"Todo\.list\.indexOf\(", text)
+    assert "Todo.list.indexOf(" in text, \
+        "the resolver no longer tries identity first"
+    assert "findIndex" in text, \
+        "the resolver lost its content fallback for copy-valued ScriptModels"
+    calls = re.findall(r"todoItem\.resolveIndex\(\)", text)
     assert len(calls) == 2, \
         (f"expected the done-toggle and the delete to resolve their index "
-         f"with Todo.list.indexOf at click time, found {len(calls)}")
+         f"through resolveIndex() at click time, found {len(calls)}")
 
 
 if __name__ == "__main__":

--- a/dots/.config/quickshell/imi/tests/test_todo_list_transitions.py
+++ b/dots/.config/quickshell/imi/tests/test_todo_list_transitions.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""The todo lists ride StyledListView's own transitions, on an identity-stable model.
+
+docs/p3drovfx-animation-research-2026-08-16.md §4.7: we own a StyledListView
+with the full positioner-transition vocabulary and use it in fewer places than
+the sibling fork. The todo TaskList was the clearest case - it drew through
+StyledListView and switched the transitions OFF (`animateAppearance: false`,
+inherited from the fork ancestry, not a decision made here: the flag predates
+this repo's history).
+
+Turning the flag back on is half the fix, and the half a reviewer cannot see is
+the model: Quickshell's ScriptModel diffs `values` by strict equality
+(scriptmodel.cpp `a.strictlyEquals(b)` with no `objectProp` set), so
+TodoWidget's old per-update wrapper - `.map(Object.assign({}, item,
+{originalIndex: i}))` - handed it a list of brand-new objects on every change.
+Every update then diffed as remove-all + add-all: with transitions off that was
+silent delegate churn, with them on it would fly the entire list out and back
+in when one task is marked done. The wrapper is gone; the filters pass
+`Todo.list`'s own objects through (Todo mutates items in place and reassigns
+the array, so identity survives a markDone/markUnfinished/delete), and the
+delegate resolves an item's index at click time with `Todo.list.indexOf`,
+which also cannot go stale across deletes the way a stored index could.
+
+`animateMovement` stays at its default (off) deliberately: the diff emits
+inserts and removes, never model moves, so the move/displaced slots have
+nothing to fire on.
+
+Why a source contract: qmltestrunner cannot construct Quickshell types, so
+neither ScriptModel's diff nor a ListView transition is reachable from the QML
+suite; the identity chain is exactly the part that reads correctly while
+broken.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from contract_runner import run  # noqa: E402
+
+ROOT = Path(__file__).resolve().parents[1]
+TASK_LIST = ROOT / "modules/imi/sidebarRight/todo/TaskList.qml"
+TODO_WIDGET = ROOT / "modules/imi/sidebarRight/todo/TodoWidget.qml"
+
+
+def code(path: Path) -> str:
+    assert path.exists(), f"{path} is gone"
+    text = path.read_text()
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.S)
+    return re.sub(r"//[^\n]*", "", text)
+
+
+def test_the_task_list_keeps_the_views_transitions_armed():
+    text = code(TASK_LIST)
+    assert "StyledListView" in text, "TaskList no longer draws through StyledListView"
+    assert not re.search(r"animateAppearance:\s*false", text), \
+        "TaskList switched the view's add/remove transitions back off"
+    assert re.search(r"ScriptModel\s*\{", text), \
+        "TaskList no longer models through ScriptModel - what diffs the list now?"
+
+
+def test_the_model_is_fed_identity_stable_values():
+    widget = code(TODO_WIDGET)
+    filters = re.findall(r"taskList:\s*Todo\.list\.filter", widget)
+    assert len(filters) == 2, \
+        (f"expected both tabs to pass Todo.list's own objects straight into "
+         f"their filter, found {len(filters)} - a per-update wrapper makes "
+         "every change diff as remove-all + add-all")
+    for path in (TODO_WIDGET, TASK_LIST):
+        assert "Object.assign" not in code(path), \
+            f"{path.name} wraps model values in fresh objects again"
+        assert "originalIndex" not in code(path), \
+            f"{path.name} stores an index that goes stale across deletes"
+
+
+def test_the_delegate_resolves_indices_at_click_time():
+    text = code(TASK_LIST)
+    calls = re.findall(r"Todo\.list\.indexOf\(", text)
+    assert len(calls) == 2, \
+        (f"expected the done-toggle and the delete to resolve their index "
+         f"with Todo.list.indexOf at click time, found {len(calls)}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(run(globals()))

--- a/dots/.config/quickshell/imi/tests/tst_ai_catalog.qml
+++ b/dots/.config/quickshell/imi/tests/tst_ai_catalog.qml
@@ -1,0 +1,158 @@
+import QtQuick
+import QtTest
+import "../services/ai_catalog.js" as AiCatalog
+
+TestCase {
+    name: "AiCatalogTest"
+
+    function test_dialect_vocabulary_is_closed_and_complete() {
+        const dialects = AiCatalog.dialects()
+        const ids = Object.keys(dialects).sort()
+        // Exactly the strategies services/ai/ implements today. A fourth
+        // dialect lands here together with its strategy file, or the
+        // contract check reddens.
+        compare(ids.join(","), "gemini,mistral,openai")
+        for (const id of ids) {
+            compare(dialects[id].id, id)
+            verify(dialects[id].endpointShape.length > 0)
+            verify(dialects[id].auth.length > 0)
+            verify(dialects[id].streaming.length > 0)
+        }
+        compare(dialects["gemini"].endpointShape, "model-in-path")
+        compare(dialects["gemini"].auth, "query-key")
+        compare(dialects["openai"].endpointShape, "chat-completions")
+        compare(dialects["openai"].auth, "bearer-header")
+    }
+
+    function test_every_model_names_a_declared_dialect() {
+        const dialects = AiCatalog.dialects()
+        for (const provider of AiCatalog.providers()) {
+            verify(dialects[provider.dialect] !== undefined,
+                   `provider ${provider.id} names undeclared dialect ${provider.dialect}`)
+            for (const model of provider.models) {
+                verify(dialects[model.dialect] !== undefined,
+                       `model ${model.id} names undeclared dialect ${model.dialect}`)
+            }
+        }
+    }
+
+    function test_builtin_models_carry_the_full_record() {
+        const models = AiCatalog.builtinModels()
+        verify(models.length >= 3)
+        for (const model of models) {
+            compare(model.id, `${model.providerId}:${model.value}`)
+            verify(model.name.length > 0)
+            verify(model.endpoint.length > 0)
+            verify(model.endpoint.indexOf("{model}") === -1,
+                   `unresolved endpoint template in ${model.id}`)
+            compare(typeof model.capabilities.tools, "boolean")
+            compare(typeof model.capabilities.vision, "boolean")
+            compare(typeof model.capabilities.thinking, "boolean")
+            if (model.requiresKey)
+                verify(model.keyId.length > 0,
+                       `${model.id} requires a key but names no keyId`)
+        }
+    }
+
+    function test_model_in_path_endpoints_resolve_the_model_slot() {
+        const gemini3 = AiCatalog.resolve("google:gemini-3-flash-preview")
+        verify(gemini3 !== null)
+        compare(gemini3.endpoint,
+                "https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash-preview:streamGenerateContent")
+        // A chat-completions endpoint has no slot and passes through whole.
+        const mistral = AiCatalog.resolve("mistral:mistral-medium-2505")
+        verify(mistral !== null)
+        compare(mistral.endpoint, "https://api.mistral.ai/v1/chat/completions")
+    }
+
+    function test_legacy_ids_resolve_to_the_same_record() {
+        // Today's Ai.qml keys, i.e. what Persistent.states.ai.model can hold.
+        const pairs = [
+            ["gemini-3-flash", "google:gemini-3-flash-preview"],
+            ["gemini-2.5-flash", "google:gemini-2.5-flash"],
+            ["mistral-medium-3", "mistral:mistral-medium-2505"],
+        ]
+        for (const [legacy, canonical] of pairs) {
+            const viaLegacy = AiCatalog.resolve(legacy)
+            const viaCanonical = AiCatalog.resolve(canonical)
+            verify(viaLegacy !== null, `legacy id ${legacy} did not resolve`)
+            compare(viaLegacy.id, viaCanonical.id)
+            compare(viaLegacy.endpoint, viaCanonical.endpoint)
+        }
+    }
+
+    function test_unknown_and_empty_ids_resolve_to_null() {
+        compare(AiCatalog.resolve("no-such-model"), null)
+        compare(AiCatalog.resolve("google:no-such-model"), null)
+        compare(AiCatalog.resolve(""), null)
+        compare(AiCatalog.resolve(undefined), null)
+        compare(AiCatalog.resolve(null), null)
+    }
+
+    function test_provider_lookup() {
+        const google = AiCatalog.provider("google")
+        verify(google !== null)
+        compare(google.dialect, "gemini")
+        compare(google.models.length, 2)
+        compare(AiCatalog.provider("no-such-provider"), null)
+
+        const ollama = AiCatalog.provider("ollama")
+        verify(ollama !== null)
+        verify(ollama.local)
+        verify(ollama.discovered)
+        compare(ollama.requiresKey, false)
+        compare(ollama.models.length, 0)
+    }
+
+    function test_build_model_merges_provider_defaults_under_entry_overrides() {
+        const providerDef = {
+            "id": "p",
+            "name": "P",
+            "icon": "p-icon",
+            "dialect": "openai",
+            "endpoint": "https://p.example/v1/chat/completions",
+            "requiresKey": true,
+            "keyId": "p",
+            "keyGetLink": "https://p.example/keys",
+            "capabilities": { "tools": true, "vision": true, "thinking": false }
+        }
+        const model = AiCatalog.buildModel(providerDef, {
+            "value": "m-1",
+            "capabilities": { "vision": false, "thinking": true },
+            "requiresKey": false
+        })
+        compare(model.id, "p:m-1")
+        compare(model.name, "m-1")           // falls back to the value
+        compare(model.icon, "p-icon")        // provider default
+        compare(model.dialect, "openai")
+        // Entry override wins per flag; untouched flags keep the default.
+        compare(model.capabilities.tools, true)
+        compare(model.capabilities.vision, false)
+        compare(model.capabilities.thinking, true)
+        compare(model.requiresKey, false)
+    }
+
+    function test_build_model_refuses_an_entry_with_no_value() {
+        const providerDef = AiCatalog.providers()[0]
+        compare(AiCatalog.buildModel(providerDef, {}), null)
+        compare(AiCatalog.buildModel(providerDef, { "value": "" }), null)
+        compare(AiCatalog.buildModel(providerDef, null), null)
+    }
+
+    function test_resolve_endpoint() {
+        compare(AiCatalog.resolveEndpoint("https://x/{model}:stream", "m"),
+                "https://x/m:stream")
+        compare(AiCatalog.resolveEndpoint("https://x/v1/chat/completions", "m"),
+                "https://x/v1/chat/completions")
+    }
+
+    function test_returned_records_are_fresh_copies() {
+        // A caller mutating what it got back must not corrupt later answers.
+        const first = AiCatalog.resolve("google:gemini-2.5-flash")
+        first.endpoint = "https://tampered.example"
+        first.capabilities.tools = false
+        const second = AiCatalog.resolve("google:gemini-2.5-flash")
+        verify(second.endpoint.indexOf("generativelanguage") !== -1)
+        compare(second.capabilities.tools, true)
+    }
+}

--- a/dots/.config/quickshell/imi/tests/tst_bar_popup_unroll.qml
+++ b/dots/.config/quickshell/imi/tests/tst_bar_popup_unroll.qml
@@ -109,4 +109,52 @@ TestCase {
         // expressiveness, and it is what the height Behavior this replaced did.
         verify(BarPopupUnroll.cardHeight(400, 141, parkedSize, false, 1.21) > 400);
     }
+
+    // ---- the section entrance's three channels ------------------------------
+    //
+    // A below-the-fold section arrives on one `appear` scalar driving opacity,
+    // a slight scale and a small rise together (the measured survey's §3
+    // three-property entrance). The scale's excursion is DERIVED from the rise
+    // over the section's own width, floored at the survey's measured 0.85 -
+    // EditModeDrawer.qml derives it the same way and says why: a fixed factor
+    // is a settle on a compact card and a zoom on a wide row.
+
+    readonly property real rise: 20
+
+    function test_a_settled_member_is_not_dressed_at_all() {
+        compare(BarPopupUnroll.entranceScale(1, rise, 300), 1);
+        compare(BarPopupUnroll.entranceOffset(1, rise), 0);
+    }
+
+    function test_the_entrance_starts_scaled_down_by_the_rise_over_the_width() {
+        compare(BarPopupUnroll.entranceScale(0, rise, 400), 1 - rise / 400);
+    }
+
+    function test_the_scale_floor_is_the_surveys_measured_085() {
+        // A narrow section would otherwise invert the derivation into a zoom:
+        // 20 of rise over 100 of width is a 0.8 start, below what was measured
+        // on the sibling fork's own compact popup cards.
+        compare(BarPopupUnroll.entranceScale(0, rise, 100), 0.85);
+    }
+
+    function test_a_section_with_no_width_yet_takes_the_floor_not_NaN() {
+        // Sections are measured before their first layout pass; a width of 0
+        // divided into the rise is -Infinity waiting to happen, and NaN
+        // geometry is a relayout that never converges.
+        compare(BarPopupUnroll.entranceScale(0, rise, 0), 0.85);
+        compare(BarPopupUnroll.entranceScale(0, rise, undefined), 0.85);
+    }
+
+    function test_the_rise_is_spent_linearly_with_appear() {
+        compare(BarPopupUnroll.entranceOffset(0, rise), rise);
+        compare(BarPopupUnroll.entranceOffset(0.5, rise), rise / 2);
+    }
+
+    function test_scale_and_rise_land_together_because_both_are_linear_in_appear() {
+        // Half the appear is half the excursion on BOTH channels - the whole
+        // point of one scalar is that the three cannot finish on different
+        // schedules.
+        const from = BarPopupUnroll.entranceScale(0, rise, 400);
+        compare(BarPopupUnroll.entranceScale(0.5, rise, 400), from + (1 - from) / 2);
+    }
 }

--- a/dots/.config/quickshell/imi/tests/tst_motion_policy.qml
+++ b/dots/.config/quickshell/imi/tests/tst_motion_policy.qml
@@ -202,4 +202,35 @@ TestCase {
         compare(Motion.entranceScaleFrom(0, 380), 1);
         compare(Motion.entranceScaleFrom(-5, 380), 1);
     }
+
+    function test_convergence_comes_from_the_members_own_side() {
+        // The thirds rule: leftmost members from further left, rightmost from
+        // further right, the middle third straight - and rows alternate.
+        compare(Motion.convergeFrom(-0.8, 0).dx, -1);
+        compare(Motion.convergeFrom(0.8, 0).dx, 1);
+        compare(Motion.convergeFrom(0, 0).dx, 0);
+        // Full-width sections sit dead centre, so a section column
+        // degenerates to pure vertical alternation.
+        compare(Motion.convergeFrom(0, 0).dy, -1);
+        compare(Motion.convergeFrom(0, 1).dy, 1);
+        compare(Motion.convergeFrom(0, 2).dy, -1);
+        // The boundary itself is the middle third, so a member exactly on it
+        // cannot flip direction on a one-pixel reflow.
+        compare(Motion.convergeFrom(-1 / 3, 0).dx, 0);
+        compare(Motion.convergeFrom(1 / 3, 0).dx, 0);
+    }
+
+    function test_the_settle_overshoots_and_lands() {
+        // Endpoints are exact, so a settled member sits precisely in place
+        // and a parked one precisely at its reach.
+        compare(Motion.convergeSettle(0), 0);
+        compare(Motion.convergeSettle(1), 1);
+        // Late in the arrival the shape crosses 1 - the overshoot that makes
+        // an arrival a landing - and returns.
+        verify(Motion.convergeSettle(0.9) > 1);
+        verify(Motion.convergeSettle(0.25) < 1);
+        // Nonsense stays parked rather than becoming NaN geometry.
+        compare(Motion.convergeSettle(NaN), 0);
+        compare(Motion.convergeSettle(undefined), 0);
+    }
 }

--- a/dots/.config/quickshell/imi/tests/tst_motion_policy.qml
+++ b/dots/.config/quickshell/imi/tests/tst_motion_policy.qml
@@ -164,4 +164,42 @@ TestCase {
         compare(Motion.staggerDelay(3, step, 0), 0,
                 "reduce motion needs no second gate on the stagger");
     }
+
+    // A wave member's entrance scale is DERIVED from the rise and the width it
+    // plays on, not picked: the survey measured 0.85 on a popup's compact
+    // cards, and on a full-width row the same factor is a horizontal swing
+    // wider than the rise it accompanies - a zoom, not a settle. Matching the
+    // scale's excursion to the rise keeps the two terms one motion at any
+    // width, with the measured 0.85 as the floor so a narrow member cannot
+    // invert the proportion.
+    function test_the_entrance_scale_matches_its_excursion_to_the_rise() {
+        // The drawer's own numbers: a 20px rise on a 380px panel. This exact
+        // value is what the drawer rendered before the derivation moved here,
+        // so a change to it is a visible change to a shipped surface.
+        fuzzyCompare(Motion.entranceScaleFrom(20, 380), 1 - 20 / 380, 1e-9);
+        // Wide member, nearer 1 - the scale excursion stays the rise's size.
+        fuzzyCompare(Motion.entranceScaleFrom(20, 4000), 0.995, 1e-9);
+    }
+
+    function test_the_entrance_scale_floors_at_the_measured_constant() {
+        compare(Motion.ENTRANCE_SCALE_FLOOR, 0.85,
+                "the floor is the survey's measured popup scale");
+        compare(Motion.entranceScaleFrom(20, 100), Motion.ENTRANCE_SCALE_FLOOR,
+                "a narrow member takes the floor, not a deeper zoom");
+        compare(Motion.entranceScaleFrom(20, 0), Motion.ENTRANCE_SCALE_FLOOR,
+                "an unmeasured width answers the floor, not 1 - rise/0");
+    }
+
+    // The absent-input rule this module already lives by: `Number(null)` is 0
+    // and NaN compares false, so a guard has to be a comparison rather than a
+    // Math.max, which returns the NaN it was supposed to remove.
+    function test_a_nonsense_entrance_input_cannot_reach_the_render() {
+        compare(Motion.entranceScaleFrom(NaN, 380), Motion.ENTRANCE_SCALE_FLOOR);
+        compare(Motion.entranceScaleFrom(undefined, 380), Motion.ENTRANCE_SCALE_FLOOR);
+        compare(Motion.entranceScaleFrom(20, NaN), Motion.ENTRANCE_SCALE_FLOOR);
+        // A rise of zero (or a nonsense negative one) is no scale excursion at
+        // all - never a member that arrives LARGER than it rests.
+        compare(Motion.entranceScaleFrom(0, 380), 1);
+        compare(Motion.entranceScaleFrom(-5, 380), 1);
+    }
 }

--- a/dots/.config/quickshell/imi/tests/tst_stagger_entrance.qml
+++ b/dots/.config/quickshell/imi/tests/tst_stagger_entrance.qml
@@ -1,0 +1,135 @@
+import QtQuick
+import QtTest
+import qs.modules.common
+import qs.modules.common.widgets
+import "../modules/common/motion_policy.js" as Motion
+
+// `StaggerEntrance`: the one spelling of how a wave member arrives - opacity,
+// a scale from a derived near-1 start, and a small rise, all riding the same
+// `appear` scalar the StaggerWave animates. It dresses a CONTAINER's members,
+// which is what keeps a tenth row added next year from being the fourth
+// hand-copied dressing that drifts by a channel.
+//
+// The two refusals are as load-bearing as the dressing: a member that does not
+// declare `appear` is not a wave member and is left alone, and a member that
+// owns an `interactionMotion` already folds `appear` into the opacity that
+// carries its disabled dim and owns `scale` through the model - a second
+// writer of either REPLACES the control's binding rather than composing with
+// it (the doubling lint_interaction_motion_double.py and
+// lint_disabled_opacity.py exist to fail on).
+TestCase {
+    name: "StaggerEntranceTest"
+    when: windowShown
+    width: 500
+    height: 400
+    visible: true
+
+    Column {
+        id: column
+        width: 400
+
+        Item {
+            id: plainMember
+            property real appear: 1
+            width: 400
+            height: 40
+        }
+
+        // The RippleButton shape, duck-typed the way the dresser sees it: a
+        // control that declares its own driver and folds its dim (and its own
+        // `appear`) into its opacity binding.
+        Item {
+            id: controlMember
+            property real appear: 1
+            property var interactionMotion: ({ scale: 1 })
+            property bool controlEnabled: true
+            opacity: controlMember.controlEnabled ? 1 : 0.4
+            width: 400
+            height: 40
+        }
+
+        Item {
+            id: bystander
+            width: 400
+            height: 40
+        }
+    }
+
+    StaggerEntrance {
+        id: entrance
+        target: column
+        reference: 380
+    }
+
+    readonly property real rise: Appearance.animation.entranceRise
+    readonly property real scaleFrom: Motion.entranceScaleFrom(rise, 380)
+
+    function liftsOf(item) {
+        const lifts = [];
+        for (let i = 0; i < item.transform.length; i++)
+            if (item.transform[i]?.objectName === "staggerEntranceLift")
+                lifts.push(item.transform[i]);
+        return lifts;
+    }
+
+    function test_a_member_arrives_on_all_three_channels() {
+        plainMember.appear = 0.25;
+        fuzzyCompare(plainMember.opacity, 0.25, 1e-6);
+        fuzzyCompare(plainMember.scale,
+                     scaleFrom + (1 - scaleFrom) * 0.25, 1e-6);
+        const lifts = liftsOf(plainMember);
+        compare(lifts.length, 1, "one rise transform, exactly");
+        fuzzyCompare(lifts[0].y, (1 - 0.25) * rise, 1e-6);
+
+        plainMember.appear = 1;
+        fuzzyCompare(plainMember.opacity, 1, 1e-6);
+        fuzzyCompare(plainMember.scale, 1, 1e-6);
+        fuzzyCompare(liftsOf(plainMember)[0].y, 0, 1e-6);
+    }
+
+    function test_a_control_keeps_its_own_channels() {
+        compare(liftsOf(controlMember).length, 0,
+                "a control's rise is its own 6px fold, not the dressing's");
+        controlMember.appear = 0.25;
+        fuzzyCompare(controlMember.scale, 1, 1e-6);
+        // The proof the opacity BINDING survived, not just its current value:
+        // flip the state it reads and watch it answer. A dresser that wrote
+        // `opacity` here would have destroyed it - the control would read
+        // enabled for the rest of the session.
+        controlMember.controlEnabled = false;
+        fuzzyCompare(controlMember.opacity, 0.4, 1e-6);
+        controlMember.controlEnabled = true;
+        controlMember.appear = 1;
+    }
+
+    function test_a_child_without_appear_is_not_a_member() {
+        compare(liftsOf(bystander).length, 0);
+        fuzzyCompare(bystander.opacity, 1, 1e-6);
+        fuzzyCompare(bystander.scale, 1, 1e-6);
+    }
+
+    // The scale start is the policy's derivation against the declared
+    // reference width - the drawer's own arithmetic, now in one place.
+    function test_the_scale_start_is_derived_from_the_reference() {
+        fuzzyCompare(scaleFrom, 1 - rise / 380, 1e-9);
+        plainMember.appear = 0;
+        fuzzyCompare(plainMember.scale, scaleFrom, 1e-6);
+        plainMember.appear = 1;
+    }
+
+    // A Repeater fills its container after the dresser completed, so arrival
+    // has to dress too - and re-dressing must not stack a second rise onto a
+    // member that already has one.
+    function test_a_member_arriving_later_is_dressed_once() {
+        const late = Qt.createQmlObject(
+            "import QtQuick; Item { property real appear: 1; width: 400; height: 40 }",
+            column, "lateMember");
+        // The dress hangs off onChildrenChanged, same turn as the add.
+        compare(liftsOf(late).length, 1, "the late member was dressed");
+        compare(liftsOf(plainMember).length, 1,
+                "the resident member was not dressed a second time");
+        late.appear = 0.5;
+        fuzzyCompare(late.opacity, 0.5, 1e-6);
+        late.destroy();
+    }
+}

--- a/dots/.config/quickshell/imi/tests/tst_stagger_wave.qml
+++ b/dots/.config/quickshell/imi/tests/tst_stagger_wave.qml
@@ -11,8 +11,10 @@ import qs.modules.common.widgets
 //
 // What is pinned: the list REPLACES the children walk (a member the target
 // does not contain is still parked and still enters), rank comes from the
-// list's order with a hidden member spending no slot, and park/enter still
-// meet in the middle - a parked member ends at 1 after an entrance.
+// list's order with a hidden member spending no slot but SETTLED rather than
+// left parked (a member hidden at the open that becomes visible later must
+// arrive at rest, not at the 0 the park wrote), and park/enter still meet in
+// the middle - a parked member ends at 1 after an entrance.
 TestCase {
     name: "StaggerWaveItemsTest"
     when: windowShown
@@ -85,8 +87,9 @@ TestCase {
         tryCompare(resident, "appear", 1);
         tryCompare(reparented, "appear", 1);
         compare(unlisted.appear, 1);
-        compare(hiddenMember.appear, 0,
-                "a hidden member spends no slot and stays parked");
+        compare(hiddenMember.appear, 1,
+                "a hidden member spends no slot and is settled, so it "
+                + "arrives at rest if something shows it mid-open");
         wave.settle();
     }
 }

--- a/dots/.config/quickshell/imi/tests/tst_stagger_wave.qml
+++ b/dots/.config/quickshell/imi/tests/tst_stagger_wave.qml
@@ -1,0 +1,92 @@
+import QtQuick
+import QtTest
+import qs.modules.common
+import qs.modules.common.widgets
+
+// `StaggerWave.items`: the members, when they are not one container's
+// children. `GroupedList` reparents each declared row into its own plate, so
+// a wave over its rows has no container whose `children` are the group - the
+// rows' shared origin is the declared list. The desktop menu is the adopter
+// that needs this; the drawer keeps the children walk.
+//
+// What is pinned: the list REPLACES the children walk (a member the target
+// does not contain is still parked and still enters), rank comes from the
+// list's order with a hidden member spending no slot, and park/enter still
+// meet in the middle - a parked member ends at 1 after an entrance.
+TestCase {
+    name: "StaggerWaveItemsTest"
+    when: windowShown
+    width: 300
+    height: 300
+    visible: true
+
+    Item {
+        id: host
+        width: 300
+        height: 200
+
+        Item {
+            id: resident
+            property real appear: 1
+            width: 10
+            height: 10
+        }
+    }
+
+    // A member living OUTSIDE the wave's target, the way a GroupedList row
+    // lives inside its plate rather than beside its siblings.
+    Item {
+        id: elsewhere
+        width: 300
+        height: 50
+
+        Item {
+            id: reparented
+            property real appear: 1
+            width: 10
+            height: 10
+        }
+
+        Item {
+            id: hiddenMember
+            visible: false
+            property real appear: 1
+            width: 10
+            height: 10
+        }
+    }
+
+    // A child of the target that the LIST does not name: the list must
+    // replace the children walk, not add to it.
+    Item {
+        id: unlisted
+        parent: host
+        property real appear: 1
+        width: 10
+        height: 10
+    }
+
+    StaggerWave {
+        id: wave
+        target: host
+        items: [resident, reparented, hiddenMember]
+    }
+
+    function test_the_list_is_the_membership() {
+        wave.park();
+        compare(resident.appear, 0, "a listed child parks");
+        compare(reparented.appear, 0,
+                "a listed member outside the target parks too");
+        compare(hiddenMember.appear, 0);
+        compare(unlisted.appear, 1,
+                "an unlisted child of the target is not a member");
+
+        wave.enter();
+        tryCompare(resident, "appear", 1);
+        tryCompare(reparented, "appear", 1);
+        compare(unlisted.appear, 1);
+        compare(hiddenMember.appear, 0,
+                "a hidden member spends no slot and stays parked");
+        wave.settle();
+    }
+}


### PR DESCRIPTION
Five streams, integrated and verified together (full suite: 1218 QML checks, all harnesses, DesignSystemCompile 185+).

**Bar popups arrive container-then-fill.** The card's below-the-fold sections hold until `card.openProgress` clears `Appearance.animation.contentsArrived` (no leadIn — the card is the second surface with a real progress to gate on), then cascade by visible rank. The hero section deliberately stays undressed: the card opens at its height precisely so it is legible on frame one. Exits ride out rigid. One wave on the overlay, never per popup; the wave arms only on a fresh open so takeovers and re-hovered exits never blink content. `lint_bar_popup_overlay_static` grew a gate section; a per-popup register (`test_bar_popup_section_entrance`) pins hero/channel/opt-in shape; nine planted mutations all caught.

**The three-channel entrance is one spelling.** `StaggerEntrance` (a QtObject beside the wave) installs opacity, a derived near-1 scale and a small rise on every member declaring `appear` — the drawer's nine hand-spelled dressings collapse into it with its exact values pinned, RippleButtons are skipped at runtime (their control owns the fold), and both composition lints learned to see the new spelling (one real detection gap found and fixed by the planted proof). Desktop menu rows adopted; **dialogs refused** into `STAGGER_DECLINED` with tree-read arguments (a cascade on a modal is latency on the question the user was interrupted to read; polkit focuses a field that would still be parked invisible).

**Text and lists move.** Media label and weather temperature slide on change (`animateChange`, already the house mechanism); clock digits refused — a seconds-capable format would tick an animation on a Top-layer bar that stays `visible` under fullscreen (53d1ff893's occlusion). Todo lists ride `StyledListView`'s own add/remove transitions, which required a real fix: the per-update `Object.assign` wrapper broke ScriptModel's identity diff, so every change had been remove-all+add-all — transitions could never fire, and stale indices across deletes are gone with it.

**AI: proposal + stage 1.** `docs/proposals/ai-assistant-upgrade.md` maps the surveyed fork's provider catalog / per-tool permissions / reviewed-mutation shapes onto our stack in five stages with eight open questions; stage 1 lands: `services/ai_catalog.js`, pure and testable, contract-pinned bidirectionally against `Ai.qml`'s literals so neither drifts before stage 2 wires them. Two defects in our tree recorded as evidence: `set_shell_config` writes config unapproved and never answers the model (the turn stalls), and custom-provider keyring keys are index-keyed so removals shift later providers off their keys.

**The sidebars materialize composed — the fork's real motion language, re-read object by object.** The right sidebar's section wave came back the register's way (the two refusal facts had been repaired by unrelated work), and the first re-adoption — gated on the slide's progress through `contentsArrived` — was measured on screen as ruined: parked content plus a gate puts the construction on stage. What shipped is the opposite: the wave runs ungated on the open's rising edge, *under* the slide, whose new `EdgeSlide.reveal` curtain (≤15% panel opacity for the first 40% of travel) masks the early frames so the panel arrives already composed and only the last-ranked members visibly land. On top of that: quick-toggle tiles converge from their own side of the grid (`convergeFrom`/`convergeSettle` in the policy), slider fills sweep from zero with the icon turning with the fill, the calendar ripples diagonally, the notification status row converges, and the left sidebar and AI pane take the same cascade. Along the way the tiles' leftover `Behavior on opacity` that swallowed the wave was removed and a lint now fails any wave member carrying one; a member hidden at the open is settled rather than left parked; a tile added mid-session fades in; the entrance survives `keepRightSidebarLoaded` being off; and a `wavePending` armed for one popup tree no longer fires against its replacement.

Exit tiers untouched: 2:1 stays per the maintainer's call, 4:1 A/B remains one central change if ever wanted.

Docs: updated AGENT.md §Design language
Changelog: updated — two Changed entries and one Fixed under [Unreleased]
