### PR TITLE
feat(phoneContacts): the phone's contacts, read from the vCards KDE Connect syncs

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -607,6 +607,18 @@ services/                  Singletons wrapping external state/processes - one pe
                               logic-only double (tests/test_phone_notifications_contract.py);
                               driven end to end by tests/test_phone_notifications_runtime.py
                               5cad7ad40 ("feat(phoneNotifications): mirror the phone's notifications off KDE Connect over busctl")
+  PhoneContacts.qml            The active phone's contacts, for the Phone tab's Contacts card
+                              and page. Not on the bus: KDE Connect writes one vCard per
+                              contact under ~/.local/share/kpeoplevcard/kdeconnect-<id>/,
+                              and scripts/phone/contacts_monitor.py reads that directory
+                              as one streaming NDJSON process per session (gio-watched, a
+                              3 s poll when it cannot be), supervised on PhoneConnect's own
+                              backoff ladder. `filtered` is the list the page draws - the
+                              query, hide-unnamed and sort decisions are pure functions
+                              kept byte-for-byte in a logic-only double
+                              (tests/test_phone_contacts_contract.py enforces it). The
+                              dialer and SMS actions are `adb shell am start` intents,
+                              refused with `lastError` when adb cannot reach the phone
   SchemePreview.qml            Per-scheme swatches for the scheme pickers: one venv run of
                               scripts/colors/scheme_preview.py quantizes the wallpaper once and
                               builds every Material variant from it. Cached against the wallpaper
@@ -653,6 +665,13 @@ scripts/                   Standalone helper scripts (Python/bash) invoked via P
                               prompted mask's clicks live in a PNG text chunk it parses by hand for
                               exactly that reason; `run` and `select` need the uv venv
                               (subject-mask-venv.sh)
