### PR TITLE
Picking a settings section scrolls the page there on the scroll tier

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -4191,6 +4191,18 @@ both `StyledFlickable`s and both `StyledListView`s already write out. Naming two
 animation is the tell.
 (fix(overview): the niri overview scrolls on the scroll tier, whole.)
 
+**A programmatic scroll goes through `StyledFlickable.scrollToY()`; a direct `contentY` write
+snaps wherever the `Behavior` is off.** `StyledFlickable`'s `Behavior on contentY` is disabled
+under `expressiveScroll` and `momentumScroll` — those paths drive `contentY` per input event and a
+Behavior would fight them — and `ContentPage` is a momentum flickable, so all fifteen settings
+pages' `goTo(term)` wrote `contentY` and jumped to the section in one frame (the maintainer's
+request, 2026-08-27). `scrollToY(y)` clamps, stops the settle/bounce/programmatic animations,
+records `scrollTargetY` and runs one `NumberAnimation` on the scroll tier taken whole; the three
+wheel paths and `onMovementStarted` stop it, so user input always wins.
+`tests/test_settings_navigation.py` pins the helper's tier, the five stop sites, and that no page
+writes `contentY` itself. (feat(settings): a section pick scrolls the page there on the scroll
+tier.)
+
 **...and the sibling defect is the one that lint deliberately waved through: a duration read out
 of `animationCurves` is the tier's BASE, and the speed multiplier is not in it.**
 `Appearance.animation.<tier>.duration` is `motion.scale(...)` applied to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ own repo; the installer pins which revision it builds.
 
 ## [Unreleased]
 
+### Changed
+- **Picking a section in Settings scrolls to it instead of jumping.** Choosing
+  a category in the left tree (or landing on a search hit) used to snap the
+  page to that section in one frame; the page now glides there on the same
+  curve every other scroll in the shell uses, and any wheel or drag takes over
+  from wherever it got to.
+
 ## [0.31.2] — 2026-08-27
 
 Two fixes found on one button and applied everywhere the same spelling lived:

