### PR TITLE
feat(phoneNotifications): mirror the phone's notifications off KDE Connect

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -596,6 +596,17 @@ services/                  Singletons wrapping external state/processes - one pe
                               - a button whose call the service does not answer is a fake
                               action). The dialog itself is driven end to end by
                               tests/test_phone_connect_dialog_runtime.py
+  PhoneNotifications.qml       The paired phone's notifications, mirrored off KDE Connect on
+                              the same busctl transport through a serialized queue of its
+                              own. No monitor of its own: the four notification signals sit
+                              on PhoneConnect's allowlist and its deviceChangeSettled() is the
+                              trigger (one stream). A sweep is activeNotifications - a list of
+                              PUBLIC ids - plus one GetAll per leaf; dismiss is the LEAF's own
+                              method (see the busctl notes below); the list is cached per
+                              device in Persistent.states.phone. Parser region synced with a
+                              logic-only double (tests/test_phone_notifications_contract.py);
+                              driven end to end by tests/test_phone_notifications_runtime.py
+                              5cad7ad40 ("feat(phoneNotifications): mirror the phone's notifications off KDE Connect over busctl")
   SchemePreview.qml            Per-scheme swatches for the scheme pickers: one venv run of
                               scripts/colors/scheme_preview.py quantizes the wallpaper once and
                               builds every Material variant from it. Cached against the wallpaper