+  phone/contacts_monitor.py   Publishes a KDE Connect device's contacts from its kpeoplevcard
+                              directory as NDJSON (`ready`, `snapshot` only when the SHA-256
+                              of the parsed set moves, `error no_contact_source`). Stdlib
+                              only: `gio monitor -d` is a subprocess, not PyGObject. See the
+                              vCard 2.1 note under "busctl monitor" below before touching the
+                              parser; tests/test_phone_contacts_monitor.py drives it against
+                              a fixture tree and never the machine's own cards
 translations/              i18n string tables (Translation.tr(...) singleton)
 assets/                    Static images/fonts bundled with the shell
 ```
@@ -4067,6 +4086,40 @@ true of six spawns in six milliseconds, which is the bug.
 (feat(phoneConnect): drive updates from the daemon's signals, not from the poll,
 fix(phoneConnect): the monitor's gate is a function, because a handler cannot read its own binding,
 test(phoneConnect): drive the monitor's start, its stream, its backoff and its ceiling.)
+
+**A phone's contacts are not on the bus - they are vCards KDE Connect writes to disk, and the
+vCards are version 2.1.** KDE Connect's contacts plugin answers no "list the contacts" call; it
+writes one `.vcf` per contact into `~/.local/share/kpeoplevcard/kdeconnect-<deviceId>/` for
+KPeople. `services/PhoneContacts.qml` reads that directory through
+`scripts/phone/contacts_monitor.py`, one streaming Python process per session on the same
+lifecycle as the busctl monitor above (`exec()`, no `running` binding, the restart-safe marker,
+and every exit through `PhoneConnect.monitorExitPlan` - *reused*, so the shell has one spelling
+of the backoff ladder rather than three). A device change restarts it from the top of the ladder,
+and Quickshell does raise `exited` for a deliberate `running = false`, measured in a headless
+`qs` before the restart was written that way. Three things measured against the 150 cards on this
+machine, none visible from the fork's parser:
+
+- **Android's exporter soft-wraps QUOTED-PRINTABLE names with a trailing `=` continued on an
+  UNINDENTED line** - 32 such lines in one export. An RFC 2425 unfold joins only indented
+  continuations, so every long non-ASCII name was truncated at the wrap and the remainder
+  parsed as a line with no `:` and skipped, silently. The unfolder joins a QP line ending in
+  `=` with the physical line after it.
+- **Photos travel inline as `data:` URIs.** The whole export carries 140 KB of photo base64,
+  so a snapshot stays small and there is no avatar cache to sweep or bust; the fork wrote each
+  photo to a cache file and emitted a path.
+- **A raw contact that never had a name arrives with its number as FN and N** (SIM imports,
+  call-blocker lists - three here, about a thousand on the fork author's phone). They are
+  flagged `nameless` rather than dropped, so `hideUnnamed` can hide them and a starred one
+  still shows: starring is an explicit statement that the number matters.
+
+The dialer and SMS actions are `adb [-s <serial>] shell am start -a <DIAL|SENDTO> -d <tel:|sms:>`
+with the serial re-resolved from `adb devices` on every intent (the wireless-debugging port
+moves on every toggle and reboot), a USB serial ahead of an ip:port, and refused with
+`lastError` when adb is absent or no device is in the `device` state - never `execDetached`,
+because a refused intent has to say so. The tests never read the machine's own cards:
+`tests/test_phone_contacts_monitor.py` builds a fixture tree shaped after the real files.
+209852182 ("feat(phone): contacts_monitor.py reads the vCards KDE Connect writes"),
+b7b8ffcda ("feat(phone): PhoneContacts.qml, the contacts model over a supervised monitor").
 
 **A player on the MPRIS bus may be a proxy for another player, and every field you would match on
 is the borrowed one.** `playerctld` is `playerctl`'s daemon, not a player: it re-publishes whichever

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,15 @@ own repo; the installer pins which revision it builds.
   reachable, kdeconnectd's own desktop pop-ups of those same notifications
   are no longer shown beside them. This is the data behind the Phone tab,
   which draws it in a following release.
+- **The phone's contacts reach the shell.** A new `PhoneContacts` service
+  reads the vCards KDE Connect syncs to `~/.local/share/kpeoplevcard`, keeps
+  the list live as the phone syncs (and parses the names Android soft-wraps,
+  which used to come out truncated in the fork this is ported from), searches
+  it by name, organization, address or digits, hides the number-only cards
+  anti-spam apps leave behind - never a starred one - and can open the
+  phone's dialer or SMS composer for a number over adb, saying why when it
+  cannot. This is the model behind the Phone tab's Contacts card; the tab
+  itself follows.
 - **Phone Connect shows your phone's wireless address and cellular network,
   and answers pairing requests.** The panel reads the address KDE Connect
   reaches the phone on and its cellular network type (LTE, 5G, …) alongside

--- a/dots/.config/quickshell/imi/scripts/phone/contacts_monitor.py
+++ b/dots/.config/quickshell/imi/scripts/phone/contacts_monitor.py
@@ -1,0 +1,411 @@
+#!/usr/bin/env python3
+"""Publish a phone's contacts from the vCards KDE Connect keeps on disk.
+
+KDE Connect's contacts plugin does not answer "list the contacts" over D-Bus;
+its job is to write one `.vcf` per contact into
+`$XDG_DATA_HOME/kpeoplevcard/kdeconnect-<deviceId>/` for KPeople to read.
+This script is the shell's KPeople: it resolves that directory (the named
+device's, else the most recently modified `kdeconnect-*`), parses every card
+and prints NDJSON on stdout:
+
+    {"event": "ready", "sourcePath": "...", "count": N}
+    {"event": "snapshot", "contacts": [...]}          only when the set changed
+    {"event": "error", "code": "no_contact_source", "message": "..."}
+
+A snapshot is published only when the SHA-256 of the parsed set moves, so the
+watcher can re-read on every directory tick and cost the shell nothing while
+nothing moved. With `--once` it prints one round and exits 0 whatever it found.
+Without it, it watches: `gio monitor -d` on the directory when gio is on PATH
+(a 250 ms debounce folds the burst one sync writes), a 3 s poll when it is not
+or when gio dies, and the poll again while there is no source at all - the
+directory appears on the first sync after pairing, and a watcher that exits on
+"nothing there yet" is a watcher the shell's restart ladder gives up on.
+
+The cards Android exports are vCard 2.1: names are QUOTED-PRINTABLE and
+soft-wrapped with a trailing `=` continued on an UNINDENTED line (a plain
+unfold truncates them), photos are base64 folded over indented lines, and a
+raw contact that never had a name arrives with its number as FN and N (SIM
+imports, call-blocker lists) - those are flagged `nameless` rather than
+dropped, so the shell can hide them and still keep a starred one.
+"""
+
+import argparse
+import base64
+import binascii
+import hashlib
+import json
+import os
+import quopri
+import re
+import select
+import shutil
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+DEBOUNCE_SECONDS = 0.25
+POLL_SECONDS = 3.0
+# A gio that exits sooner than this after starting is not watching anything
+# (no inotify, a directory it cannot read); the poll takes over rather than
+# respawning it forever.
+GIO_HEALTHY_SECONDS = 2.0
+
+PHONE_TYPES = {"HOME": "home", "WORK": "work", "MAIN": "main", "OTHER": "other", "FAX": "fax"}
+EMAIL_TYPES = {"HOME": "home", "WORK": "work"}
+PHOTO_MIME = {"JPEG": "image/jpeg", "JPG": "image/jpeg", "PNG": "image/png",
+              "GIF": "image/gif", "WEBP": "image/webp"}
+
+
+def data_root():
+    xdg = os.environ.get("XDG_DATA_HOME")
+    base = Path(xdg) if xdg else Path.home() / ".local" / "share"
+    return base / "kpeoplevcard"
+
+
+def find_device_directory(root, device_id=None):
+    if not root.is_dir():
+        return None
+    dirs = [d for d in root.iterdir() if d.is_dir() and d.name.startswith("kdeconnect-")]
+    if not dirs:
+        return None
+    if device_id:
+        for d in dirs:
+            if d.name == f"kdeconnect-{device_id}":
+                return d
+        for d in dirs:
+            if device_id in d.name:
+                return d
+    return max(dirs, key=lambda d: d.stat().st_mtime)
+
+
+def unfold(text):
+    """Logical lines: indented continuations joined (RFC 2425), and a
+    QUOTED-PRINTABLE value whose line ends in `=` continued on the next line
+    even though vCard 2.1 writes that continuation with no indent."""
+    lines = []
+    for physical in text.splitlines():
+        if lines and physical[:1] in (" ", "\t"):
+            lines[-1] += physical[1:]
+        elif lines and lines[-1].endswith("=") and _is_quoted_printable(lines[-1]):
+            lines[-1] = lines[-1][:-1] + physical
+        else:
+            lines.append(physical)
+    return lines
+
+
+def _is_quoted_printable(line):
+    head = line.split(":", 1)[0].upper()
+    return "QUOTED-PRINTABLE" in head
+
+
+def parse_params(param_text):
+    """`;CELL;PREF` / `;TYPE=CELL,VOICE` / `;ENCODING=b;TYPE=PNG` as one set of
+    upper-cased tokens (every bare param, every key, every value in a list)
+    plus the last value seen per key."""
+    tokens, values = set(), {}
+    for param in param_text.split(";"):
+        if not param:
+            continue
+        if "=" in param:
+            key, value = param.split("=", 1)
+            tokens.add(key.upper())
+            values[key.upper()] = value
+            for item in value.split(","):
+                tokens.add(item.upper())
+        else:
+            tokens.add(param.upper())
+    return tokens, values
+
+
+def unescape(value):
+    value = value.replace("\\n", "\n").replace("\\N", "\n")
+    value = value.replace("\\,", ",").replace("\\;", ";")
+    return value.strip()
+
+
+def decode_quoted_printable(value, charset):
+    try:
+        return quopri.decodestring(value.encode("ascii", errors="replace")).decode(charset, errors="replace")
+    except (LookupError, ValueError):
+        return quopri.decodestring(value.encode("ascii", errors="replace")).decode("utf-8", errors="replace")
+
+
+def normalize_phone(value):
+    return re.sub(r"[\s\-().]", "", value)
+
+
+def looks_like_number(text):
+    stripped = re.sub(r"[\s\-()./]", "", text)
+    return bool(re.fullmatch(r"\+?\d+", stripped))
+
+
+def _photo_data_uri(value, tokens, values):
+    stripped = value.strip()
+    if stripped.lower().startswith("data:"):
+        return stripped
+    inline = ("BASE64" in tokens or "B" in tokens
+              or values.get("ENCODING", "").upper() in ("B", "BASE64"))
+    if not inline:
+        return ""
+    clean = re.sub(r"\s+", "", stripped)
+    try:
+        base64.b64decode(clean, validate=True)
+    except (ValueError, binascii.Error):
+        return ""
+    mime = ""
+    for token in tokens:
+        if token in PHOTO_MIME:
+            mime = PHOTO_MIME[token]
+    if not mime:
+        declared = values.get("MEDIATYPE") or values.get("TYPE") or ""
+        mime = declared.lower() if "/" in declared else PHOTO_MIME.get(declared.upper(), "image/jpeg")
+    return f"data:{mime};base64,{clean}"
+
+
+def parse_vcard(text, file_name, source_id):
+    """One card's text as the contact record the shell reads, or None for a
+    card that carries neither a name, a number nor an address."""
+    fn = given = family = org = uid = kdeconnect_id = ""
+    phones, emails = [], []
+    photo = ""
+
+    for line in unfold(text):
+        if ":" not in line:
+            continue
+        head, value = line.split(":", 1)
+        key, _, param_text = head.partition(";")
+        key = key.upper()
+        tokens, values = parse_params(param_text)
+        if "QUOTED-PRINTABLE" in tokens or values.get("ENCODING", "").upper() == "QUOTED-PRINTABLE":
+            value = decode_quoted_printable(value, values.get("CHARSET", "utf-8"))
+
+        if key == "FN":
+            fn = unescape(value)
+        elif key == "N":
+            parts = [unescape(part) for part in value.split(";")]
+            family = parts[0] if parts else ""
+            given = parts[1] if len(parts) > 1 else ""
+        elif key == "ORG":
+            org = unescape(value).strip(";")
+        elif key == "UID":
+            uid = value.strip()
+        elif key.startswith("X-KDECONNECT-ID-DEV-"):
+            kdeconnect_id = value.strip()
+        elif key == "TEL":
+            number = unescape(value)
+            if number.lower().startswith("tel:"):
+                number = number[4:].strip()
+            if not number:
+                continue
+            kind = "mobile"
+            if not tokens & {"CELL", "MOBILE"}:
+                for token, name in PHONE_TYPES.items():
+                    if token in tokens:
+                        kind = name
+                        break
+            phones.append({
+                "value": number,
+                "normalized": normalize_phone(number),
+                "type": kind,
+                "primary": "PREF" in tokens,
+            })
+        elif key == "EMAIL":
+            address = unescape(value)
+            if not address:
+                continue
+            kind = "personal"
+            for token, name in EMAIL_TYPES.items():
+                if token in tokens:
+                    kind = name
+                    break
+            emails.append({"value": address, "type": kind, "primary": "PREF" in tokens})
+        elif key == "PHOTO":
+            photo = _photo_data_uri(value, tokens, values) or photo
+
+    phones = _dedupe(phones, lambda p: p["normalized"])
+    emails = _dedupe(emails, lambda e: e["value"].lower())
+    for entries in (phones, emails):
+        if entries and not any(entry["primary"] for entry in entries):
+            entries[0]["primary"] = True
+
+    display_name = fn or f"{given} {family}".strip() or (phones[0]["value"] if phones else "")
+    if not display_name and not emails:
+        return None
+    if not display_name:
+        display_name = emails[0]["value"]
+
+    nameless = not any(part and not looks_like_number(part) for part in (fn, given, family, org))
+
+    if not uid:
+        uid = kdeconnect_id
+    if not uid:
+        seed = f"{file_name}_{display_name}_{phones[0]['value'] if phones else ''}"
+        uid = hashlib.sha256(seed.encode("utf-8")).hexdigest()[:16]
+
+    return {
+        "id": uid,
+        "displayName": display_name,
+        "givenName": given,
+        "familyName": family,
+        "organization": org,
+        "phones": phones,
+        "emails": emails,
+        "photo": photo,
+        "nameless": nameless,
+        "source": source_id,
+    }
+
+
+def _dedupe(entries, key):
+    seen, kept = set(), []
+    for entry in entries:
+        marker = key(entry)
+        if marker in seen:
+            continue
+        seen.add(marker)
+        kept.append(entry)
+    return kept
+
+
+def parse_vcard_file(path, source_id):
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+    return parse_vcard(text, path.name, source_id)
+
+
+def read_contacts(directory):
+    contacts = []
+    for path in sorted(directory.glob("*.vcf")):
+        parsed = parse_vcard_file(path, directory.name)
+        if parsed:
+            contacts.append(parsed)
+    contacts.sort(key=lambda c: c["displayName"].lower())
+    return contacts
+
+
+def emit(message):
+    try:
+        print(json.dumps(message), flush=True)
+    except BrokenPipeError:
+        # The shell that was reading went away; there is nobody to tell.
+        os._exit(0)
+
+
+class ContactMonitor:
+    def __init__(self, device_id=None):
+        self.device_id = device_id
+        self.source = None
+        self.last_hash = None
+        self.missing_reported = False
+
+    def update_and_emit(self):
+        """Re-read the source and publish what changed. False when there is no
+        source, reported once per stretch of absence."""
+        directory = find_device_directory(data_root(), self.device_id)
+        if directory is None:
+            if not self.missing_reported:
+                emit({"event": "error", "code": "no_contact_source",
+                      "message": "No KDE Connect contacts directory under " + str(data_root())})
+            self.missing_reported = True
+            self.source = None
+            self.last_hash = None
+            return False
+
+        self.missing_reported = False
+        contacts = read_contacts(directory)
+        payload = json.dumps(contacts, sort_keys=True)
+        digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+        source = str(directory)
+        if source != self.source or digest != self.last_hash:
+            emit({"event": "ready", "sourcePath": source, "count": len(contacts)})
+        if digest != self.last_hash:
+            emit({"event": "snapshot", "contacts": contacts})
+        self.source, self.last_hash = source, digest
+        return True
+
+
+def _die_with_parent():
+    # PR_SET_PDEATHSIG: the gio child follows this process down even when
+    # this process is killed outright and its `finally` never runs.
+    try:
+        import ctypes
+        ctypes.CDLL("libc.so.6", use_errno=True).prctl(1, signal.SIGTERM)
+    except (OSError, AttributeError):
+        pass
+
+
+def _sleep_unless_orphaned(seconds, parent):
+    deadline = time.monotonic() + seconds
+    while time.monotonic() < deadline:
+        if os.getppid() != parent:
+            sys.exit(0)
+        time.sleep(min(0.5, max(0.0, deadline - time.monotonic())))
+
+
+def _watch_with_gio(monitor, gio, parent):
+    """True while gio held the directory long enough to count as working;
+    False when it died fast, so the caller stops asking it."""
+    started = time.monotonic()
+    proc = subprocess.Popen([gio, "monitor", "-d", monitor.source],
+                            stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+                            preexec_fn=_die_with_parent)
+    fd = proc.stdout.fileno()
+    pending = False
+    try:
+        while True:
+            ready, _, _ = select.select([fd], [], [], DEBOUNCE_SECONDS if pending else POLL_SECONDS)
+            if os.getppid() != parent:
+                sys.exit(0)
+            if ready:
+                if os.read(fd, 65536) == b"":
+                    return time.monotonic() - started >= GIO_HEALTHY_SECONDS
+                pending = True
+                continue
+            if pending:
+                pending = False
+                if not monitor.update_and_emit():
+                    return True
+    finally:
+        if proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+
+
+def watch(monitor):
+    parent = os.getppid()
+    gio = shutil.which("gio")
+    while True:
+        if not monitor.update_and_emit():
+            _sleep_unless_orphaned(POLL_SECONDS, parent)
+            continue
+        if gio is None:
+            _sleep_unless_orphaned(POLL_SECONDS, parent)
+            continue
+        if not _watch_with_gio(monitor, gio, parent):
+            sys.stderr.write("gio monitor exited immediately; polling instead\n")
+            gio = None
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Publish a KDE Connect device's contacts as NDJSON")
+    parser.add_argument("--device", help="KDE Connect device id whose kdeconnect-<id> directory to read")
+    parser.add_argument("--once", action="store_true", help="print one round and exit")
+    args = parser.parse_args()
+
+    monitor = ContactMonitor(args.device)
+    if args.once:
+        monitor.update_and_emit()
+        return 0
+    watch(monitor)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dots/.config/quickshell/imi/services/PhoneContacts.qml
+++ b/dots/.config/quickshell/imi/services/PhoneContacts.qml
@@ -1,0 +1,435 @@
+pragma Singleton
+pragma ComponentBehavior: Bound
+
+import Quickshell
+import Quickshell.Io
+import QtQuick
+import qs.modules.common
+
+/**
+ * The active phone's contacts (docs/superpowers/specs/2026-08-27-phone-tab-design.md, W4).
+ *
+ * KDE Connect writes one vCard per contact into
+ * ~/.local/share/kpeoplevcard/kdeconnect-<deviceId>/ and answers no "list
+ * the contacts" call over D-Bus, so the source is that directory, read by
+ * scripts/phone/contacts_monitor.py: one long-lived Python process per
+ * shell session that parses the cards, watches the directory (gio, else a
+ * poll) and streams NDJSON - `ready`, `snapshot` only when the parsed set
+ * changed, `error {code: "no_contact_source"}`. The device it follows is
+ * PhoneConnect.activeDevice; with no active device the script reads the
+ * most recently synced device's directory, so the count is on screen while
+ * the phone is off the network.
+ *
+ * The monitor is a streaming Process, so it is started imperatively and
+ * never by a `running` binding (CONTRIBUTING.md): restarts go through
+ * PhoneConnect.monitorExitPlan - the one spelling of the backoff ladder,
+ * a ceiling of five per device, a healthy-run reset - after which the
+ * service holds whatever it last read. A device change restarts it from
+ * the top of the ladder: a new device is a new opportunity, not the next
+ * rung.
+ *
+ * Config keys under phone.contacts (favoriteIds, hideUnnamed, sortBy,
+ * enabled) are read with optional chaining and defaults because the block
+ * is declared by the scrcpy workstream (W3); until it lands the defaults
+ * run and toggleFavorite() refuses rather than writing into a key the
+ * JsonAdapter would drop on the next launch (AGENT.md, "A key with no
+ * declared property is destroyed by the first write").
+ *
+ * The dialer and SMS intents go to the phone over adb - `adb devices`
+ * first, then `adb -s <serial> shell am start` - both argv arrays; a
+ * missing adb or no device in the `device` state is refused with
+ * lastError rather than spawned into.
+ *
+ * The functions between the sync markers are kept byte-for-byte in sync
+ * with the logic-only double (tests/imports/testservices/PhoneContacts.qml);
+ * tests/test_phone_contacts_contract.py enforces it.
+ */
+Singleton {
+    id: root
+
+    readonly property bool enabled: Config.options.phone?.contacts?.enabled ?? true
+    readonly property bool hideUnnamed: Config.options.phone?.contacts?.hideUnnamed ?? true
+    readonly property string sortBy: Config.options.phone?.contacts?.sortBy ?? "first"
+    readonly property var favorites: Config.options.phone?.contacts?.favoriteIds ?? []
+    readonly property string deviceId: PhoneConnect.activeDevice?.id ?? ""
+
+    property bool ready: false
+    property string sourcePath: ""
+    // [{ id, displayName, givenName, familyName, organization,
+    //    phones: [{ value, normalized, type, primary }],
+    //    emails: [{ value, type, primary }], photo (data URI or ""),
+    //    nameless, source }] - what contacts_monitor.py emits, sorted by it.
+    property var contacts: []
+    readonly property int count: root.contacts.length
+    property string query: ""
+    readonly property var filtered: root.filterContacts(root.contacts, root.query, root.hideUnnamed, root.favorites, root.sortBy)
+    // Why the last dialer/SMS request was refused; "" once one goes through.
+    // Written empty-then-message so a repeat of the same refusal still
+    // raises lastErrorChanged for whoever toasts it.
+    property string lastError: ""
+
+    property bool gioAvailable: false // gio found on PATH; without it the monitor polls
+    property bool adbAvailable: false // adb found on PATH; without it no intent is attempted
+
+    readonly property string monitorScript: `${Directories.scriptPath}/phone/contacts_monitor.py`
+
+    // BEGIN phone-contacts logic (synced with tests/imports/testservices/PhoneContacts.qml)
+    // A query in its two spellings: lower-cased text for names, organizations
+    // and addresses, and digits-only for numbers - "555 010" is typed the way
+    // a number is drawn, and the stored number is "+1 (555) 010-0001".
+    function normalizeQuery(query: var): var {
+        const text = String(query ?? "").trim().toLowerCase();
+        return { text: text, digits: text.replace(/[\s\-().]/g, "") };
+    }
+
+    function contactMatches(contact: var, needle: var): bool {
+        if (!contact) return false;
+        if (needle.text.length === 0) return true;
+        const texts = [contact.displayName, contact.organization];
+        for (const text of texts)
+            if (typeof text === "string" && text.toLowerCase().includes(needle.text)) return true;
+        const phones = contact.phones ?? [];
+        for (let i = 0; i < phones.length; i++) {
+            const phone = phones[i];
+            if (typeof phone?.value === "string" && phone.value.toLowerCase().includes(needle.text)) return true;
+            if (needle.digits.length > 0 && typeof phone?.normalized === "string"
+                    && phone.normalized.includes(needle.digits)) return true;
+        }
+        const emails = contact.emails ?? [];
+        for (let i = 0; i < emails.length; i++)
+            if (typeof emails[i]?.value === "string" && emails[i].value.toLowerCase().includes(needle.text)) return true;
+        return false;
+    }
+
+    // By index rather than includes(): a list<var> that crossed a Config
+    // boundary keeps its length and its indices and nothing else (109e6d897).
+    function isFavorite(uid: var, favorites: var): bool {
+        const list = favorites ?? [];
+        for (let i = 0; i < list.length; i++)
+            if (list[i] === uid) return true;
+        return false;
+    }
+
+    // Hidden only when the card had no human-readable name AND nobody starred
+    // it: starring is an explicit statement that the number matters.
+    function isHidden(contact: var, hideUnnamed: bool, favorites: var): bool {
+        return hideUnnamed && contact?.nameless === true && !root.isFavorite(contact.id, favorites);
+    }
+
+    function sortKey(contact: var, sortBy: string): string {
+        const name = sortBy === "last" ? contact?.familyName : contact?.givenName;
+        return String(name || contact?.displayName || "").toLowerCase();
+    }
+
+    function sortContacts(list: var, sortBy: string): var {
+        return [...(list ?? [])].sort((a, b) => root.sortKey(a, sortBy).localeCompare(root.sortKey(b, sortBy))
+            || String(a?.displayName ?? "").localeCompare(String(b?.displayName ?? "")));
+    }
+
+    function filterContacts(list: var, query: var, hideUnnamed: bool, favorites: var, sortBy: string): var {
+        const needle = root.normalizeQuery(query);
+        const source = list ?? [];
+        const kept = [];
+        for (let i = 0; i < source.length; i++) {
+            const contact = source[i];
+            if (root.isHidden(contact, hideUnnamed, favorites)) continue;
+            if (root.contactMatches(contact, needle)) kept.push(contact);
+        }
+        return root.sortContacts(kept, sortBy);
+    }
+
+    // A new list every time: the stored one is a Config property, and a
+    // splice in place would neither notify nor survive the JsonAdapter.
+    function toggledFavorites(favorites: var, uid: string): var {
+        const source = favorites ?? [];
+        const list = [];
+        let found = false;
+        for (let i = 0; i < source.length; i++) {
+            if (source[i] === uid) { found = true; continue; }
+            list.push(source[i]);
+        }
+        if (!found) list.push(uid);
+        return list;
+    }
+
+    // `adb devices` -> the serial an intent is aimed at. Only the `device`
+    // state counts (unauthorized and offline cannot take an `am start`), and
+    // a USB serial - no ':' in it - wins over a wireless ip:port.
+    function adbSerialFromDevices(text: var): string {
+        const serials = [];
+        for (const line of String(text ?? "").split("\n")) {
+            const cells = line.trim().split(/\s+/);
+            if (cells.length >= 2 && cells[1] === "device" && cells[0] !== "List") serials.push(cells[0]);
+        }
+        return serials.find(serial => !serial.includes(":")) ?? serials[0] ?? "";
+    }
+
+    // RFC 3966 lets a tel: URI carry digits, '+' and the visual separators
+    // unencoded; whitespace is dropped and anything else (a USSD code's '#',
+    // which a URI reads as a fragment marker) is percent-encoded.
+    function intentUri(scheme: string, number: var): string {
+        const dial = String(number ?? "").replace(/\s+/g, "");
+        let out = "";
+        for (const ch of dial)
+            out += /[0-9+\-().*]/.test(ch) ? ch : encodeURIComponent(ch);
+        return scheme + ":" + out;
+    }
+
+    function intentArgv(serial: string, action: string, uri: string): var {
+        const target = serial ? ["-s", serial] : [];
+        return ["adb", ...target, "shell", "am", "start", "-a", action, "-d", uri];
+    }
+
+    function monitorArgv(script: string, deviceId: string): var {
+        const device = deviceId ? ["--device", deviceId] : [];
+        return ["python3", script, ...device];
+    }
+
+    // One NDJSON line from the monitor as its event object, or null.
+    function parseMonitorEvent(line: var): var {
+        const trimmed = String(line ?? "").trim();
+        if (trimmed.length === 0) return null;
+        let doc;
+        try {
+            doc = JSON.parse(trimmed);
+        } catch (e) {
+            return null;
+        }
+        if (!doc || typeof doc !== "object" || Array.isArray(doc) || typeof doc.event !== "string") return null;
+        return doc;
+    }
+    // END phone-contacts logic
+
+    // ---- favorites ----
+
+    function toggleFavorite(uid: string): void {
+        if (!uid) return;
+        const store = Config.options.phone?.contacts;
+        if (!store || store.favoriteIds === undefined) {
+            console.warn("[PhoneContacts] phone.contacts.favoriteIds is not declared in Config.qml; a favorite cannot be stored");
+            return;
+        }
+        store.favoriteIds = root.toggledFavorites(store.favoriteIds, uid);
+    }
+
+    // ---- dialer and SMS over adb ----
+
+    function openDialer(number: var): void {
+        root.startIntent("android.intent.action.DIAL", "tel", number);
+    }
+
+    function composeSms(number: var): void {
+        root.startIntent("android.intent.action.SENDTO", "sms", number);
+    }
+
+    function refuse(message: string): void {
+        root.lastError = "";
+        root.lastError = message;
+    }
+
+    property var pendingIntent: null
+
+    function startIntent(action: string, scheme: string, number: var): void {
+        const uri = root.intentUri(scheme, number);
+        if (uri === scheme + ":") {
+            root.refuse(Translation.tr("This contact has no number"));
+            return;
+        }
+        if (!root.adbAvailable) {
+            root.refuse(Translation.tr("adb was not found - install android-tools to reach the phone"));
+            return;
+        }
+        // The wireless-debugging port changes on every toggle and reboot, so
+        // the target is re-resolved for every intent rather than remembered.
+        root.pendingIntent = { action: action, uri: uri };
+        if (!adbDevicesProc.running) adbDevicesProc.exec(["adb", "devices"]);
+    }
+
+    Process {
+        id: adbDevicesProc
+        environment: ({
+            LANG: "C",
+            LC_ALL: "C"
+        })
+        stdout: StdioCollector {
+            id: adbDevicesOut
+        }
+        stderr: StdioCollector {}
+        onExited: (exitCode, exitStatus) => {
+            const intent = root.pendingIntent;
+            root.pendingIntent = null;
+            if (!intent) return;
+            const serial = root.adbSerialFromDevices(adbDevicesOut.text);
+            if (serial === "") {
+                root.refuse(Translation.tr("ADB cannot reach the phone - enable USB debugging or Wireless debugging"));
+                return;
+            }
+            intentProc.exec(root.intentArgv(serial, intent.action, intent.uri));
+        }
+    }
+
+    Process {
+        id: intentProc
+        environment: ({
+            LANG: "C",
+            LC_ALL: "C"
+        })
+        stderr: StdioCollector {
+            id: intentErr
+        }
+        onExited: (exitCode, exitStatus) => {
+            if (exitCode !== 0) {
+                root.refuse(intentErr.text.trim() || Translation.tr("adb could not start the intent on the phone"));
+                return;
+            }
+            root.lastError = "";
+        }
+    }
+
+    // ---- the monitor ----
+
+    property string monitorState: "idle" // idle | running | backoff | failed
+    property int monitorAttempts: 0
+    property real monitorStartedAt: 0
+    // Set by restartMonitor() while the running monitor is being stopped so
+    // the exit handler starts the next one at once, outside the ladder.
+    property bool monitorRestartWanted: false
+
+    readonly property int monitorAttemptCeiling: 5
+    readonly property int monitorHealthyMs: 30000
+    readonly property bool monitorLive: root.monitorState === "running"
+
+    function monitorWanted(): bool {
+        return root.enabled && root.monitorState !== "failed";
+    }
+
+    function startMonitor(): void {
+        if (monitorProc.running || !root.monitorWanted()) return;
+        monitorRestart.stop();
+        root.monitorStartedAt = Date.now();
+        root.monitorState = "running";
+        monitorProc.exec(root.monitorArgv(root.monitorScript, root.deviceId));
+    }
+
+    function stopMonitor(): void {
+        monitorRestart.stop();
+        root.monitorRestartWanted = false;
+        root.monitorAttempts = 0;
+        root.monitorState = "idle";
+        monitorProc.running = false;
+    }
+
+    // The inputs changed under the monitor (a different device, the feature
+    // switched back on): the next start is from the top of the ladder, and
+    // the list is "syncing" again until the new source answers.
+    function restartMonitor(): void {
+        monitorRestart.stop();
+        root.monitorAttempts = 0;
+        root.ready = false;
+        if (root.monitorState === "failed") root.monitorState = "idle";
+        if (monitorProc.running) {
+            root.monitorRestartWanted = true;
+            monitorProc.running = false;
+            return;
+        }
+        root.startMonitor();
+    }
+
+    function handleMonitorLine(line: string): void {
+        const message = root.parseMonitorEvent(line);
+        if (!message) return;
+        switch (message.event) {
+        case "ready":
+            root.sourcePath = typeof message.sourcePath === "string" ? message.sourcePath : "";
+            root.ready = true;
+            break;
+        case "snapshot":
+            root.contacts = Array.isArray(message.contacts) ? message.contacts : [];
+            break;
+        case "error":
+            if (message.code === "no_contact_source") root.ready = false;
+            console.warn("[PhoneContacts]", message.code ?? "error", message.message ?? "");
+            break;
+        }
+    }
+
+    Timer {
+        id: monitorRestart
+        onTriggered: root.startMonitor()
+    }
+
+    Process {
+        id: monitorProc
+        // process-lifecycle: restart-safe -- capped exponential backoff; no running binding.
+        environment: ({
+            LANG: "C",
+            LC_ALL: "C"
+        })
+        stdout: SplitParser {
+            onRead: data => root.handleMonitorLine(data)
+        }
+        stderr: SplitParser {
+            onRead: data => console.warn("[PhoneContacts]", data)
+        }
+        onExited: (exitCode, exitStatus) => {
+            if (root.monitorRestartWanted) {
+                root.monitorRestartWanted = false;
+                root.monitorState = "idle";
+                root.startMonitor();
+                return;
+            }
+            const plan = PhoneConnect.monitorExitPlan(root.monitorAttempts, Date.now() - root.monitorStartedAt,
+                root.monitorWanted(), root.monitorHealthyMs, root.monitorAttemptCeiling);
+            root.monitorAttempts = plan.attempts;
+            if (!plan.retry) {
+                if (root.monitorWanted()) {
+                    root.monitorState = "failed";
+                    console.warn(`[PhoneContacts] contacts monitor gave up after ${root.monitorAttemptCeiling} restarts`);
+                } else {
+                    root.monitorState = "idle";
+                }
+                return;
+            }
+            root.monitorState = "backoff";
+            monitorRestart.interval = plan.delay;
+            monitorRestart.restart();
+        }
+    }
+
+    onEnabledChanged: {
+        if (root.enabled) {
+            root.restartMonitor();
+        } else {
+            root.stopMonitor();
+            root.ready = false;
+        }
+    }
+
+    onDeviceIdChanged: {
+        if (root.enabled) root.restartMonitor();
+    }
+
+    Component.onCompleted: {
+        if (root.enabled) root.startMonitor();
+    }
+
+    // One-shot presence checks, started here rather than from the feature
+    // that needs them (tests/lint_capability_probe_gating.py).
+    Process {
+        id: gioProbe
+        running: true
+        command: ["sh", "-c", "command -v gio"]
+        onExited: (exitCode, exitStatus) => {
+            root.gioAvailable = (exitCode === 0);
+        }
+    }
+
+    Process {
+        id: adbProbe
+        running: true
+        command: ["sh", "-c", "command -v adb"]
+        onExited: (exitCode, exitStatus) => {
+            root.adbAvailable = (exitCode === 0);
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/services/PhoneContacts.qml
+++ b/dots/.config/quickshell/imi/services/PhoneContacts.qml
@@ -121,9 +121,23 @@ Singleton {
         return String(name || contact?.displayName || "").toLowerCase();
     }
 
+    // The tie-break is CASE-FOLDED and compared by code point, not by
+    // localeCompare: collation is the runner's locale, and "adam" vs "Adam B"
+    // orders one way under en_US.UTF-8 and the other under C - green here and
+    // red in CI. The primary key keeps localeCompare (it is already folded, so
+    // case cannot reach it, and accents order the way a reader expects); the
+    // tie-break is what has to be the same on every machine.
+    function compareFolded(a: var, b: var): int {
+        const x = String(a ?? "").toLowerCase();
+        const y = String(b ?? "").toLowerCase();
+        if (x === y) return 0;
+        return x < y ? -1 : 1;
+    }
+
     function sortContacts(list: var, sortBy: string): var {
         return [...(list ?? [])].sort((a, b) => root.sortKey(a, sortBy).localeCompare(root.sortKey(b, sortBy))
-            || String(a?.displayName ?? "").localeCompare(String(b?.displayName ?? "")));
+            || root.compareFolded(a?.displayName, b?.displayName)
+            || root.compareFolded(a?.id, b?.id));
     }
 
     function filterContacts(list: var, query: var, hideUnnamed: bool, favorites: var, sortBy: string): var {

--- a/dots/.config/quickshell/imi/tests/imports/testservices/PhoneContacts.qml
+++ b/dots/.config/quickshell/imi/tests/imports/testservices/PhoneContacts.qml
@@ -70,9 +70,23 @@ Singleton {
         return String(name || contact?.displayName || "").toLowerCase();
     }
 
+    // The tie-break is CASE-FOLDED and compared by code point, not by
+    // localeCompare: collation is the runner's locale, and "adam" vs "Adam B"
+    // orders one way under en_US.UTF-8 and the other under C - green here and
+    // red in CI. The primary key keeps localeCompare (it is already folded, so
+    // case cannot reach it, and accents order the way a reader expects); the
+    // tie-break is what has to be the same on every machine.
+    function compareFolded(a: var, b: var): int {
+        const x = String(a ?? "").toLowerCase();
+        const y = String(b ?? "").toLowerCase();
+        if (x === y) return 0;
+        return x < y ? -1 : 1;
+    }
+
     function sortContacts(list: var, sortBy: string): var {
         return [...(list ?? [])].sort((a, b) => root.sortKey(a, sortBy).localeCompare(root.sortKey(b, sortBy))
-            || String(a?.displayName ?? "").localeCompare(String(b?.displayName ?? "")));
+            || root.compareFolded(a?.displayName, b?.displayName)
+            || root.compareFolded(a?.id, b?.id));
     }
 
     function filterContacts(list: var, query: var, hideUnnamed: bool, favorites: var, sortBy: string): var {

--- a/dots/.config/quickshell/imi/tests/imports/testservices/PhoneContacts.qml
+++ b/dots/.config/quickshell/imi/tests/imports/testservices/PhoneContacts.qml
@@ -1,0 +1,151 @@
+pragma Singleton
+pragma ComponentBehavior: Bound
+
+import Quickshell
+import QtQuick
+
+// Logic-only double of services/PhoneContacts.qml. The functions between the
+// sync markers are kept byte-for-byte in sync with the real service
+// (tests/test_phone_contacts_contract.py enforces it), and so is the
+// `filtered` binding that composes them; the monitor Process, the adb
+// Processes and the Config reads are omitted so tests stay deterministic
+// and offline.
+Singleton {
+    id: root
+
+    property var contacts: []
+    property string query: ""
+    property bool hideUnnamed: true
+    property string sortBy: "first"
+    property var favorites: []
+
+    readonly property int count: root.contacts.length
+    readonly property var filtered: root.filterContacts(root.contacts, root.query, root.hideUnnamed, root.favorites, root.sortBy)
+
+    // BEGIN phone-contacts logic (synced with services/PhoneContacts.qml)
+    // A query in its two spellings: lower-cased text for names, organizations
+    // and addresses, and digits-only for numbers - "555 010" is typed the way
+    // a number is drawn, and the stored number is "+1 (555) 010-0001".
+    function normalizeQuery(query: var): var {
+        const text = String(query ?? "").trim().toLowerCase();
+        return { text: text, digits: text.replace(/[\s\-().]/g, "") };
+    }
+
+    function contactMatches(contact: var, needle: var): bool {
+        if (!contact) return false;
+        if (needle.text.length === 0) return true;
+        const texts = [contact.displayName, contact.organization];
+        for (const text of texts)
+            if (typeof text === "string" && text.toLowerCase().includes(needle.text)) return true;
+        const phones = contact.phones ?? [];
+        for (let i = 0; i < phones.length; i++) {
+            const phone = phones[i];
+            if (typeof phone?.value === "string" && phone.value.toLowerCase().includes(needle.text)) return true;
+            if (needle.digits.length > 0 && typeof phone?.normalized === "string"
+                    && phone.normalized.includes(needle.digits)) return true;
+        }
+        const emails = contact.emails ?? [];
+        for (let i = 0; i < emails.length; i++)
+            if (typeof emails[i]?.value === "string" && emails[i].value.toLowerCase().includes(needle.text)) return true;
+        return false;
+    }
+
+    // By index rather than includes(): a list<var> that crossed a Config
+    // boundary keeps its length and its indices and nothing else (109e6d897).
+    function isFavorite(uid: var, favorites: var): bool {
+        const list = favorites ?? [];
+        for (let i = 0; i < list.length; i++)
+            if (list[i] === uid) return true;
+        return false;
+    }
+
+    // Hidden only when the card had no human-readable name AND nobody starred
+    // it: starring is an explicit statement that the number matters.
+    function isHidden(contact: var, hideUnnamed: bool, favorites: var): bool {
+        return hideUnnamed && contact?.nameless === true && !root.isFavorite(contact.id, favorites);
+    }
+
+    function sortKey(contact: var, sortBy: string): string {
+        const name = sortBy === "last" ? contact?.familyName : contact?.givenName;
+        return String(name || contact?.displayName || "").toLowerCase();
+    }
+
+    function sortContacts(list: var, sortBy: string): var {
+        return [...(list ?? [])].sort((a, b) => root.sortKey(a, sortBy).localeCompare(root.sortKey(b, sortBy))
+            || String(a?.displayName ?? "").localeCompare(String(b?.displayName ?? "")));
+    }
+
+    function filterContacts(list: var, query: var, hideUnnamed: bool, favorites: var, sortBy: string): var {
+        const needle = root.normalizeQuery(query);
+        const source = list ?? [];
+        const kept = [];
+        for (let i = 0; i < source.length; i++) {
+            const contact = source[i];
+            if (root.isHidden(contact, hideUnnamed, favorites)) continue;
+            if (root.contactMatches(contact, needle)) kept.push(contact);
+        }
+        return root.sortContacts(kept, sortBy);
+    }
+
+    // A new list every time: the stored one is a Config property, and a
+    // splice in place would neither notify nor survive the JsonAdapter.
+    function toggledFavorites(favorites: var, uid: string): var {
+        const source = favorites ?? [];
+        const list = [];
+        let found = false;
+        for (let i = 0; i < source.length; i++) {
+            if (source[i] === uid) { found = true; continue; }
+            list.push(source[i]);
+        }
+        if (!found) list.push(uid);
+        return list;
+    }
+
+    // `adb devices` -> the serial an intent is aimed at. Only the `device`
+    // state counts (unauthorized and offline cannot take an `am start`), and
+    // a USB serial - no ':' in it - wins over a wireless ip:port.
+    function adbSerialFromDevices(text: var): string {
+        const serials = [];
+        for (const line of String(text ?? "").split("\n")) {
+            const cells = line.trim().split(/\s+/);
+            if (cells.length >= 2 && cells[1] === "device" && cells[0] !== "List") serials.push(cells[0]);
+        }
+        return serials.find(serial => !serial.includes(":")) ?? serials[0] ?? "";
+    }
+
+    // RFC 3966 lets a tel: URI carry digits, '+' and the visual separators
+    // unencoded; whitespace is dropped and anything else (a USSD code's '#',
+    // which a URI reads as a fragment marker) is percent-encoded.
+    function intentUri(scheme: string, number: var): string {
+        const dial = String(number ?? "").replace(/\s+/g, "");
+        let out = "";
+        for (const ch of dial)
+            out += /[0-9+\-().*]/.test(ch) ? ch : encodeURIComponent(ch);
+        return scheme + ":" + out;
+    }
+
+    function intentArgv(serial: string, action: string, uri: string): var {
+        const target = serial ? ["-s", serial] : [];
+        return ["adb", ...target, "shell", "am", "start", "-a", action, "-d", uri];
+    }
+
+    function monitorArgv(script: string, deviceId: string): var {
+        const device = deviceId ? ["--device", deviceId] : [];
+        return ["python3", script, ...device];
+    }
+
+    // One NDJSON line from the monitor as its event object, or null.
+    function parseMonitorEvent(line: var): var {
+        const trimmed = String(line ?? "").trim();
+        if (trimmed.length === 0) return null;
+        let doc;
+        try {
+            doc = JSON.parse(trimmed);
+        } catch (e) {
+            return null;
+        }
+        if (!doc || typeof doc !== "object" || Array.isArray(doc) || typeof doc.event !== "string") return null;
+        return doc;
+    }
+    // END phone-contacts logic
+}

--- a/dots/.config/quickshell/imi/tests/imports/testservices/qmldir
+++ b/dots/.config/quickshell/imi/tests/imports/testservices/qmldir
@@ -8,3 +8,4 @@ singleton PhoneNotifications PhoneNotifications.qml
 singleton PluginStore PluginStore.qml
 singleton Tailscale Tailscale.qml
 singleton Vpn Vpn.qml
+singleton PhoneContacts PhoneContacts.qml

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -1617,6 +1617,16 @@ if ! python3 "$SCRIPT_DIR/test_phone_notifications_runtime.py"; then
     exit 1
 fi
 
+# The contacts reader: the kpeoplevcard directory KDE Connect writes, parsed
+# against a fixture shaped after the real vCard 2.1 cards (soft-wrapped
+# QUOTED-PRINTABLE names, folded base64 photos, a card that is only a
+# number), the publish-only-on-change rule, and both watch modes.
+echo "Running Phone contacts monitor tests..."
+if ! python3 "$SCRIPT_DIR/test_phone_contacts_monitor.py"; then
+    echo "Phone contacts monitor tests failed."
+    exit 1
+fi
+
 echo "Running registry entry validator tests..."
 if ! python3 "$SCRIPT_DIR/test_registry_validate.py"; then
     echo "Registry entry validator tests failed."

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -1627,6 +1627,15 @@ if ! python3 "$SCRIPT_DIR/test_phone_contacts_monitor.py"; then
     exit 1
 fi
 
+# The QML suite drives a logic-only double of PhoneContacts; this is the sync
+# check that makes its green transfer, plus the argv-only rule, the monitor's
+# lifecycle ladder, and the refusals the adb intents must make.
+echo "Running Phone contacts contract tests..."
+if ! python3 "$SCRIPT_DIR/test_phone_contacts_contract.py"; then
+    echo "Phone contacts contract tests failed."
+    exit 1
+fi
+
 echo "Running registry entry validator tests..."
 if ! python3 "$SCRIPT_DIR/test_registry_validate.py"; then
     echo "Registry entry validator tests failed."

--- a/dots/.config/quickshell/imi/tests/test_phone_contacts_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_contacts_contract.py
@@ -1,0 +1,253 @@
+"""Contract checks for services/PhoneContacts.qml.
+
+The QML suite (tst_phone_contacts.qml) drives the contacts list's decisions
+through a logic-only double, so the double proving something transfers to
+the shell only while the real service carries the same logic: the region
+between the `BEGIN/END phone-contacts logic` markers must be byte-for-byte
+identical in both files (the BEGIN line may differ - each side points its
+"synced with" note at the other), and so must the `filtered` binding that
+composes those functions.
+
+The rest pins what the double deliberately omits:
+- every adb and python invocation is an argv array built by the synced
+  builders; the only shell strings are the two static `command -v` probes,
+  with nothing interpolated, and both start themselves;
+- the monitor Process carries no `running` binding and the restart-safe
+  marker, is started through exec(), and every exit consults the one
+  backoff ladder (PhoneConnect.monitorExitPlan) - the rule CONTRIBUTING.md
+  states outright for a streaming process;
+- the dialer and SMS intents are refused with lastError when adb is absent
+  or no device is in the `device` state, and go through `adb devices`
+  first because the wireless-debugging port moves;
+- the Config keys W3 declares are read with optional chaining and defaults,
+  and a favorite is written only when the key exists;
+- the device followed is PhoneConnect.activeDevice, and the script the
+  service names is the one in the tree.
+"""
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SERVICE = ROOT / "services" / "PhoneContacts.qml"
+DOUBLE = ROOT / "tests" / "imports" / "testservices" / "PhoneContacts.qml"
+SCRIPT = ROOT / "scripts" / "phone" / "contacts_monitor.py"
+
+BEGIN = "// BEGIN phone-contacts logic"
+END = "    // END phone-contacts logic"
+
+
+def _synced_region(path: Path) -> str:
+    text = path.read_text()
+    assert text.count(BEGIN) == 1, f"{path}: expected exactly one BEGIN marker"
+    assert text.count(END) == 1, f"{path}: expected exactly one END marker"
+    start = text.index("\n", text.index(BEGIN)) + 1
+    return text[start:text.index(END)]
+
+
+def _process_block(source: str, process_id: str) -> str:
+    """The `Process { ... }` block declaring `id: <process_id>`, brace-counted
+    rather than regexed to an indent, so it can say a binding is absent."""
+    for match in re.finditer(r"\bProcess\s*\{", source):
+        depth, index = 1, match.end()
+        while index < len(source) and depth:
+            if source[index] == "{":
+                depth += 1
+            elif source[index] == "}":
+                depth -= 1
+            index += 1
+        block = source[match.start():index]
+        if re.search(rf"\bid:\s*{process_id}\b", block):
+            return block
+    raise AssertionError(f"Process block for id {process_id} not found")
+
+
+def _function(source: str, name: str) -> str:
+    body = re.search(rf"    function {name}\(.*?\n    \}}\n", source, re.S)
+    assert body, f"{name}() missing"
+    return body.group(0)
+
+
+# ---- the double ------------------------------------------------------------
+
+
+def test_the_logic_region_is_byte_identical_between_service_and_double():
+    service_region = _synced_region(SERVICE)
+    double_region = _synced_region(DOUBLE)
+    assert service_region, "synced region is empty"
+    assert service_region == double_region, (
+        "services/PhoneContacts.qml and tests/imports/testservices/PhoneContacts.qml "
+        "have drifted between the phone-contacts logic markers; edit both sides identically"
+    )
+
+
+def test_the_region_carries_every_decision_the_qml_suite_drives():
+    region = _synced_region(DOUBLE)
+    for name in ("normalizeQuery", "contactMatches", "isFavorite", "isHidden", "sortKey",
+                 "sortContacts", "filterContacts", "toggledFavorites", "adbSerialFromDevices",
+                 "intentUri", "intentArgv", "monitorArgv", "parseMonitorEvent"):
+        assert f"function {name}(" in region, f"{name} is outside the synced region"
+
+
+def test_the_filtered_binding_matches_the_double():
+    pattern = r"    readonly property var filtered:.*\n"
+    service_line = re.search(pattern, SERVICE.read_text())
+    double_line = re.search(pattern, DOUBLE.read_text())
+    assert service_line and double_line, "filtered binding missing on one side"
+    assert service_line.group(0) == double_line.group(0), "the filtered binding drifted"
+    assert "root.filterContacts(root.contacts, root.query, root.hideUnnamed, root.favorites, root.sortBy)" in service_line.group(0)
+
+
+# ---- argv only -------------------------------------------------------------
+
+
+def test_only_shell_strings_are_the_two_static_presence_probes():
+    source = SERVICE.read_text()
+    shell_commands = re.findall(r'\["sh",\s*"-c",\s*(.*?)\]', source)
+    assert sorted(shell_commands) == ['"command -v adb"', '"command -v gio"'], (
+        f"unexpected shell strings in PhoneContacts.qml: {shell_commands}"
+    )
+    for line in source.splitlines():
+        if '"sh"' in line and "${" in line:
+            raise AssertionError(f"interpolation into a shell command: {line.strip()}")
+    assert "execDetached" not in source, "an intent must be a Process whose exit is read, not fire-and-forget"
+
+
+def test_the_presence_probes_start_themselves():
+    source = SERVICE.read_text()
+    for probe in ("gioProbe", "adbProbe"):
+        block = _process_block(source, probe)
+        assert re.search(r"^\s*running:\s*true", block, re.M), f"{probe} does not start itself"
+
+
+def test_adb_is_invoked_only_through_the_argv_builder_and_devices():
+    source = SERVICE.read_text()
+    region = _synced_region(SERVICE)
+    assert 'return ["adb", ...target, "shell", "am", "start", "-a", action, "-d", uri];' in region
+    outside = source.replace(region, "")
+    adb_literals = [line.strip() for line in outside.splitlines()
+                    if '"adb"' in line and "command -v" not in line]
+    assert adb_literals == ['if (!adbDevicesProc.running) adbDevicesProc.exec(["adb", "devices"]);'], (
+        f"adb invoked outside the builders: {adb_literals}"
+    )
+    assert "intentProc.exec(root.intentArgv(serial, intent.action, intent.uri))" in source
+
+
+def test_the_monitor_is_spawned_from_the_argv_builder_at_the_script_in_the_tree():
+    source = SERVICE.read_text()
+    assert SCRIPT.exists(), "scripts/phone/contacts_monitor.py is missing"
+    assert "/phone/contacts_monitor.py`" in source, "the service names a different script"
+    assert "monitorProc.exec(root.monitorArgv(root.monitorScript, root.deviceId))" in source
+    assert 'return ["python3", script, ...device];' in _synced_region(SERVICE)
+
+
+# ---- the monitor's lifetime ---------------------------------------------------
+
+
+def test_the_monitor_process_has_no_running_binding_and_carries_the_marker():
+    block = _process_block(SERVICE.read_text(), "monitorProc")
+    bindings = re.findall(r"^\s*running\s*:", block, re.M)
+    assert bindings == [], f"monitorProc declares a running binding: {bindings}"
+    assert "process-lifecycle: restart-safe" in block, (
+        "the monitor block must carry the restart-safe marker the plugin lifecycle lint recognises"
+    )
+
+
+def test_every_monitor_exit_consults_the_one_backoff_ladder():
+    """No second spelling of the ladder: the exit handler asks
+    PhoneConnect.monitorExitPlan, honours its refusal, and arms the timer
+    with the delay it returned. The one restart outside it is the
+    deliberate one, gated on the flag restartMonitor() sets while it stops
+    the process, and it is what a device change goes through."""
+    source = SERVICE.read_text()
+    block = _process_block(source, "monitorProc")
+    assert "PhoneConnect.monitorExitPlan(" in block, "the exit handler does not consult the plan"
+    assert "monitorRestart.interval = plan.delay" in block, (
+        "the restart timer is armed with something other than the plan's delay"
+    )
+    assert re.search(r"if\s*\(!plan\.retry\)", block), "the exit handler does not honour the plan's refusal"
+    assert "if (root.monitorRestartWanted)" in block
+    assert not re.search(r"function monitorExitPlan|function monitorBackoffDelay|Math\.pow\(2", source), (
+        "a second copy of the backoff ladder"
+    )
+    code = re.sub(r"//[^\n]*", "", source)
+    starts = [line.strip() for line in code.splitlines()
+              if re.search(r"\bstartMonitor\(\)", line) and "function startMonitor" not in line]
+    assert starts, "nothing starts the monitor"
+    for line in starts:
+        assert "root.startMonitor()" in line, f"unexpected monitor start path: {line}"
+
+
+def test_the_ceiling_is_declared_and_reachable_and_the_gate_is_a_function():
+    source = SERVICE.read_text()
+    assert re.search(r"readonly property int monitorAttemptCeiling:\s*\d+", source)
+    assert re.search(r"readonly property int monitorHealthyMs:\s*\d+", source)
+    assert 'root.monitorState = "failed"' in source
+    assert re.search(r"function monitorWanted\(\): bool \{", source), "the monitor's gate must be a function"
+    assert not re.search(r"property bool (wantMonitor|monitorWanted)", source), (
+        "the monitor's gate is a binding on the property its own handler hangs off"
+    )
+    assert 'root.monitorState !== "failed"' in _function(source, "monitorWanted")
+
+
+def test_a_device_change_restarts_the_monitor_from_the_top_of_the_ladder():
+    source = SERVICE.read_text()
+    assert "readonly property string deviceId: PhoneConnect.activeDevice?.id ?? \"\"" in source
+    handler = re.search(r"onDeviceIdChanged: \{(.*?)\n    \}", source, re.S)
+    assert handler and "root.restartMonitor()" in handler.group(1)
+    restart = _function(source, "restartMonitor")
+    assert "root.monitorAttempts = 0" in restart
+    assert "root.monitorRestartWanted = true" in restart and "monitorProc.running = false" in restart
+
+
+# ---- the intents -------------------------------------------------------------
+
+
+def test_dialer_and_sms_are_the_two_android_intents_over_a_resolved_serial():
+    source = SERVICE.read_text()
+    assert 'root.startIntent("android.intent.action.DIAL", "tel", number)' in _function(source, "openDialer")
+    assert 'root.startIntent("android.intent.action.SENDTO", "sms", number)' in _function(source, "composeSms")
+    start = _function(source, "startIntent")
+    assert "if (!root.adbAvailable)" in start and "root.refuse(" in start, (
+        "an intent with no adb must be refused with lastError, not spawned"
+    )
+    devices = _process_block(source, "adbDevicesProc")
+    assert "root.adbSerialFromDevices(adbDevicesOut.text)" in devices
+    assert 'if (serial === "")' in devices and "root.refuse(" in devices, (
+        "no device in the `device` state must be refused with lastError"
+    )
+    refuse = _function(source, "refuse")
+    assert 'root.lastError = "";' in refuse and "root.lastError = message;" in refuse, (
+        "a repeated refusal must still raise lastErrorChanged"
+    )
+
+
+# ---- the config keys ----------------------------------------------------------
+
+
+def test_config_reads_are_optional_and_defaulted_and_a_favorite_is_written_only_when_declared():
+    source = SERVICE.read_text()
+    expected = {
+        "enabled": 'Config.options.phone?.contacts?.enabled ?? true',
+        "hideUnnamed": 'Config.options.phone?.contacts?.hideUnnamed ?? true',
+        "sortBy": 'Config.options.phone?.contacts?.sortBy ?? "first"',
+        "favorites": 'Config.options.phone?.contacts?.favoriteIds ?? []',
+    }
+    for name, expression in expected.items():
+        assert f"property {'string' if name == 'sortBy' else 'bool' if name != 'favorites' else 'var'} {name}: {expression}" in source, (
+            f"{name} does not read its Config key with optional chaining and a default"
+        )
+    for line in source.splitlines():
+        if "Config.options.phone." in line:
+            raise AssertionError(f"a Config read without optional chaining: {line.strip()}")
+    toggle = _function(source, "toggleFavorite")
+    assert "store.favoriteIds === undefined" in toggle, "toggleFavorite writes into an undeclared key"
+    assert "store.favoriteIds = root.toggledFavorites(store.favoriteIds, uid)" in toggle
+    writes = [line.strip() for line in source.splitlines() if re.search(r"favoriteIds\s*=[^=]", line)]
+    assert writes == ["store.favoriteIds = root.toggledFavorites(store.favoriteIds, uid);"], writes
+
+
+if __name__ == "__main__":
+    import sys
+    from contract_runner import run
+    sys.exit(run(globals()))

