### PR TITLE
fix(discordVoice): survive null payloads and retry when Discord is absent

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -4054,6 +4054,28 @@ box. Derive the growing axis too, but compute it *arithmetically* from the input
 child layout's `implicitWidth`: the content is anchored to this item's width, so reading its implicit
 size back would bind width to itself. Cap the result and let the grid wrap instead of growing forever.
 
+**Discord's RPC sends `"data": null`, and `.get("data", {})` does not default on it.** A dict default
+applies only when the key is absent; an explicit null comes through as `None`, and leaving a voice
+channel is exactly that — a `VOICE_CHANNEL_SELECT` dispatch and then a `GET_SELECTED_VOICE_CHANNEL`
+reply, both null. Four `.get()` sites in `scripts/discordVoice/discord_voice_bridge.py` raised on
+it, the read loop died with the bridge, and after five backoff restarts `services/DiscordVoice.qml`
+reported "Discord bridge stopped after repeated failures" — for the most ordinary thing a user does
+in a call. Read a nullable field as `payload.get("data") or {}`. The sibling trap is in the service:
+its restart ladder covers the bridge *process* only, and the two answers that mean "nothing to talk
+to" (`unavailable`, `disconnected`) come from a bridge that is alive and idle, so nothing retried
+them and a Discord started after the shell sat unconnected until the popup's manual connect. The
+service carries a second ladder for those now — the same arithmetic (`backoffDelay`, 1s doubling to
+a 30s cap), one shot per answer so the bridge's reply decides the next rung, disarmed by
+`connected`, by `authenticated` (the Vesktop companion backend never says `connected`), by the
+manual connect, and by the process exit handler, because a retry landing on a dead bridge goes
+through `send()` → `start(true)`, which zeroes the process ladder's ceiling.
+`tests/tst_discord_voice_reconnect.qml` drives the real singleton for it — the `Process` and
+`SplitParser` mocks under `tests/mocks/Quickshell/Io` grew the bridge's surface so it loads under
+`qmltestrunner` — and `tests/test_discord_voice_plugin.py` pins the one-shot shape, the shared
+ladder and the exit-handler disarm, beside the read-loop test that feeds the null frames.
+874311484 ("fix(discordVoice): treat a null data field from Discord as an empty payload"),
+8d8d97965 ("fix(discordVoice): retry the connection with backoff when Discord is not there").
+
 **A Wayland client is never told about keys aimed at something else, so the OSK's
 physical-key highlight reads /dev/input — and its LIFETIME is the safeguard, not
 a promise in a comment.** `scripts/keyboard/key_monitor.py` needs membership of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ own repo; the installer pins which revision it builds.
 
 ## [Unreleased]
 
+### Fixed
+- **Leaving a Discord voice channel no longer kills the voice bridge.** Discord
+  reports the empty selection as a null payload, which the bridge treated as a
+  crash; after five restarts the widget gave up with "Discord bridge stopped
+  after repeated failures". A null payload is read as an empty one now.
+- **Discord started after the shell is picked up on its own.** With Discord
+  closed, or its RPC socket dropped, the voice widget used to sit on "Start
+  Discord, then reconnect" until you pressed connect. It now retries by itself,
+  backing off from one second to every thirty, and stops the moment it
+  connects.
+
 ## [0.32.0] — 2026-08-27
 
 One behaviour change, small in code and large on the hand: picking a section

--- a/dots/.config/quickshell/imi/scripts/discordVoice/discord_voice_bridge.py
+++ b/dots/.config/quickshell/imi/scripts/discordVoice/discord_voice_bridge.py
@@ -344,6 +344,8 @@ class Bridge:
             emit("disconnected")
 
     async def handle(self, payload: dict[str, Any]) -> None:
+        # Discord sends "data": null on some events (leaving a voice channel is
+        # the common one), and .get("data", {}) only defaults on an ABSENT key.
         nonce = payload.get("nonce", "")
         event = payload.get("evt", "")
         if event == "ERROR":