@@ -3996,6 +4007,34 @@ across daemon restarts. Four more things about that path, each of which cost a m
   is the paired phone, which never asked — so the guard refuses a device without a request
   and the contract pins the absence of the fallback. 9395932d3 ("feat(phoneConnect): surface a
   peer's pairing request, and answer it").
+- **A notification is dismissed on its LEAF, and the daemon's `sendAction` is keyed on the
+  internalId.** `<device>/notifications` answers `activeNotifications` with a list of PUBLIC
+  ids (`"70"`), and each `<device>/notifications/<publicId>` leaf carries the fields and a
+  `dismiss()` of its own - introspected live. The device-level `sendAction(key, action)`
+  invokes a named Android action button, so the fork's first dismiss, `sendAction(id,
+  "cancel")`, removed the card and left the phone showing it ("cancel" is not a button); and
+  its `key` is the Android notification key the daemon relays as `internalId`, not the public
+  id. The daemon exposes no action names over D-Bus at all, so `actions` is whatever a leaf
+  happens to carry - empty on the daemon this was measured against.
+  `services/PhoneNotifications.qml` runs no monitor of its own: its four signals are on
+  `signalChangesDevices`' allowlist and `deviceChangeSettled()` is its trigger, which the
+  runtime harness proves by seeding both timers far out so only the signal can deliver the
+  second notification. Two traps from that harness: a second `exec()` on a running `Process`
+  is refused rather than queued, so writes share the serialized read queue (dismissAll is one
+  call per leaf); and a bash fake that strips a suffix off `$*` directly strips it per
+  argument, which left the fake's state file untouched and the driver's dismiss list red.
+  5cad7ad40 ("feat(phoneNotifications): mirror the phone's notifications off KDE Connect over
+  busctl"), dbe6e73d5 ("test(phoneNotifications): drive the sweep, a signal, dismiss and reply
+  against a fake busctl").
+- **kdeconnectd's desktop copy of a mirrored notification is dropped at ingestion, behind the
+  mirror gate.** `services/Notifications.qml`'s `onNotification` asks
+  `PhoneNotifications.mirrorsDesktopNotification(appName)` before tracking - the daemon posts
+  relayed notifications as "KDE Connect" or as the phone's own name - and the gate is
+  `mirrorActive` (tab enabled AND the active device reachable), because with the tab off or
+  the phone away the daemon's copy is the only one the user gets. The tab switch is read as
+  `Config.options.sidebar?.phone?.enable ?? true`: the key is declared by another workstream,
+  and an undeclared key reads `undefined`, not an error. 1cead70b8 ("feat(notifications): drop
+  the daemon's copy of a notification the phone tab mirrors").
 
 - **`Process.exec` on a Process that is still running terminates it first, so one Process fed
   straight from `exec` keeps the last action of a burst and kills the rest.** Measured under

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ own repo; the installer pins which revision it builds.
   the bare mount. The device you pick in the panel is remembered across
   restarts, with the last five picks kept for the list. The buttons for the
   new actions arrive with the Phone tab; the notifications work now.
+- **Your phone's notifications are mirrored into the shell.** With a phone
+  paired through KDE Connect, the shell reads its active notifications off
+  the daemon as they arrive, keeps them grouped by app, dismisses one on the
+  phone itself rather than only hiding the card, replies inline where the app
+  allows it, and remembers the list across a restart. While the phone is
+  reachable, kdeconnectd's own desktop pop-ups of those same notifications
+  are no longer shown beside them. This is the data behind the Phone tab,
+  which draws it in a following release.
 - **Phone Connect shows your phone's wireless address and cellular network,
   and answers pairing requests.** The panel reads the address KDE Connect
   reaches the phone on and its cellular network type (LTE, 5G, …) alongside

--- a/docs/proposals/phone-connect.md
+++ b/docs/proposals/phone-connect.md
@@ -173,6 +173,41 @@ W5), so the dialog still draws three actions until the tab replaces it.
   fork's extra guard on the previous charge being ≥ 20 (which kept a phone
   already at 15% at boot silent) is not carried.
 
+**The notification slice has landed** (5cad7ad40 "feat(phoneNotifications):
+mirror the phone's notifications off KDE Connect over busctl", 1cead70b8
+"feat(notifications): drop the daemon's copy of a notification the phone tab
+mirrors"), as the Phone tab design's W2:
+
+- `services/PhoneNotifications.qml`, a second singleton on the same transport
+  with a serialized busctl queue of its own and no monitor: the four
+  notification signals joined `signalChangesDevices`' allowlist and
+  `PhoneConnect.deviceChangeSettled()` is the refetch trigger, beside a change
+  of the active device and a 60s reconcile. A sweep is the device's
+  `activeNotifications` - a list of PUBLIC ids, captured live as
+  `{"type":"as","data":[["70"]]}` - and one `GetAll` per
+  `<device>/notifications/<publicId>` leaf; the package comes out of the
+  `internalId` (`0|com.truecaller|…`).
+- Dismiss is the leaf's own `dismiss()`, never `sendAction("cancel")`; a
+  reply is device-level `sendReply(replyId, text)` and a refetch 800ms later
+  (a declared constant); `sendAction` is keyed on the `internalId`, which is
+  the Android key the daemon relays - the daemon exposes no action names over
+  D-Bus, so the leaf's `actions` is empty on the daemon this was measured
+  against.
+- The list is cached per device in `Persistent.states.phone` and restored
+  once the active device is known, so the tab is not empty before the first
+  sweep.
+- The dedupe: `services/Notifications.qml` drops a desktop notification posted
+  as `kdeconnect` / `kde connect` / `org.kde.kdeconnect` or as a paired
+  device's name, at ingestion, only while the tab is enabled and the active
+  device is reachable.
+- Covered by `tests/tst_phone_notifications.qml` (on the captured replies),
+  `tests/test_phone_notifications_contract.py` (parser region synced with the
+  double, argv only, leaf dismiss, declared delay, one stream, the gate) and
+  `tests/test_phone_notifications_runtime.py` (a fake busctl serving one
+  notification whose monitor verb posts a second - the signal is the only
+  thing that can deliver it - with dismiss, sendReply and sendAction scored
+  off the fake's log on the leaf path).
+
 ## Prior art: P3DROVFX/ii-p3drovfx
 
 Recorded because the next slice is decided from it, not because any of it is
@@ -287,25 +322,20 @@ Ordered by value. Each borrows the fork's shape and none of its transport:
 every read is a `busctl` argv, every write goes through `runAction`, and both
 backends stay behind the one model.
 
-**Slices 1 (signal-driven updates) through 6 are done** — see "Current
-state" above. The next slice is now notification mirroring, and it inherits
-the stream and the surface: its signals go in `signalChangesDevices`'
-allowlist, the match rule already covers the whole `/modules/kdeconnect`
-namespace, and the notification area is already the fill item waiting for
-it, so nothing about the transport or the layout has to be rebuilt. What is
-still open from slice 1 is Valent: its signal set was not verifiable and it
-keeps the poll until it is.
+**Slices 1 (signal-driven updates) through 6 and the notification slice are
+done** — see "Current state" above. What is still open from slice 1 is
+Valent: its signal set was not verifiable and it keeps the poll until it
+is, and the notification mirror is KDE Connect only for the same reason.
 
-1. **Notification mirroring.** Borrow: the leaf `notification.dismiss` (not
-   `sendAction("cancel")`), `sendReply` with a re-fetch, `internalId` →
-   package, group-by-app, and the dedupe rule against kdeconnectd's own
-   desktop notifications with its "only while we are showing them" gate. Not:
-   the second `RemoteNotification*` list — the "Approach" below still says
-   route through the shell's own notification system, and that is the
-   decision to make first; the parallel-list design is what makes the dedupe
-   necessary. Not: the qdbus/`fetch_notifications.py` split; one `busctl`
-   `GetAll` per leaf covers it. Not: "open on phone" — that is scrcpy+adb,
-   out of scope.
+1. **Notification mirroring.** Done — see "Current state". The design
+   (`docs/superpowers/specs/2026-08-27-phone-tab-design.md`) decided the
+   question this item left open: a dedicated list in the Phone tab, deduped
+   at the desktop server, rather than routing through the shell's own
+   notification system. Borrowed as planned: the leaf `notification.dismiss`,
+   `sendReply` with a re-fetch, `internalId` → package, group-by-app, and the
+   gated dedupe. Not borrowed: the qdbus/`fetch_notifications.py` split (one
+   `busctl` `GetAll` per leaf), and "open on phone" (scrcpy+adb, another
+   workstream).
 2. **`connectivity_report` and `reachableAddresses`.** Done — see "Current
    state". One more `GetAll` per device, at the report's own leaf path, and
    one more signal; the model carries the addresses and the cellular

--- a/dots/.config/quickshell/imi/PhoneNotificationsRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/PhoneNotificationsRuntimeTest.qml
@@ -1,0 +1,192 @@
+import QtQuick
+import Quickshell
+import qs.modules.common
+import qs.services
+
+/**
+ * services/PhoneNotifications.qml against the real services/PhoneConnect.qml
+ * in a real Quickshell process, fed by a fake `busctl` on PATH.
+ *
+ * Driven by tests/test_phone_notifications_runtime.py, which reads the fake's
+ * recorded invocations back afterwards. The fake daemon exposes one paired,
+ * reachable phone with ONE active notification; its `monitor` verb then adds
+ * a second to its own state and prints a notificationPosted signal. The
+ * second notification reaching the model is the oracle for the whole trigger
+ * chain - the signal on PhoneConnect's allowlist, its settle, its
+ * deviceChangeSettled(), this service's refetch - because the reconcile is
+ * a minute out and PhoneConnect's poll ten minutes out, so nothing else can
+ * deliver it inside the harness's lifetime.
+ *
+ * What is scored here: the sweep's model (fields, package, groups), the
+ * dedupe gate, the local effect of dismiss/reply/sendAction/dismissAll, and
+ * the cache reaching Persistent. What is scored driver-side: which argv
+ * reached the daemon - dismiss on the LEAF path, sendReply/sendAction as the
+ * device-level two-string calls, and the refetch landing after the declared
+ * delay.
+ *
+ *   PATH=<dir with fake busctl>:$PATH qs -p PhoneNotificationsRuntimeTest.qml
+ */
+ShellRoot {
+    id: harness
+
+    property int failures: 0
+    property int checksRun: 0
+    property int elapsed: 0
+
+    readonly property string phoneId: Quickshell.env("PHONE_ID") ?? ""
+    readonly property string phoneName: Quickshell.env("PHONE_NAME") ?? ""
+
+    function check(label, ok) {
+        harness.checksRun++;
+        console.log(`[PhoneNotifications] ${label}: ${ok ? "ok" : "FAIL"}`);
+        if (!ok)
+            harness.failures++;
+    }
+
+    function finish() {
+        console.log(`[PhoneNotifications] checks: ${harness.checksRun} failures: ${harness.failures}`);
+        Qt.exit(harness.failures === 0 ? 0 : 1);
+    }
+
+    function ids() {
+        return PhoneNotifications.notifications.map(n => n.publicId).sort();
+    }
+
+    Component.onCompleted: {
+        // A singleton is constructed on first use; these reads start
+        // PhoneConnect's presence probe and this service's triggers.
+        console.log(`[PhoneNotifications] services constructed, installed=${PhoneConnect.installed} count=${PhoneNotifications.count}`);
+    }
+
+    Timer {
+        id: waitForReady
+        interval: 250
+        repeat: true
+        running: true
+        onTriggered: {
+            harness.elapsed += waitForReady.interval;
+            if (!Config.ready || !Persistent.ready || !PhoneConnect.installed || PhoneNotifications.count !== 1) {
+                if (harness.elapsed >= 30000) {
+                    harness.check(`Config and Persistent ready, busctl found and the first sweep landed (got ${PhoneNotifications.count})`, false);
+                    harness.finish();
+                }
+                return;
+            }
+            waitForReady.running = false;
+            steps.running = true;
+        }
+    }
+
+    property var stepList: [
+        // ---- the sweep: one notification, read off the leaf ---------------
+        () => {
+            const n = PhoneNotifications.notifications[0];
+            harness.check(`the sweep read the one active notification, got ${harness.ids()}`,
+                          PhoneNotifications.count === 1 && n.publicId === "70");
+            harness.check("the leaf's fields are on the model",
+                          n.appName === "Truecaller" && n.title === "Stay protected 24/7"
+                          && n.deviceId === harness.phoneId && n.dismissable === true && n.replyId === "");
+            harness.check("the package is read out of the internalId", n.package === "com.truecaller");
+            harness.check("the groups follow the desktop list's derivation",
+                          PhoneNotifications.appNameList.length === 1 && PhoneNotifications.appNameList[0] === "Truecaller"
+                          && PhoneNotifications.groupsByAppName["Truecaller"].notifications.length === 1);
+            harness.check("the active device is the paired phone", PhoneNotifications.activeDeviceId === harness.phoneId);
+        },
+
+        // ---- the dedupe gate ----------------------------------------------
+        () => {
+            harness.check("the mirror is active for a reachable phone with the tab on", PhoneNotifications.mirrorActive);
+            harness.check("the daemon's own desktop notifications are mirrored",
+                          PhoneNotifications.mirrorsDesktopNotification("KDE Connect")
+                          && PhoneNotifications.mirrorsDesktopNotification("kdeconnect"));
+            harness.check(`a notification posted as the paired phone (${harness.phoneName}) is mirrored`,
+                          PhoneNotifications.mirrorsDesktopNotification(harness.phoneName));
+            harness.check("any other app's notification is not", !PhoneNotifications.mirrorsDesktopNotification("Firefox"));
+        },
+
+        // ---- the second notification arrives from the SIGNAL --------------
+        // The fake's monitor prints notificationPosted about a second later
+        // than the sweep; wait for it rather than assuming the schedule.
+        () => harness.waitFor(() => PhoneNotifications.count === 2, 8000, "signal"),
+        () => {
+            harness.check(`the notificationPosted signal fetched the new notification, got ${harness.ids()}`,
+                          PhoneNotifications.count === 2 && harness.ids().join(",") === "70,71");
+            const wa = PhoneNotifications.notifications.find(n => n.publicId === "71");
+            harness.check("the new one carries its reply id", wa !== undefined && wa.replyId === "r1" && wa.appName === "WhatsApp");
+            harness.check("the app that arrived last sorts first",
+                          PhoneNotifications.appNameList.join(",") === "WhatsApp,Truecaller");
+        },
+
+        // ---- the cache reaches Persistent -----------------------------------
+        () => harness.waitFor(() => (Persistent.states.phone.cachedNotificationsJson ?? "").indexOf('"71"') !== -1,
+                              PhoneNotifications.cacheSaveDelay + 3000, "cache"),
+        () => {
+            const cached = PhoneNotifications.cachedNotificationsFor(Persistent.states.phone.cachedNotificationsJson, harness.phoneId);
+            harness.check(`the list is cached per device in Persistent, got ${cached.map(n => n.publicId)}`,
+                          cached.length === 2 && cached.some(n => n.publicId === "70") && cached.some(n => n.publicId === "71"));
+        },
+
+        // ---- writes, scored driver-side off the fake's log -----------------
+        () => {
+            PhoneNotifications.dismiss("70");
+            harness.check(`dismiss takes the card off the list at once, got ${harness.ids()}`,
+                          PhoneNotifications.count === 1 && harness.ids()[0] === "71");
+        },
+        () => {
+            PhoneNotifications.reply("71", "hi there");
+            PhoneNotifications.sendAction("71", "Mark as read");
+            // A reply to a notification without a reply id, or an empty one,
+            // must reach nothing - the driver counts sendReply calls.
+            PhoneNotifications.reply("71", "");
+            harness.replyRefetchArmedAt = Date.now();
+        },
+        // The reply's refetch lands replyRefetchDelay later and finds the
+        // fake still answering 71: the count holds, the sweep ran (scored
+        // driver-side off the timestamps).
+        () => harness.waitFor(() => Date.now() - harness.replyRefetchArmedAt > PhoneNotifications.replyRefetchDelay + 600, 3000, "refetch"),
+        () => {
+            harness.check(`the refetch after the reply keeps the remaining notification, got ${harness.ids()}`,
+                          PhoneNotifications.count === 1 && harness.ids()[0] === "71");
+            PhoneNotifications.dismissAll();
+            harness.check("dismissAll empties the list", PhoneNotifications.count === 0);
+        },
+
+        () => harness.finish()
+    ]
+
+    property real replyRefetchArmedAt: 0
+
+    // Holds the step list until `predicate` is true or `timeoutMs` passes;
+    // a timeout is a failed check, not a hang.
+    property var pendingPredicate: null
+    property int pendingDeadline: 0
+    property string pendingLabel: ""
+    function waitFor(predicate, timeoutMs, label) {
+        harness.pendingPredicate = predicate;
+        harness.pendingDeadline = harness.elapsed + timeoutMs;
+        harness.pendingLabel = label;
+    }
+
+    property int stepIndex: 0
+    Timer {
+        id: steps
+        interval: 250
+        repeat: true
+        onTriggered: {
+            harness.elapsed += steps.interval;
+            if (harness.pendingPredicate !== null) {
+                if (harness.pendingPredicate()) {
+                    harness.pendingPredicate = null;
+                } else if (harness.elapsed >= harness.pendingDeadline) {
+                    harness.check(`waited for ${harness.pendingLabel}`, false);
+                    harness.pendingPredicate = null;
+                } else {
+                    return;
+                }
+            }
+            if (harness.stepIndex >= harness.stepList.length)
+                return;
+            harness.stepList[harness.stepIndex++]();
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/modules/common/Persistent.qml
+++ b/dots/.config/quickshell/imi/modules/common/Persistent.qml
@@ -167,6 +167,9 @@ Singleton {
                 }
             }
 
+            // The Phone tab's state. The notification cache is
+            // PhoneNotifications' (one JSON document keyed by device id);
+            // the scrcpy/contacts workstreams add their keys beside it.
             property JsonObject timer: JsonObject {
                 property JsonObject pomodoro: JsonObject {
                     property bool running: false
@@ -184,6 +187,7 @@ Singleton {
             property JsonObject phone: JsonObject {
                 property string activeDeviceId: ""
                 property list<string> recentDeviceIds: []
+                property string cachedNotificationsJson: ""
             }
         }
     }

--- a/dots/.config/quickshell/imi/services/Notifications.qml
+++ b/dots/.config/quickshell/imi/services/Notifications.qml
@@ -164,6 +164,13 @@ Singleton {
         persistenceSupported: true
 
         onNotification: (notification) => {
+            // The Phone tab mirrors the daemon's notifications itself, so
+            // kdeconnectd's desktop copy - posted as "KDE Connect" or as the
+            // phone - would be the same notification twice. Dropped only
+            // while the tab is showing them (PhoneNotifications.mirrorActive
+            // is inside the wrapper); otherwise the daemon's copy is the
+            // only one the user gets. Untracked, the server discards it.
+            if (PhoneNotifications.mirrorsDesktopNotification(notification.appName)) return;
             notification.tracked = true
             const newNotifObject = notifComponent.createObject(root, {
                 "notificationId": notification.id + root.idOffset,

--- a/dots/.config/quickshell/imi/services/PhoneConnect.qml
+++ b/dots/.config/quickshell/imi/services/PhoneConnect.qml
@@ -79,6 +79,11 @@ Singleton {
         root.actionFeedback(message, false);
     }
 
+    // One coalesced "something on the daemon changed" per signal burst, raised
+    // as the settle fires. PhoneNotifications refetches on it; nothing else
+    // needs to hear it, since the model is what everything else reads.
+    signal deviceChangeSettled()
+
     // BEGIN phone-connect parser logic (synced with tests/imports/testservices/PhoneConnect.qml)
     // Parses one `busctl --json=short` reply. Returns the payload ("data")
     // array, or null when the text is not a busctl JSON document (empty
@@ -259,7 +264,11 @@ Singleton {
             "org.kde.kdeconnect.device": ["reachableChanged", "pairStateChanged", "nameChanged",
                 "typeChanged", "pluginsChanged"],
             "org.kde.kdeconnect.device.battery": ["refreshed"],
-            "org.kde.kdeconnect.device.connectivity_report": ["refreshed"]
+            "org.kde.kdeconnect.device.connectivity_report": ["refreshed"],
+            // The notification set is PhoneNotifications' to read; it fetches
+            // on deviceChangeSettled rather than running a monitor of its own.
+            "org.kde.kdeconnect.device.notifications": ["notificationPosted", "notificationUpdated",
+                "notificationRemoved", "allNotificationsRemoved"]
         }[signal.iface];
         return Array.isArray(members) && members.includes(signal.member);
     }
@@ -520,6 +529,7 @@ Singleton {
                 return;
             }
             root.refresh();
+            root.deviceChangeSettled();
         }
     }
 

--- a/dots/.config/quickshell/imi/services/PhoneNotifications.qml
+++ b/dots/.config/quickshell/imi/services/PhoneNotifications.qml
@@ -1,0 +1,409 @@
+pragma Singleton
+pragma ComponentBehavior: Bound
+
+import Quickshell
+import Quickshell.Io
+import QtQuick
+import qs.modules.common
+
+/**
+ * The paired phone's notifications, mirrored off KDE Connect
+ * (docs/superpowers/specs/2026-08-27-phone-tab-design.md, W2).
+ *
+ * Reads and writes are `busctl --json=short` argv arrays through a serialized
+ * queue built like PhoneConnect's, and there is no monitor here: the four
+ * notification signals are on PhoneConnect's allowlist, so its coalesced
+ * deviceChangeSettled() is what triggers a refetch, beside a change of the
+ * active device and a slow reconcile. A sweep is the device's
+ * activeNotifications (a list of PUBLIC ids, not of notifications) and one
+ * GetAll per notification leaf - measured shapes, see the fixtures in
+ * tests/tst_phone_notifications.qml.
+ *
+ * Dismiss is the LEAF method, notification.dismiss on
+ * <device>/notifications/<publicId>: the device-level sendAction(key,
+ * "cancel") the fork once used invokes a named Android action button, and
+ * "cancel" is not one, so the phone kept the notification while the sidebar
+ * dropped its card (the fork's KdeConnectService.qml:892-901 records it).
+ * A reply is device-level sendReply(replyId, text) followed by a refetch
+ * `replyRefetchDelay` later, because the daemon's notificationUpdated can
+ * land before the phone has rewritten the body.
+ *
+ * The list is cached per device in Persistent.states.phone (saved
+ * `cacheSaveDelay` after a change) and restored when the active device is
+ * known, so the tab is not empty between boot and the first sweep.
+ *
+ * Everything between the sync markers is kept byte-for-byte in sync with the
+ * logic-only double (tests/imports/testservices/PhoneNotifications.qml);
+ * tests/test_phone_notifications_contract.py enforces it.
+ */
+Singleton {
+    id: root
+
+    // The key is declared by the Phone tab's workstream; until then the
+    // optional chain reads undefined and the tab defaults on.
+    readonly property bool tabEnabled: Config.options.sidebar?.phone?.enable ?? true
+    readonly property bool serviceEnabled: root.tabEnabled && PhoneConnect.enableService
+    readonly property string activeDeviceId: PhoneConnect.activeDevice?.id ?? ""
+    // The gate services/Notifications.qml drops the daemon's own desktop
+    // notifications behind: only while this tab is showing them. Off, the
+    // daemon's copy is the only one the user would get.
+    readonly property bool mirrorActive: root.tabEnabled && (PhoneConnect.activeDevice?.reachable ?? false)
+
+    // [{ publicId, deviceId, internalId, package, appName, title, text, ticker,
+    //    iconPath, dismissable, replyId, actions, receivedAt }]
+    property var notifications: []
+    readonly property int count: root.notifications.length
+    readonly property var groupsByAppName: root.groupsForList(root.notifications)
+    readonly property list<string> appNameList: root.appNameListForGroups(root.groupsByAppName)
+
+    // How long after sendReply the list is re-read (the fork measured the
+    // daemon's own update as racy; 800ms is what it settled on).
+    readonly property int replyRefetchDelay: 800
+    readonly property int reconcileInterval: 60000
+    readonly property int cacheSaveDelay: 2000
+
+    // BEGIN phone-notifications parser logic (synced with tests/imports/testservices/PhoneNotifications.qml)
+    // A public id is spliced into an object path. The daemon mints them as
+    // decimal counters ("70"); anything else is refused rather than escaped.
+    function validPublicId(id: var): bool {
+        return typeof id === "string" && /^[A-Za-z0-9_]+$/.test(id);
+    }
+
+    // internalId is the Android notification key the daemon relays:
+    // "0|<package>|<id>|<tag>|<uid>" ("0|com.truecaller|2131366136|null|10553"
+    // off the live daemon). The package is the second field, and only of a
+    // zero-prefixed key.
+    function packageFromInternalId(internalId: var): string {
+        const parts = String(internalId ?? "").split("|");
+        return (parts.length >= 2 && parts[0] === "0") ? parts[1].trim() : "";
+    }
+
+    // One notification leaf's GetAll (a{sv}) onto the model. Every field the
+    // leaf may omit degrades to its empty value; `dismissable` defaults to
+    // true because a leaf that does not say is one the daemon will dismiss.
+    function normalizeNotification(publicId: string, deviceId: string, rawProps: var, receivedAt: real): var {
+        const props = PhoneConnect.unwrapVariants(rawProps);
+        const str = key => typeof props[key] === "string" ? props[key] : "";
+        return {
+            publicId: publicId,
+            deviceId: deviceId,
+            internalId: str("internalId"),
+            package: root.packageFromInternalId(props.internalId),
+            appName: str("appName"),
+            title: str("title"),
+            text: str("text"),
+            ticker: str("ticker"),
+            iconPath: str("iconPath"),
+            dismissable: props.dismissable !== false,
+            replyId: str("replyId"),
+            actions: Array.isArray(props.actions) ? props.actions.filter(a => typeof a === "string") : [],
+            receivedAt: receivedAt
+        };
+    }
+
+    // A refetch replaces the list, but a notification already shown keeps the
+    // time it first arrived: the groups sort on it, and a sweep that stamped
+    // every entry "now" would reshuffle the tab on every signal.
+    function carryReceivedAt(previous: var, fresh: var): var {
+        const seen = {};
+        for (const n of (previous ?? [])) seen[n.publicId] = n.receivedAt;
+        return (fresh ?? []).map(n => seen[n.publicId] === undefined
+            ? n : Object.assign({}, n, { receivedAt: seen[n.publicId] }));
+    }
+
+    // The same derivation as services/Notifications.qml's groupsForList /
+    // appNameListForGroups, on this model's fields: one group per app,
+    // carrying the app's icon and the newest arrival in it.
+    function groupsForList(list: var): var {
+        const groups = {};
+        (list ?? []).forEach(n => {
+            if (!groups[n.appName]) {
+                groups[n.appName] = {
+                    appName: n.appName,
+                    appIcon: n.iconPath,
+                    notifications: [],
+                    time: 0
+                };
+            }
+            groups[n.appName].notifications.push(n);
+            groups[n.appName].time = Math.max(groups[n.appName].time, n.receivedAt || 0);
+        });
+        return groups;
+    }
+
+    function appNameListForGroups(groups: var): var {
+        return Object.keys(groups ?? {}).sort((a, b) => groups[b].time - groups[a].time);
+    }
+
+    // Whether a desktop notification is the daemon's own copy of something
+    // this tab already shows: posted under one of kdeconnectd's app names,
+    // or under a paired device's name (the daemon posts relayed
+    // notifications as the phone).
+    function mirrorsAppName(appName: var, deviceNames: var): bool {
+        const lower = String(appName ?? "").toLowerCase();
+        if (lower === "") return false;
+        if (["kdeconnect", "kde connect", "org.kde.kdeconnect"].includes(lower)) return true;
+        return (deviceNames ?? []).some(name => String(name ?? "").toLowerCase() === lower);
+    }
+
+    // The persisted cache is one JSON document keyed by device id:
+    // { "<deviceId>": { savedAt, notifications } }. An entry whose public id
+    // would not pass validPublicId is dropped on the way back in, since
+    // nothing could dismiss it.
+    function cachedNotificationsFor(json: var, deviceId: string): var {
+        let doc;
+        try {
+            doc = JSON.parse(String(json ?? ""));
+        } catch (e) {
+            return [];
+        }
+        const entry = (doc && typeof doc === "object") ? doc[deviceId] : null;
+        if (!entry || !Array.isArray(entry.notifications)) return [];
+        return entry.notifications.filter(n => n && typeof n === "object" && root.validPublicId(n.publicId));
+    }
+
+    function cacheWith(json: var, deviceId: string, list: var, savedAt: real): string {
+        let doc;
+        try {
+            doc = JSON.parse(String(json ?? ""));
+        } catch (e) {
+            doc = null;
+        }
+        if (!doc || typeof doc !== "object" || Array.isArray(doc)) doc = {};
+        doc[deviceId] = { savedAt: savedAt, notifications: list ?? [] };
+        return JSON.stringify(doc);
+    }
+    // END phone-notifications parser logic
+
+    function applyNotifications(list: var, deviceId: string): void {
+        if (deviceId !== root.activeDeviceId) return;
+        root.notifications = root.carryReceivedAt(root.notifications, list);
+        cacheSave.restart();
+    }
+
+    // Whether a desktop notification arriving at services/Notifications.qml
+    // is the daemon's copy of something this tab shows.
+    function mirrorsDesktopNotification(appName: var): bool {
+        return root.mirrorActive
+            && root.mirrorsAppName(appName, PhoneConnect.devices.filter(d => d.paired).map(d => d.name));
+    }
+
+    function notificationsPath(deviceId: string): string {
+        return `/modules/kdeconnect/devices/${deviceId}/notifications`;
+    }
+
+    // ---- reads ----
+
+    // The public entry: every trigger lands here and coalesces on the settle,
+    // which re-arms while a sweep is in flight rather than dropping the
+    // change that asked for it.
+    function refresh(): void {
+        sweepSettle.restart();
+    }
+
+    function sweep(): void {
+        if (!root.serviceEnabled || !PhoneConnect.installed) return;
+        const deviceId = root.activeDeviceId;
+        if (PhoneConnect.backend !== "kdeconnect" || !PhoneConnect.validDeviceId(deviceId)) return;
+        const path = root.notificationsPath(deviceId);
+        root.enqueue(PhoneConnect.busctlCall("org.kde.kdeconnect.daemon", path, "org.kde.kdeconnect.device.notifications", "activeNotifications", []), text => {
+            const data = PhoneConnect.parseBusctlReply(text);
+            // "Call failed" (no notifications plugin, device gone) parses to
+            // null and reads as nothing to show.
+            const ids = (data?.[0] ?? []).filter(id => root.validPublicId(id));
+            if (ids.length === 0) { root.applyNotifications([], deviceId); return; }
+            const collected = [];
+            let answered = 0;
+            const receivedAt = Date.now();
+            for (const publicId of ids) {
+                root.enqueue(PhoneConnect.busctlCall("org.kde.kdeconnect.daemon", `${path}/${publicId}`, "org.freedesktop.DBus.Properties", "GetAll", ["s", "org.kde.kdeconnect.device.notifications.notification"]), leafText => {
+                    const leaf = PhoneConnect.parseBusctlReply(leafText);
+                    // A leaf dismissed between the two reads answers nothing
+                    // and is simply not in this sweep.
+                    if (leaf !== null) collected.push(root.normalizeNotification(publicId, deviceId, leaf[0] ?? {}, receivedAt));
+                    if (++answered === ids.length) root.applyNotifications(collected, deviceId);
+                });
+            }
+        });
+    }
+
+    Timer {
+        id: sweepSettle
+        interval: 120
+        onTriggered: {
+            if (busProc.running || root.callQueue.length > 0) {
+                sweepSettle.restart();
+                return;
+            }
+            root.sweep();
+        }
+    }
+
+    // ---- writes ----
+
+    function dismiss(publicId: string): void {
+        const deviceId = root.activeDeviceId;
+        if (PhoneConnect.backend !== "kdeconnect" || !PhoneConnect.validDeviceId(deviceId) || !root.validPublicId(publicId)) return;
+        root.runAction(PhoneConnect.busctlCall("org.kde.kdeconnect.daemon", `${root.notificationsPath(deviceId)}/${publicId}`, "org.kde.kdeconnect.device.notifications.notification", "dismiss", []));
+        // The card goes at once; the daemon's notificationRemoved reconciles.
+        root.notifications = root.notifications.filter(n => n.publicId !== publicId);
+        cacheSave.restart();
+    }
+
+    function dismissAll(): void {
+        for (const n of root.notifications.slice())
+            if (n.dismissable !== false) root.dismiss(n.publicId);
+    }
+
+    function reply(publicId: string, text: string): void {
+        const deviceId = root.activeDeviceId;
+        const n = root.notifications.find(entry => entry.publicId === publicId) ?? null;
+        if (!n || n.replyId === "" || String(text ?? "") === "") return;
+        if (PhoneConnect.backend !== "kdeconnect" || !PhoneConnect.validDeviceId(deviceId)) return;
+        root.runAction(PhoneConnect.busctlCall("org.kde.kdeconnect.daemon", root.notificationsPath(deviceId), "org.kde.kdeconnect.device.notifications", "sendReply", ["ss", n.replyId, text]));
+        replyRefetch.restart();
+    }
+
+    // The daemon's sendAction(key, action) is keyed on the notification's
+    // internalId - the Android key it relays, and what its own KNotification
+    // path hands back on an action - not on the public id. The daemon does
+    // not expose action names over D-Bus, so `actions` is what the leaf
+    // happens to carry.
+    function sendAction(publicId: string, key: string): void {
+        const deviceId = root.activeDeviceId;
+        const n = root.notifications.find(entry => entry.publicId === publicId) ?? null;
+        if (!n || n.internalId === "" || String(key ?? "") === "") return;
+        if (PhoneConnect.backend !== "kdeconnect" || !PhoneConnect.validDeviceId(deviceId)) return;
+        root.runAction(PhoneConnect.busctlCall("org.kde.kdeconnect.daemon", root.notificationsPath(deviceId), "org.kde.kdeconnect.device.notifications", "sendAction", ["ss", n.internalId, key]));
+    }
+
+    // Writes share the serialized queue: dismissAll is one call per leaf,
+    // and a second exec on a running Process is refused, not queued.
+    function runAction(argv: var): void {
+        root.enqueue(argv, (text, exitCode, errorText) => {
+            if (exitCode !== 0) {
+                Quickshell.execDetached(["notify-send",
+                    Translation.tr("Phone Connect"),
+                    errorText.trim() || Translation.tr("Phone Connect command failed"),
+                    "-a", "Shell"
+                ]);
+            }
+        });
+    }
+
+    Timer {
+        id: replyRefetch
+        interval: root.replyRefetchDelay
+        onTriggered: root.refresh()
+    }
+
+    // ---- serialized busctl queue ----
+
+    property var callQueue: []
+    property var activeCallback: null
+
+    function enqueue(argv: var, callback: var): void {
+        root.callQueue.push({ argv: argv, callback: callback });
+        root.pump();
+    }
+
+    function pump(): void {
+        if (busProc.running || root.callQueue.length === 0) return;
+        const next = root.callQueue.shift();
+        root.activeCallback = next.callback;
+        busProc.exec(next.argv);
+    }
+
+    Process {
+        id: busProc
+        environment: ({
+            LANG: "C",
+            LC_ALL: "C"
+        })
+        stdout: StdioCollector {
+            id: busOut
+        }
+        // "Call failed: ..." is expected for a leaf that went away mid-sweep;
+        // the text is handed to the callback, which decides.
+        stderr: StdioCollector {
+            id: busErr
+        }
+        onExited: (exitCode, exitStatus) => {
+            const callback = root.activeCallback;
+            root.activeCallback = null;
+            callback?.(busOut.text, exitCode, busErr.text);
+            root.pump();
+        }
+    }
+
+    // ---- triggers ----
+
+    Connections {
+        target: PhoneConnect
+        function onDeviceChangeSettled(): void {
+            root.refresh();
+        }
+    }
+
+    onActiveDeviceIdChanged: {
+        // The device that walked away keeps its list on screen (the footer
+        // says it is offline); a different device gets its own cache back
+        // before the sweep replaces it.
+        if (root.activeDeviceId === "") return;
+        root.restoreCache();
+        root.refresh();
+    }
+
+    onServiceEnabledChanged: {
+        if (!root.serviceEnabled) {
+            root.callQueue = [];
+            root.activeCallback = null;
+        } else {
+            root.refresh();
+        }
+    }
+
+    Timer {
+        interval: root.reconcileInterval
+        running: root.serviceEnabled && PhoneConnect.installed && root.activeDeviceId !== ""
+        repeat: true
+        onTriggered: root.refresh()
+    }
+
+    // ---- the per-device cache ----
+
+    function restoreCache(): void {
+        if (!Persistent.ready) return;
+        const deviceId = root.activeDeviceId;
+        if (deviceId === "") return;
+        // A list already fetched for this device is newer than any cache.
+        if (root.notifications.length > 0 && root.notifications[0].deviceId === deviceId) return;
+        root.notifications = root.cachedNotificationsFor(Persistent.states.phone?.cachedNotificationsJson ?? "", deviceId);
+    }
+
+    Connections {
+        target: Persistent
+        function onReadyChanged(): void {
+            if (Persistent.ready) root.restoreCache();
+        }
+    }
+
+    Timer {
+        id: cacheSave
+        interval: root.cacheSaveDelay
+        onTriggered: {
+            const deviceId = root.activeDeviceId;
+            if (!Persistent.ready || !PhoneConnect.validDeviceId(deviceId)) return;
+            // Every entry on the list is this device's or the list is stale
+            // for it; only the former is worth writing.
+            if (root.notifications.some(n => n.deviceId !== deviceId)) return;
+            Persistent.states.phone.cachedNotificationsJson = root.cacheWith(
+                Persistent.states.phone.cachedNotificationsJson, deviceId, root.notifications, Date.now());
+        }
+    }
+
+    Component.onCompleted: {
+        root.restoreCache();
+        root.refresh();
+    }
+}

--- a/dots/.config/quickshell/imi/tests/imports/testservices/PhoneConnect.qml
+++ b/dots/.config/quickshell/imi/tests/imports/testservices/PhoneConnect.qml
@@ -206,7 +206,11 @@ Singleton {
             "org.kde.kdeconnect.device": ["reachableChanged", "pairStateChanged", "nameChanged",
                 "typeChanged", "pluginsChanged"],
             "org.kde.kdeconnect.device.battery": ["refreshed"],
-            "org.kde.kdeconnect.device.connectivity_report": ["refreshed"]
+            "org.kde.kdeconnect.device.connectivity_report": ["refreshed"],
+            // The notification set is PhoneNotifications' to read; it fetches
+            // on deviceChangeSettled rather than running a monitor of its own.
+            "org.kde.kdeconnect.device.notifications": ["notificationPosted", "notificationUpdated",
+                "notificationRemoved", "allNotificationsRemoved"]
         }[signal.iface];
         return Array.isArray(members) && members.includes(signal.member);
     }

--- a/dots/.config/quickshell/imi/tests/imports/testservices/PhoneNotifications.qml
+++ b/dots/.config/quickshell/imi/tests/imports/testservices/PhoneNotifications.qml
@@ -1,0 +1,142 @@
+pragma Singleton
+pragma ComponentBehavior: Bound
+
+import Quickshell
+import QtQuick
+
+// Logic-only double of services/PhoneNotifications.qml. The parser/derivation
+// functions between the sync markers are kept byte-for-byte in sync with the
+// real service (tests/test_phone_notifications_contract.py enforces it); the
+// busctl Process/Timer I/O and the Persistent cache are omitted so tests stay
+// deterministic and offline. It reads the PhoneConnect double beside it for
+// the busctl reply helpers, as the service reads the real one.
+Singleton {
+    id: root
+
+    property string activeDeviceId: ""
+    property bool mirrorActive: false
+    // [{ publicId, deviceId, internalId, package, appName, title, text, ticker,
+    //    iconPath, dismissable, replyId, actions, receivedAt }]
+    property var notifications: []
+    readonly property int count: root.notifications.length
+    readonly property var groupsByAppName: root.groupsForList(root.notifications)
+    readonly property list<string> appNameList: root.appNameListForGroups(root.groupsByAppName)
+
+    // BEGIN phone-notifications parser logic (synced with services/PhoneNotifications.qml)
+    // A public id is spliced into an object path. The daemon mints them as
+    // decimal counters ("70"); anything else is refused rather than escaped.
+    function validPublicId(id: var): bool {
+        return typeof id === "string" && /^[A-Za-z0-9_]+$/.test(id);
+    }
+
+    // internalId is the Android notification key the daemon relays:
+    // "0|<package>|<id>|<tag>|<uid>" ("0|com.truecaller|2131366136|null|10553"
+    // off the live daemon). The package is the second field, and only of a
+    // zero-prefixed key.
+    function packageFromInternalId(internalId: var): string {
+        const parts = String(internalId ?? "").split("|");
+        return (parts.length >= 2 && parts[0] === "0") ? parts[1].trim() : "";
+    }
+
+    // One notification leaf's GetAll (a{sv}) onto the model. Every field the
+    // leaf may omit degrades to its empty value; `dismissable` defaults to
+    // true because a leaf that does not say is one the daemon will dismiss.
+    function normalizeNotification(publicId: string, deviceId: string, rawProps: var, receivedAt: real): var {
+        const props = PhoneConnect.unwrapVariants(rawProps);
+        const str = key => typeof props[key] === "string" ? props[key] : "";
+        return {
+            publicId: publicId,
+            deviceId: deviceId,
+            internalId: str("internalId"),
+            package: root.packageFromInternalId(props.internalId),
+            appName: str("appName"),
+            title: str("title"),
+            text: str("text"),
+            ticker: str("ticker"),
+            iconPath: str("iconPath"),
+            dismissable: props.dismissable !== false,
+            replyId: str("replyId"),
+            actions: Array.isArray(props.actions) ? props.actions.filter(a => typeof a === "string") : [],
+            receivedAt: receivedAt
+        };
+    }
+
+    // A refetch replaces the list, but a notification already shown keeps the
+    // time it first arrived: the groups sort on it, and a sweep that stamped
+    // every entry "now" would reshuffle the tab on every signal.
+    function carryReceivedAt(previous: var, fresh: var): var {
+        const seen = {};
+        for (const n of (previous ?? [])) seen[n.publicId] = n.receivedAt;
+        return (fresh ?? []).map(n => seen[n.publicId] === undefined
+            ? n : Object.assign({}, n, { receivedAt: seen[n.publicId] }));
+    }
+
+    // The same derivation as services/Notifications.qml's groupsForList /
+    // appNameListForGroups, on this model's fields: one group per app,
+    // carrying the app's icon and the newest arrival in it.
+    function groupsForList(list: var): var {
+        const groups = {};
+        (list ?? []).forEach(n => {
+            if (!groups[n.appName]) {
+                groups[n.appName] = {
+                    appName: n.appName,
+                    appIcon: n.iconPath,
+                    notifications: [],
+                    time: 0
+                };
+            }
+            groups[n.appName].notifications.push(n);
+            groups[n.appName].time = Math.max(groups[n.appName].time, n.receivedAt || 0);
+        });
+        return groups;
+    }
+
+    function appNameListForGroups(groups: var): var {
+        return Object.keys(groups ?? {}).sort((a, b) => groups[b].time - groups[a].time);
+    }
+
+    // Whether a desktop notification is the daemon's own copy of something
+    // this tab already shows: posted under one of kdeconnectd's app names,
+    // or under a paired device's name (the daemon posts relayed
+    // notifications as the phone).
+    function mirrorsAppName(appName: var, deviceNames: var): bool {
+        const lower = String(appName ?? "").toLowerCase();
+        if (lower === "") return false;
+        if (["kdeconnect", "kde connect", "org.kde.kdeconnect"].includes(lower)) return true;
+        return (deviceNames ?? []).some(name => String(name ?? "").toLowerCase() === lower);
+    }
+
+    // The persisted cache is one JSON document keyed by device id:
+    // { "<deviceId>": { savedAt, notifications } }. An entry whose public id
+    // would not pass validPublicId is dropped on the way back in, since
+    // nothing could dismiss it.
+    function cachedNotificationsFor(json: var, deviceId: string): var {
+        let doc;
+        try {
+            doc = JSON.parse(String(json ?? ""));
+        } catch (e) {
+            return [];
+        }
+        const entry = (doc && typeof doc === "object") ? doc[deviceId] : null;
+        if (!entry || !Array.isArray(entry.notifications)) return [];
+        return entry.notifications.filter(n => n && typeof n === "object" && root.validPublicId(n.publicId));
+    }
+
+    function cacheWith(json: var, deviceId: string, list: var, savedAt: real): string {
+        let doc;
+        try {
+            doc = JSON.parse(String(json ?? ""));
+        } catch (e) {
+            doc = null;
+        }
+        if (!doc || typeof doc !== "object" || Array.isArray(doc)) doc = {};
+        doc[deviceId] = { savedAt: savedAt, notifications: list ?? [] };
+        return JSON.stringify(doc);
+    }
+    // END phone-notifications parser logic
+
+    function applyNotifications(list: var, deviceId: string): void {
+        if (deviceId !== root.activeDeviceId) return;
+        root.notifications = root.carryReceivedAt(root.notifications, list);
+    }
+}

--- a/dots/.config/quickshell/imi/tests/imports/testservices/qmldir
+++ b/dots/.config/quickshell/imi/tests/imports/testservices/qmldir
@@ -4,6 +4,7 @@ singleton BluetoothStatus BluetoothStatus.qml
 singleton MediaCapture MediaCapture.qml
 singleton OpenRgb OpenRgb.qml
 singleton PhoneConnect PhoneConnect.qml
+singleton PhoneNotifications PhoneNotifications.qml
 singleton PluginStore PluginStore.qml
 singleton Tailscale Tailscale.qml
 singleton Vpn Vpn.qml

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -1598,6 +1598,25 @@ if ! python3 "$SCRIPT_DIR/test_phone_connect_dialog_runtime.py"; then
     exit 1
 fi
 
+# The phone's notification mirror: the parser region synced with its double,
+# argv only, dismiss on the LEAF, the declared reply refetch delay, one
+# stream, the desktop dedupe gate at ingestion, and the cache key declared.
+echo "Running Phone Notifications contract tests..."
+if ! python3 "$SCRIPT_DIR/test_phone_notifications_contract.py"; then
+    echo "Phone Notifications contract tests failed."
+    exit 1
+fi
+
+# The mirror against the real services and a fake daemon: the sweep's model,
+# the second notification arriving from a SIGNAL (the trigger chain's
+# oracle), the cache in Persistent, and dismiss/reply/sendAction read back
+# off the fake's log - on the leaf path, never as a cancel action.
+echo "Running Phone Notifications runtime tests..."
+if ! python3 "$SCRIPT_DIR/test_phone_notifications_runtime.py"; then
+    echo "Phone Notifications runtime tests failed."
+    exit 1
+fi
+
 echo "Running registry entry validator tests..."
 if ! python3 "$SCRIPT_DIR/test_registry_validate.py"; then
     echo "Registry entry validator tests failed."

--- a/dots/.config/quickshell/imi/tests/test_phone_notifications_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_notifications_contract.py
@@ -1,0 +1,211 @@
+"""Contract checks for services/PhoneNotifications.qml.
+
+The QML suite (tst_phone_notifications.qml) drives a logic-only double, so
+its green transfers to the real service only while the region between the
+`BEGIN/END phone-notifications parser logic` markers is byte-for-byte
+identical in both files (the BEGIN line may differ - each side points its
+"synced with" note at the other), and while the three derived properties
+the tab reads are spelled the same.
+
+The rest pins the busctl I/O the double omits, and the two decisions the
+spec (docs/superpowers/specs/2026-08-27-phone-tab-design.md, W2) names
+outright:
+- every busctl invocation is an argv array built by PhoneConnect.busctlCall;
+  the service carries no busctl literal and no shell string at all;
+- dismiss is the LEAF's notification.dismiss on <device>/notifications/<id>,
+  never the device-level sendAction("cancel") the fork once used;
+- the reply refetch delay is a declared constant the timer reads;
+- there is no monitor here (one stream: PhoneConnect's), the refetch hangs
+  off PhoneConnect.deviceChangeSettled, and no Process carries a running
+  binding;
+- ids are validated before they are spliced into a path;
+- services/Notifications.qml drops the daemon's copy behind the mirror gate,
+  before it tracks the notification, and the gate reads the tab's switch
+  through an optional chain (the key is declared by another workstream);
+- Persistent declares the cache key the service writes.
+"""
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SERVICE = ROOT / "services" / "PhoneNotifications.qml"
+DOUBLE = ROOT / "tests" / "imports" / "testservices" / "PhoneNotifications.qml"
+PHONE_CONNECT = ROOT / "services" / "PhoneConnect.qml"
+NOTIFICATIONS = ROOT / "services" / "Notifications.qml"
+PERSISTENT = ROOT / "modules" / "common" / "Persistent.qml"
+
+COMMENT = re.compile(r"/\*.*?\*/|//[^\n]*", re.S)
+
+BEGIN = "// BEGIN phone-notifications parser logic"
+END = "    // END phone-notifications parser logic"
+
+LEAF_IFACE = "org.kde.kdeconnect.device.notifications.notification"
+DEVICE_IFACE = "org.kde.kdeconnect.device.notifications"
+
+
+def _synced_region(path: Path) -> str:
+    text = path.read_text()
+    assert text.count(BEGIN) == 1, f"{path}: expected exactly one BEGIN marker"
+    assert text.count(END) == 1, f"{path}: expected exactly one END marker"
+    start = text.index("\n", text.index(BEGIN)) + 1
+    return text[start:text.index(END)]
+
+
+def _code(path: Path) -> str:
+    """The file with its comments stripped: the header records the cancel
+    action and the monitor it does NOT use, and a check that reads prose
+    as code reddens on the explanation."""
+    return COMMENT.sub("", path.read_text())
+
+
+def _function(source: str, name: str) -> str:
+    body = re.search(rf"    function {name}\(.*?\n    \}}\n", source, re.S)
+    assert body, f"{name}() missing"
+    return body.group(0)
+
+
+def _process_blocks(source: str):
+    for match in re.finditer(r"\bProcess\s*\{", source):
+        depth, index = 1, match.end()
+        while index < len(source) and depth:
+            if source[index] == "{":
+                depth += 1
+            elif source[index] == "}":
+                depth -= 1
+            index += 1
+        yield source[match.start():index]
+
+
+def test_parser_region_is_byte_identical_between_service_and_double():
+    service_region = _synced_region(SERVICE)
+    double_region = _synced_region(DOUBLE)
+    assert service_region, "synced region is empty"
+    assert service_region == double_region, (
+        "services/PhoneNotifications.qml and tests/imports/testservices/PhoneNotifications.qml "
+        "have drifted between the phone-notifications parser logic markers; edit both "
+        "sides identically"
+    )
+
+
+def test_the_derived_properties_the_tab_reads_match_the_double():
+    """count, groupsByAppName and appNameList sit outside the region (they
+    are bindings on `notifications`), and the QML suite drives the double's
+    copies - so the spellings are held to each other."""
+    for name in ("count", "groupsByAppName", "appNameList"):
+        pattern = rf"    readonly property [\w<>]+ {name}:.*\n"
+        service_line = re.search(pattern, SERVICE.read_text())
+        double_line = re.search(pattern, DOUBLE.read_text())
+        assert service_line and double_line, f"{name} missing on one side"
+        assert service_line.group(0) == double_line.group(0), f"{name} drifted"
+
+
+def test_every_busctl_call_is_an_argv_array_from_phone_connects_builder():
+    source = SERVICE.read_text()
+    assert '"busctl"' not in source, "the service spells a busctl argv of its own"
+    assert '"sh"' not in source and '"bash"' not in source, "the service reaches a shell"
+    execs = [line.strip() for line in source.splitlines() if ".exec(" in line]
+    assert execs == ["busProc.exec(next.argv);"], f"a Process is started outside the queue: {execs}"
+    calls = [line.strip() for line in source.splitlines() if "root.enqueue(" in line or "root.runAction(" in line]
+    started = [line for line in calls if "PhoneConnect.busctlCall(" in line]
+    forwarded = [line for line in calls if line.startswith("root.enqueue(argv")]
+    assert started and len(started) + len(forwarded) == len(calls), (
+        f"a call that is not PhoneConnect.busctlCall's argv: {calls}"
+    )
+
+
+def test_dismiss_is_the_leafs_own_method_and_never_a_cancel_action():
+    """The fork's first version called the device-level sendAction with
+    "cancel" as the action - which invokes a named Android action button, and
+    "cancel" is not one, so the phone kept showing what the sidebar had
+    dropped. The leaf object has a dismiss() of its own; it is the only
+    dismiss there is."""
+    source = SERVICE.read_text()
+    body = _function(source, "dismiss")
+    assert f'"{LEAF_IFACE}", "dismiss", []' in body, "dismiss() does not call the leaf's dismiss method"
+    assert "`${root.notificationsPath(deviceId)}/${publicId}`" in body, "dismiss() is not aimed at the leaf path"
+    assert '"cancel"' not in _code(SERVICE), "a cancel action has crept back in"
+    all_body = _function(source, "dismissAll")
+    assert "root.dismiss(" in all_body, "dismissAll() does not go through dismiss()"
+    for name in ("sendReply", "sendAction"):
+        assert f'"{DEVICE_IFACE}", "{name}", ["ss"' in source, f"{name} is not the device-level two-string call"
+
+
+def test_the_reply_refetch_delay_is_a_declared_constant_the_timer_reads():
+    source = SERVICE.read_text()
+    assert re.search(r"readonly property int replyRefetchDelay:\s*800\b", source), (
+        "the reply refetch delay must be declared as replyRefetchDelay: 800"
+    )
+    timer = re.search(r"Timer \{\n\s*id: replyRefetch(.*?)\n    \}", source, re.S)
+    assert timer, "replyRefetch timer missing"
+    assert "interval: root.replyRefetchDelay" in timer.group(1), "the timer does not read the constant"
+    assert "replyRefetch.restart()" in _function(source, "reply"), "reply() does not arm the refetch"
+    for name in ("reconcileInterval", "cacheSaveDelay"):
+        assert re.search(rf"readonly property int {name}:\s*\d+", source), f"{name} not declared"
+        assert f"interval: root.{name}" in source, f"no timer reads {name}"
+
+
+def test_one_stream_the_refetch_hangs_off_phone_connects_settled_signal():
+    source = SERVICE.read_text()
+    assert "monitor" not in _code(SERVICE).lower(), "the service runs a monitor of its own"
+    assert "function onDeviceChangeSettled()" in source, "no refetch on PhoneConnect.deviceChangeSettled"
+    assert "signal deviceChangeSettled()" in PHONE_CONNECT.read_text(), "PhoneConnect does not declare the signal"
+    settle = re.search(r"Timer \{\n\s*id: signalSettle(.*?)\n    \}", PHONE_CONNECT.read_text(), re.S)
+    assert settle and "root.deviceChangeSettled()" in settle.group(1), "PhoneConnect's settle does not raise it"
+    allow = _function(PHONE_CONNECT.read_text(), "signalChangesDevices")
+    for member in ("notificationPosted", "notificationUpdated", "notificationRemoved", "allNotificationsRemoved"):
+        assert member in allow, f"{member} is not on PhoneConnect's allowlist"
+    for block in _process_blocks(source):
+        assert not re.search(r"^\s*running\s*:", block, re.M), f"a Process carries a running binding: {block[:80]}"
+
+
+def test_ids_are_validated_before_they_are_spliced_into_a_path():
+    source = SERVICE.read_text()
+    assert ".filter(id => root.validPublicId(id))" in source, "public ids are not filtered before the leaf reads"
+    for name in ("dismiss", "reply", "sendAction", "sweep"):
+        body = _function(source, name)
+        assert "PhoneConnect.validDeviceId(deviceId)" in body, f"{name}() splices a device id without validating"
+    assert "root.validPublicId(publicId)" in _function(source, "dismiss")
+
+
+def test_the_mirror_gate_reads_the_tabs_switch_through_an_optional_chain():
+    source = SERVICE.read_text()
+    assert "Config.options.sidebar?.phone?.enable ?? true" in source, (
+        "the tab switch is declared by another workstream; read it through ?. with a default"
+    )
+    assert re.search(r"readonly property bool mirrorActive: root\.tabEnabled && \(PhoneConnect\.activeDevice\?\.reachable \?\? false\)", source), (
+        "mirrorActive is not tabEnabled && the active device's reachability"
+    )
+
+
+def test_the_desktop_server_drops_the_daemons_copy_before_tracking_it():
+    """The dedupe belongs at ingestion: an untracked notification is
+    discarded by the server, a tracked one is on the list and the popup."""
+    source = NOTIFICATIONS.read_text()
+    handler = re.search(r"onNotification: \(notification\) => \{(.*?)\n        \}", source, re.S)
+    assert handler, "onNotification handler missing"
+    body = handler.group(1)
+    gate = body.find("PhoneNotifications.mirrorsDesktopNotification(notification.appName)")
+    assert gate != -1, "the server does not ask PhoneNotifications before accepting a notification"
+    assert gate < body.find("notification.tracked = true"), "the gate sits after the notification is tracked"
+    assert "return;" in body[gate:body.find("notification.tracked = true")], "the gate does not drop"
+    wrapper = _function(SERVICE.read_text(), "mirrorsDesktopNotification")
+    assert "root.mirrorActive" in wrapper and "d.paired" in wrapper, (
+        "the wrapper must gate on mirrorActive and compare against PAIRED devices' names"
+    )
+
+
+def test_persistent_declares_the_cache_key_the_service_writes():
+    persistent = PERSISTENT.read_text()
+    block = re.search(r"property JsonObject phone: JsonObject \{(.*?)\n            \}", persistent, re.S)
+    assert block, "Persistent has no phone JsonObject"
+    assert 'property string cachedNotificationsJson: ""' in block.group(1)
+    source = SERVICE.read_text()
+    assert "Persistent.states.phone.cachedNotificationsJson = root.cacheWith(" in source, "the cache is not written through cacheWith"
+    assert "Persistent.ready" in _function(source, "restoreCache"), "restoreCache does not wait for Persistent"
+
+
+if __name__ == "__main__":
+    import sys
+    from contract_runner import run
+    sys.exit(run(globals()))

--- a/dots/.config/quickshell/imi/tests/test_phone_notifications_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_notifications_runtime.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""The phone's notification mirror, driven against a fake daemon in a real shell.
+
+`PhoneNotificationsRuntimeTest.qml` runs the real `services/PhoneNotifications.qml`
+over the real `services/PhoneConnect.qml`, with a fake `busctl` on PATH
+exposing one paired, reachable phone. The fake is stateful: its
+`activeNotifications` answers from a file holding one public id, its
+`monitor` verb adds a second id to that file and prints one
+`notificationPosted` signal line, and its leaf `dismiss` removes the id it
+was aimed at. The harness reads the model back - the sweep's one
+notification with the leaf's fields and the package, the groups, the dedupe
+gate, the SECOND notification arriving from the signal (the oracle for the
+trigger chain: PhoneConnect's allowlist, its settle, deviceChangeSettled(),
+the refetch - with the reconcile a minute out and PhoneConnect's poll ten
+minutes out, nothing else can deliver it), the cache landing in Persistent,
+and the local effect of dismiss, reply and dismissAll.
+
+The writes are scored HERE, off the fake's recorded invocations:
+- `dismiss` reached the LEAF path (`…/notifications/<id>`) on the leaf
+  interface's own `dismiss` method, once for 70 and once for 71 - and never
+  as a device-level `sendAction … cancel`;
+- `sendReply` reached the device-level interface as the two-string call
+  with the notification's reply id, exactly once (the empty reply and the
+  reply to a notification with no reply id reached nothing);
+- `sendAction` reached the same interface keyed on the internalId;
+- the refetch after the reply landed no sooner than the declared 800ms;
+- exactly ONE busctl monitor was spawned in the whole run - PhoneConnect's.
+
+A click that reached nothing would leave the harness green (the card goes
+either way) and this red.
+
+Brings its own headless weston and its own session bus (`dbus-run-session`).
+Skips when weston, qs or dbus-run-session are missing, as in CI.
+"""
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HARNESS = ROOT / "PhoneNotificationsRuntimeTest.qml"
+SOCKET = "wayland-imi-phonenotifications"
+
+PHONE_ID = "6131a746_571a_4176_a007_95625ff8e08e"
+PHONE_NAME = "Galaxy S23 Ultra"
+PHONE_ADDRESS = "192.168.100.179"
+NOTIFICATIONS_PATH = f"/modules/kdeconnect/devices/{PHONE_ID}/notifications"
+DEVICE_IFACE = "org.kde.kdeconnect.device.notifications"
+LEAF_IFACE = f"{DEVICE_IFACE}.notification"
+
+# The service's own declared delay, read out of the source rather than copied.
+REPLY_REFETCH_DELAY = int(re.search(
+    r"readonly property int replyRefetchDelay:\s*(\d+)",
+    (ROOT / "services" / "PhoneNotifications.qml").read_text()).group(1)) / 1000
+
+# A literal, never read back out of the harness's own output: a step list
+# that shrinks must redden here instead of reporting `failures: 0` for a
+# shorter run.
+EXPECTED_CHECKS = 16
+
+RECORD = """#!/usr/bin/env bash
+printf '%s %s\\n' "$(date +%s.%N)" "$*" >> "$PHONE_EXEC_LOG"
+__BODY__
+"""
+
+# --json=short shapes lifted from a real busctl against a live KDE Connect
+# daemon (2026-08-27): the device's activeNotifications is a list of PUBLIC
+# ids, and leaf 70 is the captured Truecaller notification verbatim. Leaf 71
+# is the same shape carrying a reply id.
+BUSCTL_BODY = """\
+state="$PHONE_STATE_DIR"
+active_json() {
+  local out="" id
+  for id in $(cat "$state/active" 2>/dev/null); do
+    out="$out${out:+,}\\"$id\\""
+  done
+  printf '{"type":"as","data":[[%%s]]}\\n' "$out"
+}
+case "$*" in
+  *"org.freedesktop.DBus ListNames")
+    printf '{"type":"as","data":[[":1.5","org.freedesktop.DBus","org.kde.kdeconnect.daemon"]]}\\n'
+    ;;
+  *"org.kde.kdeconnect.daemon devices bb false false")
+    printf '{"type":"as","data":[["%(phone)s"]]}\\n'
+    ;;
+  *"/notifications org.kde.kdeconnect.device.notifications activeNotifications")
+    active_json
+    ;;
+  *"/notifications/70 org.freedesktop.DBus.Properties GetAll s org.kde.kdeconnect.device.notifications.notification")
+    printf '{"type":"a{sv}","data":[{"appName":{"type":"s","data":"Truecaller"},"dismissable":{"type":"b","data":true},"groupName":{"type":"s","data":""},"hasIcon":{"type":"b","data":true},"iconPath":{"type":"s","data":"/tmp/kdeconnect_xephy/eb39605216ceabbbd952b1ab18d00267"},"internalId":{"type":"s","data":"0|com.truecaller|2131366136|null|10553"},"isConversation":{"type":"b","data":false},"isGroupConversation":{"type":"b","data":false},"replyId":{"type":"s","data":""},"silent":{"type":"b","data":false},"text":{"type":"s","data":"Allow Truecaller to run in the background to identify and block calls while you are not using the app"},"ticker":{"type":"s","data":"Stay protected 24/7: Allow Truecaller to run in the background to identify and block calls while you are not using the app"},"title":{"type":"s","data":"Stay protected 24/7"}}]}\\n'
+    ;;
+  *"/notifications/71 org.freedesktop.DBus.Properties GetAll s org.kde.kdeconnect.device.notifications.notification")
+    printf '{"type":"a{sv}","data":[{"appName":{"type":"s","data":"WhatsApp"},"dismissable":{"type":"b","data":true},"groupName":{"type":"s","data":""},"hasIcon":{"type":"b","data":false},"iconPath":{"type":"s","data":""},"internalId":{"type":"s","data":"0|com.whatsapp|1|N3JGW5Lg6vbO|10466"},"isConversation":{"type":"b","data":true},"isGroupConversation":{"type":"b","data":false},"replyId":{"type":"s","data":"r1"},"silent":{"type":"b","data":false},"text":{"type":"s","data":"see you at 8"},"ticker":{"type":"s","data":"Sam: see you at 8"},"title":{"type":"s","data":"Sam"}}]}\\n'
+    ;;
+  *"/notifications/"*" org.kde.kdeconnect.device.notifications.notification dismiss")
+    # $* joined first: a suffix strip on $* itself applies per argument.
+    argv="$*"
+    id="${argv%% org.kde.kdeconnect.device.notifications.notification dismiss}"
+    id="${id##*/}"
+    grep -v -x "$id" "$state/active" > "$state/active.next" || true
+    mv "$state/active.next" "$state/active"
+    ;;
+  *"devices/%(phone)s/battery org.freedesktop.DBus.Properties GetAll s org.kde.kdeconnect.device.battery")
+    printf '{"type":"a{sv}","data":[{"charge":{"type":"i","data":85},"hasBattery":{"type":"b","data":true},"isCharging":{"type":"b","data":false}}]}\\n'
+    ;;
+  *"devices/%(phone)s/connectivity_report org.freedesktop.DBus.Properties GetAll s org.kde.kdeconnect.device.connectivity_report")
+    printf '{"type":"a{sv}","data":[{"cellularNetworkStrength":{"type":"i","data":4},"cellularNetworkType":{"type":"s","data":"LTE"},"iconName":{"type":"s","data":"network-mobile-100-lte"}}]}\\n'
+    ;;
+  *"devices/%(phone)s org.freedesktop.DBus.Properties GetAll s org.kde.kdeconnect.device")
+    printf '{"type":"a{sv}","data":[{"name":{"type":"s","data":"%(name)s"},"type":{"type":"s","data":"phone"},"isPaired":{"type":"b","data":true},"isReachable":{"type":"b","data":true},"isPairRequestedByPeer":{"type":"b","data":false},"pairState":{"type":"i","data":3},"reachableAddresses":{"type":"as","data":["%(address)s"]}}]}\\n'
+    ;;
+  *monitor*)
+    sleep 1.5
+    printf '70\\n71\\n' > "$state/active"
+    printf '{"type":"signal","endian":"l","flags":1,"version":1,"cookie":410,"timestamp-realtime":1787149977815500,"sender":":1.55","path":"%(path)s","interface":"org.kde.kdeconnect.device.notifications","member":"notificationPosted","payload":{"type":"s","data":["71"]}}\\n'
+    sleep 3600
+    ;;
+esac
+exit 0
+""" % {"phone": PHONE_ID, "name": PHONE_NAME, "address": PHONE_ADDRESS, "path": NOTIFICATIONS_PATH}
+
+
+def _stop(proc):
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+
+
+def _runtime_available():
+    return all(shutil.which(name) for name in ("qs", "weston", "dbus-run-session"))
+
+
+@unittest.skipUnless(_runtime_available(), "needs qs, weston and dbus-run-session on PATH")
+class PhoneNotificationsRuntimeTest(unittest.TestCase):
+    def setUp(self):
+        self.home = Path(tempfile.mkdtemp(prefix="imi-phonenotifications-"))
+        self.addCleanup(shutil.rmtree, self.home, ignore_errors=True)
+        self.exec_log = self.home / "exec.log"
+        self.state = self.home / "phone-state"
+        self.state.mkdir()
+        (self.state / "active").write_text("70\n")
+        self.bin = self.home / "bin"
+        self.bin.mkdir(parents=True)
+        fake = self.bin / "busctl"
+        fake.write_text(RECORD.replace("__BODY__", BUSCTL_BODY))
+        fake.chmod(0o755)
+
+        shell_config = self.home / "config" / "immaterial-impulse"
+        shell_config.mkdir(parents=True)
+        # PhoneConnect's poll is ten minutes out: the startup sweep populates
+        # the device model (the timer fires on start) and nothing re-sweeps
+        # on a schedule, so the second notification can only arrive through
+        # the signal.
+        (shell_config / "config.json").write_text(json.dumps({
+            "networking": {"phoneConnect": {"enable": True, "pollInterval": 600000}},
+        }, indent=2))
+
+    def invocations(self):
+        if not self.exec_log.exists():
+            return []
+        out = []
+        for line in self.exec_log.read_text().splitlines():
+            if not line.strip():
+                continue
+            stamp, _, argv = line.partition(" ")
+            out.append((float(stamp), argv))
+        return out
+
+    def test_the_mirror_reads_the_leaves_and_writes_to_the_daemon(self):
+        env = dict(os.environ)
+        runtime = self.home / "runtime"
+        runtime.mkdir(mode=0o700)
+        env["XDG_RUNTIME_DIR"] = str(runtime)
+        env["WAYLAND_DISPLAY"] = SOCKET
+        env.pop("DISPLAY", None)
+        env.pop("HYPRLAND_INSTANCE_SIGNATURE", None)
+
+        weston = subprocess.Popen(
+            ["weston", "--backend=headless", "--renderer=pixman",
+             f"--socket={SOCKET}", "--width=800", "--height=600"],
+            env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        self.addCleanup(_stop, weston)
+
+        socket_path = runtime / SOCKET
+        deadline = time.monotonic() + 15
+        while not socket_path.exists() and time.monotonic() < deadline:
+            time.sleep(0.2)
+        self.assertTrue(socket_path.exists(), "headless weston never came up")
+
+        env["LIBGL_ALWAYS_SOFTWARE"] = "1"
+        env["QT_QUICK_BACKEND"] = "software"
+        env["XDG_CONFIG_HOME"] = str(self.home / "config")
+        env["XDG_STATE_HOME"] = str(self.home / "state")
+        env["XDG_CACHE_HOME"] = str(self.home / "cache")
+        env["XDG_DATA_HOME"] = str(self.home / "data")
+        env["PATH"] = f"{self.bin}{os.pathsep}{env['PATH']}"
+        env["PHONE_EXEC_LOG"] = str(self.exec_log)
+        env["PHONE_STATE_DIR"] = str(self.state)
+        env["PHONE_ID"] = PHONE_ID
+        env["PHONE_NAME"] = PHONE_NAME
+
+        # dbus-run-session, not the inherited bus: the fake busctl is the only
+        # daemon this harness may see.
+        proc = subprocess.run(
+            ["dbus-run-session", "--", "qs", "-p", str(HARNESS)],
+            cwd=str(ROOT), env=env, capture_output=True, text=True, timeout=240)
+        output = proc.stdout + proc.stderr
+        failed = [line for line in output.splitlines() if "FAIL" in line]
+        self.assertEqual(failed, [], f"harness reported failures:\n{output}\n{self.exec_log.read_text() if self.exec_log.exists() else ''}")
+        self.assertIn(f"[PhoneNotifications] checks: {EXPECTED_CHECKS} failures: 0", output,
+                      f"harness did not finish cleanly:\n{output}")
+
+        calls = self.invocations()
+        argvs = [argv for _, argv in calls]
+
+        # dismiss: the LEAF's own method, on the leaf path, once per id.
+        dismissed = [argv for argv in argvs if argv.endswith(f" {LEAF_IFACE} dismiss")]
+        self.assertEqual(
+            [argv.split(" ")[-3].rsplit("/", 1)[1] for argv in dismissed], ["70", "71"],
+            f"expected dismiss on leaf 70 then leaf 71, got {dismissed}")
+        for argv in dismissed:
+            self.assertIn(f"{NOTIFICATIONS_PATH}/", argv)
+        self.assertEqual([argv for argv in argvs if "cancel" in argv], [], "a cancel action reached the daemon")
+
+        # reply: the device-level two-string call with the reply id, once.
+        replies = [argv for argv in argvs if f" {DEVICE_IFACE} sendReply " in argv]
+        self.assertEqual(replies, [
+            f"--user --json=short --timeout=5 call org.kde.kdeconnect.daemon {NOTIFICATIONS_PATH} {DEVICE_IFACE} sendReply ss r1 hi there"
+        ])
+        actions = [argv for argv in argvs if f" {DEVICE_IFACE} sendAction " in argv]
+        self.assertEqual(actions, [
+            f"--user --json=short --timeout=5 call org.kde.kdeconnect.daemon {NOTIFICATIONS_PATH} {DEVICE_IFACE} sendAction ss 0|com.whatsapp|1|N3JGW5Lg6vbO|10466 Mark as read"
+        ])
+
+        # The refetch after the reply: the next activeNotifications after
+        # sendReply lands no sooner than the declared delay.
+        reply_at = next(stamp for stamp, argv in calls if f" {DEVICE_IFACE} sendReply " in argv)
+        refetches = [stamp for stamp, argv in calls
+                     if argv.endswith(f" {DEVICE_IFACE} activeNotifications") and stamp > reply_at]
+        self.assertTrue(refetches, "no refetch followed the reply")
+        gap = refetches[0] - reply_at
+        self.assertGreaterEqual(gap, REPLY_REFETCH_DELAY, f"the refetch came {gap:.2f}s after the reply")
+        self.assertLess(gap, REPLY_REFETCH_DELAY + 2.5, f"the refetch came {gap:.2f}s after the reply")
+
+        # One stream: PhoneConnect's monitor and nobody else's.
+        monitors = [argv for argv in argvs if " monitor " in argv]
+        self.assertEqual(len(monitors), 1, f"expected exactly one busctl monitor, got {monitors}")
+
+        # The cache reached the disk, keyed by the device.
+        states = list((self.home / "state").rglob("states.json"))
+        self.assertEqual(len(states), 1, f"expected one states.json, found {states}")
+        cache = json.loads(json.loads(states[0].read_text())["phone"]["cachedNotificationsJson"])
+        self.assertIn(PHONE_ID, cache)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dots/.config/quickshell/imi/tests/tst_phone_connect.qml
+++ b/dots/.config/quickshell/imi/tests/tst_phone_connect.qml
@@ -426,6 +426,20 @@ TestCase {
         verify(PhoneConnect.signalChangesDevices({ iface: "org.kde.kdeconnect.device.connectivity_report", member: "refreshed", args: ["LTE", 4] }))
     }
 
+    function test_signal_changes_devices_hears_the_notification_signals() {
+        // Introspected off the live daemon's <device>/notifications object:
+        // three carry the public id (s), allNotificationsRemoved carries
+        // nothing. PhoneNotifications refetches on the coalesced change these
+        // cause rather than on a monitor of its own.
+        for (const member of ["notificationPosted", "notificationUpdated", "notificationRemoved"])
+            verify(PhoneConnect.signalChangesDevices({ iface: "org.kde.kdeconnect.device.notifications", member: member, args: ["70"] }),
+                   `notifications.${member} should re-read`)
+        verify(PhoneConnect.signalChangesDevices({ iface: "org.kde.kdeconnect.device.notifications", member: "allNotificationsRemoved", args: [] }))
+        // The leaf's own `ready` is not in the set: it fires per notification
+        // object as it is built, before the daemon has posted it.
+        verify(!PhoneConnect.signalChangesDevices({ iface: "org.kde.kdeconnect.device.notifications.notification", member: "ready", args: [] }))
+    }
+
     function test_signal_changes_devices_reads_the_interface_out_of_properties_changed() {
         verify(PhoneConnect.signalChangesDevices({
             iface: "org.freedesktop.DBus.Properties", member: "PropertiesChanged",

--- a/dots/.config/quickshell/imi/tests/tst_phone_notifications.qml
+++ b/dots/.config/quickshell/imi/tests/tst_phone_notifications.qml
@@ -1,0 +1,221 @@
+import QtQuick
+import QtTest
+import testservices
+
+// Behavioral tests for the parsing/normalization logic of
+// services/PhoneNotifications.qml, exercised through the logic-only double in
+// tests/imports/testservices. The two fixtures are verbatim `busctl
+// --json=short` replies captured from a live KDE Connect daemon (2026-08-27):
+// the device's activeNotifications list and one notification leaf's GetAll.
+TestCase {
+    name: "PhoneNotificationsTest"
+
+    readonly property string deviceId: "6131a746_571a_4176_a007_95625ff8e08e"
+
+    // busctl --user --json=short call org.kde.kdeconnect.daemon
+    //   /modules/kdeconnect/devices/<id>/notifications
+    //   org.kde.kdeconnect.device.notifications activeNotifications
+    readonly property string activeReply: '{"type":"as","data":[["70"]]}'
+
+    // busctl --user --json=short call org.kde.kdeconnect.daemon
+    //   /modules/kdeconnect/devices/<id>/notifications/70
+    //   org.freedesktop.DBus.Properties GetAll s
+    //   org.kde.kdeconnect.device.notifications.notification
+    readonly property string leafReply: '{"type":"a{sv}","data":[{"appName":{"type":"s","data":"Truecaller"},"dismissable":{"type":"b","data":true},"groupName":{"type":"s","data":""},"hasIcon":{"type":"b","data":true},"iconPath":{"type":"s","data":"/tmp/kdeconnect_xephy/eb39605216ceabbbd952b1ab18d00267"},"internalId":{"type":"s","data":"0|com.truecaller|2131366136|null|10553"},"isConversation":{"type":"b","data":false},"isGroupConversation":{"type":"b","data":false},"replyId":{"type":"s","data":""},"silent":{"type":"b","data":false},"text":{"type":"s","data":"Allow Truecaller to run in the background to identify and block calls while you are not using the app"},"ticker":{"type":"s","data":"Stay protected 24/7: Allow Truecaller to run in the background to identify and block calls while you are not using the app"},"title":{"type":"s","data":"Stay protected 24/7"}}]}'
+
+    function init() {
+        PhoneNotifications.activeDeviceId = deviceId
+        PhoneNotifications.mirrorActive = false
+        PhoneNotifications.notifications = []
+    }
+
+    function leaf(publicId, overrides) {
+        const props = JSON.parse(leafReply).data[0]
+        for (const key in (overrides ?? {}))
+            props[key] = overrides[key]
+        return PhoneNotifications.normalizeNotification(publicId, deviceId, props, 1000)
+    }
+
+    // ---- the activeNotifications reply ----
+
+    function test_active_notifications_reply_is_a_list_of_public_ids() {
+        const data = PhoneConnect.parseBusctlReply(activeReply)
+        compare(data.length, 1)
+        compare(data[0], ["70"])
+        verify(PhoneNotifications.validPublicId("70"))
+    }
+
+    function test_public_ids_are_kept_boring_before_they_reach_a_path() {
+        verify(PhoneNotifications.validPublicId("70"))
+        verify(PhoneNotifications.validPublicId("abc_9"))
+        verify(!PhoneNotifications.validPublicId(""))
+        verify(!PhoneNotifications.validPublicId("70/../battery"))
+        verify(!PhoneNotifications.validPublicId("70 71"))
+        verify(!PhoneNotifications.validPublicId(70))
+        verify(!PhoneNotifications.validPublicId(null))
+    }
+
+    // ---- packageFromInternalId ----
+
+    function test_package_is_the_second_field_of_a_zero_prefixed_internal_id() {
+        compare(PhoneNotifications.packageFromInternalId("0|com.truecaller|2131366136|null|10553"), "com.truecaller")
+        compare(PhoneNotifications.packageFromInternalId("0|com.whatsapp|1|N3JGW5Lg6vbO|10466"), "com.whatsapp")
+        compare(PhoneNotifications.packageFromInternalId("0| com.spaced |x"), "com.spaced")
+    }
+
+    function test_package_is_empty_when_the_internal_id_has_another_shape() {
+        compare(PhoneNotifications.packageFromInternalId(""), "")
+        compare(PhoneNotifications.packageFromInternalId(null), "")
+        compare(PhoneNotifications.packageFromInternalId("0"), "")
+        compare(PhoneNotifications.packageFromInternalId("1|com.other|x"), "")
+        compare(PhoneNotifications.packageFromInternalId("com.other"), "")
+    }
+
+    // ---- normalizeNotification ----
+
+    function test_normalize_reads_the_captured_leaf_onto_the_model() {
+        const raw = PhoneConnect.parseBusctlReply(leafReply)[0]
+        const n = PhoneNotifications.normalizeNotification("70", deviceId, raw, 1234)
+        compare(n.publicId, "70")
+        compare(n.deviceId, deviceId)
+        compare(n.internalId, "0|com.truecaller|2131366136|null|10553")
+        compare(n.package, "com.truecaller")
+        compare(n.appName, "Truecaller")
+        compare(n.title, "Stay protected 24/7")
+        compare(n.text, "Allow Truecaller to run in the background to identify and block calls while you are not using the app")
+        verify(n.ticker.startsWith("Stay protected 24/7: "))
+        compare(n.iconPath, "/tmp/kdeconnect_xephy/eb39605216ceabbbd952b1ab18d00267")
+        compare(n.dismissable, true)
+        compare(n.replyId, "")
+        compare(n.actions, [])
+        compare(n.receivedAt, 1234)
+    }
+
+    function test_normalize_degrades_a_sparse_leaf_to_empty_strings_and_a_dismissable_default() {
+        const n = PhoneNotifications.normalizeNotification("3", deviceId, {}, 5)
+        compare(n.appName, "")
+        compare(n.title, "")
+        compare(n.text, "")
+        compare(n.ticker, "")
+        compare(n.iconPath, "")
+        compare(n.internalId, "")
+        compare(n.package, "")
+        compare(n.dismissable, true)
+        compare(n.replyId, "")
+        compare(n.actions, [])
+        const undismissable = leaf("4", { "dismissable": { "type": "b", "data": false }, "replyId": { "type": "s", "data": "reply-9" } })
+        compare(undismissable.dismissable, false)
+        compare(undismissable.replyId, "reply-9")
+    }
+
+    function test_normalize_keeps_only_string_actions() {
+        const n = leaf("5", { "actions": { "type": "as", "data": ["Mark as read", 7, null, "Reply"] } })
+        compare(n.actions, ["Mark as read", "Reply"])
+    }
+
+    // ---- carryReceivedAt ----
+
+    function test_a_refetch_keeps_the_time_a_known_notification_first_arrived() {
+        const before = [leaf("70")]
+        before[0].receivedAt = 100
+        const fresh = [leaf("70"), leaf("71")]
+        fresh[0].receivedAt = 900
+        fresh[1].receivedAt = 900
+        const merged = PhoneNotifications.carryReceivedAt(before, fresh)
+        compare(merged.length, 2)
+        compare(merged[0].publicId, "70")
+        compare(merged[0].receivedAt, 100)
+        compare(merged[1].publicId, "71")
+        compare(merged[1].receivedAt, 900)
+        // The previous list is not mutated and a dropped id does not come back.
+        compare(PhoneNotifications.carryReceivedAt(before, []).length, 0)
+    }
+
+    // ---- groups ----
+
+    function test_groups_by_app_name_newest_app_first_like_the_desktop_list() {
+        const older = leaf("70")
+        older.receivedAt = 100
+        const newer = leaf("71", { "appName": { "type": "s", "data": "WhatsApp" }, "iconPath": { "type": "s", "data": "/tmp/wa" } })
+        newer.receivedAt = 300
+        const sibling = leaf("72")
+        sibling.receivedAt = 200
+        const groups = PhoneNotifications.groupsForList([older, newer, sibling])
+        compare(Object.keys(groups).sort(), ["Truecaller", "WhatsApp"])
+        compare(groups["Truecaller"].notifications.length, 2)
+        compare(groups["Truecaller"].time, 200)
+        compare(groups["Truecaller"].appIcon, "/tmp/kdeconnect_xephy/eb39605216ceabbbd952b1ab18d00267")
+        compare(groups["WhatsApp"].appIcon, "/tmp/wa")
+        compare(groups["WhatsApp"].time, 300)
+        compare(PhoneNotifications.appNameListForGroups(groups), ["WhatsApp", "Truecaller"])
+    }
+
+    function test_the_double_derives_groups_from_its_list() {
+        const a = leaf("70")
+        a.receivedAt = 10
+        const b = leaf("71", { "appName": { "type": "s", "data": "Signal" } })
+        b.receivedAt = 20
+        PhoneNotifications.applyNotifications([a, b], deviceId)
+        compare(PhoneNotifications.count, 2)
+        compare(PhoneNotifications.appNameList, ["Signal", "Truecaller"])
+        compare(PhoneNotifications.groupsByAppName["Signal"].notifications[0].publicId, "71")
+        // A sweep for a device that is no longer the active one is dropped.
+        PhoneNotifications.applyNotifications([leaf("9")], "someone-else")
+        compare(PhoneNotifications.count, 2)
+    }
+
+    // ---- the desktop dedupe predicate ----
+
+    function test_the_daemons_own_app_names_are_mirrored_case_insensitively() {
+        for (const name of ["kdeconnect", "KDE Connect", "kde connect", "org.kde.kdeconnect", "KDEConnect"])
+            verify(PhoneNotifications.mirrorsAppName(name, []), `${name} is the daemon`)
+    }
+
+    function test_a_paired_devices_name_is_mirrored_and_other_apps_are_not() {
+        const names = ["Galaxy S23 Ultra", "rox-xbox-ally-x"]
+        verify(PhoneNotifications.mirrorsAppName("Galaxy S23 Ultra", names))
+        verify(PhoneNotifications.mirrorsAppName("galaxy s23 ultra", names))
+        verify(!PhoneNotifications.mirrorsAppName("Firefox", names))
+        verify(!PhoneNotifications.mirrorsAppName("", names))
+        verify(!PhoneNotifications.mirrorsAppName(null, names))
+        verify(!PhoneNotifications.mirrorsAppName("Galaxy", names))
+        verify(!PhoneNotifications.mirrorsAppName("Galaxy S23 Ultra", null))
+    }
+
+    // ---- the persisted cache ----
+
+    function test_the_cache_round_trips_per_device_and_keeps_other_devices_entries() {
+        const first = PhoneNotifications.cacheWith("", deviceId, [leaf("70")], 500)
+        const second = PhoneNotifications.cacheWith(first, "other", [leaf("1"), leaf("2")], 600)
+        const doc = JSON.parse(second)
+        compare(Object.keys(doc).sort(), [deviceId, "other"])
+        compare(doc[deviceId].savedAt, 500)
+        compare(doc[deviceId].notifications.length, 1)
+        compare(doc["other"].notifications.length, 2)
+        const restored = PhoneNotifications.cachedNotificationsFor(second, deviceId)
+        compare(restored.length, 1)
+        compare(restored[0].publicId, "70")
+        compare(restored[0].appName, "Truecaller")
+        compare(PhoneNotifications.cachedNotificationsFor(second, "other").length, 2)
+    }
+
+    function test_the_cache_answers_nothing_for_an_unknown_device_or_a_broken_document() {
+        compare(PhoneNotifications.cachedNotificationsFor("", deviceId), [])
+        compare(PhoneNotifications.cachedNotificationsFor(null, deviceId), [])
+        compare(PhoneNotifications.cachedNotificationsFor("{not json", deviceId), [])
+        compare(PhoneNotifications.cachedNotificationsFor('{"x":{"notifications":[]}}', deviceId), [])
+        compare(PhoneNotifications.cachedNotificationsFor('{"' + deviceId + '":{"notifications":"nope"}}', deviceId), [])
+        // An entry without a usable public id cannot be dismissed, so it is
+        // not restored either.
+        const doc = '{"' + deviceId + '":{"savedAt":1,"notifications":[{"publicId":"70","appName":"A"},{"appName":"B"},null,{"publicId":"../x"}]}}'
+        const restored = PhoneNotifications.cachedNotificationsFor(doc, deviceId)
+        compare(restored.length, 1)
+        compare(restored[0].publicId, "70")
+    }
+
+    function test_a_broken_cache_document_is_replaced_rather_than_kept() {
+        const doc = JSON.parse(PhoneNotifications.cacheWith("{not json", deviceId, [], 7))
+        compare(Object.keys(doc), [deviceId])
+        compare(doc[deviceId].notifications, [])
+    }
+}