--- a/dots/.config/quickshell/imi/tests/test_phone_contacts_monitor.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_contacts_monitor.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+"""scripts/phone/contacts_monitor.py: what it reads, what it emits, and when.
+
+The reader is driven against a throwaway `kpeoplevcard/kdeconnect-<id>/`
+tree, never the machine's own: the vCards KDE Connect writes there are the
+user's contacts, and a fixture is the only thing that may be committed. The
+fixture is shaped after the real files - vCard 2.1 with QUOTED-PRINTABLE
+names carrying a soft line break (a trailing `=` continued on a line with NO
+leading space, which a plain unfold truncates), a base64 photo folded over
+several lines, several TELs with PREF on one of them, a card that is nothing
+but a number, and a card with nothing in it at all.
+
+Three things are pinned beyond the parse. A snapshot is published only when
+the set changes (the SHA-256 rule), so a watcher that re-reads on every
+directory tick costs the shell nothing while nothing moved. A missing source
+is an `error` event and a clean exit, never a traceback. And the watch mode
+keeps running whichever way it can: through `gio monitor -d` when gio is on
+PATH (driven here by a fake that reports a change when the directory listing
+moves), and through a 3 s poll when it is not.
+"""
+
+import base64
+import importlib.util
+import io
+import json
+import os
+import queue
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "phone" / "contacts_monitor.py"
+
+SPEC = importlib.util.spec_from_file_location("contacts_monitor", SCRIPT)
+contacts_monitor = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(contacts_monitor)
+
+JPEG_BYTES = b"\xff\xd8\xff\xe0" + bytes(range(64)) * 3
+PNG_BYTES = b"\x89PNG\r\n\x1a\n" + bytes(range(32))
+
+
+def _fold_base64(data: bytes, width: int = 60) -> str:
+    text = base64.b64encode(data).decode("ascii")
+    chunks = [text[i:i + width] for i in range(0, len(text), width)]
+    return "\n ".join(chunks)
+
+
+# "أحمد علي" as Android's vCard 2.1 exporter spells it: QUOTED-PRINTABLE,
+# soft-wrapped with a trailing `=` and the continuation on an unindented line.
+ALICE = (
+    "BEGIN:VCARD\n"
+    "VERSION:2.1\n"
+    "N;CHARSET=UTF-8;ENCODING=QUOTED-PRINTABLE:=D8=B9=D9=84=D9=8A;=D8=A3=D8=AD=D9=85=D8=AF;;;\n"
+    "FN;CHARSET=UTF-8;ENCODING=QUOTED-PRINTABLE:=D8=A3=D8=AD=D9=85=D8=AF =D8=B9=D9=84=\n"
+    "=D9=8A\n"
+    "TEL;CELL;PREF:+1 (555) 010-0001\n"
+    "TEL;HOME:555 010 0002\n"
+    "TEL;CELL:+1 (555) 010-0001\n"
+    "EMAIL;PREF;HOME:ahmed@example.com\n"
+    "ORG:Example Corp\n"
+    "PHOTO;ENCODING=BASE64;JPEG:" + _fold_base64(JPEG_BYTES) + "\n"
+    "\n"
+    "X-KDECONNECT-ID-DEV-dev1:42\n"
+    "REV:20260101T000000Z\n"
+    "END:VCARD\n"
+)
+
+BOB = (
+    "BEGIN:VCARD\n"
+    "VERSION:3.0\n"
+    "UID:bob-uid-1\n"
+    "FN:Bob Stone\n"
+    "N:Stone;Bob;;;\n"
+    "TEL;TYPE=CELL,VOICE:+15550100010\n"
+    "TEL;TYPE=WORK,PREF:+15550100011\n"
+    "TEL;X-CUSTOM(CHARSET=UTF-8,ENCODING=QUOTED-PRINTABLE,=D9=85):+15550100012\n"
+    "EMAIL;TYPE=WORK:bob@example.com\n"
+    "PHOTO;ENCODING=b;TYPE=PNG:" + base64.b64encode(PNG_BYTES).decode("ascii") + "\n"
+    "END:VCARD\n"
+)
+
+CARLA = (
+    "BEGIN:VCARD\n"
+    "VERSION:4.0\n"
+    "FN:Carla Díaz\n"
+    "N:Díaz;Carla;;;\n"
+    "TEL;VALUE=uri;TYPE=home:tel:+15550100020\n"
+    "PHOTO:data:image/png;base64,iVBORw0KGgo=\n"
+    "END:VCARD\n"
+)
+
+NAMELESS = (
+    "BEGIN:VCARD\n"
+    "VERSION:2.1\n"
+    "N:;+15550100099;;;\n"
+    "FN:+15550100099\n"
+    "TEL;CELL:+15550100099\n"
+    "END:VCARD\n"
+)
+
+EMPTY = "BEGIN:VCARD\nVERSION:2.1\nNOTE:nothing here\nEND:VCARD\n"
+
+OTHER_DEVICE = (
+    "BEGIN:VCARD\nVERSION:2.1\nFN:Dana Other\nN:Other;Dana;;;\n"
+    "TEL;CELL:+15550100030\nEND:VCARD\n"
+)
+
+
+class Fixture:
+    """A temp XDG_DATA_HOME holding kpeoplevcard/kdeconnect-dev1 (four real
+    contacts plus an empty card) and an older kdeconnect-dev2 (one contact)."""
+
+    def __init__(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.data_home = Path(self.tmp.name) / "data"
+        self.root = self.data_home / "kpeoplevcard"
+        self.dev1 = self.root / "kdeconnect-dev1"
+        self.dev2 = self.root / "kdeconnect-dev2"
+        self.dev1.mkdir(parents=True)
+        self.dev2.mkdir(parents=True)
+        for name, text in (("alice", ALICE), ("bob", BOB), ("carla", CARLA),
+                           ("nameless", NAMELESS), ("empty", EMPTY)):
+            (self.dev1 / f"{name}.vcf").write_text(text, encoding="utf-8")
+        (self.dev2 / "dana.vcf").write_text(OTHER_DEVICE, encoding="utf-8")
+        old = time.time() - 3600
+        os.utime(self.dev2, (old, old))
+        now = time.time()
+        os.utime(self.dev1, (now, now))
+
+    def env(self, path=None):
+        env = {k: v for k, v in os.environ.items() if not k.startswith("XDG_")}
+        env["XDG_DATA_HOME"] = str(self.data_home)
+        env["HOME"] = self.tmp.name
+        if path is not None:
+            env["PATH"] = path
+        return env
+
+    def cleanup(self):
+        self.tmp.cleanup()
+
+
+def run_once(fixture, *args, env=None):
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), "--once", *args],
+        capture_output=True, text=True, timeout=30, env=env or fixture.env())
+    events = [json.loads(line) for line in proc.stdout.splitlines() if line.strip()]
+    return proc, events
+
+
+class Stream:
+    """Lines of a running monitor, as parsed events, with a timeout per wait."""
+
+    def __init__(self, proc):
+        self.proc = proc
+        self.events = queue.Queue()
+        threading.Thread(target=self._pump, daemon=True).start()
+
+    def _pump(self):
+        for raw in self.proc.stdout:
+            line = raw.decode("utf-8", errors="replace").strip()
+            if line:
+                self.events.put(json.loads(line))
+        self.events.put(None)
+
+    def expect(self, event, timeout):
+        deadline = time.monotonic() + timeout
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise AssertionError(f"no {event!r} event within {timeout}s")
+            try:
+                message = self.events.get(timeout=remaining)
+            except queue.Empty:
+                raise AssertionError(f"no {event!r} event within {timeout}s")
+            if message is None:
+                raise AssertionError(f"monitor exited before a {event!r} event")
+            if message.get("event") == event:
+                return message
+
+    def expect_none(self, seconds):
+        try:
+            message = self.events.get(timeout=seconds)
+        except queue.Empty:
+            return
+        raise AssertionError(f"expected silence, got {message}")
+
+
+def start_watch(fixture, env, *args):
+    proc = subprocess.Popen(
+        [sys.executable, str(SCRIPT), *args],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)
+    return proc, Stream(proc)
+
+
+def stop(proc):
+    if proc.poll() is None:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+    proc.stdout.close()
+    proc.stderr.close()
+
+
+FAKE_GIO = """#!/bin/sh
+# A stand-in for `gio monitor -d <dir>`: prints one line whenever the
+# directory listing changes, the way the real one prints one per event.
+dir="$3"
+prev=""
+while :; do
+    cur=$(ls -l "$dir" 2>/dev/null)
+    if [ "$cur" != "$prev" ]; then
+        [ -n "$prev" ] && echo "$dir: $dir/changed.vcf: changed"
+        prev="$cur"
+    fi
+    sleep 0.1
+done
+"""
+
+
+class ContactsMonitorOnceTest(unittest.TestCase):
+    def setUp(self):
+        self.fixture = Fixture()
+        self.addCleanup(self.fixture.cleanup)
+
+    def test_once_reports_the_device_directory_then_the_snapshot_and_exits_zero(self):
+        proc, events = run_once(self.fixture, "--device", "dev1")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(proc.stderr, "")
+        self.assertEqual([e["event"] for e in events], ["ready", "snapshot"])
+        ready = events[0]
+        self.assertEqual(ready["sourcePath"], str(self.fixture.dev1))
+        self.assertEqual(ready["count"], 4, "the empty card must be dropped, the nameless one kept")
+        self.assertEqual(len(events[1]["contacts"]), 4)
+
+    def test_the_snapshot_shape(self):
+        _, events = run_once(self.fixture, "--device", "dev1")
+        contacts = {c["displayName"]: c for c in events[1]["contacts"]}
+        self.assertEqual(set(contacts), {"أحمد علي", "Bob Stone", "Carla Díaz", "+15550100099"})
+        for contact in contacts.values():
+            self.assertEqual(set(contact), {"id", "displayName", "givenName", "familyName",
+                                            "organization", "phones", "emails", "photo",
+                                            "nameless", "source"})
+            self.assertEqual(contact["source"], "kdeconnect-dev1")
+
+        alice = contacts["أحمد علي"]
+        self.assertEqual(alice["givenName"], "أحمد")
+        self.assertEqual(alice["familyName"], "علي")
+        self.assertEqual(alice["organization"], "Example Corp")
+        self.assertEqual(alice["id"], "42", "the KDE Connect device id line is the uid when there is no UID")
+        self.assertEqual(alice["phones"], [
+            {"value": "+1 (555) 010-0001", "normalized": "+15550100001", "type": "mobile", "primary": True},
+            {"value": "555 010 0002", "normalized": "5550100002", "type": "home", "primary": False},
+        ], "the duplicate mobile number is folded, PREF marks the primary")
+        self.assertEqual(alice["emails"], [{"value": "ahmed@example.com", "type": "home", "primary": True}])
+        self.assertTrue(alice["photo"].startswith("data:image/jpeg;base64,"))
+        self.assertEqual(base64.b64decode(alice["photo"].split(",", 1)[1]), JPEG_BYTES,
+                         "a folded 2.1 photo must survive unfolding byte for byte")
+        self.assertFalse(alice["nameless"])
+
+        bob = contacts["Bob Stone"]
+        self.assertEqual(bob["id"], "bob-uid-1")
+        self.assertEqual([(p["type"], p["primary"]) for p in bob["phones"]],
+                         [("mobile", False), ("work", True), ("mobile", False)],
+                         "a 3.0 TYPE list resolves, PREF wins over 'first is primary', an X- type is a mobile")
+        self.assertEqual(bob["emails"], [{"value": "bob@example.com", "type": "work", "primary": True}])
+        self.assertEqual(bob["photo"], "data:image/png;base64," + base64.b64encode(PNG_BYTES).decode("ascii"))
+
+        carla = contacts["Carla Díaz"]
+        self.assertEqual(carla["phones"], [
+            {"value": "+15550100020", "normalized": "+15550100020", "type": "home", "primary": True}
+        ], "a 4.0 tel: URI is a number")
+        self.assertEqual(carla["photo"], "data:image/png;base64,iVBORw0KGgo=",
+                         "a 4.0 inline photo is already a data URI and passes through")
+        self.assertEqual(len(carla["id"]), 16, "a card with no UID gets a stable derived id")
+
+        nameless = contacts["+15550100099"]
+        self.assertTrue(nameless["nameless"])
+        self.assertEqual(nameless["phones"][0]["type"], "mobile")
+
+    def test_contacts_are_sorted_by_display_name(self):
+        _, events = run_once(self.fixture, "--device", "dev1")
+        names = [c["displayName"] for c in events[1]["contacts"]]
+        self.assertEqual(names, sorted(names, key=str.lower))
+
+    def test_an_unknown_device_falls_back_to_the_newest_directory(self):
+        _, events = run_once(self.fixture, "--device", "nobody")
+        self.assertEqual(events[0]["sourcePath"], str(self.fixture.dev1))
+        _, events = run_once(self.fixture, "--device", "dev2")
+        self.assertEqual(events[0]["sourcePath"], str(self.fixture.dev2))
+        self.assertEqual(events[0]["count"], 1)
+        _, events = run_once(self.fixture)
+        self.assertEqual(events[0]["sourcePath"], str(self.fixture.dev1), "no --device means the newest")
+
+    def test_no_source_is_an_error_event_and_a_clean_exit(self):
+        shutil.rmtree(self.fixture.root)
+        proc, events = run_once(self.fixture, "--device", "dev1")
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0]["event"], "error")
+        self.assertEqual(events[0]["code"], "no_contact_source")
+        self.assertTrue(events[0]["message"])
+
+    def test_an_unchanged_set_publishes_no_second_snapshot(self):
+        os.environ["XDG_DATA_HOME"] = str(self.fixture.data_home)
+        self.addCleanup(os.environ.pop, "XDG_DATA_HOME", None)
+        monitor = contacts_monitor.ContactMonitor("dev1")
+
+        def emitted():
+            out = io.StringIO()
+            with redirect_stdout(out):
+                self.assertTrue(monitor.update_and_emit())
+            return [json.loads(line) for line in out.getvalue().splitlines() if line.strip()]
+
+        self.assertEqual([e["event"] for e in emitted()], ["ready", "snapshot"])
+        self.assertEqual(emitted(), [], "the SHA-256 of an unchanged set publishes nothing")
+        (self.fixture.dev1 / "erin.vcf").write_text(
+            "BEGIN:VCARD\nVERSION:2.1\nFN:Erin New\nTEL;CELL:+15550100040\nEND:VCARD\n")
+        again = emitted()
+        self.assertEqual([e["event"] for e in again], ["ready", "snapshot"])
+        self.assertEqual(again[0]["count"], 5)
+
+
+class ContactsMonitorWatchTest(unittest.TestCase):
+    def setUp(self):
+        self.fixture = Fixture()
+        self.addCleanup(self.fixture.cleanup)
+        self.bin = Path(self.fixture.tmp.name) / "bin"
+        self.bin.mkdir()
+        self.empty_bin = Path(self.fixture.tmp.name) / "nothing"
+        self.empty_bin.mkdir()
+
+    def with_fake_gio(self):
+        gio = self.bin / "gio"
+        gio.write_text(FAKE_GIO)
+        gio.chmod(0o755)
+        return self.fixture.env(path=f"{self.bin}:{os.environ.get('PATH', '')}")
+
+    def without_gio(self):
+        return self.fixture.env(path=str(self.empty_bin))
+
+    def test_a_change_gio_reports_republishes_after_the_debounce(self):
+        proc, stream = start_watch(self.fixture, self.with_fake_gio(), "--device", "dev1")
+        self.addCleanup(stop, proc)
+        self.assertEqual(stream.expect("ready", 10)["count"], 4)
+        stream.expect("snapshot", 5)
+        stream.expect_none(1.0)
+        (self.fixture.dev1 / "erin.vcf").write_text(
+            "BEGIN:VCARD\nVERSION:2.1\nFN:Erin New\nTEL;CELL:+15550100040\nEND:VCARD\n")
+        self.assertEqual(stream.expect("ready", 5)["count"], 5)
+        snapshot = stream.expect("snapshot", 5)
+        self.assertIn("Erin New", [c["displayName"] for c in snapshot["contacts"]])
+        self.assertIsNone(proc.poll(), "the watcher stays up after a change")
+
+    def test_without_gio_the_watcher_polls(self):
+        proc, stream = start_watch(self.fixture, self.without_gio(), "--device", "dev1")
+        self.addCleanup(stop, proc)
+        self.assertEqual(stream.expect("ready", 10)["count"], 4)
+        stream.expect("snapshot", 5)
+        (self.fixture.dev1 / "erin.vcf").write_text(
+            "BEGIN:VCARD\nVERSION:2.1\nFN:Erin New\nTEL;CELL:+15550100040\nEND:VCARD\n")
+        self.assertEqual(stream.expect("ready", contacts_monitor.POLL_SECONDS + 5)["count"], 5)
+        stream.expect("snapshot", 5)
+
+    def test_a_missing_source_is_reported_once_and_found_when_it_appears(self):
+        shutil.rmtree(self.fixture.root)
+        proc, stream = start_watch(self.fixture, self.without_gio(), "--device", "dev1")
+        self.addCleanup(stop, proc)
+        self.assertEqual(stream.expect("error", 10)["code"], "no_contact_source")
+        stream.expect_none(contacts_monitor.POLL_SECONDS + 1)
+        self.assertIsNone(proc.poll(), "no source is a state to wait in, not an exit")
+        self.fixture.dev1.mkdir(parents=True)
+        (self.fixture.dev1 / "bob.vcf").write_text(BOB, encoding="utf-8")
+        self.assertEqual(stream.expect("ready", contacts_monitor.POLL_SECONDS + 5)["count"], 1)
+        stream.expect("snapshot", 5)
+
+
+if __name__ == "__main__":
+    sys.exit(0 if unittest.main(exit=False).result.wasSuccessful() else 1)