@@ -353,14 +355,14 @@ class Bridge:
                 self.clear_token()
                 emit("auth_required")
             else:
-                emit("error", message=payload.get("data", {}).get("message", "Discord RPC error"))
+                emit("error", message=(payload.get("data") or {}).get("message", "Discord RPC error"))
             return
         if nonce in self.pending:
             self.cancel_authorization_timeout(nonce)
-            await self.response(self.pending.pop(nonce), payload.get("data", {}))
+            await self.response(self.pending.pop(nonce), payload.get("data") or {})
             return
         if payload.get("cmd") == "DISPATCH":
-            await self.dispatch(event, payload.get("data", {}))
+            await self.dispatch(event, payload.get("data") or {})
 
     async def response(self, command: str, data: dict[str, Any]) -> None:
         if command == "AUTHORIZE":
@@ -380,7 +382,7 @@ class Bridge:
             await self.subscribe("VOICE_SETTINGS_UPDATE")
             await self.command("GET_SELECTED_VOICE_CHANNEL")
         elif command == "GET_SELECTED_VOICE_CHANNEL":
-            await self.select_channel(data if data.get("id") else None)
+            await self.select_channel(data if data and data.get("id") else None)
         elif command in ("GET_VOICE_SETTINGS", "SET_VOICE_SETTINGS"):
             self.settings = {"mute": bool(data.get("mute")), "deaf": bool(data.get("deaf"))}
             emit("voice_settings", **self.settings)

