### PR TITLE
feat(sidebar): quick slider cards fade, zoom and rise into place

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -4607,6 +4607,29 @@ and stay free.
 15688f7c ("fix(quickToggles): drop the tile's leftover opacity Behavior that swallowed the wave"),
 a5ef0c29 ("test(lint): fail on a wave member carrying a Behavior on opacity").
 
+**A quick slider is two entrances on one trigger, and the card's is the shared wave.** The fill
+sweep's reading of the fork — 4a8ddce51 ("feat(sidebar): every widget owns its entrance - the
+fork's real motion language"), "sliders never fade" — is true of the FILL and not of the card
+around it: the fork's `AndroidSliderWidgetBase` fades, zooms (0.85 → 1) and rises (20px) every
+slider card after a per-index delay, with the sweep running inside it. `QuickSliders.qml` gives
+its three cards exactly that through `StaggerWave` + `StaggerEntrance` rather than a fourth
+hand-copied dressing — each `Loader` declares `appear`, and that is its whole opt-in. Three things
+about the wiring are worth not re-deriving. **The members are handed in as a list**
+(`StaggerWave.items`): the bottom row packs volume and mic side by side, so a wave walking
+`children` would find the row and the row is not a member — and the list is the only place the
+bottom-up order is written. **The dressing is per container** (one `StaggerEntrance` in the column
+and one in the row), because it installs itself on a container's children and a list is not a
+container. **The card wave runs on the sidebar's `entranceTrigger`**, park-and-enter, ungated,
+beside the fill sweep that already runs on it, so the two channels cannot start on different
+gestures; it carries the toggle grid's 80ms lead-in for that grid's reason. The sliders' section in
+`SidebarRightContent` stays out of the section wave — a fading section over fading cards is the
+compound the toggle grid paid for. `tests/test_quick_sliders_entrance_contract.py` walks the file
+per MEMBER: `appear` at its own top level, a dressed container, the list in order, no `Behavior on
+opacity`/`scale` anywhere (the tree-wide lint above sees only root-level members, and these are
+nested Loaders), and the sweep still there.
+d1dc6671d ("feat(sidebar): the quick sliders' cards fade, zoom and rise into place, bottom-up"),
+4f6a95dff ("test(sidebar): pin the quick sliders' cards to the wave, and register the adopter").
+
 **The adoption is the thing that decays, so the adoption is what is pinned.**
 `docs/p3drovfx-motion-measured-2026-08-22.md` §4.2 measured the sibling fork's motion off screen and
 found our arithmetic correct, our guideline written, and the wiring at **three** files against their

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ own repo; the installer pins which revision it builds.
 
 ## [Unreleased]
 
