### PR TITLE
feat(phoneConnect): share, SFTP browse, a persisted device and battery notices

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -580,8 +580,13 @@ services/                  Singletons wrapping external state/processes - one pe
                               binding) - backend detection from the bus name list, one
                               normalized device model for both daemons (battery, the
                               reachable addresses, the cellular report, a peer's pairing
-                              request), ring/ping/clipboard actions and the two pairing
-                              answers. KDE Connect's changes arrive as SIGNALS
+                              request), ring/ping/clipboard actions, the two pairing
+                              answers, share (file URLs, text, the clipboard as a link or
+                              as text, the house kdialog picker), an SFTP browse that opens
+                              the phone's storage, the persisted pick + MRU
+                              (Persistent.states.phone) and the low-battery notices. Every
+                              action is a queued argv; feedback is one actionFeedback
+                              signal plus lastActionError. KDE Connect's changes arrive as SIGNALS
                               (`busctl monitor`, see the streaming note below); Valent's
                               still arrive on the poll, which stays on for both as the
                               reconcile. Its parser logic is kept byte-for-byte in
@@ -3991,6 +3996,25 @@ across daemon restarts. Four more things about that path, each of which cost a m
   is the paired phone, which never asked — so the guard refuses a device without a request
   and the contract pins the absence of the fallback. 9395932d3 ("feat(phoneConnect): surface a
   peer's pairing request, and answer it").
+
+- **`Process.exec` on a Process that is still running terminates it first, so one Process fed
+  straight from `exec` keeps the last action of a burst and kills the rest.** Measured under
+  headless weston: a 2s command followed 500ms later by a second `exec` on the same Process
+  came back `exited code=15 status=1` with no output, and only the second ran. `PhoneConnect`'s
+  `runAction` was exactly that shape and would have dropped every `shareUrl` of a multi-file
+  send but one — silently, since a killed busctl prints nothing. It is a queue now
+  (`actionQueue`, pumped from the Process's own `onExited`); the contract refuses an `exec`
+  outside the pump. Anything else here that answers several clicks with one `Process` has the
+  same question. c7e160da1 ("feat(phoneConnect): actions queue behind one another instead of
+  killing the one in flight").
+- **A string the daemon hands to a `QUrl` is parsed as one, so a share URL is built like one.**
+  `share.shareUrl` takes a string and `QUrl`s it: a schemeless host (`example.org`, which the
+  fork's clipboard heuristic sends as-is) is relative to nothing, and a raw `#` or `?` in a
+  filename spliced after `file://` is a fragment or a query. `clipboardShareTarget` puts
+  `https://` on a bare host and `pickedFileUrls` percent-encodes each path segment; both are
+  in the synced region so `tst_phone_connect.qml` pins the strings. 8c29fc2be
+  ("feat(phoneConnect): share the clipboard as a link or as text"), 58f4cd225
+  ("feat(phoneConnect): pick files with kdialog and share each as a file URL").
 
 The gate deciding whether to start it was first written as a `readonly property bool` derived from
 `backend` and read from `onBackendChanged` — the change-handler trap under

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ own repo; the installer pins which revision it builds.
 ## [Unreleased]
 
 ### Added
+- **Phone Connect warns when your phone's battery is low, and can send it
+  files, links and your clipboard, or open its storage.** A desktop
+  notification arrives once when the paired phone drops below 20% while
+  not charging, and again when it is back at 25% or plugged in. The phone
+  service can now share files picked with the file dialog, a link or a
+  piece of text from the clipboard (a link is recognised and sent as one),
+  and browse the phone over SFTP, opening its internal storage rather than
+  the bare mount. The device you pick in the panel is remembered across
+  restarts, with the last five picks kept for the list. The buttons for the
+  new actions arrive with the Phone tab; the notifications work now.
 - **Phone Connect shows your phone's wireless address and cellular network,
   and answers pairing requests.** The panel reads the address KDE Connect
   reaches the phone on and its cellular network type (LTE, 5G, …) alongside

--- a/docs/proposals/phone-connect.md
+++ b/docs/proposals/phone-connect.md
@@ -124,6 +124,55 @@ them:
   the real service against a fake daemon and reads all of it back,
   including the area growing by exactly a card when that card goes.
 
+**Slices 4, 5 and 6 have landed** on the service; the buttons that reach
+them are the Phone tab's (`docs/superpowers/specs/2026-08-27-phone-tab-design.md`,
+W5), so the dialog still draws three actions until the tab replaces it.
+
+- **Actions queue** (c7e160da1 "feat(phoneConnect): actions queue behind one
+  another instead of killing the one in flight"). Measured first: `Process.exec`
+  on a Process still running terminates it (exit 15, status 1, no output), so
+  `runAction` fed straight from `exec` kept the last action of a burst and
+  killed the rest — and one `shareUrl` per file IS a burst. `runAction` pushes
+  onto a queue the Process's own exit pumps. Feedback is one channel
+  (d021d10b0 "feat(phoneConnect): lastActionError and an actionFeedback signal
+  for toasts"): every action raises `actionFeedback(message, ok)`, every
+  failure sets `lastActionError` through one `reportFailure`.
+- **Send** (39f359ad4 "feat(phoneConnect): shareUrls and shareText through
+  the share plugin"; 8c29fc2be "feat(phoneConnect): share the clipboard as a
+  link or as text"; 58f4cd225 "feat(phoneConnect): pick files with kdialog
+  and share each as a file URL"). `share.shareUrl`/`shareText` on the
+  device's `/share` leaf, one string argument each (busctl signature `s`),
+  never a shell — the fork's `_shellQuote` has no counterpart here.
+  `shareClipboard` reads `wl-paste --no-newline` as a constant argv and
+  decides through the fork's heuristic (`/^https?:\/\//i`, or a host-shaped
+  token that is the whole string or starts a path), with one correction: a
+  bare host leaves with `https://` on it, because the daemon hands the string
+  to a `QUrl` and `example.org` is relative to nothing. The picker is the
+  house `kdialog --getopenfilename $HOME --multiple` (the wallpaper picker's
+  shape), its lines percent-encoded per segment before `file://` for the same
+  `QUrl` reason — a raw `#` in a filename is a fragment. Not taken: the
+  zenity fallback, and the proposal's own "drop shelf rather than a picker":
+  the spec answered both, the picker here and a `DropArea` on the tab.
+- **SFTP** (c487842e4 "feat(phoneConnect): browse the phone over SFTP,
+  opening its storage when it has one"). `sftp.mount`, then — on the read
+  queue, not the action process — `isMounted` every 600 ms up to ten times
+  (`mount()` returns before sshfs is up), then `mountPoint`, then a `test -d`
+  argv on `<mount>/storage/emulated/0` (the fork's 3a7f653b4: the mount root
+  is not the user's storage), then `xdg-open` on whichever exists.
+  `sftpMounted` is the daemon's last `isMounted` answer. Not taken: `gio open`
+  ahead of `xdg-open`, and the unmount — nothing in the tab asks for it yet.
+- **Persisted device, MRU, battery** (b603cbeb7 "feat(phoneConnect):
+  remember the picked device, and the five picked before it"; cdad588f8
+  "feat(phoneConnect): a low-battery notice once, and a recovery notice").
+  `Persistent.states.phone.{activeDeviceId, recentDeviceIds}`; `activeDevice`
+  prefers the persisted device while it is paired and reachable, else the
+  rule that was there. The MRU walk goes by index because a `list<string>`
+  off a `JsonAdapter` fails `Array.isArray`. The thresholds are the
+  proposal's, literally, pinned as numbers in `tests/tst_phone_connect.qml`:
+  low once below 20 and not charging, recovered at 25 or on charging; the
+  fork's extra guard on the previous charge being ≥ 20 (which kept a phone
+  already at 15% at boot silent) is not carried.
+
 ## Prior art: P3DROVFX/ii-p3drovfx
 
 Recorded because the next slice is decided from it, not because any of it is
@@ -238,14 +287,14 @@ Ordered by value. Each borrows the fork's shape and none of its transport:
 every read is a `busctl` argv, every write goes through `runAction`, and both
 backends stay behind the one model.
 
-**Slices 1 (signal-driven updates), 2 and 3 are done** — see "Current
+**Slices 1 (signal-driven updates) through 6 are done** — see "Current
 state" above. The next slice is now notification mirroring, and it inherits
 the stream and the surface: its signals go in `signalChangesDevices`'
 allowlist, the match rule already covers the whole `/modules/kdeconnect`
-namespace, and the dialog's notification area is already the fill item
-waiting for it, so nothing about the transport or the layout has to be
-rebuilt. What is still open from slice 1 is Valent: its signal set was not
-verifiable and it keeps the poll until it is.
+namespace, and the notification area is already the fill item waiting for
+it, so nothing about the transport or the layout has to be rebuilt. What is
+still open from slice 1 is Valent: its signal set was not verifiable and it
+keeps the poll until it is.
 
 1. **Notification mirroring.** Borrow: the leaf `notification.dismiss` (not
    `sendAction("cancel")`), `sendReply` with a re-fetch, `internalId` →
@@ -266,15 +315,16 @@ verifiable and it keeps the poll until it is.
    through the stream; the calls are `acceptPairing`/`cancelPairing` on the
    device path, aimed only at a device that asked, with the id validated and
    passed as an argument rather than interpolated into a shell string.
-4. **Send and receive.** `share.shareUrl("file://…")` for file send, drop
-   target on the drop shelf (`modules/imi/dropShelf/`) rather than a picker
-   dialog, and `share.shareReceived` surfaced as a notification. Not: the
-   kdialog/zenity picker chain.
-5. **SFTP mount/browse.** `sftp.mount`/`unmount` plus a file-manager open;
-   the fork's `3a7f653b4` records that the mount root is not the user's
-   storage — open `<mount>/storage/emulated/0` when it exists.
-6. **Persisted active device, MRU, and low-battery hooks.** Small; take the
-   thresholds (<20% not charging, recover at ≥25% or charging) as they are.
+4. **Send and receive.** Done for the send half — see "Current state":
+   `share.shareUrl("file://…")` per file, the clipboard as a link or text,
+   and the house kdialog picker (the spec overruled "rather than a picker":
+   the tab gets a `DropArea` as well). Still open: `share.shareReceived`
+   surfaced as a notification, which belongs with notification mirroring.
+5. **SFTP mount/browse.** Done — see "Current state". `sftp.mount`, a
+   bounded wait on `isMounted`, `mountPoint`, and `<mount>/storage/emulated/0`
+   when it exists. Unmount is not wired; nothing asks for it yet.
+6. **Persisted active device, MRU, and low-battery hooks.** Done — see
+   "Current state", thresholds taken literally.
 
 Still open regardless: media (`mprisremote`), clipboard *receive*, and Valent
 action coverage beyond `findmyphone.ring` (its other action names were not
@@ -336,8 +386,11 @@ would be both laggy and wasteful.
   path, and the wrapping is narrow on purpose — an answer is refused for any
   device that has not asked, the card says to accept only a pairing the user
   started on that device, and nothing about the id ever reaches a shell.
-- Whether file-send should accept drops onto the drop shelf
-  (`modules/imi/dropShelf/`), which already handles mid-drag interaction.
+- ~~Whether file-send should accept drops onto the drop shelf
+  (`modules/imi/dropShelf/`), which already handles mid-drag interaction.~~
+  Answered by the Phone tab spec: both — the picker landed with slice 4 on
+  the service, and the tab carries a `DropArea` that hands dropped `file://`
+  URLs to the same `shareUrls`.
 
 ## Out of scope
 

--- a/docs/superpowers/specs/2026-08-27-phone-tab-design.md
+++ b/docs/superpowers/specs/2026-08-27-phone-tab-design.md
@@ -1,0 +1,361 @@
+# Phone tab — design
+
+Status: approved for implementation (maintainer, 2026-08-27). Supersedes the
+"surface" paragraphs of `docs/proposals/phone-connect.md`; that proposal's
+transport constraint still governs every KDE Connect read and write.
+
+## Goal
+
+A **Phone** tab in the LEFT sidebar (beside Intelligence / Translator /
+Media / Anime) that reproduces the fork's phone panel
+(P3DROVFX/ii-p3drovfx, `modules/ii/sidebarPolicies/phone/`) on our tokens
+and our transport. Top to bottom, exactly the reference screenshot:
+
+1. Header: device chip (name + `expand_more`) that opens the roster; a
+   connection pill (`wifi`, label = cellular type such as "LTE", else the
+   first reachable address, else "Connected"/"Offline"); a battery pill with
+   the charge and a charging mark.
+2. One row of **six** round actions: ring (`phone_in_talk`), ping
+   (`notifications_active`), send clipboard (`content_paste`), send file
+   (`file_upload`), share link/text from clipboard (`link`), browse files
+   over SFTP (`folder_shared`). Each enabled only when the device is
+   reachable and the backend answers the action.
+3. Two navigation cards: **Contacts** ("150 contacts", `contacts` glyph)
+   and **Android Apps** ("scrcpy 4.x App Mode", `apps` glyph), each with
+   `chevron_right`, opening a sub-page that slides over the tab.
+4. The notification area owning the remaining height: phone notifications
+   grouped by app (dismiss, reply, actions, copy), with the empty state
+   "No notifications / Make sure KDE Connect has Notification Access on
+   your phone".
+5. Footer toolbar: sync (`sync`), a "N notif." pill, clear (`delete_sweep`).
+6. Bottom card stack: **Install scrcpy** (when scrcpy is missing; opens the
+   install guide), **Phone Webcam** ("Tap to start · settings to
+   configure"), **Phone Microphone** ("Tap to start · uses scrcpy or
+   DroidCam"). Pairing-request cards join this stack when a peer asks.
+
+Everything the fork does with `qdbus` / `python-dbus` / `gi` we do with
+`busctl --json=short` argv through the existing `PhoneConnect` queue. Every
+external process is supervised the way `services/DiscordVoice.qml` and
+`services/PhoneConnect.qml` are (`process-lifecycle: restart-safe` marker,
+no `running` binding on a streaming process, backoff + ceiling).
+
+## Non-goals (this round)
+
+- Android launcher icon extraction (`android_icon_extractor.py`); apps show
+  the `android` glyph. Follow-up.
+- The bar indicator and dock widget for scrcpy. Follow-up.
+- Valent parity beyond what `PhoneConnect` already has (Valent keeps
+  ring only; every other action is hidden on that backend).
+- Implementing the KDE Connect protocol, or anything needing a phone-side
+  app change.
+
+## Decisions
+
+- **The tab replaces the right-sidebar dialog.** The `phoneConnect` quick
+  toggle's menu opens the left sidebar on the Phone tab
+  (`GlobalStates.sidebarLeftTab = "phone"`, consumed by
+  `SidebarLeftContent`); `PhoneConnectDialog.qml` and the `ToggleDialog`
+  wiring are deleted. Shared pieces move to `modules/imi/phone/` (chip,
+  action button, device item, pairing card) and are imported from there.
+- **Dedicated notification list, deduped.** The tab draws its own
+  phone-notification list (the design the maintainer rated). To stop the
+  same notification arriving twice, `services/Notifications.qml` drops a
+  desktop notification whose `appName` is `kdeconnect` / `kde connect` /
+  `org.kde.kdeconnect` or equals a paired device's name — **only while**
+  the Phone tab is enabled and the active device is reachable (the fork's
+  gate).
+- **One monitor stream.** Notification signals join
+  `signalChangesDevices`' allowlist in `PhoneConnect`; `PhoneNotifications`
+  subscribes to `PhoneConnect`'s coalesced change, then fetches. No second
+  `busctl monitor`.
+- **Send file uses the house picker** (`kdialog --getopenfilename`, the
+  pattern at `SidebarRightContent.qml:113`), plus a `DropArea` over the tab
+  that shares dropped `file://` URLs. The drop shelf question in the
+  proposal is answered: both.
+- **Sub-pages** are `Item`s hosted by `Phone.qml`'s overlay loader:
+  `PhoneSubPage { title; signal back() }` slides in with the sidebar's
+  motion tiers; Escape and the back button pop it.
+- **Config** goes under `Config.options.phone.*` (new JsonObject, append-only
+  at the end of `Config.qml`'s options), with `sidebar.phone.enable` beside
+  `sidebar.media.enable`. Persistent state under
+  `Persistent.states.phone.*`.
+- **Dependencies stay optional.** Nothing new is added to the installer's
+  hard dependency lists. Each capability probes with `command -v` at
+  service start (lint `lint_capability_probe_gating.py` applies) and the
+  UI says exactly what is missing with per-distro install commands
+  (arch / fedora / debian), copied from the fork's `InstallGuidePopup`.
+  `sdata/deps-info.md` gains a "Phone (optional)" paragraph.
+
+## Components and ownership
+
+Five workstreams. Phase 1 (parallel, services + scripts + tests, no UI
+beyond what already exists), then Phase 2 (parallel UI in
+`modules/imi/sidebarLeft/phone/`). File ownership is exclusive; shared
+files are listed with the owner.
+
+### W1 — `PhoneConnect` actions: share, SFTP, persisted device, battery hooks
+
+Owner of `services/PhoneConnect.qml` action region, its shim
+`tests/imports/testservices/PhoneConnect.qml`, `tests/test_phone_connect_contract.py`,
+`tests/tst_phone_connect.qml`, `docs/proposals/phone-connect.md` (slices 4–6).
+
+Model additions (kdeconnect only; Valent hides them):
+
+- `canShare`, `canBrowseFiles` (readonly bool).
+- `shareUrls(device, urls)` → one `org.kde.kdeconnect.device.share.shareUrl`
+  per `file://` or `http(s)://` entry, serialized through `runAction`.
+- `shareText(device, text)` → `share.shareText`.
+- `shareClipboard(device)` — reads `wl-paste --no-newline`; URL heuristic
+  `/^https?:\/\//i` or `/^[\w.-]+\.\w{2,}(\/|$)/` → `shareUrls`, else
+  `shareText`; empty clipboard → `lastActionError = "Clipboard is empty"`.
+- `pickAndSendFiles(device)` — `kdialog --getopenfilename $HOME --multiple`
+  through a `Process`, one `shareUrl` per line.
+- `browseFiles(device)` — `sftp.mount`, then read `mountPoint`
+  (`org.kde.kdeconnect.device.sftp.mountPoint` method), prefer
+  `<mount>/storage/emulated/0` when it exists, open with `xdg-open`.
+  `sftpMounted` (bool) tracks the answer of `sftp.isMounted`.
+- Persisted active device: `Persistent.states.phone.activeDeviceId` and
+  `recentDeviceIds` (MRU, max 5). `selectDevice(id)` writes both;
+  `activeDevice` prefers the persisted id when that device is paired and
+  reachable, else the existing rule.
+- Low-battery hooks: `notify-send -i phone -u normal "Low battery: <name>"
+  "Charge is at <n>%."` once when charge < 20 and not charging; recovery
+  notice at ≥ 25 or charging. Thresholds are literal per the proposal.
+- `lastActionError` (string) and `actionFeedback(message, ok)` signal for
+  toasts.
+
+Tests: extend the contract (`MODEL_ACTIONS` grows; every argv still an
+array; `wl-paste` and `kdialog` are constant argv, nothing interpolated into
+a shell string), the QML unit suite (URL heuristic, MRU rule, battery
+threshold edge cases 19/20/24/25 and charging), and the dialog runtime
+harness becomes the tab runtime harness in Phase 2 (W1 leaves the current
+one green).
+
+### W2 — Notification mirroring: `services/PhoneNotifications.qml`
+
+Owner of the new singleton, its shim `tests/imports/testservices/PhoneNotifications.qml`,
+`tests/tst_phone_notifications.qml`, `tests/test_phone_notifications_contract.py`,
+the allowlist hunk in `services/PhoneConnect.qml` (`signalChangesDevices`
+only — coordinate: append the four notification signal names and the
+`org.kde.kdeconnect.device.notifications` interface; nothing else in that
+file), and the dedupe hunk in `services/Notifications.qml`.
+
+Reads (busctl argv, serialized through its own queue built like
+`PhoneConnect`'s):
+
+- `org.kde.kdeconnect.device.notifications.activeNotifications` at
+  `/modules/kdeconnect/devices/<id>/notifications` → list of public ids.
+- `org.freedesktop.DBus.Properties.GetAll` on
+  `/modules/kdeconnect/devices/<id>/notifications/<publicId>`, interface
+  `org.kde.kdeconnect.device.notifications.notification`: `internalId`,
+  `appName`, `ticker`, `title`, `text`, `iconPath`, `dismissable`,
+  `hasReplyAction`, `replyId`, `silent`, `actions` (string list).
+  Package = `internalId.split("|")[1]`.
+
+Model: `notifications` (array of `{publicId, deviceId, internalId, package,
+appName, title, text, ticker, iconPath, dismissable, replyId, actions,
+receivedAt}`), `count`, `groupsByAppName`, `appNameList` (same derivation
+as `services/Notifications.qml`), `activeDeviceId` follows
+`PhoneConnect.activeDevice`.
+
+Writes through `runAction`-style argv:
+
+- `dismiss(publicId)` → leaf `…notifications.notification.dismiss` (never
+  `sendAction("cancel")` — the fork's `KdeConnectService.qml:892-901`
+  records why).
+- `dismissAll()` loops `dismiss`.
+- `reply(publicId, text)` → device-level `notifications.sendReply
+  <replyId> <text>`, then a 800 ms delayed refetch.
+- `sendAction(publicId, key)` → `notifications.sendAction <key>`.
+- `refresh()` — full refetch; the footer's sync button.
+
+Triggers: `PhoneConnect` exposes `signal deviceChangeSettled()` fired from
+`signalSettle` (W2 adds the one signal and its emit; W1 does not touch
+`signalSettle`). `PhoneNotifications` refetches on it, on
+`activeDeviceChanged`, and on a 60 s reconcile timer.
+
+Dedupe in `services/Notifications.qml` `notifServer.onNotification`:
+drop when `PhoneNotifications.mirrorActive` and the incoming `appName` is
+one of the kdeconnect names or a paired device's name. `mirrorActive =
+Config.options.sidebar.phone.enable && PhoneConnect.activeDevice?.reachable`.
+
+Persistence: `Persistent.states.phone.cachedNotificationsJson` (per active
+device, saved 2 s after change, restored at boot so the tab is not empty
+before the first sweep).
+
+Tests: unit (parse of a captured `activeNotifications` reply and one leaf
+`GetAll`, package extraction, group derivation, dedupe predicate), contract
+(argv-only, leaf dismiss, reply refetch delay is a declared constant, the
+shim's parser region byte-identical), and a runtime harness
+`PhoneNotificationsRuntimeTest.qml` over a fake busctl that serves two
+notifications and records the dismiss call on the leaf path.
+
+### W3 — scrcpy: mirror, app mode, webcam, microphone
+
+Owner of `scripts/phone/scrcpy_session_manager.py`,
+`scripts/phone/droidcam_session.sh`, `scripts/phone/droidcam_status.sh`,
+`scripts/phone/setup_droidcam_input.sh`, `scripts/phone/teardown_droidcam_input.sh`,
+`scripts/phone/install_droidcam.sh`, `services/PhoneScrcpy.qml`,
+`services/PhoneCamera.qml`, `services/PhoneMic.qml`,
+`services/PhoneDeps.qml`, their shims, `tests/test_phone_scrcpy_manager.py`
+(drives the Python supervisor with a fake `scrcpy`/`adb` on PATH),
+`tests/tst_phone_scrcpy.qml`, `tests/test_phone_sessions_contract.py`,
+`Config.qml` (the new `phone` JsonObject — W3 owns the whole block; W1/W2/W4
+put nothing in Config), `Persistent.qml` (the `phone` JsonObject — W3 owns;
+W1 and W2 tell W3 their keys: `activeDeviceId`, `recentDeviceIds`,
+`cachedNotificationsJson`, and W3 declares them), `sdata/deps-info.md`.
+
+`scripts/phone/scrcpy_session_manager.py` — NDJSON supervisor on
+stdin/stdout, ported from the fork (`launch`, `stop`, `stop_all`, `focus`,
+`list_apps`; events `started`, `exited`, `error`, `apps_list`,
+`apps_error`). Exact scrcpy line:
+`scrcpy [-s <serial>] --window-title=imi-phone-<type>-<id> <extra...>`.
+`focus` uses `hyprctl dispatch focuswindow title:^<title>$`. Target
+resolution: `adb devices`; a USB serial (no `:`) wins over `ip:port`.
+App list: `scrcpy <target> --list-apps`, regex
+`^\s*([\*\-])\s+(.+?)\s+([a-zA-Z0-9_]+\.[a-zA-Z0-9_.]+)\s*$`, fallback
+`adb shell pm list packages -3`; cached at
+`~/.cache/immaterial-impulse/phone/apps/<deviceId>.json`.
+
+`services/PhoneDeps.qml` — one probe singleton: `scrcpy`, `adb`,
+`droidcam-cli`, `v4l2-ctl`, `pactl`, `mpv`, `kdialog`, `wl-paste`
+presence (`command -v`, started at construction), `v4l2loopback` loaded /
+installed (`lsmod`, `modinfo`), scrcpy major version (`scrcpy --version`),
+`distro` (`/etc/arch-release`, `/etc/fedora-release`, `/etc/debian_version`),
+and `missingFor(feature)` → `[{key, name, description, commands: {arch,
+fedora, debian}}]` with the fork's exact command table. `recheck()`.
+
+`services/PhoneScrcpy.qml` — `mirrorRunning`, `mirrorLaunching`,
+`sessions` (ListModel of `{id, type, title, pid, package}`),
+`apps` (`[{name, package, system}]`), `appsLoading`, `appsError`,
+`appModeSupported` (major ≥ 4), `launchMirror()`, `stopMirror()`,
+`focusMirror()`, `refreshApps()`, `launchApp(package)`, `stopApp(package)`,
+`stopAllApps()`, `focusApp(package)`, `toggleFavorite(package)`,
+`favorites` (Config), `recents` (Persistent, max 20), `lastError`. Mirror
+flags from `Config.options.phone.scrcpy.*` (the fork's table); app mode
+adds `--start-app=<pkg>` and, with `flexDisplay`,
+`--new-display=WxH/density --flex-display [--keep-active]
+[--no-vd-system-decorations]`. Manager process is started on demand and
+stopped by a 10 s idle timer when no session is live; `onExited` follows
+the DiscordVoice ladder.
+
+`services/PhoneCamera.qml` — DroidCam webcam: `available` (droidcam-cli +
+v4l2loopback), `state` (`unavailable|offline|connecting|ready|active`),
+`device` (`/dev/videoN` from `v4l2-ctl --list-devices`), `start()`,
+`stop()`, `flip()`, `mirror(bool)`, `openPreview()` (mpv →
+ffplay → vlc fallback). Command:
+`droidcam-cli -nocontrols [-size=WxH] [-hflip] [-vflip] {adb <port> | <ip> <port>}`
+via `droidcam_session.sh launch video …` so it survives a shell restart
+(the pidfile is the binary's). USB-first: `adb get-state` = `device` →
+`adb <port>`; else the phone's first `reachableAddresses` entry (KDE
+Connect's own report), else `Config.options.phone.webcam.wifiIp`.
+
+`services/PhoneMic.qml` — `available` (pactl + (scrcpy | droidcam-cli)),
+`state`, `backend` (`scrcpy|droidcam`), `muted`, `gain`, `isDefaultInput`,
+`start()`, `stop()`, `toggleMute()`, `setGain(pct)`, `setAsDefaultInput()`,
+`restoreDefaultInput()`. Routing exactly as the fork: `setup_droidcam_input.sh`
+loads `module-null-sink sink_name=DroidCam-Mic`; scrcpy backend runs
+`scrcpy --no-video --no-window --audio-source=mic --audio-buffer=50 [-s
+<serial>]` with the default sink temporarily swapped to `DroidCam-Mic`
+(original persisted in `Persistent.states.phone.mic.originalDefaultSink`,
+restored once the stream appears); droidcam backend runs
+`env PULSE_SINK=DroidCam-Mic droidcam-cli -a -nocontrols …`. Boot
+reconciliation restores a leftover default sink. Teardown unloads
+loopbacks and the null sink.
+
+Config (`Config.options.phone`, defaults = the fork's table in the research
+map): `showPeripheralCards`, `contacts.{enabled, favoriteIds, sortBy,
+hideUnnamed}`, `scrcpy.{stayAwake, turnScreenOff, noPowerOn, noAudio,
+showTouches, fullscreen, alwaysOnTop, maxFps, bitRate, maxSize,
+videoBuffer, useWireless, autoWirelessIp, wirelessIp, wirelessPort}`,
+`scrcpy.appMode.{enabled, flexDisplay, displayWidth, displayHeight,
+density, keepActive, systemDecorations, favoritePackages}`,
+`webcam.{cameraFacing, resolution, mirrorHorizontally, rotateDegrees,
+connection, wifiIp, port}`, `microphone.{connection, wifiIp, port,
+micGain, setAsDefault}`. Plus `Config.options.sidebar.phone.enable`
+(default `true`).
+
+Tests: the Python supervisor test with fake binaries (launch/exit/focus/
+list_apps parsing incl. the `pm list packages` fallback); QML unit tests
+for flag assembly (`mirrorArgs()`, `appModeArgs()` are pure functions),
+state ladders, and the URL of every command (argv arrays; the only shell
+strings are the constant probes); contract test pinning the
+`process-lifecycle` marker on every long-running process, the idle timer,
+and that no `Process` here has a `running` binding.
+
+### W4 — Contacts
+
+Owner of `scripts/phone/contacts_monitor.py`, `services/PhoneContacts.qml`,
+its shim, `tests/test_phone_contacts_monitor.py` (feeds a temp
+`kpeoplevcard/kdeconnect-<id>/` with vCards, incl. a nameless one),
+`tests/tst_phone_contacts.qml`.
+
+`contacts_monitor.py --device <id> [--once]`: source dir
+`$XDG_DATA_HOME/kpeoplevcard` (default `~/.local/share/kpeoplevcard`),
+subdir `kdeconnect-<deviceId>` else the newest `kdeconnect-*`; parse
+`*.vcf` (FN, N, TEL with types, EMAIL, PHOTO as data URI when inline,
+UID), emit NDJSON `ready {sourcePath, count}`, `snapshot {contacts}` only
+when the SHA-256 of the set changes, `error {code: "no_contact_source"}`.
+Without `--once`, watch with `gio monitor -d`, 250 ms debounce, 3 s poll
+fallback.
+
+`services/PhoneContacts.qml`: `ready`, `count`, `contacts`, `query`,
+`filtered` (name/number match, `hideUnnamed` honoured, favorites never
+hidden), `favorites` (Config `phone.contacts.favoriteIds`),
+`toggleFavorite(uid)`, `openDialer(number)` →
+`adb [-s <serial>] shell am start -a android.intent.action.DIAL -d tel:<n>`,
+`composeSms(number)` → `… SENDTO -d sms:<n>`, both refused with
+`lastError` when adb is not reachable. Sort by `sortBy` (first/last).
+Monitor process follows the lifecycle rule (restart-safe marker).
+
+### W5 — The tab (Phase 2, after W1–W4 land)
+
+Owner of `modules/imi/sidebarLeft/phone/*`, `modules/imi/phone/*` (moved
+shared pieces), `SidebarLeftContent.qml`, `modules/imi/bar/LeftSidebarButton.qml`,
+`GlobalStates.qml` (`sidebarLeftTab`), the quick-toggle retarget in
+`sidebarRight/`, deletion of `sidebarRight/phoneConnect/PhoneConnectDialog.qml`
+and its `ToggleDialog`, `modules/imi/settings/pages/SidebarsPanelsConfig.qml`
+(the Phone switch) and a new `modules/imi/settings/pages/PhoneConfig.qml`
+("Devices & Phone": the fork's `DevicesPhoneConfig` + `KdeConnectConfig`
+rows, on the row grammar from #310), the tab runtime harness
+`PhoneTabRuntimeTest.qml` + `tests/test_phone_tab_runtime.py`, and the
+tab-set pin `tests/test_sidebar_left_tabs.py`.
+
+Files in `modules/imi/sidebarLeft/phone/`:
+
+- `Phone.qml` — the tab root (`Item`, accepts focus), the ColumnLayout in
+  the order above, the `DropArea`, the toast (`actionFeedback`), the
+  sub-page overlay loader, `StaggerWave` entrance keyed to the sidebar's
+  open flag like `SidebarLeftContent`'s.
+- `PhoneHeader.qml`, `PhoneActionsRow.qml` (six `PhoneActionButton`s from
+  `modules/imi/phone/`), `PhoneNavCards.qml`, `PhoneNotificationList.qml`
+  (group-by-app, swipe dismiss, reply field, action chips, copy; reuses
+  `NotificationGroup`'s shape on `PhoneNotifications` data),
+  `PhoneFooterBar.qml`, `PhoneFeatureCard.qml` (state machine
+  `unavailable|offline|connecting|ready|active`, expands when active with
+  detail line + Stop + chips), `PhoneFeatureCards.qml` (the three cards +
+  pairing cards), `InstallGuidePopup.qml` (distro pills, per-dep command
+  box with copy, Re-check), `PhoneSubPage.qml` (title bar + back),
+  `PhoneContactsPage.qml`, `PhoneAppsPage.qml`, `PhoneWebcamPage.qml`,
+  `PhoneMicPage.qml`.
+
+Strings through `Translation.tr`; every dimension, radius, duration from
+`Appearance.*`; motion on the tiers (lints will refuse literals). The
+contract test's `SURFACE` widens to both directories and its dialog-shaped
+assertions become tab-shaped: one `id: actionRow` with six buttons in the
+order `ring, ping, sendClipboard, pickAndSendFiles, shareClipboard,
+browseFiles`, one `Layout.fillHeight: true` on the notification list.
+
+## Verification
+
+- Suite green on each branch (`./tests/run_tests.sh` from the shell dir);
+  runtime harnesses bring their own weston + session bus.
+- Maintainer verifies live after deploy: pair state, LTE pill, six
+  actions against the real phone, contacts count = 150, app list via USB
+  adb, webcam device appears in `v4l2-ctl --list-devices`, mic source
+  `DroidCam-Mic` in `pactl list sources short`.
+
+## Merge order
+
+W1 → W2 → W3 → W4 (each rebased onto the previous; `PhoneConnect.qml`
+hunks are disjoint by construction), then W5.

--- a/dots/.config/quickshell/imi/modules/common/Persistent.qml
+++ b/dots/.config/quickshell/imi/modules/common/Persistent.qml
@@ -180,6 +180,11 @@ Singleton {
                     property list<var> laps: []
                 }
             }
+
+            property JsonObject phone: JsonObject {
+                property string activeDeviceId: ""
+                property list<string> recentDeviceIds: []
+            }
         }
     }
 }

--- a/dots/.config/quickshell/imi/services/PhoneConnect.qml
+++ b/dots/.config/quickshell/imi/services/PhoneConnect.qml
@@ -57,9 +57,10 @@ Singleton {
     // cards are drawn from.
     readonly property var pairingRequests: root.devices.filter(d => d.hasPairingRequest === true)
 
-    readonly property var activeDevice: root.devices.find(d => d.paired && d.reachable && d.type === "phone")
-        ?? root.devices.find(d => d.paired && d.reachable)
-        ?? null
+    // The device the user picked, remembered across sessions
+    // (Persistent.states.phone), and the MRU list behind the roster.
+    readonly property string persistedActiveDeviceId: Persistent.states?.phone?.activeDeviceId ?? ""
+    readonly property var activeDevice: root.preferredActiveDevice(root.devices, root.persistedActiveDeviceId)
     readonly property string materialSymbol: (root.available && root.activeDevice) ? "mobile" : "mobile_off"
 
     // Valent action names beyond findmyphone.ring were not verifiable against
@@ -332,6 +333,31 @@ Singleton {
         const root_ = (typeof mount === "string" ? mount : "").replace(/\/+$/, "");
         if (root_.length === 0) return "";
         return hasStorage ? root.sftpStoragePath(root_) : root_;
+    }
+
+    // Which device the surface is about: the persisted choice while that
+    // device is paired and reachable, else a reachable paired phone, else
+    // any reachable paired device.
+    function preferredActiveDevice(devices: var, persistedId: var): var {
+        const list = devices ?? [];
+        return list.find(d => d.id === persistedId && d.paired && d.reachable)
+            ?? list.find(d => d.paired && d.reachable && d.type === "phone")
+            ?? list.find(d => d.paired && d.reachable)
+            ?? null;
+    }
+
+    // The MRU list after a pick: the id first, once, at most `max` long.
+    // Walked by index rather than as an Array, because a list<string> read
+    // off a JsonAdapter is a QML sequence that fails Array.isArray.
+    function recentDeviceIdsAfterSelect(list: var, id: var, max: int): var {
+        const out = [];
+        if (root.validDeviceId(id)) out.push(id);
+        const src = list ?? [];
+        for (let i = 0; i < (src.length ?? 0); i++) {
+            const entry = src[i];
+            if (typeof entry === "string" && entry !== id && !out.includes(entry)) out.push(entry);
+        }
+        return out.slice(0, Math.max(0, max));
     }
     // END phone-connect parser logic
 
@@ -701,6 +727,14 @@ Singleton {
         onExited: (exitCode, exitStatus) => {
             Quickshell.execDetached(["xdg-open", root.sftpBrowseTarget(storageProbe.mount, exitCode === 0)]);
         }
+    }
+
+    // Persist a pick. Guarded on Persistent.ready: a write before the
+    // states file has loaded would be flushed back over it as defaults.
+    function selectDevice(id: var): void {
+        if (!root.validDeviceId(id) || !Persistent.ready) return;
+        Persistent.states.phone.activeDeviceId = id;
+        Persistent.states.phone.recentDeviceIds = root.recentDeviceIdsAfterSelect(Persistent.states.phone.recentDeviceIds, id, 5);
     }
 
     // Both answer a request the PEER made, so neither falls back to the

--- a/dots/.config/quickshell/imi/services/PhoneConnect.qml
+++ b/dots/.config/quickshell/imi/services/PhoneConnect.qml
@@ -317,6 +317,22 @@ Singleton {
             .filter(line => line.startsWith("/"))
             .map(path => "file://" + path.split("/").map(encodeURIComponent).join("/"));
     }
+
+    // Where the phone's user storage sits under an SFTP mount. The mount
+    // root is not the user's storage (the fork's 3a7f653b4 records it):
+    // storage/emulated/0 is, when the phone exposes it.
+    function sftpStoragePath(mount: var): string {
+        const root_ = (typeof mount === "string" ? mount : "").replace(/\/+$/, "");
+        return root_.length === 0 ? "" : `${root_}/storage/emulated/0`;
+    }
+
+    // The directory to open for a browse: the storage when it exists, the
+    // mount root otherwise.
+    function sftpBrowseTarget(mount: var, hasStorage: bool): string {
+        const root_ = (typeof mount === "string" ? mount : "").replace(/\/+$/, "");
+        if (root_.length === 0) return "";
+        return hasStorage ? root.sftpStoragePath(root_) : root_;
+    }
     // END phone-connect parser logic
 
     function applyBackend(newBackend: string): void {
@@ -627,6 +643,63 @@ Singleton {
             root.actionFeedback(urls.length === 1
                 ? Translation.tr("Sending file…")
                 : Translation.tr("Sending %1 files…").arg(String(urls.length)), true);
+        }
+    }
+
+    // Browse the phone over SFTP: sftp.mount, then wait for isMounted (the
+    // mount is sshfs coming up, and the daemon's mount() returns before it
+    // has), read mountPoint, prefer the phone's storage under it, and open
+    // the directory. sftpMounted is the daemon's last isMounted answer.
+    property bool sftpMounted: false
+    property string sftpBrowseDeviceId: ""
+    property int sftpMountAttempts: 0
+    readonly property int sftpMountAttemptCeiling: 10
+
+    function browseFiles(device: var): void {
+        const d = device ?? root.activeDevice;
+        if (!d || root.backend !== "kdeconnect" || !root.validDeviceId(d.id)) return;
+        root.lastActionError = "";
+        root.sftpBrowseDeviceId = d.id;
+        root.sftpMountAttempts = 0;
+        root.runAction(root.busctlCall("org.kde.kdeconnect.daemon", `/modules/kdeconnect/devices/${d.id}/sftp`, "org.kde.kdeconnect.device.sftp", "mount", []));
+        root.actionFeedback(Translation.tr("Mounting phone storage…"), true);
+        sftpMountWait.restart();
+    }
+
+    function pollSftpMount(): void {
+        const id = root.sftpBrowseDeviceId;
+        if (!root.validDeviceId(id)) return;
+        const sftpPath = `/modules/kdeconnect/devices/${id}/sftp`;
+        root.enqueue(root.busctlCall("org.kde.kdeconnect.daemon", sftpPath, "org.kde.kdeconnect.device.sftp", "isMounted", []), mountedText => {
+            root.sftpMounted = root.parseBusctlReply(mountedText)?.[0] === true;
+            if (!root.sftpMounted) {
+                if (++root.sftpMountAttempts < root.sftpMountAttemptCeiling) sftpMountWait.restart();
+                else root.reportFailure(Translation.tr("Phone storage did not mount"));
+                return;
+            }
+            root.enqueue(root.busctlCall("org.kde.kdeconnect.daemon", sftpPath, "org.kde.kdeconnect.device.sftp", "mountPoint", []), pointText => {
+                const mount = root.parseBusctlReply(pointText)?.[0];
+                if (typeof mount !== "string" || mount.length === 0) {
+                    root.reportFailure(Translation.tr("Phone storage has no mount point"));
+                    return;
+                }
+                storageProbe.mount = mount;
+                storageProbe.exec(["test", "-d", root.sftpStoragePath(mount)]);
+            });
+        });
+    }
+
+    Timer {
+        id: sftpMountWait
+        interval: 600
+        onTriggered: root.pollSftpMount()
+    }
+
+    Process {
+        id: storageProbe
+        property string mount: ""
+        onExited: (exitCode, exitStatus) => {
+            Quickshell.execDetached(["xdg-open", root.sftpBrowseTarget(storageProbe.mount, exitCode === 0)]);
         }
     }
 

--- a/dots/.config/quickshell/imi/services/PhoneConnect.qml
+++ b/dots/.config/quickshell/imi/services/PhoneConnect.qml
@@ -67,6 +67,16 @@ Singleton {
     readonly property bool canPing: root.backend === "kdeconnect"
     readonly property bool canSendClipboard: root.backend === "kdeconnect"
 
+    // What the last action had to say: the toast reads the signal, an
+    // inline line reads the string. Cleared by the next action that starts.
+    property string lastActionError: ""
+    signal actionFeedback(string message, bool ok)
+
+    function reportFailure(message: string): void {
+        root.lastActionError = message;
+        root.actionFeedback(message, false);
+    }
+
     // BEGIN phone-connect parser logic (synced with tests/imports/testservices/PhoneConnect.qml)
     // Parses one `busctl --json=short` reply. Returns the payload ("data")
     // array, or null when the text is not a busctl JSON document (empty
@@ -536,9 +546,11 @@ Singleton {
         }
         onExited: (exitCode, exitStatus) => {
             if (exitCode !== 0) {
+                const message = actionErr.text.trim() || Translation.tr("Phone Connect command failed");
+                root.reportFailure(message);
                 Quickshell.execDetached(["notify-send",
                     Translation.tr("Phone Connect"),
-                    actionErr.text.trim() || Translation.tr("Phone Connect command failed"),
+                    message,
                     "-a", "Shell"
                 ]);
             }

--- a/dots/.config/quickshell/imi/services/PhoneConnect.qml
+++ b/dots/.config/quickshell/imi/services/PhoneConnect.qml
@@ -510,8 +510,19 @@ Singleton {
         root.runAction(root.busctlCall("org.kde.kdeconnect.daemon", `/modules/kdeconnect/devices/${d.id}`, "org.kde.kdeconnect.device", "cancelPairing", []));
     }
 
+    // Queued, never exec'd straight onto the Process: exec on a running
+    // Process terminates it first (measured - the first of two commands
+    // exited 15/crashed with no output), and a multi-file share is a burst.
+    property var actionQueue: []
+
     function runAction(argv: var): void {
-        actionProc.exec(argv);
+        root.actionQueue.push(argv);
+        root.pumpActions();
+    }
+
+    function pumpActions(): void {
+        if (actionProc.running || root.actionQueue.length === 0) return;
+        actionProc.exec(root.actionQueue.shift());
     }
 
     Process {
@@ -531,6 +542,7 @@ Singleton {
                     "-a", "Shell"
                 ]);
             }
+            root.pumpActions();
         }
     }
 

--- a/dots/.config/quickshell/imi/services/PhoneConnect.qml
+++ b/dots/.config/quickshell/imi/services/PhoneConnect.qml
@@ -613,18 +613,22 @@ Singleton {
             root.runAction(root.busctlCall("org.kde.kdeconnect.daemon", `/modules/kdeconnect/devices/${d.id}/findmyphone`, "org.kde.kdeconnect.device.findmyphone", "ring", []));
         else if (root.backend === "valent" && root.validValentObjectPath(d.objectPath))
             root.runAction(root.busctlCall("ca.andyholmes.Valent", d.objectPath, "org.gtk.Actions", "Activate", ["sava{sv}", "findmyphone.ring", "0", "0"]));
+        else return;
+        root.actionFeedback(Translation.tr("Ringing phone…"), true);
     }
 
     function ping(device: var): void {
         const d = device ?? root.activeDevice;
         if (!d || root.backend !== "kdeconnect" || !root.validDeviceId(d.id)) return;
         root.runAction(root.busctlCall("org.kde.kdeconnect.daemon", `/modules/kdeconnect/devices/${d.id}/ping`, "org.kde.kdeconnect.device.ping", "sendPing", []));
+        root.actionFeedback(Translation.tr("Ping sent"), true);
     }
 
     function sendClipboard(device: var): void {
         const d = device ?? root.activeDevice;
         if (!d || root.backend !== "kdeconnect" || !root.validDeviceId(d.id)) return;
         root.runAction(root.busctlCall("org.kde.kdeconnect.daemon", `/modules/kdeconnect/devices/${d.id}/clipboard`, "org.kde.kdeconnect.device.clipboard", "sendClipboard", []));
+        root.actionFeedback(Translation.tr("Clipboard sent"), true);
     }
 
     // One share.shareUrl per entry, each its own queued action, so a

--- a/dots/.config/quickshell/imi/services/PhoneConnect.qml
+++ b/dots/.config/quickshell/imi/services/PhoneConnect.qml
@@ -292,6 +292,19 @@ Singleton {
             .map(entry => typeof entry === "string" ? entry.trim() : "")
             .filter(entry => /^(file|https?):\/\//i.test(entry));
     }
+
+    // What to do with the desktop clipboard: a link goes as a URL, prose as
+    // text, nothing is refused. The URL heuristic is the fork's - a scheme,
+    // or a host-shaped token that is the whole string or the start of a
+    // path. A bare host leaves with https:// on it: the daemon hands the
+    // string to a QUrl, and a schemeless one is relative to nothing.
+    function clipboardShareTarget(text: var): var {
+        const value = (typeof text === "string" ? text : "").trim();
+        if (value.length === 0) return { kind: "empty", value: "" };
+        if (/^https?:\/\//i.test(value)) return { kind: "url", value: value };
+        if (/^[\w.-]+\.\w{2,}(\/|$)/.test(value)) return { kind: "url", value: `https://${value}` };
+        return { kind: "text", value: value };
+    }
     // END phone-connect parser logic
 
     function applyBackend(newBackend: string): void {
@@ -529,6 +542,46 @@ Singleton {
         const d = device ?? root.activeDevice;
         if (!d || root.backend !== "kdeconnect" || !root.validDeviceId(d.id) || !text) return;
         root.runAction(root.busctlCall("org.kde.kdeconnect.daemon", `/modules/kdeconnect/devices/${d.id}/share`, "org.kde.kdeconnect.device.share", "shareText", ["s", text]));
+    }
+
+    // The desktop clipboard, shared as a link or as text. Read with
+    // wl-paste rather than Quickshell's clipboard binding so the service
+    // stays a process it can observe; the read is one-shot, and a second
+    // click while it runs is dropped rather than restarting it.
+    property var clipboardShareDevice: null
+
+    function shareClipboard(device: var): void {
+        const d = device ?? root.activeDevice;
+        if (!d || root.backend !== "kdeconnect" || !root.validDeviceId(d.id)) return;
+        if (clipboardProc.running) return;
+        root.lastActionError = "";
+        root.clipboardShareDevice = d;
+        clipboardProc.running = true;
+    }
+
+    Process {
+        id: clipboardProc
+        command: ["wl-paste", "--no-newline"]
+        stdout: StdioCollector {
+            id: clipboardOut
+        }
+        // "Nothing is copied" on stderr and exit 1 is an empty clipboard;
+        // the empty stdout says the same thing.
+        stderr: StdioCollector {}
+        onExited: (exitCode, exitStatus) => {
+            const target = root.clipboardShareTarget(clipboardOut.text);
+            const d = root.clipboardShareDevice;
+            root.clipboardShareDevice = null;
+            if (target.kind === "empty") {
+                root.reportFailure(Translation.tr("Clipboard is empty"));
+            } else if (target.kind === "url") {
+                root.shareUrls(d, [target.value]);
+                root.actionFeedback(Translation.tr("Link shared"), true);
+            } else {
+                root.shareText(d, target.value);
+                root.actionFeedback(Translation.tr("Text shared"), true);
+            }
+        }
     }
 
     // Both answer a request the PEER made, so neither falls back to the

--- a/dots/.config/quickshell/imi/services/PhoneConnect.qml
+++ b/dots/.config/quickshell/imi/services/PhoneConnect.qml
@@ -66,6 +66,7 @@ Singleton {
     // a live daemon, so only the verified surface is offered there.
     readonly property bool canPing: root.backend === "kdeconnect"
     readonly property bool canSendClipboard: root.backend === "kdeconnect"
+    readonly property bool canShare: root.backend === "kdeconnect"
 
     // What the last action had to say: the toast reads the signal, an
     // inline line reads the string. Cleared by the next action that starts.
@@ -279,6 +280,17 @@ Singleton {
         if (!wanted || settled >= ceiling)
             return { attempts: settled, retry: false, delay: 0 };
         return { attempts: settled + 1, retry: true, delay: root.monitorBackoffDelay(settled + 1) };
+    }
+
+    // What the share plugin may be handed as a URL: a file:// or http(s)://
+    // string, trimmed. Everything else - a bare path, an empty picker line,
+    // a non-string - is dropped rather than sent as a URL the daemon
+    // cannot open.
+    function shareableUrls(entries: var): var {
+        if (!Array.isArray(entries)) return [];
+        return entries
+            .map(entry => typeof entry === "string" ? entry.trim() : "")
+            .filter(entry => /^(file|https?):\/\//i.test(entry));
     }
     // END phone-connect parser logic
 
@@ -502,6 +514,21 @@ Singleton {
         const d = device ?? root.activeDevice;
         if (!d || root.backend !== "kdeconnect" || !root.validDeviceId(d.id)) return;
         root.runAction(root.busctlCall("org.kde.kdeconnect.daemon", `/modules/kdeconnect/devices/${d.id}/clipboard`, "org.kde.kdeconnect.device.clipboard", "sendClipboard", []));
+    }
+
+    // One share.shareUrl per entry, each its own queued action, so a
+    // multi-file send arrives as N calls rather than the last one.
+    function shareUrls(device: var, urls: var): void {
+        const d = device ?? root.activeDevice;
+        if (!d || root.backend !== "kdeconnect" || !root.validDeviceId(d.id)) return;
+        for (const url of root.shareableUrls(urls))
+            root.runAction(root.busctlCall("org.kde.kdeconnect.daemon", `/modules/kdeconnect/devices/${d.id}/share`, "org.kde.kdeconnect.device.share", "shareUrl", ["s", url]));
+    }
+
+    function shareText(device: var, text: string): void {
+        const d = device ?? root.activeDevice;
+        if (!d || root.backend !== "kdeconnect" || !root.validDeviceId(d.id) || !text) return;
+        root.runAction(root.busctlCall("org.kde.kdeconnect.daemon", `/modules/kdeconnect/devices/${d.id}/share`, "org.kde.kdeconnect.device.share", "shareText", ["s", text]));
     }
 
     // Both answer a request the PEER made, so neither falls back to the

--- a/dots/.config/quickshell/imi/services/PhoneConnect.qml
+++ b/dots/.config/quickshell/imi/services/PhoneConnect.qml
@@ -305,6 +305,18 @@ Singleton {
         if (/^[\w.-]+\.\w{2,}(\/|$)/.test(value)) return { kind: "url", value: `https://${value}` };
         return { kind: "text", value: value };
     }
+
+    // A file picker's stdout - one absolute path per line - as the file://
+    // URLs the share plugin takes. Percent-encoded per segment, since the
+    // daemon hands each to a QUrl and a raw "#" or "?" in a name would be
+    // read as a fragment or a query. A cancelled picker prints nothing.
+    function pickedFileUrls(text: var): var {
+        return (typeof text === "string" ? text : "")
+            .split("\n")
+            .map(line => line.trim())
+            .filter(line => line.startsWith("/"))
+            .map(path => "file://" + path.split("/").map(encodeURIComponent).join("/"));
+    }
     // END phone-connect parser logic
 
     function applyBackend(newBackend: string): void {
@@ -581,6 +593,40 @@ Singleton {
                 root.shareText(d, target.value);
                 root.actionFeedback(Translation.tr("Text shared"), true);
             }
+        }
+    }
+
+    // The house file picker (kdialog, as SidebarRightContent's wallpaper
+    // picker uses it), one file:// share per line it prints. One picker at
+    // a time: a click while it is open is dropped rather than opening a
+    // second dialog over the first.
+    property var filePickerDevice: null
+
+    function pickAndSendFiles(device: var): void {
+        const d = device ?? root.activeDevice;
+        if (!d || root.backend !== "kdeconnect" || !root.validDeviceId(d.id)) return;
+        if (filePickerProc.running) return;
+        root.lastActionError = "";
+        root.filePickerDevice = d;
+        filePickerProc.running = true;
+    }
+
+    Process {
+        id: filePickerProc
+        command: ["kdialog", "--getopenfilename", Quickshell.env("HOME") ?? "", "--multiple"]
+        stdout: StdioCollector {
+            id: filePickerOut
+        }
+        stderr: StdioCollector {}
+        onExited: (exitCode, exitStatus) => {
+            const urls = root.pickedFileUrls(filePickerOut.text);
+            const d = root.filePickerDevice;
+            root.filePickerDevice = null;
+            if (urls.length === 0) return; // cancelled
+            root.shareUrls(d, urls);
+            root.actionFeedback(urls.length === 1
+                ? Translation.tr("Sending file…")
+                : Translation.tr("Sending %1 files…").arg(String(urls.length)), true);
         }
     }
 

--- a/dots/.config/quickshell/imi/services/PhoneConnect.qml
+++ b/dots/.config/quickshell/imi/services/PhoneConnect.qml
@@ -359,6 +359,18 @@ Singleton {
         }
         return out.slice(0, Math.max(0, max));
     }
+
+    // The low-battery latch, as one decision. Thresholds are the
+    // proposal's, literally: "low" once when the charge is below 20 and
+    // the phone is not charging; "recovered" at 25 or above, or the moment
+    // it charges, while the latch is set. An unknown charge (-1) moves
+    // nothing.
+    function batteryNoticeTransition(notified: bool, charge: int, charging: bool): var {
+        if (charge < 0) return { notice: "", notified: notified };
+        if (!notified && charge < 20 && !charging) return { notice: "low", notified: true };
+        if (notified && (charge >= 25 || charging)) return { notice: "recovered", notified: false };
+        return { notice: "", notified: notified };
+    }
     // END phone-connect parser logic
 
     function applyBackend(newBackend: string): void {
@@ -558,6 +570,38 @@ Singleton {
         if (root.monitorState === "failed") root.monitorState = "idle";
         if (root.monitorMatchRule(root.backend) === "") root.stopMonitor();
         else root.startMonitor();
+    }
+
+    // ---- low-battery hooks ----
+
+    // The latch is per device: a different active device starts clean.
+    property string batteryNoticeDeviceId: ""
+    property bool batteryNoticed: false
+
+    // activeDevice is rebuilt on every sweep, so this handler sees every
+    // battery change the model does.
+    onActiveDeviceChanged: root.observeBattery()
+
+    function observeBattery(): void {
+        const d = root.activeDevice;
+        if (!d) return;
+        if (d.id !== root.batteryNoticeDeviceId) {
+            root.batteryNoticeDeviceId = d.id;
+            root.batteryNoticed = false;
+        }
+        if (!d.batteryAvailable) return;
+        const next = root.batteryNoticeTransition(root.batteryNoticed, d.batteryCharge, d.batteryCharging);
+        root.batteryNoticed = next.notified;
+        const name = d.name || Translation.tr("Phone");
+        if (next.notice === "low") {
+            Quickshell.execDetached(["notify-send", "-i", "phone", "-u", "normal",
+                Translation.tr("Low battery: %1").arg(name),
+                Translation.tr("Charge is at %1%.").arg(String(d.batteryCharge))]);
+        } else if (next.notice === "recovered") {
+            Quickshell.execDetached(["notify-send", "-i", "phone", "-u", "low",
+                Translation.tr("Battery recovered: %1").arg(name),
+                Translation.tr("Charge is back to %1%.").arg(String(d.batteryCharge))]);
+        }
     }
 
     // ---- actions ----

--- a/dots/.config/quickshell/imi/tests/imports/testservices/PhoneConnect.qml
+++ b/dots/.config/quickshell/imi/tests/imports/testservices/PhoneConnect.qml
@@ -266,6 +266,22 @@ Singleton {
             .filter(line => line.startsWith("/"))
             .map(path => "file://" + path.split("/").map(encodeURIComponent).join("/"));
     }
+
+    // Where the phone's user storage sits under an SFTP mount. The mount
+    // root is not the user's storage (the fork's 3a7f653b4 records it):
+    // storage/emulated/0 is, when the phone exposes it.
+    function sftpStoragePath(mount: var): string {
+        const root_ = (typeof mount === "string" ? mount : "").replace(/\/+$/, "");
+        return root_.length === 0 ? "" : `${root_}/storage/emulated/0`;
+    }
+
+    // The directory to open for a browse: the storage when it exists, the
+    // mount root otherwise.
+    function sftpBrowseTarget(mount: var, hasStorage: bool): string {
+        const root_ = (typeof mount === "string" ? mount : "").replace(/\/+$/, "");
+        if (root_.length === 0) return "";
+        return hasStorage ? root.sftpStoragePath(root_) : root_;
+    }
     // END phone-connect parser logic
 
     function applyBackend(newBackend: string): void {

--- a/dots/.config/quickshell/imi/tests/imports/testservices/PhoneConnect.qml
+++ b/dots/.config/quickshell/imi/tests/imports/testservices/PhoneConnect.qml
@@ -241,6 +241,19 @@ Singleton {
             .map(entry => typeof entry === "string" ? entry.trim() : "")
             .filter(entry => /^(file|https?):\/\//i.test(entry));
     }
+
+    // What to do with the desktop clipboard: a link goes as a URL, prose as
+    // text, nothing is refused. The URL heuristic is the fork's - a scheme,
+    // or a host-shaped token that is the whole string or the start of a
+    // path. A bare host leaves with https:// on it: the daemon hands the
+    // string to a QUrl, and a schemeless one is relative to nothing.
+    function clipboardShareTarget(text: var): var {
+        const value = (typeof text === "string" ? text : "").trim();
+        if (value.length === 0) return { kind: "empty", value: "" };
+        if (/^https?:\/\//i.test(value)) return { kind: "url", value: value };
+        if (/^[\w.-]+\.\w{2,}(\/|$)/.test(value)) return { kind: "url", value: `https://${value}` };
+        return { kind: "text", value: value };
+    }
     // END phone-connect parser logic
 
     function applyBackend(newBackend: string): void {

--- a/dots/.config/quickshell/imi/tests/imports/testservices/PhoneConnect.qml
+++ b/dots/.config/quickshell/imi/tests/imports/testservices/PhoneConnect.qml
@@ -254,6 +254,18 @@ Singleton {
         if (/^[\w.-]+\.\w{2,}(\/|$)/.test(value)) return { kind: "url", value: `https://${value}` };
         return { kind: "text", value: value };
     }
+
+    // A file picker's stdout - one absolute path per line - as the file://
+    // URLs the share plugin takes. Percent-encoded per segment, since the
+    // daemon hands each to a QUrl and a raw "#" or "?" in a name would be
+    // read as a fragment or a query. A cancelled picker prints nothing.
+    function pickedFileUrls(text: var): var {
+        return (typeof text === "string" ? text : "")
+            .split("\n")
+            .map(line => line.trim())
+            .filter(line => line.startsWith("/"))
+            .map(path => "file://" + path.split("/").map(encodeURIComponent).join("/"));
+    }
     // END phone-connect parser logic
 
     function applyBackend(newBackend: string): void {

--- a/dots/.config/quickshell/imi/tests/imports/testservices/PhoneConnect.qml
+++ b/dots/.config/quickshell/imi/tests/imports/testservices/PhoneConnect.qml
@@ -306,6 +306,18 @@ Singleton {
         }
         return out.slice(0, Math.max(0, max));
     }
+
+    // The low-battery latch, as one decision. Thresholds are the
+    // proposal's, literally: "low" once when the charge is below 20 and
+    // the phone is not charging; "recovered" at 25 or above, or the moment
+    // it charges, while the latch is set. An unknown charge (-1) moves
+    // nothing.
+    function batteryNoticeTransition(notified: bool, charge: int, charging: bool): var {
+        if (charge < 0) return { notice: "", notified: notified };
+        if (!notified && charge < 20 && !charging) return { notice: "low", notified: true };
+        if (notified && (charge >= 25 || charging)) return { notice: "recovered", notified: false };
+        return { notice: "", notified: notified };
+    }
     // END phone-connect parser logic
 
     function applyBackend(newBackend: string): void {

--- a/dots/.config/quickshell/imi/tests/imports/testservices/PhoneConnect.qml
+++ b/dots/.config/quickshell/imi/tests/imports/testservices/PhoneConnect.qml
@@ -230,6 +230,17 @@ Singleton {
             return { attempts: settled, retry: false, delay: 0 };
         return { attempts: settled + 1, retry: true, delay: root.monitorBackoffDelay(settled + 1) };
     }
+
+    // What the share plugin may be handed as a URL: a file:// or http(s)://
+    // string, trimmed. Everything else - a bare path, an empty picker line,
+    // a non-string - is dropped rather than sent as a URL the daemon
+    // cannot open.
+    function shareableUrls(entries: var): var {
+        if (!Array.isArray(entries)) return [];
+        return entries
+            .map(entry => typeof entry === "string" ? entry.trim() : "")
+            .filter(entry => /^(file|https?):\/\//i.test(entry));
+    }
     // END phone-connect parser logic
 
     function applyBackend(newBackend: string): void {

--- a/dots/.config/quickshell/imi/tests/imports/testservices/PhoneConnect.qml
+++ b/dots/.config/quickshell/imi/tests/imports/testservices/PhoneConnect.qml
@@ -22,9 +22,8 @@ Singleton {
     // cards are drawn from.
     readonly property var pairingRequests: root.devices.filter(d => d.hasPairingRequest === true)
 
-    readonly property var activeDevice: root.devices.find(d => d.paired && d.reachable && d.type === "phone")
-        ?? root.devices.find(d => d.paired && d.reachable)
-        ?? null
+    property string persistedActiveDeviceId: ""
+    readonly property var activeDevice: root.preferredActiveDevice(root.devices, root.persistedActiveDeviceId)
     readonly property string materialSymbol: (root.available && root.activeDevice) ? "mobile" : "mobile_off"
 
     // BEGIN phone-connect parser logic (synced with services/PhoneConnect.qml)
@@ -281,6 +280,31 @@ Singleton {
         const root_ = (typeof mount === "string" ? mount : "").replace(/\/+$/, "");
         if (root_.length === 0) return "";
         return hasStorage ? root.sftpStoragePath(root_) : root_;
+    }
+
+    // Which device the surface is about: the persisted choice while that
+    // device is paired and reachable, else a reachable paired phone, else
+    // any reachable paired device.
+    function preferredActiveDevice(devices: var, persistedId: var): var {
+        const list = devices ?? [];
+        return list.find(d => d.id === persistedId && d.paired && d.reachable)
+            ?? list.find(d => d.paired && d.reachable && d.type === "phone")
+            ?? list.find(d => d.paired && d.reachable)
+            ?? null;
+    }
+
+    // The MRU list after a pick: the id first, once, at most `max` long.
+    // Walked by index rather than as an Array, because a list<string> read
+    // off a JsonAdapter is a QML sequence that fails Array.isArray.
+    function recentDeviceIdsAfterSelect(list: var, id: var, max: int): var {
+        const out = [];
+        if (root.validDeviceId(id)) out.push(id);
+        const src = list ?? [];
+        for (let i = 0; i < (src.length ?? 0); i++) {
+            const entry = src[i];
+            if (typeof entry === "string" && entry !== id && !out.includes(entry)) out.push(entry);
+        }
+        return out.slice(0, Math.max(0, max));
     }
     // END phone-connect parser logic
 

--- a/dots/.config/quickshell/imi/tests/test_phone_connect_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_connect_contract.py
@@ -34,7 +34,8 @@ DIALOG = SURFACE / "PhoneConnectDialog.qml"
 # dialog is shaped after a fork whose action row carries six buttons; ours
 # carries the three this model backs, and a fourth appears here or not at
 # all - a button whose call the service does not answer is a fake action.
-MODEL_ACTIONS = {"refresh", "ring", "ping", "sendClipboard", "acceptPairing", "cancelPairing"}
+MODEL_ACTIONS = {"refresh", "ring", "ping", "sendClipboard", "acceptPairing", "cancelPairing",
+                 "shareUrls", "shareText"}
 
 BEGIN = "// BEGIN phone-connect parser logic"
 END = "    // END phone-connect parser logic"
@@ -180,7 +181,8 @@ def test_device_ids_are_validated_before_path_splicing():
         "valent object paths must be validated before DescribeAll is called on them"
     )
     # Actions build paths from ids/paths too - each must re-check.
-    for action in ("ring", "ping", "sendClipboard", "acceptPairing", "cancelPairing"):
+    for action in ("ring", "ping", "sendClipboard", "acceptPairing", "cancelPairing",
+                   "shareUrls", "shareText"):
         body = re.search(rf"function {action}\(.*?\n    \}}\n", source, re.S)
         assert body, f"{action}() missing"
         assert "validDeviceId" in body.group(0) or "validValentObjectPath" in body.group(0), (
@@ -378,6 +380,33 @@ def test_feedback_is_one_signal_and_one_error_string_and_a_failed_action_reaches
     )
     block = _process_block(source, "actionProc")
     assert "root.reportFailure(" in block, "a failed busctl action does not report through reportFailure"
+
+
+def test_share_goes_through_the_share_plugin_one_url_per_call():
+    """Slice 4's transport: `org.kde.kdeconnect.device.share.shareUrl` /
+    `shareText` on the device's /share leaf, one string argument each
+    (busctl signature "s"), serialized through runAction. shareUrls takes
+    whatever list it is handed and keeps only file:// and http(s):// entries
+    through the synced shareableUrls filter, so a stray path or an empty
+    line never reaches the daemon as a URL."""
+    source = SERVICE.read_text()
+    assert re.search(r'readonly property bool canShare: root\.backend === "kdeconnect"', source), (
+        "canShare is not declared as kdeconnect-only"
+    )
+    urls = re.search(r"function shareUrls\(.*?\n    \}\n", source, re.S)
+    assert urls, "shareUrls() missing"
+    assert "root.shareableUrls(" in urls.group(0), "shareUrls does not filter through shareableUrls"
+    assert 'root.runAction(root.busctlCall("org.kde.kdeconnect.daemon", `/modules/kdeconnect/devices/${d.id}/share`, "org.kde.kdeconnect.device.share", "shareUrl", ["s", url]))' in urls.group(0), (
+        "shareUrls does not call share.shareUrl on the share leaf with one string argument"
+    )
+    text = re.search(r"function shareText\(.*?\n    \}\n", source, re.S)
+    assert text, "shareText() missing"
+    assert '"org.kde.kdeconnect.device.share", "shareText", ["s", text]' in text.group(0), (
+        "shareText does not call share.shareText with one string argument"
+    )
+    assert "root.runAction(" in text.group(0)
+    for body in (urls, text):
+        assert 'root.backend !== "kdeconnect"' in body.group(0), "a share action runs on a backend that has no share plugin"
 
 
 # ---- the sidebar surface ----------------------------------------------------

--- a/dots/.config/quickshell/imi/tests/test_phone_connect_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_connect_contract.py
@@ -35,7 +35,8 @@ DIALOG = SURFACE / "PhoneConnectDialog.qml"
 # carries the three this model backs, and a fourth appears here or not at
 # all - a button whose call the service does not answer is a fake action.
 MODEL_ACTIONS = {"refresh", "ring", "ping", "sendClipboard", "acceptPairing", "cancelPairing",
-                 "shareUrls", "shareText", "shareClipboard", "pickAndSendFiles"}
+                 "shareUrls", "shareText", "shareClipboard", "pickAndSendFiles",
+                 "browseFiles"}
 
 BEGIN = "// BEGIN phone-connect parser logic"
 END = "    // END phone-connect parser logic"
@@ -453,6 +454,44 @@ def test_the_file_picker_is_kdialog_as_a_constant_argv_and_its_lines_become_file
     assert body, "pickAndSendFiles() missing"
     assert "filePickerProc.running" in body.group(0), "pickAndSendFiles does not start the picker (or guard one already open)"
     assert "root.validDeviceId(d.id)" in body.group(0), "pickAndSendFiles aims at an unvalidated device"
+
+
+def test_browse_files_mounts_then_reads_the_mount_point_and_opens_it_as_argv():
+    """Slice 5's transport: sftp.mount on the device's /sftp leaf through
+    runAction; then, on the read queue, sftp.isMounted until it answers
+    true (bounded - a mount that never comes up is a reported failure, not
+    a timer that polls for ever) and sftp.mountPoint, the daemon's own
+    answer for where it put the phone. `<mount>/storage/emulated/0` is
+    preferred when that directory exists (the fork's 3a7f653b4: the mount
+    root is not the user's storage), decided by the synced sftpBrowseTarget
+    from a `test -d` argv, and opened with an xdg-open argv. sftpMounted
+    tracks the isMounted answer."""
+    source = SERVICE.read_text()
+    assert re.search(r"^    property bool sftpMounted: false$", source, re.M), "sftpMounted missing"
+    assert re.search(r"readonly property int sftpMountAttemptCeiling:\s*\d+", source), (
+        "the wait for the mount has no declared ceiling"
+    )
+    body = re.search(r"function browseFiles\(.*?\n    \}\n", source, re.S)
+    assert body, "browseFiles() missing"
+    assert "root.validDeviceId(d.id)" in body.group(0)
+    assert 'root.runAction(root.busctlCall("org.kde.kdeconnect.daemon", `/modules/kdeconnect/devices/${d.id}/sftp`, "org.kde.kdeconnect.device.sftp", "mount", []))' in body.group(0), (
+        "browseFiles does not call sftp.mount on the sftp leaf"
+    )
+    poll = re.search(r"function pollSftpMount\(.*?\n    \}\n", source, re.S)
+    assert poll, "pollSftpMount() missing"
+    for member in ("isMounted", "mountPoint"):
+        assert f'"org.kde.kdeconnect.device.sftp", "{member}", []' in poll.group(0), (
+            f"the mount wait does not read sftp.{member}"
+        )
+    assert "root.sftpMounted = " in poll.group(0), "the isMounted answer does not land on sftpMounted"
+    assert "root.enqueue(" in poll.group(0) and "root.runAction(" not in poll.group(0), (
+        "reads belong on the serialized read queue, not the action process"
+    )
+    assert "root.reportFailure(" in poll.group(0), "a mount that never comes up is not reported"
+    probe = _process_block(source, "storageProbe")
+    assert 'storageProbe.exec(["test", "-d"' in source, "the storage directory is not probed with a test -d argv"
+    assert "root.sftpBrowseTarget(" in probe, "the directory to open is not decided by sftpBrowseTarget"
+    assert 'Quickshell.execDetached(["xdg-open", ' in probe, "the mount is not opened with an xdg-open argv"
 
 
 # ---- the sidebar surface ----------------------------------------------------

--- a/dots/.config/quickshell/imi/tests/test_phone_connect_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_connect_contract.py
@@ -36,7 +36,7 @@ DIALOG = SURFACE / "PhoneConnectDialog.qml"
 # all - a button whose call the service does not answer is a fake action.
 MODEL_ACTIONS = {"refresh", "ring", "ping", "sendClipboard", "acceptPairing", "cancelPairing",
                  "shareUrls", "shareText", "shareClipboard", "pickAndSendFiles",
-                 "browseFiles"}
+                 "browseFiles", "selectDevice"}
 
 BEGIN = "// BEGIN phone-connect parser logic"
 END = "    // END phone-connect parser logic"
@@ -110,6 +110,43 @@ def test_pairing_is_answered_on_the_device_path_with_the_daemon_s_two_methods():
         # copy of ring() would carry here.
         assert "!d.hasPairingRequest" in text, f"{name}() answers a device that never asked"
         assert "root.activeDevice" not in text, f"{name}() falls back to the active device"
+
+
+def test_the_active_device_rule_matches_the_double_and_reads_the_persisted_choice():
+    """Slice 6: activeDevice prefers the persisted device while it is paired
+    and reachable, else the old rule. The rule is preferredActiveDevice in
+    the synced region; the binding that calls it is outside it and the QML
+    suite drives the double's, so both bindings are held to each other. The
+    service reads the persisted id off Persistent; the double carries it as
+    a plain property the suite can set."""
+    pattern = r"    readonly property var activeDevice:.*\n"
+    service_line = re.search(pattern, SERVICE.read_text())
+    double_line = re.search(pattern, DOUBLE.read_text())
+    assert service_line and double_line, "activeDevice missing on one side"
+    assert service_line.group(0) == double_line.group(0), "activeDevice drifted"
+    assert "root.preferredActiveDevice(root.devices, root.persistedActiveDeviceId)" in service_line.group(0)
+    assert re.search(r"readonly property string persistedActiveDeviceId: Persistent\.states\?\.phone\?\.activeDeviceId \?\? \"\"",
+                     SERVICE.read_text()), "the service does not read the persisted id off Persistent.states.phone"
+    assert re.search(r"^    property string persistedActiveDeviceId: \"\"$", DOUBLE.read_text(), re.M), (
+        "the double does not carry persistedActiveDeviceId as a settable property"
+    )
+
+
+def test_select_device_writes_the_persisted_id_and_the_recent_list():
+    source = SERVICE.read_text()
+    body = re.search(r"function selectDevice\(.*?\n    \}\n", source, re.S)
+    assert body, "selectDevice() missing"
+    text = body.group(0)
+    assert "root.validDeviceId(id)" in text, "selectDevice persists an unvalidated id"
+    assert "Persistent.states.phone.activeDeviceId = id" in text, "selectDevice does not persist the choice"
+    assert "Persistent.states.phone.recentDeviceIds = root.recentDeviceIdsAfterSelect(" in text, (
+        "selectDevice does not maintain the MRU list through the synced rule"
+    )
+    persistent = (ROOT / "modules" / "common" / "Persistent.qml").read_text()
+    block = re.search(r"property JsonObject phone: JsonObject \{(.*?)\n            \}", persistent, re.S)
+    assert block, "Persistent.states has no phone JsonObject"
+    assert re.search(r'property string activeDeviceId: ""', block.group(1)), "phone.activeDeviceId missing"
+    assert re.search(r"property list<string> recentDeviceIds: \[\]", block.group(1)), "phone.recentDeviceIds missing"
 
 
 def test_state_application_helpers_match_the_double():

--- a/dots/.config/quickshell/imi/tests/test_phone_connect_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_connect_contract.py
@@ -531,6 +531,31 @@ def test_browse_files_mounts_then_reads_the_mount_point_and_opens_it_as_argv():
     assert 'Quickshell.execDetached(["xdg-open", ' in probe, "the mount is not opened with an xdg-open argv"
 
 
+def test_low_battery_is_observed_on_the_active_device_and_reported_with_notify_send_argv():
+    """Slice 6's battery half: the model is observed (onActiveDeviceChanged
+    fires on every sweep, since the model is rebuilt), the crossing is
+    decided by the synced batteryNoticeTransition the QML suite pins the
+    thresholds of, and each notice is one notify-send argv - the fork's
+    exact lines: `-i phone -u normal "Low battery: <name>" "Charge is at
+    <n>%."` and `-i phone -u low "Battery recovered: <name>" "Charge is
+    back to <n>%."` - never a shell string."""
+    source = SERVICE.read_text()
+    assert re.search(r"^    onActiveDeviceChanged: root\.observeBattery\(\)$", source, re.M), (
+        "the battery is not observed from onActiveDeviceChanged"
+    )
+    body = re.search(r"function observeBattery\(.*?\n    \}\n", source, re.S)
+    assert body, "observeBattery() missing"
+    text = body.group(0)
+    assert "root.batteryNoticeTransition(" in text, "the crossing is not decided by batteryNoticeTransition"
+    assert '"notify-send", "-i", "phone", "-u", "normal"' in text, "the low notice is not the fork's notify-send argv"
+    assert '"notify-send", "-i", "phone", "-u", "low"' in text, "the recovery notice is not the fork's notify-send argv"
+    assert 'Translation.tr("Low battery: %1")' in text and 'Translation.tr("Charge is at %1%.")' in text
+    assert 'Translation.tr("Battery recovered: %1")' in text and 'Translation.tr("Charge is back to %1%.")' in text
+    assert '"sh"' not in text and '"bash"' not in text and "${" not in text
+    # A different active device starts from a clean latch.
+    assert "root.batteryNoticeDeviceId" in text, "the latch is not per device"
+
+
 # ---- the sidebar surface ----------------------------------------------------
 
 

--- a/dots/.config/quickshell/imi/tests/test_phone_connect_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_connect_contract.py
@@ -35,7 +35,7 @@ DIALOG = SURFACE / "PhoneConnectDialog.qml"
 # carries the three this model backs, and a fourth appears here or not at
 # all - a button whose call the service does not answer is a fake action.
 MODEL_ACTIONS = {"refresh", "ring", "ping", "sendClipboard", "acceptPairing", "cancelPairing",
-                 "shareUrls", "shareText"}
+                 "shareUrls", "shareText", "shareClipboard"}
 
 BEGIN = "// BEGIN phone-connect parser logic"
 END = "    // END phone-connect parser logic"
@@ -407,6 +407,31 @@ def test_share_goes_through_the_share_plugin_one_url_per_call():
     assert "root.runAction(" in text.group(0)
     for body in (urls, text):
         assert 'root.backend !== "kdeconnect"' in body.group(0), "a share action runs on a backend that has no share plugin"
+
+
+def test_share_clipboard_reads_wl_paste_as_a_constant_argv_and_decides_through_the_synced_rule():
+    """The clipboard is read with `wl-paste --no-newline` - a constant argv,
+    never a shell string with anything interpolated - and what to do with
+    the text is the synced clipboardShareTarget decision, so the QML suite
+    pins the URL heuristic. An empty clipboard is a reported failure
+    ("Clipboard is empty"), not a share of nothing."""
+    source = SERVICE.read_text()
+    block = _process_block(source, "clipboardProc")
+    assert re.search(r'command:\s*\["wl-paste", "--no-newline"\]', block), (
+        "the clipboard read is not the constant argv [wl-paste, --no-newline]"
+    )
+    assert "${" not in block and '"sh"' not in block and '"bash"' not in block
+    assert "root.clipboardShareTarget(" in block, "the clipboard text is not classified through clipboardShareTarget"
+    assert 'root.reportFailure(Translation.tr("Clipboard is empty"))' in block, (
+        "an empty clipboard is not reported as one"
+    )
+    assert "root.shareUrls(" in block and "root.shareText(" in block, (
+        "the clipboard does not reach both share actions"
+    )
+    body = re.search(r"function shareClipboard\(.*?\n    \}\n", source, re.S)
+    assert body, "shareClipboard() missing"
+    assert "clipboardProc.running" in body.group(0), "shareClipboard does not start the read (or guard a read in flight)"
+    assert "root.validDeviceId(d.id)" in body.group(0), "shareClipboard aims at an unvalidated device"
 
 
 # ---- the sidebar surface ----------------------------------------------------

--- a/dots/.config/quickshell/imi/tests/test_phone_connect_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_connect_contract.py
@@ -338,6 +338,26 @@ def test_signal_bursts_are_coalesced_and_never_dropped():
     )
 
 
+def test_actions_queue_behind_one_another_instead_of_killing_the_one_in_flight():
+    """`Process.exec` on a Process that is still running terminates it first
+    (measured under headless weston: a 2s command followed 500ms later by a
+    second exec exited with code 15, status 1, and no output). One
+    `actionProc` fed straight from runAction therefore drops every action but
+    the last of a burst - and a multi-file share IS a burst. runAction pushes
+    onto a queue that the process's own exit pumps."""
+    source = SERVICE.read_text()
+    body = re.search(r"function runAction\(.*?\n    \}\n", source, re.S)
+    assert body, "runAction() missing"
+    assert "actionProc.exec(" not in body.group(0), "runAction execs straight onto a Process that may be busy"
+    assert "root.actionQueue.push(" in body.group(0), "runAction does not queue"
+    pump = re.search(r"function pumpActions\(.*?\n    \}\n", source, re.S)
+    assert pump, "pumpActions() missing"
+    assert "actionProc.running" in pump.group(0), "the pump does not check whether the process is busy"
+    assert "actionProc.exec(" in pump.group(0), "the pump is not what starts the process"
+    block = _process_block(source, "actionProc")
+    assert "root.pumpActions()" in block, "the action process's exit does not pump the queue"
+
+
 # ---- the sidebar surface ----------------------------------------------------
 
 

--- a/dots/.config/quickshell/imi/tests/test_phone_connect_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_connect_contract.py
@@ -396,6 +396,12 @@ def test_actions_queue_behind_one_another_instead_of_killing_the_one_in_flight()
     assert "actionProc.exec(" in pump.group(0), "the pump is not what starts the process"
     block = _process_block(source, "actionProc")
     assert "root.pumpActions()" in block, "the action process's exit does not pump the queue"
+    # ...and the pump is the ONLY exec on that Process, anywhere in the file:
+    # a second one written beside a new action is the kill coming back.
+    execs = [line.strip() for line in source.splitlines() if "actionProc.exec(" in line]
+    assert execs == ["actionProc.exec(root.actionQueue.shift());"], (
+        f"actionProc is exec'd outside the pump: {execs}"
+    )
 
 
 def test_feedback_is_one_signal_and_one_error_string_and_a_failed_action_reaches_both():

--- a/dots/.config/quickshell/imi/tests/test_phone_connect_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_connect_contract.py
@@ -35,7 +35,7 @@ DIALOG = SURFACE / "PhoneConnectDialog.qml"
 # carries the three this model backs, and a fourth appears here or not at
 # all - a button whose call the service does not answer is a fake action.
 MODEL_ACTIONS = {"refresh", "ring", "ping", "sendClipboard", "acceptPairing", "cancelPairing",
-                 "shareUrls", "shareText", "shareClipboard"}
+                 "shareUrls", "shareText", "shareClipboard", "pickAndSendFiles"}
 
 BEGIN = "// BEGIN phone-connect parser logic"
 END = "    // END phone-connect parser logic"
@@ -432,6 +432,27 @@ def test_share_clipboard_reads_wl_paste_as_a_constant_argv_and_decides_through_t
     assert body, "shareClipboard() missing"
     assert "clipboardProc.running" in body.group(0), "shareClipboard does not start the read (or guard a read in flight)"
     assert "root.validDeviceId(d.id)" in body.group(0), "shareClipboard aims at an unvalidated device"
+
+
+def test_the_file_picker_is_kdialog_as_a_constant_argv_and_its_lines_become_file_urls():
+    """The house picker (`kdialog --getopenfilename $HOME --multiple`, the
+    pattern at SidebarRightContent.qml:113) as a constant argv: the only
+    non-literal element is the start directory, read from the environment
+    and never interpolated into a shell string. Its stdout is one path per
+    line, turned into file:// URLs by the synced pickedFileUrls and handed
+    to shareUrls - so the picker never talks to the daemon itself."""
+    source = SERVICE.read_text()
+    block = _process_block(source, "filePickerProc")
+    command = re.search(r'command:\s*\["kdialog", "--getopenfilename", ([^\]]*)\]', block)
+    assert command, "the picker is not the constant argv [kdialog, --getopenfilename, <home>, --multiple]"
+    assert command.group(1).endswith('"--multiple"'), f"the picker does not ask for several files: {command.group(0)}"
+    assert "${" not in block and '"sh"' not in block and '"bash"' not in block
+    assert "root.pickedFileUrls(" in block, "the picker's lines are not turned into URLs by pickedFileUrls"
+    assert "root.shareUrls(" in block, "the picker does not hand its files to shareUrls"
+    body = re.search(r"function pickAndSendFiles\(.*?\n    \}\n", source, re.S)
+    assert body, "pickAndSendFiles() missing"
+    assert "filePickerProc.running" in body.group(0), "pickAndSendFiles does not start the picker (or guard one already open)"
+    assert "root.validDeviceId(d.id)" in body.group(0), "pickAndSendFiles aims at an unvalidated device"
 
 
 # ---- the sidebar surface ----------------------------------------------------

--- a/dots/.config/quickshell/imi/tests/test_phone_connect_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_connect_contract.py
@@ -358,6 +358,28 @@ def test_actions_queue_behind_one_another_instead_of_killing_the_one_in_flight()
     assert "root.pumpActions()" in block, "the action process's exit does not pump the queue"
 
 
+def test_feedback_is_one_signal_and_one_error_string_and_a_failed_action_reaches_both():
+    """The tab's toast is fed by `actionFeedback(message, ok)` and its inline
+    error by `lastActionError`; every failure the service can see reports
+    through both, and a busctl action exiting non-zero is the one every
+    action shares."""
+    source = SERVICE.read_text()
+    assert re.search(r"^    signal actionFeedback\(string message, bool ok\)$", source, re.M), (
+        "actionFeedback(message, ok) is not declared with that exact signature"
+    )
+    assert re.search(r"^    property string lastActionError: \"\"$", source, re.M), (
+        "lastActionError is not a string property defaulting to empty"
+    )
+    helper = re.search(r"function reportFailure\(message: string\): void \{\n(.*?)\n    \}", source, re.S)
+    assert helper, "reportFailure(message) missing - the one spelling of a failure"
+    assert "root.lastActionError = message" in helper.group(1), "reportFailure does not set lastActionError"
+    assert "root.actionFeedback(message, false)" in helper.group(1), (
+        "reportFailure does not raise actionFeedback(message, false)"
+    )
+    block = _process_block(source, "actionProc")
+    assert "root.reportFailure(" in block, "a failed busctl action does not report through reportFailure"
+
+
 # ---- the sidebar surface ----------------------------------------------------
 
 

--- a/dots/.config/quickshell/imi/tests/test_phone_connect_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_connect_contract.py
@@ -418,6 +418,13 @@ def test_feedback_is_one_signal_and_one_error_string_and_a_failed_action_reaches
     )
     block = _process_block(source, "actionProc")
     assert "root.reportFailure(" in block, "a failed busctl action does not report through reportFailure"
+    # ...and every fire-and-forget action acknowledges the click, so the
+    # toast is one channel rather than one per action.
+    for name in ("ring", "ping", "sendClipboard"):
+        body = re.search(rf"function {name}\(.*?\n    \}}\n", source, re.S)
+        assert body and re.search(r"root\.actionFeedback\(Translation\.tr\(.*\), true\)", body.group(0)), (
+            f"{name}() raises no actionFeedback on success"
+        )
 
 
 def test_share_goes_through_the_share_plugin_one_url_per_call():

--- a/dots/.config/quickshell/imi/tests/tst_phone_connect.qml
+++ b/dots/.config/quickshell/imi/tests/tst_phone_connect.qml
@@ -563,6 +563,28 @@ TestCase {
         compare(PhoneConnect.pickedFileUrls("relative/path\n/abs/ok").join("|"), "file:///abs/ok")
     }
 
+    // ---- SFTP browse (slice 5) ----
+
+    function test_sftp_browse_target_prefers_the_phone_s_storage_when_it_exists() {
+        // The mount root is not the user's storage (the fork's 3a7f653b4);
+        // storage/emulated/0 is, when the phone exposes it.
+        const mount = "/run/user/1000/6131a746/kdeconnect_6131a746"
+        compare(PhoneConnect.sftpBrowseTarget(mount, true), mount + "/storage/emulated/0")
+        compare(PhoneConnect.sftpBrowseTarget(mount, false), mount)
+        compare(PhoneConnect.sftpBrowseTarget(mount + "/", true), mount + "/storage/emulated/0")
+        compare(PhoneConnect.sftpBrowseTarget("", true), "")
+        compare(PhoneConnect.sftpBrowseTarget(null, false), "")
+    }
+
+    function test_sftp_storage_path_is_where_the_probe_looks() {
+        // The directory the `test -d` probe is aimed at is the one the
+        // target prefers - one spelling of "storage/emulated/0".
+        const mount = "/run/user/1000/x/kdeconnect_x"
+        compare(PhoneConnect.sftpStoragePath(mount), mount + "/storage/emulated/0")
+        compare(PhoneConnect.sftpStoragePath(mount + "/"), mount + "/storage/emulated/0")
+        compare(PhoneConnect.sftpStoragePath(""), "")
+    }
+
     // ---- device id guard ----
 
     function test_valid_device_id_accepts_kdeconnect_and_valent_ids() {

--- a/dots/.config/quickshell/imi/tests/tst_phone_connect.qml
+++ b/dots/.config/quickshell/imi/tests/tst_phone_connect.qml
@@ -550,6 +550,19 @@ TestCase {
         compare(PhoneConnect.clipboardShareTarget(null).kind, "empty")
     }
 
+    function test_picked_file_urls_turn_picker_lines_into_file_urls() {
+        // kdialog --multiple prints one path per line; a cancelled picker
+        // prints nothing. The daemon hands each URL to a QUrl, so a path is
+        // percent-encoded per segment - a raw "#" would become a fragment.
+        compare(PhoneConnect.pickedFileUrls("/home/me/a.jpg\n/home/me/with space #1.txt\n").join("|"),
+                "file:///home/me/a.jpg|file:///home/me/with%20space%20%231.txt")
+        compare(PhoneConnect.pickedFileUrls("  /home/me/a.jpg  \n\n   \n").join("|"), "file:///home/me/a.jpg")
+        compare(PhoneConnect.pickedFileUrls("").length, 0)
+        compare(PhoneConnect.pickedFileUrls(null).length, 0)
+        // A line that is not an absolute path is not a file.
+        compare(PhoneConnect.pickedFileUrls("relative/path\n/abs/ok").join("|"), "file:///abs/ok")
+    }
+
     // ---- device id guard ----
 
     function test_valid_device_id_accepts_kdeconnect_and_valent_ids() {

--- a/dots/.config/quickshell/imi/tests/tst_phone_connect.qml
+++ b/dots/.config/quickshell/imi/tests/tst_phone_connect.qml
@@ -16,6 +16,7 @@ TestCase {
         PhoneConnect.installed = false
         PhoneConnect.backend = "none"
         PhoneConnect.devices = []
+        PhoneConnect.persistedActiveDeviceId = ""
     }
 
     // ---- parseBusctlReply ----
@@ -583,6 +584,48 @@ TestCase {
         compare(PhoneConnect.sftpStoragePath(mount), mount + "/storage/emulated/0")
         compare(PhoneConnect.sftpStoragePath(mount + "/"), mount + "/storage/emulated/0")
         compare(PhoneConnect.sftpStoragePath(""), "")
+    }
+
+    // ---- persisted active device and MRU (slice 6) ----
+
+    function test_active_device_prefers_the_persisted_choice_while_it_is_usable() {
+        PhoneConnect.applyBackend("kdeconnect")
+        PhoneConnect.applyDevices([
+            device("phone1", { type: "phone", paired: true, reachable: true, name: "aaa" }),
+            device("tablet", { type: "tablet", paired: true, reachable: true, name: "zzz" })
+        ])
+        compare(PhoneConnect.activeDevice.id, "phone1")
+        PhoneConnect.persistedActiveDeviceId = "tablet"
+        compare(PhoneConnect.activeDevice.id, "tablet")
+    }
+
+    function test_active_device_falls_back_when_the_persisted_choice_is_not_usable() {
+        PhoneConnect.applyBackend("kdeconnect")
+        PhoneConnect.applyDevices([
+            device("phone1", { type: "phone", paired: true, reachable: true }),
+            device("tablet", { type: "tablet", paired: true, reachable: false }),
+            device("laptop", { type: "laptop", paired: false, reachable: true })
+        ])
+        PhoneConnect.persistedActiveDeviceId = "tablet"
+        compare(PhoneConnect.activeDevice.id, "phone1")
+        PhoneConnect.persistedActiveDeviceId = "laptop"
+        compare(PhoneConnect.activeDevice.id, "phone1")
+        PhoneConnect.persistedActiveDeviceId = "gone"
+        compare(PhoneConnect.activeDevice.id, "phone1")
+        compare(PhoneConnect.preferredActiveDevice([], "phone1"), null)
+    }
+
+    function test_recent_device_ids_is_a_capped_most_recent_first_list() {
+        compare(PhoneConnect.recentDeviceIdsAfterSelect([], "a", 5).join(","), "a")
+        compare(PhoneConnect.recentDeviceIdsAfterSelect(["a", "b"], "c", 5).join(","), "c,a,b")
+        // Re-selecting moves to the front rather than duplicating.
+        compare(PhoneConnect.recentDeviceIdsAfterSelect(["a", "b", "c"], "b", 5).join(","), "b,a,c")
+        // Capped at max, oldest dropped.
+        compare(PhoneConnect.recentDeviceIdsAfterSelect(["a", "b", "c", "d", "e"], "f", 5).join(","), "f,a,b,c,d")
+        compare(PhoneConnect.recentDeviceIdsAfterSelect(null, "a", 5).join(","), "a")
+        // An id that fails the validator is not remembered.
+        compare(PhoneConnect.recentDeviceIdsAfterSelect(["a"], "../x", 5).join(","), "a")
+        compare(PhoneConnect.recentDeviceIdsAfterSelect(["a", "b"], "c", 2).join(","), "c,a")
     }
 
     // ---- device id guard ----

--- a/dots/.config/quickshell/imi/tests/tst_phone_connect.qml
+++ b/dots/.config/quickshell/imi/tests/tst_phone_connect.qml
@@ -628,6 +628,49 @@ TestCase {
         compare(PhoneConnect.recentDeviceIdsAfterSelect(["a", "b"], "c", 2).join(","), "c,a")
     }
 
+    // ---- low-battery hooks (slice 6) ----
+    //
+    // The thresholds are the proposal's, literally: low once below 20 and
+    // not charging, recovered at 25 or above, or on charging.
+
+    function test_battery_notice_fires_once_below_twenty_while_not_charging() {
+        const low = PhoneConnect.batteryNoticeTransition(false, 19, false)
+        compare(low.notice, "low")
+        compare(low.notified, true)
+        // Twenty is not below twenty.
+        compare(PhoneConnect.batteryNoticeTransition(false, 20, false).notice, "")
+        compare(PhoneConnect.batteryNoticeTransition(false, 20, false).notified, false)
+        // Charging at 19 is not a low battery.
+        compare(PhoneConnect.batteryNoticeTransition(false, 19, true).notice, "")
+        // Once: already notified, still low, nothing more.
+        compare(PhoneConnect.batteryNoticeTransition(true, 19, false).notice, "")
+        compare(PhoneConnect.batteryNoticeTransition(true, 19, false).notified, true)
+        compare(PhoneConnect.batteryNoticeTransition(false, 0, false).notice, "low")
+    }
+
+    function test_battery_notice_recovers_at_twenty_five_or_on_charging() {
+        // 24 is inside the hysteresis band: still notified, no notice.
+        const band = PhoneConnect.batteryNoticeTransition(true, 24, false)
+        compare(band.notice, "")
+        compare(band.notified, true)
+        const recovered = PhoneConnect.batteryNoticeTransition(true, 25, false)
+        compare(recovered.notice, "recovered")
+        compare(recovered.notified, false)
+        // Plugging it in recovers at any charge.
+        const charging = PhoneConnect.batteryNoticeTransition(true, 10, true)
+        compare(charging.notice, "recovered")
+        compare(charging.notified, false)
+        // Nothing to recover from: no notice.
+        compare(PhoneConnect.batteryNoticeTransition(false, 25, false).notice, "")
+        compare(PhoneConnect.batteryNoticeTransition(false, 10, true).notice, "")
+    }
+
+    function test_battery_notice_ignores_an_unknown_charge() {
+        compare(PhoneConnect.batteryNoticeTransition(false, -1, false).notice, "")
+        compare(PhoneConnect.batteryNoticeTransition(true, -1, false).notice, "")
+        compare(PhoneConnect.batteryNoticeTransition(true, -1, false).notified, true)
+    }
+
     // ---- device id guard ----
 
     function test_valid_device_id_accepts_kdeconnect_and_valent_ids() {

--- a/dots/.config/quickshell/imi/tests/tst_phone_connect.qml
+++ b/dots/.config/quickshell/imi/tests/tst_phone_connect.qml
@@ -525,6 +525,31 @@ TestCase {
         compare(PhoneConnect.shareableUrls("https://example.org").length, 0)
     }
 
+    function test_clipboard_share_target_sends_a_url_as_a_link() {
+        // The fork's heuristic: a scheme, or something shaped like a host.
+        compare(JSON.stringify(PhoneConnect.clipboardShareTarget("https://example.org/a?b=c")),
+                JSON.stringify({ kind: "url", value: "https://example.org/a?b=c" }))
+        compare(PhoneConnect.clipboardShareTarget("HTTP://EXAMPLE.ORG").kind, "url")
+        compare(PhoneConnect.clipboardShareTarget("  https://example.org  ").value, "https://example.org")
+        // A bare host is a link too - but the daemon opens a QUrl, and a
+        // schemeless one is relative, so it leaves with https:// on it.
+        compare(JSON.stringify(PhoneConnect.clipboardShareTarget("example.org")),
+                JSON.stringify({ kind: "url", value: "https://example.org" }))
+        compare(PhoneConnect.clipboardShareTarget("docs.example.co.uk/path/to").value, "https://docs.example.co.uk/path/to")
+    }
+
+    function test_clipboard_share_target_sends_prose_as_text_and_refuses_nothing() {
+        compare(JSON.stringify(PhoneConnect.clipboardShareTarget("meet me at 5")),
+                JSON.stringify({ kind: "text", value: "meet me at 5" }))
+        // A host followed by more words is a sentence, not a link.
+        compare(PhoneConnect.clipboardShareTarget("example.org is down again").kind, "text")
+        compare(PhoneConnect.clipboardShareTarget("v1.2").kind, "text")
+        compare(PhoneConnect.clipboardShareTarget("  two words  ").value, "two words")
+        compare(PhoneConnect.clipboardShareTarget("").kind, "empty")
+        compare(PhoneConnect.clipboardShareTarget("   \n").kind, "empty")
+        compare(PhoneConnect.clipboardShareTarget(null).kind, "empty")
+    }
+
     // ---- device id guard ----
 
     function test_valid_device_id_accepts_kdeconnect_and_valent_ids() {

--- a/dots/.config/quickshell/imi/tests/tst_phone_connect.qml
+++ b/dots/.config/quickshell/imi/tests/tst_phone_connect.qml
@@ -505,6 +505,26 @@ TestCase {
         compare(PhoneConnect.monitorExitPlan(3, 90000, false, 30000, 5).attempts, 0)
     }
 
+    // ---- share (slice 4) ----
+
+    function test_shareable_urls_keeps_only_file_and_http_entries() {
+        const kept = PhoneConnect.shareableUrls([
+            "file:///home/me/photo.jpg",
+            "https://example.org/a?b=c",
+            "HTTP://EXAMPLE.ORG",
+            "  file:///with/spaces in it.txt  ",
+            "/home/me/not-a-url",
+            "ftp://example.org/x",
+            "",
+            "   ",
+            null,
+            42
+        ])
+        compare(kept.join("|"), "file:///home/me/photo.jpg|https://example.org/a?b=c|HTTP://EXAMPLE.ORG|file:///with/spaces in it.txt")
+        compare(PhoneConnect.shareableUrls(null).length, 0)
+        compare(PhoneConnect.shareableUrls("https://example.org").length, 0)
+    }
+
     // ---- device id guard ----
 
     function test_valid_device_id_accepts_kdeconnect_and_valent_ids() {


### PR DESCRIPTION
Phone tab, W1: PhoneConnect grows share, SFTP browse, a persisted device and low-battery notices

The service half of the Phone tab design (`docs/superpowers/specs/2026-08-27-phone-tab-design.md`, committed here as the first commit): slices 4, 5 and 6 of `docs/proposals/phone-connect.md`, on the busctl argv transport.

- **Actions queue.** Measured: `Process.exec` on a running Process terminates it (exit 15, no output), so `runAction` fed straight from `exec` kept the last action of a burst — and one `shareUrl` per file *is* a burst. It is a queue pumped by the Process's own exit; the contract admits one `exec`, the pump's.
- **Feedback is one channel**: `actionFeedback(message, ok)` for the toast, `lastActionError` for the inline line, through one `reportFailure`.
- **Share**: `shareUrls` (one `share.shareUrl` per `file://`/`http(s)://` entry), `shareText`, `shareClipboard` (`wl-paste --no-newline` as constant argv; the fork's heuristic decides link-or-text, a bare host leaves with `https://` because the daemon `QUrl`s it), `pickAndSendFiles` (the house `kdialog` picker, paths percent-encoded per segment).
- **SFTP**: `browseFiles` mounts, waits on `isMounted` (600 ms × 10), reads `mountPoint`, probes `<mount>/storage/emulated/0` with a `test -d` argv and opens the answer with `xdg-open`.
- **Persisted device**: `Persistent.states.phone.{activeDeviceId, recentDeviceIds}`; `activeDevice` prefers the persisted pick while paired and reachable. MRU walked by index (a `list<string>` off a `JsonAdapter` fails `Array.isArray`).
- **Battery**: the proposal's thresholds literally — low once below 20 not charging, recovered at 25 or on charging — as `notify-send` argv, latched per device.

Tests: `MODEL_ACTIONS` grows by six; the contract pins argv-only, the constant `wl-paste`/`kdialog` argv, the share leaf, the SFTP read/write split and the single `exec`. `tst_phone_connect.qml` drives the URL heuristic, the picker lines, the SFTP target, the persisted pick, the MRU and the 19/20/24/25/charging thresholds.

Docs: updated AGENT.md §Directory map (PhoneConnect) and §Dynamic/data-driven QML gotchas (Process.exec kills the running one; a share string is a QUrl); docs/proposals/phone-connect.md slices 4-6 marked done; docs/superpowers/specs/2026-08-27-phone-tab-design.md added
Changelog: updated