### PR DESCRIPTION
Notification mirroring for the Phone tab (W2 of `docs/superpowers/specs/2026-08-27-phone-tab-design.md`).

Stacked on 312 — review the last commits only.

`services/PhoneNotifications.qml` mirrors the paired phone's notifications off KDE Connect on the busctl transport: its own serialized queue, argv only, **no monitor of its own** — the four notification signals join `PhoneConnect`'s allowlist and its new `deviceChangeSettled()` is the refetch trigger, beside the active device changing and a 60 s reconcile. A sweep is `activeNotifications` (a list of public ids, captured live) plus one `GetAll` per leaf; dismiss is the leaf's own method (never `sendAction("cancel")`), reply is `sendReply` plus a refetch after a declared 800 ms, and the list is cached per device in `Persistent.states.phone`. `services/Notifications.qml` drops kdeconnectd's desktop copy at ingestion while the tab is enabled and the phone reachable.

Tests: `tst_phone_notifications.qml` on captured replies through a logic-only double; `test_phone_notifications_contract.py` (region synced, argv only, leaf dismiss, declared delay, one stream, the gate); `test_phone_notifications_runtime.py`, a fake busctl whose monitor verb posts a second notification that only the signal can deliver, with the writes scored off its log.

Open point: `sendAction` is keyed on the `internalId` (the daemon's Android key), not the public id the fork sends; unverifiable live since the daemon publishes no action names.

Docs: updated AGENT.md §Directory map (PhoneNotifications.qml) and §busctl monitor gotchas (leaf dismiss / sendAction key; the dedupe gate); docs/proposals/phone-connect.md notification slice marked done
Changelog: updated