+### Changed
+- **The right sidebar's quick sliders arrive one card at a time.** Each slider
+  card now fades in, zooms up from slightly smaller and rises into place —
+  the bottom row first, brightness last — while its fill still sweeps up from
+  zero with the icon turning, as before. It is the sibling fork's slider
+  entrance on the shell's own motion tiers, so the animation speed slider and
+  reduce motion reach it.
+
 ### Fixed
 - **Leaving a Discord voice channel no longer kills the voice bridge.** Discord
   reports the empty selection as a null payload, which the bridge treated as a

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/QuickSliders.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/QuickSliders.qml
@@ -11,9 +11,37 @@ import Quickshell.Services.UPower
 Rectangle {
     id: root
 
+    // The sidebar's one entrance counter. Two things run on it here, and they
+    // are deliberately two channels: each slider's FILL sweeps up from zero
+    // (the QuickSlider component below), and each CARD arrives - a fade, a
+    // zoom from a derived near-1 start and a rise, all on the one `appear`
+    // scalar - the fork's AndroidSliderWidgetBase entrance, spelled with the
+    // shared wave and dressing rather than as a fourth copy of the
+    // three-channel choreography. Park-and-enter on the trigger, ungated,
+    // for the reason SidebarRightContent gives: the wave runs UNDER the
+    // slide's curtain, and only the last-ranked card visibly lands after it.
     property int entranceTrigger: -1
+    onEntranceTriggerChanged: {
+        sliderWave.park();
+        sliderWave.enter();
+    }
     property var screen: root.QsWindow.window?.screen
     property var brightnessMonitor: Brightness.getMonitorForScreen(screen)
+
+    // The cards are not one container's children - the bottom row packs
+    // volume and mic side by side - so the members are handed in as a list,
+    // in the order they arrive: the bottom row first, brightness last.
+    // `target` stays this card, the thing whose being on screen the runner
+    // waits for before it starts.
+    StaggerWave {
+        id: sliderWave
+        target: root
+        items: [volumeLoader, micLoader, brightnessLoader]
+        // The toggle grid's head start, for its reason: without one the
+        // first-ranked card begins fading the instant the panel edge
+        // appears and is well-lit before anything above it has started.
+        leadIn: 80
+    }
 
     implicitWidth: contentItem.implicitWidth + root.horizontalPadding * 2
     implicitHeight: contentItem.implicitHeight + root.verticalPadding * 2
@@ -32,7 +60,17 @@ Rectangle {
             bottomMargin: root.verticalPadding
         }
 
+        // Dresses the one member that is this column's own child; the row
+        // below dresses its two. The dressing is per CONTAINER because it
+        // installs itself on a container's children, and the wave's list is
+        // not a container.
+        StaggerEntrance {
+            target: contentItem
+        }
+
         Loader {
+            id: brightnessLoader
+            property real appear: 1
             anchors {
                 left: parent.left
                 right: parent.right
@@ -66,12 +104,18 @@ Rectangle {
         }
 
         Row {
+            id: bottomRow
             width: parent.width
             height: Math.max(volumeLoader.implicitHeight, micLoader.implicitHeight)
             spacing: Appearance.spacing.space50
 
+            StaggerEntrance {
+                target: bottomRow
+            }
+
             Loader {
                 id: volumeLoader
+                property real appear: 1
                 width: micLoader.active ? (parent.width - parent.spacing) / 2 : parent.width
                 visible: active
                 active: Config.options.sidebar.quickSliders.showVolume
@@ -89,6 +133,7 @@ Rectangle {
 
             Loader {
                 id: micLoader
+                property real appear: 1
                 width: volumeLoader.active ? (parent.width - parent.spacing) / 2 : parent.width
                 visible: active
                 active: Config.options.sidebar.quickSliders.showMic
@@ -106,15 +151,17 @@ Rectangle {
         }
     }
 
-    component QuickSlider: StyledSlider { 
+    component QuickSlider: StyledSlider {
         id: quickSlider
         required property string materialSymbol
         property string secondaryMaterialSymbol
-        // The entrance is a FILL SWEEP, the sibling fork's slider grammar:
-        // the value holds at zero while the panel is away and glides up to
-        // the real reading when the open's trigger fires, staggered per
-        // slider - no fade anywhere. Call sites bind `shownValue`; `value`
-        // stays this component's own so the hold cannot destroy a binding.
+        // The slider's own entrance is a FILL SWEEP, the sibling fork's
+        // slider grammar: the value holds at zero while the panel is away
+        // and glides up to the real reading when the open's trigger fires,
+        // staggered per slider. The CARD's fade is the Loader's, one level
+        // up, through the wave - never this control's opacity. Call sites
+        // bind `shownValue`; `value` stays this component's own so the hold
+        // cannot destroy a binding.
         property int entranceTrigger: -1
         property int sliderIndex: 0
         property real shownValue: 0
@@ -172,7 +219,7 @@ Rectangle {
         configuration: StyledSlider.Configuration.M
         stopIndicatorValues: []
         dividerValues: secondaryMaterialSymbol.length > 0 ? [secondaryIcon.iconLocation] : []
-        
+
         MaterialSymbol {
             id: icon
             property bool nearFull: quickSlider.value >= 0.9

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/SidebarRightContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/SidebarRightContent.qml
@@ -374,9 +374,11 @@ Item {
 
             Loader {
                 id: slidersLoader
-                // Not a wave member: the sliders own their entrance (the
-                // fill sweep) - a fading section over sweeping sliders is
-                // the compound the toggle grid already paid for.
+                // Not a wave member: the sliders own their entrance - the
+                // fill sweep, and a card wave of their own inside
+                // (QuickSliders.qml), the toggle grid's shape. A fading
+                // section over fading cards is the compound that grid
+                // already paid for.
                 Layout.fillWidth: true
                 visible: active
                 active: {

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -1013,6 +1013,16 @@ if ! python3 "$SCRIPT_DIR/test_motion_policy_contract.py"; then
     exit 1
 fi
 
+# The quick sliders' cards ride the shared wave, bottom-up, beside their fill
+# sweep: each card declares `appear`, sits in a dressed container, and is in
+# the wave's list in order. None of it builds under qmltestrunner and all of
+# it fails silently on screen, so the shape is pinned in the source.
+echo "Running quick sliders entrance contract tests..."
+if ! python3 "$SCRIPT_DIR/test_quick_sliders_entrance_contract.py"; then
+    echo "Quick sliders entrance contract tests failed."
+    exit 1
+fi
+
 # ...and the same thing read back off a real shell against a seeded config,
 # because the QML default and the adapter's merged answer are different
 # numbers and only the second one runs.

--- a/dots/.config/quickshell/imi/tests/test_motion_policy_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_motion_policy_contract.py
@@ -79,6 +79,12 @@ STAGGER_ADOPTERS = {
     # The android toggle grid's nested tile wave (convergent - tiles from
     # their own third of the grid), gated on the section's own appear.
     "modules/imi/sidebarRight/quickToggles/AndroidQuickPanel.qml",
+    # The quick sliders' nested card wave (uniform - fade, scale and rise on
+    # the three cards, bottom-up, members handed in as a list because the
+    # bottom row packs two of them), park-and-enter on the sidebar's
+    # trigger beside the fill sweep each slider already runs on it.
+    # tests/test_quick_sliders_entrance_contract.py holds the shape.
+    "modules/imi/sidebarRight/QuickSliders.qml",
     # The left sidebar, adopted after its refusal's hazard was answered
     # rather than waved off: the gate keys on the OPEN flag, which a detach
     # does not flip, so undocking the chat to keep reading cannot re-run the

--- a/dots/.config/quickshell/imi/tests/test_quick_sliders_entrance_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_quick_sliders_entrance_contract.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""The quick sliders' cards arrive through the shared wave, bottom-up.
+
+Each quick slider is two entrances on one trigger, and they are deliberately
+two channels rather than one. The FILL sweeps from zero to the real reading
+through `StyledSlider`'s glide velocity (4a8ddce51, "feat(sidebar): every
+widget owns its entrance - the fork's real motion language"); the CARD fades,
+scales and rises into place on the `appear` scalar a `StaggerWave` animates and
+a `StaggerEntrance` dresses - the fork's `AndroidSliderWidgetBase` entrance
+(opacity 0 -> 1, scale 0.85 -> 1, 20px rise, after a per-slider delay), spelled
+with the two shared components rather than as a fourth hand-copied
+three-channel dressing.
+
+What this file pins is the shape that decays, because none of it is reachable
+from `qmltestrunner` (a `StyledSlider` will not build there) and all of it
+fails silently on screen:
+
+- The three cards are the wave's members, handed in as a LIST in bottom-up
+  order. They are not one container's children - the bottom row packs volume
+  and mic side by side - so a wave walking `children` would find the row and
+  not the cards, and the row is not a member. Order is the design: the spec is
+  bottom-up, and a list is the only place that order is written.
+- Each card declares `appear` at its own top level. A card without it is not a
+  member: the wave skips it and the dresser skips it, and it arrives drawn at
+  full strength one frame before its neighbours start fading - the "always
+  there, then the animation begins" read the toggle grid already paid for.
+- Every container holding a member has a `StaggerEntrance` aimed at it. The
+  dresser installs opacity, scale and the rise on a container's CHILDREN, so a
+  member whose container has no dresser rides the wave on `appear` alone -
+  which is a number changing and nothing moving.
+- The wave runs on the sidebar's trigger, park-and-enter, ungated - the same
+  edge the fill sweep already runs on, so the two channels cannot start on
+  different gestures.
+- No `Behavior on opacity` or `Behavior on scale` anywhere in the file. Both
+  are the dressing's channels, and a Behavior on either swallows the park and
+  retargets every frame of the wave (`lint_wave_member_opacity_behavior.py`
+  holds the root-level case tree-wide; the members here are nested Loaders,
+  which that lint does not see).
+- The fill sweep stays. The cards' entrance is IN ADDITION to it, not instead.
+
+Every check is proven against an in-memory mutation of the real file, so a
+regex that stops matching reads as a failure rather than as a clean tree.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from contract_runner import run  # noqa: E402
+
+ROOT = Path(__file__).resolve().parents[1]
+QUICK_SLIDERS = ROOT / "modules/imi/sidebarRight/QuickSliders.qml"
+
+# Bottom-up: the bottom row's two cards first, brightness (the top card) last.
+MEMBERS = ["volumeLoader", "micLoader", "brightnessLoader"]
+WAVE_ID = "sliderWave"
+
+ID_LINE = re.compile(r"^\s*id:\s*(\w+)\s*$")
+APPEAR_LINE = re.compile(r"^\s*property real appear\b")
+TARGET_LINE = re.compile(r"^\s*target:\s*(\w+)\s*$")
+ITEMS_LINE = re.compile(r"^\s*items:\s*\[([^\]]*)\]")
+BEHAVIOR_ON = re.compile(r"^\s*Behavior on (opacity|scale)\b")
+CHANNEL_WRITE = re.compile(r"^\s*(opacity|scale)\s*:")
+
+
+def strip_comments(line: str) -> str:
+    return line.split("//", 1)[0]
+
+
+class Block:
+    def __init__(self, header: str, start: int, depth: int, parent):
+        self.header = header.strip()
+        self.start = start
+        self.end = None
+        self.depth = depth
+        self.parent = parent
+        self.id = None
+        # (line number, text, depth-at-line-start) for every line inside.
+        self.lines = []
+
+    def own_lines(self):
+        """Lines at the block's own top level - its properties and handlers."""
+        return [(n, t) for n, t, d in self.lines if d == self.depth + 1]
+
+    def enclosing_id(self):
+        block = self.parent
+        while block is not None:
+            if block.id is not None:
+                return block.id
+            block = block.parent
+        return None
+
+
+def parse(text: str):
+    """A brace walk over the file: every `{ ... }` is a Block, ids attach to
+    the block they sit in. JS bodies and template literals balance their own
+    braces and simply become anonymous blocks nobody asks about."""
+    blocks = []
+    stack = []
+    depth = 0
+    for number, raw in enumerate(text.splitlines(), start=1):
+        line = strip_comments(raw)
+        for block in stack:
+            block.lines.append((number, raw, depth))
+        match = ID_LINE.match(line)
+        if match and stack:
+            stack[-1].id = match.group(1)
+        for char in line:
+            if char == "{":
+                header = line.split("{", 1)[0]
+                block = Block(header, number, depth, stack[-1] if stack else None)
+                blocks.append(block)
+                stack.append(block)
+                depth += 1
+            elif char == "}":
+                depth -= 1
+                if stack:
+                    stack.pop().end = number
+    return blocks
+
+
+def by_id(blocks, wanted):
+    return [b for b in blocks if b.id == wanted]
+
+
+def check(text: str) -> list:
+    problems = []
+    blocks = parse(text)
+    root = blocks[0] if blocks else None
+    if root is None or root.depth != 0:
+        return ["QuickSliders.qml has no root object"]
+
+    # --- the wave, and its members in order ------------------------------
+    waves = [b for b in blocks if b.header.startswith("StaggerWave")]
+    if len(waves) != 1:
+        problems.append(f"expected exactly one StaggerWave, found {len(waves)}")
+    else:
+        wave = waves[0]
+        if wave.id != WAVE_ID:
+            problems.append(f"the wave is `{wave.id}`, not `{WAVE_ID}`")
+        targets = [TARGET_LINE.match(t).group(1) for _, t in wave.own_lines()
+                   if TARGET_LINE.match(t)]
+        if targets != [root.id]:
+            problems.append(
+                f"the wave's target is {targets}, not the card ({root.id}) - the "
+                f"runner waits on its target being on screen before starting")
+        items = [ITEMS_LINE.match(t) for _, t in wave.own_lines()]
+        items = [m for m in items if m]
+        if not items:
+            problems.append("the wave has no `items:` list - its members are not "
+                            "one container's children")
+        else:
+            listed = [s.strip() for s in items[0].group(1).split(",") if s.strip()]
+            if listed != MEMBERS:
+                problems.append(
+                    f"the wave's members are {listed}; expected bottom-up "
+                    f"{MEMBERS}")
+
+    # --- each member: appear, its own dresser, no second channel writer ---
+    dressers = [b for b in blocks if b.header.startswith("StaggerEntrance")]
+    dressed = set()
+    for dresser in dressers:
+        for _, t in dresser.own_lines():
+            match = TARGET_LINE.match(t)
+            if match:
+                dressed.add(match.group(1))
+    for member in MEMBERS:
+        found = by_id(blocks, member)
+        if len(found) != 1:
+            problems.append(f"`{member}` is declared {len(found)} times")
+            continue
+        block = found[0]
+        own = block.own_lines()
+        if not any(APPEAR_LINE.match(t) for _, t in own):
+            problems.append(f"`{member}` declares no `property real appear` - "
+                            f"it is not a wave member")
+        for _, t in own:
+            if CHANNEL_WRITE.match(t):
+                problems.append(f"`{member}` writes `{t.strip()}` itself; the "
+                                f"dresser owns that channel")
+        container = block.enclosing_id()
+        if container not in dressed:
+            problems.append(
+                f"`{member}` sits in `{container}`, which no StaggerEntrance "
+                f"targets - the wave moves its `appear` and nothing on screen "
+                f"follows")
+
+    # --- the trigger runs the wave -----------------------------------------
+    handlers = [b for b in blocks
+                if b.header.startswith("onEntranceTriggerChanged:")
+                and b.parent is root]
+    if len(handlers) != 1:
+        problems.append("the root declares no onEntranceTriggerChanged handler")
+    else:
+        body = "\n".join(t for _, t, _ in handlers[0].lines)
+        for call in (f"{WAVE_ID}.park()", f"{WAVE_ID}.enter()"):
+            if call not in body:
+                problems.append(f"the trigger handler does not call {call}")
+
+    # --- no second animation on the dressing's channels -------------------
+    for number, raw in enumerate(text.splitlines(), start=1):
+        if BEHAVIOR_ON.match(strip_comments(raw)):
+            problems.append(f"line {number}: {raw.strip()} - a Behavior on a "
+                            f"channel the wave animates")
+
+    # --- the fill sweep is still there -------------------------------------
+    for token in ("sweepTimer", "entranceParked", "valueVelocity"):
+        if token not in text:
+            problems.append(f"the fill sweep is gone (`{token}` not found) - "
+                            f"the card entrance is in addition to it")
+    return problems
+
+
+def real() -> str:
+    return QUICK_SLIDERS.read_text(encoding="utf-8")
+
+
+def mutated(before: str, after: str, count: int = 1) -> str:
+    text = real()
+    assert text.count(before) == count, \
+        f"the mutation's anchor `{before}` appears {text.count(before)} times"
+    return text.replace(before, after)
+
+
+def expect(problems, fragment):
+    assert any(fragment in p for p in problems), \
+        f"expected a problem mentioning `{fragment}`, got {problems}"
+
+
+def test_the_quick_sliders_pass():
+    problems = check(real())
+    assert not problems, "\n  ".join(["QuickSliders.qml:"] + problems)
+
+
+def test_a_card_without_appear_is_not_a_member():
+    text = real()
+    block = next(b for b in parse(text) if b.id == "brightnessLoader")
+    line = next(t for _, t in block.own_lines() if APPEAR_LINE.match(t))
+    expect(check(text.replace(line + "\n", "", 1)), "`brightnessLoader` declares no")
+
+
+def test_the_members_are_listed_bottom_up():
+    text = mutated("items: [volumeLoader, micLoader, brightnessLoader]",
+                   "items: [brightnessLoader, volumeLoader, micLoader]")
+    expect(check(text), "expected bottom-up")
+
+
+def test_a_member_dropped_from_the_list_is_caught():
+    text = mutated("items: [volumeLoader, micLoader, brightnessLoader]",
+                   "items: [volumeLoader, brightnessLoader]")
+    expect(check(text), "expected bottom-up")
+
+
+def test_a_container_without_its_dresser_is_caught():
+    text = real()
+    blocks = parse(text)
+    row = next(b for b in blocks if b.id == "bottomRow")
+    dresser = next(b for b in blocks
+                   if b.header.startswith("StaggerEntrance") and b.parent is row)
+    lines = text.splitlines()
+    del lines[dresser.start - 1:dresser.end]
+    expect(check("\n".join(lines)), "which no StaggerEntrance targets")
+
+
+def test_a_behavior_on_a_channel_is_caught():
+    text = mutated(
+        "                id: volumeLoader\n",
+        "                id: volumeLoader\n"
+        "                Behavior on opacity {}\n")
+    expect(check(text), "a Behavior on a channel the wave animates")
+
+
+def test_a_member_writing_its_own_opacity_is_caught():
+    text = mutated(
+        "                id: micLoader\n",
+        "                id: micLoader\n"
+        "                opacity: 1\n")
+    expect(check(text), "`micLoader` writes")
+
+
+def test_the_trigger_must_run_the_wave():
+    text = mutated(f"        {WAVE_ID}.enter();\n", "")
+    expect(check(text), f"does not call {WAVE_ID}.enter()")
+
+
+def test_the_wave_waits_on_the_card():
+    text = mutated("        target: root\n        items:",
+                   "        target: contentItem\n        items:")
+    expect(check(text), "the wave's target is")
+
+
+def test_the_fill_sweep_stays():
+    text = real().replace("sweepTimer", "gone")
+    expect(check(text), "the fill sweep is gone")
+
+
+def test_the_walker_reads_the_file_it_is_pointed_at():
+    """A parse that finds no members passes every per-member check for the
+    wrong reason; pin the shape it must recover from the real file."""
+    blocks = parse(real())
+    ids = {b.id for b in blocks if b.id}
+    assert set(MEMBERS) <= ids, f"members not found by the walker: {ids}"
+    assert next(b for b in blocks if b.id == "volumeLoader").enclosing_id() == "bottomRow"
+    assert next(b for b in blocks if b.id == "brightnessLoader").enclosing_id() == "contentItem"
+
+
+if __name__ == "__main__":
+    sys.exit(run(globals()))


### PR DESCRIPTION
The right sidebar's quick sliders get the fork's card entrance: each card fades in, zooms from a derived near-1 start and rises 20px into place, staggered bottom-up under the slide, while the fill sweep from #296 keeps running on the same trigger. Spelled with StaggerWave + StaggerEntrance (members handed in as a list because the bottom row packs two cards; one dresser per container) rather than a fourth copy of the three-channel dressing, so the speed slider and reduce motion reach it. A contract test walks QuickSliders.qml per member, and the file joins STAGGER_ADOPTERS.

Review points: `leadIn: 80` (fork 150, section wave 0); the scale start is the derived `entranceScaleFrom` with the house settle curve, no OutBack overshoot; cards enter bottom-up while the fill sweep stays top-down.

Docs: updated AGENT.md §Design language (the quick-slider card wave, beside the wave-member rules)
Changelog: updated
