### PR TITLE
The overview opens on the focused monitor again: one surface per screen, latched at the open

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -4694,6 +4694,21 @@ a surface picked from the END of the list, and with the bar/OSK after the panel,
 never activates and every keypress is silently dropped (the persistent-sidebar contract pins the
 order; fix(sidebars): route the focus grab's keyboard to the opening panel). `SessionScreen` still
 maps per open and pays this same 61ms.
+
+A fourth cost, found by the first multi-monitor user to update (#297): **a persistent surface has
+to say which screen it lives on.** A `PanelWindow` with no `screen:` asks the compositor to choose
+— Quickshell passes a null output — and Hyprland answers with the monitor focused *at creation*. A
+window rebuilt on every open therefore followed focus, silently, and nobody had ever written that
+down; a window created once at boot lands on whichever monitor had focus at boot and never moves.
+The overview is one window per screen now (`Variants` over `Quickshell.screens`, `screen:
+modelData`), and the scope latches the focused monitor's name at the open edge and opens only that
+screen's window — latched, not live, so focus moving mid-open does not teleport the card. Two
+gates follow from having siblings: `keyboardFocus` and the `mask` read the target predicate as
+well as the flag, or every screen's surface turns OnDemand on one open and the compositor picks
+which gets the keyboard. `tests/test_persistent_surface_screen.py` pins the shape. The sidebars
+carry the same latent bug and are not converted yet: the left one reparents a single content tree
+between two windows, so per-screen there is more than a wrap. (fix(overview): one surface per
+screen, and the open picks the focused monitor's.)
 (feat(widgets): EdgeSlide, the runner for a panel whose surface stays mapped;
 fix(sidebar): the right sidebar's surface outlives the gesture;
 fix(sidebar): the left sidebar's surface outlives the gesture;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@ own repo; the installer pins which revision it builds.
   finishing a task in the to-do list animates the row in or out.
 
 ### Fixed
+- **The overview opens on the monitor you are using again.** Since 0.30.0 it
+  opened on whichever monitor had focus when the shell started — usually the
+  primary — no matter where the cursor was, because the overview's window is
+  created once at startup now and the compositor places a window without a
+  screen of its own on the monitor focused at that moment. There is one
+  overview window per monitor now, and each open picks the focused one.
+  (#297)
 - **The to-do list's buttons no longer aim at the wrong row after a delete.**
   Each row resolved its task by an index taken when the row was built, so
   deleting a task left every row below it one off. Rows now find their task

--- a/dots/.config/quickshell/imi/modules/imi/overview/Overview.qml
+++ b/dots/.config/quickshell/imi/modules/imi/overview/Overview.qml
@@ -34,271 +34,325 @@ Scope {
     // `openProgress`) the blur regions. A closed overview is a full-screen
     // surface with a null input mask, keyboardFocus None and nothing drawn,
     // which is exactly what the bar's surface is under a fullscreen window.
-    property bool reallyOpen: false
+    //
+    // One surface PER SCREEN, and the open picks which one shows. A persistent
+    // surface has to say which screen it lives on: a PanelWindow with no
+    // `screen:` asks the compositor to choose (Quickshell passes a null
+    // output), and Hyprland answers with the monitor that has focus AT
+    // CREATION. While the window was rebuilt per open that was "the focused
+    // monitor, every time" - the behaviour a multi-monitor user relies on.
+    // Created once at boot, it was "whichever monitor had focus at boot,
+    // forever" (#297: the overview stuck to the primary monitor after
+    // 0.30.0). So the family is one window per screen, each pinned to its
+    // own output, and `targetScreen` - the focused monitor's name, read once
+    // at the open edge and held for the open - decides which of them opens.
+    // Latched, not live: focus moving mid-open must not teleport the card.
+    property string targetScreen: ""
+    property PanelWindow activeWindow: null
 
-    PanelWindow {
-        id: panelWindow
-        property string searchingText: ""
-        readonly property HyprlandMonitor monitor: Hyprland.monitorFor(panelWindow.screen)
-        property bool monitorIsFocused: (Hyprland.focusedMonitor?.id == monitor?.id)
+    function latchTarget() {
+        overviewScope.targetScreen = WM.focusedMonitor?.name ?? "";
+    }
 
-        WlrLayershell.namespace: "quickshell:overview"
-        WlrLayershell.layer: WlrLayer.Top
-        WlrLayershell.keyboardFocus: GlobalStates.overviewOpen ? WlrKeyboardFocus.OnDemand : WlrKeyboardFocus.None
-        color: "transparent"
+    // The window an open (or a search-prefix toggle about to open) should
+    // address. Already open: the one that is showing, wherever focus has
+    // moved since. Closed: the focused monitor's, latched now.
+    function targetWindow() {
+        if (GlobalStates.overviewOpen && overviewScope.activeWindow)
+            return overviewScope.activeWindow;
+        overviewScope.latchTarget();
+        const windows = overviewWindows.instances;
+        return windows.find(w => w.modelData.name === overviewScope.targetScreen)
+            ?? windows[0] ?? null;
+    }
 
-        // The proxy, not the column: the card scales during its entrance and
-        // a Region maps the item through its render transform, while
-        // Hyprland snapshots the input region when the focus grab lands -
-        // two frames into that entrance. The selector shipped the full
-        // failure (see WallpaperSelector.qml's mask note for the click-map);
-        // this one had the same scaled item under its mask and the same
-        // grab timing. Anchors track layout geometry and ignore render
-        // transforms, so the proxy is the settled rect at every instant.
-        Item {
-            id: inputRegionProxy
-            anchors.fill: columnLayout
-        }
-        mask: Region {
-            item: GlobalStates.overviewOpen ? inputRegionProxy : null
-        }
-
-        // Blur only the painted body cards. This one surface carries two of
-        // them - the search widget and the overview below it - and both draw a
-        // drop shadow in the elevation margin around themselves, which the
-        // catch-all whole-surface blur frosted (#89, the deferred half of #82).
-        // Pairs with rules.lua turning the layerrule blur off for this
-        // namespace. The niri style contributes nothing (see NiriOverview.qml).
-        //
-        // The gate is the CARD's own progress rather than the open flag, and
-        // that only started mattering when the card got a transition. A blur
-        // region is a rectangle the compositor frosts whether or not anything is
-        // drawn over it: gated on the flag it arrives a full entrance before the
-        // card does and stays a full exit after it has gone, which is a frosted
-        // ghost of the card with no card in it. It cannot be faded - the region
-        // is on or off - so it switches at the half way point of the card's own
-        // opacity, where the card itself is the least transparent thing it can
-        // be while the switch happens. This is a choice about where to put an
-        // unavoidable step, not a measurement.
-        readonly property bool bodyFrosted: columnLayout.openProgress >= 0.5
-        onBodyFrostedChanged: blurRegion.publishNow()
-
-        // The composed region's INNER items swap identity at runtime - the
-        // grid is rebuilt by its loader every open, and bodyFrosted flips
-        // both items in and out - and BackgroundEffect's live geometry
-        // tracking follows a given item, not a binding that replaces it.
-        // On the persistent surface nothing else republishes any more (the
-        // window never resizes and never remaps), so the first open showed
-        // the frost where the HALF-BUILT grid had been when the region was
-        // first pushed: a sharp unblurred band down the card's left edge,
-        // user-reported. Each identity flip republishes now; the settle
-        // timer inside publishNow covers the layout that follows it.
-        WindowBlurRegion {
-            id: blurRegion
-            targetWindow: panelWindow
-            region: Region {
-                Region {
-                    item: panelWindow.bodyFrosted ? searchWidget.backgroundItem : null
-                    radius: searchWidget.backgroundRadius
-                }
-                Region {
-                    item: (panelWindow.bodyFrosted && (overviewLoader.item?.backgroundPainted ?? false)) ? overviewLoader.item.backgroundItem : null
-                    radius: overviewLoader.item?.backgroundRadius ?? 0
-                }
+    // One dispatcher for the whole family, at the scope: per-window handlers
+    // would each read the latch, and nothing orders a Connections in one
+    // window against the latch being written in another. Here the latch is
+    // written, THEN the one target is opened.
+    Connections {
+        target: GlobalStates
+        function onOverviewOpenChanged() {
+            if (GlobalStates.overviewOpen) {
+                overviewScope.activeWindow = overviewScope.targetWindow();
+                overviewScope.activeWindow?.open();
+            } else {
+                overviewScope.dontAutoCancelSearch = false;
+                overviewScope.activeWindow?.close();
             }
         }
+    }
 
-        anchors {
-            top: true
-            bottom: true
-            left: true
-            right: true
+    Connections {
+        target: GlobalFocusGrab
+        function onDismissed() {
+            GlobalStates.overviewOpen = false;
         }
+    }
 
-        // The grab is taken after the surface has RENDERED two frames with the
-        // card open, not in the tick the flag flips - the sidebars' rule (see
-        // SidebarRight.qml): on a surface that is mapped all the time the new
-        // `keyboardFocus` value rides the next commit, and a grab that reaches
-        // Hyprland first lands on a surface it still knows as interactivity
-        // None, is cleared within milliseconds, and the clear is read as a
-        // click-outside that closes the overview it just opened.
-        FrameAnimation {
-            id: focusGrabAfterCommit
-            property int framesLeft: 0
-            running: framesLeft > 0
-            onTriggered: {
-                if (--framesLeft > 0)
-                    return;
-                if (GlobalStates.overviewOpen)
-                    GlobalFocusGrab.addDismissable(panelWindow);
+    Variants {
+        id: overviewWindows
+        model: Quickshell.screens
+
+        PanelWindow {
+            id: panelWindow
+            required property ShellScreen modelData
+            screen: modelData
+            readonly property bool isTarget: overviewScope.activeWindow === panelWindow
+            property bool reallyOpen: false
+            property string searchingText: ""
+
+            WlrLayershell.namespace: "quickshell:overview"
+            WlrLayershell.layer: WlrLayer.Top
+            // Gated on being the target as well as on the flag: with one surface
+            // per screen, every sibling would otherwise turn OnDemand on the same
+            // open and the compositor would pick which of them gets the keyboard.
+            WlrLayershell.keyboardFocus: (GlobalStates.overviewOpen && panelWindow.isTarget) ? WlrKeyboardFocus.OnDemand : WlrKeyboardFocus.None
+            color: "transparent"
+
+            // The proxy, not the column: the card scales during its entrance and
+            // a Region maps the item through its render transform, while
+            // Hyprland snapshots the input region when the focus grab lands -
+            // two frames into that entrance. The selector shipped the full
+            // failure (see WallpaperSelector.qml's mask note for the click-map);
+            // this one had the same scaled item under its mask and the same
+            // grab timing. Anchors track layout geometry and ignore render
+            // transforms, so the proxy is the settled rect at every instant.
+            Item {
+                id: inputRegionProxy
+                anchors.fill: columnLayout
             }
-        }
+            mask: Region {
+                item: (GlobalStates.overviewOpen && panelWindow.isTarget) ? inputRegionProxy : null
+            }
 
-        Connections {
-            target: GlobalStates
-            function onOverviewOpenChanged() {
-                if (!GlobalStates.overviewOpen) {
-                    searchWidget.disableExpandAnimation();
-                    overviewScope.dontAutoCancelSearch = false;
-                    focusGrabAfterCommit.framesLeft = 0;
-                    GlobalFocusGrab.dismiss();
-                    columnLayout.leave();
-                } else {
-                    // The content is asked for before the card is asked to
-                    // arrive, in this order: an entrance started against an
-                    // unbuilt card is an entrance nothing advances.
-                    overviewScope.reallyOpen = true;
-                    if (!overviewScope.dontAutoCancelSearch) {
-                        searchWidget.cancelSearch();
+            // Blur only the painted body cards. This one surface carries two of
+            // them - the search widget and the overview below it - and both draw a
+            // drop shadow in the elevation margin around themselves, which the
+            // catch-all whole-surface blur frosted (#89, the deferred half of #82).
+            // Pairs with rules.lua turning the layerrule blur off for this
+            // namespace. The niri style contributes nothing (see NiriOverview.qml).
+            //
+            // The gate is the CARD's own progress rather than the open flag, and
+            // that only started mattering when the card got a transition. A blur
+            // region is a rectangle the compositor frosts whether or not anything is
+            // drawn over it: gated on the flag it arrives a full entrance before the
+            // card does and stays a full exit after it has gone, which is a frosted
+            // ghost of the card with no card in it. It cannot be faded - the region
+            // is on or off - so it switches at the half way point of the card's own
+            // opacity, where the card itself is the least transparent thing it can
+            // be while the switch happens. This is a choice about where to put an
+            // unavoidable step, not a measurement.
+            readonly property bool bodyFrosted: columnLayout.openProgress >= 0.5
+            onBodyFrostedChanged: blurRegion.publishNow()
+
+            // The composed region's INNER items swap identity at runtime - the
+            // grid is rebuilt by its loader every open, and bodyFrosted flips
+            // both items in and out - and BackgroundEffect's live geometry
+            // tracking follows a given item, not a binding that replaces it.
+            // On the persistent surface nothing else republishes any more (the
+            // window never resizes and never remaps), so the first open showed
+            // the frost where the HALF-BUILT grid had been when the region was
+            // first pushed: a sharp unblurred band down the card's left edge,
+            // user-reported. Each identity flip republishes now; the settle
+            // timer inside publishNow covers the layout that follows it.
+            WindowBlurRegion {
+                id: blurRegion
+                targetWindow: panelWindow
+                region: Region {
+                    Region {
+                        item: panelWindow.bodyFrosted ? searchWidget.backgroundItem : null
+                        radius: searchWidget.backgroundRadius
                     }
-                    focusGrabAfterCommit.framesLeft = 2;
-                    // A persistent window is created once, at boot, without
-                    // keyboard focus - so an open has to say where keys go
-                    // (the sidebars' lesson, SidebarLeft.qml) or the window
-                    // activates with no focus item and every key is dropped.
-                    searchWidget.focusSearchInput();
-                    columnLayout.arrive();
+                    Region {
+                        item: (panelWindow.bodyFrosted && (overviewLoader.item?.backgroundPainted ?? false)) ? overviewLoader.item.backgroundItem : null
+                        radius: overviewLoader.item?.backgroundRadius ?? 0
+                    }
                 }
             }
-        }
 
-        Connections {
-            target: GlobalFocusGrab
-            function onDismissed() {
-                GlobalStates.overviewOpen = false;
-            }
-        }
-        implicitWidth: columnLayout.implicitWidth
-        implicitHeight: columnLayout.implicitHeight
-
-        function setSearchingText(text) {
-            searchWidget.setSearchingText(text);
-            searchWidget.focusFirstItem();
-        }
-
-        Column {
-            id: columnLayout
-            visible: overviewScope.reallyOpen
             anchors {
-                horizontalCenter: parent.horizontalCenter
-                top: parent.top
-            }
-            spacing: -Appearance.spacing.space100
-
-            // ONE scalar drives both channels, because docs/M3_GUIDELINES.md §2
-            // requires the opacity to finish on the same schedule as the scale -
-            // two Behaviors at two tiers is what makes a component reach full
-            // opacity while it is still growing, which reads as a hiccup.
-            //
-            // No translate, and that is a constraint rather than a preference.
-            // The sibling fork drops this card in from above the screen edge and
-            // pays for the room with a negative margin on all four sides of the
-            // surface; here the column is anchored to the top of a surface that
-            // stops at the bar's exclusive zone, so a rise would be drawn
-            // outside the window and clipped. `transformOrigin: Item.Top`
-            // already says which edge the card comes out of: it unfurls
-            // downwards from its own top edge, which is where it hangs from.
-            //
-            // The entrance takes `elementMoveSmall` for its CURVE, not only its
-            // duration. `expressiveFastSpatial` overshoots by construction (its
-            // second control point is 1.67), so the card settles with a bounce
-            // rather than easing flat into place - which is the half of the
-            // fork's "bounce" style that survives having no room to travel.
-            // The overshoot is left on the scale and clamped off the opacity: a
-            // card that fades past opaque and back is a flicker, a card that
-            // grows 2% past its size and settles is the bounce.
-            property real openProgress: 0
-            readonly property real entranceScaleFrom: 0.9
-
-            opacity: Math.min(1, columnLayout.openProgress)
-            scale: columnLayout.entranceScaleFrom
-                + (1 - columnLayout.entranceScaleFrom) * columnLayout.openProgress
-            transformOrigin: Item.Top
-
-            function arrive() {
-                exitAnim.stop();
-                enterAnim.start();
-            }
-            function leave() {
-                enterAnim.stop();
-                exitAnim.start();
+                top: true
+                bottom: true
+                left: true
+                right: true
             }
 
-            // Started animations rather than a `Behavior`: a Behavior never
-            // raises `finished` at any duration (motion_policy.js records the
-            // probe), and this exit's `finished` is what owns the window.
-            // `openProgress` starts at 0 as its DECLARED value and is only ever
-            // written by these two - a start value written through the animated
-            // property is what lint_animated_start_write.py exists for.
-            NumberAnimation {
-                id: enterAnim
-                target: columnLayout
-                property: "openProgress"
-                to: 1
-                duration: Appearance.animation.elementMoveSmall.duration
-                easing.type: Appearance.animation.elementMoveSmall.type
-                easing.bezierCurve: Appearance.animation.elementMoveSmall.bezierCurve
-            }
-
-            NumberAnimation {
-                id: exitAnim
-                target: columnLayout
-                property: "openProgress"
-                to: 0
-                // The effects tier rather than `elementMoveExit`, for the
-                // reasoning WallpaperSelector.qml's exit animation writes out:
-                // this is an opacity transition with a scale nudge on it rather
-                // than a departure across the screen, and `emphasizedAccel` at
-                // its own 200ms spends 46% of the transition in its last two
-                // frames - on an opacity that is a card which sits there and
-                // then blinks out.
-                duration: Appearance.animation.elementMoveFast.duration
-                easing.type: Appearance.animation.elementMoveFast.type
-                easing.bezierCurve: Appearance.animation.elementMoveFast.bezierCurve
-                // The window's lifetime IS this animation's.
-                onFinished: overviewScope.reallyOpen = false
-            }
-
-            Keys.onPressed: event => {
-                if (event.key === Qt.Key_Escape) {
-                    GlobalStates.overviewOpen = false;
-                } else if (event.key === Qt.Key_Left) {
-                    if (!panelWindow.searchingText)
-                        Hyprland.dispatch("workspace r-1");
-                } else if (event.key === Qt.Key_Right) {
-                    if (!panelWindow.searchingText)
-                        Hyprland.dispatch("workspace r+1");
+            // The grab is taken after the surface has RENDERED two frames with the
+            // card open, not in the tick the flag flips - the sidebars' rule (see
+            // SidebarRight.qml): on a surface that is mapped all the time the new
+            // `keyboardFocus` value rides the next commit, and a grab that reaches
+            // Hyprland first lands on a surface it still knows as interactivity
+            // None, is cleared within milliseconds, and the clear is read as a
+            // click-outside that closes the overview it just opened.
+            FrameAnimation {
+                id: focusGrabAfterCommit
+                property int framesLeft: 0
+                running: framesLeft > 0
+                onTriggered: {
+                    if (--framesLeft > 0)
+                        return;
+                    if (GlobalStates.overviewOpen)
+                        GlobalFocusGrab.addDismissable(panelWindow);
                 }
             }
 
-            SearchWidget {
-                id: searchWidget
-                anchors.horizontalCenter: parent.horizontalCenter
-                Synchronizer on searchingText {
-                    property alias source: panelWindow.searchingText
+            function open() {
+                // The content is asked for before the card is asked to
+                // arrive, in this order: an entrance started against an
+                // unbuilt card is an entrance nothing advances.
+                panelWindow.reallyOpen = true;
+                if (!overviewScope.dontAutoCancelSearch) {
+                    searchWidget.cancelSearch();
                 }
+                focusGrabAfterCommit.framesLeft = 2;
+                // A persistent window is created once, at boot, without
+                // keyboard focus - so an open has to say where keys go
+                // (the sidebars' lesson, SidebarLeft.qml) or the window
+                // activates with no focus item and every key is dropped.
+                searchWidget.focusSearchInput();
+                columnLayout.arrive();
             }
 
-            Loader {
-                id: overviewLoader
-                active: overviewScope.reallyOpen && (Config?.options.overview.enable ?? true)
-                onItemChanged: blurRegion.publishNow()
-                sourceComponent: (Config?.options.overview.style ?? "default") === "niri" ? niriComponent : defaultComponent
+            function close() {
+                searchWidget.disableExpandAnimation();
+                focusGrabAfterCommit.framesLeft = 0;
+                GlobalFocusGrab.dismiss();
+                columnLayout.leave();
+            }
 
-                Component {
-                    id: defaultComponent
-                    OverviewWidget {
-                        screen: panelWindow.screen
-                        visible: (panelWindow.searchingText == "")
+            implicitWidth: columnLayout.implicitWidth
+            implicitHeight: columnLayout.implicitHeight
+
+            function setSearchingText(text) {
+                searchWidget.setSearchingText(text);
+                searchWidget.focusFirstItem();
+            }
+
+            Column {
+                id: columnLayout
+                visible: panelWindow.reallyOpen
+                anchors {
+                    horizontalCenter: parent.horizontalCenter
+                    top: parent.top
+                }
+                spacing: -Appearance.spacing.space100
+
+                // ONE scalar drives both channels, because docs/M3_GUIDELINES.md §2
+                // requires the opacity to finish on the same schedule as the scale -
+                // two Behaviors at two tiers is what makes a component reach full
+                // opacity while it is still growing, which reads as a hiccup.
+                //
+                // No translate, and that is a constraint rather than a preference.
+                // The sibling fork drops this card in from above the screen edge and
+                // pays for the room with a negative margin on all four sides of the
+                // surface; here the column is anchored to the top of a surface that
+                // stops at the bar's exclusive zone, so a rise would be drawn
+                // outside the window and clipped. `transformOrigin: Item.Top`
+                // already says which edge the card comes out of: it unfurls
+                // downwards from its own top edge, which is where it hangs from.
+                //
+                // The entrance takes `elementMoveSmall` for its CURVE, not only its
+                // duration. `expressiveFastSpatial` overshoots by construction (its
+                // second control point is 1.67), so the card settles with a bounce
+                // rather than easing flat into place - which is the half of the
+                // fork's "bounce" style that survives having no room to travel.
+                // The overshoot is left on the scale and clamped off the opacity: a
+                // card that fades past opaque and back is a flicker, a card that
+                // grows 2% past its size and settles is the bounce.
+                property real openProgress: 0
+                readonly property real entranceScaleFrom: 0.9
+
+                opacity: Math.min(1, columnLayout.openProgress)
+                scale: columnLayout.entranceScaleFrom
+                    + (1 - columnLayout.entranceScaleFrom) * columnLayout.openProgress
+                transformOrigin: Item.Top
+
+                function arrive() {
+                    exitAnim.stop();
+                    enterAnim.start();
+                }
+                function leave() {
+                    enterAnim.stop();
+                    exitAnim.start();
+                }
+
+                // Started animations rather than a `Behavior`: a Behavior never
+                // raises `finished` at any duration (motion_policy.js records the
+                // probe), and this exit's `finished` is what owns the window.
+                // `openProgress` starts at 0 as its DECLARED value and is only ever
+                // written by these two - a start value written through the animated
+                // property is what lint_animated_start_write.py exists for.
+                NumberAnimation {
+                    id: enterAnim
+                    target: columnLayout
+                    property: "openProgress"
+                    to: 1
+                    duration: Appearance.animation.elementMoveSmall.duration
+                    easing.type: Appearance.animation.elementMoveSmall.type
+                    easing.bezierCurve: Appearance.animation.elementMoveSmall.bezierCurve
+                }
+
+                NumberAnimation {
+                    id: exitAnim
+                    target: columnLayout
+                    property: "openProgress"
+                    to: 0
+                    // The effects tier rather than `elementMoveExit`, for the
+                    // reasoning WallpaperSelector.qml's exit animation writes out:
+                    // this is an opacity transition with a scale nudge on it rather
+                    // than a departure across the screen, and `emphasizedAccel` at
+                    // its own 200ms spends 46% of the transition in its last two
+                    // frames - on an opacity that is a card which sits there and
+                    // then blinks out.
+                    duration: Appearance.animation.elementMoveFast.duration
+                    easing.type: Appearance.animation.elementMoveFast.type
+                    easing.bezierCurve: Appearance.animation.elementMoveFast.bezierCurve
+                    // The window's lifetime IS this animation's.
+                    onFinished: panelWindow.reallyOpen = false
+                }
+
+                Keys.onPressed: event => {
+                    if (event.key === Qt.Key_Escape) {
+                        GlobalStates.overviewOpen = false;
+                    } else if (event.key === Qt.Key_Left) {
+                        if (!panelWindow.searchingText)
+                            Hyprland.dispatch("workspace r-1");
+                    } else if (event.key === Qt.Key_Right) {
+                        if (!panelWindow.searchingText)
+                            Hyprland.dispatch("workspace r+1");
                     }
                 }
 
-                Component {
-                    id: niriComponent
-                    NiriOverview {
-                        screen: panelWindow.screen
-                        panelWindow: panelWindow
-                        visible: (panelWindow.searchingText == "")
+                SearchWidget {
+                    id: searchWidget
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    Synchronizer on searchingText {
+                        property alias source: panelWindow.searchingText
+                    }
+                }
+
+                Loader {
+                    id: overviewLoader
+                    active: panelWindow.reallyOpen && (Config?.options.overview.enable ?? true)
+                    onItemChanged: blurRegion.publishNow()
+                    sourceComponent: (Config?.options.overview.style ?? "default") === "niri" ? niriComponent : defaultComponent
+
+                    Component {
+                        id: defaultComponent
+                        OverviewWidget {
+                            screen: panelWindow.screen
+                            visible: (panelWindow.searchingText == "")
+                        }
+                    }
+
+                    Component {
+                        id: niriComponent
+                        NiriOverview {
+                            screen: panelWindow.screen
+                            panelWindow: panelWindow
+                            visible: (panelWindow.searchingText == "")
+                        }
                     }
                 }
             }
@@ -311,7 +365,7 @@ Scope {
             return;
         }
         overviewScope.dontAutoCancelSearch = true;
-        panelWindow.setSearchingText(Config.options.search.prefix.clipboard);
+        overviewScope.targetWindow()?.setSearchingText(Config.options.search.prefix.clipboard);
         GlobalStates.overviewOpen = true;
     }
 
@@ -321,7 +375,7 @@ Scope {
             return;
         }
         overviewScope.dontAutoCancelSearch = true;
-        panelWindow.setSearchingText(Config.options.search.prefix.emojis);
+        overviewScope.targetWindow()?.setSearchingText(Config.options.search.prefix.emojis);
         GlobalStates.overviewOpen = true;
     }
 
@@ -331,7 +385,7 @@ Scope {
             return;
         }
         overviewScope.dontAutoCancelSearch = true;
-        panelWindow.setSearchingText(Config.options.search.prefix.symbols);
+        overviewScope.targetWindow()?.setSearchingText(Config.options.search.prefix.symbols);
         GlobalStates.overviewOpen = true;
     }
 

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -484,6 +484,15 @@ if ! python3 "$SCRIPT_DIR/test_exit_owned_surface_contract.py"; then
     exit 1
 fi
 
+# A persistent surface is one window per screen, pinned to its output, with
+# the open edge latching which of them shows - a window with no screen of its
+# own is created once, on the monitor focused at boot, and never moves (#297).
+echo "Running persistent surface screen contract tests..."
+if ! python3 "$SCRIPT_DIR/test_persistent_surface_screen.py"; then
+    echo "Persistent surface screen contract tests failed."
+    exit 1
+fi
+
 # The shell has two password prompts - the lock screen and the polkit dialog -
 # and they were two different text fields, one of them Material's outlined
 # container with the prompt floating in a notch. The check derives the control

--- a/dots/.config/quickshell/imi/tests/test_persistent_surface_screen.py
+++ b/dots/.config/quickshell/imi/tests/test_persistent_surface_screen.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""A persistent surface says which screen it lives on.
+
+A PanelWindow with no `screen:` asks the compositor to choose: Quickshell
+passes a null wl_output to get_layer_surface (wlr_layershell.cpp sets
+compositorPicksScreen when the screen is unset), and Hyprland answers with the
+monitor that has focus AT CREATION (LayerSurface.cpp: an empty monitor name
+resolves to focusState()->monitor()). A window rebuilt on every open therefore
+landed on the focused monitor every time. A window created once at boot lands
+on whichever monitor had focus at boot and stays there for the life of the
+shell - which is what #297 reported after the overview went persistent in
+0.30.0: "opens strictly on the primary monitor instead of the currently
+focused one".
+
+So a persistent surface is one window PER SCREEN, each pinned to its own
+output, and a latch - the focused monitor's name, read at the open edge and
+held for the open - picks which of them opens. Read at the declaration that
+carries the namespace, three things:
+
+- it is a delegate of a `Variants` over `Quickshell.screens` and declares
+  `screen: modelData` - the compositor never chooses;
+- its `keyboardFocus:` and `mask:` read the target predicate, not just the
+  open flag - N surfaces turning OnDemand on one open would leave the
+  compositor to pick which gets the keyboard, and N masks would let every
+  screen's edge eat clicks;
+- the open edge latches the target (`latchTarget()`) and reads focus through
+  `WM.focusedMonitor`, the shell's one window-manager facade.
+
+Every sweep asserts it FOUND what it swept for.
+"""
+
+import re
+from pathlib import Path
+
+from contract_runner import run
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# Persistent surfaces (see test_exit_owned_surface_contract.py and
+# test_persistent_sidebar_contract.py) and the predicate each one gates its
+# input on. The sidebars carry the same latent shape (no `screen:` on a
+# window created at boot) and are not listed yet: the left one reparents a
+# single content tree between two windows, so per-screen there is a larger
+# change than a wrap, and #297 is about the overview.
+SURFACES = {
+    ROOT / "modules/imi/overview/Overview.qml": ("quickshell:overview", "isTarget", "onOverviewOpenChanged"),
+}
+
+
+def read(path: Path) -> str:
+    assert path.exists(), f"{path} is gone - the sweep has nothing to look at"
+    text = path.read_text()
+    assert text.strip(), f"{path} is empty"
+    return text
+
+
+def code(path: Path) -> str:
+    text = read(path)
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.S)
+    return re.sub(r"//[^\n]*", "", text)
+
+
+def blocks(text: str, type_name: str):
+    found = []
+    for opener in re.finditer(rf"(?<![\w.]){re.escape(type_name)}\s*\{{", text):
+        start = opener.end() - 1
+        depth = 0
+        for index in range(start, len(text)):
+            if text[index] == "{":
+                depth += 1
+            elif text[index] == "}":
+                depth -= 1
+                if depth == 0:
+                    found.append((opener.start(), text[opener.start():index + 1]))
+                    break
+    return found
+
+
+def mapping_block(text: str, namespace: str, name: str):
+    owning = [(start, block) for start, block in blocks(text, "PanelWindow")
+              if namespace in block]
+    assert len(owning) == 1, \
+        (f"{name} has {len(owning)} PanelWindow declarations carrying "
+         f"{namespace} - this rule is about the one that maps it")
+    return owning[0]
+
+
+def top_level_value(block: str, prop: str):
+    values = []
+    depth = 0
+    for line in block.splitlines():
+        if depth == 1:
+            match = re.match(rf"\s*{re.escape(prop)}\s*:(.*)", line)
+            if match:
+                values.append(match.group(1).strip())
+        depth += line.count("{") - line.count("}")
+    return values
+
+
+def test_the_surface_is_one_window_per_screen_pinned_to_its_output():
+    for path, (namespace, _, _) in SURFACES.items():
+        text = code(path)
+        name = path.relative_to(ROOT).as_posix()
+        start, block = mapping_block(text, namespace, name)
+        families = [(s, b) for s, b in blocks(text, "Variants")
+                    if s < start < s + len(b)]
+        assert len(families) == 1, \
+            (f"{name}'s {namespace} window is not a Variants delegate - a "
+             "persistent window with no screen of its own is created once, on "
+             "whichever monitor had focus at boot, and never moves (#297)")
+        models = top_level_value(families[0][1], "model")
+        assert models and all("Quickshell.screens" in m for m in models), \
+            (f"{name}'s window family iterates {models}, not Quickshell.screens")
+        assert top_level_value(block, "screen") == ["modelData"], \
+            (f"{name}'s {namespace} window declares `screen: "
+             f"{top_level_value(block, 'screen')}` - it must pin itself to the "
+             "delegate's screen, or the compositor picks one at creation")
+
+
+def test_input_and_keyboard_follow_the_target_not_just_the_flag():
+    for path, (namespace, predicate, _) in SURFACES.items():
+        text = code(path)
+        name = path.relative_to(ROOT).as_posix()
+        _, block = mapping_block(text, namespace, name)
+        values = top_level_value(block, "WlrLayershell.keyboardFocus")
+        assert values, f"{name}'s window declares no `WlrLayershell.keyboardFocus:`"
+        for value in values:
+            assert predicate in value, \
+                (f"{name}'s `WlrLayershell.keyboardFocus: {value}` ignores "
+                 f"`{predicate}` - with one surface per screen every sibling "
+                 "would turn OnDemand on the same open, and the compositor "
+                 "would pick which of them gets the keyboard")
+        # The mask is a Region block, so its gate is one level down.
+        assert top_level_value(block, "mask"), f"{name}'s window declares no `mask:`"
+        mask = re.search(r"mask\s*:\s*Region\s*\{(.*?)\}", block, flags=re.S)
+        assert mask, f"{name}'s mask is not a Region"
+        assert predicate in mask.group(1), \
+            (f"{name}'s mask Region does not read `{predicate}` - every "
+             "screen's surface would take input on one open")
+
+
+def test_the_open_edge_latches_the_focused_monitor():
+    for path, (namespace, _, handler) in SURFACES.items():
+        text = code(path)
+        name = path.relative_to(ROOT).as_posix()
+        handlers = re.findall(rf"function\s+{handler}\s*\(\)\s*\{{(.*?)\n    \}}", text, flags=re.S)
+        assert len(handlers) == 1, \
+            (f"{name} has {len(handlers)} `{handler}` handlers - the open edge "
+             "is dispatched once, at the scope, so the latch is written before "
+             "any window reads it")
+        latch = re.search(r"function\s+latchTarget\s*\(\)\s*\{(.*?)\}", text, flags=re.S)
+        assert latch, f"{name} has no latchTarget() - nothing decides which screen opens"
+        assert "WM.focusedMonitor" in latch.group(1), \
+            (f"{name}'s latch reads focus from somewhere other than "
+             "WM.focusedMonitor - the shell's one window-manager facade")
+        assert "targetWindow()" in handlers[0] or "latchTarget()" in handlers[0], \
+            f"{name}'s `{handler}` opens without latching the target first"
+
+
+if __name__ == "__main__":
+    raise SystemExit(run(globals()))


### PR DESCRIPTION
Fixes #297.

**Cause.** A `PanelWindow` with no `screen:` asks the compositor to choose: Quickshell passes a null `wl_output` to `get_layer_surface` (`wlr_layershell.cpp` sets `compositorPicksScreen` when the screen is unset), and Hyprland answers with the monitor focused *at creation* (`LayerSurface.cpp`: an empty monitor name resolves to `focusState()->monitor()`). While the overview's window was rebuilt on every open that meant "the focused monitor, every time" — a behaviour multi-monitor users relied on and nobody had written down. Since feb041d60 (0.30.0, the surface stays mapped) the window is created once at boot, so it landed on whichever monitor had focus at boot and never moved.

**Fix.** The overview is a `Variants` family over `Quickshell.screens`, each window pinned with `screen: modelData` — the repo's pattern for the bar, popups, dock and lock. The scope latches `WM.focusedMonitor`'s name at the open edge (latched, not live: focus moving mid-open must not teleport the card) and opens only that screen's window; `reallyOpen` moved into the window so a sibling never builds its grid. One dispatcher `Connections` at the scope rather than one per window, because nothing orders a window's handler against another window's write of the latch. Siblings add two gates: `keyboardFocus` and the `mask` read `isTarget` as well as the flag, or every screen's surface turns OnDemand on the same open and the compositor picks which gets the keyboard. The three prefix toggles resolve the target window before flipping the flag, so the text lands on the window about to open (or the one already showing). `test_persistent_surface_screen.py` pins the shape; `test_exit_owned_surface_contract.py` still passes unchanged (one `PanelWindow` carrying the namespace, one blur region, card gated on `reallyOpen`).

**Not in this PR.** The sidebars have the same latent bug — no `screen:` on a window created at boot — and are named as pending in the new contract's docstring rather than swept: the left sidebar reparents a single content tree between two windows (detach mode), so per-screen there is more than a wrap. Worth its own issue if a multi-monitor user confirms it bites.

**Verification.** Full suite on the branch: 1220 QML passed, 207 harnesses, exit 0. Live on this machine — single monitor, so it can only prove no regression: one instance, one `quickshell:overview` layer on DP-1 before and during an open, `search open` / `close` / `clipboardToggle` via IPC clean, no binding loop or reference error in the log. The behaviour the issue is about needs a second monitor; @Ulitkad, if you can run this branch, open the overview with the cursor on the non-primary monitor and say where it lands.

Docs: updated AGENT.md §persistent surfaces (the fourth cost)
Changelog: updated — Fixed entry under [Unreleased]
