### PR TITLE
feat(phoneConnect): connectivity report, pairing requests, reshaped panel

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -578,13 +578,19 @@ services/                  Singletons wrapping external state/processes - one pe
   PhoneConnect.qml             Paired-phone state from KDE Connect or Valent, driven over
                               `busctl --json=short` Process calls (the shell has no D-Bus
                               binding) - backend detection from the bus name list, one
-                              normalized device/battery model for both daemons, ring/ping/
-                              clipboard actions. KDE Connect's changes arrive as SIGNALS
+                              normalized device model for both daemons (battery, the
+                              reachable addresses, the cellular report, a peer's pairing
+                              request), ring/ping/clipboard actions and the two pairing
+                              answers. KDE Connect's changes arrive as SIGNALS
                               (`busctl monitor`, see the streaming note below); Valent's
                               still arrive on the poll, which stays on for both as the
                               reconcile. Its parser logic is kept byte-for-byte in
                               sync with a logic-only test double
-                              (tests/test_phone_connect_contract.py enforces it)
+                              (tests/test_phone_connect_contract.py enforces it, and holds
+                              the sidebar's phone dialog to the actions the model declares
+                              - a button whose call the service does not answer is a fake
+                              action). The dialog itself is driven end to end by
+                              tests/test_phone_connect_dialog_runtime.py
   SchemePreview.qml            Per-scheme swatches for the scheme pickers: one venv run of
                               scripts/colors/scheme_preview.py quantizes the wallpaper once and
                               builds every Material variant from it. Cached against the wallpaper
@@ -3968,6 +3974,23 @@ across daemon restarts. Four more things about that path, each of which cost a m
   `linksChanged`, `deviceAdded`, `deviceListChanged`), and each re-read is a chain of `busctl`
   spawns. The settle timer also has to **re-arm** rather than fire while a sweep is in flight,
   because the sweep declines then and firing would drop the change that asked for it.
