### PR TITLE
Icon buttons centre their glyph, and the text field's confirm button arrives and leaves smoothly

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -2448,6 +2448,16 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   that is showing (`showingBefore`/`showingAfter`), so the widget beside a collapsed pill gets the
   full end radius. `tests/tst_bar_group_collapse.qml` pins both.
   (fix(bar): a group whose content collapsed paints nothing, and the row's ends follow.)
+- **A `MaterialSymbol` used as a `Control`'s `contentItem` declares both alignments; anchors on it
+  are ignored.** A Control sizes its content item to the padded rect and positions it itself, so
+  `anchors.centerIn: parent` on the glyph is decoration, and a Text with no alignment draws its
+  glyph at the top-left of that rect — the icon sits up-left of centre. Eight buttons had that
+  spelling (the presets "save" button is the one photographed, 2026-08-27), one of them hiding it
+  with a hand `horizontalCenterOffset: -2`. `IconToolbarButton.qml` is the spelling that is right —
+  `horizontalAlignment: Text.AlignHCenter` and `verticalAlignment: Text.AlignVCenter` on the glyph —
+  and `tests/lint_icon_glyph_alignment.py` fails any `contentItem: MaterialSymbol` block without
+  both. (fix(widgets): every contentItem glyph is centred by alignment, not by an anchor the
+  Control ignores.)
 - **The two bars load the same widget files out of `modules/imi/bar/`, and each used to decide
   which file for itself.** `Config.options.bar.layouts.*` is shared and Settings > Bar offers a
   plugin's bar widget whatever the orientation, but only `BarContent.qml` ever learned the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ own repo; the installer pins which revision it builds.
 
 ## [Unreleased]
 
+### Fixed
+- **Icon buttons draw their icon in the middle.** The presets "save" button, the
+  password-reveal eye, the phone panel's ring and send buttons, the wallpaper
+  selector's close and audio buttons, the edit-mode menu's back arrow and the
+  clock-depth inspector all drew their glyph up-left of centre. The glyph was
+  told to centre itself in a way its button ignores; it now says so in the way
+  the button honours.
+
 ## [0.31.1] — 2026-08-26
 
 Three fixes: the overview really does follow the focused monitor now (the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ own repo; the installer pins which revision it builds.
   clock-depth inspector all drew their glyph up-left of centre. The glyph was
   told to centre itself in a way its button ignores; it now says so in the way
   the button honours.
+- **The presets "save" button arrives and leaves smoothly.** It used to pop in
+  at full size the moment you typed a name and vanish the moment you cleared
+  it, shoving the text field a button-width in one frame each way. It now
+  glides in and out like the bar's pills, and the field reflows with it.
 
 ## [0.31.1] — 2026-08-26
 

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/notes/Widget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/notes/Widget.qml
@@ -248,6 +248,7 @@ Item {
                                     onClicked: Notes.deleteNote(noteRow.modelData.id)
 
                                     contentItem: MaterialSymbol {
+                                        verticalAlignment: Text.AlignVCenter
                                         anchors.centerIn: parent
                                         horizontalAlignment: Text.AlignHCenter
                                         text: "delete"
@@ -280,6 +281,7 @@ Item {
                         onClicked: root.saveAndBack()
 
                         contentItem: MaterialSymbol {
+                            verticalAlignment: Text.AlignVCenter
                             anchors.centerIn: parent
                             horizontalAlignment: Text.AlignHCenter
                             text: "arrow_back"

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DatePicker.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/DatePicker.qml
@@ -129,6 +129,7 @@ Item {
                 enabled: !root.yearMode
                 onClicked: root.monthShift--
                 contentItem: MaterialSymbol {
+                    verticalAlignment: Text.AlignVCenter
                     text: "chevron_left"; iconSize: Appearance.font.pixelSize.normal
                     horizontalAlignment: Text.AlignHCenter; color: Appearance.colors.colOnLayer1
                 }
@@ -140,6 +141,7 @@ Item {
                 enabled: !root.yearMode
                 onClicked: root.monthShift++
                 contentItem: MaterialSymbol {
+                    verticalAlignment: Text.AlignVCenter
                     text: "chevron_right"; iconSize: Appearance.font.pixelSize.normal
                     horizontalAlignment: Text.AlignHCenter; color: Appearance.colors.colOnLayer1
                 }

--- a/dots/.config/quickshell/imi/modules/common/widgets/AddressBar.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/AddressBar.qml
@@ -37,6 +37,8 @@ Rectangle {
             id: parentDirButton
             downAction: () => root.navigateToDirectory(FileUtils.parentDirectory(root.directory))
             contentItem: MaterialSymbol {
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
                 text: "drive_folder_upload"
                 iconSize: Appearance.font.pixelSize.larger
             }
@@ -107,6 +109,8 @@ Rectangle {
             toggled: !root.showBreadcrumb
             downAction: () => root.showBreadcrumb = !root.showBreadcrumb
             contentItem: MaterialSymbol {
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
                 text: "edit"
                 iconSize: Appearance.font.pixelSize.larger
                 color: dirEditButton.toggled ? Appearance.colors.colOnPrimary : Appearance.colors.colOnLayer2

--- a/dots/.config/quickshell/imi/modules/common/widgets/AttachedFileIndicator.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/AttachedFileIndicator.qml
@@ -112,6 +112,7 @@ Rectangle {
                 implicitHeight: 28
                 implicitWidth: 28
                 contentItem: MaterialSymbol {
+                    verticalAlignment: Text.AlignVCenter
                     anchors.centerIn: parent
                     text: "close"
                     horizontalAlignment: Text.AlignHCenter

--- a/dots/.config/quickshell/imi/modules/common/widgets/AutostartApps.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/AutostartApps.qml
@@ -70,6 +70,7 @@ ColumnLayout {
                 Quickshell.execDetached(["python3", `${Directories.scriptPath}/hyprland/autostart.py`])
             }
             contentItem: MaterialSymbol {
+                verticalAlignment: Text.AlignVCenter
                 anchors.centerIn: parent
                 horizontalAlignment: Text.AlignHCenter
                 text: "motion_play"
@@ -170,6 +171,7 @@ ColumnLayout {
                     colRipple: ColorUtils.transparentize(Appearance.colors.colError, 0.5)
                     onClicked: root.removeEntry(entryRow.index)
                     contentItem: MaterialSymbol {
+                        verticalAlignment: Text.AlignVCenter
                         anchors.centerIn: parent
                         horizontalAlignment: Text.AlignHCenter
                         text: "delete"

--- a/dots/.config/quickshell/imi/modules/common/widgets/ConfigTextArea.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/ConfigTextArea.qml
@@ -190,7 +190,8 @@ RowLayout {
 
             contentItem: MaterialSymbol {
                 anchors.centerIn: parent
-                anchors.horizontalCenterOffset: -2
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
                 iconSize: Appearance.font.pixelSize.larger
                 text: root.revealed ? "visibility_off" : "visibility"
                 color: Appearance.colors.colOnLayer1
@@ -210,6 +211,8 @@ RowLayout {
 
         contentItem: MaterialSymbol {
             anchors.centerIn: parent
+            horizontalAlignment: Text.AlignHCenter
+            verticalAlignment: Text.AlignVCenter
             text: root.confirmButtonIcon
             iconSize: Appearance.font.pixelSize.large
             color: root.colOnConfirmBackground

--- a/dots/.config/quickshell/imi/modules/common/widgets/ConfigTextArea.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/ConfigTextArea.qml
@@ -198,10 +198,30 @@ RowLayout {
             }
         }
     }
+    // Enters and leaves the way the bar's standalone pills do (TimerPill,
+    // SubmapIndicator): the width glides between 0 and its size on the same
+    // tier as the fade and the scale, so the field beside it reflows with the
+    // motion instead of jumping a button-width in one frame, and the button
+    // leaves the layout only once its width is gone. Recorded by the
+    // maintainer on the presets "save" button: it snapped in and out.
     RippleButton {
-        visible: root.confirmButtonVisible
-        implicitWidth: 40
+        readonly property bool shown: root.confirmButtonVisible
+        visible: implicitWidth > 0
+        enabled: shown
+        implicitWidth: shown ? 40 : 0
         implicitHeight: 40
+        opacity: shown ? 1 : 0
+        scale: shown ? 1 : 0.7
+        transformOrigin: Item.Center
+        Behavior on implicitWidth {
+            animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
+        }
+        Behavior on opacity {
+            animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
+        }
+        Behavior on scale {
+            animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
+        }
         Layout.alignment: Qt.AlignVCenter
         buttonRadius: Appearance.rounding.small
         colBackground: root.colConfirmBackground

--- a/dots/.config/quickshell/imi/modules/common/widgets/DragApps.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/DragApps.qml
@@ -654,6 +654,7 @@ Item {
                                         baseHeight:   root.windowControlsHeight
                                         buttonRadius: Appearance.rounding.full
                                         contentItem: MaterialSymbol {
+                                            verticalAlignment: Text.AlignVCenter
                                             anchors.centerIn: parent
                                             horizontalAlignment: Text.AlignHCenter
                                             text: "close"

--- a/dots/.config/quickshell/imi/modules/common/widgets/EditRemoveBadge.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/EditRemoveBadge.qml
@@ -25,6 +25,7 @@ RippleButton {
     colRipple: Appearance.colors.colErrorActive
 
     contentItem: MaterialSymbol {
+        verticalAlignment: Text.AlignVCenter
         anchors.centerIn: parent
         horizontalAlignment: Text.AlignHCenter
         text: "close"

--- a/dots/.config/quickshell/imi/modules/common/widgets/NavigationRailExpandButton.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/NavigationRailExpandButton.qml
@@ -20,6 +20,7 @@ RippleButton {
     }
 
     contentItem: MaterialSymbol {
+        verticalAlignment: Text.AlignVCenter
         id: icon
         anchors.centerIn: parent
         horizontalAlignment: Text.AlignHCenter

--- a/dots/.config/quickshell/imi/modules/common/widgets/NotificationItem.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/NotificationItem.qml
@@ -259,6 +259,7 @@ Item { // Notification item area
                                 }
 
                                 contentItem: MaterialSymbol {
+                                    verticalAlignment: Text.AlignVCenter
                                     iconSize: Appearance.font.pixelSize.larger
                                     horizontalAlignment: Text.AlignHCenter
                                     color: (notificationObject.urgency == NotificationUrgency.Critical) ? 
@@ -304,6 +305,7 @@ Item { // Notification item area
                                 }
 
                                 contentItem: MaterialSymbol {
+                                    verticalAlignment: Text.AlignVCenter
                                     id: copyIcon
                                     iconSize: Appearance.font.pixelSize.larger
                                     horizontalAlignment: Text.AlignHCenter

--- a/dots/.config/quickshell/imi/modules/common/widgets/PlayerControls.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/PlayerControls.qml
@@ -29,6 +29,7 @@ Item {
         colBackgroundHover: root.blendedColors.colSecondaryContainerHover
         colRipple: root.blendedColors.colSecondaryContainerActive
         contentItem: MaterialSymbol {
+            verticalAlignment: Text.AlignVCenter
             iconSize: Appearance.font.pixelSize.huge
             fill: 1
             horizontalAlignment: Text.AlignHCenter
@@ -199,6 +200,7 @@ Item {
                     colRipple: root.player?.isPlaying ? root.blendedColors.colPrimaryActive : root.blendedColors.colSecondaryContainerActive
 
                     contentItem: MaterialSymbol {
+                        verticalAlignment: Text.AlignVCenter
                         iconSize: Appearance.font.pixelSize.huge
                         fill: 1
                         horizontalAlignment: Text.AlignHCenter

--- a/dots/.config/quickshell/imi/modules/common/widgets/PlayerControlsLyrics.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/PlayerControlsLyrics.qml
@@ -29,6 +29,7 @@ Item {
         colBackgroundHover: root.blendedColors.colSecondaryContainerHover
         colRipple: root.blendedColors.colSecondaryContainerActive
         contentItem: MaterialSymbol {
+            verticalAlignment: Text.AlignVCenter
             iconSize: Appearance.font.pixelSize.huge
             fill: 1
             horizontalAlignment: Text.AlignHCenter
@@ -225,6 +226,7 @@ Item {
                     colRipple: root.player?.isPlaying ? root.blendedColors.colPrimaryActive : root.blendedColors.colSecondaryContainerActive
 
                     contentItem: MaterialSymbol {
+                        verticalAlignment: Text.AlignVCenter
                         iconSize: Appearance.font.pixelSize.huge
                         fill: 1
                         horizontalAlignment: Text.AlignHCenter

--- a/dots/.config/quickshell/imi/modules/imi/bar/Media.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/Media.qml
@@ -383,6 +383,7 @@ Item {
                         colRipple: root.isPlaying ? Appearance.colors.colPrimaryActive : Appearance.colors.colPrimaryContainerActive
                         downAction: () => root.activePlayer?.togglePlaying()
                         contentItem: MaterialSymbol {
+                            verticalAlignment: Text.AlignVCenter
                             anchors.centerIn: parent
                             horizontalAlignment: Text.AlignHCenter
                             text: root.isPlaying ? "pause" : "play_arrow"
@@ -404,6 +405,7 @@ Item {
                         downAction: () => root.activePlayer?.next()
                         altAction: () => root.activePlayer?.previous()
                         contentItem: MaterialSymbol {
+                            verticalAlignment: Text.AlignVCenter
                             anchors.centerIn: parent
                             horizontalAlignment: Text.AlignHCenter
                             text: "skip_next"

--- a/dots/.config/quickshell/imi/modules/imi/bar/SysTray.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/SysTray.qml
@@ -109,6 +109,7 @@ Item {
             colRippleToggled: Appearance.colors.colSecondaryContainerActive
 
             contentItem: MaterialSymbol {
+                verticalAlignment: Text.AlignVCenter
                 anchors.centerIn: parent
                 iconSize: Appearance.font.pixelSize.larger
                 text: Config.options.bar.bottom ? "keyboard_control_key" : "expand_more"

--- a/dots/.config/quickshell/imi/modules/imi/cheatsheet/Cheatsheet.qml
+++ b/dots/.config/quickshell/imi/modules/imi/cheatsheet/Cheatsheet.qml
@@ -142,6 +142,7 @@ Scope { // Scope
                     }
 
                     contentItem: MaterialSymbol {
+                        verticalAlignment: Text.AlignVCenter
                         anchors.centerIn: parent
                         horizontalAlignment: Text.AlignHCenter
                         font.pixelSize: Appearance.font.pixelSize.title

--- a/dots/.config/quickshell/imi/modules/imi/cheatsheet/CheatsheetKeybinds.qml
+++ b/dots/.config/quickshell/imi/modules/imi/cheatsheet/CheatsheetKeybinds.qml
@@ -306,6 +306,7 @@ Item {
                                                     }
 
                                                     contentItem: MaterialSymbol {
+                                                        verticalAlignment: Text.AlignVCenter
                                                         anchors.centerIn: parent
                                                         horizontalAlignment: Text.AlignHCenter
                                                         iconSize: Appearance.font.pixelSize.normal

--- a/dots/.config/quickshell/imi/modules/imi/dock/Dock.qml
+++ b/dots/.config/quickshell/imi/modules/imi/dock/Dock.qml
@@ -271,6 +271,7 @@ Scope {
                                     toggled: root.pinned
                                     onClicked: root.pinned = !root.pinned
                                     contentItem: MaterialSymbol {
+                                        verticalAlignment: Text.AlignVCenter
                                         text: "keep"
                                         horizontalAlignment: Text.AlignHCenter
                                         iconSize: Appearance.font.pixelSize.larger

--- a/dots/.config/quickshell/imi/modules/imi/dock/DockMedia.qml
+++ b/dots/.config/quickshell/imi/modules/imi/dock/DockMedia.qml
@@ -244,6 +244,7 @@ Item {
                         : root.blendedColors.colSecondaryContainerActive
                     downAction: () => root.player?.togglePlaying()
                     contentItem: MaterialSymbol {
+                        verticalAlignment: Text.AlignVCenter
                         anchors.centerIn: parent
                         horizontalAlignment: Text.AlignHCenter
                         text: root.isPlaying ? "pause" : "play_arrow"
@@ -267,6 +268,7 @@ Item {
                     colRipple:          root.blendedColors.colSecondaryContainerActive
                     downAction: () => root.player?.next()
                     contentItem: MaterialSymbol {
+                        verticalAlignment: Text.AlignVCenter
                         anchors.centerIn: parent
                         horizontalAlignment: Text.AlignHCenter
                         text: "skip_next"

--- a/dots/.config/quickshell/imi/modules/imi/editMode/EditWidgetMenuContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/editMode/EditWidgetMenuContent.qml
@@ -228,6 +228,8 @@ Item {
                     colBackgroundHover: Appearance.colors.colLayer2
                     contentItem: MaterialSymbol {
                         anchors.centerIn: parent
+                        horizontalAlignment: Text.AlignHCenter
+                        verticalAlignment: Text.AlignVCenter
                         text: "chevron_left"
                         iconSize: Appearance.font.pixelSize.larger
                         color: Appearance.colors.colOnLayer1
@@ -250,6 +252,8 @@ Item {
                     colBackgroundHover: Appearance.colors.colLayer2
                     contentItem: MaterialSymbol {
                         anchors.centerIn: parent
+                        horizontalAlignment: Text.AlignHCenter
+                        verticalAlignment: Text.AlignVCenter
                         text: "chevron_right"
                         iconSize: Appearance.font.pixelSize.larger
                         color: Appearance.colors.colOnLayer1

--- a/dots/.config/quickshell/imi/modules/imi/onScreenKeyboard/OnScreenKeyboard.qml
+++ b/dots/.config/quickshell/imi/modules/imi/onScreenKeyboard/OnScreenKeyboard.qml
@@ -108,6 +108,7 @@ Scope { // Scope
                             toggled: root.pinned
                             downAction: () => root.pinned = !root.pinned
                             contentItem: MaterialSymbol {
+                                verticalAlignment: Text.AlignVCenter
                                 text: "keep"
                                 horizontalAlignment: Text.AlignHCenter
                                 iconSize: Appearance.font.pixelSize.larger
@@ -119,6 +120,7 @@ Scope { // Scope
                                 oskRoot.hide()
                             }
                             contentItem: MaterialSymbol {
+                                verticalAlignment: Text.AlignVCenter
                                 horizontalAlignment: Text.AlignHCenter
                                 text: "keyboard_hide"
                                 iconSize: Appearance.font.pixelSize.larger

--- a/dots/.config/quickshell/imi/modules/imi/overlay/notes/NotesContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/overlay/notes/NotesContent.qml
@@ -280,6 +280,7 @@ OverlayBackground {
                 onClicked: root.startNewNote()
 
                 contentItem: MaterialSymbol {
+                    verticalAlignment: Text.AlignVCenter
                     anchors.centerIn: parent
                     horizontalAlignment: Text.AlignHCenter
                     text: "add"
@@ -301,6 +302,7 @@ OverlayBackground {
                 onClicked: root.deleteCurrentNote()
 
                 contentItem: MaterialSymbol {
+                    verticalAlignment: Text.AlignVCenter
                     anchors.centerIn: parent
                     horizontalAlignment: Text.AlignHCenter
                     text: "delete"

--- a/dots/.config/quickshell/imi/modules/imi/sessionScreen/SessionActionButton.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sessionScreen/SessionActionButton.qml
@@ -51,6 +51,7 @@ RippleButton {
     }
 
     contentItem: MaterialSymbol {
+        verticalAlignment: Text.AlignVCenter
         id: icon
         anchors.fill: parent
         color: button.colText

--- a/dots/.config/quickshell/imi/modules/imi/settings/Settings.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/Settings.qml
@@ -89,6 +89,7 @@ Scope {
             onClicked: GlobalStates.settingsOpen = false
 
             contentItem: MaterialSymbol {
+                verticalAlignment: Text.AlignVCenter
                 anchors.centerIn: parent
                 horizontalAlignment: Text.AlignHCenter
                 text: "close"

--- a/dots/.config/quickshell/imi/modules/imi/settings/SettingsContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/SettingsContent.qml
@@ -321,6 +321,8 @@ Item {
                     colBackground: "transparent"
                     onClicked: settingsSearchField.text = ""
                     contentItem: MaterialSymbol {
+                        horizontalAlignment: Text.AlignHCenter
+                        verticalAlignment: Text.AlignVCenter
                         anchors.centerIn: parent
                         text: "close"
                         iconSize: Appearance.font.pixelSize.large

--- a/dots/.config/quickshell/imi/modules/imi/settings/pages/HyprlandConfig.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/pages/HyprlandConfig.qml
@@ -485,6 +485,7 @@ ContentPage {
                                     HyprlandKeybinds.findBinding(overrideRow.modelData.identity);
                             }
                             contentItem: MaterialSymbol {
+                                verticalAlignment: Text.AlignVCenter
                                 anchors.centerIn: parent
                                 horizontalAlignment: Text.AlignHCenter
                                 iconSize: Appearance.font.pixelSize.larger
@@ -501,6 +502,7 @@ ContentPage {
                             buttonRadius: Appearance.rounding.full
                             onClicked: HyprlandKeybindOverrides.reset(overrideRow.modelData.identity)
                             contentItem: MaterialSymbol {
+                                verticalAlignment: Text.AlignVCenter
                                 anchors.centerIn: parent
                                 horizontalAlignment: Text.AlignHCenter
                                 iconSize: Appearance.font.pixelSize.larger

--- a/dots/.config/quickshell/imi/modules/imi/settings/pages/PluginsPage.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/pages/PluginsPage.qml
@@ -436,6 +436,8 @@ Item {
                                             onClicked: PluginManager.requestUninstall(pluginCard.modelData.id)
 
                                             contentItem: MaterialSymbol {
+                                                horizontalAlignment: Text.AlignHCenter
+                                                verticalAlignment: Text.AlignVCenter
                                                 anchors.centerIn: parent
                                                 text: "delete"
                                                 iconSize: Appearance.font.pixelSize.larger

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/AiChat.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/AiChat.qml
@@ -775,6 +775,7 @@ Inline w/ backslash and round brackets \\(e^{i\\pi} + 1 = 0\\)
                     }
 
                     contentItem: MaterialSymbol {
+                        verticalAlignment: Text.AlignVCenter
                         anchors.centerIn: parent
                         horizontalAlignment: Text.AlignHCenter
                         iconSize: 22

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/Anime.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/Anime.qml
@@ -458,6 +458,7 @@ Item {
                     }
 
                     contentItem: MaterialSymbol {
+                        verticalAlignment: Text.AlignVCenter
                         anchors.centerIn: parent
                         horizontalAlignment: Text.AlignHCenter
                         iconSize: 22

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/SidebarPlayerControl.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/SidebarPlayerControl.qml
@@ -321,6 +321,7 @@ Item {
                     colRipple: blendedColors.colSecondaryContainerActive
                     downAction: () => root.player?.previous()
                     contentItem: MaterialSymbol {
+                        verticalAlignment: Text.AlignVCenter
                         iconSize: 25
                         fill: 1
                         horizontalAlignment: Text.AlignHCenter
@@ -339,6 +340,7 @@ Item {
                     colRipple: (root.player?.isPlaying ?? false) ? blendedColors.colPrimaryActive : blendedColors.colSecondaryContainerActive
                     downAction: () => root.player?.togglePlaying()  
                     contentItem: MaterialSymbol {
+                        verticalAlignment: Text.AlignVCenter
                         iconSize: 50
                         fill: 1
                         horizontalAlignment: Text.AlignHCenter
@@ -360,6 +362,7 @@ Item {
                     colRipple: blendedColors.colSecondaryContainerActive
                     downAction: () => root.player?.next()
                     contentItem: MaterialSymbol {
+                        verticalAlignment: Text.AlignVCenter
                         iconSize: 25
                         fill: 1
                         horizontalAlignment: Text.AlignHCenter
@@ -387,6 +390,7 @@ Item {
                         if (root.player) root.player.volume = (root.player.volume > 0) ? 0 : 1.0  
                     }
                     contentItem: MaterialSymbol {
+                        verticalAlignment: Text.AlignVCenter
                         iconSize: 18
                         fill: 1
                         horizontalAlignment: Text.AlignHCenter
@@ -409,6 +413,7 @@ Item {
                         if (root.player) root.player.volume = Math.max(0, (root.player.volume ?? 1) - 0.1)  
                     }
                     contentItem: MaterialSymbol {
+                        verticalAlignment: Text.AlignVCenter
                         iconSize: 18
                         fill: 1
                         horizontalAlignment: Text.AlignHCenter
@@ -429,6 +434,7 @@ Item {
                         if (root.player) root.player.volume = Math.min(1.5, (root.player.volume ?? 1) + 0.1)  
                     }
                     contentItem: MaterialSymbol {
+                        verticalAlignment: Text.AlignVCenter
                         iconSize: 18
                         fill: 1
                         horizontalAlignment: Text.AlignHCenter

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/Translator.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/Translator.qml
@@ -127,6 +127,7 @@ Item {
                 baseWidth: height
                 buttonRadius: Appearance.rounding.small
                 contentItem: MaterialSymbol {
+                    verticalAlignment: Text.AlignVCenter
                     anchors.centerIn: parent
                     horizontalAlignment: Text.AlignHCenter
                     iconSize: Appearance.font.pixelSize.larger
@@ -143,6 +144,7 @@ Item {
                 buttonRadius: Appearance.rounding.small
                 enabled: inputCanvas.inputTextArea.text.length > 0
                 contentItem: MaterialSymbol {
+                    verticalAlignment: Text.AlignVCenter
                     anchors.centerIn: parent
                     horizontalAlignment: Text.AlignHCenter
                     iconSize: Appearance.font.pixelSize.larger
@@ -175,6 +177,7 @@ Item {
                 colBackgroundHover: Appearance.colors.colTertiaryContainerHover
                 buttonRadius: Appearance.rounding.full
                 contentItem: MaterialSymbol {
+                    verticalAlignment: Text.AlignVCenter
                     anchors.centerIn: parent
                     horizontalAlignment: Text.AlignHCenter
                     iconSize: Appearance.font.pixelSize.larger
@@ -208,6 +211,7 @@ Item {
                 buttonRadius: Appearance.rounding.small
                 enabled: outputCanvas.displayedText.trim().length > 0
                 contentItem: MaterialSymbol {
+                    verticalAlignment: Text.AlignVCenter
                     anchors.centerIn: parent
                     horizontalAlignment: Text.AlignHCenter
                     iconSize: Appearance.font.pixelSize.larger
@@ -224,6 +228,7 @@ Item {
                 buttonRadius: Appearance.rounding.small
                 enabled: outputCanvas.displayedText.trim().length > 0
                 contentItem: MaterialSymbol {
+                    verticalAlignment: Text.AlignVCenter
                     anchors.centerIn: parent
                     horizontalAlignment: Text.AlignHCenter
                     iconSize: Appearance.font.pixelSize.larger

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/aiChat/AiMessageControlButton.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/aiChat/AiMessageControlButton.qml
@@ -13,6 +13,7 @@ GroupButton {
     colBackgroundActive: Appearance.colors.colSecondaryContainerActive
 
     contentItem: MaterialSymbol {
+        verticalAlignment: Text.AlignVCenter
         horizontalAlignment: Text.AlignHCenter
         iconSize: Appearance.font.pixelSize.larger
         text: buttonIcon

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/aiChat/AttachedFileIndicator.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/aiChat/AttachedFileIndicator.qml
@@ -106,6 +106,7 @@ Rectangle {
                 implicitHeight: 28
                 implicitWidth: 28
                 contentItem: MaterialSymbol {
+                    verticalAlignment: Text.AlignVCenter
                     anchors.centerIn: parent
                     text: "close"
                     horizontalAlignment: Text.AlignHCenter

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/anime/BooruImage.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/anime/BooruImage.qml
@@ -93,6 +93,7 @@ Button {
             colRipple: ColorUtils.transparentize(ColorUtils.mix(Appearance.m3colors.m3surface, Appearance.m3colors.m3onSurface, 0.6), 0.1)
 
             contentItem: MaterialSymbol {
+                verticalAlignment: Text.AlignVCenter
                 horizontalAlignment: Text.AlignHCenter
                 iconSize: Appearance.font.pixelSize.large
                 color: Appearance.m3colors.m3onSurface

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/BottomWidgetGroup.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/BottomWidgetGroup.qml
@@ -108,6 +108,7 @@ Rectangle {
                 root.setCollapsed(false);
             }
             contentItem: MaterialSymbol {
+                verticalAlignment: Text.AlignVCenter
                 text: "keyboard_arrow_up"
                 iconSize: Appearance.font.pixelSize.larger
                 horizontalAlignment: Text.AlignHCenter
@@ -185,6 +186,7 @@ Rectangle {
                     root.setCollapsed(true);
                 }
                 contentItem: MaterialSymbol {
+                    verticalAlignment: Text.AlignVCenter
                     text: "keyboard_arrow_down"
                     iconSize: Appearance.font.pixelSize.larger
                     horizontalAlignment: Text.AlignHCenter

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/calendar/CalendarWidget.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/calendar/CalendarWidget.qml
@@ -103,6 +103,7 @@ Item {
                     monthShift--;
                 }
                 contentItem: MaterialSymbol {
+                    verticalAlignment: Text.AlignVCenter
                     text: "chevron_left"
                     iconSize: Appearance.font.pixelSize.larger
                     horizontalAlignment: Text.AlignHCenter
@@ -115,6 +116,7 @@ Item {
                     monthShift++;
                 }
                 contentItem: MaterialSymbol {
+                    verticalAlignment: Text.AlignVCenter
                     text: "chevron_right"
                     iconSize: Appearance.font.pixelSize.larger
                     horizontalAlignment: Text.AlignHCenter

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/phoneConnect/PhoneConnectDeviceItem.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/phoneConnect/PhoneConnectDeviceItem.qml
@@ -76,6 +76,8 @@ DialogListItem {
 
             contentItem: MaterialSymbol {
                 anchors.centerIn: parent
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
                 text: "ring_volume"
                 iconSize: Appearance.font.pixelSize.larger
                 color: ringButton.colEnabled
@@ -95,6 +97,8 @@ DialogListItem {
 
             contentItem: MaterialSymbol {
                 anchors.centerIn: parent
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
                 text: "send"
                 iconSize: Appearance.font.pixelSize.larger
                 color: pingButton.colEnabled
@@ -114,6 +118,8 @@ DialogListItem {
 
             contentItem: MaterialSymbol {
                 anchors.centerIn: parent
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
                 text: "content_paste"
                 iconSize: Appearance.font.pixelSize.larger
                 color: clipboardButton.colEnabled

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/phoneConnect/PhoneConnectDialog.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/phoneConnect/PhoneConnectDialog.qml
@@ -27,6 +27,8 @@ WindowDialog {
             onClicked: PhoneConnect.refresh()
 
             contentItem: MaterialSymbol {
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
                 anchors.centerIn: parent
                 text: "refresh"
                 iconSize: Appearance.font.pixelSize.larger

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/tailscale/TailscaleDialog.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/tailscale/TailscaleDialog.qml
@@ -27,6 +27,8 @@ WindowDialog {
             onClicked: Tailscale.refresh()
 
             contentItem: MaterialSymbol {
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
                 anchors.centerIn: parent
                 text: "refresh"
                 iconSize: Appearance.font.pixelSize.larger

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/todo/TaskList.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/todo/TaskList.qml
@@ -111,6 +111,7 @@ Item {
                                     Todo.markUnfinished(index);
                             }
                             contentItem: MaterialSymbol {
+                                verticalAlignment: Text.AlignVCenter
                                 anchors.centerIn: parent
                                 horizontalAlignment: Text.AlignHCenter
                                 text: todoItem.modelData.done ? "remove_done" : "check"
@@ -126,6 +127,7 @@ Item {
                                     Todo.deleteItem(index);
                             }
                             contentItem: MaterialSymbol {
+                                verticalAlignment: Text.AlignVCenter
                                 anchors.centerIn: parent
                                 horizontalAlignment: Text.AlignHCenter
                                 text: "delete_forever"

--- a/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/ClockDepthPicker.qml
+++ b/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/ClockDepthPicker.qml
@@ -196,6 +196,8 @@ Item {
                 onClicked: root.inspect = !root.inspect
                 contentItem: MaterialSymbol {
                     anchors.centerIn: parent
+                    horizontalAlignment: Text.AlignHCenter
+                    verticalAlignment: Text.AlignVCenter
                     text: "chrome_reader_mode"
                     iconSize: Appearance.font.pixelSize.larger
                     color: inspectButton.toggled
@@ -213,6 +215,8 @@ Item {
                 onClicked: root.closeRequested()
                 contentItem: MaterialSymbol {
                     anchors.centerIn: parent
+                    horizontalAlignment: Text.AlignHCenter
+                    verticalAlignment: Text.AlignVCenter
                     text: "close"
                     iconSize: Appearance.font.pixelSize.larger
                     color: Appearance.colors.colOnLayer0

--- a/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/LocalWallpaperGrid.qml
+++ b/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/LocalWallpaperGrid.qml
@@ -70,6 +70,8 @@ Item {
                 onClicked: contextMenu.visible = false
                 contentItem: MaterialSymbol {
                     anchors.centerIn: parent
+                    horizontalAlignment: Text.AlignHCenter
+                    verticalAlignment: Text.AlignVCenter
                     text: "close"
                     iconSize: Appearance.font.pixelSize.larger
                     color: Appearance.colors.colPrimary
@@ -85,6 +87,8 @@ Item {
                 }
                 contentItem: MaterialSymbol {
                     anchors.centerIn: parent
+                    horizontalAlignment: Text.AlignHCenter
+                    verticalAlignment: Text.AlignVCenter
                     text: "check"
                     iconSize: Appearance.font.pixelSize.larger
                     color: Appearance.colors.colPrimary

--- a/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/WallpaperSelectorContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/WallpaperSelectorContent.qml
@@ -447,6 +447,8 @@ MouseArea {
                                     onClicked: Config.options.wallpaperSelector.wallpaperEngine.silent = !Config.options.wallpaperSelector.wallpaperEngine.silent
                                     contentItem: MaterialSymbol {
                                         anchors.centerIn: parent
+                                        horizontalAlignment: Text.AlignHCenter
+                                        verticalAlignment: Text.AlignVCenter
                                         text: Config.options.wallpaperSelector.wallpaperEngine.silent ? "volume_off" : "volume_up"
                                         color: parent.toggled ? Appearance.colors.colOnPrimary : Appearance.colors.colOnLayer2
                                     }
@@ -502,6 +504,8 @@ MouseArea {
                             }
                             contentItem: MaterialSymbol {
                                 anchors.centerIn: parent
+                                horizontalAlignment: Text.AlignHCenter
+                                verticalAlignment: Text.AlignVCenter
                                 text: "search"
                                 iconSize: Appearance.font.pixelSize.larger
                                 color: root.toolbarVisible

--- a/dots/.config/quickshell/imi/tests/lint_icon_glyph_alignment.py
+++ b/dots/.config/quickshell/imi/tests/lint_icon_glyph_alignment.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""A MaterialSymbol used as a Control's contentItem says how it is aligned.
+
+A Control (RippleButton is one) sizes its `contentItem` to the padded rect
+and positions it itself; anchors set on the contentItem are ignored. A
+`MaterialSymbol` is a Text, and a Text with no alignment draws its glyph at
+the top-left of whatever rect it is given - so `anchors.centerIn: parent`
+on a contentItem glyph is decoration, and the icon sits up-left of centre.
+That is the presets "save" button the maintainer photographed (2026-08-27),
+and seven more buttons had the same spelling, one of them hand-nudged with
+`anchors.horizontalCenterOffset: -2` to hide it.
+
+`IconToolbarButton.qml` is the spelling that is right: both alignments on
+the glyph. This lint fails any `contentItem: MaterialSymbol { ... }` block
+that lacks either one.
+"""
+
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+OPENER = re.compile(r"contentItem\s*:\s*MaterialSymbol\s*\{")
+
+
+def blocks(text):
+    for m in OPENER.finditer(text):
+        depth, i = 0, m.end() - 1
+        while i < len(text):
+            if text[i] == "{":
+                depth += 1
+            elif text[i] == "}":
+                depth -= 1
+                if depth == 0:
+                    yield text[:m.start()].count("\n") + 1, text[m.start():i + 1]
+                    break
+            i += 1
+
+
+failures = []
+checked = 0
+for path in sorted((ROOT / "modules").rglob("*.qml")):
+    text = re.sub(r"//[^\n]*", "", path.read_text(errors="replace"))
+    for line, block in blocks(text):
+        checked += 1
+        missing = [a for a in ("horizontalAlignment: Text.AlignHCenter", "verticalAlignment: Text.AlignVCenter") if a not in block]
+        if missing:
+            failures.append(f"{path.relative_to(ROOT)}:{line}: contentItem MaterialSymbol lacks {', '.join(missing)}")
+
+assert checked, "no contentItem: MaterialSymbol blocks found - the sweep has nothing to look at"
+for f in failures:
+    print(f"MISALIGNED: {f}")
+if failures:
+    sys.exit(1)
+print(f"Icon glyph alignment lint passed ({checked} contentItem glyphs declare both alignments)")

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -985,6 +985,14 @@ if ! python3 "$SCRIPT_DIR/lint_suite_registration.py"; then
     exit 1
 fi
 
+# A glyph used as a Control's contentItem declares both alignments: anchors on
+# a contentItem are ignored, and an unaligned Text draws top-left of its rect.
+echo "Running icon glyph alignment lint..."
+if ! python3 "$SCRIPT_DIR/lint_icon_glyph_alignment.py"; then
+    echo "Icon glyph alignment lint failed."
+    exit 1
+fi
+
 # The bar popup's section wave: armed on a takeover from idle, released by
 # the gate, and never fired against a tree that was not parked. This register
 # existed for a while without being wired in here - the mutations it plants


### PR DESCRIPTION
Two things the maintainer photographed and recorded on the presets "save" button, both fixed at their root rather than at the button.

**The icon sat up-left of centre.** A `Control` sizes its `contentItem` to the padded rect and positions it itself, so `anchors.centerIn: parent` on the glyph was decoration, and a `Text` with no alignment draws its glyph at the top-left of the rect it is given. `IconToolbarButton` already had the right spelling — both alignments on the glyph. The lint written for it found the same spelling on **82** `contentItem: MaterialSymbol` blocks across 45 files (most carried the horizontal half only; the password-reveal eye hid the problem with a hand `horizontalCenterOffset: -2`). All 82 declare both now, the nudge is gone, and `tests/lint_icon_glyph_alignment.py` fails the next one. One real defect of the mechanical pass was caught by the design-system compile sweep in the first suite run — two `DatePicker` glyphs already carried the alignment on a semicolon-joined line, and the pass doubled the property — fixed and folded into the fix commit.

**The button snapped in and out in one frame** (recording: typing a name popped it in at full size and shoved the field a button-width narrower; clearing reversed it). It now enters and leaves the way the bar's standalone pills do — `implicitWidth` glides 0↔40 on `elementMoveFast`, opacity and scale ride the same tier, `visible` drops only once the width is gone — so the field reflows with the motion.

Verified: full suite in the worktree (1226 QML, 209 harnesses, compile sweep 186/0), motion/opacity/tier lints green, deployed live for the maintainer's look.

Docs: updated AGENT.md (a contentItem glyph is aligned, not anchored)
Changelog: updated — two Fixed entries under [Unreleased]
