### PR TITLE
The overview latches the focused monitor at every open, not only the first (#297 reopened)

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -4718,7 +4718,17 @@ modelData`), and the scope latches the focused monitor's name at the open edge a
 screen's window — latched, not live, so focus moving mid-open does not teleport the card. Two
 gates follow from having siblings: `keyboardFocus` and the `mask` read the target predicate as
 well as the flag, or every screen's surface turns OnDemand on one open and the compositor picks
-which gets the keyboard. `tests/test_persistent_surface_screen.py` pins the shape. The sidebars
+which gets the keyboard. `tests/test_persistent_surface_screen.py` pins the shape. **The latch is
+taken at every open edge, by a function that does nothing else.** The first version resolved the
+target through the prefix toggles' helper, whose "already open? then the window that is showing"
+shortcut is right for a toggle pressed while the overview is up — and always taken at the open
+edge, where the flag has just flipped, so every open after the first reused the first screen's
+window. One monitor cannot show that; #297 reopened on two. The shell's `WM.focusedMonitor` was
+following every `focusedmon` event the whole time (verified against Hyprland's event socket on a
+nested two-output session). `tests/run_overview_focus_probe.sh` is that session, run by hand:
+two wayland outputs, focus moved between them, `search activeScreen` compared with
+`hyprctl monitors` `focused` on each open. (fix(overview): every open latches the focused
+monitor afresh; the toggles alone keep the already-open shortcut.) The sidebars
 carry the same latent bug and are not converted yet: the left one reparents a single content tree
 between two windows, so per-screen there is more than a wrap. (fix(overview): one surface per
 screen, and the open picks the focused monitor's.)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ own repo; the installer pins which revision it builds.
 ## [Unreleased]
 
 ### Fixed
+- **The overview opens on the focused monitor every time, not just the first
+  time.** 0.31.0's fix picked the right monitor for the first open and then
+  kept reusing that monitor's window for every open after it — on one
+  monitor invisible, on two the same bug as before (#297, reopened). Each
+  open now asks which monitor has focus.
 - **No more empty pill in the bar.** With the timer or the submap indicator
   at the end of a bar section, an empty rounded stub sat beside the last
   widget whenever the pill had nothing to show — the group around the pill

--- a/dots/.config/quickshell/imi/modules/imi/overview/Overview.qml
+++ b/dots/.config/quickshell/imi/modules/imi/overview/Overview.qml
@@ -54,16 +54,30 @@ Scope {
         overviewScope.targetScreen = WM.focusedMonitor?.name ?? "";
     }
 
-    // The window an open (or a search-prefix toggle about to open) should
-    // address. Already open: the one that is showing, wherever focus has
-    // moved since. Closed: the focused monitor's, latched now.
-    function targetWindow() {
-        if (GlobalStates.overviewOpen && overviewScope.activeWindow)
-            return overviewScope.activeWindow;
+    // The focused monitor's window, latched now. Called at EVERY open edge:
+    // the first version of this asked "already open?" first and handed back
+    // the window that was showing - but at the open edge the flag has just
+    // flipped, so that question was always yes once any open had happened,
+    // and every open after the first reused the first screen's window. On
+    // one monitor that is invisible; on two it is #297 reopened ("still on
+    // the primary"). Reproduced on a nested two-output Hyprland, where the
+    // shell's WM.focusedMonitor followed every focusedmon event and the
+    // latch still returned the stale window.
+    function windowForFocusedMonitor() {
         overviewScope.latchTarget();
         const windows = overviewWindows.instances;
         return windows.find(w => w.modelData.name === overviewScope.targetScreen)
             ?? windows[0] ?? null;
+    }
+
+    // The window a search-prefix toggle should address. Already open: the
+    // one that is showing, wherever focus has moved since (the text goes
+    // where the user is looking). Closed: the focused monitor's, latched now;
+    // the open edge that follows latches again and lands on the same answer.
+    function targetWindow() {
+        if (GlobalStates.overviewOpen && overviewScope.activeWindow)
+            return overviewScope.activeWindow;
+        return overviewScope.windowForFocusedMonitor();
     }
 
     // One dispatcher for the whole family, at the scope: per-window handlers
@@ -74,7 +88,7 @@ Scope {
         target: GlobalStates
         function onOverviewOpenChanged() {
             if (GlobalStates.overviewOpen) {
-                overviewScope.activeWindow = overviewScope.targetWindow();
+                overviewScope.activeWindow = overviewScope.windowForFocusedMonitor();
                 overviewScope.activeWindow?.open();
             } else {
                 overviewScope.dontAutoCancelSearch = false;
@@ -409,6 +423,12 @@ Scope {
         }
         function clipboardToggle() {
             overviewScope.toggleClipboard();
+        }
+        // Which screen's window the last open landed on - what
+        // tests/run_overview_focus_probe.sh reads after moving focus between
+        // two outputs. Empty until the first open.
+        function activeScreen(): string {
+            return overviewScope.activeWindow?.modelData.name ?? "";
         }
     }
 

--- a/dots/.config/quickshell/imi/tests/run_overview_focus_probe.sh
+++ b/dots/.config/quickshell/imi/tests/run_overview_focus_probe.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# The overview opens on the monitor that has focus, every time - not the one
+# it opened on first.
+#
+# A nested Hyprland with two wayland outputs (each a window on the parent
+# session; headless outputs never take a mode under the nested backend), the
+# full shell inside it against an empty config, and the overview opened by
+# IPC after focus is moved to each output in turn. `search activeScreen` is
+# the shell's own answer for which screen's window the open landed on; the
+# probe compares it with `hyprctl monitors` `focused`. #297 reopened on
+# exactly this: on one monitor the first fix looked right, on two every open
+# after the first reused the first screen's window.
+#
+# Not part of run_tests.sh: it needs a Wayland parent and opens two windows
+# on it. Run by hand from a graphical session.
+set -u
+if [ -z "${WAYLAND_DISPLAY:-}" ]; then echo "SKIPPED: no WAYLAND_DISPLAY - the nested compositor needs a parent"; exit 0; fi
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PARENT_SOCKET="$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY"
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP" 2>/dev/null' EXIT
+export XDG_CONFIG_HOME="$TMP/config" XDG_CACHE_HOME="$TMP/cache" XDG_STATE_HOME="$TMP/state" XDG_DATA_HOME="$TMP/data"
+mkdir -p "$XDG_CONFIG_HOME/immaterial-impulse" "$XDG_CONFIG_HOME/quickshell" "$XDG_CACHE_HOME" "$XDG_STATE_HOME" "$XDG_DATA_HOME" "$TMP/run"
+ln -s "$ROOT" "$XDG_CONFIG_HOME/quickshell/imi"
+printf '%s' '{}' > "$XDG_CONFIG_HOME/immaterial-impulse/config.json"
+cat > "$TMP/hypr.lua" <<'LUA'
+hl.monitor({ output = "WAYLAND-2", mode = "preferred", position = "1280x0", scale = 1 })
+hl.monitor({ output = "", mode = "1280x720@60", position = "0x0", scale = 1 })
+hl.config({ misc = { disable_hyprland_logo = true, disable_splash_rendering = true, force_default_wallpaper = 0, disable_autoreload = true }, animations = { enabled = false } })
+LUA
+export XDG_RUNTIME_DIR="$TMP/run"
+export WAYLAND_DISPLAY="$PARENT_SOCKET"
+dbus-run-session -- bash -s "$TMP" <<'NESTED'
+set -u
+TMP="$1"
+Hyprland -c "$TMP/hypr.lua" > "$TMP/hypr.log" 2>&1 &
+HPID=$!
+SIG=""
+for _ in $(seq 1 60); do sleep 0.5; SIG=$(ls "$XDG_RUNTIME_DIR/hypr" 2>/dev/null | head -1); [ -n "$SIG" ] && [ -S "$XDG_RUNTIME_DIR/hypr/$SIG/.socket.sock" ] && break; SIG=""; done
+if [ -z "$SIG" ]; then echo "FAILED: the nested compositor never came up"; tail -5 "$TMP/hypr.log"; kill $HPID 2>/dev/null; exit 1; fi
+export HYPRLAND_INSTANCE_SIGNATURE="$SIG"
+export WAYLAND_DISPLAY=$(ls "$XDG_RUNTIME_DIR" | grep -E '^wayland-[0-9]+$' | head -1)
+hyprctl output create wayland >/dev/null; sleep 2
+MONS=$(hyprctl monitors -j | python3 -c 'import json,sys; print(" ".join(m["name"] for m in json.load(sys.stdin) if m["width"]>0))')
+if [ "$(echo $MONS | wc -w)" -lt 2 ]; then echo "FAILED: second output never came up ($MONS)"; kill $HPID; exit 1; fi
+qs -c imi > "$TMP/qs.log" 2>&1 &
+QPID=$!
+sleep 12
+fail=0; checks=0
+for M in $MONS $MONS $MONS; do
+  WS=$(hyprctl monitors -j | python3 -c "import json,sys; print([m for m in json.load(sys.stdin) if m['name']=='$M'][0]['activeWorkspace']['id'])")
+  hyprctl dispatch workspace $WS >/dev/null; sleep 0.3; hyprctl dispatch focusmonitor "$M" >/dev/null; sleep 0.6
+  FOCUSED=$(hyprctl monitors -j | python3 -c 'import json,sys; print(",".join(m["name"] for m in json.load(sys.stdin) if m["focused"]))')
+  qs -c imi ipc call search open >/dev/null 2>&1; sleep 1.0
+  LANDED=$(qs -c imi ipc call search activeScreen 2>/dev/null | tr -d '\n')
+  qs -c imi ipc call search close >/dev/null 2>&1; sleep 0.8
+  checks=$((checks+1))
+  if [ "$LANDED" = "$FOCUSED" ]; then echo "ok   focused=$FOCUSED opened on $LANDED"; else echo "FAIL focused=$FOCUSED opened on ${LANDED:-<none>}"; fail=1; fi
+done
+kill $QPID 2>/dev/null; sleep 1; kill $HPID 2>/dev/null; sleep 1; kill -9 $HPID 2>/dev/null
+echo "$checks checks, $( [ $fail = 0 ] && echo all on the focused monitor || echo FAILED )"
+exit $fail
+NESTED

--- a/dots/.config/quickshell/imi/tests/test_persistent_surface_screen.py
+++ b/dots/.config/quickshell/imi/tests/test_persistent_surface_screen.py
@@ -23,8 +23,10 @@ carries the namespace, three things:
   open flag - N surfaces turning OnDemand on one open would leave the
   compositor to pick which gets the keyboard, and N masks would let every
   screen's edge eat clicks;
-- the open edge latches the target (`latchTarget()`) and reads focus through
-  `WM.focusedMonitor`, the shell's one window-manager facade.
+- the open edge resolves the focused monitor's window AFRESH
+  (`windowForFocusedMonitor()`, which latches through `WM.focusedMonitor`,
+  the shell's one window-manager facade) - never through the prefix
+  toggles' already-open shortcut, which at the open edge is always taken.
 
 Every sweep asserts it FOUND what it swept for.
 """
@@ -153,8 +155,14 @@ def test_the_open_edge_latches_the_focused_monitor():
         assert "WM.focusedMonitor" in latch.group(1), \
             (f"{name}'s latch reads focus from somewhere other than "
              "WM.focusedMonitor - the shell's one window-manager facade")
-        assert "targetWindow()" in handlers[0] or "latchTarget()" in handlers[0], \
-            f"{name}'s `{handler}` opens without latching the target first"
+        assert "windowForFocusedMonitor()" in handlers[0], \
+            (f"{name}'s `{handler}` does not resolve the focused monitor's window "
+             "afresh - the first version reused the window already showing, and "
+             "at the open edge the flag has just flipped, so every open after the "
+             "first landed on the first screen (#297 reopened)")
+        assert "targetWindow()" not in handlers[0], \
+            (f"{name}'s `{handler}` goes through targetWindow(), whose already-open "
+             "shortcut is for the prefix toggles, not the open edge")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #297 (reopened after #299).

**What was wrong with #299.** The per-screen family and the latch were right; the open edge resolved its window through `targetWindow()`, whose first question is "already open? then the window that is showing". That shortcut is correct for a search-prefix toggle pressed while the overview is up — the text goes where the user is looking — and it is *always* taken at the open edge, where `GlobalStates.overviewOpen` has just flipped to true. So the first open latched the focused monitor correctly and every later open reused that window. One monitor cannot show the difference, which is why the single-monitor verification passed and the reporter saw no change.

**Reproduced, not guessed.** A nested Hyprland with two wayland outputs and the full shell inside it: Hyprland's event socket emitted `focusedmon` on every switch, the shell's `WM.focusedMonitor` followed each one, and the probe line at the open edge read `focused=WAYLAND-1 target=WAYLAND-2 active=WAYLAND-2` — the stale window.

**Fix.** `windowForFocusedMonitor()` latches and finds, nothing else; the open edge calls it directly. `targetWindow()` keeps the already-open shortcut for the three toggles and falls through to it when closed. `search activeScreen` is a new IPC query answering which screen's window the last open landed on.

**Proof.** `tests/run_overview_focus_probe.sh` — the reproduction turned into a check (nested two-output Hyprland, focus moved by workspace + `focusmonitor`, `search activeScreen` vs `hyprctl monitors` `focused`, six opens alternating outputs): 6/6 on this branch. Manual, needs a graphical parent; documented as such. The contract test now forbids the open edge going through `targetWindow()`. Full suite in the worktree: 1220 QML passed, 207 harnesses, exit 0.

Docs: updated AGENT.md §persistent surfaces (the latch is taken at every open edge; the probe)
Changelog: updated — Fixed entry under [Unreleased]