--- a/dots/.config/quickshell/imi/tests/tst_phone_contacts.qml
+++ b/dots/.config/quickshell/imi/tests/tst_phone_contacts.qml
@@ -1,0 +1,220 @@
+import QtQuick
+import QtTest
+import testservices
+
+// The contacts list's decisions - what a query matches, which cards the
+// nameless filter hides and which it may never hide, how the list sorts,
+// what starring does, and what argv reaches adb - exercised through the
+// logic-only double in tests/imports/testservices. The fixture is shaped
+// after what scripts/phone/contacts_monitor.py emits.
+TestCase {
+    name: "PhoneContactsTest"
+
+    function contact(overrides) {
+        return Object.assign({
+            id: "", displayName: "", givenName: "", familyName: "", organization: "",
+            phones: [], emails: [], photo: "", nameless: false, source: "kdeconnect-dev1"
+        }, overrides)
+    }
+
+    function phone(value, type, primary) {
+        return { value: value, normalized: value.replace(/[\s\-().]/g, ""), type: type, primary: primary === true }
+    }
+
+    readonly property var ada: contact({ id: "ada", displayName: "Ada Zed", givenName: "Ada", familyName: "Zed",
+        organization: "Zed Labs", phones: [phone("+1 (555) 010-0001", "mobile", true)],
+        emails: [{ value: "ada@zed.example", type: "work", primary: true }] })
+    readonly property var bo: contact({ id: "bo", displayName: "Bo Ander", givenName: "Bo", familyName: "Ander",
+        phones: [phone("555 010 0002", "home", true)] })
+    readonly property var bare: contact({ id: "bare", displayName: "+15550100099", givenName: "+15550100099",
+        phones: [phone("+15550100099", "mobile", true)], nameless: true })
+    readonly property var starredBare: contact({ id: "starred", displayName: "+15550100077",
+        phones: [phone("+15550100077", "mobile", true)], nameless: true })
+    readonly property var orgOnly: contact({ id: "org", displayName: "Example Corp", organization: "Example Corp",
+        phones: [phone("+15550100050", "work", true)] })
+
+    function ids(list) {
+        const out = []
+        for (let i = 0; i < list.length; i++) out.push(list[i].id)
+        return out
+    }
+
+    function init() {
+        PhoneContacts.contacts = [bare, ada, starredBare, bo, orgOnly]
+        PhoneContacts.query = ""
+        PhoneContacts.hideUnnamed = true
+        PhoneContacts.favorites = []
+        PhoneContacts.sortBy = "first"
+    }
+
+    // ---- the filter ----
+
+    function test_no_query_lists_every_named_contact_sorted_by_first_name() {
+        compare(ids(PhoneContacts.filtered), ["ada", "bo", "org"])
+        compare(PhoneContacts.count, 5, "count is the whole set, not the drawn list")
+    }
+
+    function test_a_query_matches_a_name_case_insensitively() {
+        PhoneContacts.query = "aDa"
+        compare(ids(PhoneContacts.filtered), ["ada"])
+    }
+
+    function test_a_query_matches_the_organization() {
+        PhoneContacts.query = "labs"
+        compare(ids(PhoneContacts.filtered), ["ada"])
+    }
+
+    function test_a_query_matches_an_email_address() {
+        PhoneContacts.query = "zed.example"
+        compare(ids(PhoneContacts.filtered), ["ada"])
+    }
+
+    function test_digits_match_a_number_across_its_separators() {
+        // "555 010" is typed the way the number is drawn; the number is
+        // stored as "+1 (555) 010-0001", so only the digits may be compared.
+        PhoneContacts.query = "555 010-000"
+        compare(ids(PhoneContacts.filtered), ["ada", "bo"])
+        PhoneContacts.query = "(555) 010-0001"
+        compare(ids(PhoneContacts.filtered), ["ada"], "separators in the query are dropped, not matched")
+    }
+
+    function test_a_query_that_matches_nothing_is_an_empty_list() {
+        PhoneContacts.query = "nobody"
+        compare(PhoneContacts.filtered.length, 0)
+    }
+
+    function test_whitespace_around_a_query_is_ignored() {
+        PhoneContacts.query = "  bo  "
+        compare(ids(PhoneContacts.filtered), ["bo"])
+    }
+
+    // ---- the nameless filter ----
+
+    function test_hide_unnamed_drops_a_card_that_is_only_a_number() {
+        verify(!ids(PhoneContacts.filtered).includes("bare"))
+        PhoneContacts.hideUnnamed = false
+        compare(ids(PhoneContacts.filtered), ["starred", "bare", "ada", "bo", "org"],
+                "with the filter off the numbers sort ahead of the letters, 0077 before 0099")
+    }
+
+    function test_a_starred_nameless_card_is_never_hidden() {
+        PhoneContacts.favorites = ["starred"]
+        compare(ids(PhoneContacts.filtered), ["starred", "ada", "bo", "org"])
+    }
+
+    function test_a_starred_nameless_card_still_has_to_match_the_query() {
+        PhoneContacts.favorites = ["starred"]
+        PhoneContacts.query = "ada"
+        compare(ids(PhoneContacts.filtered), ["ada"], "never hidden is about the nameless filter, not the search")
+        PhoneContacts.query = "0077"
+        compare(ids(PhoneContacts.filtered), ["starred"])
+    }
+
+    function test_the_nameless_query_still_finds_a_hidden_card_by_its_number_only_when_shown() {
+        PhoneContacts.query = "0099"
+        compare(PhoneContacts.filtered.length, 0, "hidden means hidden, even to a search")
+        PhoneContacts.hideUnnamed = false
+        compare(ids(PhoneContacts.filtered), ["bare"])
+    }
+
+    // ---- sorting ----
+
+    function test_sort_by_last_name_orders_by_family_name() {
+        PhoneContacts.sortBy = "last"
+        compare(ids(PhoneContacts.filtered), ["bo", "org", "ada"],
+                "Ander, then a card with no family name by its display name, then Zed")
+    }
+
+    function test_a_card_without_a_given_name_sorts_by_its_display_name() {
+        PhoneContacts.contacts = [ada, orgOnly]
+        compare(ids(PhoneContacts.filtered), ["ada", "org"])
+        PhoneContacts.contacts = [contact({ id: "z", displayName: "Zulu Org", organization: "Zulu Org" }), ada]
+        compare(ids(PhoneContacts.filtered), ["ada", "z"])
+    }
+
+    function test_sorting_is_case_insensitive_and_stable_on_ties() {
+        const lower = contact({ id: "l", displayName: "adam", givenName: "adam" })
+        const upper = contact({ id: "u", displayName: "Adam B", givenName: "Adam", familyName: "B" })
+        PhoneContacts.contacts = [upper, lower]
+        compare(ids(PhoneContacts.filtered), ["l", "u"], "equal keys fall back to the display name")
+    }
+
+    function test_the_filter_does_not_mutate_the_source_list() {
+        const before = ids(PhoneContacts.contacts)
+        PhoneContacts.sortBy = "last"
+        void PhoneContacts.filtered
+        compare(ids(PhoneContacts.contacts), before)
+    }
+
+    // ---- favorites ----
+
+    function test_toggling_adds_then_removes_and_never_mutates_the_input() {
+        const start = ["ada"]
+        const added = PhoneContacts.toggledFavorites(start, "bo")
+        compare(added, ["ada", "bo"])
+        compare(start, ["ada"], "the stored list is replaced, never spliced in place")
+        compare(PhoneContacts.toggledFavorites(added, "ada"), ["bo"])
+        compare(PhoneContacts.toggledFavorites([], "x"), ["x"])
+        compare(PhoneContacts.toggledFavorites(null, "x"), ["x"])
+    }
+
+    function test_is_favorite_reads_the_list_by_index() {
+        verify(PhoneContacts.isFavorite("ada", ["bo", "ada"]))
+        verify(!PhoneContacts.isFavorite("ada", ["bo"]))
+        verify(!PhoneContacts.isFavorite("ada", null))
+        verify(!PhoneContacts.isFavorite("", ["ada"]))
+    }
+
+    // ---- adb ----
+
+    function test_the_serial_comes_from_a_device_in_the_device_state() {
+        const listing = "List of devices attached\nR58M12ABCDE\tdevice\n\n"
+        compare(PhoneContacts.adbSerialFromDevices(listing), "R58M12ABCDE")
+    }
+
+    function test_a_usb_serial_wins_over_a_wireless_target() {
+        const listing = "List of devices attached\n192.168.1.20:5555\tdevice\nR58M12ABCDE\tdevice\n"
+        compare(PhoneContacts.adbSerialFromDevices(listing), "R58M12ABCDE")
+        compare(PhoneContacts.adbSerialFromDevices("List of devices attached\n192.168.1.20:5555\tdevice\n"),
+                "192.168.1.20:5555", "wireless is the answer when it is the only one")
+    }
+
+    function test_unauthorized_and_offline_devices_are_not_a_target() {
+        const listing = "List of devices attached\nR58M12ABCDE\tunauthorized\n10.0.0.2:5555\toffline\n"
+        compare(PhoneContacts.adbSerialFromDevices(listing), "")
+        compare(PhoneContacts.adbSerialFromDevices(""), "")
+        compare(PhoneContacts.adbSerialFromDevices("* daemon not running; starting now at tcp:5037\n* daemon started successfully\nList of devices attached\n"), "")
+    }
+
+    function test_a_tel_uri_keeps_the_dial_string_and_encodes_the_rest() {
+        compare(PhoneContacts.intentUri("tel", "+1 (555) 010-0001"), "tel:+1(555)010-0001")
+        compare(PhoneContacts.intentUri("sms", " 5550100002 "), "sms:5550100002")
+        compare(PhoneContacts.intentUri("tel", "*100#"), "tel:*100%23", "a USSD code's # is a fragment marker unless encoded")
+        compare(PhoneContacts.intentUri("tel", ""), "tel:")
+        compare(PhoneContacts.intentUri("tel", null), "tel:")
+    }
+
+    function test_the_intent_argv_targets_the_serial_and_never_a_shell() {
+        compare(PhoneContacts.intentArgv("R58M", "android.intent.action.DIAL", "tel:+15550100001"),
+                ["adb", "-s", "R58M", "shell", "am", "start", "-a", "android.intent.action.DIAL", "-d", "tel:+15550100001"])
+        compare(PhoneContacts.intentArgv("", "android.intent.action.SENDTO", "sms:5550100002"),
+                ["adb", "shell", "am", "start", "-a", "android.intent.action.SENDTO", "-d", "sms:5550100002"])
+    }
+
+    // ---- the monitor ----
+
+    function test_the_monitor_argv_names_the_device_only_when_there_is_one() {
+        compare(PhoneContacts.monitorArgv("/s/contacts_monitor.py", "dev1"),
+                ["python3", "/s/contacts_monitor.py", "--device", "dev1"])
+        compare(PhoneContacts.monitorArgv("/s/contacts_monitor.py", ""),
+                ["python3", "/s/contacts_monitor.py"])
+    }
+
+    function test_a_monitor_line_is_an_event_or_nothing() {
+        compare(PhoneContacts.parseMonitorEvent('{"event": "ready", "sourcePath": "/x", "count": 3}').count, 3)
+        compare(PhoneContacts.parseMonitorEvent("   "), null)
+        compare(PhoneContacts.parseMonitorEvent("not json"), null)
+        compare(PhoneContacts.parseMonitorEvent('{"count": 3}'), null, "no event name, no event")
+        compare(PhoneContacts.parseMonitorEvent('[1, 2]'), null)
+    }
+}