+- **A `GetAll` naming an interface the object does not implement is not an error on a Qt
+  adaptor — it answers with every property of the object.** KDE Connect's connectivity report
+  is a child object (`<device>/connectivity_report`), and a `GetAll` naming its interface on
+  the DEVICE path came back with the device's own properties, measured live. A sweep reading
+  a leaf off the wrong path therefore parses a report with no cellular fields in it and shows
+  "unknown" for ever, with nothing in any log. Read a leaf at its own path, and pin the path
+  rather than the interface name (`tests/test_phone_connect_contract.py` does; the runtime
+  fake answers the report at the leaf only). f7a2952ed ("feat(phoneConnect): read
+  connectivity_report and reachableAddresses onto the device model").
+- **Pairing is two methods on the device path, and an answer is aimed only at a device that
+  asked.** `acceptPairing`/`cancelPairing` on `org.kde.kdeconnect.device`, introspected live;
+  the request itself is `pairState` 2 (`Device::PairState`: 0 NotPaired, 1 Requested *by us*,
+  2 RequestedByPeer, 3 Paired) or the older `isPairRequestedByPeer` bool, and either spelling
+  counts. Neither answer falls back to the active device the way `ring()` does — that device
+  is the paired phone, which never asked — so the guard refuses a device without a request
+  and the contract pins the absence of the fallback. 9395932d3 ("feat(phoneConnect): surface a
+  peer's pairing request, and answer it").
 
 The gate deciding whether to start it was first written as a `readonly property bool` derived from
 `backend` and read from `onBackendChanged` — the change-handler trap under
@@ -4125,6 +4148,19 @@ cosmetic error: when the missing token feeds a positioner's `spacing`/`margin`, 
 freezes the shell (this is exactly what a bulk token migration did to `ConfigRow.qml`,
 `NotificationListView.qml`, `PluginOptions.qml`, and `StyledPopupMenu.qml`). `tests/lint_qml_imports.sh`
 (run by `tests/run_tests.sh` and CI) guards against reintroducing it.
+
+**`Translation` is a `qs.services` singleton, not a `qs.modules.common` one, and the same
+non-transitivity applies.** A `modules/` file rewritten without `import qs.services` while
+keeping every `Translation.tr(...)` passes every static check and logs `ReferenceError:
+Translation is not defined` per binding at runtime — the phone panel's roster row did exactly
+that, and only the runtime harness that builds the real dialog saw it; the chip beside it had
+the same hole behind a ternary no device-full run evaluates, which no harness could have seen.
+`tests/lint_qml_imports.sh` covers `Translation` now (its table is one line per singleton), and
+it skips files that live IN the declaring module, since a sibling type is in scope on its own —
+every `services/*.qml` that translates a string would otherwise be an offender.
+0c6429028 ("feat(phoneConnect): the dialog becomes a device chip, pills, one action row and a
+notification area"), f37d0ac9e ("test(lint): a bareword Translation needs import qs.services,
+and a module's own files do not").
 
 **Strict UI Guidelines:** See [`docs/M3_GUIDELINES.md`](docs/M3_GUIDELINES.md) for the definitive rules on tokens, rounding, layering, and expressive motion that all new components must follow.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ own repo; the installer pins which revision it builds.
 
 ## [Unreleased]
 
+### Added
+- **Phone Connect shows your phone's wireless address and cellular network,
+  and answers pairing requests.** The panel reads the address KDE Connect
+  reaches the phone on and its cellular network type (LTE, 5G, …) alongside
+  the battery. When another device asks to pair with this one, the panel
+  shows the request as a card with Accept and Decline, so pairing no longer
+  needs KDE Connect's own window — and it is answered only for the device
+  that asked.
+
 ### Changed
 - **The right sidebar's quick sliders arrive one card at a time.** Each slider
   card now fades in, zooms up from slightly smaller and rises into place —
@@ -28,6 +37,15 @@ own repo; the installer pins which revision it builds.
   float their labels into the field; and every explanation moved from a
   paragraph under its row to an (i) you hover. The other settings pages are
   unchanged and follow in later releases.
+- **The phone panel is laid out like a phone panel.** The device sits on a
+  chip whose arrow opens the list of every device the daemon knows; its
+  connection, battery and cellular network are pills beside it; the actions
+  are one row of round buttons (ring, ping, send clipboard) instead of
+  buttons repeated on every device row; the middle of the panel is reserved
+  for your phone's notifications and says so while there is nothing to show;
+  and secondary features — pairing requests today — stack as cards at the
+  bottom. Picking a device in the list makes it the one the panel is about
+  for the rest of the session.
 
 ### Fixed
 - **Leaving a Discord voice channel no longer kills the voice bridge.** Discord

--- a/docs/proposals/phone-connect.md
+++ b/docs/proposals/phone-connect.md
@@ -1,7 +1,8 @@
 # Proposal: Phone Connect (KDE Connect / Valent integration)
 
-> Draft / tracking proposal. The service, its sidebar surface and
-> signal-driven updates are implemented; the slices below are what remains.
+> Draft / tracking proposal. The service, its sidebar surface,
+> signal-driven updates, the connectivity report and pairing are
+> implemented; the slices below are what remains.
 
 ## Goal
 
@@ -75,6 +76,53 @@ as a `readonly property bool` read from `onBackendChanged`, which is AGENT.md's
 change-handler trap — it answered with the previous backend, the monitor never
 started, and nothing showed it because the poll kept the model correct. It is a
 function now.
+
+**Slices 2 and 3 have landed**, and the sidebar surface was reshaped with
+them:
+
+- **`connectivity_report` and `reachableAddresses`** (f7a2952ed
+  "feat(phoneConnect): read connectivity_report and reachableAddresses onto
+  the device model"). One more `GetAll` per device, at the report's own
+  leaf path, plus the device's `reachableAddresses` property it was already
+  fetching; the model gains `reachableAddresses` (string entries only),
+  `cellularNetworkType` and `cellularNetworkStrength` (-1 when unknown), and
+  `connectivity_report.refreshed` joins the monitor's allowlist. Shapes read
+  off the live daemon: `reachableAddresses ["192.168.100.179"]`, the report
+  `{cellularNetworkType "LTE", cellularNetworkStrength 4}`. The finding
+  worth keeping: a `GetAll` naming the report's interface on the *device*
+  path is not an error — Qt's adaptor answers with every device property —
+  so the contract pins the leaf path, not the interface name. Valent
+  carries the fields at their "unknown" values.
+- **Pairing requests** (9395932d3 "feat(phoneConnect): surface a peer's
+  pairing request, and answer it"). This closes the open question below:
+  pairing *is* driveable from the shell, and it is `acceptPairing` /
+  `cancelPairing` on `org.kde.kdeconnect.device` at the device path,
+  introspected live. A request is `pairState` 2 (`Device::PairState`: 0
+  NotPaired, 1 Requested by us, 2 RequestedByPeer, 3 Paired) or the older
+  `isPairRequestedByPeer` bool; the model carries `hasPairingRequest` and a
+  derived `pairingRequests` list. Neither answer falls back to the active
+  device the way `ring()` does — that device is the paired phone, which
+  never asked — and the id reaches the path as a validated argument, never
+  through a shell string (the fork splices `devId` unquoted into `bash -c`).
+  Valent stays at `hasPairingRequest: false`, unverified.
+- **The surface** (0c6429028 "feat(phoneConnect): the dialog becomes a device
+  chip, pills, one action row and a notification area"). The device dialog
+  now follows the layout the maintainer rated on the fork: the device on a
+  chip whose arrow opens the roster; a connection pill (the wireless address
+  from `reachableAddresses`, or Offline), a battery pill and a cellular
+  pill; ONE row of round actions — ring, ping, clipboard, the three the
+  model answers, where the fork's other three are scrcpy, a file picker and
+  SFTP and are not drawn; the notification area owning the remaining height
+  with a real empty state (it says why while there is nothing to show — no
+  busctl, no daemon, no devices, not mirrored yet); and the secondary
+  features as cards stacked at the bottom, today the pairing request with
+  Accept and Decline. The roster row a user picks becomes the device the
+  chip, the pills and the actions are about, for the session — the
+  persisted choice is slice 6. `tests/test_phone_connect_contract.py` holds
+  the surface to the actions the model declares, and
+  `tests/test_phone_connect_dialog_runtime.py` builds the real dialog over
+  the real service against a fake daemon and reads all of it back,
+  including the area growing by exactly a card when that card goes.
 
 ## Prior art: P3DROVFX/ii-p3drovfx
 
@@ -190,12 +238,14 @@ Ordered by value. Each borrows the fork's shape and none of its transport:
 every read is a `busctl` argv, every write goes through `runAction`, and both
 backends stay behind the one model.
 
-**Slice 1 (signal-driven updates) is done** — see "Current state" above. The
-next slice is now notification mirroring, and it inherits the stream: its
-signals go in `signalChangesDevices`' allowlist and the match rule already
-covers the whole `/modules/kdeconnect` namespace, so nothing about the
-transport has to be rebuilt for it. What is still open from slice 1 is Valent:
-its signal set was not verifiable and it keeps the poll until it is.
+**Slices 1 (signal-driven updates), 2 and 3 are done** — see "Current
+state" above. The next slice is now notification mirroring, and it inherits
+the stream and the surface: its signals go in `signalChangesDevices`'
+allowlist, the match rule already covers the whole `/modules/kdeconnect`
+namespace, and the dialog's notification area is already the fill item
+waiting for it, so nothing about the transport or the layout has to be
+rebuilt. What is still open from slice 1 is Valent: its signal set was not
+verifiable and it keeps the poll until it is.
 
 1. **Notification mirroring.** Borrow: the leaf `notification.dismiss` (not
    `sendAction("cancel")`), `sendReply` with a re-fetch, `internalId` →
@@ -207,15 +257,15 @@ its signal set was not verifiable and it keeps the poll until it is.
    necessary. Not: the qdbus/`fetch_notifications.py` split; one `busctl`
    `GetAll` per leaf covers it. Not: "open on phone" — that is scrcpy+adb,
    out of scope.
-2. **`connectivity_report` and `reachableAddresses`.** One more `GetAll` on
-   the device path and one more signal, both already in the fork's event set;
-   the model gains cellular type/strength. Cheap now the stream exists.
-3. **Pairing requests.** Accept/decline banners in the device dialog, fed by
-   `pairingRequestsChanged` and `pairStateChanged`; the calls are
-   `acceptPairing`/`cancelPairing` on the device path. This closes the "Open
-   questions" item — the fork shows it wraps cleanly. Not: interpolating
-   `devId` into a shell string; the id is validated (`validDeviceId`) and
-   passed as an argument.
+2. **`connectivity_report` and `reachableAddresses`.** Done — see "Current
+   state". One more `GetAll` per device, at the report's own leaf path, and
+   one more signal; the model carries the addresses and the cellular
+   type/strength.
+3. **Pairing requests.** Done — see "Current state". Accept/decline cards in
+   the device dialog, fed by `pairingRequestsChanged` and `pairStateChanged`
+   through the stream; the calls are `acceptPairing`/`cancelPairing` on the
+   device path, aimed only at a device that asked, with the id validated and
+   passed as an argument rather than interpolated into a shell string.
 4. **Send and receive.** `share.shareUrl("file://…")` for file send, drop
    target on the drop shelf (`modules/imi/dropShelf/`) rather than a picker
    dialog, and `share.shareReceived` surfaced as a notification. Not: the
@@ -281,9 +331,11 @@ would be both laggy and wasteful.
 
 ## Open questions
 
-- Whether pairing should be driveable from the shell or deferred to the
-  daemon's own UI. Pairing involves a confirmation on both ends and is
-  security-relevant; wrapping it badly is worse than not wrapping it.
+- ~~Whether pairing should be driveable from the shell or deferred to the
+  daemon's own UI.~~ Answered by slice 3: it is, as two methods on the device
+  path, and the wrapping is narrow on purpose — an answer is refused for any
+  device that has not asked, the card says to accept only a pairing the user
+  started on that device, and nothing about the id ever reaches a shell.
 - Whether file-send should accept drops onto the drop shelf
   (`modules/imi/dropShelf/`), which already handles mid-drag interaction.
 

--- a/dots/.config/quickshell/imi/PhoneConnectDialogRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/PhoneConnectDialogRuntimeTest.qml
@@ -1,0 +1,267 @@
+import QtQuick
+import QtTest
+import Quickshell
+import qs
+import qs.services
+import qs.modules.common
+import qs.modules.common.widgets
+import qs.modules.imi.sidebarRight.phoneConnect
+
+/**
+ * Builds the REAL phone dialog over the REAL services/PhoneConnect.qml,
+ * fed by a fake `busctl` on PATH, and reads the surface back: which device
+ * the chip names, what the pills say, how many action buttons there are and
+ * whether they answer, which child of the column owns the leftover height,
+ * and what the pairing card does when its two buttons are clicked.
+ *
+ * Driven by tests/test_phone_connect_dialog_runtime.py, which reads the
+ * fake's recorded invocations afterwards: the two pairing clicks are scored
+ * there, as `acceptPairing`/`cancelPairing` argv aimed at the device that
+ * asked and never at the paired phone.
+ *
+ * The fake daemon exposes two devices - a paired, reachable phone with a
+ * battery, an address and an LTE report, and an unpaired laptop whose
+ * pairState says the peer asked (2) and which has no battery or report leaf
+ * at all - so every branch of the surface is on screen at once.
+ *
+ *   PATH=<dir with fake busctl>:$PATH qs -p PhoneConnectDialogRuntimeTest.qml
+ */
+ShellRoot {
+    id: harness
+
+    property int failures: 0
+    property int checksRun: 0
+    property int elapsed: 0
+
+    readonly property string phoneId: Quickshell.env("PHONE_ID") ?? ""
+    readonly property string laptopId: Quickshell.env("LAPTOP_ID") ?? ""
+    readonly property string expectAddress: Quickshell.env("PHONE_EXPECT_ADDRESS") ?? ""
+    readonly property string expectLaptopAddress: Quickshell.env("LAPTOP_EXPECT_ADDRESS") ?? ""
+
+    function check(label, ok) {
+        harness.checksRun++;
+        console.log(`[PhoneConnectDialog] ${label}: ${ok ? "ok" : "FAIL"}`);
+        if (!ok)
+            harness.failures++;
+    }
+
+    function typeName(obj) {
+        return `${obj}`.split("(")[0].split("_QML")[0].trim();
+    }
+
+    function findAll(item, type, out) {
+        for (const child of item.children) {
+            if (harness.typeName(child) === type)
+                out.push(child);
+            harness.findAll(child, type, out);
+        }
+        return out;
+    }
+
+    function all(type) {
+        return harness.findAll(loader.item, type, []);
+    }
+
+    function first(type) {
+        return harness.all(type)[0] ?? null;
+    }
+
+    function badge(label) {
+        return harness.all("Badge").find(b => b.label === label) ?? null;
+    }
+
+    function dialogButton(label) {
+        return harness.all("DialogButton").find(b => b.buttonText === label) ?? null;
+    }
+
+    function click(item) {
+        const centre = item.mapToItem(loader.item, item.width / 2, item.height / 2);
+        driver.mouseClick(loader.item, centre.x, centre.y, Qt.LeftButton);
+    }
+
+    // The dialog's content column: the one ColumnLayout whose children
+    // include the notification area.
+    function contentColumn() {
+        const area = harness.first("PhoneConnectNotificationArea");
+        return area ? area.parent : null;
+    }
+
+    FloatingWindow {
+        id: window
+        visible: true
+        implicitWidth: 500
+        implicitHeight: 800
+        color: "black"
+
+        TestCase {
+            id: driver
+            when: false
+            name: "PhoneConnectDialogDriver"
+        }
+
+        Loader {
+            id: loader
+            anchors.fill: parent
+            active: false
+            sourceComponent: PhoneConnectDialog {}
+        }
+    }
+
+    Component.onCompleted: {
+        // A singleton is constructed on first use; this read starts the
+        // presence probe and the first sweep.
+        console.log(`[PhoneConnectDialog] service constructed, installed=${PhoneConnect.installed}`);
+    }
+
+    Timer {
+        id: waitForReady
+        interval: 250
+        repeat: true
+        running: true
+        onTriggered: {
+            harness.elapsed += waitForReady.interval;
+            if (!Config.ready || !PhoneConnect.installed || PhoneConnect.devices.length !== 2) {
+                if (harness.elapsed >= 30000) {
+                    harness.check(`Config ready, busctl found and both devices swept (got ${PhoneConnect.devices.length})`, false);
+                    harness.finish();
+                }
+                return;
+            }
+            waitForReady.running = false;
+            steps.running = true;
+        }
+    }
+
+    function finish() {
+        console.log(`[PhoneConnectDialog] checks: ${harness.checksRun} failures: ${harness.failures}`);
+        Qt.exit(harness.failures === 0 ? 0 : 1);
+    }
+
+    property var stepList: [
+        () => {
+            loader.active = true;
+            loader.item.show = true;
+        },
+
+        // ---- the chip and its pills read the active phone ---------------
+        () => {
+            const chip = harness.first("PhoneConnectDeviceChip");
+            harness.check(`the chip names the paired phone, got ${chip?.device?.name}`,
+                          chip !== null && chip.device?.id === harness.phoneId);
+            const address = harness.badge(harness.expectAddress);
+            harness.check(`the connection pill carries the phone's address ${harness.expectAddress}`,
+                          address !== null && address.visible);
+            const battery = harness.badge("85%");
+            harness.check("the battery pill carries the phone's charge",
+                          battery !== null && battery.visible);
+            const cellular = harness.badge("LTE");
+            harness.check("the cellular pill carries the report's network type",
+                          cellular !== null && cellular.visible);
+        },
+
+        // ---- one row of the three model actions, live for a paired phone --
+        () => {
+            const buttons = harness.all("PhoneConnectActionButton");
+            harness.check(`one action row of three buttons, got ${buttons.length}`, buttons.length === 3);
+            harness.check("every action answers for a paired, reachable phone",
+                          buttons.length === 3 && buttons.every(b => b.enabled && b.visible));
+            const rows = new Set(buttons.map(b => b.parent));
+            harness.check("the three sit in one row", rows.size === 1);
+        },
+
+        // ---- the notification area owns the leftover height --------------
+        () => {
+            const area = harness.first("PhoneConnectNotificationArea");
+            const chip = harness.first("PhoneConnectDeviceChip");
+            const action = harness.first("PhoneConnectActionButton");
+            console.log(`[PhoneConnectDialog] area=${area?.height} chip=${chip?.height} action=${action?.height}`);
+            harness.check("the notification area stands taller than the fixed rows around it",
+                          area !== null && area.height > chip.height && area.height > action.height);
+            const empty = harness.findAll(area, "StyledText", []).filter(t => t.visible);
+            harness.check("and it draws a real empty state rather than nothing",
+                          empty.length >= 1 && harness.findAll(area, "MaterialSymbol", []).some(s => s.visible));
+        },
+
+        // ---- the pairing card, for the device that asked ------------------
+        () => {
+            const cards = harness.all("PhoneConnectPairingCard");
+            harness.check(`one pairing card, for the laptop, got ${cards.length}`,
+                          cards.length === 1 && cards[0].device?.id === harness.laptopId);
+            const accept = harness.dialogButton("Accept");
+            const decline = harness.dialogButton("Decline");
+            harness.check("Accept is the filled action and Decline the outlined one",
+                          accept !== null && decline !== null
+                          && accept.dialogActionFilled && !accept.outlined
+                          && decline.outlined && !decline.dialogActionFilled);
+        },
+        () => harness.click(harness.dialogButton("Accept")),
+        () => harness.click(harness.dialogButton("Decline")),
+
+        // ---- the roster, behind the chip's arrow --------------------------
+        () => {
+            harness.check("the roster is folded until the chip is opened",
+                          harness.all("PhoneConnectDeviceItem").filter(i => i.visible).length === 0);
+            harness.click(harness.first("PhoneConnectDeviceChip"));
+        },
+        () => {
+            const rows = harness.all("PhoneConnectDeviceItem").filter(i => i.visible);
+            harness.check(`opening the chip lists both devices, got ${rows.length}`, rows.length === 2);
+            const laptop = rows.find(r => r.device?.id === harness.laptopId) ?? null;
+            if (laptop) harness.click(laptop);
+        },
+        () => {
+            const chip = harness.first("PhoneConnectDeviceChip");
+            harness.check(`picking a row shows that device on the chip, got ${chip?.device?.name}`,
+                          chip?.device?.id === harness.laptopId);
+            const buttons = harness.all("PhoneConnectActionButton");
+            harness.check("the actions stand down for a device that is not paired",
+                          buttons.length === 3 && buttons.every(b => !b.enabled));
+            harness.check("the connection pill follows the shown device",
+                          harness.badge(harness.expectLaptopAddress) !== null
+                          && harness.badge(harness.expectAddress) === null);
+            harness.check("a device without a battery has no battery pill",
+                          harness.badge("85%") === null);
+        },
+
+        // ---- what the area owns is what is LEFT: take a card away and it
+        // grows by exactly that card. Driven through the model, since the
+        // fake daemon is stateless; the poll is seeded far out so a sweep
+        // cannot put the card back between the two reads. -----------------
+        () => {
+            const area = harness.first("PhoneConnectNotificationArea");
+            const card = harness.first("PhoneConnectPairingCard");
+            harness.areaWithCard = area.height;
+            harness.cardHeight = card.height;
+            harness.columnSpacing = harness.contentColumn().spacing;
+            PhoneConnect.applyDevices(PhoneConnect.devices.map(d => Object.assign({}, d, { hasPairingRequest: false })));
+        },
+        () => {
+            const area = harness.first("PhoneConnectNotificationArea");
+            const cards = harness.all("PhoneConnectPairingCard");
+            const grewBy = area.height - harness.areaWithCard;
+            console.log(`[PhoneConnectDialog] cards=${cards.length} area ${harness.areaWithCard} -> ${area.height}`
+                        + ` (+${grewBy}; card was ${harness.cardHeight}, spacing ${harness.columnSpacing})`);
+            harness.check("answering the request takes its card off the stack", cards.length === 0);
+            harness.check("and the notification area grows by exactly the card it no longer shares the column with",
+                          grewBy === harness.cardHeight + harness.columnSpacing);
+        },
+
+        () => harness.finish()
+    ]
+
+    property real areaWithCard: 0
+    property real cardHeight: 0
+    property real columnSpacing: 0
+
+    property int stepIndex: 0
+    Timer {
+        id: steps
+        interval: 500
+        repeat: true
+        onTriggered: {
+            if (harness.stepIndex >= harness.stepList.length)
+                return;
+            harness.stepList[harness.stepIndex++]();
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/PhoneConnectMonitorRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/PhoneConnectMonitorRuntimeTest.qml
@@ -21,8 +21,9 @@ import qs.services
  * that never worked.
  *
  * What each case pins:
- * - stream: the monitor comes up for KDE Connect and a battery change
- *   arrives from the signal rather than from the timer.
+ * - stream: the monitor comes up for KDE Connect, the model carries the
+ *   device's reachable address and its cellular report off the sweep, and a
+ *   battery change arrives from the signal rather than from the timer.
  * - crash: a busctl that exits immediately - the shape CONTRIBUTING.md
  *   forbids answering with a `running` binding - is retried a bounded number
  *   of times and then given up on, with the poll still populating the model.
@@ -44,6 +45,8 @@ ShellRoot {
     readonly property string expectBackend: Quickshell.env("PHONE_EXPECT_BACKEND") ?? "none"
     readonly property string expectMonitor: Quickshell.env("PHONE_EXPECT_MONITOR") ?? "idle"
     readonly property int expectCharge: Number(Quickshell.env("PHONE_EXPECT_CHARGE") ?? "-1")
+    readonly property string expectAddress: Quickshell.env("PHONE_EXPECT_ADDRESS") ?? ""
+    readonly property string expectCellular: Quickshell.env("PHONE_EXPECT_CELLULAR") ?? ""
     readonly property int settleMs: Number(Quickshell.env("PHONE_SETTLE_MS") ?? "6000")
 
     function check(label, ok) {
@@ -111,6 +114,14 @@ ShellRoot {
             harness.check("the device is reachable and paired", (device?.reachable ?? false) && (device?.paired ?? false));
             harness.check(`battery charge is ${harness.expectCharge}, got ${device?.batteryCharge}`,
                           (device?.batteryCharge ?? -99) === harness.expectCharge);
+            if (harness.expectBackend === "kdeconnect") {
+                // The sweep's two slice-2 reads: the device's own
+                // reachableAddresses and the connectivity_report leaf.
+                harness.check(`reachable address is ${harness.expectAddress}, got ${device?.reachableAddresses?.[0]}`,
+                              (device?.reachableAddresses?.[0] ?? "") === harness.expectAddress);
+                harness.check(`cellular type is ${harness.expectCellular}, got ${device?.cellularNetworkType}`,
+                              (device?.cellularNetworkType ?? "") === harness.expectCellular);
+            }
             harness.finish();
         }
     }

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/phoneConnect/PhoneConnectActionButton.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/phoneConnect/PhoneConnectActionButton.qml
@@ -1,0 +1,35 @@
+import qs.modules.common
+import qs.modules.common.widgets
+import QtQuick
+
+/**
+ * One round action on the phone panel's action row. The row is the fork's
+ * shape; each button here is an action the service answers, and the
+ * control dims itself while it cannot (RippleButton owns the disabled dim,
+ * so nothing in here repeats it).
+ */
+RippleButton {
+    id: root
+    property string glyph
+    property string label
+
+    implicitWidth: 48
+    implicitHeight: 48
+    buttonRadius: Appearance.rounding.full
+    colBackground: Appearance.colors.colPrimaryContainer
+    colBackgroundHover: Appearance.colors.colPrimaryContainerHover
+    colRipple: Appearance.colors.colPrimaryContainerActive
+
+    contentItem: MaterialSymbol {
+        anchors.centerIn: parent
+        horizontalAlignment: Text.AlignHCenter
+        verticalAlignment: Text.AlignVCenter
+        text: root.glyph
+        iconSize: Appearance.font.pixelSize.huge
+        color: Appearance.colors.colOnPrimaryContainer
+    }
+
+    StyledToolTip {
+        text: root.label
+    }
+}

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/phoneConnect/PhoneConnectDeviceChip.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/phoneConnect/PhoneConnectDeviceChip.qml
@@ -1,0 +1,60 @@
+import qs.modules.common
+import qs.modules.common.widgets
+import QtQuick
+import QtQuick.Layouts
+
+/**
+ * The device the phone panel is about, as a chip: its kind as a glyph, its
+ * name, and an arrow that opens the roster of every device the daemon
+ * knows. With no device at all it still draws, so the panel has somewhere
+ * to say so.
+ */
+RippleButton {
+    id: root
+    property var device: null
+    property bool open: false
+
+    implicitHeight: 36
+    implicitWidth: chipRow.implicitWidth + Appearance.spacing.space300
+    buttonRadius: Appearance.rounding.full
+    colBackground: Appearance.colors.colSecondaryContainer
+    colBackgroundHover: Appearance.colors.colSecondaryContainerHover
+    colRipple: Appearance.colors.colSecondaryContainerActive
+
+    contentItem: RowLayout {
+        id: chipRow
+        anchors.centerIn: parent
+        spacing: Appearance.spacing.space50
+
+        MaterialSymbol {
+            iconSize: Appearance.font.pixelSize.larger
+            color: Appearance.colors.colOnSecondaryContainer
+            text: {
+                switch (root.device?.type ?? "") {
+                case "phone": return "smartphone";
+                case "tablet": return "tablet";
+                case "laptop": return "laptop";
+                case "desktop": return "computer";
+                case "tv": return "tv";
+                case "": return "mobile_off";
+                default: return "devices";
+                }
+            }
+        }
+        StyledText {
+            Layout.maximumWidth: 180
+            elide: Text.ElideRight
+            // A device's name is the phone's own; never markup.
+            textFormat: Text.PlainText
+            font.pixelSize: Appearance.font.pixelSize.small
+            color: Appearance.colors.colOnSecondaryContainer
+            text: root.device ? (root.device.name || root.device.id) : Translation.tr("No device")
+        }
+        MaterialSymbol {
+            visible: root.enabled
+            iconSize: Appearance.font.pixelSize.larger
+            color: Appearance.colors.colOnSecondaryContainer
+            text: root.open ? "expand_less" : "expand_more"
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/phoneConnect/PhoneConnectDeviceChip.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/phoneConnect/PhoneConnectDeviceChip.qml
@@ -1,3 +1,4 @@
+import qs.services
 import qs.modules.common
 import qs.modules.common.widgets
 import QtQuick

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/phoneConnect/PhoneConnectDeviceItem.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/phoneConnect/PhoneConnectDeviceItem.qml
@@ -4,14 +4,17 @@ import qs.modules.common.widgets
 import QtQuick
 import QtQuick.Layouts
 
+/**
+ * One row of the phone panel's roster: a device the daemon knows, its kind
+ * and its state. Clicking it makes that device the one the chip, the pills
+ * and the action row are about; the actions themselves live on the panel's
+ * one action row, not here.
+ */
 DialogListItem {
     id: root
     // Device entry from PhoneConnect.devices.
     required property var device
     readonly property bool online: root.device.paired && root.device.reachable
-
-    active: PhoneConnect.activeDevice !== null && PhoneConnect.activeDevice.id === root.device.id
-    pointingHandCursor: false
 
     contentItem: RowLayout {
         anchors {
@@ -56,6 +59,7 @@ DialogListItem {
                 elide: Text.ElideRight
                 textFormat: Text.PlainText
                 text: {
+                    if (root.device.hasPairingRequest) return Translation.tr("Wants to pair");
                     if (!root.device.paired) return Translation.tr("Not paired");
                     if (!root.device.reachable) return Translation.tr("Paired • Offline");
                     if (root.device.batteryAvailable)
@@ -64,69 +68,6 @@ DialogListItem {
                             : Translation.tr("%1%").arg(root.device.batteryCharge);
                     return Translation.tr("Connected");
                 }
-            }
-        }
-
-        DialogButton {
-            id: ringButton
-            visible: root.online
-            implicitWidth: implicitHeight
-
-            onClicked: PhoneConnect.ring(root.device)
-
-            contentItem: MaterialSymbol {
-                anchors.centerIn: parent
-                horizontalAlignment: Text.AlignHCenter
-                verticalAlignment: Text.AlignVCenter
-                text: "ring_volume"
-                iconSize: Appearance.font.pixelSize.larger
-                color: ringButton.colEnabled
-            }
-
-            StyledToolTip {
-                text: Translation.tr("Ring")
-            }
-        }
-
-        DialogButton {
-            id: pingButton
-            visible: root.online && PhoneConnect.canPing
-            implicitWidth: implicitHeight
-
-            onClicked: PhoneConnect.ping(root.device)
-
-            contentItem: MaterialSymbol {
-                anchors.centerIn: parent
-                horizontalAlignment: Text.AlignHCenter
-                verticalAlignment: Text.AlignVCenter
-                text: "send"
-                iconSize: Appearance.font.pixelSize.larger
-                color: pingButton.colEnabled
-            }
-
-            StyledToolTip {
-                text: Translation.tr("Ping")
-            }
-        }
-
-        DialogButton {
-            id: clipboardButton
-            visible: root.online && PhoneConnect.canSendClipboard
-            implicitWidth: implicitHeight
-
-            onClicked: PhoneConnect.sendClipboard(root.device)
-
-            contentItem: MaterialSymbol {
-                anchors.centerIn: parent
-                horizontalAlignment: Text.AlignHCenter
-                verticalAlignment: Text.AlignVCenter
-                text: "content_paste"
-                iconSize: Appearance.font.pixelSize.larger
-                color: clipboardButton.colEnabled
-            }
-
-            StyledToolTip {
-                text: Translation.tr("Send clipboard")
             }
         }
     }

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/phoneConnect/PhoneConnectDialog.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/phoneConnect/PhoneConnectDialog.qml
@@ -6,9 +6,33 @@ import QtQuick
 import QtQuick.Layouts
 import Quickshell
 
+/**
+ * The phone panel: one device on a chip with its state as pills, one row of
+ * the actions the service answers, the notification area owning whatever
+ * height is left, and the secondary features stacked at the bottom.
+ *
+ * Shaped after the fork's Phone tab (docs/proposals/phone-connect.md, "Prior
+ * art") on the sidebar's own dialog pattern. Its action row carries six
+ * buttons; ours carries the three this model backs - the other three are
+ * scrcpy, a file picker and SFTP, which are drawn nowhere rather than drawn
+ * dead. The roster of every device sits behind the chip's arrow.
+ */
 WindowDialog {
     id: root
-    backgroundHeight: 480
+    backgroundHeight: 600
+
+    // Which device the chip, the pills and the action row are about: the
+    // roster row the user picked, else the active device, else whichever is
+    // first. Session state only - a persisted choice is the proposal's
+    // slice 6.
+    property string pickedDeviceId: ""
+    property bool rosterOpen: false
+    readonly property var shownDevice: PhoneConnect.devices.find(d => d.id === root.pickedDeviceId)
+        ?? PhoneConnect.activeDevice
+        ?? (PhoneConnect.devices[0] ?? null)
+    readonly property bool shownOnline: root.shownDevice !== null
+        && root.shownDevice.paired && root.shownDevice.reachable
+    readonly property string shownAddress: root.shownDevice?.reachableAddresses?.[0] ?? ""
 
     RowLayout {
         Layout.fillWidth: true
@@ -41,38 +65,116 @@ WindowDialog {
         }
     }
     WindowDialogSeparator {}
-    ListView {
-        Layout.fillHeight: true
+
+    // ---- the device, and its state as pills ----
+    Flow {
         Layout.fillWidth: true
-        Layout.topMargin: -Appearance.spacing.space200
-        Layout.bottomMargin: -Appearance.spacing.space200
+        spacing: Appearance.spacing.space100
+
+        PhoneConnectDeviceChip {
+            id: deviceChip
+            device: root.shownDevice
+            open: root.rosterOpen
+            enabled: PhoneConnect.devices.length > 0
+            onClicked: root.rosterOpen = !root.rosterOpen
+        }
+        Badge {
+            id: connectionPill
+            visible: root.shownDevice !== null
+            badgeIcon: root.shownDevice?.reachable ? "wifi" : "wifi_off"
+            label: !root.shownDevice?.reachable
+                ? Translation.tr("Offline")
+                : (root.shownAddress || Translation.tr("Connected"))
+        }
+        Badge {
+            id: batteryPill
+            visible: root.shownDevice?.batteryAvailable ?? false
+            badgeIcon: root.shownDevice?.batteryCharging ? "battery_charging_full" : "battery_full"
+            label: `${root.shownDevice?.batteryCharge ?? 0}%`
+        }
+        Badge {
+            id: cellularPill
+            visible: (root.shownDevice?.cellularNetworkType ?? "") !== ""
+            badgeIcon: "signal_cellular_alt"
+            label: root.shownDevice?.cellularNetworkType ?? ""
+        }
+    }
+
+    // ---- the roster, behind the chip's arrow ----
+    ColumnLayout {
+        id: roster
+        visible: root.rosterOpen
+        Layout.fillWidth: true
         Layout.leftMargin: -root.contentPadding
         Layout.rightMargin: -root.contentPadding
-
-        clip: true
         spacing: 0
 
-        model: ScriptModel {
-            values: PhoneConnect.devices
+        Repeater {
+            model: ScriptModel {
+                values: PhoneConnect.devices
+            }
+            delegate: PhoneConnectDeviceItem {
+                required property var modelData
+                device: modelData
+                Layout.fillWidth: true
+                active: root.shownDevice !== null && root.shownDevice.id === modelData.id
+                onClicked: {
+                    root.pickedDeviceId = modelData.id;
+                    root.rosterOpen = false;
+                }
+            }
         }
-        delegate: PhoneConnectDeviceItem {
+    }
+
+    // ---- one row of the actions the model answers ----
+    RowLayout {
+        id: actionRow
+        Layout.alignment: Qt.AlignHCenter
+        spacing: Appearance.spacing.space150
+
+        PhoneConnectActionButton {
+            id: ringButton
+            glyph: "ring_volume"
+            label: Translation.tr("Ring")
+            enabled: root.shownOnline
+            onClicked: PhoneConnect.ring(root.shownDevice)
+        }
+        PhoneConnectActionButton {
+            id: pingButton
+            glyph: "send"
+            label: Translation.tr("Ping")
+            visible: PhoneConnect.canPing
+            enabled: root.shownOnline
+            onClicked: PhoneConnect.ping(root.shownDevice)
+        }
+        PhoneConnectActionButton {
+            id: clipboardButton
+            glyph: "content_paste"
+            label: Translation.tr("Send clipboard")
+            visible: PhoneConnect.canSendClipboard
+            enabled: root.shownOnline
+            onClicked: PhoneConnect.sendClipboard(root.shownDevice)
+        }
+    }
+
+    // ---- the notification area owns what is left ----
+    PhoneConnectNotificationArea {
+        Layout.fillWidth: true
+        Layout.fillHeight: true
+    }
+
+    // ---- the bottom stack: secondary features as cards ----
+    Repeater {
+        model: ScriptModel {
+            values: PhoneConnect.pairingRequests
+        }
+        delegate: PhoneConnectPairingCard {
             required property var modelData
             device: modelData
-            width: ListView.view.width
+            Layout.fillWidth: true
         }
     }
-    StyledText {
-        visible: PhoneConnect.devices.length === 0
-        Layout.fillWidth: true
-        wrapMode: Text.WordWrap
-        color: Appearance.colors.colSubtext
-        font.pixelSize: Appearance.font.pixelSize.small
-        text: !PhoneConnect.installed
-            ? Translation.tr("busctl was not found on PATH")
-            : !PhoneConnect.available
-                ? Translation.tr("Neither KDE Connect nor Valent is running")
-                : Translation.tr("No devices yet — pair your phone from KDE Connect or Valent")
-    }
+
     WindowDialogSeparator {}
     WindowDialogButtonRow {
         StyledText {

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/phoneConnect/PhoneConnectNotificationArea.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/phoneConnect/PhoneConnectNotificationArea.qml
@@ -1,0 +1,61 @@
+import qs.services
+import qs.modules.common
+import qs.modules.common.widgets
+import QtQuick
+import QtQuick.Layouts
+
+/**
+ * The part of the phone panel that owns whatever height the rows above and
+ * below it leave. It will hold the phone's mirrored notifications
+ * (docs/proposals/phone-connect.md, slice 1 of "Next slices"); until then it
+ * is an empty state that says what it is for - and, while the panel has no
+ * device to show, why.
+ */
+Item {
+    id: root
+
+    readonly property string headline: {
+        if (!PhoneConnect.installed) return Translation.tr("busctl was not found");
+        if (!PhoneConnect.available) return Translation.tr("No phone daemon is running");
+        if (PhoneConnect.devices.length === 0) return Translation.tr("No devices yet");
+        return Translation.tr("No notifications");
+    }
+    readonly property string detail: {
+        if (!PhoneConnect.installed) return Translation.tr("Phone Connect drives KDE Connect and Valent over D-Bus through busctl, which ships with systemd.");
+        if (!PhoneConnect.available) return Translation.tr("Start KDE Connect or Valent to see your phone here.");
+        if (PhoneConnect.devices.length === 0) return Translation.tr("Pair your phone from KDE Connect or Valent and it will appear here.");
+        return Translation.tr("Your phone's notifications are not mirrored yet.");
+    }
+
+    implicitHeight: emptyState.implicitHeight
+
+    ColumnLayout {
+        id: emptyState
+        anchors.centerIn: parent
+        width: parent.width
+        spacing: Appearance.spacing.space100
+
+        MaterialSymbol {
+            Layout.alignment: Qt.AlignHCenter
+            iconSize: 40
+            color: Appearance.colors.colSubtext
+            text: PhoneConnect.devices.length === 0 ? "mobile_off" : "notifications_off"
+        }
+        StyledText {
+            Layout.fillWidth: true
+            horizontalAlignment: Text.AlignHCenter
+            wrapMode: Text.WordWrap
+            color: Appearance.colors.colOnSurfaceVariant
+            font.pixelSize: Appearance.font.pixelSize.normal
+            text: root.headline
+        }
+        StyledText {
+            Layout.fillWidth: true
+            horizontalAlignment: Text.AlignHCenter
+            wrapMode: Text.WordWrap
+            color: Appearance.colors.colSubtext
+            font.pixelSize: Appearance.font.pixelSize.small
+            text: root.detail
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/phoneConnect/PhoneConnectPairingCard.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/phoneConnect/PhoneConnectPairingCard.qml
@@ -1,0 +1,82 @@
+import qs.services
+import qs.modules.common
+import qs.modules.common.widgets
+import QtQuick
+import QtQuick.Layouts
+
+/**
+ * A peer's pairing request, as a card in the phone panel's bottom stack,
+ * with the two answers the daemon takes. The buttons sit in a
+ * WindowDialogButtonRow so the filled-confirm / outlined-dismiss rule is
+ * the row's to derive, not this card's to spell.
+ */
+Rectangle {
+    id: root
+    property var device: null
+
+    implicitHeight: cardColumn.implicitHeight + Appearance.spacing.space200 * 2
+    radius: Appearance.rounding.normal
+    color: Appearance.colors.colLayer2
+
+    ColumnLayout {
+        id: cardColumn
+        anchors {
+            fill: parent
+            margins: Appearance.spacing.space200
+        }
+        spacing: Appearance.spacing.space100
+
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: Appearance.spacing.space150
+
+            MaterialSymbol {
+                text: "handshake"
+                iconSize: Appearance.font.pixelSize.huge
+                color: Appearance.colors.colPrimary
+            }
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: 0
+
+                StyledText {
+                    Layout.fillWidth: true
+                    elide: Text.ElideRight
+                    // The peer's name is the peer's own; never markup.
+                    textFormat: Text.PlainText
+                    color: Appearance.colors.colOnLayer2
+                    text: Translation.tr("%1 wants to pair").arg(root.device?.name || root.device?.id || "")
+                }
+                StyledText {
+                    Layout.fillWidth: true
+                    wrapMode: Text.WordWrap
+                    color: Appearance.colors.colSubtext
+                    font.pixelSize: Appearance.font.pixelSize.smaller
+                    text: Translation.tr("Accept only if you started this from that device.")
+                }
+            }
+        }
+
+        WindowDialogButtonRow {
+            Layout.fillWidth: true
+
+            Item {
+                Layout.fillWidth: true
+            }
+            DialogButton {
+                id: declineButton
+                buttonText: Translation.tr("Decline")
+                onClicked: PhoneConnect.cancelPairing(root.device)
+            }
+            DialogButton {
+                id: acceptButton
+                buttonText: Translation.tr("Accept")
+                colBackground: Appearance.colors.colPrimary
+                colBackgroundHover: Appearance.colors.colPrimaryHover
+                colRipple: Appearance.colors.colPrimaryActive
+                colEnabled: Appearance.colors.colOnPrimary
+                onClicked: PhoneConnect.acceptPairing(root.device)
+            }
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/services/PhoneConnect.qml
+++ b/dots/.config/quickshell/imi/services/PhoneConnect.qml
@@ -49,7 +49,9 @@ Singleton {
     property bool installed: false // busctl found on PATH
     property string backend: "none" // "kdeconnect" | "valent" | "none"
     readonly property bool available: root.backend !== "none"
-    // [{ id, name, type, reachable, paired, batteryAvailable, batteryCharge, batteryCharging }]
+    // [{ id, name, type, reachable, paired, reachableAddresses,
+    //    cellularNetworkType, cellularNetworkStrength,
+    //    batteryAvailable, batteryCharge, batteryCharging }]
     property var devices: []
 
     readonly property var activeDevice: root.devices.find(d => d.paired && d.reachable && d.type === "phone")
@@ -101,18 +103,26 @@ Singleton {
     }
 
     // Normalizes one org.kde.kdeconnect.device GetAll reply (plus its
-    // battery GetAll, or null when the battery object does not exist - it is
-    // absent for unpaired devices) onto the shared device model.
-    function normalizeKdeconnectDevice(id: string, rawProps: var, rawBatteryProps: var): var {
+    // battery GetAll and its connectivity_report GetAll, either null when
+    // that leaf object does not exist - both are absent for unpaired
+    // devices) onto the shared device model.
+    function normalizeKdeconnectDevice(id: string, rawProps: var, rawBatteryProps: var, rawConnectivityProps: var): var {
         const props = root.unwrapVariants(rawProps);
         const battery = rawBatteryProps === null || rawBatteryProps === undefined
             ? null : root.unwrapVariants(rawBatteryProps);
+        const report = rawConnectivityProps === null || rawConnectivityProps === undefined
+            ? null : root.unwrapVariants(rawConnectivityProps);
+        const addresses = Array.isArray(props.reachableAddresses)
+            ? props.reachableAddresses.filter(address => typeof address === "string") : [];
         return {
             id: id,
             name: props.name ?? "",
             type: props.type ?? "",
             reachable: props.isReachable === true,
             paired: props.isPaired === true,
+            reachableAddresses: addresses,
+            cellularNetworkType: typeof report?.cellularNetworkType === "string" ? report.cellularNetworkType : "",
+            cellularNetworkStrength: typeof report?.cellularNetworkStrength === "number" ? report.cellularNetworkStrength : -1,
             batteryAvailable: battery !== null && typeof battery.charge === "number",
             batteryCharge: (battery !== null && typeof battery.charge === "number") ? battery.charge : -1,
             batteryCharging: battery !== null && battery.isCharging === true
@@ -135,6 +145,9 @@ Singleton {
                 type: props.Type ?? "",
                 reachable: (state & 1) !== 0,
                 paired: (state & 2) !== 0,
+                reachableAddresses: [],
+                cellularNetworkType: "",
+                cellularNetworkStrength: -1,
                 objectPath: path,
                 batteryAvailable: false,
                 batteryCharge: -1,
@@ -224,7 +237,8 @@ Singleton {
                 "deviceVisibilityChanged", "pairingRequestsChanged"],
             "org.kde.kdeconnect.device": ["reachableChanged", "pairStateChanged", "nameChanged",
                 "typeChanged", "pluginsChanged"],
-            "org.kde.kdeconnect.device.battery": ["refreshed"]
+            "org.kde.kdeconnect.device.battery": ["refreshed"],
+            "org.kde.kdeconnect.device.connectivity_report": ["refreshed"]
         }[signal.iface];
         return Array.isArray(members) && members.includes(signal.member);
     }
@@ -305,8 +319,15 @@ Singleton {
             // failed GetAll parses to null and normalization degrades cleanly.
             root.enqueue(root.busctlCall("org.kde.kdeconnect.daemon", devicePath + "/battery", "org.freedesktop.DBus.Properties", "GetAll", ["s", "org.kde.kdeconnect.device.battery"]), batteryText => {
                 const batteryData = root.parseBusctlReply(batteryText);
-                collected.push(root.normalizeKdeconnectDevice(id, propsData?.[0] ?? {}, batteryData?.[0] ?? null));
-                if (collected.length === total) root.applyDevices(collected);
+                // At the report's OWN leaf path. Naming its interface on the
+                // device path is not an error: Qt's adaptor answers with every
+                // property of the device, which parses as a report with no
+                // cellular fields in it (measured against the live daemon).
+                root.enqueue(root.busctlCall("org.kde.kdeconnect.daemon", devicePath + "/connectivity_report", "org.freedesktop.DBus.Properties", "GetAll", ["s", "org.kde.kdeconnect.device.connectivity_report"]), connText => {
+                    const connData = root.parseBusctlReply(connText);
+                    collected.push(root.normalizeKdeconnectDevice(id, propsData?.[0] ?? {}, batteryData?.[0] ?? null, connData?.[0] ?? null));
+                    if (collected.length === total) root.applyDevices(collected);
+                });
             });
         });
     }

--- a/dots/.config/quickshell/imi/services/PhoneConnect.qml
+++ b/dots/.config/quickshell/imi/services/PhoneConnect.qml
@@ -49,10 +49,13 @@ Singleton {
     property bool installed: false // busctl found on PATH
     property string backend: "none" // "kdeconnect" | "valent" | "none"
     readonly property bool available: root.backend !== "none"
-    // [{ id, name, type, reachable, paired, reachableAddresses,
+    // [{ id, name, type, reachable, paired, hasPairingRequest, reachableAddresses,
     //    cellularNetworkType, cellularNetworkStrength,
     //    batteryAvailable, batteryCharge, batteryCharging }]
     property var devices: []
+    // The devices whose peer has asked to pair - what the dialog's pairing
+    // cards are drawn from.
+    readonly property var pairingRequests: root.devices.filter(d => d.hasPairingRequest === true)
 
     readonly property var activeDevice: root.devices.find(d => d.paired && d.reachable && d.type === "phone")
         ?? root.devices.find(d => d.paired && d.reachable)
@@ -106,6 +109,10 @@ Singleton {
     // battery GetAll and its connectivity_report GetAll, either null when
     // that leaf object does not exist - both are absent for unpaired
     // devices) onto the shared device model.
+    //
+    // A pairing request is Device::PairState 2 (RequestedByPeer; 1 is a
+    // request WE made, 3 is Paired) or the older isPairRequestedByPeer bool
+    // - both were read off the live daemon, and either spelling counts.
     function normalizeKdeconnectDevice(id: string, rawProps: var, rawBatteryProps: var, rawConnectivityProps: var): var {
         const props = root.unwrapVariants(rawProps);
         const battery = rawBatteryProps === null || rawBatteryProps === undefined
@@ -120,6 +127,7 @@ Singleton {
             type: props.type ?? "",
             reachable: props.isReachable === true,
             paired: props.isPaired === true,
+            hasPairingRequest: props.isPairRequestedByPeer === true || props.pairState === 2,
             reachableAddresses: addresses,
             cellularNetworkType: typeof report?.cellularNetworkType === "string" ? report.cellularNetworkType : "",
             cellularNetworkStrength: typeof report?.cellularNetworkStrength === "number" ? report.cellularNetworkStrength : -1,
@@ -145,6 +153,7 @@ Singleton {
                 type: props.Type ?? "",
                 reachable: (state & 1) !== 0,
                 paired: (state & 2) !== 0,
+                hasPairingRequest: false,
                 reachableAddresses: [],
                 cellularNetworkType: "",
                 cellularNetworkStrength: -1,
@@ -483,6 +492,22 @@ Singleton {
         const d = device ?? root.activeDevice;
         if (!d || root.backend !== "kdeconnect" || !root.validDeviceId(d.id)) return;
         root.runAction(root.busctlCall("org.kde.kdeconnect.daemon", `/modules/kdeconnect/devices/${d.id}/clipboard`, "org.kde.kdeconnect.device.clipboard", "sendClipboard", []));
+    }
+
+    // Both answer a request the PEER made, so neither falls back to the
+    // active device the way the actions above do: that device is the paired
+    // phone, which never asked, and cancelPairing aimed at it is at best a
+    // no-op the daemon logs. A device without a request is refused.
+    function acceptPairing(device: var): void {
+        const d = device ?? null;
+        if (!d || !d.hasPairingRequest || root.backend !== "kdeconnect" || !root.validDeviceId(d.id)) return;
+        root.runAction(root.busctlCall("org.kde.kdeconnect.daemon", `/modules/kdeconnect/devices/${d.id}`, "org.kde.kdeconnect.device", "acceptPairing", []));
+    }
+
+    function cancelPairing(device: var): void {
+        const d = device ?? null;
+        if (!d || !d.hasPairingRequest || root.backend !== "kdeconnect" || !root.validDeviceId(d.id)) return;
+        root.runAction(root.busctlCall("org.kde.kdeconnect.daemon", `/modules/kdeconnect/devices/${d.id}`, "org.kde.kdeconnect.device", "cancelPairing", []));
     }
 
     function runAction(argv: var): void {

--- a/dots/.config/quickshell/imi/tests/imports/testservices/PhoneConnect.qml
+++ b/dots/.config/quickshell/imi/tests/imports/testservices/PhoneConnect.qml
@@ -14,10 +14,13 @@ Singleton {
     property bool installed: false // busctl found on PATH
     property string backend: "none" // "kdeconnect" | "valent" | "none"
     readonly property bool available: root.backend !== "none"
-    // [{ id, name, type, reachable, paired, reachableAddresses,
+    // [{ id, name, type, reachable, paired, hasPairingRequest, reachableAddresses,
     //    cellularNetworkType, cellularNetworkStrength,
     //    batteryAvailable, batteryCharge, batteryCharging }]
     property var devices: []
+    // The devices whose peer has asked to pair - what the dialog's pairing
+    // cards are drawn from.
+    readonly property var pairingRequests: root.devices.filter(d => d.hasPairingRequest === true)
 
     readonly property var activeDevice: root.devices.find(d => d.paired && d.reachable && d.type === "phone")
         ?? root.devices.find(d => d.paired && d.reachable)
@@ -66,6 +69,10 @@ Singleton {
     // battery GetAll and its connectivity_report GetAll, either null when
     // that leaf object does not exist - both are absent for unpaired
     // devices) onto the shared device model.
+    //
+    // A pairing request is Device::PairState 2 (RequestedByPeer; 1 is a
+    // request WE made, 3 is Paired) or the older isPairRequestedByPeer bool
+    // - both were read off the live daemon, and either spelling counts.
     function normalizeKdeconnectDevice(id: string, rawProps: var, rawBatteryProps: var, rawConnectivityProps: var): var {
         const props = root.unwrapVariants(rawProps);
         const battery = rawBatteryProps === null || rawBatteryProps === undefined
@@ -80,6 +87,7 @@ Singleton {
             type: props.type ?? "",
             reachable: props.isReachable === true,
             paired: props.isPaired === true,
+            hasPairingRequest: props.isPairRequestedByPeer === true || props.pairState === 2,
             reachableAddresses: addresses,
             cellularNetworkType: typeof report?.cellularNetworkType === "string" ? report.cellularNetworkType : "",
             cellularNetworkStrength: typeof report?.cellularNetworkStrength === "number" ? report.cellularNetworkStrength : -1,
@@ -105,6 +113,7 @@ Singleton {
                 type: props.Type ?? "",
                 reachable: (state & 1) !== 0,
                 paired: (state & 2) !== 0,
+                hasPairingRequest: false,
                 reachableAddresses: [],
                 cellularNetworkType: "",
                 cellularNetworkStrength: -1,

--- a/dots/.config/quickshell/imi/tests/imports/testservices/PhoneConnect.qml
+++ b/dots/.config/quickshell/imi/tests/imports/testservices/PhoneConnect.qml
@@ -14,7 +14,9 @@ Singleton {
     property bool installed: false // busctl found on PATH
     property string backend: "none" // "kdeconnect" | "valent" | "none"
     readonly property bool available: root.backend !== "none"
-    // [{ id, name, type, reachable, paired, batteryAvailable, batteryCharge, batteryCharging }]
+    // [{ id, name, type, reachable, paired, reachableAddresses,
+    //    cellularNetworkType, cellularNetworkStrength,
+    //    batteryAvailable, batteryCharge, batteryCharging }]
     property var devices: []
 
     readonly property var activeDevice: root.devices.find(d => d.paired && d.reachable && d.type === "phone")
@@ -61,18 +63,26 @@ Singleton {
     }
 
     // Normalizes one org.kde.kdeconnect.device GetAll reply (plus its
-    // battery GetAll, or null when the battery object does not exist - it is
-    // absent for unpaired devices) onto the shared device model.
-    function normalizeKdeconnectDevice(id: string, rawProps: var, rawBatteryProps: var): var {
+    // battery GetAll and its connectivity_report GetAll, either null when
+    // that leaf object does not exist - both are absent for unpaired
+    // devices) onto the shared device model.
+    function normalizeKdeconnectDevice(id: string, rawProps: var, rawBatteryProps: var, rawConnectivityProps: var): var {
         const props = root.unwrapVariants(rawProps);
         const battery = rawBatteryProps === null || rawBatteryProps === undefined
             ? null : root.unwrapVariants(rawBatteryProps);
+        const report = rawConnectivityProps === null || rawConnectivityProps === undefined
+            ? null : root.unwrapVariants(rawConnectivityProps);
+        const addresses = Array.isArray(props.reachableAddresses)
+            ? props.reachableAddresses.filter(address => typeof address === "string") : [];
         return {
             id: id,
             name: props.name ?? "",
             type: props.type ?? "",
             reachable: props.isReachable === true,
             paired: props.isPaired === true,
+            reachableAddresses: addresses,
+            cellularNetworkType: typeof report?.cellularNetworkType === "string" ? report.cellularNetworkType : "",
+            cellularNetworkStrength: typeof report?.cellularNetworkStrength === "number" ? report.cellularNetworkStrength : -1,
             batteryAvailable: battery !== null && typeof battery.charge === "number",
             batteryCharge: (battery !== null && typeof battery.charge === "number") ? battery.charge : -1,
             batteryCharging: battery !== null && battery.isCharging === true
@@ -95,6 +105,9 @@ Singleton {
                 type: props.Type ?? "",
                 reachable: (state & 1) !== 0,
                 paired: (state & 2) !== 0,
+                reachableAddresses: [],
+                cellularNetworkType: "",
+                cellularNetworkStrength: -1,
                 objectPath: path,
                 batteryAvailable: false,
                 batteryCharge: -1,
@@ -184,7 +197,8 @@ Singleton {
                 "deviceVisibilityChanged", "pairingRequestsChanged"],
             "org.kde.kdeconnect.device": ["reachableChanged", "pairStateChanged", "nameChanged",
                 "typeChanged", "pluginsChanged"],
-            "org.kde.kdeconnect.device.battery": ["refreshed"]
+            "org.kde.kdeconnect.device.battery": ["refreshed"],
+            "org.kde.kdeconnect.device.connectivity_report": ["refreshed"]
         }[signal.iface];
         return Array.isArray(members) && members.includes(signal.member);
     }

--- a/dots/.config/quickshell/imi/tests/lint_qml_imports.sh
+++ b/dots/.config/quickshell/imi/tests/lint_qml_imports.sh
@@ -24,6 +24,17 @@
 # well as modules/: the original knew only about Appearance and looked only under
 # modules/, so it missed EfiBoot.qml on both counts.
 #
+#   Translation - the phone panel's roster row was rewritten without
+#                `import qs.services` and kept every `Translation.tr(...)`. Every
+#                static check passed; the runtime harness that builds the real
+#                dialog logged `ReferenceError: Translation is not defined` per
+#                binding. The chip beside it had the same hole behind a ternary
+#                no device-full run evaluates, and this line found it.
+#
+# A file that lives IN the declaring module needs no import - a sibling type is
+# in scope on its own - so a check skips the module's own directory. Without
+# that, `Translation` flags every services/*.qml that translates a string.
+#
 # Adding a singleton to CHECKS costs one line and buys a whole class of silent
 # failure. Exits non-zero and lists offenders.
 
@@ -38,6 +49,7 @@ CHECKS=(
     "Session:qs.modules.common.functions"
     "ColorUtils:qs.modules.common.functions"
     "StringUtils:qs.modules.common.functions"
+    "Translation:qs.services"
 )
 
 # services/ is included deliberately: EfiBoot.qml lives there, not under modules/.
@@ -52,10 +64,19 @@ for check in "${CHECKS[@]}"; do
     # requirement for `qs.modules.common.functions`. Trailing comment allowed;
     # an aliased `... as X` is not.
     module_escaped="${module//./\\.}"
+    # `qs.modules.common.functions` is the directory modules/common/functions;
+    # a file in it sees its siblings without importing them. The module's
+    # dots are turned into slashes BEFORE the root is prefixed - the checkout
+    # can sit under a dotted directory (`dots/.config/`), and turning that dot
+    # into a slash makes the skip match nothing.
+    module_rel="${module#qs.}"
+    module_dir="$PROJECT_ROOT/${module_rel//.//}"
 
     while IFS= read -r -d '' f; do
         # A singleton's own declaration file refers to itself; skip it.
         [[ "$(basename "$f")" == "$singleton.qml" ]] && continue
+        # ...and so does any file declared in the same module.
+        [[ "$(dirname "$f")" == "$module_dir" ]] && continue
         # Match against CODE only. Prose naming a singleton is not a use of it,
         # and a lint that cannot tell the difference gets switched off the first
         # time it fires on a comment explaining why the singleton is not used

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -1589,6 +1589,15 @@ if ! python3 "$SCRIPT_DIR/test_phone_connect_monitor_runtime.py"; then
     exit 1
 fi
 
+# The reshaped phone dialog against the real service and a fake daemon: the
+# chip, the pills, one row of three model actions, the notification area's
+# height, and the pairing card's two clicks read back off the fake's log.
+echo "Running Phone Connect dialog runtime tests..."
+if ! python3 "$SCRIPT_DIR/test_phone_connect_dialog_runtime.py"; then
+    echo "Phone Connect dialog runtime tests failed."
+    exit 1
+fi
+
 echo "Running registry entry validator tests..."
 if ! python3 "$SCRIPT_DIR/test_registry_validate.py"; then
     echo "Registry entry validator tests failed."

--- a/dots/.config/quickshell/imi/tests/test_phone_connect_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_connect_contract.py
@@ -27,6 +27,14 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 SERVICE = ROOT / "services" / "PhoneConnect.qml"
 DOUBLE = ROOT / "tests" / "imports" / "testservices" / "PhoneConnect.qml"
+SURFACE = ROOT / "modules" / "imi" / "sidebarRight" / "phoneConnect"
+DIALOG = SURFACE / "PhoneConnectDialog.qml"
+
+# Everything the sidebar surface may ask the service to DO. The device
+# dialog is shaped after a fork whose action row carries six buttons; ours
+# carries the three this model backs, and a fourth appears here or not at
+# all - a button whose call the service does not answer is a fake action.
+MODEL_ACTIONS = {"refresh", "ring", "ping", "sendClipboard", "acceptPairing", "cancelPairing"}
 
 BEGIN = "// BEGIN phone-connect parser logic"
 END = "    // END phone-connect parser logic"
@@ -328,6 +336,54 @@ def test_signal_bursts_are_coalesced_and_never_dropped():
         r"function handleMonitorLine\(.*?\n    \}", source, re.S).group(0), (
         "monitor lines do not go through the settle timer"
     )
+
+
+# ---- the sidebar surface ----------------------------------------------------
+
+
+def test_the_surface_calls_only_actions_the_model_exposes():
+    called = set()
+    for path in sorted(SURFACE.glob("*.qml")):
+        called |= set(re.findall(r"\bPhoneConnect\.(\w+)\(", path.read_text()))
+    assert called, "the surface calls nothing on the service"
+    assert called <= MODEL_ACTIONS, f"the surface invents actions: {sorted(called - MODEL_ACTIONS)}"
+    declared = set(re.findall(r"^    function (\w+)\(", SERVICE.read_text(), re.M))
+    assert called <= declared, f"the surface calls what the service does not declare: {sorted(called - declared)}"
+
+
+def test_the_dialog_has_one_action_row_of_the_three_model_actions():
+    """ONE row of round action buttons, each a model action, in the fork's
+    order (ring, ping, clipboard) minus the three it backs with scrcpy, a
+    picker and SFTP."""
+    dialog = DIALOG.read_text()
+    assert dialog.count("id: actionRow") == 1, "the dialog must carry exactly one action row"
+    buttons = re.findall(r"PhoneConnectActionButton \{(.*?)\n(?:\s{12}|\s{8})\}", dialog, re.S)
+    assert len(buttons) == 3, f"expected three action buttons, found {len(buttons)}"
+    called = [re.search(r"PhoneConnect\.(\w+)\(", body).group(1) for body in buttons]
+    assert called == ["ring", "ping", "sendClipboard"], called
+
+
+def test_the_pairing_card_answers_through_the_two_device_methods_in_a_button_row():
+    """Accept and Decline are the model's two pairing calls, and they sit in a
+    WindowDialogButtonRow so the filled-confirm / outlined-dismiss rule is
+    derived by the row rather than spelled at the card (the polkit contract
+    refuses an `outlined:` outside the widgets directory for that reason)."""
+    card = (SURFACE / "PhoneConnectPairingCard.qml").read_text()
+    assert "PhoneConnect.acceptPairing(" in card and "PhoneConnect.cancelPairing(" in card
+    assert "WindowDialogButtonRow {" in card, "the two answers must sit in a WindowDialogButtonRow"
+    assert "outlined:" not in card, "the card spells the outline rule for itself"
+
+
+def test_the_notification_area_owns_the_remaining_height():
+    """The area is the one child of the dialog's column that fills, so every
+    other row keeps its own height and the empty state takes what is left -
+    nothing floats in empty space, and nothing else competes for it."""
+    dialog = DIALOG.read_text()
+    fills = [line.strip() for line in dialog.splitlines() if "Layout.fillHeight: true" in line]
+    assert len(fills) == 1, f"expected exactly one fillHeight in the dialog, found {fills}"
+    area = re.search(r"PhoneConnectNotificationArea \{(.*?)\n    \}", dialog, re.S)
+    assert area, "the dialog does not declare a PhoneConnectNotificationArea"
+    assert "Layout.fillHeight: true" in area.group(1), "the notification area does not fill"
 
 
 if __name__ == "__main__":

--- a/dots/.config/quickshell/imi/tests/test_phone_connect_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_connect_contract.py
@@ -51,6 +51,17 @@ def test_parser_region_is_byte_identical_between_service_and_double():
     )
 
 
+def test_the_derived_pairing_request_list_matches_the_double():
+    """`pairingRequests` sits outside the marked region like applyDevices does
+    (it is a binding on `devices`, not parser logic), and the QML suite drives
+    the double's copy - so the two spellings are held to each other."""
+    pattern = r"    readonly property var pairingRequests:.*\n"
+    service_line = re.search(pattern, SERVICE.read_text())
+    double_line = re.search(pattern, DOUBLE.read_text())
+    assert service_line and double_line, "pairingRequests missing on one side"
+    assert service_line.group(0) == double_line.group(0), "pairingRequests drifted"
+
+
 def test_the_kdeconnect_sweep_reads_the_connectivity_report_at_its_own_leaf():
     """The report is a child object (`<device>/connectivity_report`), and the
     path matters more than it reads: measured against the live daemon, a
@@ -65,6 +76,30 @@ def test_the_kdeconnect_sweep_reads_the_connectivity_report_at_its_own_leaf():
     assert 'devicePath + "/connectivity_report"' in calls[0], (
         f"the report must be read at its own leaf path: {calls[0].strip()}"
     )
+
+
+def test_pairing_is_answered_on_the_device_path_with_the_daemon_s_two_methods():
+    """Slice 3's whole transport: acceptPairing/cancelPairing are methods of
+    org.kde.kdeconnect.device on the device path itself (introspected live),
+    not of a plugin leaf, and the id reaches the path as an argument the
+    validator has already passed - never through a shell string."""
+    source = SERVICE.read_text()
+    for name in ("acceptPairing", "cancelPairing"):
+        body = re.search(rf"function {name}\(.*?\n    \}}\n", source, re.S)
+        assert body, f"{name}() missing"
+        text = body.group(0)
+        assert "root.runAction(root.busctlCall(" in text, f"{name}() does not go through runAction"
+        assert f'"org.kde.kdeconnect.device", "{name}", []' in text, (
+            f"{name}() does not call the device interface's {name} method"
+        )
+        assert "`/modules/kdeconnect/devices/${d.id}`" in text, (
+            f"{name}() is aimed at something other than the device path"
+        )
+        # An answer is to a request the peer made. Defaulting to the active
+        # device - the paired phone, which never asked - is the one shape a
+        # copy of ring() would carry here.
+        assert "!d.hasPairingRequest" in text, f"{name}() answers a device that never asked"
+        assert "root.activeDevice" not in text, f"{name}() falls back to the active device"
 
 
 def test_state_application_helpers_match_the_double():
@@ -137,7 +172,7 @@ def test_device_ids_are_validated_before_path_splicing():
         "valent object paths must be validated before DescribeAll is called on them"
     )
     # Actions build paths from ids/paths too - each must re-check.
-    for action in ("ring", "ping", "sendClipboard"):
+    for action in ("ring", "ping", "sendClipboard", "acceptPairing", "cancelPairing"):
         body = re.search(rf"function {action}\(.*?\n    \}}\n", source, re.S)
         assert body, f"{action}() missing"
         assert "validDeviceId" in body.group(0) or "validValentObjectPath" in body.group(0), (

--- a/dots/.config/quickshell/imi/tests/test_phone_connect_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_connect_contract.py
@@ -51,6 +51,22 @@ def test_parser_region_is_byte_identical_between_service_and_double():
     )
 
 
+def test_the_kdeconnect_sweep_reads_the_connectivity_report_at_its_own_leaf():
+    """The report is a child object (`<device>/connectivity_report`), and the
+    path matters more than it reads: measured against the live daemon, a
+    GetAll that names the report's interface on the DEVICE path does not fail
+    - Qt's adaptor answers it with every property of the device - which
+    parses as a report carrying no cellular fields and reads as "unknown" for
+    ever, with nothing in any log."""
+    source = SERVICE.read_text()
+    calls = [line for line in source.splitlines()
+             if "org.kde.kdeconnect.device.connectivity_report" in line and "GetAll" in line]
+    assert len(calls) == 1, f"expected one connectivity_report GetAll, got {calls}"
+    assert 'devicePath + "/connectivity_report"' in calls[0], (
+        f"the report must be read at its own leaf path: {calls[0].strip()}"
+    )
+
+
 def test_state_application_helpers_match_the_double():
     # applyBackend/applyDevices sit outside the marked region (the double's
     # versions are what the QML suite drives), but their semantics are part

--- a/dots/.config/quickshell/imi/tests/test_phone_connect_dialog_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_connect_dialog_runtime.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""The reshaped phone dialog, driven against a fake daemon in a real shell.
+
+`PhoneConnectDialogRuntimeTest.qml` builds the real `PhoneConnectDialog` over
+the real `services/PhoneConnect.qml`, with a fake `busctl` on PATH exposing
+two devices: a paired, reachable phone (battery, address, LTE report) and an
+unpaired laptop whose pairState says the peer asked. The harness reads the
+surface back - the chip, the three pills, one row of three actions, the
+notification area owning the leftover height (measured: take the pairing
+card away and the area grows by exactly that card), the pairing card and the
+roster behind the chip's arrow - and clicks Accept and Decline.
+
+Those two clicks are scored HERE, off the fake's recorded invocations:
+`acceptPairing` and `cancelPairing` must each have been called once, on the
+laptop's device path, and never on the phone's. A click that reached nothing
+would leave the harness green (a button is a button) and this red.
+
+Brings its own headless weston and its own session bus (`dbus-run-session`).
+Skips when weston, qs or dbus-run-session are missing, as in CI.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HARNESS = ROOT / "PhoneConnectDialogRuntimeTest.qml"
+SOCKET = "wayland-imi-phoneconnect-dialog"
+
+PHONE_ID = "6131a746_571a_4176_a007_95625ff8e08e"
+LAPTOP_ID = "3b767a2479954eceaf9f1e7fa212f48e"
+PHONE_ADDRESS = "192.168.100.179"
+LAPTOP_ADDRESS = "192.168.100.99"
+
+# A literal, never read back out of the harness's own output: a step list
+# that shrinks must redden here instead of reporting `failures: 0` for a
+# shorter run.
+EXPECTED_CHECKS = 19
+
+RECORD = """#!/usr/bin/env bash
+printf '%s %s\\n' "$(date +%s.%N)" "$*" >> "$PHONE_EXEC_LOG"
+__BODY__
+"""
+
+# --json=short shapes lifted from a real busctl against a live KDE Connect
+# daemon. The laptop has no battery or connectivity_report leaf, as an
+# unpaired device has not: those GetAlls print nothing, which the service
+# parses to null.
+BUSCTL_BODY = """\
+case "$*" in
+  *"org.freedesktop.DBus ListNames")
+    printf '{"type":"as","data":[[":1.5","org.freedesktop.DBus","org.kde.kdeconnect.daemon"]]}\\n'
+    ;;
+  *"org.kde.kdeconnect.daemon devices bb false false")
+    printf '{"type":"as","data":[["%(laptop)s","%(phone)s"]]}\\n'
+    ;;
+  *"devices/%(phone)s/battery org.freedesktop.DBus.Properties GetAll s org.kde.kdeconnect.device.battery")
+    printf '{"type":"a{sv}","data":[{"charge":{"type":"i","data":85},"hasBattery":{"type":"b","data":true},"isCharging":{"type":"b","data":false}}]}\\n'
+    ;;
+  *"devices/%(phone)s/connectivity_report org.freedesktop.DBus.Properties GetAll s org.kde.kdeconnect.device.connectivity_report")
+    printf '{"type":"a{sv}","data":[{"cellularNetworkStrength":{"type":"i","data":4},"cellularNetworkType":{"type":"s","data":"LTE"},"iconName":{"type":"s","data":"network-mobile-100-lte"}}]}\\n'
+    ;;
+  *"devices/%(phone)s org.freedesktop.DBus.Properties GetAll s org.kde.kdeconnect.device")
+    printf '{"type":"a{sv}","data":[{"name":{"type":"s","data":"Galaxy S23 Ultra"},"type":{"type":"s","data":"phone"},"isPaired":{"type":"b","data":true},"isReachable":{"type":"b","data":true},"isPairRequestedByPeer":{"type":"b","data":false},"pairState":{"type":"i","data":3},"reachableAddresses":{"type":"as","data":["%(phone_address)s"]}}]}\\n'
+    ;;
+  *"devices/%(laptop)s org.freedesktop.DBus.Properties GetAll s org.kde.kdeconnect.device")
+    printf '{"type":"a{sv}","data":[{"name":{"type":"s","data":"rox-xbox-ally-x"},"type":{"type":"s","data":"desktop"},"isPaired":{"type":"b","data":false},"isReachable":{"type":"b","data":true},"isPairRequestedByPeer":{"type":"b","data":true},"pairState":{"type":"i","data":2},"reachableAddresses":{"type":"as","data":["%(laptop_address)s"]}}]}\\n'
+    ;;
+  *monitor*)
+    sleep 3600
+    ;;
+esac
+exit 0
+""" % {"phone": PHONE_ID, "laptop": LAPTOP_ID,
+       "phone_address": PHONE_ADDRESS, "laptop_address": LAPTOP_ADDRESS}
+
+
+def _stop(proc):
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+
+
+def _runtime_available():
+    return all(shutil.which(name) for name in ("qs", "weston", "dbus-run-session"))
+
+
+@unittest.skipUnless(_runtime_available(), "needs qs, weston and dbus-run-session on PATH")
+class PhoneConnectDialogRuntimeTest(unittest.TestCase):
+    def setUp(self):
+        self.home = Path(tempfile.mkdtemp(prefix="imi-phoneconnect-dialog-"))
+        self.addCleanup(shutil.rmtree, self.home, ignore_errors=True)
+        self.exec_log = self.home / "exec.log"
+        self.bin = self.home / "bin"
+        self.bin.mkdir(parents=True)
+        fake = self.bin / "busctl"
+        fake.write_text(RECORD.replace("__BODY__", BUSCTL_BODY))
+        fake.chmod(0o755)
+
+        shell_config = self.home / "config" / "immaterial-impulse"
+        shell_config.mkdir(parents=True)
+        # The poll is ten minutes out: the startup sweep populates the model
+        # (the timer fires on start), and nothing may re-sweep while the
+        # harness takes a pairing card away through the model and measures
+        # what the notification area does with the room.
+        (shell_config / "config.json").write_text(json.dumps({
+            "networking": {"phoneConnect": {"enable": True, "pollInterval": 600000}},
+        }, indent=2))
+
+    def invocations(self):
+        if not self.exec_log.exists():
+            return []
+        return [line.partition(" ")[2] for line in self.exec_log.read_text().splitlines() if line.strip()]
+
+    def test_the_dialog_reads_the_model_and_answers_the_pairing_request(self):
+        env = dict(os.environ)
+        # A runtime dir of the harness's own: everything this test starts talks
+        # to its own weston and can never map a surface on the user's display.
+        runtime = self.home / "runtime"
+        runtime.mkdir(mode=0o700)
+        env["XDG_RUNTIME_DIR"] = str(runtime)
+        env["WAYLAND_DISPLAY"] = SOCKET
+        env.pop("DISPLAY", None)
+        env.pop("HYPRLAND_INSTANCE_SIGNATURE", None)
+
+        weston = subprocess.Popen(
+            ["weston", "--backend=headless", "--renderer=pixman",
+             f"--socket={SOCKET}", "--width=900", "--height=900"],
+            env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        self.addCleanup(_stop, weston)
+
+        socket_path = runtime / SOCKET
+        deadline = time.monotonic() + 15
+        while not socket_path.exists() and time.monotonic() < deadline:
+            time.sleep(0.2)
+        self.assertTrue(socket_path.exists(), "headless weston never came up")
+
+        env["LIBGL_ALWAYS_SOFTWARE"] = "1"
+        env["QT_QUICK_BACKEND"] = "software"
+        env["XDG_CONFIG_HOME"] = str(self.home / "config")
+        env["XDG_STATE_HOME"] = str(self.home / "state")
+        env["XDG_CACHE_HOME"] = str(self.home / "cache")
+        env["XDG_DATA_HOME"] = str(self.home / "data")
+        env["PATH"] = f"{self.bin}{os.pathsep}{env['PATH']}"
+        env["PHONE_EXEC_LOG"] = str(self.exec_log)
+        env["PHONE_ID"] = PHONE_ID
+        env["LAPTOP_ID"] = LAPTOP_ID
+        env["PHONE_EXPECT_ADDRESS"] = PHONE_ADDRESS
+        env["LAPTOP_EXPECT_ADDRESS"] = LAPTOP_ADDRESS
+
+        # dbus-run-session, not the inherited bus: the fake busctl is the only
+        # daemon this harness may see.
+        proc = subprocess.run(
+            ["dbus-run-session", "--", "qs", "-p", str(HARNESS)],
+            cwd=str(ROOT), env=env, capture_output=True, text=True, timeout=240)
+        output = proc.stdout + proc.stderr
+        failed = [line for line in output.splitlines() if "FAIL" in line]
+        self.assertEqual(failed, [], f"harness reported failures:\\n{output}")
+        self.assertIn(f"[PhoneConnectDialog] checks: {EXPECTED_CHECKS} failures: 0", output,
+                      f"harness did not finish cleanly:\\n{output}")
+
+        # The two clicks, scored off what reached the daemon.
+        laptop_path = f"/modules/kdeconnect/devices/{LAPTOP_ID}"
+        pairing = [argv for argv in self.invocations()
+                   if argv.endswith("acceptPairing") or argv.endswith("cancelPairing")]
+        self.assertEqual(
+            [argv.rsplit(" ", 1)[1] for argv in pairing], ["acceptPairing", "cancelPairing"],
+            f"expected one accept then one decline, got {pairing}")
+        for argv in pairing:
+            self.assertIn(f"{laptop_path} org.kde.kdeconnect.device", argv,
+                          f"a pairing answer was aimed away from the device that asked: {argv}")
+            self.assertNotIn(PHONE_ID, argv)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dots/.config/quickshell/imi/tests/test_phone_connect_monitor_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_connect_monitor_runtime.py
@@ -10,8 +10,9 @@ by a `running` binding is a tight respawn loop that starves Quickshell.
 So this drives the real singleton in a real `qs` with a fake `busctl` on PATH
 and reads the spawns back:
 
-- stream: the monitor comes up for KDE Connect, and a battery change reaches
-  the shell from a SIGNAL. That is an oracle rather than an observation
+- stream: the monitor comes up for KDE Connect, the device's reachable
+  address and its connectivity_report reach the model off the sweep's two
+  extra reads, and a battery change reaches the shell from a SIGNAL. That is an oracle rather than an observation
   because the poll interval is seeded at ten minutes for this case - the
   timer cannot deliver the new charge inside the run, so a stream that never
   worked reports the pre-signal value and reddens. (Seeded through
@@ -50,6 +51,12 @@ SOCKET = "wayland-imi-phoneconnect-monitor"
 DEVICE_ID = "6131a746_571a_4176_a007_95625ff8e08e"
 CHARGE_BEFORE = 41
 CHARGE_AFTER = 87
+# What the device's reachableAddresses and its connectivity_report leaf say -
+# the two reads slice 2 added to the sweep, checked back off the model so a
+# sweep that dropped either GetAll (or read the report off the device path,
+# where the daemon answers with something else) reddens here.
+ADDRESS = "192.168.100.179"
+CELLULAR = "LTE"
 
 # The service's own declared ceiling. Read out of the source rather than
 # copied: a check that carries its own copy of the number passes when the
@@ -88,8 +95,15 @@ case "$*" in
   *"GetAll s org.kde.kdeconnect.device.battery")
     printf '{"type":"a{sv}","data":[{"charge":{"type":"i","data":%%s},"isCharging":{"type":"b","data":false}}]}\\n' "$charge"
     ;;
+  *"/connectivity_report org.freedesktop.DBus.Properties GetAll s org.kde.kdeconnect.device.connectivity_report")
+    # Answered at the leaf's own path only. The real daemon answers the same
+    # interface named on the DEVICE path with the device's properties, which
+    # carry no cellular fields; the fake answers it with nothing. Either way
+    # a sweep reading the report off the wrong path never sees the LTE.
+    printf '{"type":"a{sv}","data":[{"cellularNetworkStrength":{"type":"i","data":4},"cellularNetworkType":{"type":"s","data":"%(cellular)s"},"iconName":{"type":"s","data":"network-mobile-100-lte"}}]}\\n'
+    ;;
   *"GetAll s org.kde.kdeconnect.device")
-    printf '{"type":"a{sv}","data":[{"name":{"type":"s","data":"Galaxy S23 Ultra"},"type":{"type":"s","data":"phone"},"isPaired":{"type":"b","data":true},"isReachable":{"type":"b","data":true}}]}\\n'
+    printf '{"type":"a{sv}","data":[{"name":{"type":"s","data":"Galaxy S23 Ultra"},"type":{"type":"s","data":"phone"},"isPaired":{"type":"b","data":true},"isReachable":{"type":"b","data":true},"pairState":{"type":"i","data":3},"reachableAddresses":{"type":"as","data":["%(address)s"]}}]}\\n'
     ;;
   *"GetManagedObjects")
     printf '{"type":"a{oa{sa{sv}}}","data":[{"/ca/andyholmes/Valent/Device/0":{"ca.andyholmes.Valent.Device":{"Id":{"type":"s","data":"abc123"},"Name":{"type":"s","data":"Pixel 9"},"Type":{"type":"s","data":"phone"},"State":{"type":"u","data":3}}}}]}\\n'
@@ -115,15 +129,18 @@ case "$*" in
     ;;
 esac
 exit 0
-""" % {"device": DEVICE_ID, "before": CHARGE_BEFORE, "after": CHARGE_AFTER}
+""" % {"device": DEVICE_ID, "before": CHARGE_BEFORE, "after": CHARGE_AFTER,
+       "address": ADDRESS, "cellular": CELLULAR}
 
 
 # How many checks the harness runs, per shape it is launched in. Literals
 # rather than anything read back out of the harness's own output: a harness
 # whose step list shrinks must redden here instead of reporting
-# `failures: 0` for a shorter run.
-EXPECTED_CHECKS_STREAMING = 5
-EXPECTED_CHECKS_GAVE_UP = 6
+# `failures: 0` for a shorter run. KDE Connect cases carry two more than
+# Valent's: the address and the cellular report are its reads alone.
+EXPECTED_CHECKS_STREAMING = 7
+EXPECTED_CHECKS_GAVE_UP = 8
+EXPECTED_CHECKS_VALENT = 5
 EXPECTED_CHECKS_NO_DAEMON = 3
 
 
@@ -207,6 +224,8 @@ class PhoneConnectMonitorRuntimeTest(unittest.TestCase):
         env["PHONE_EXPECT_BACKEND"] = backend
         env["PHONE_EXPECT_MONITOR"] = expect_monitor
         env["PHONE_EXPECT_CHARGE"] = str(expect_charge)
+        env["PHONE_EXPECT_ADDRESS"] = ADDRESS
+        env["PHONE_EXPECT_CELLULAR"] = CELLULAR
         env["PHONE_SETTLE_MS"] = str(settle_ms)
         # dbus-run-session, not the inherited DBUS_SESSION_BUS_ADDRESS: this
         # harness must see the services it declares and no others.
@@ -281,7 +300,7 @@ class PhoneConnectMonitorRuntimeTest(unittest.TestCase):
     def test_valent_is_never_streamed_because_its_signals_are_unverified(self):
         self.launch(backend="valent", monitor_mode="crash",
                     expect_monitor="idle", expect_charge=CHARGE_BEFORE,
-                    checks=EXPECTED_CHECKS_STREAMING,
+                    checks=EXPECTED_CHECKS_VALENT,
                     poll_ms=2000, settle_ms=6000)
         self.assertEqual(self.monitor_spawns(), [],
                          "a monitor was spawned for a backend with no verified signal set")

--- a/dots/.config/quickshell/imi/tests/tst_phone_connect.qml
+++ b/dots/.config/quickshell/imi/tests/tst_phone_connect.qml
@@ -179,6 +179,44 @@ TestCase {
         compare(scalar.reachableAddresses.length, 0)
     }
 
+    // ---- pairing requests (slice 3) ----
+
+    function test_pairing_request_is_pair_state_requested_by_peer() {
+        // Device::PairState: 0 NotPaired, 1 Requested (by us), 2
+        // RequestedByPeer, 3 Paired. Only 2 is something to accept.
+        const asked = PhoneConnect.normalizeKdeconnectDevice("x", {
+            "pairState": { "type": "i", "data": 2 }
+        }, null, null)
+        compare(asked.hasPairingRequest, true)
+        compare(PhoneConnect.normalizeKdeconnectDevice("x", pairedPhoneProps(), null, null).hasPairingRequest, false)
+        compare(PhoneConnect.normalizeKdeconnectDevice("x", {
+            "pairState": { "type": "i", "data": 1 }
+        }, null, null).hasPairingRequest, false)
+        compare(PhoneConnect.normalizeKdeconnectDevice("x", {}, null, null).hasPairingRequest, false)
+    }
+
+    function test_pairing_request_reads_the_bool_a_daemon_without_pair_state_exposes() {
+        // isPairRequestedByPeer predates the pairState property; either
+        // spelling of "the peer asked" counts.
+        const asked = PhoneConnect.normalizeKdeconnectDevice("x", {
+            "isPairRequestedByPeer": { "type": "b", "data": true }
+        }, null, null)
+        compare(asked.hasPairingRequest, true)
+    }
+
+    function test_pairing_requests_lists_the_devices_asking() {
+        PhoneConnect.applyBackend("kdeconnect")
+        PhoneConnect.applyDevices([
+            device("phone1", { paired: true, reachable: true }),
+            device("laptop", { type: "laptop", reachable: true, hasPairingRequest: true }),
+            device("tablet", { type: "tablet", reachable: false })
+        ])
+        compare(PhoneConnect.pairingRequests.length, 1)
+        compare(PhoneConnect.pairingRequests[0].id, "laptop")
+        PhoneConnect.applyBackend("none")
+        compare(PhoneConnect.pairingRequests.length, 0)
+    }
+
     // ---- Valent ----
 
     function valentManagedObjects() {
@@ -221,10 +259,11 @@ TestCase {
     }
 
     function test_normalize_valent_objects_carry_the_kdeconnect_only_fields_empty() {
-        // Valent's connectivity surface was not verifiable against a live
-        // daemon; the model still has the fields so the UI reads one shape,
-        // at the values that mean "unknown".
+        // Valent's pairing and connectivity surfaces were not verifiable
+        // against a live daemon; the model still has the fields so the UI
+        // reads one shape, at the values that mean "unknown".
         const phone = PhoneConnect.normalizeValentObjects(valentManagedObjects()).find(d => d.id === "abc123")
+        compare(phone.hasPairingRequest, false)
         compare(phone.reachableAddresses.length, 0)
         compare(phone.cellularNetworkType, "")
         compare(phone.cellularNetworkStrength, -1)
@@ -267,7 +306,7 @@ TestCase {
     function device(id, overrides) {
         return Object.assign({
             id: id, name: id, type: "phone", reachable: false, paired: false,
-            reachableAddresses: [],
+            hasPairingRequest: false, reachableAddresses: [],
             cellularNetworkType: "", cellularNetworkStrength: -1,
             batteryAvailable: false, batteryCharge: -1, batteryCharging: false
         }, overrides ?? {})

--- a/dots/.config/quickshell/imi/tests/tst_phone_connect.qml
+++ b/dots/.config/quickshell/imi/tests/tst_phone_connect.qml
@@ -83,7 +83,19 @@ TestCase {
             "type": { "type": "s", "data": "phone" },
             "isPaired": { "type": "b", "data": true },
             "isReachable": { "type": "b", "data": true },
-            "isPairRequestedByPeer": { "type": "b", "data": false }
+            "isPairRequestedByPeer": { "type": "b", "data": false },
+            "pairState": { "type": "i", "data": 3 },
+            "reachableAddresses": { "type": "as", "data": ["192.168.100.179"] }
+        }
+    }
+
+    // Captured shape: GetAll on org.kde.kdeconnect.device.connectivity_report
+    // at the device's /connectivity_report leaf.
+    function lteReport() {
+        return {
+            "cellularNetworkStrength": { "type": "i", "data": 4 },
+            "cellularNetworkType": { "type": "s", "data": "LTE" },
+            "iconName": { "type": "s", "data": "network-mobile-100-lte" }
         }
     }
 
@@ -124,6 +136,47 @@ TestCase {
         compare(device.type, "")
         compare(device.paired, false)
         compare(device.reachable, false)
+    }
+
+    // ---- connectivity_report and reachableAddresses (slice 2) ----
+
+    function test_normalize_kdeconnect_reads_reachable_addresses_and_the_cellular_report() {
+        const device = PhoneConnect.normalizeKdeconnectDevice("6131a746", pairedPhoneProps(), {
+            "charge": { "type": "i", "data": 85 },
+            "isCharging": { "type": "b", "data": false }
+        }, lteReport())
+        compare(device.reachableAddresses.length, 1)
+        compare(device.reachableAddresses[0], "192.168.100.179")
+        compare(device.cellularNetworkType, "LTE")
+        compare(device.cellularNetworkStrength, 4)
+    }
+
+    function test_normalize_kdeconnect_missing_connectivity_report_degrades_cleanly() {
+        // The leaf does not exist for an unpaired device, or where the plugin
+        // is off - its GetAll fails, parses to null, and the model says
+        // "unknown" rather than inventing a signal.
+        const device = PhoneConnect.normalizeKdeconnectDevice("x", {}, null, null)
+        compare(device.reachableAddresses.length, 0)
+        compare(device.cellularNetworkType, "")
+        compare(device.cellularNetworkStrength, -1)
+        // A report with the wrong shapes in it is the same as none.
+        const odd = PhoneConnect.normalizeKdeconnectDevice("x", {}, null, {
+            "cellularNetworkStrength": { "type": "s", "data": "four" },
+            "cellularNetworkType": { "type": "i", "data": 4 }
+        })
+        compare(odd.cellularNetworkType, "")
+        compare(odd.cellularNetworkStrength, -1)
+    }
+
+    function test_normalize_kdeconnect_keeps_only_string_addresses() {
+        const device = PhoneConnect.normalizeKdeconnectDevice("x", {
+            "reachableAddresses": { "type": "as", "data": ["10.0.0.5", 7, null, "fe80::1"] }
+        }, null, null)
+        compare(device.reachableAddresses.join(","), "10.0.0.5,fe80::1")
+        const scalar = PhoneConnect.normalizeKdeconnectDevice("x", {
+            "reachableAddresses": { "type": "s", "data": "not-a-list" }
+        }, null, null)
+        compare(scalar.reachableAddresses.length, 0)
     }
 
     // ---- Valent ----
@@ -167,6 +220,16 @@ TestCase {
         compare(tablet.paired, true)
     }
 
+    function test_normalize_valent_objects_carry_the_kdeconnect_only_fields_empty() {
+        // Valent's connectivity surface was not verifiable against a live
+        // daemon; the model still has the fields so the UI reads one shape,
+        // at the values that mean "unknown".
+        const phone = PhoneConnect.normalizeValentObjects(valentManagedObjects()).find(d => d.id === "abc123")
+        compare(phone.reachableAddresses.length, 0)
+        compare(phone.cellularNetworkType, "")
+        compare(phone.cellularNetworkStrength, -1)
+    }
+
     function test_normalize_valent_objects_ignores_non_device_paths() {
         const devices = PhoneConnect.normalizeValentObjects([{
             "/ca/andyholmes/Valent": { "org.freedesktop.DBus.ObjectManager": {} }
@@ -204,6 +267,8 @@ TestCase {
     function device(id, overrides) {
         return Object.assign({
             id: id, name: id, type: "phone", reachable: false, paired: false,
+            reachableAddresses: [],
+            cellularNetworkType: "", cellularNetworkStrength: -1,
             batteryAvailable: false, batteryCharge: -1, batteryCharging: false
         }, overrides ?? {})
     }
@@ -317,6 +382,8 @@ TestCase {
             verify(PhoneConnect.signalChangesDevices({ iface: "org.kde.kdeconnect.device", member: member, args: [] }),
                    `device.${member} should re-read`)
         verify(PhoneConnect.signalChangesDevices({ iface: "org.kde.kdeconnect.device.battery", member: "refreshed", args: [true, 87] }))
+        // connectivity_report.refreshed(si) - the cellular type and strength.
+        verify(PhoneConnect.signalChangesDevices({ iface: "org.kde.kdeconnect.device.connectivity_report", member: "refreshed", args: ["LTE", 4] }))
     }
 
     function test_signal_changes_devices_reads_the_interface_out_of_properties_changed() {


### PR DESCRIPTION
Slices 2 and 3 of docs/proposals/phone-connect.md, plus the sidebar surface reshaped toward the layout rated on the fork.

- The KDE Connect sweep reads each device's reachableAddresses and its connectivity_report leaf (cellular type/strength); the report's `refreshed` signal joins the monitor's allowlist. Valent carries the fields at "unknown".
- A peer's pairing request (pairState 2 / isPairRequestedByPeer) is on the model as hasPairingRequest + a derived pairingRequests list; acceptPairing / cancelPairing call the two device-path methods, aimed only at a device that asked, id validated and passed as an argument. Closes the proposal's open question.
- The dialog: device chip with an expand arrow over the roster, connection / battery / cellular pills, ONE row of the three actions the model answers (ring, ping, clipboard — the fork's other three are scrcpy, a picker and SFTP and are not drawn), the notification area owning the remaining height with a real empty state, and pairing cards stacked at the bottom.
- Found and mechanized: a modules/ file using `Translation` without `import qs.services` passes every static check; lint_qml_imports.sh now covers it (and skips a module's own directory), and its first run caught the new chip.

Tests: tst_phone_connect.qml (fields, pairing, signal), the contract test (leaf path, pairing guard, surface holds to the model's actions), the monitor runtime harness (address + report read back off a real shell), and a new dialog runtime harness (real dialog over the real service against a fake daemon; Accept/Decline scored off the fake's argv; the area measured to grow by exactly a removed card).

Not live-verified on the running shell yet; device selection is session state (slice 6 later); notification area is an empty state only (mirroring is slice 1, out of scope).

Docs: updated AGENT.md §Directory map (PhoneConnect), §busctl monitor (GetAll-on-the-wrong-path and pairing entries), §Design language (Translation import); docs/proposals/phone-connect.md
Changelog: updated