--- a/dots/.config/quickshell/imi/modules/common/widgets/StyledFlickable.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/StyledFlickable.qml
@@ -43,6 +43,7 @@ Flickable {
         anchors.fill: parent
         acceptedButtons: Qt.NoButton
         onWheel: function(wheelEvent) {
+            programmaticScroll.stop();
             const delta = wheelEvent.angleDelta.y / root.mouseScrollDeltaThreshold;
             var scrollFactor = Math.abs(wheelEvent.angleDelta.y) >= root.mouseScrollDeltaThreshold ? root.mouseScrollFactor : root.touchpadScrollFactor;
 
@@ -56,6 +57,34 @@ Flickable {
         }
     }
 
+    // A programmatic scroll - a settings page jumping to the section the user
+    // picked in the tree, a search hit - animates on the scroll tier in every
+    // mode. The contentY Behavior below is off under expressive and
+    // momentum scrolling (those paths drive contentY per event and a Behavior
+    // would fight them), so a page that wrote `contentY = y` directly snapped
+    // there in one frame on every settings page (ContentPage is momentum).
+    // Any user input takes the scroll back: each wheel path and a drag stop
+    // this animation first and continue from wherever it got to.
+    function scrollToY(y) {
+        const maxY = Math.max(0, root.contentHeight - root.height);
+        const target = Math.max(0, Math.min(y, maxY));
+        settleAnim.stop();
+        bounceAnim.stop();
+        programmaticScroll.stop();
+        root.scrollTargetY = target;
+        programmaticScroll.from = root.contentY;
+        programmaticScroll.to = target;
+        programmaticScroll.start();
+    }
+    NumberAnimation {
+        id: programmaticScroll
+        target: root
+        property: "contentY"
+        duration: Appearance.animation.scroll.duration
+        easing.type: Appearance.animation.scroll.type
+        easing.bezierCurve: Appearance.animation.scroll.bezierCurve
+    }
+    onMovementStarted: programmaticScroll.stop()
     Behavior on contentY {
         enabled: !root.expressiveScroll && !root.momentumScroll
         NumberAnimation {
@@ -79,6 +108,7 @@ Flickable {
         anchors.fill: parent
         acceptedButtons: Qt.NoButton
         onWheel: function(wheelEvent) {
+            programmaticScroll.stop();
             const maxY = Math.max(0, root.contentHeight - root.height);
             var scrollFactor = Math.abs(wheelEvent.angleDelta.y) >= root.mouseScrollDeltaThreshold ? root.mouseScrollFactor : root.touchpadScrollFactor;
             const delta = wheelEvent.angleDelta.y / root.mouseScrollDeltaThreshold;
@@ -153,6 +183,7 @@ Flickable {
         enabled: root.momentumScroll
         acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchPad
         onWheel: function(wheelEvent) {
+            programmaticScroll.stop();
             const maxY = Math.max(0, root.contentHeight - root.height);
             const px = wheelEvent.pixelDelta.y;
             const ang = wheelEvent.angleDelta.y;

--- a/dots/.config/quickshell/imi/modules/imi/settings/pages/AppearanceConfig.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/pages/AppearanceConfig.qml
@@ -89,7 +89,7 @@ ContentPage {
         let target = findTarget(mainLayout)
         if (target) {
             let pos = target.mapToItem(mainLayout, 0, 0)
-            page.contentY = Math.max(0, pos.y - 0)
+            page.scrollToY(pos.y)
         }
     }
 

--- a/dots/.config/quickshell/imi/modules/imi/settings/pages/BackgroundConfig.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/pages/BackgroundConfig.qml
@@ -33,7 +33,7 @@ ContentPage {
         let target = findTarget(mainLayout)
         if (target) {
             let pos = target.mapToItem(mainLayout, 0, 0)
-            page.contentY = Math.max(0, pos.y - 0)
+            page.scrollToY(pos.y)
         }
     }
 

--- a/dots/.config/quickshell/imi/modules/imi/settings/pages/BarConfig.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/pages/BarConfig.qml
@@ -34,7 +34,7 @@ ContentPage {
         let target = findTarget(mainLayout)
         if (target) {
             let pos = target.mapToItem(mainLayout, 0, 0)
-            page.contentY = Math.max(0, pos.y - 0)
+            page.scrollToY(pos.y)
         }
     }
 

--- a/dots/.config/quickshell/imi/modules/imi/settings/pages/CaptureConfig.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/pages/CaptureConfig.qml
@@ -32,7 +32,7 @@ ContentPage {
         let target = findTarget(mainLayout)
         if (target) {
             let pos = target.mapToItem(mainLayout, 0, 0)
-            page.contentY = Math.max(0, pos.y - 0)
+            page.scrollToY(pos.y)
         }
     }
 

--- a/dots/.config/quickshell/imi/modules/imi/settings/pages/CursorConfig.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/pages/CursorConfig.qml
@@ -28,7 +28,7 @@ ContentPage {
         let target = findTarget(mainLayout)
         if (target) {
             let pos = target.mapToItem(mainLayout, 0, 0)
-            page.contentY = Math.max(0, pos.y - 0)
+            page.scrollToY(pos.y)
         }
     }
 

--- a/dots/.config/quickshell/imi/modules/imi/settings/pages/GeneralConfig.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/pages/GeneralConfig.qml
@@ -32,7 +32,7 @@ ContentPage {
         let target = findTarget(mainLayout)
         if (target) {
             let pos = target.mapToItem(mainLayout, 0, 0)
-            page.contentY = Math.max(0, pos.y - 0)
+            page.scrollToY(pos.y)
         }
     }
     

--- a/dots/.config/quickshell/imi/modules/imi/settings/pages/HyprlandConfig.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/pages/HyprlandConfig.qml
@@ -32,7 +32,7 @@ ContentPage {
         let target = findTarget(mainLayout)
         if (target) {
             let pos = target.mapToItem(mainLayout, 0, 0)
-            page.contentY = Math.max(0, pos.y - 0)
+            page.scrollToY(pos.y)
         }
     }
 

--- a/dots/.config/quickshell/imi/modules/imi/settings/pages/LockIdleConfig.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/pages/LockIdleConfig.qml
@@ -32,7 +32,7 @@ ContentPage {
         let target = findTarget(mainLayout)
         if (target) {
             let pos = target.mapToItem(mainLayout, 0, 0)
-            page.contentY = Math.max(0, pos.y - 0)
+            page.scrollToY(pos.y)
         }
     }
 

--- a/dots/.config/quickshell/imi/modules/imi/settings/pages/NotificationsConfig.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/pages/NotificationsConfig.qml
@@ -32,7 +32,7 @@ ContentPage {
         let target = findTarget(mainLayout)
         if (target) {
             let pos = target.mapToItem(mainLayout, 0, 0)
-            page.contentY = Math.max(0, pos.y - 0)
+            page.scrollToY(pos.y)
         }
     }
 

--- a/dots/.config/quickshell/imi/modules/imi/settings/pages/QuickConfig.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/pages/QuickConfig.qml
@@ -51,7 +51,7 @@ ContentPage {
         let target = findTarget(mainLayout)
         if (target) {
             let pos = target.mapToItem(mainLayout, 0, 0)
-            page.contentY = Math.max(0, pos.y - 0)
+            page.scrollToY(pos.y)
         }
     }
 

--- a/dots/.config/quickshell/imi/modules/imi/settings/pages/ServicesConfig.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/pages/ServicesConfig.qml
@@ -66,7 +66,7 @@ ContentPage {
         let target = findTarget(mainLayout)
         if (target) {
             let pos = target.mapToItem(mainLayout, 0, 0)
-            page.contentY = Math.max(0, pos.y - 0)
+            page.scrollToY(pos.y)
         }
     }
 

--- a/dots/.config/quickshell/imi/modules/imi/settings/pages/SidebarsPanelsConfig.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/pages/SidebarsPanelsConfig.qml
@@ -32,7 +32,7 @@ ContentPage {
         let target = findTarget(mainLayout)
         if (target) {
             let pos = target.mapToItem(mainLayout, 0, 0)
-            page.contentY = Math.max(0, pos.y - 0)
+            page.scrollToY(pos.y)
         }
     }
 

--- a/dots/.config/quickshell/imi/tests/test_settings_navigation.py
+++ b/dots/.config/quickshell/imi/tests/test_settings_navigation.py
@@ -43,6 +43,30 @@ class SettingsNavigationTests(unittest.TestCase):
             source = (ROOT / f"modules/imi/settings/pages/{page}.qml").read_text(encoding="utf-8")
             self.assertIn("function goTo(term)", source, page)
 
+    def test_section_jumps_animate_on_the_scroll_tier(self):
+        """A page's goTo() must not write contentY: ContentPage is a momentum
+        StyledFlickable, and momentum (like expressive) disables the
+        `Behavior on contentY`, so a direct write snaps the page to the section
+        in one frame. StyledFlickable.scrollToY animates on the scroll tier in
+        every mode, whole (duration, type and curve from one tier), and every
+        user input stops it."""
+        flickable = (ROOT / "modules/common/widgets/StyledFlickable.qml").read_text(encoding="utf-8")
+        self.assertIn("function scrollToY(y)", flickable)
+        anim = re.search(r"NumberAnimation \{\s*id: programmaticScroll(.*?)\n    \}", flickable, re.S)
+        self.assertIsNotNone(anim, "no programmaticScroll animation on StyledFlickable")
+        for prop in ("duration: Appearance.animation.scroll.duration",
+                     "easing.type: Appearance.animation.scroll.type",
+                     "easing.bezierCurve: Appearance.animation.scroll.bezierCurve"):
+            self.assertIn(prop, anim.group(1), prop)
+        self.assertEqual(flickable.count("programmaticScroll.stop()"), 5,
+                         "scrollToY itself, the three wheel paths and onMovementStarted each stop the programmatic scroll")
+        for page in sorted((ROOT / "modules/imi/settings/pages").glob("*.qml")):
+            source = page.read_text(encoding="utf-8")
+            if "function goTo(term)" not in source:
+                continue
+            self.assertNotIn("page.contentY =", source, f"{page.name} writes contentY directly - that snaps under momentum scrolling")
+            self.assertIn("page.scrollToY(", source, f"{page.name}'s goTo does not scroll through scrollToY")
+
     def test_branches_animate_height_opacity_and_arrow(self):
         self.assertIn("id: sectionRevealer", self.source)
         self.assertIn("vertical: true", self.source)


### PR DESCRIPTION
Choosing a category in the settings tree snapped the page to that section in one frame. Cause, not symptom: `ContentPage` is a `StyledFlickable` with `momentumScroll` on, and momentum (like expressive) disables the flickable's `Behavior on contentY` — those paths drive `contentY` per input event and a Behavior would fight them — so the twelve pages' `goTo(term)`, which wrote `contentY` directly, had no animation under them.

`StyledFlickable.scrollToY(y)` clamps, stops the settle/bounce/previous programmatic scroll, records `scrollTargetY` and runs one `NumberAnimation` on the scroll tier taken whole. The three wheel paths and `onMovementStarted` stop it, so any user input continues from wherever the scroll got to. Every page's `goTo` goes through it; no page writes `contentY` any more.

`test_settings_navigation.py` pins the helper's tier (duration, type, curve from `Appearance.animation.scroll`), the five stop sites, and that no page writes `contentY`. The first suite run went red on the momentum-scroll contract because my new comment contained its literal marker text — reworded, folded in. Motion lints and the compile sweep green; deployed live and confirmed by the maintainer ("works well").

Docs: updated AGENT.md (a programmatic scroll goes through scrollToY)
Changelog: updated — Changed entry under [Unreleased]