--- a/dots/.config/quickshell/imi/services/DiscordVoice.qml
+++ b/dots/.config/quickshell/imi/services/DiscordVoice.qml
@@ -25,6 +25,13 @@ Singleton {
     property bool muted: false
     property bool deafened: false
     property int restartAttempts: 0
+    // The process ladder (restartAttempts, onExited) never sees a bridge that
+    // is up with nothing behind it - Discord not running ("unavailable") or
+    // its RPC socket gone ("disconnected"). This second ladder re-issues
+    // connect on those, so a Discord started after the shell is picked up
+    // without the popup's manual connect.
+    property int reconnectAttempts: 0
+    readonly property alias reconnectPending: reconnectTimer.running
     property var pendingMessages: []
     readonly property bool authenticated: status === "authenticated" || channel !== null
     readonly property bool inVoice: channel !== null
@@ -81,8 +88,28 @@ Singleton {
     }
 
     function connect() {
+        disarmReconnect();
+        issueConnect();
+    }
+
+    function issueConnect() {
         errorMessage = "";
         send({cmd: "connect"});
+    }
+
+    function backoffDelay(attempt) {
+        return Math.min(30000, 1000 * Math.pow(2, attempt - 1));
+    }
+
+    function armReconnect() {
+        reconnectAttempts++;
+        reconnectTimer.interval = backoffDelay(reconnectAttempts);
+        reconnectTimer.restart();
+    }
+
+    function disarmReconnect() {
+        reconnectTimer.stop();
+        reconnectAttempts = 0;
     }
 
     function authorize() { send({cmd: "authorize"}); }
@@ -110,7 +137,7 @@ Singleton {
         switch (message.type) {
         case "ready": connect(); break;
         case "backend": backend = message.backend || ""; break;
-        case "connected": status = "connected"; break;
+        case "connected": status = "connected"; disarmReconnect(); break;
         case "auth_required": status = "auth_required"; break;
         case "authorizing":
             status = "authorizing";
@@ -119,6 +146,8 @@ Singleton {
             status = "authenticated";
             currentUser = message.user || {};
             restartAttempts = 0;
+            // The companion backend emits no "connected" before this.
+            disarmReconnect();
             break;
         case "voice_channel":
             channel = message.channel || null;
@@ -129,12 +158,12 @@ Singleton {
             muted = message.mute === true;
             deafened = message.deaf === true;
             break;
-        case "unavailable": status = "unavailable"; errorMessage = message.message || ""; break;
+        case "unavailable": status = "unavailable"; errorMessage = message.message || ""; armReconnect(); break;
         // The companion is one of two backends. Its failure leaves Discord's
         // own RPC usable, so this reports the reason without moving `status`
         // into an authorization state the user cannot act on.
         case "companion_error": errorMessage = message.message || ""; break;
-        case "disconnected": status = "disconnected"; backend = ""; channel = null; updateParticipants([]); break;
+        case "disconnected": status = "disconnected"; backend = ""; channel = null; updateParticipants([]); armReconnect(); break;
         case "error":
             status = "auth_required";
             errorMessage = message.message || "Discord RPC error";
@@ -147,6 +176,13 @@ Singleton {
     Timer {
         id: restartTimer
         onTriggered: root.start(false)
+    }
+
+    // One shot on purpose: the bridge answers every connect with "connected"
+    // or "unavailable", and that answer is what arms the next rung.
+    Timer {
+        id: reconnectTimer
+        onTriggered: root.issueConnect()
     }
 
     Timer {
@@ -164,6 +200,9 @@ Singleton {
         stdout: SplitParser { onRead: data => root.handleLine(data) }
         stderr: SplitParser { onRead: data => console.warn("[DiscordVoice]", data) }
         onExited: (code, status) => {
+            // A retry landing on a dead bridge would go through send() ->
+            // start(true), which zeroes the ceiling below.
+            root.disarmReconnect();
             root.channel = null;
             root.updateParticipants([]);
             if (root.restartAttempts >= root.maxRestartAttempts) {
@@ -173,7 +212,7 @@ Singleton {
             }
             root.restartAttempts++;
             root.status = "restarting";
-            restartTimer.interval = Math.min(30000, 1000 * Math.pow(2, root.restartAttempts - 1));
+            restartTimer.interval = root.backoffDelay(root.restartAttempts);
             restartTimer.restart();
         }
     }

--- a/dots/.config/quickshell/imi/tests/imports/qs/services/DiscordVoice.qml
+++ b/dots/.config/quickshell/imi/tests/imports/qs/services/DiscordVoice.qml
@@ -1,0 +1,1 @@
+../../../../services/DiscordVoice.qml

--- a/dots/.config/quickshell/imi/tests/imports/qs/services/qmldir
+++ b/dots/.config/quickshell/imi/tests/imports/qs/services/qmldir
@@ -2,3 +2,4 @@ module qs.services
 singleton Audio Audio.qml
 singleton ResourceUsage ResourceUsage.qml
 singleton Translation Translation.qml
+singleton DiscordVoice DiscordVoice.qml

--- a/dots/.config/quickshell/imi/tests/mocks/Quickshell/Io/Process.qml
+++ b/dots/.config/quickshell/imi/tests/mocks/Quickshell/Io/Process.qml
@@ -4,7 +4,12 @@ QtObject {
     property var command
     property var environment
     property bool running: false
+    property bool stdinEnabled: false
     property var stdout
-    
+    property var stderr
+
+    signal started()
     signal exited(int exitCode, int exitStatus)
+
+    function write(data) {}
 }

--- a/dots/.config/quickshell/imi/tests/mocks/Quickshell/Io/SplitParser.qml
+++ b/dots/.config/quickshell/imi/tests/mocks/Quickshell/Io/SplitParser.qml
@@ -1,0 +1,7 @@
+import QtQuick
+
+QtObject {
+    property string splitMarker: "\n"
+
+    signal read(string data)
+}

--- a/dots/.config/quickshell/imi/tests/mocks/Quickshell/Io/qmldir
+++ b/dots/.config/quickshell/imi/tests/mocks/Quickshell/Io/qmldir
@@ -5,3 +5,4 @@ FileView 1.0 FileView.qml
 Process 1.0 Process.qml
 StdioCollector 1.0 StdioCollector.qml
 IpcHandler 1.0 IpcHandler.qml
+SplitParser 1.0 SplitParser.qml

--- a/dots/.config/quickshell/imi/tests/test_discord_voice_plugin.py
+++ b/dots/.config/quickshell/imi/tests/test_discord_voice_plugin.py
@@ -6,6 +6,7 @@ import io
 import json
 import os
 import stat
+import struct
 import tempfile
 import unittest
 import warnings
@@ -307,6 +308,62 @@ class DiscordVoiceBridgeTests(unittest.TestCase):
         # that the good frame survived the bad one is what reached the shell.
         self.assertIn("voice_channel", emitted)
         self.assertLess(emitted.index("voice_channel"), emitted.index("disconnected"))
+
+    def test_a_null_data_frame_does_not_end_the_read_loop(self):
+        # Discord sends "data": null on some events - leaving a voice channel
+        # is the common one - and dict.get("data", {}) only defaults on an
+        # ABSENT key, so None reached the payload's .get() sites, the read
+        # loop raised out of the bridge, and after five backoff restarts the
+        # shell gave up with "Discord bridge stopped after repeated failures".
+        def frame(payload):
+            body = json.dumps(payload).encode()
+            return struct.pack("<II", bridge_module.OP_FRAME, len(body)) + body
+
+        class Writer:
+            def __init__(self): self.closed = False
+            def is_closing(self): return self.closed
+            def write(self, data): pass
+            async def drain(self): pass
+            def close(self): self.closed = True
+
+        class Reader:
+            def __init__(self, frames): self.buffer = b"".join(frames)
+            async def readexactly(self, size):
+                if len(self.buffer) < size:
+                    raise asyncio.IncompleteReadError(self.buffer, size)
+                chunk, self.buffer = self.buffer[:size], self.buffer[size:]
+                return chunk
+
+        frames = [
+            frame({"cmd": "DISPATCH", "evt": "VOICE_CHANNEL_SELECT", "data": None}),
+            # The bridge answers that dispatch with GET_SELECTED_VOICE_CHANNEL
+            # under nonce "1"; this is Discord's reply to it once no channel
+            # is selected.
+            frame({"cmd": "GET_SELECTED_VOICE_CHANNEL", "nonce": "1", "data": None}),
+            frame({"cmd": "DISPATCH", "evt": "VOICE_STATE_DELETE", "data": None}),
+            frame({"evt": "ERROR", "nonce": "99", "data": None}),
+            # A frame AFTER the null ones is what proves the loop kept reading.
+            frame({"cmd": "DISPATCH", "evt": "VOICE_SETTINGS_UPDATE",
+                   "data": {"mute": True, "deaf": False}}),
+        ]
+
+        async def scenario():
+            bridge = bridge_module.Bridge()
+            writer = Writer()
+            bridge.writer = writer
+            await bridge.read_loop(Reader(frames), writer)
+
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            asyncio.run(scenario())
+        emitted = [json.loads(line) for line in output.getvalue().splitlines() if line]
+        types = [message["type"] for message in emitted]
+        self.assertIn("voice_channel", types)
+        self.assertIsNone(emitted[types.index("voice_channel")]["channel"])
+        self.assertEqual(emitted[types.index("error")]["message"], "Discord RPC error")
+        self.assertTrue(emitted[types.index("voice_settings")]["mute"])
+        # End of stream is the only way this loop may end, and it says so.
+        self.assertEqual(types[-1], "disconnected")
 
     def test_companion_failure_does_not_masquerade_as_an_auth_prompt(self):
         bridge = BRIDGE_PATH.read_text()

--- a/dots/.config/quickshell/imi/tests/test_discord_voice_plugin.py
+++ b/dots/.config/quickshell/imi/tests/test_discord_voice_plugin.py
@@ -422,6 +422,26 @@ class DiscordVoicePluginSafetyTests(unittest.TestCase):
         self.assertIn("pendingMessages = pendingMessages.concat([message])", service)
         self.assertIn("onStarted: root.flushPendingMessages()", service)
 
+    def test_session_reconnect_is_one_shot_and_stands_down_with_the_process(self):
+        # The behavioural half is tst_discord_voice_reconnect.qml. This pins
+        # what a test driving handleLine() cannot see: the retry timer is one
+        # shot (the bridge's answer decides the next rung), both ladders are
+        # one arithmetic, and the exit handler disarms the retry - a retry
+        # landing on a dead bridge goes through send() -> start(true), which
+        # zeroes the process ladder's ceiling.
+        service = SERVICE.read_text()
+        timer = service[service.index("id: reconnectTimer"):]
+        timer = timer[:timer.index("}")]
+        self.assertNotIn("repeat: true", timer)
+        self.assertIn("reconnectTimer.interval = backoffDelay(reconnectAttempts)", service)
+        self.assertIn("restartTimer.interval = root.backoffDelay(root.restartAttempts)", service)
+        exited = service[service.index("onExited: (code, status) => {"):]
+        exited = exited[:exited.index("if (root.restartAttempts")]
+        self.assertIn("root.disarmReconnect()", exited)
+        # "authenticated" disarms as well: the companion backend never emits
+        # "connected", so on that path it is the only answer that can.
+        self.assertRegex(service, r'(?s)case "authenticated":(?:(?!break;).)*disarmReconnect\(\)')
+
     def test_native_bar_route_is_click_only_and_closes_on_focus_loss(self):
         # Which file draws a bar widget is one mapping both bars ask now, so
         # the native route is pinned there - and holds for the vertical bar

--- a/dots/.config/quickshell/imi/tests/tst_discord_voice_reconnect.qml
+++ b/dots/.config/quickshell/imi/tests/tst_discord_voice_reconnect.qml
@@ -51,6 +51,16 @@ TestCase {
         compare(DiscordVoice.reconnectAttempts, 0)
     }
 
+    function test_authenticated_disarms_the_retry_too() {
+        // The Vesktop companion backend emits no "connected" - its first word
+        // is "authenticated" - so on that path this is the only answer that
+        // can stop the retry.
+        DiscordVoice.handleLine(line("unavailable"))
+        DiscordVoice.handleLine(line("authenticated", {user: {id: "1"}}))
+        verify(!DiscordVoice.reconnectPending)
+        compare(DiscordVoice.reconnectAttempts, 0)
+    }
+
     function test_a_manual_connect_disarms_the_retry_and_resets_the_ladder() {
         DiscordVoice.handleLine(line("unavailable"))
         DiscordVoice.handleLine(line("unavailable"))

--- a/dots/.config/quickshell/imi/tests/tst_discord_voice_reconnect.qml
+++ b/dots/.config/quickshell/imi/tests/tst_discord_voice_reconnect.qml
@@ -1,0 +1,81 @@
+import QtQuick
+import QtTest
+import qs.services
+
+// services/DiscordVoice.qml's session-level reconnect, driven through the real
+// singleton over the Quickshell.Io mocks. The bridge PROCESS already had a
+// restart ladder (onExited); "unavailable" and "disconnected" arrive from a
+// bridge that is alive with nothing behind it, and nothing retried those, so
+// a Discord started after the shell was never picked up until a manual
+// connect.
+TestCase {
+    name: "DiscordVoiceReconnectTest"
+
+    function line(type, extra) {
+        return JSON.stringify(Object.assign({type: type}, extra || {}))
+    }
+
+    function init() {
+        DiscordVoice.handleLine(line("connected", {socket: "/run/user/1000/discord-ipc-0"}))
+        verify(!DiscordVoice.reconnectPending)
+        compare(DiscordVoice.reconnectAttempts, 0)
+    }
+
+    function test_unavailable_arms_the_retry() {
+        DiscordVoice.handleLine(line("unavailable", {message: "Discord is not running or RPC is unavailable"}))
+        compare(DiscordVoice.status, "unavailable")
+        verify(DiscordVoice.reconnectPending)
+        compare(DiscordVoice.reconnectAttempts, 1)
+    }
+
+    function test_disconnected_arms_the_retry() {
+        DiscordVoice.handleLine(line("disconnected"))
+        compare(DiscordVoice.status, "disconnected")
+        verify(DiscordVoice.reconnectPending)
+        compare(DiscordVoice.reconnectAttempts, 1)
+    }
+
+    function test_every_failed_answer_climbs_the_ladder() {
+        DiscordVoice.handleLine(line("disconnected"))
+        DiscordVoice.handleLine(line("unavailable"))
+        DiscordVoice.handleLine(line("unavailable"))
+        compare(DiscordVoice.reconnectAttempts, 3)
+        verify(DiscordVoice.reconnectPending)
+    }
+
+    function test_connected_disarms_the_retry_and_resets_the_ladder() {
+        DiscordVoice.handleLine(line("unavailable"))
+        DiscordVoice.handleLine(line("unavailable"))
+        DiscordVoice.handleLine(line("connected", {socket: "/run/user/1000/discord-ipc-0"}))
+        verify(!DiscordVoice.reconnectPending)
+        compare(DiscordVoice.reconnectAttempts, 0)
+    }
+
+    function test_a_manual_connect_disarms_the_retry_and_resets_the_ladder() {
+        DiscordVoice.handleLine(line("unavailable"))
+        DiscordVoice.handleLine(line("unavailable"))
+        DiscordVoice.connect()
+        verify(!DiscordVoice.reconnectPending)
+        compare(DiscordVoice.reconnectAttempts, 0)
+    }
+
+    function test_a_fired_retry_stands_down_until_the_bridge_answers_again() {
+        // One shot, not a repeating timer: the retry is re-armed by the
+        // bridge's next "unavailable", one rung further up the ladder.
+        DiscordVoice.handleLine(line("unavailable"))
+        wait(DiscordVoice.backoffDelay(1) + 100)
+        verify(!DiscordVoice.reconnectPending)
+        compare(DiscordVoice.reconnectAttempts, 1)
+        DiscordVoice.handleLine(line("unavailable"))
+        compare(DiscordVoice.reconnectAttempts, 2)
+    }
+
+    function test_the_ladder_doubles_from_one_second_to_a_thirty_second_cap() {
+        compare(DiscordVoice.backoffDelay(1), 1000)
+        compare(DiscordVoice.backoffDelay(2), 2000)
+        compare(DiscordVoice.backoffDelay(3), 4000)
+        compare(DiscordVoice.backoffDelay(5), 16000)
+        compare(DiscordVoice.backoffDelay(6), 30000)
+        compare(DiscordVoice.backoffDelay(40), 30000)
+    }
+}


### PR DESCRIPTION
Two robustness fixes in the Discord voice plugin, ported from P3DROVFX/ii-p3drovfx's copy of it.

**Leaving a voice channel killed the bridge.** Discord sends `"data": null` on some events, and `.get("data", {})` only defaults on an absent key, so `None` reached four `.get()` sites, the read loop raised, and after five backoff restarts the service reported "Discord bridge stopped after repeated failures". A null payload is read as an empty one now; `test_a_null_data_frame_does_not_end_the_read_loop` drives `read_loop` with the exact leaving-a-channel sequence.

**Discord started after the shell was never picked up.** The service re-issued `connect` only when the bridge *process* exited; `unavailable` and `disconnected` come from a bridge that is alive and idle, so nothing retried them until the popup's manual connect. A second, session-level ladder now retries those (1s doubling to a 30s cap, one shot per answer), disarmed by `connected`, by `authenticated` (the Vesktop companion backend never says `connected`), by a manual connect, and by the process exit handler (a retry on a dead bridge would go through `send()` → `start(true)` and zero the restart ceiling). `tst_discord_voice_reconnect.qml` drives the real singleton for it — the `Process`/`SplitParser` mocks grew the bridge's surface so it loads under `qmltestrunner` — and `test_discord_voice_plugin.py` pins the one-shot shape, the shared ladder and the exit-handler disarm.

Deliberate divergence from the fork: it uses a fixed 3s repeating timer; this backs off so a machine that never runs Discord is asked every 30s, not every 3.

Docs: updated AGENT.md §Design language (Discord voice notes — null payload and the session-level retry)
Changelog: updated
