### PR TITLE
No empty pill in the bar, and the notifications section stops bleeding over its neighbours

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -2437,6 +2437,17 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   transform, press scale included, cancels out — and set the target to pressStart + delta, as
   `widgetCanvas/AbstractWidget.qml` now does. d2ebb5aeb ("fix(widgetCanvas): compute the drag by
   hand - MouseArea.drag cannot track it").
+- **A `BarGroup` whose content has collapsed paints nothing, and the row's ends follow what is
+  showing.** The standalone pills (`TimerPill`, `SubmapIndicator`, `PrivacyIndicator`) animate
+  their `implicitWidth` to 0 when idle and hide themselves — and the group around one kept its
+  padding, so any layout ending in a pill carried a small empty stub beside its last widget all
+  day (user-reported, 2026-08-26). `BarGroup.collapsed` reads the grid's implicit size on the axis
+  the bar runs along, and `visible` follows it, except in edit mode, where every slot has to stay
+  on the bar to be dragged. The end radii used to come from `currentIndex`/`totalCount`, which
+  still count a collapsed neighbour; they now walk the parent's children for the nearest group
+  that is showing (`showingBefore`/`showingAfter`), so the widget beside a collapsed pill gets the
+  full end radius. `tests/tst_bar_group_collapse.qml` pins both.
+  (fix(bar): a group whose content collapsed paints nothing, and the row's ends follow.)
 - **The two bars load the same widget files out of `modules/imi/bar/`, and each used to decide
   which file for itself.** `Config.options.bar.layouts.*` is shared and Settings > Bar offers a
   plugin's bar widget whatever the orientation, but only `BarContent.qml` ever learned the
@@ -2445,7 +2456,9 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   `plugin:docker_plugin` resolved to `Plugin:docker_plugin.qml` - measured with a `qml6` probe, the
   `Loader` reaches `Loader.Error` with a null `item`, and the only evidence is one
   `No such file or directory` line per widget. That is neither a `WARN scene:` nor an `ERROR:`, so
-  the configuration still loads and the bar simply draws the empty `BarGroup` stub around nothing.
+  the configuration still loads and the bar simply drew the empty `BarGroup` stub around nothing
+  (an empty group collapses now - see the bar-group point below - so that evidence is gone too;
+  the parity test is what catches it).
   `modules/imi/bar/bar_widget_source.js` is the one mapping now; it answers with a **file name**
   and the caller prepends its own directory, because the two bars reach that directory by different
   relative paths and a `.pragma library` has no engine context to assume for `Qt.resolvedUrl`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ own repo; the installer pins which revision it builds.
 
 ## [Unreleased]
 
+### Fixed
+- **No more empty pill in the bar.** With the timer or the submap indicator
+  at the end of a bar section, an empty rounded stub sat beside the last
+  widget whenever the pill had nothing to show — the group around the pill
+  kept its padding after the pill itself had collapsed. A group whose
+  content is gone now goes with it, and the widget next to it gets the
+  rounded end it is entitled to. Edit mode still shows every slot so an idle
+  pill can be dragged.
+- **The notifications section no longer bleeds over its neighbours.** When
+  the media player and an expanded timer/calendar left the right sidebar no
+  room for notifications, the empty-state bell, "Nothing" and the
+  "0 notifications" pill still painted, over the media player and the tab
+  row. The section now paints nothing when it has no room and hides its
+  list until there is space for the status row and a line above it.
+
 ## [0.31.0] — 2026-08-26
 
 The motion language's second half: the panels arrive composed, with their

--- a/dots/.config/quickshell/imi/modules/imi/bar/BarGroup.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/BarGroup.qml
@@ -55,21 +55,51 @@ Item {
 
     readonly property real fullRadius: height / 2
     readonly property real midRadius: Config.options.bar.cornerStyle === 2 ? Appearance.rounding.unsharpenmore + 2 : Appearance.rounding.unsharpenmore
-    property real startRadius: {
-        if (totalCount <= 1) return fullRadius;
-        if (currentIndex === 0) return fullRadius;
-        return midRadius;
+    // The ends of a row are decided by which neighbours are SHOWING, not by
+    // index: a group beside a collapsed one is the end of the row for as
+    // long as that neighbour is gone, and gets the full radius the index
+    // arithmetic would only give it if the neighbour were not in the layout
+    // at all. Walks the parent's children, which is the Repeater's row order;
+    // non-groups (the Repeater itself) carry no widgetId and are skipped. A
+    // group with no row around it (a harness, a preview) has no neighbours
+    // either way, which is the old `totalCount <= 1` answer.
+    function neighbourShowing(step) {
+        const siblings = root.parent?.children ?? [];
+        let here = -1;
+        for (let k = 0; k < siblings.length; k++) {
+            if (siblings[k] === root) { here = k; break; }
+        }
+        if (here < 0) return false;
+        for (let k = here + step; k >= 0 && k < siblings.length; k += step) {
+            const sibling = siblings[k];
+            if (sibling.widgetId === undefined) continue;
+            if (!sibling.collapsed) return true;
+        }
+        return false;
     }
-    property real endRadius: {
-        if (totalCount <= 1) return fullRadius;
-        if (currentIndex === totalCount - 1) return fullRadius;
-        return midRadius;
-    }
+    readonly property bool showingBefore: neighbourShowing(-1)
+    readonly property bool showingAfter: neighbourShowing(1)
+    property real startRadius: showingBefore ? midRadius : fullRadius
+    property real endRadius: showingAfter ? midRadius : fullRadius
 
     implicitWidth: vertical && root.isMaterial ? Appearance.sizes.baseVerticalBarWidth - 6 : (gridLayout.implicitWidth + padding * 2)
     implicitHeight: vertical ? (gridLayout.implicitHeight + padding * 2) : Appearance.sizes.baseBarHeight
 
     default property alias items: gridLayout.children
+
+    // A group whose content has collapsed to nothing paints nothing. The
+    // standalone pills (timer, submap, privacy) animate their implicitWidth
+    // to 0 when idle and hide themselves - and this group's padding was
+    // left standing around that 0 as a small empty pill beside the
+    // neighbour, all day, for every layout that ends in one of them. Read
+    // from the grid, which is what those pills drive, on the axis the bar
+    // lays out along. Edit mode keeps every group on the bar: an idle pill
+    // still has to be there to drag.
+    readonly property bool contentEmpty: root.vertical
+        ? gridLayout.implicitHeight <= 0
+        : gridLayout.implicitWidth <= 0
+    readonly property bool collapsed: contentEmpty && !editLoader.active
+    visible: !collapsed
 
     Rectangle {
         id: background

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/CenterWidgetGroup.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/CenterWidgetGroup.qml
@@ -13,9 +13,20 @@ Rectangle {
     radius: Appearance.rounding.normal
     color: Appearance.colors.colLayer1
 
+    // The column hands this section whatever height is left after the
+    // fixed-height ones - banner, toggles, sliders, the media player, the
+    // bottom group expanded - and that can be nothing. The list inside kept
+    // painting its unclipped parts around a rectangle with no area: the
+    // empty state's bell and "Nothing", and the "0 notifications" pill,
+    // drawn over the media player and the bottom group's tabs. Clipped now,
+    // and the list stands down below the height at which it could show its
+    // status row and one line above it, so a sliver never shows a cut pill.
+    clip: true
     NotificationList {
+        id: list
         anchors.fill: parent
         anchors.margins: Appearance.spacing.space100
+        visible: root.height >= list.minimumUsefulHeight + Appearance.spacing.space100 * 2
         entranceTrigger: root.entranceTrigger
     }
 }

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/notifications/NotificationList.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/notifications/NotificationList.qml
@@ -9,6 +9,13 @@ import QtQuick.Layouts
 Item {
     id: root
 
+    // The least height at which this list is worth drawing: its status row,
+    // the gap above it, and one line of the empty state (or the top of a
+    // card). Below this the owner hides it rather than let the unclipped
+    // pieces paint outside a rectangle with no area.
+    readonly property real minimumUsefulHeight: statusRow.implicitHeight
+        + Appearance.spacing.space100 + Appearance.font.pixelSize.large * 2
+
     NotificationListView { // Scrollable window
         id: listview
         anchors.left: parent.left

--- a/dots/.config/quickshell/imi/tests/fixtures/BarGroupRow.qml
+++ b/dots/.config/quickshell/imi/tests/fixtures/BarGroupRow.qml
@@ -1,0 +1,43 @@
+import QtQuick
+import QtQuick.Layouts
+import qs.modules.imi.bar
+
+// Two BarGroups in a row, the second holding a child shaped like the
+// standalone pills: 0 wide when idle, and hidden with it. Built through
+// Qt.createComponent by tst_bar_group_collapse.qml, because BarGroup draws
+// per-corner radii that Qt below 6.7 does not have - declared inline, the
+// whole test file would fail to compile there instead of skipping.
+RowLayout {
+    spacing: 4
+    property alias first: first
+    property alias second: second
+    property alias secondContent: secondContent
+
+    // Enough of the edit controller for BarWidgetEditItem to bind against
+    // when edit mode instantiates it; nothing here drags.
+    property QtObject fakeController: QtObject {
+        property var bucketNames: ["left"]
+        function dropBuckets() { return []; }
+        function beginDrag() {}
+        function dragMoved() {}
+        function commitReorder() {}
+        function endDrag() {}
+        function removeAt() {}
+    }
+
+    BarGroup {
+        id: first
+        currentIndex: 0
+        totalCount: 2
+        widgetId: "activeWindow"
+        Item { implicitWidth: 40; implicitHeight: 10 }
+    }
+    BarGroup {
+        id: second
+        currentIndex: 1
+        totalCount: 2
+        widgetId: "timerPill"
+        editController: fakeController
+        Item { id: secondContent; implicitWidth: 0; implicitHeight: 10; visible: implicitWidth > 0 }
+    }
+}

--- a/dots/.config/quickshell/imi/tests/imports/qs/GlobalStates.qml
+++ b/dots/.config/quickshell/imi/tests/imports/qs/GlobalStates.qml
@@ -5,4 +5,5 @@ import Quickshell
 
 Singleton {
     property bool screenLocked: false
+    property bool editMode: false
 }

--- a/dots/.config/quickshell/imi/tests/imports/qs/modules/imi/bar/BarFlipRegistry.qml
+++ b/dots/.config/quickshell/imi/tests/imports/qs/modules/imi/bar/BarFlipRegistry.qml
@@ -1,0 +1,1 @@
+../../../../../../modules/imi/bar/BarFlipRegistry.qml

--- a/dots/.config/quickshell/imi/tests/imports/qs/modules/imi/bar/BarGroup.qml
+++ b/dots/.config/quickshell/imi/tests/imports/qs/modules/imi/bar/BarGroup.qml
@@ -1,0 +1,1 @@
+../../../../../../modules/imi/bar/BarGroup.qml

--- a/dots/.config/quickshell/imi/tests/imports/qs/modules/imi/bar/BarWidgetEditItem.qml
+++ b/dots/.config/quickshell/imi/tests/imports/qs/modules/imi/bar/BarWidgetEditItem.qml
@@ -1,0 +1,11 @@
+import QtQuick
+
+// Stand-in for the edit-mode overlay BarGroup loads in edit mode. The real one
+// pulls in ReorderDragArea and the drag controller; nothing under test here
+// drags, so this carries the properties BarGroup writes and nothing else.
+Item {
+    property var controller: null
+    property string bucket: ""
+    property string widgetId: ""
+    property int visibleIndex: 0
+}

--- a/dots/.config/quickshell/imi/tests/imports/qs/modules/imi/bar/bar_flip.js
+++ b/dots/.config/quickshell/imi/tests/imports/qs/modules/imi/bar/bar_flip.js
@@ -1,0 +1,1 @@
+../../../../../../modules/imi/bar/bar_flip.js

--- a/dots/.config/quickshell/imi/tests/imports/qs/modules/imi/bar/qmldir
+++ b/dots/.config/quickshell/imi/tests/imports/qs/modules/imi/bar/qmldir
@@ -1,0 +1,4 @@
+module qs.modules.imi.bar
+BarGroup 1.0 BarGroup.qml
+BarFlipRegistry 1.0 BarFlipRegistry.qml
+BarWidgetEditItem 1.0 BarWidgetEditItem.qml

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -493,6 +493,15 @@ if ! python3 "$SCRIPT_DIR/test_persistent_surface_screen.py"; then
     exit 1
 fi
 
+# The right sidebar's fill-height section clips and hides its list when the
+# column has no room for it - the notification list's unclipped pieces used to
+# paint over the media player and the bottom group.
+echo "Running sidebar center group contract tests..."
+if ! python3 "$SCRIPT_DIR/test_sidebar_center_group_contract.py"; then
+    echo "Sidebar center group contract tests failed."
+    exit 1
+fi
+
 # The shell has two password prompts - the lock screen and the polkit dialog -
 # and they were two different text fields, one of them Material's outlined
 # container with the prompt floating in a notch. The check derives the control

--- a/dots/.config/quickshell/imi/tests/test_bar_widget_parity.py
+++ b/dots/.config/quickshell/imi/tests/test_bar_widget_parity.py
@@ -10,7 +10,8 @@ which capitalises a widget name into a file name, and produced
 `Plugin:docker_plugin.qml`. Measured with a `qml6` probe: `Loader.status` 3
 (`Loader.Error`), `item` null, and one `No such file or directory` line per
 widget - not a `WARN scene:` and not an `ERROR:`, so the configuration still
-loaded and the bar simply drew the empty BarGroup stub around nothing.
+loaded and the bar simply drew the empty BarGroup stub around nothing
+(an empty group collapses entirely now, so not even that shows).
 
 The defect class is not the missing branch, it is that a capability could be
 added to one bar and not the other at all. So the resolution is one module,

--- a/dots/.config/quickshell/imi/tests/test_sidebar_center_group_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_sidebar_center_group_contract.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""The right sidebar's fill-height section paints nothing when it has no room.
+
+`CenterWidgetGroup` is the column's only `Layout.fillHeight: true` item and
+declares no minimum, so when the fixed-height sections around it (banner,
+toggles, sliders, media player, the bottom group expanded) fill the column,
+the layout hands it 0 - and the notification list inside, inset by its
+margins, ends up with NEGATIVE height. Only the list's scroll view clipped;
+the empty state's bell and "Nothing" and the "0 notifications" status pill
+kept painting around a rectangle with no area, over the media player and
+the bottom group's tabs (user-reported, 2026-08-26).
+
+Two rules, read at the group and the list:
+
+- the group clips, so nothing inside can ever paint outside its area;
+- the list is hidden below a height the list itself names
+  (`minimumUsefulHeight`: its status row, the gap, one line above), so a
+  sliver of room never shows a cut-off pill either.
+
+Every sweep asserts it FOUND what it swept for.
+"""
+
+import re
+from pathlib import Path
+
+from contract_runner import run
+
+ROOT = Path(__file__).resolve().parent.parent
+GROUP = ROOT / "modules/imi/sidebarRight/CenterWidgetGroup.qml"
+LIST = ROOT / "modules/imi/sidebarRight/notifications/NotificationList.qml"
+COLUMN = ROOT / "modules/imi/sidebarRight/SidebarRightContent.qml"
+
+
+def code(path: Path) -> str:
+    assert path.exists(), f"{path} is gone - the sweep has nothing to look at"
+    text = path.read_text()
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.S)
+    return re.sub(r"//[^\n]*", "", text)
+
+
+def test_the_group_is_the_columns_fill_height_section():
+    text = code(COLUMN)
+    block = re.search(r"CenterWidgetGroup\s*\{(.*?)\n\s{12}\}", text, flags=re.S)
+    assert block, "SidebarRightContent no longer places a CenterWidgetGroup"
+    assert re.search(r"Layout\.fillHeight\s*:\s*true", block.group(1)), \
+        ("CenterWidgetGroup is no longer the fill-height section - this rule "
+         "is about the one item the layout can hand nothing to")
+
+
+def test_the_group_clips_and_hides_its_list_below_a_useful_height():
+    text = code(GROUP)
+    assert re.search(r"^\s{4}clip\s*:\s*true", text, flags=re.M), \
+        ("CenterWidgetGroup does not clip - a list inset into a zero-height "
+         "rectangle paints its unclipped pieces over the neighbours")
+    gate = re.search(r"NotificationList\s*\{(.*?)\n\s{4}\}", text, flags=re.S)
+    assert gate, "CenterWidgetGroup no longer holds a NotificationList"
+    visible = re.search(r"visible\s*:(.*)", gate.group(1))
+    assert visible, "the NotificationList has no `visible:` gate of its own"
+    assert "minimumUsefulHeight" in visible.group(1) and "height" in visible.group(1), \
+        (f"the list's gate `{visible.group(1).strip()}` does not compare the "
+         "group's height against the list's minimumUsefulHeight")
+
+
+def test_the_list_names_its_own_minimum():
+    text = code(LIST)
+    decl = re.search(r"readonly\s+property\s+real\s+minimumUsefulHeight\s*:(.*?)\n\n", text, flags=re.S)
+    assert decl, "NotificationList declares no minimumUsefulHeight"
+    assert "statusRow.implicitHeight" in decl.group(1), \
+        ("minimumUsefulHeight does not start from the status row's own height "
+         "- the row is the piece that was painting over the media player")
+
+
+if __name__ == "__main__":
+    raise SystemExit(run(globals()))

--- a/dots/.config/quickshell/imi/tests/tst_bar_group_collapse.qml
+++ b/dots/.config/quickshell/imi/tests/tst_bar_group_collapse.qml
@@ -1,0 +1,117 @@
+import QtQuick
+import QtQuick.Layouts
+import QtTest
+import qs
+import qs.modules.common
+import qs.modules.imi.bar
+
+// A BarGroup whose content has collapsed paints nothing, and the ends of a
+// row follow which neighbours are showing.
+//
+// The standalone pills (timer, submap, privacy) animate their implicitWidth
+// to 0 when idle and hide themselves; the group around one kept its padding,
+// so every layout ending in a pill carried a small empty stub beside its last
+// widget (user-reported, 2026-08-26). What is pinned: a group with a
+// zero-width child is collapsed and invisible, it comes back when the child
+// grows, edit mode keeps it on the bar regardless, and the group beside a
+// collapsed one gets the full end radius its index alone would not give it.
+TestCase {
+    name: "BarGroupCollapseTest"
+    when: windowShown
+
+    property bool savedEditMode: false
+    function initTestCase() { savedEditMode = GlobalStates.editMode; }
+    function cleanupTestCase() { GlobalStates.editMode = savedEditMode; }
+
+    // Enough of the edit controller for BarWidgetEditItem to bind against
+    // when edit mode instantiates it; no test here drags anything.
+    QtObject {
+        id: fakeController
+        property var bucketNames: ["left"]
+        function dropBuckets() { return []; }
+        function beginDrag() {}
+        function dragMoved() {}
+        function commitReorder() {}
+        function endDrag() {}
+        function removeAt() {}
+    }
+
+    Component {
+        id: rowComponent
+        RowLayout {
+            spacing: 4
+            property alias first: first
+            property alias second: second
+            property alias secondContent: secondContent
+            BarGroup {
+                id: first
+                currentIndex: 0
+                totalCount: 2
+                widgetId: "activeWindow"
+                Item { implicitWidth: 40; implicitHeight: 10 }
+            }
+            BarGroup {
+                id: second
+                currentIndex: 1
+                totalCount: 2
+                widgetId: "timerPill"
+                editController: fakeController
+                // The pills' own shape: 0 wide when idle, and hidden with it.
+                Item { id: secondContent; implicitWidth: 0; implicitHeight: 10; visible: implicitWidth > 0 }
+            }
+        }
+    }
+
+    function test_a_group_with_nothing_in_it_is_collapsed_and_invisible() {
+        GlobalStates.editMode = false;
+        const row = createTemporaryObject(rowComponent, this);
+        verify(row.second.contentEmpty, "a zero-width child is not read as empty");
+        verify(row.second.collapsed, "an empty group is not collapsed");
+        verify(!row.first.collapsed, "a group with content collapsed");
+        // The layout is the evidence: a collapsed group takes no width and
+        // no spacing, so the row is exactly its one showing member.
+        compare(row.implicitWidth, row.first.implicitWidth,
+                "the collapsed group still takes room in the row");
+    }
+
+    function test_the_group_comes_back_when_its_content_does() {
+        GlobalStates.editMode = false;
+        const row = createTemporaryObject(rowComponent, this);
+        verify(row.second.collapsed);
+        row.secondContent.implicitWidth = 36;
+        tryVerify(() => !row.second.collapsed, 500, "the group stayed collapsed after its content grew");
+        tryCompare(row, "implicitWidth",
+                   row.first.implicitWidth + row.spacing + row.second.implicitWidth, 500);
+        row.secondContent.implicitWidth = 0;
+        tryVerify(() => row.second.collapsed, 500, "the group did not collapse again");
+        tryCompare(row, "implicitWidth", row.first.implicitWidth, 500);
+    }
+
+    function test_edit_mode_keeps_an_empty_group_on_the_bar() {
+        GlobalStates.editMode = true;
+        const row = createTemporaryObject(rowComponent, this);
+        verify(row.second.contentEmpty, "still empty");
+        verify(!row.second.collapsed, "edit mode collapsed a slot the user has to be able to drag");
+        // Empty, but on the bar: its padding is its width, and it takes spacing.
+        compare(row.second.implicitWidth, row.second.padding * 2);
+        compare(row.implicitWidth, row.first.implicitWidth + row.spacing + row.second.implicitWidth);
+        GlobalStates.editMode = false;
+        tryVerify(() => row.second.collapsed, 500, "leaving edit mode did not collapse the empty group");
+    }
+
+    function test_the_row_end_follows_the_showing_neighbour_not_the_index() {
+        GlobalStates.editMode = false;
+        const row = createTemporaryObject(rowComponent, this);
+        // Index says first is not last; its only neighbour is collapsed, so it is.
+        verify(!row.first.showingAfter, "a collapsed neighbour counts as showing");
+        compare(row.first.endRadius, row.first.fullRadius,
+                "the group beside a collapsed one did not get the full end radius");
+        compare(row.first.startRadius, row.first.fullRadius);
+        row.secondContent.implicitWidth = 36;
+        tryVerify(() => row.first.showingAfter, 500, "a neighbour that came back is not seen");
+        compare(row.first.endRadius, row.first.midRadius,
+                "with a showing neighbour the shared edge is not the mid radius");
+        compare(row.second.startRadius, row.second.midRadius);
+        compare(row.second.endRadius, row.second.fullRadius);
+    }
+}

--- a/dots/.config/quickshell/imi/tests/tst_bar_group_collapse.qml
+++ b/dots/.config/quickshell/imi/tests/tst_bar_group_collapse.qml
@@ -1,9 +1,7 @@
 import QtQuick
-import QtQuick.Layouts
 import QtTest
 import qs
 import qs.modules.common
-import qs.modules.imi.bar
 
 // A BarGroup whose content has collapsed paints nothing, and the ends of a
 // row follow which neighbours are showing.
@@ -20,49 +18,31 @@ TestCase {
     when: windowShown
 
     property bool savedEditMode: false
-    function initTestCase() { savedEditMode = GlobalStates.editMode; }
     function cleanupTestCase() { GlobalStates.editMode = savedEditMode; }
 
-    // Enough of the edit controller for BarWidgetEditItem to bind against
-    // when edit mode instantiates it; no test here drags anything.
-    QtObject {
-        id: fakeController
-        property var bucketNames: ["left"]
-        function dropBuckets() { return []; }
-        function beginDrag() {}
-        function dragMoved() {}
-        function commitReorder() {}
-        function endDrag() {}
-        function removeAt() {}
-    }
-
-    Component {
-        id: rowComponent
-        RowLayout {
-            spacing: 4
-            property alias first: first
-            property alias second: second
-            property alias secondContent: secondContent
-            BarGroup {
-                id: first
-                currentIndex: 0
-                totalCount: 2
-                widgetId: "activeWindow"
-                Item { implicitWidth: 40; implicitHeight: 10 }
-            }
-            BarGroup {
-                id: second
-                currentIndex: 1
-                totalCount: 2
-                widgetId: "timerPill"
-                editController: fakeController
-                // The pills' own shape: 0 wide when idle, and hidden with it.
-                Item { id: secondContent; implicitWidth: 0; implicitHeight: 10; visible: implicitWidth > 0 }
-            }
+    // Built from a URL rather than declared inline, for the reason
+    // tst_grouped_list.qml records: BarGroup draws per-corner radii that Qt
+    // below 6.7 does not have, and declared inline the whole file fails to
+    // compile there. Through createComponent the version dependency is a
+    // STATUS this test can read and skip on.
+    property Component rowComponent: null
+    function initTestCase() {
+        savedEditMode = GlobalStates.editMode;
+        rowComponent = Qt.createComponent("fixtures/BarGroupRow.qml");
+        if (rowComponent.status === Component.Error) {
+            const reason = rowComponent.errorString();
+            verify(/(top|bottom)(Left|Right)Radius/.test(reason),
+                   "BarGroupRow failed to build for a reason that is not Qt's version: " + reason);
         }
+    }
+    function ensureComponent() {
+        if (rowComponent.status === Component.Error)
+            skip("Qt is older than 6.7, so the per-corner radii BarGroup draws its pill with do not exist here");
+        compare(rowComponent.status, Component.Ready, rowComponent.errorString());
     }
 
     function test_a_group_with_nothing_in_it_is_collapsed_and_invisible() {
+        ensureComponent();
         GlobalStates.editMode = false;
         const row = createTemporaryObject(rowComponent, this);
         verify(row.second.contentEmpty, "a zero-width child is not read as empty");
@@ -75,6 +55,7 @@ TestCase {
     }
 
     function test_the_group_comes_back_when_its_content_does() {
+        ensureComponent();
         GlobalStates.editMode = false;
         const row = createTemporaryObject(rowComponent, this);
         verify(row.second.collapsed);
@@ -88,6 +69,7 @@ TestCase {
     }
 
     function test_edit_mode_keeps_an_empty_group_on_the_bar() {
+        ensureComponent();
         GlobalStates.editMode = true;
         const row = createTemporaryObject(rowComponent, this);
         verify(row.second.contentEmpty, "still empty");
@@ -100,6 +82,7 @@ TestCase {
     }
 
     function test_the_row_end_follows_the_showing_neighbour_not_the_index() {
+        ensureComponent();
         GlobalStates.editMode = false;
         const row = createTemporaryObject(rowComponent, this);
         // Index says first is not last; its only neighbour is collapsed, so it is.


### PR DESCRIPTION
Two overflow fixes, both user-reported on 2026-08-26 with screenshots.

**The empty pill in the bar.** The standalone pills (`TimerPill`, `SubmapIndicator`, `PrivacyIndicator`) animate their `implicitWidth` to 0 when idle and hide themselves — and the `BarGroup` around one kept its padding, so any layout ending in a pill (`activeWindow, timerPill` on the left here; `powerButton, submapIndicator` on the right) carried a small empty rounded stub beside its last widget all day. `BarGroup.collapsed` reads the grid's implicit size on the axis the bar runs along and `visible` follows it, except in edit mode, where every slot has to stay on the bar to be dragged. The end radii used to come from `currentIndex`/`totalCount`, which still count a collapsed neighbour; they now walk the parent's children for the nearest group that is showing, so the widget beside a collapsed pill gets the full end radius. `tst_bar_group_collapse.qml` pins collapse, return, edit mode, and the radius flip — read off the `RowLayout`'s implicit width, since a `TestCase` item is never shown and effective `visible` proves nothing under it. `qs.modules.imi.bar` joins the test symlink farm with a stand-in `BarWidgetEditItem`; the `GlobalStates` shim learns `editMode`. One side effect recorded in AGENT.md: the "empty stub around nothing" that used to betray a widget file that failed to load is gone too — `test_bar_widget_parity.py` is what catches that now.

**The notifications section bleeding over its neighbours.** `CenterWidgetGroup` is the right sidebar column's only `Layout.fillHeight` item and declares no minimum, so with the media player and the bottom group expanded the layout hands it 0, and the list inside — inset by its margins — ends up with negative height. Only the list's scroll view clipped; the empty state's bell and "Nothing" and the "0 notifications" pill kept painting around a rectangle with no area, over the media player and the tab row. The group clips now and hides the list below a height the list itself names (`minimumUsefulHeight`: status row + gap + one line), so a sliver of room never shows a cut-off pill either. Layout untouched. `test_sidebar_center_group_contract.py` pins both rules and that the group is still the fill-height section.

Verified: full suite in the worktree (1226 QML, 208 harnesses, exit 0), and deployed live for the maintainer's own look at both screenshots' cases.

Docs: updated AGENT.md (bar-group collapse rule; the parity paragraph's stub sentence corrected)
Changelog: updated — two Fixed entries under [Unreleased]