--- a/dots/.config/quickshell/imi/tests/tst_phone_contacts.qml
+++ b/dots/.config/quickshell/imi/tests/tst_phone_contacts.qml
@@ -137,6 +137,12 @@ TestCase {
         const upper = contact({ id: "u", displayName: "Adam B", givenName: "Adam", familyName: "B" })
         PhoneContacts.contacts = [upper, lower]
         compare(ids(PhoneContacts.filtered), ["l", "u"], "equal keys fall back to the display name")
+        // The tie-break must not be the runner's collation: this ordering was
+        // green under en_US.UTF-8 and red in CI's C locale, because
+        // localeCompare put "Adam B" before "adam" there.
+        compare(PhoneContacts.compareFolded("adam", "Adam B"), -1, "the fold decides, not the case")
+        compare(PhoneContacts.compareFolded("Adam B", "adam"), 1, "and it decides the same way round")
+        compare(PhoneContacts.compareFolded("ADAM", "adam"), 0, "case alone is not an ordering")
     }
 
     function test_the_filter_does_not_mutate_the_source_list() {


### PR DESCRIPTION
W4 — Contacts: the model behind the Phone tab's Contacts card

Stacked on 313 — review the last commits only.

`scripts/phone/contacts_monitor.py` reads the vCards KDE Connect writes to `~/.local/share/kpeoplevcard/kdeconnect-<id>/` and streams `ready` / `snapshot` (only when the set changes) / `error` as NDJSON, watching with `gio monitor -d` and polling when it cannot. `services/PhoneContacts.qml` supervises it on the PhoneConnect backoff ladder (reused, not copied), exposes `ready`/`count`/`contacts`/`query`/`filtered`/`favorites`, and opens the phone's dialer or SMS composer over adb, refusing with `lastError` when adb cannot reach the phone.

Ported from the fork with three measured departures: Android's vCard 2.1 export soft-wraps quoted-printable names on unindented lines (32 in one real export — the fork truncated them); photos travel inline as data URIs (140 KB across 150 cards, so no avatar cache exists); number-only cards are flagged `nameless` rather than dropped, so a starred one survives the filter.

Tests: `test_phone_contacts_monitor.py` (fixture tree, never the machine's cards), `tst_phone_contacts.qml` over a synced double, `test_phone_contacts_contract.py`. Also live-loaded in a disposable headless `qs` against a fake adb; the real phone was never dialled.

Docs: updated AGENT.md §Directory map, §busctl monitor (contacts / vCard 2.1 entry)
Changelog: updated
