### PR TITLE
feat(phone): the scrcpy mirror, App Mode, the DroidCam webcam and the phone microphone

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -713,8 +713,9 @@ scripts/                   Standalone helper scripts (Python/bash) invoked via P
                               and unload the DroidCam-Mic null sink; install_droidcam.sh
                               is the per-distro installer the guide offers. Every process
                               match is `pgrep -x` on the binary's name with the signature
-                              checked on the cmdline - the fork's `pgrep -f` adopted its
-                              own launcher, and this repo's lint refuses the bare form
+                              checked on the cmdline - the fork matched the full command
+                              line and adopted its own launcher; this repo's lint refuses
+                              that form (the map is a fenced block, so it counts as code)
 translations/              i18n string tables (Translation.tr(...) singleton)
 assets/                    Static images/fonts bundled with the shell
 ```

--- a/AGENT.md
+++ b/AGENT.md
@@ -619,6 +619,36 @@ services/                  Singletons wrapping external state/processes - one pe
                               (tests/test_phone_contacts_contract.py enforces it). The
                               dialer and SMS actions are `adb shell am start` intents,
                               refused with `lastError` when adb cannot reach the phone
+  PhoneDeps.qml                What the Phone tab's OPTIONAL tooling looks like on this
+                              machine: scrcpy, adb, droidcam-cli, v4l2-ctl, pactl, the
+                              preview players, the v4l2loopback module (loaded/installed),
+                              scrcpy's major version and the distro - every one a constant
+                              `command -v`/argv probe started at construction, never from a
+                              feature's own activation (lint_capability_probe_gating.py).
+                              missingFor(feature) is the install guide's rows with the
+                              sibling fork's per-distro commands verbatim; nothing here is
+                              an installer dependency (sdata/deps-info.md "Phone (optional)")
+  PhoneScrcpy.qml              The screen mirror and app mode. QML holds no scrcpy handle:
+                              scripts/phone/scrcpy_session_manager.py is ONE supervisor
+                              speaking NDJSON on stdin/stdout that owns every scrcpy child
+                              and its imi-phone-<type>-<id> window title; this sends
+                              launch/stop/focus/list_apps and applies started/exited/
+                              apps_list. Started by the first command, stopped by a 10 s
+                              idle timer once nothing is live, restarted on the DiscordVoice
+                              ladder only while commands are queued. mirrorArgs()/
+                              appModeArgs() are the pure flag tables (tst_phone_scrcpy.qml)
+  PhoneCamera.qml              The phone as a webcam through droidcam-cli into v4l2loopback,
+                              launched DETACHED by scripts/phone/droidcam_session.sh (the
+                              pidfile is the binary's own) so it outlives a shell restart
+                              and is re-adopted at boot from the session's state file.
+                              USB first: adb get-state, then KDE Connect's address
+  PhoneMic.qml                 The phone as a microphone: the stream lands on a null sink
+                              (DroidCam-Mic) whose .monitor is what applications record.
+                              scrcpy's SDL audio ignores PULSE_SINK on PipeWire, so the
+                              DEFAULT sink is swapped for exactly as long as the stream
+                              takes to appear, the original persisted in Persistent so a
+                              restart mid-swap still undoes it - see the entry under
+                              "External binaries the shell drives"
   SchemePreview.qml            Per-scheme swatches for the scheme pickers: one venv run of
                               scripts/colors/scheme_preview.py quantizes the wallpaper once and
                               builds every Material variant from it. Cached against the wallpaper
@@ -672,6 +702,19 @@ scripts/                   Standalone helper scripts (Python/bash) invoked via P
                               vCard 2.1 note under "busctl monitor" below before touching the
                               parser; tests/test_phone_contacts_monitor.py drives it against
                               a fixture tree and never the machine's own cards
+  phone/                      The Phone tab's process owners. scrcpy_session_manager.py is
+                              the NDJSON supervisor PhoneScrcpy speaks to (protocol in its
+                              docstring; tests/test_phone_scrcpy_manager.py drives it with
+                              fake scrcpy/adb/hyprctl on PATH). droidcam_session.sh
+                              launches droidcam-cli / the scrcpy mic stream detached under
+                              ${XDG_STATE_HOME:-~/.local/state}/quickshell/imi/phone/ and
+                              answers status/stop by pidfile; droidcam_status.sh is the
+                              read-only JSON probe; setup_/teardown_droidcam_input.sh load
+                              and unload the DroidCam-Mic null sink; install_droidcam.sh
+                              is the per-distro installer the guide offers. Every process
+                              match is `pgrep -x` on the binary's name with the signature
+                              checked on the cmdline - the fork's `pgrep -f` adopted its
+                              own launcher, and this repo's lint refuses the bare form
 translations/              i18n string tables (Translation.tr(...) singleton)
 assets/                    Static images/fonts bundled with the shell
 ```
@@ -4120,6 +4163,44 @@ because a refused intent has to say so. The tests never read the machine's own c
 `tests/test_phone_contacts_monitor.py` builds a fixture tree shaped after the real files.
 209852182 ("feat(phone): contacts_monitor.py reads the vCards KDE Connect writes"),
 b7b8ffcda ("feat(phone): PhoneContacts.qml, the contacts model over a supervised monitor").
+**scrcpy's microphone stream cannot be aimed at a sink, so the DEFAULT sink is swapped under it,
+and the swap is undone by evidence rather than by a timer.** `scrcpy --audio-source=mic` plays
+through SDL, whose PulseAudio backend opens its stream on the default sink and ignores
+`PULSE_SINK` on PipeWire (the sibling fork measured this; `droidcam-cli -a` does honour it).
+`services/PhoneMic.qml` therefore reads `pactl get-default-sink`, records it in
+`Persistent.states.phone.mic.originalDefaultSink`, sets `DroidCam-Mic` as the default, launches
+scrcpy detached, and restores the original the moment `pactl list sink-inputs` names scrcpy -
+polled every 250 ms with a 3 s ceiling, because every millisecond past the stream's creation is
+silence on the user's speakers, and a blind wait muted the desktop on every launch. Three exit
+paths also restore it (`becomeActive`, `fail`, `stop`) and the boot reconciliation undoes a swap a
+dead shell left behind (`restorePlan`: default is `DroidCam-Mic`, no live mic session, so back to
+the saved sink or `@DEFAULT_SINK@`). The persisted field is the whole reason a restart mid-swap
+does not strand the user on a null sink. `tests/test_phone_sessions_contract.py` holds all four
+restores and the persistence.
+("feat(phone): PhoneMic - the phone as a microphone, routed through a null sink").
+
+**A `Process` whose binary is not on PATH never emits `exited`; `running` still drops.** Measured
+with a `qs -p` probe under headless weston: `["definitely-not-a-binary"]` produced one
+`runningChanged(false)` and no `exited` at all, while `["true"]` produced both. So a probe
+counter that waits for `exited` to come back to zero waits for ever on the one machine the probe
+exists for - the one missing the tool. `services/PhoneDeps.qml` hangs its pending count off
+`onRunningChanged` and writes the flag from `onExited`, and its `ready` is what a card reads to
+show "checking" rather than "install" while the sweep runs.
+("feat(phone): PhoneDeps - one probe singleton for the tab's optional tooling").
+
+**The four session services and their doubles are one more synced-region pair, and the pattern
+now has a generator's worth of shape.** `PhoneDeps`, `PhoneScrcpy`, `PhoneCamera` and `PhoneMic`
+each keep everything decidable between `BEGIN/END <name> logic` markers - flag tables, argv
+builders, state ladders, the event handler - and `tests/imports/testservices/<Name>.qml` carries
+the region byte-for-byte with the process I/O replaced: `send()` records what the supervisor
+would have been written, `run(argv, cb)` answers synchronously from a test-provided `responder`
+and records every argv, timers become counters. That is what lets `tests/tst_phone_scrcpy.qml`
+drive a whole launch (probe adb, launch detached, swap the sink, verify the stream) as a list of
+argv strings compared literally, and it is why the synced region may reference sibling
+singletons (`PhoneConnect.activeDevice`, `PhoneScrcpy.targetArgs`) - the doubles module carries
+them too. The one-shot serialized queue (`run`/`pump`/one `Process` with `exec`) is
+`PhoneConnect`'s busctl queue, reused rather than one Process per command.
+("test(phone): pin the four session services' process I/O to their doubles").
 
 **A player on the MPRIS bus may be a proxy for another player, and every field you would match on
 is the borrowed one.** `playerctld` is `playerctl`'s daemon, not a player: it re-publishes whichever

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,17 @@ own repo; the installer pins which revision it builds.
   phone's dialer or SMS composer for a number over adb, saying why when it
   cannot. This is the model behind the Phone tab's Contacts card; the tab
   itself follows.
+- **The phone's screen, camera and microphone reach the desktop.** Groundwork
+  for the Phone tab: scrcpy mirrors the phone in a window and opens one
+  Android app on a virtual display of its own (scrcpy 4+, "App Mode"), the
+  phone's camera becomes a `/dev/videoN` webcam through DroidCam, and its
+  microphone becomes a `DroidCam-Mic` input that any app can record from -
+  through scrcpy with no app on the phone, or through DroidCam. Every one of
+  these is optional: nothing is added to the installer, each tool is probed
+  when the shell starts, and what is missing is answered with the install
+  command for Arch, Fedora and Debian. The settings live under
+  `phone.*` in config.json (mirror flags, app-mode display, webcam and
+  microphone connection); the tab that shows them follows.
 - **Phone Connect shows your phone's wireless address and cellular network,
   and answers pairing requests.** The panel reads the address KDE Connect
   reaches the phone on and its cellular network type (LTE, 5G, …) alongside

--- a/docs/superpowers/specs/2026-08-27-phone-tab-design.md
+++ b/docs/superpowers/specs/2026-08-27-phone-tab-design.md
@@ -272,8 +272,10 @@ videoBuffer, useWireless, autoWirelessIp, wirelessIp, wirelessPort}`,
 density, keepActive, systemDecorations, favoritePackages}`,
 `webcam.{cameraFacing, resolution, mirrorHorizontally, rotateDegrees,
 connection, wifiIp, port}`, `microphone.{connection, wifiIp, port,
-micGain, setAsDefault}`. Plus `Config.options.sidebar.phone.enable`
-(default `true`).
+micGain, setAsDefault}`. Plus `Config.options.sidebar.phone.enable`,
+which ships **`false`** until W5: it also gates the mirror's dedupe, and
+on before there is a list to read them in, the phone's notifications
+would stop arriving anywhere. W5 flips it to `true` with the tab.
 
 Tests: the Python supervisor test with fake binaries (launch/exit/focus/
 list_apps parsing incl. the `pm list packages` fallback); QML unit tests

--- a/dots/.config/quickshell/imi/modules/common/Config.qml
+++ b/dots/.config/quickshell/imi/modules/common/Config.qml
@@ -1442,7 +1442,14 @@ Singleton {
                     property bool artColors: false
                 }
                 property JsonObject phone: JsonObject {
-                    property bool enable: true
+                    // Off until the tab exists (W5 of the Phone tab design).
+                    // It gates more than the tab: PhoneNotifications reads it
+                    // as `mirrorActive`, and that is what tells
+                    // services/Notifications.qml to drop kdeconnectd's own
+                    // desktop copy of a phone notification. On before there is
+                    // a list to read them in, the phone's notifications would
+                    // simply stop arriving anywhere. W5 turns it on.
+                    property bool enable: false
                 }
                 
                 property JsonObject ai: JsonObject {

--- a/dots/.config/quickshell/imi/modules/common/Config.qml
+++ b/dots/.config/quickshell/imi/modules/common/Config.qml
@@ -1441,6 +1441,9 @@ Singleton {
                     property bool enable: true
                     property bool artColors: false
                 }
+                property JsonObject phone: JsonObject {
+                    property bool enable: true
+                }
                 
                 property JsonObject ai: JsonObject {
                     property bool textFadeIn: false
@@ -1626,6 +1629,63 @@ Singleton {
                     property list<string> networkNameKeywords: ["airport", "cafe", "college", "company", "eduroam", "free", "guest", "public", "school", "university"]
                     property list<string> fileKeywords: ["anime", "booru", "ecchi", "hentai", "yande.re", "konachan", "breast", "nipples", "pussy", "nsfw", "spoiler", "girl"]
                     property list<string> linkKeywords: ["hentai", "porn", "sukebei", "hitomi.la", "rule34", "gelbooru", "fanbox", "dlsite"]
+                }
+            }
+
+            // The Phone tab (docs/superpowers/specs/2026-08-27-phone-tab-design.md).
+            // Appended at the end deliberately: the block is owned by one
+            // workstream while others touch this file, so it lands with no
+            // hunk in common. Defaults are the sibling fork's table.
+            property JsonObject phone: JsonObject {
+                property bool showPeripheralCards: true // the mirror / webcam / microphone cards
+                property JsonObject contacts: JsonObject {
+                    property bool enabled: true
+                    property list<string> favoriteIds: []
+                    property string sortBy: "first" // first | last
+                    property bool hideUnnamed: true
+                }
+                property JsonObject scrcpy: JsonObject {
+                    property bool stayAwake: false
+                    property bool turnScreenOff: false
+                    property bool noPowerOn: false
+                    property bool noAudio: false
+                    property bool showTouches: false
+                    property bool fullscreen: false
+                    property bool alwaysOnTop: false
+                    property int maxFps: 0 // 0 = the phone's own rate
+                    property string bitRate: "8M"
+                    property int maxSize: 0 // 0 = native
+                    property int videoBuffer: 0 // ms
+                    property bool useWireless: false
+                    property bool autoWirelessIp: true // the address KDE Connect reports
+                    property string wirelessIp: ""
+                    property string wirelessPort: "5555"
+                    property JsonObject appMode: JsonObject {
+                        property bool enabled: true
+                        property bool flexDisplay: true // --new-display + --flex-display
+                        property int displayWidth: 1280
+                        property int displayHeight: 960
+                        property int density: 160
+                        property bool keepActive: true
+                        property bool systemDecorations: true
+                        property list<string> favoritePackages: []
+                    }
+                }
+                property JsonObject webcam: JsonObject {
+                    property string cameraFacing: "front" // front | back - switched in the DroidCam app, recorded here
+                    property string resolution: "1280x720"
+                    property bool mirrorHorizontally: false
+                    property int rotateDegrees: 0
+                    property string connection: "wifi" // wifi | usb
+                    property string wifiIp: ""
+                    property int port: 4747
+                }
+                property JsonObject microphone: JsonObject {
+                    property string connection: "wifi" // wifi | usb
+                    property string wifiIp: ""
+                    property int port: 4748
+                    property int micGain: 100 // percent
+                    property bool setAsDefault: false
                 }
             }
         }

--- a/dots/.config/quickshell/imi/modules/common/Persistent.qml
+++ b/dots/.config/quickshell/imi/modules/common/Persistent.qml
@@ -185,9 +185,31 @@ Singleton {
             }
 
             property JsonObject phone: JsonObject {
+                // The device the Phone tab is about, and the ones it was
+                // about recently (MRU, newest first).
                 property string activeDeviceId: ""
                 property list<string> recentDeviceIds: []
+                // The last notification sweep, so the tab is not empty
+                // before the first one after a restart.
                 property string cachedNotificationsJson: ""
+                property JsonObject scrcpy: JsonObject {
+                    property list<string> recentPackages: []
+                }
+                property JsonObject camera: JsonObject {
+                    property string lastMode: "wifi"
+                    property string lastIp: ""
+                    property int lastPort: 4747
+                }
+                property JsonObject mic: JsonObject {
+                    // The user's real default sink while it is swapped to
+                    // DroidCam-Mic for scrcpy's stream to land on. Persisted
+                    // so a shell restart mid-launch can put it back.
+                    property string originalDefaultSink: ""
+                    property string lastBackend: ""
+                    property string lastMode: "wifi"
+                    property string lastIp: ""
+                    property int lastPort: 4748
+                }
             }
         }
     }

--- a/dots/.config/quickshell/imi/scripts/phone/droidcam_session.sh
+++ b/dots/.config/quickshell/imi/scripts/phone/droidcam_session.sh
@@ -1,0 +1,323 @@
+#!/usr/bin/env bash
+# droidcam_session.sh — Persistent lifecycle manager for DroidCam sessions.
+#
+# The droidcam-cli / scrcpy process is launched DETACHED (setsid + nohup) so it
+# keeps running when the Quickshell process dies, reloads, or restarts. A small
+# JSON state file records the PID + connection info so the shell can re-adopt
+# the existing process on boot instead of spawning a duplicate.
+#
+# Sessions:
+#   video      — droidcam-cli -nocontrols [ip|adb] <port>           (webcam)
+#   audio      — env PULSE_SINK=DroidCam-Mic droidcam-cli -a ...    (mic via droidcam)
+#   scrcpy-mic — scrcpy --no-video --no-window --audio-source=mic   (preferred mic)
+#
+# Usage:
+#   droidcam_session.sh launch <session> <bin> <args...>   Start detached + save state, print PID
+#   droidcam_session.sh status <session>                   Validate process → JSON on stdout
+#   droidcam_session.sh stop <session>                     Kill saved PID (only if cmdline matches)
+#   droidcam_session.sh killall                            Stop every tracked session
+#
+# State is written atomically (tmp + mv). Idempotent.
+
+set -u
+IFS=$'\n\t'
+
+STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/quickshell/imi/phone"
+mkdir -p "$STATE_DIR"
+
+logfile_for()   { printf '%s/%s.log'   "$STATE_DIR" "$1"; }
+statefile_for() { printf '%s/%s.json'  "$STATE_DIR" "$1"; }
+
+# ─── Helpers ─────────────────────────────────────────────────────────────
+
+# atomically_write <file> <content>
+atomically_write() {
+    local file="$1" content="$2" tmp
+    tmp="$file.tmp.$$"
+    printf '%s' "$content" > "$tmp" && mv -f "$tmp" "$file"
+}
+
+# cmdline_of <pid> → normalized single-line cmdline (NUL → space)
+cmdline_of() { tr '\0' ' ' < "/proc/$1/cmdline" 2>/dev/null | sed 's/[[:space:]]*$//'; }
+
+# is_alive <pid> → 0 if process exists
+is_alive() { [ -n "$1" ] && [ -d "/proc/$1" ] 2>/dev/null; }
+
+# read_json_field <file> <key> → value (naive parser for our single-line JSON;
+# supports both string and numeric values)
+read_json_field() {
+    sed -n "s/.*\"$2\"[[:space:]]*:[[:space:]]*\"\{0,1\}\([^\",}]*\)\"\{0,1\}.*/\1/p" "$1" 2>/dev/null | head -n1
+}
+
+# session_signature <session> → substring the process cmdline must contain
+session_signature() {
+    case "$1" in
+        video)      echo "droidcam-cli" ;;
+        audio)      echo "droidcam-cli -a" ;;
+        scrcpy-mic) echo "--audio-source=mic" ;;
+        *)          echo "" ;;
+    esac
+}
+
+# find_running <session> [port] → pid (empty if none). Matches live processes
+# of the session kind whose cmdline contains the port (when given).
+find_running() {
+    local session="$1" port="${2:-}" sig pid cl comm argv0 want
+    sig="$(session_signature "$session")"
+    [ -n "$sig" ] || return 1
+    case "$session" in
+        scrcpy-mic) want="scrcpy" ;;
+        *)          want="droidcam-cli" ;;
+    esac
+    # `pgrep -x` on the binary's own name, never a full-cmdline match on
+    # the signature: that matches every process carrying these args,
+    # including the shell that was invoked to launch one, so a session would
+    # "adopt" its own launcher (this repo's lint refuses the bare form for
+    # exactly that reason). The signature is then checked on the cmdline.
+    for pid in $(pgrep -x "$want" 2>/dev/null); do
+        [ -r "/proc/$pid/cmdline" ] || continue
+        cl="$(cmdline_of "$pid")"
+        case "$cl" in
+            *"$sig"*)
+                if [ -z "$port" ]; then printf '%s' "$pid"; return 0; fi
+                case "$cl" in
+                    *"$port"*) printf '%s' "$pid"; return 0 ;;
+                esac
+                ;;
+        esac
+    done
+    return 1
+}
+
+# extract_port <args...> → last standalone numeric token
+extract_port() {
+    local a last=""
+    for a in "$@"; do
+        case "$a" in
+            ''|*[!0-9]*) ;;
+            *) last="$a" ;;
+        esac
+    done
+    printf '%s' "$last"
+}
+
+# extract_ip <mode> <args...> → the token before the port (wifi) or "adb" (usb)
+extract_ip() {
+    local mode="$1"; shift
+    local a prev=""
+    for a in "$@"; do
+        case "$a" in
+            ''|*[!0-9]*) ;;
+            *) [ "$mode" = "usb" ] && printf 'adb' && return 0
+               printf '%s' "$prev"; return 0 ;;
+        esac
+        prev="$a"
+    done
+    printf ''
+}
+
+# ─── Commands ────────────────────────────────────────────────────────────
+
+# cmd_launch <session> <bin> <args...>
+cmd_launch() {
+    local session="$1" bin="$2"; shift 2
+    [ $# -ge 1 ] || { echo "droidcam_session: launch needs args" >&2; exit 1; }
+
+    local statefile logfile
+    statefile="$(statefile_for "$session")"
+    logfile="$(logfile_for "$session")"
+
+    local port mode ip
+    port="$(extract_port "$@")"
+    mode="wifi"
+    for a in "$@"; do
+        [ "$a" = "adb" ] && mode="usb" && break
+    done
+    ip="$(extract_ip "$mode" "$@")"
+
+    # If a live process with the same signature + port already exists, adopt
+    # it instead of double-launching.
+    local existing
+    existing="$(find_running "$session" "$port" 2>/dev/null || true)"
+    if [ -n "$existing" ]; then
+        local cl
+        cl="$(cmdline_of "$existing")"
+        atomically_write "$statefile" \
+            "{\"pid\":\"$existing\",\"started\":$(date +%s),\"port\":\"$port\",\"mode\":\"$mode\",\"ip\":\"$ip\",\"cmdline\":\"$cl\"}"
+        echo "$existing"
+        exit 0
+    fi
+
+    # An idle wireless ADB transport drops the first command thrown at it.
+    # scrcpy then dies on startup with "Could not list ADB devices" or a
+    # failed "adb push", while `adb devices` looks perfectly healthy a second
+    # later. Waking the transport first noticeably improves launch odds.
+    # Bounded, because an unreachable phone must not hang the launch.
+    case "$session" in
+        scrcpy-mic)
+            timeout 3 adb devices  > /dev/null 2>&1 || true
+            timeout 3 adb shell true > /dev/null 2>&1 || true
+            ;;
+    esac
+
+    # The detached process reports its own PID: `exec` replaces this inner
+    # shell, so what lands in the pidfile IS the binary. $! cannot be used
+    # (setsid's parent exits at once), and re-deriving the PID by scanning
+    # the process table made a perfectly healthy session look like a failed
+    # launch every time the scan came up empty.
+    local pidfile="$STATE_DIR/$session.pid"
+    rm -f "$pidfile"
+    setsid nohup bash -c 'echo $$ > "$1"; shift; exec "$@"' _ "$pidfile" "$bin" "$@" \
+        > "$logfile" 2>&1 < /dev/null &
+
+    local pid=""
+    for _ in 1 2 3 4 5 6 7 8 9 10; do
+        sleep 0.1
+        if [ -s "$pidfile" ]; then pid="$(cat "$pidfile" 2>/dev/null || true)"; break; fi
+    done
+    is_alive "$pid" || pid=""
+    # Last resort for a session adopted from an earlier launch.
+    if [ -z "$pid" ]; then
+        pid="$(find_running "$session" "$port" 2>/dev/null || true)"
+    fi
+    if [ -z "$pid" ]; then
+        echo "droidcam_session: failed to start session '$session'" >&2
+        exit 1
+    fi
+
+    local cl
+    cl="$(cmdline_of "$pid")"
+    atomically_write "$statefile" \
+        "{\"pid\":\"$pid\",\"started\":$(date +%s),\"port\":\"$port\",\"mode\":\"$mode\",\"ip\":\"$ip\",\"cmdline\":\"$cl\"}"
+    echo "$pid"
+}
+
+# cmd_status <session> → JSON:
+#   {session,pid,alive,started,port,mode,ip,device,video_running,audio_running}
+cmd_status() {
+    local session="$1"
+    local statefile logfile
+    statefile="$(statefile_for "$session")"
+    logfile="$(logfile_for "$session")"
+
+    local pid="" alive="false" port="" mode="unknown" ip="" started=""
+    if [ -f "$statefile" ]; then
+        pid="$(read_json_field "$statefile" pid)"
+        port="$(read_json_field "$statefile" port)"
+        mode="$(read_json_field "$statefile" mode)"
+        ip="$(read_json_field "$statefile" ip)"
+        started="$(read_json_field "$statefile" started)"
+        [ -z "$mode" ] && mode="unknown"
+        if is_alive "$pid"; then
+            alive="true"
+        else
+            pid=""
+        fi
+    fi
+
+    # Stale/absent state — try to re-discover a live process for this session.
+    if [ "$alive" = "false" ]; then
+        pid="$(find_running "$session" "$port" 2>/dev/null || true)"
+        if [ -n "$pid" ]; then
+            alive="true"
+            local cl
+            cl="$(cmdline_of "$pid")"
+            if [ -z "$port" ]; then
+                port="$(extract_port $cl)"
+            fi
+            case "$cl" in
+                *" adb "*) mode="usb" ;;
+                *) mode="wifi" ;;
+            esac
+            if [ "$mode" = "wifi" ] && [ -z "$ip" ]; then
+                ip="$(extract_ip "$mode" $cl)"
+            fi
+            [ -z "$started" ] && started="$(stat -c %Y "/proc/$pid" 2>/dev/null || echo 0)"
+        fi
+    fi
+
+    local video_running="false" audio_running="false"
+    case "$session" in
+        video)      [ "$alive" = "true" ] && video_running="true" ;;
+        audio|scrcpy-mic) [ "$alive" = "true" ] && audio_running="true" ;;
+    esac
+
+    # Device: droidcam sessions print "Video: /dev/videoN" on stdout (logged).
+    local device=""
+    if [ -f "$logfile" ]; then
+        device="$(grep -oE 'Video: /dev/video[0-9]+' "$logfile" | head -n1 | awk '{print $2}' || true)"
+    fi
+
+    printf '{"session":"%s","pid":"%s","alive":%s,"started":"%s","port":"%s","mode":"%s","ip":"%s","device":"%s","video_running":%s,"audio_running":%s}\n' \
+        "$session" "$pid" "$alive" "$started" "$port" "$mode" "$ip" "$device" "$video_running" "$audio_running"
+}
+
+# cmd_stop <session> — kill the saved PID only if the cmdline still matches.
+cmd_stop() {
+    local session="$1"
+    local statefile
+    statefile="$(statefile_for "$session")"
+    if [ ! -f "$statefile" ]; then
+        # No state — still try to stop any matching live process.
+        local stray
+        stray="$(find_running "$session" "" 2>/dev/null || true)"
+        if [ -n "$stray" ]; then
+            kill -TERM "$stray" 2>/dev/null || true
+            for _ in 1 2 3 4 5 6 7 8; do
+                is_alive "$stray" || break
+                sleep 0.25
+            done
+            is_alive "$stray" && kill -KILL "$stray" 2>/dev/null || true
+        fi
+        echo "droidcam_session: no state for '$session'" >&2
+        exit 0
+    fi
+
+    local pid
+    pid="$(read_json_field "$statefile" pid)"
+    if [ -z "$pid" ] || ! is_alive "$pid"; then
+        rm -f "$statefile"
+        echo "droidcam_session: '$session' not running" >&2
+        exit 0
+    fi
+
+    # Safety: only kill if the cmdline still looks like our kind of process.
+    local cl
+    cl="$(cmdline_of "$pid")"
+    case "$cl" in
+        *"droidcam-cli"*|*"scrcpy"*)
+            kill -TERM "$pid" 2>/dev/null
+            for _ in 1 2 3 4 5 6 7 8; do
+                is_alive "$pid" || break
+                sleep 0.25
+            done
+            if is_alive "$pid"; then
+                kill -KILL "$pid" 2>/dev/null || true
+            fi
+            ;;
+        *)
+            echo "droidcam_session: pid $pid no longer matches droidcam/scrcpy — not killing" >&2
+            ;;
+    esac
+    rm -f "$statefile"
+}
+
+# cmd_killall — stop every tracked session.
+cmd_killall() {
+    for session in video audio scrcpy-mic; do
+        cmd_stop "$session" >/dev/null 2>&1 || true
+    done
+}
+
+# ─── Dispatch ────────────────────────────────────────────────────────────
+
+case "${1:-}" in
+    launch)  shift; cmd_launch "$@" ;;
+    status)  shift; cmd_status "$@" ;;
+    stop)    shift; cmd_stop "$@" ;;
+    killall) shift; cmd_killall "$@" ;;
+    *)
+        echo "Usage: droidcam_session.sh {launch|status|stop|killall} <session> [args...]" >&2
+        exit 1
+        ;;
+esac

--- a/dots/.config/quickshell/imi/scripts/phone/droidcam_status.sh
+++ b/dots/.config/quickshell/imi/scripts/phone/droidcam_status.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# droidcam_status.sh — Emits JSON state of DroidCam installation and active devices.
+# Called from PhoneCameraService / PhoneMicService on demand.
+#
+# Output shape:
+# {
+#   "installed": true|false,
+#   "v4l2_device": "/dev/videoN" or "",
+#   "device_has_stream": true|false,
+#   "audio_source": "alsa_output.droidcam_input.monitor" or "",
+#   "audio_has_sink_input": true|false,
+#   "audio_running": true|false,
+#   "video_running": true|false,
+#   "video_pid": 12345 or 0,
+#   "video_port": 4747 or 0,
+#   "video_mode": "wifi"|"usb"|""
+# }
+#
+# This script is READ-ONLY — it never starts/stops anything.
+
+set -u
+IFS=$'\n\t'
+
+installed=false
+v4l2_device=""
+device_has_stream=false
+audio_source=""
+audio_has_sink_input=false
+audio_running=false
+video_running=false
+video_pid=0
+video_port=0
+video_mode=""
+
+if command -v droidcam-cli >/dev/null 2>&1; then
+    installed=true
+fi
+
+# ─── Video: /dev/videoN associated with DroidCam (v4l2loopback) ─────────
+# `v4l2-ctl --list-devices` output looks like:
+#   DroidCam (usb-0000:00:14.0-...):
+#       /dev/video10
+#       /dev/video11
+# We pick the first /dev/videoN under a DroidCam-named block, then fall back
+# to any v4l2loopback device when no explicit DroidCam block exists.
+if command -v v4l2-ctl >/dev/null 2>&1; then
+    list_output="$(v4l2-ctl --list-devices 2>/dev/null || true)"
+    if [ -n "$list_output" ]; then
+        in_droidcam_block=false
+        for line in $list_output; do
+            if echo "$line" | grep -qi "droidcam"; then
+                in_droidcam_block=true
+                continue
+            fi
+            if $in_droidcam_block; then
+                if echo "$line" | grep -qE '^\s*/dev/video[0-9]+'; then
+                    v4l2_device="$(echo "$line" | awk '{print $1}')"
+                    break
+                else
+                    # Block ended (a new device name line appeared).
+                    in_droidcam_block=false
+                fi
+            fi
+        done
+    fi
+
+    # Fallback: no DroidCam-named block, but a v4l2loopback device exists.
+    # Only treated as a DroidCam target when a droidcam-cli process is
+    # actually running (see below) — otherwise a leftover scrcpy-loopback
+    # device would be misreported as the webcam.
+    if [ -z "$v4l2_device" ] && [ -n "$list_output" ]; then
+        in_loop_block=false
+        for line in $list_output; do
+            if echo "$line" | grep -qiE "loopback|v4l2loopback"; then
+                in_loop_block=true
+                continue
+            fi
+            if $in_loop_block; then
+                if echo "$line" | grep -qE '^\s*/dev/video[0-9]+'; then
+                    v4l2_device="$(echo "$line" | awk '{print $1}')"
+                    break
+                else
+                    in_loop_block=false
+                fi
+            fi
+        done
+    fi
+fi
+
+# ─── Processes: droidcam-cli (video or audio) and scrcpy (mic) ──────────
+if command -v pgrep >/dev/null 2>&1; then
+    for pid in $(pgrep -x droidcam-cli 2>/dev/null); do
+        cl="$(tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null | sed 's/[[:space:]]*$//')"
+        case "$cl" in
+            *' -a '*|*'-a '*)   # audio mode: droidcam-cli ... -a ...
+                audio_running=true
+                ;;
+            *)                   # video mode
+                if [ "$video_pid" -eq 0 ]; then
+                    video_pid="$pid"
+                    video_mode="wifi"
+                    case "$cl" in
+                        *' adb '*) video_mode="usb" ;;
+                    esac
+                    # Port = last numeric token.
+                    video_port="$(echo "$cl" | grep -oE '[0-9]{3,5}$' | tail -n1 || echo 0)"
+                fi
+                video_running=true
+                ;;
+        esac
+    done
+    # scrcpy with --audio-source=mic is an audio session too.
+    for pid in $(pgrep -x scrcpy 2>/dev/null); do
+        cl="$(tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null | sed 's/[[:space:]]*$//')"
+        case "$cl" in
+            *'--audio-source=mic'*) audio_running=true ;;
+        esac
+    done
+fi
+
+# ─── device_has_stream: only meaningful while a droidcam video process runs ─
+# A v4l2loopback device with the client NOT connected usually fails or
+# reports an empty/invalid format. Timeout guards against a hung ioctl.
+# The device may have been resolved from a DroidCam-named block (with a live
+# process) or from the generic loopback fallback — but only when video is
+# running do we claim an active stream.
+if [ "$video_running" = "true" ] && [ -n "$v4l2_device" ] && command -v v4l2-ctl >/dev/null 2>&1; then
+    fmt_out="$(timeout 2 v4l2-ctl -d "$v4l2_device" --get-fmt-video 2>/dev/null || true)"
+    if [ -n "$fmt_out" ] && echo "$fmt_out" | grep -q "Width/Height"; then
+        device_has_stream=true
+    fi
+fi
+
+# ─── Audio: virtual null-sink "DroidCam-Mic" + active sink-input ────────
+if command -v pactl >/dev/null 2>&1; then
+    sources_output="$(pactl list sources short 2>/dev/null || true)"
+    if [ -n "$sources_output" ]; then
+        match="$(echo "$sources_output" | awk '$0 ~ /DroidCam-Mic/ || $0 ~ /droidcam/ {print $1; exit}')"
+        if [ -n "$match" ]; then
+            audio_source="$match"
+        fi
+    fi
+
+    # audio_has_sink_input: something is actively feeding DroidCam-Mic.
+    # Sink-input blocks carry no "State:" line (only sinks do) and name
+    # their sink by index, so scanning them for a running DroidCam-Mic
+    # input can never match. The null-sink itself reports RUNNING exactly
+    # while an uncorked stream feeds it — that is the evidence we want.
+    if pactl list short sinks 2>/dev/null \
+        | awk '$2 == "DroidCam-Mic" && $NF == "RUNNING" { found=1 } END { exit found ? 0 : 1 }'; then
+        audio_has_sink_input=true
+    fi
+fi
+
+# Emit JSON. printf to avoid echo interpreting backslashes.
+printf '{"installed":%s,"v4l2_device":%s,"device_has_stream":%s,"audio_source":%s,"audio_has_sink_input":%s,"audio_running":%s,"video_running":%s,"video_pid":%s,"video_port":%s,"video_mode":%s}\n' \
+    "$( $installed && echo true || echo false )" \
+    "\"$v4l2_device\"" \
+    "$( $device_has_stream && echo true || echo false )" \
+    "\"$audio_source\"" \
+    "$( $audio_has_sink_input && echo true || echo false )" \
+    "$( $audio_running && echo true || echo false )" \
+    "$( $video_running && echo true || echo false )" \
+    "$video_pid" \
+    "$video_port" \
+    "\"$video_mode\""

--- a/dots/.config/quickshell/imi/scripts/phone/install_droidcam.sh
+++ b/dots/.config/quickshell/imi/scripts/phone/install_droidcam.sh
@@ -1,0 +1,284 @@
+#!/usr/bin/env bash
+# install_droidcam.sh — Detects distro and installs DroidCam + deps.
+#
+# Supports:
+#   • Arch Linux (AUR: droidcam package includes everything)
+#   • Fedora (RPMFusion for v4l2loopback + official DroidCam client installer)
+#   • Debian/Ubuntu (official DroidCam installer zip)
+#
+# Installs: droidcam-cli, v4l2loopback (kernel module), pactl (audio routing),
+#           libappindicator-gtk3, adb (android-tools), ffmpeg, alsa-lib.
+
+set -u
+IFS=$'\n\t'
+
+echo "╔═══════════════════════════════════════════════╗"
+echo "║     DroidCam Installer for the ImI Phone tab     ║"
+echo "╚═══════════════════════════════════════════════╝"
+echo ""
+
+# ─── Distro detection ─────────────────────────────────
+detect_distro() {
+    if [ -f /etc/arch-release ]; then
+        echo "arch"
+    elif [ -f /etc/fedora-release ]; then
+        echo "fedora"
+    elif [ -f /etc/debian_version ] || grep -qiE "ubuntu|debian" /etc/os-release 2>/dev/null; then
+        echo "debian"
+    else
+        echo "unknown"
+    fi
+}
+
+DISTRO=$(detect_distro)
+
+# Common pause helper
+press_enter_to_close() {
+    echo ""
+    echo "Press Enter to close..."
+    read -r
+}
+
+# URL of the official DroidCam Linux client zip.
+# Changed from .com to .net — the .com host stopped resolving in 2025-2026.
+# And switched from droidcam_latest.zip to versioned droidcam_2.1.5.zip.
+DROIDCAM_URL="https://files.dev47apps.net/linux/droidcam_2.1.5.zip"
+DROIDCAM_SHA1="ce44abefbadec0a2183837605df23643ca13fb02"
+
+download_droidcam() {
+    local outpath="$1"
+    echo "▸ Downloading DroidCam client from $DROIDCAM_URL"
+    if command -v curl >/dev/null 2>&1; then
+        if curl -fSL --connect-timeout 15 --retry 3 --retry-delay 2 \
+                -o "$outpath" "$DROIDCAM_URL"; then
+            echo "  ✓ Downloaded successfully."
+            return 0
+        fi
+    elif command -v wget >/dev/null 2>&1; then
+        if wget -q --tries=3 --timeout=15 \
+                -O "$outpath" "$DROIDCAM_URL"; then
+            echo "  ✓ Downloaded successfully."
+            return 0
+        fi
+    else
+        echo "✗ Neither curl nor wget is installed."
+        return 1
+    fi
+    echo "✗ Failed to download. The DroidCam site may be unreachable."
+    echo "  Try manually from: https://www.dev47apps.com/droidcam/linux/"
+    return 1
+}
+
+verify_droidcam() {
+    local outpath="$1"
+    if ! command -v sha1sum >/dev/null 2>&1; then
+        echo "  ! sha1sum not available — skipping verification."
+        return 0
+    fi
+    local actual
+    actual="$(sha1sum "$outpath" | awk '{print $1}')"
+    if [ "$actual" = "$DROIDCAM_SHA1" ]; then
+        echo "  ✓ SHA1 verified."
+        return 0
+    fi
+    echo "  ✗ SHA1 mismatch (got $actual, expected $DROIDCAM_SHA1)"
+    echo "  The downloaded file may be corrupt. Aborting."
+    return 1
+}
+
+install_from_official_zip() {
+    local tmpdir
+    tmpdir="$(mktemp -d)"
+    local zpath="$tmpdir/droidcam.zip"
+
+    download_droidcam "$zpath" || { rm -rf "$tmpdir"; return 1; }
+    verify_droidcam "$zpath" || { rm -rf "$tmpdir"; return 1; }
+
+    echo "▸ Extracting..."
+    unzip -q -o "$zpath" -d "$tmpdir/droidcam"
+
+    echo "▸ Running install-client (sudo required)..."
+    cd "$tmpdir/droidcam"
+    sudo ./install-client || {
+        echo "✗ install-client failed."
+        rm -rf "$tmpdir"
+        return 1
+    }
+
+    echo ""
+    echo "▸ Compiling video module (v4l2loopback-dc) ..."
+    sudo ./install-video || {
+        echo "  ! install-video failed (this may be expected if you already have v4l2loopback from your distro)."
+    }
+
+    echo ""
+    echo "▸ Loading audio loopback module ..."
+    sudo ./install-sound || {
+        echo "  ! install-sound failed (optional — you may already have pipe wire/PulseAudio working)."
+    }
+
+    rm -rf "$tmpdir"
+    echo ""
+    echo "✓ DroidCam installed (official installer)."
+    return 0
+}
+
+case "$DISTRO" in
+    arch)
+        echo "▸ Detected: Arch Linux"
+        echo ""
+
+        # Find AUR helper
+        AUR_HELPER=""
+        for helper in yay paru; do
+            if command -v "$helper" >/dev/null 2>&1; then
+                AUR_HELPER="$helper"
+                break
+            fi
+        done
+
+        if [ -z "$AUR_HELPER" ]; then
+            echo "✗ No AUR helper (yay/paru) found."
+            echo "  Install one first:"
+            echo "    sudo pacman -S --needed base-devel git"
+            echo "    git clone https://aur.archlinux.org/yay.git /tmp/yay"
+            echo "    cd /tmp/yay && makepkg -si"
+            press_enter_to_close
+            exit 1
+        fi
+
+        echo "▸ Using AUR helper: $AUR_HELPER"
+        echo ""
+        # The 'droidcam' AUR package bundles the client AND the v4l2loopback-dc
+        # kernel module, so this single command covers everything.
+        $AUR_HELPER -S --needed droidcam
+
+        # Also install pactl (in pulseaudio-utils) for microphone routing.
+        if ! command -v pactl >/dev/null 2>&1; then
+            echo ""
+            echo "▸ Installing pactl (for microphone routing)..."
+            sudo pacman -S --needed --noconfirm pulseaudio-utils || \
+                sudo pacman -S --needed --noconfirm pipewire-pulse
+        fi
+
+        echo ""
+        echo "✓ DroidCam installed (Arch/AUR)."
+        ;;
+
+    fedora)
+        echo "▸ Detected: Fedora"
+        echo ""
+
+        # Enable RPM Fusion free repo (provides akmod-v4l2loopback and
+        # other multimedia packages we need).
+        if ! rpm -q rpmfusion-free-release >/dev/null 2>&1; then
+            fedora_ver="$(rpm -E %fedora 2>/dev/null || echo '')"
+            if [ -n "$fedora_ver" ]; then
+                echo "▸ Enabling RPM Fusion free repo (Fedora $fedora_ver)..."
+                sudo dnf install -y \
+                    "https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-${fedora_ver}.noarch.rpm" || {
+                    echo "  ! Could not enable RPM Fusion. Continuing anyway..."
+                }
+            fi
+        else
+            echo "▸ RPM Fusion already enabled."
+        fi
+        echo ""
+
+        # Install build/runtime deps.
+        #   • v4l2loopback-dkms does NOT exist on Fedora — use akmod-v4l2loopback
+        #     from RPM Fusion (auto-builds for any kernel).
+        #   • android-tools = adb
+        #   • libappindicator-gtk3 = systray icon (Ubuntu 21+/Fedora 33+ removed it pre-installed)
+        echo "▸ Installing runtime dependencies..."
+        sudo dnf install -y --skip-broken \
+            akmod-v4l2loopback \
+            v4l-utils \
+            pulseaudio-utils \
+            android-tools \
+            ffmpeg \
+            alsa-lib \
+            libappindicator-gtk3 \
+            kernel-devel \
+            kernel-headers \
+            gcc \
+            make \
+            curl \
+            unzip \
+            2>&1 || echo "  ! Some deps failed to install (continuing)."
+        echo ""
+
+        # Load the v4l2loopback kernel module now (akmod should have built it
+        # against the running kernel during the dnf install above).
+        echo "▸ Loading v4l2loopback kernel module..."
+        sudo modprobe v4l2loopback || echo "  ! modprobe v4l2loopback failed — you may need to reboot."
+        echo "v4l2loopback" | sudo tee /etc/modules-load.d/v4l2loopback.conf >/dev/null 2>&1 || true
+        echo ""
+
+        # Install the DroidCam client binary from official zip
+        # (it's not packaged in Fedora's repositories; only the kernel module is).
+        install_from_official_zip || {
+            echo ""
+            echo "✗ Installation failed."
+            press_enter_to_close
+            exit 1
+        }
+        ;;
+
+    debian)
+        echo "▸ Detected: Debian/Ubuntu"
+        echo ""
+
+        echo "▸ Installing build deps and pactl..."
+        sudo apt update
+        sudo apt install -y \
+            v4l2loopback-dkms \
+            v4l-utils \
+            pulseaudio-utils \
+            adb \
+            ffmpeg \
+            libappindicator3-1 \
+            libappindicator-gtk3-1 \
+            linux-headers-"$(uname -r)" \
+            build-essential \
+            curl \
+            unzip \
+            2>&1 || echo "  ! Some deps failed to install (continuing)."
+        echo ""
+
+        echo "▸ Loading v4l2loopback kernel module..."
+        sudo modprobe v4l2loopback || echo "  ! modprobe failed — you may need to reboot."
+        echo ""
+
+        install_from_official_zip || {
+            echo ""
+            echo "✗ Installation failed."
+            press_enter_to_close
+            exit 1
+        }
+        ;;
+
+    *)
+        echo "✗ Unsupported distribution."
+        echo ""
+        echo "Install manually following the docs below:"
+        echo "  Arch:    yay -S droidcam v4l2loopback-dkms pulseaudio-utils"
+        echo "  Fedora:  sudo dnf install akmod-v4l2loopback v4l-utils pulseaudio-utils"
+        echo "           Enable RPM Fusion free, then:"
+        echo "           Download from https://www.dev47apps.com/droidcam/linux/"
+        echo "  Debian:  sudo apt install v4l2loopback-dkms v4l-utils pulseaudio-utils"
+        echo "           Download from https://www.dev47apps.com/droidcam/linux/"
+        press_enter_to_close
+        exit 1
+        ;;
+esac
+
+echo ""
+echo "═══════════════════════════════════════════════"
+echo " Next steps:"
+echo "   1. Install DroidCam app on your Android phone"
+echo "   2. Open DroidCam on phone, enter IP, connect"
+echo "   3. Re-open the Phone tab in ImI — cards should"
+echo "      now show 'Ready' instead of 'Install'"
+echo "═══════════════════════════════════════════════"
+press_enter_to_close

--- a/dots/.config/quickshell/imi/scripts/phone/scrcpy_session_manager.py
+++ b/dots/.config/quickshell/imi/scripts/phone/scrcpy_session_manager.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""scrcpy session supervisor for the Phone tab (services/PhoneScrcpy.qml).
+
+One long-lived process speaking NDJSON on stdin/stdout. QML holds no scrcpy
+process handles: it sends commands and reads events, and this supervisor owns
+every scrcpy child, its window title and its exit.
+
+Commands (one JSON object per line on stdin):
+  {"cmd": "launch", "id": <session id>, "type": "mirror"|"app",
+   "target_args": [...], "extra_args": [...]}
+  {"cmd": "stop", "id": <session id>}
+  {"cmd": "stop_all"}
+  {"cmd": "focus", "id": <session id>}
+  {"cmd": "list_apps", "target_args": [...], "deviceId": <cache key>}
+
+Events (one JSON object per line on stdout):
+  started    {id, pid, title[, alreadyRunning]}
+  exited     {id, code, error}          error = scrcpy's last stderr line
+  error      {id, message}
+  apps_list  {deviceId, apps[, cached]} apps = [{package, name, system}]
+  apps_error {message}
+
+Every scrcpy child is spawned as
+  scrcpy [-s <serial>] --window-title=imi-phone-<type>-<id> <extra_args...>
+so that `focus` can address the window by its title and nothing else. The
+`-s` target is resolved from `adb devices` on every launch: a USB serial (no
+":" in it) wins over any ip:port, and only when adb lists nothing do the
+caller's target_args stand. A wireless target the caller names is `adb
+connect`ed first, bounded, so a phone on wireless debugging that adb has not
+seen yet still resolves.
+
+stdin closing means the shell went away; every session is stopped then, so a
+shell restart never leaves headless scrcpy windows behind.
+"""
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+CACHE_DIR = (Path(os.environ.get("XDG_CACHE_HOME") or Path.home() / ".cache")
+             / "immaterial-impulse" / "phone" / "apps")
+TITLE_PREFIX = "imi-phone-"
+
+# `scrcpy --list-apps` prints one app per line: `*` for a system app, `-` for
+# a user app, then the label, then the package. The label may carry spaces.
+APP_LINE = re.compile(r"^\s*([\*\-])\s+(.+?)\s+([a-zA-Z0-9_]+\.[a-zA-Z0-9_\.]+)\s*$")
+
+
+def session_title(type_str, session_id):
+    return TITLE_PREFIX + str(type_str) + "-" + str(session_id).replace(":", "_")
+
+
+def parse_app_list(lines):
+    apps = []
+    for line in lines:
+        match = APP_LINE.match(line)
+        if match:
+            symbol, name, pkg = match.groups()
+            apps.append({"package": pkg.strip(), "name": name.strip(),
+                         "system": symbol == "*"})
+    return apps
+
+
+def parse_pm_list(lines):
+    apps = []
+    for line in lines:
+        line = line.strip()
+        if line.startswith("package:"):
+            pkg = line[len("package:"):].strip()
+            apps.append({"package": pkg, "name": pkg.split(".")[-1].capitalize(),
+                         "system": False})
+    return apps
+
+
+def dedupe_sorted(apps):
+    seen = set()
+    unique = []
+    for app in apps:
+        if app["package"] in seen:
+            continue
+        seen.add(app["package"])
+        unique.append(app)
+    unique.sort(key=lambda app: app["name"].lower())
+    return unique
+
+
+def cache_path(device_id):
+    safe = re.sub(r"[^A-Za-z0-9_.-]", "_", str(device_id) or "default")
+    return CACHE_DIR / f"{safe}.json"
+
+
+class ScrcpySessionManager:
+    def __init__(self):
+        self.lock = threading.Lock()
+        self.processes = {}     # session_id -> subprocess.Popen
+        self.session_info = {}  # session_id -> {id, type, title, pid, startedAt}
+
+    def emit(self, event):
+        try:
+            print(json.dumps(event), flush=True)
+        except Exception as error:  # a closed stdout: nothing left to tell
+            sys.stderr.write(f"emit failed: {error}\n")
+
+    # ---- adb -------------------------------------------------------------
+
+    @staticmethod
+    def wireless_serial(target_args):
+        args = list(target_args or [])
+        for index, arg in enumerate(args):
+            if arg == "-s" and index + 1 < len(args) and ":" in args[index + 1]:
+                return args[index + 1]
+        return ""
+
+    def connect_wireless(self, target_args):
+        serial = self.wireless_serial(target_args)
+        if not serial:
+            return
+        try:
+            subprocess.run(["adb", "connect", serial], capture_output=True,
+                           text=True, timeout=4)
+        except Exception:
+            pass
+
+    def resolve_adb_target(self, target_args=None):
+        self.connect_wireless(target_args)
+        try:
+            res = subprocess.run(["adb", "devices"], capture_output=True,
+                                 text=True, timeout=4)
+            usb_devices = []
+            ip_devices = []
+            for line in res.stdout.splitlines():
+                line = line.strip()
+                if not line or line.startswith("List of"):
+                    continue
+                parts = line.split()
+                if len(parts) >= 2 and parts[1] == "device":
+                    serial = parts[0]
+                    (ip_devices if ":" in serial else usb_devices).append(serial)
+            if usb_devices:
+                return ["-s", usb_devices[0]]
+            if ip_devices:
+                return ["-s", ip_devices[0]]
+        except Exception:
+            pass
+        return list(target_args or [])
+
+    # ---- apps ------------------------------------------------------------
+
+    def emit_cached_apps(self, device_id):
+        path = cache_path(device_id)
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            apps = data.get("apps")
+        except Exception:
+            return
+        if isinstance(apps, list) and apps:
+            self.emit({"event": "apps_list", "deviceId": device_id,
+                       "apps": apps, "cached": True})
+
+    def write_cache(self, device_id, apps):
+        try:
+            CACHE_DIR.mkdir(parents=True, exist_ok=True)
+            path = cache_path(device_id)
+            tmp = path.with_suffix(".json.tmp")
+            tmp.write_text(json.dumps({"deviceId": device_id,
+                                       "generatedAt": int(time.time()),
+                                       "apps": apps}), encoding="utf-8")
+            os.replace(tmp, path)
+        except Exception as error:
+            sys.stderr.write(f"cache write failed: {error}\n")
+
+    def list_apps(self, target_args=None, device_id="default"):
+        device_id = device_id or "default"
+        self.emit_cached_apps(device_id)
+        target_args = self.resolve_adb_target(target_args)
+        try:
+            res = subprocess.run(["scrcpy"] + target_args + ["--list-apps"],
+                                 capture_output=True, text=True, timeout=10)
+            apps = parse_app_list(res.stdout.splitlines() + res.stderr.splitlines())
+
+            device_ok = True
+            if not apps:
+                res_adb = subprocess.run(
+                    ["adb"] + target_args + ["shell", "pm", "list", "packages", "-3"],
+                    capture_output=True, text=True, timeout=8)
+                device_ok = res_adb.returncode == 0
+                if device_ok:
+                    apps = parse_pm_list(res_adb.stdout.splitlines())
+
+            # A phone that dropped off ADB is an error, not an empty catalog:
+            # an empty list would wipe the apps already on screen.
+            if not apps and not device_ok:
+                self.emit({"event": "apps_error", "message": "Phone not reachable over ADB"})
+                return
+
+            unique = dedupe_sorted(apps)
+            self.write_cache(device_id, unique)
+            self.emit({"event": "apps_list", "deviceId": device_id, "apps": unique})
+        except Exception as error:
+            self.emit({"event": "apps_error", "message": f"Failed to list apps: {error}"})
+
+    # ---- sessions --------------------------------------------------------
+
+    def launch_session(self, session_id, type_str, target_args, extra_args):
+        if not session_id:
+            self.emit({"event": "error", "id": "", "message": "launch needs an id"})
+            return
+        with self.lock:
+            proc = self.processes.get(session_id)
+            if proc is not None and proc.poll() is None:
+                pid = proc.pid
+            else:
+                pid = None
+        if pid is not None:
+            self.focus_session(session_id)
+            self.emit({"event": "started", "id": session_id, "pid": pid,
+                       "title": session_title(type_str, session_id),
+                       "alreadyRunning": True})
+            return
+
+        title = session_title(type_str, session_id)
+        cmd = (["scrcpy"] + self.resolve_adb_target(target_args)
+               + ["--window-title=" + title] + list(extra_args or []))
+        try:
+            proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL,
+                                    stderr=subprocess.PIPE, text=True)
+        except Exception as error:
+            self.emit({"event": "error", "id": session_id,
+                       "message": f"Failed to launch scrcpy: {error}"})
+            return
+
+        with self.lock:
+            self.processes[session_id] = proc
+            self.session_info[session_id] = {
+                "id": session_id, "type": type_str, "title": title,
+                "pid": proc.pid, "startedAt": int(time.time())}
+        self.emit({"event": "started", "id": session_id, "pid": proc.pid, "title": title})
+        threading.Thread(target=self._wait_process, args=(session_id, proc),
+                         daemon=True).start()
+
+    def _wait_process(self, session_id, proc):
+        code = proc.wait()
+        err_msg = ""
+        try:
+            stderr_output = proc.stderr.read() if proc.stderr else ""
+            lines = [line for line in (stderr_output or "").splitlines() if line.strip()]
+            if lines:
+                err_msg = lines[-1].strip()
+        except Exception:
+            pass
+        with self.lock:
+            if self.processes.get(session_id) is proc:
+                del self.processes[session_id]
+                self.session_info.pop(session_id, None)
+        self.emit({"event": "exited", "id": session_id, "code": code, "error": err_msg})
+
+    def stop_session(self, session_id):
+        with self.lock:
+            proc = self.processes.get(session_id)
+        if proc is None or proc.poll() is not None:
+            return
+        try:
+            proc.terminate()
+            for _ in range(20):
+                if proc.poll() is not None:
+                    return
+                time.sleep(0.1)
+            proc.kill()
+        except Exception:
+            pass
+
+    def stop_all(self):
+        with self.lock:
+            ids = list(self.processes.keys())
+        for session_id in ids:
+            self.stop_session(session_id)
+
+    def focus_session(self, session_id):
+        with self.lock:
+            info = self.session_info.get(session_id)
+        if not info or not info.get("title"):
+            return
+        try:
+            subprocess.run(["hyprctl", "dispatch", "focuswindow", f"title:^{info['title']}$"],
+                           check=False, capture_output=True, timeout=4)
+        except Exception:
+            pass
+
+    # ---- protocol --------------------------------------------------------
+
+    def handle_line(self, line):
+        line = line.strip()
+        if not line:
+            return
+        try:
+            msg = json.loads(line)
+        except Exception as error:
+            sys.stderr.write(f"command parse error: {error}\n")
+            return
+        cmd = msg.get("cmd")
+        if cmd == "list_apps":
+            self.list_apps(target_args=msg.get("target_args"),
+                           device_id=msg.get("deviceId", "default"))
+        elif cmd == "launch":
+            self.launch_session(msg.get("id"), msg.get("type", "app"),
+                                msg.get("target_args"), msg.get("extra_args"))
+        elif cmd == "stop":
+            self.stop_session(msg.get("id"))
+        elif cmd == "stop_all":
+            self.stop_all()
+        elif cmd == "focus":
+            self.focus_session(msg.get("id"))
+        else:
+            sys.stderr.write(f"unknown command: {cmd}\n")
+
+    def run(self):
+        for line in sys.stdin:
+            self.handle_line(line)
+        self.stop_all()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="scrcpy session supervisor for Immaterial Impulse")
+    parser.add_argument("--list-apps", action="store_true", help="list apps once and exit")
+    parser.add_argument("--device-id", default="default", help="cache key for --list-apps")
+    args = parser.parse_args()
+
+    manager = ScrcpySessionManager()
+    if args.list_apps:
+        manager.list_apps(device_id=args.device_id)
+        return 0
+    manager.run()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dots/.config/quickshell/imi/scripts/phone/setup_droidcam_input.sh
+++ b/dots/.config/quickshell/imi/scripts/phone/setup_droidcam_input.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# setup_droidcam_input.sh — Creates a virtual null-sink for routing the DroidCam
+# audio stream as a microphone source in PulseAudio/PipeWire.
+#
+# Why: droidcam-cli (in audio mode) writes PCM to the default sink. To use it
+# as a *microphone* (source), we create a null-sink named "DroidCam-Mic" whose
+# `.monitor` source becomes an available input device for system apps.
+#
+# Output: prints the monitor source name on stdout (e.g. "alsa_output.DroidCam-Mic.monitor")
+#         so the QML service can use it with `pactl set-source-*` commands.
+# Exit codes: 0 on success (sink already existed or was created), 1 on failure.
+
+set -u
+
+SINK_NAME="DroidCam-Mic"
+SINK_DESC="DroidCam Microphone"
+
+if ! command -v pactl >/dev/null 2>&1; then
+    echo "pactl not installed" >&2
+    exit 1
+fi
+
+# Check if the null-sink is already loaded (idempotent).
+existing="$(pactl list short sinks 2>/dev/null | awk -v sink="$SINK_NAME" '$2 == sink {print $1; exit}' || true)"
+if [ -n "$existing" ]; then
+    # Already loaded — emit the monitor source name.
+    monitor_name=""
+    # PulseAudio convention: <driver>.<sink_name>.monitor
+    monitor_name="$(pactl list short sources 2>/dev/null | awk -v sink="$SINK_NAME" -v monitor="$SINK_NAME.monitor" '$2 == monitor {print $2; exit}')"
+    if [ -z "$monitor_name" ]; then
+        # Fallback: search by description match
+        monitor_name="$(pactl list sources 2>/dev/null | awk -v desc="$SINK_DESC" '
+            /Name:/ { name=$2 }
+            /Description:/ && $0 ~ desc { print name; exit }
+        ')"
+    fi
+    if [ -n "$monitor_name" ]; then
+        echo "$monitor_name"
+        exit 0
+    fi
+    # Fall through to recreate if monitor not found.
+fi
+
+# Load module-null-sink with the DroidCam name and description.
+pactl load-module module-null-sink \
+    sink_name="$SINK_NAME" \
+    sink_properties="device.description='$SINK_DESC'" \
+    >/dev/null 2>&1 || {
+        echo "Failed to load module-null-sink" >&2
+        exit 1
+    }
+
+# The monitor source follows the naming convention:
+#   <server_type>.<sink_name>.monitor
+# PipeWire (most common now): "alsa_output.DroidCam-Mic.monitor"
+# PulseAudio: same convention.
+MONITOR="alsa_output.${SINK_NAME}.monitor"
+found="$(pactl list short sources 2>/dev/null | awk -v m="$MONITOR" '$2 == m {print $2; exit}')"
+
+if [ -z "$found" ]; then
+    # Try alternate naming: just <sink_name>.monitor
+    MONITOR="${SINK_NAME}.monitor"
+    found="$(pactl list short sources 2>/dev/null | awk -v m="$MONITOR" '$2 == m {print $2; exit}')"
+fi
+
+if [ -z "$found" ]; then
+    # Last resort: search by description.
+    found="$(pactl list sources 2>/dev/null | awk -v desc="$SINK_DESC" '
+        /Name:/ { name=$2 }
+        /Description:/ && $0 ~ desc { print name; exit }
+    ')"
+fi
+
+if [ -z "$found" ]; then
+    echo "Could not find monitor source after loading null-sink" >&2
+    exit 1
+fi
+
+echo "$found"
+exit 0

--- a/dots/.config/quickshell/imi/scripts/phone/teardown_droidcam_input.sh
+++ b/dots/.config/quickshell/imi/scripts/phone/teardown_droidcam_input.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# teardown_droidcam_input.sh — Unloads the virtual null-sink created by
+# setup_droidcam_input.sh, cleaning up audio routing after DroidCam stops.
+#
+# Idempotent: does nothing if the null-sink isn't loaded.
+# Exit codes: 0 on success or no-op.
+
+set -u
+
+SINK_NAME="DroidCam-Mic"
+
+if ! command -v pactl >/dev/null 2>&1; then
+    exit 0
+fi
+
+# Find the module ID of the null-sink with our name and unload it.
+# `pactl list short modules` is the safest cross-server (PA/PW) way.
+module_id="$(pactl list short modules 2>/dev/null | awk -v sink="$SINK_NAME" '
+    $0 ~ "sink_name="sink { print $1; exit }
+' || true)"
+
+if [ -n "$module_id" ]; then
+    pactl unload-module "$module_id" >/dev/null 2>&1 || true
+fi
+
+exit 0

--- a/dots/.config/quickshell/imi/services/PhoneCamera.qml
+++ b/dots/.config/quickshell/imi/services/PhoneCamera.qml
@@ -1,0 +1,365 @@
+pragma Singleton
+pragma ComponentBehavior: Bound
+
+import Quickshell
+import Quickshell.Io
+import QtQuick
+import qs.modules.common
+
+/**
+ * The phone as a webcam, through DroidCam
+ * (docs/superpowers/specs/2026-08-27-phone-tab-design.md, W3).
+ *
+ * `droidcam-cli` streams the phone's camera into a v4l2loopback device.
+ * It is launched DETACHED through scripts/phone/droidcam_session.sh - the
+ * pidfile is the binary's own - so the webcam survives a shell restart and
+ * is re-adopted at boot from the session's state file. No streaming
+ * Process lives here: every command is a one-shot argv through one
+ * serialized queue, and liveness is the session script's `status` verb on
+ * a watchdog.
+ *
+ * Connection, USB first: an explicit `connection: "usb"` or a configured
+ * Wi-Fi address is taken as written; otherwise `adb get-state` answering
+ * `device` wins, then the first address KDE Connect reports for the phone.
+ *
+ * Everything between the sync markers is kept byte-for-byte in sync with
+ * the logic-only double (tests/imports/testservices/PhoneCamera.qml);
+ * tests/test_phone_sessions_contract.py enforces it.
+ */
+Singleton {
+    id: root
+
+    readonly property bool available: PhoneDeps.droidcamCli
+        && (PhoneDeps.v4l2loopbackLoaded || PhoneDeps.v4l2loopbackInstalled)
+    readonly property bool deviceReachable: PhoneConnect.activeDevice?.reachable === true
+    readonly property string activeDeviceId: String(PhoneConnect.activeDevice?.id ?? "")
+
+    property bool connecting: false
+    property bool active: false
+    // unavailable | offline | connecting | ready | active
+    readonly property string state: root.stateFor(root.available, root.deviceReachable, root.connecting, root.active)
+
+    property string device: "" // /dev/videoN
+    property string activeMode: "" // usb | wifi
+    property string activeIp: ""
+    property int activePort: 0
+    property int sessionPid: 0
+    property int startedAt: 0 // unix seconds
+    property string lastError: ""
+    property bool userStopped: false
+
+    readonly property string sessionScript: `${Directories.scriptPath}/phone/droidcam_session.sh`
+    readonly property int connectTimeoutMs: 9000
+    readonly property int successAfterMs: 6000
+
+    signal errorOccurred(string message)
+
+    // BEGIN phone-camera logic (synced with tests/imports/testservices/PhoneCamera.qml)
+    function stateFor(available: bool, reachable: bool, connecting: bool, active: bool): string {
+        if (!available) return "unavailable";
+        if (active) return "active";
+        if (connecting) return "connecting";
+        if (!reachable) return "offline";
+        return "ready";
+    }
+
+    // `v4l2-ctl --list-devices` prints a name line per device followed by
+    // its indented nodes. The first node under a DroidCam block wins; a
+    // loopback block is the fallback.
+    function parseV4l2Devices(text: string): string {
+        const lines = (text ?? "").split("\n");
+        const firstNodeUnder = (matcher) => {
+            let inBlock = false;
+            for (const raw of lines) {
+                const line = raw.replace(/\s+$/, "");
+                if (line.length === 0) continue;
+                const isNode = /^\s+\/dev\/video\d+/.test(line);
+                if (!isNode) {
+                    inBlock = matcher.test(line);
+                    continue;
+                }
+                if (inBlock) return line.trim();
+            }
+            return "";
+        };
+        return firstNodeUnder(/droid\s*cam/i) || firstNodeUnder(/loopback|dummy/i);
+    }
+
+    // droidcam-cli 2.1.5: single-dash flags, `-size=WxH`, then either
+    // `adb <port>` or `<ip> <port>`. Facing is not a flag (the app decides);
+    // 180 degrees is both flips.
+    function droidcamArgs(conf: var, mode: string, ip: string, port: int): var {
+        const c = conf ?? {};
+        const args = ["droidcam-cli", "-nocontrols"];
+        const size = String(c.resolution ?? "").trim();
+        if (size.length > 0) args.push("-size=" + size);
+        const rotate180 = Number(c.rotateDegrees) === 180;
+        if (c.mirrorHorizontally || rotate180) args.push("-hflip");
+        if (rotate180) args.push("-vflip");
+        if (mode === "usb") args.push("adb", String(port));
+        else args.push(String(ip), String(port));
+        return args;
+    }
+
+    // Where to connect, USB first. `adbState` is `adb get-state`'s answer
+    // (or "" when adb is absent); `addresses` is what KDE Connect reports.
+    function connectionPlan(conf: var, adbState: string, addresses: var): var {
+        const c = conf ?? {};
+        const port = Number(c.port) > 0 ? Number(c.port) : 4747;
+        if (c.connection === "usb") return { mode: "usb", ip: "", port: port };
+        const configured = String(c.wifiIp ?? "").trim();
+        if (configured.length > 0) return { mode: "wifi", ip: configured, port: port };
+        if (String(adbState ?? "").trim() === "device") return { mode: "usb", ip: "", port: port };
+        for (let i = 0; i < (addresses?.length ?? 0); i++) {
+            const address = String(addresses[i] ?? "").trim();
+            if (address.length > 0) return { mode: "wifi", ip: address, port: port };
+        }
+        return { error: "Could not detect USB or Wi-Fi IP. Plug the phone in with USB debugging on, or set the phone's Wi-Fi IP from the DroidCam app in the webcam settings." };
+    }
+
+    // The preview player: mpv, else ffplay, else vlc. Empty when none is there.
+    function previewCommand(device: string, deps: var): var {
+        const d = deps ?? {};
+        if (!device) return [];
+        if (d.mpv) return ["mpv", "--profile=low-latency", "--no-fullscreen", "--no-osc",
+                           "--title=imi webcam preview", "av://v4l2:" + device];
+        if (d.ffplay) return ["ffplay", "-fflags", "nobuffer", "-framedrop",
+                              "-window_title", "imi webcam preview", "-f", "v4l2", "-i", device];
+        if (d.vlc) return ["vlc", "--no-video-title-show", "--no-fullscreen", "v4l2://" + device];
+        return [];
+    }
+
+    // One `droidcam_session.sh status video` reply.
+    function parseSessionStatus(text: string): var {
+        try {
+            const doc = JSON.parse((text ?? "").trim());
+            if (!doc || typeof doc !== "object") return null;
+            return {
+                alive: doc.alive === true || doc.alive === "true",
+                pid: parseInt(doc.pid) || 0,
+                started: parseInt(doc.started) || 0,
+                port: parseInt(doc.port) || 0,
+                mode: String(doc.mode ?? ""),
+                ip: String(doc.ip ?? ""),
+                device: String(doc.device ?? "")
+            };
+        } catch (e) {
+            return null;
+        }
+    }
+
+    function fail(message: string): void {
+        root.connecting = false;
+        root.active = false;
+        root.lastError = message;
+        root.errorOccurred(message);
+    }
+
+    function start(): void {
+        if (!root.available || root.connecting || root.active) return;
+        if (!root.deviceReachable) {
+            root.fail("No reachable phone - pair a device first");
+            return;
+        }
+        root.connecting = true;
+        root.userStopped = false;
+        root.lastError = "";
+        const conf = Config.options.phone.webcam;
+        const direct = root.connectionPlan(conf, "", []);
+        if (!direct.error) {
+            root.launch(direct);
+            return;
+        }
+        root.run(["adb", "get-state"], (text, code) => {
+            const plan = root.connectionPlan(conf, code === 0 ? text : "",
+                PhoneConnect.activeDevice?.reachableAddresses ?? []);
+            if (plan.error) {
+                root.fail(plan.error);
+                return;
+            }
+            root.launch(plan);
+        });
+    }
+
+    function launch(plan: var): void {
+        const conf = Config.options.phone.webcam;
+        root.activeMode = plan.mode;
+        root.activeIp = plan.ip;
+        root.activePort = plan.port;
+        Persistent.states.phone.camera.lastMode = plan.mode;
+        Persistent.states.phone.camera.lastIp = plan.ip;
+        Persistent.states.phone.camera.lastPort = plan.port;
+        const argv = ["bash", root.sessionScript, "launch", "video"]
+            .concat(root.droidcamArgs(conf, plan.mode, plan.ip, plan.port));
+        root.run(argv, (text, code) => {
+            if (!root.connecting) return;
+            if (code !== 0) {
+                root.fail("DroidCam did not start - is the DroidCam app open on the phone?");
+                return;
+            }
+            root.sessionPid = parseInt(text) || 0;
+            root.armConnectTimers();
+        });
+    }
+
+    function adoptStatus(status: var): void {
+        root.sessionPid = status.pid;
+        root.startedAt = status.started;
+        root.activeMode = status.mode;
+        root.activeIp = status.ip;
+        root.activePort = status.port;
+        if (status.device) root.device = status.device;
+        root.connecting = false;
+        root.active = true;
+        root.lastError = "";
+        if (!status.device) root.detectDevice();
+        root.armWatchdog();
+    }
+
+    function checkSession(): void {
+        root.run(["bash", root.sessionScript, "status", "video"], (text, code) => {
+            const status = root.parseSessionStatus(text);
+            if (status && status.alive) {
+                if (!root.active) root.adoptStatus(status);
+                return;
+            }
+            if (root.active) {
+                root.active = false;
+                root.device = "";
+                root.disarmWatchdog();
+                if (!root.userStopped) root.fail("The webcam stream ended");
+            } else if (root.connecting && root.connectDeadlinePassed()) {
+                root.fail("Could not connect within " + Math.round(root.connectTimeoutMs / 1000)
+                    + "s - check that the DroidCam app is open and in Start mode");
+            }
+        });
+    }
+
+    function detectDevice(): void {
+        if (!PhoneDeps.v4l2Ctl) return;
+        root.run(["v4l2-ctl", "--list-devices"], (text, code) => {
+            const found = root.parseV4l2Devices(text);
+            if (found) root.device = found;
+        });
+    }
+
+    function stop(): void {
+        if (!root.connecting && !root.active) return;
+        root.userStopped = true;
+        root.disarmWatchdog();
+        root.connecting = false;
+        root.active = false;
+        root.device = "";
+        root.sessionPid = 0;
+        root.run(["bash", root.sessionScript, "stop", "video"], null);
+    }
+
+    function toggle(): void {
+        if (root.connecting || root.active) root.stop();
+        else root.start();
+    }
+
+    // Facing is the DroidCam app's setting; the shell only records the
+    // choice for the card.
+    function flip(): void {
+        const conf = Config.options.phone.webcam;
+        conf.cameraFacing = conf.cameraFacing === "front" ? "back" : "front";
+    }
+
+    function mirror(on: bool): void {
+        Config.options.phone.webcam.mirrorHorizontally = on;
+        if (root.active && root.device && PhoneDeps.v4l2Ctl)
+            root.run(["v4l2-ctl", "-d", root.device, "--set-ctrl=horizontal_flip=" + (on ? "1" : "0")], null);
+    }
+
+    function openPreview(): void {
+        const argv = root.previewCommand(root.device, PhoneDeps);
+        if (argv.length === 0) {
+            root.lastError = "No preview player found - install mpv";
+            root.errorOccurred(root.lastError);
+            return;
+        }
+        Quickshell.execDetached(argv);
+    }
+    // END phone-camera logic
+
+    // ---- timers ----
+
+    property real connectStartedAt: 0
+
+    function connectDeadlinePassed(): bool {
+        return Date.now() - root.connectStartedAt >= root.connectTimeoutMs;
+    }
+
+    function armConnectTimers(): void {
+        root.connectStartedAt = Date.now();
+        successTimer.restart();
+        failTimer.restart();
+    }
+
+    function armWatchdog(): void { watchdog.restart(); }
+    function disarmWatchdog(): void {
+        watchdog.stop();
+        successTimer.stop();
+        failTimer.stop();
+    }
+
+    // droidcam-cli stays alive through connection negotiation and prints
+    // transient errors; a process still alive this long in is a connection.
+    Timer {
+        id: successTimer
+        interval: root.successAfterMs
+        onTriggered: if (root.connecting) root.checkSession()
+    }
+
+    Timer {
+        id: failTimer
+        interval: root.connectTimeoutMs
+        onTriggered: if (root.connecting) root.checkSession()
+    }
+
+    Timer {
+        id: watchdog
+        interval: 5000
+        repeat: true
+        onTriggered: {
+            if (!root.active) { watchdog.stop(); return; }
+            root.checkSession();
+        }
+    }
+
+    // ---- the serialized command queue ----
+
+    property var callQueue: []
+    property var activeCallback: null
+
+    function run(argv: var, callback: var): void {
+        root.callQueue.push({ argv: argv, callback: callback });
+        root.pump();
+    }
+
+    function pump(): void {
+        if (cmdProc.running || root.callQueue.length === 0) return;
+        const next = root.callQueue.shift();
+        root.activeCallback = next.callback;
+        cmdProc.exec(next.argv);
+    }
+
+    Process {
+        id: cmdProc
+        environment: ({ LANG: "C", LC_ALL: "C" })
+        stdout: StdioCollector { id: cmdOut }
+        stderr: StdioCollector {}
+        onExited: (exitCode, exitStatus) => {
+            const callback = root.activeCallback;
+            root.activeCallback = null;
+            callback?.(cmdOut.text, exitCode);
+            root.pump();
+        }
+    }
+
+    // A webcam left running by the previous shell is adopted, not doubled.
+    Component.onCompleted: root.checkSession()
+
+    onActiveDeviceIdChanged: if (root.active || root.connecting) root.stop()
+}

--- a/dots/.config/quickshell/imi/services/PhoneDeps.qml
+++ b/dots/.config/quickshell/imi/services/PhoneDeps.qml
@@ -1,0 +1,364 @@
+pragma Singleton
+pragma ComponentBehavior: Bound
+
+import Quickshell
+import Quickshell.Io
+import QtQuick
+
+/**
+ * What the Phone tab's optional tooling looks like on this machine
+ * (docs/superpowers/specs/2026-08-27-phone-tab-design.md, W3).
+ *
+ * Nothing here is an installer dependency: scrcpy, adb, DroidCam, the
+ * v4l2loopback module, pactl and the preview players are all probed with a
+ * constant `command -v` at construction (tests/lint_capability_probe_gating.py
+ * is why every probe starts itself), and `missingFor(feature)` turns the
+ * flags into the install guide's rows - one per missing dependency, with
+ * the sibling fork's per-distro commands verbatim. `recheck()` re-runs
+ * every probe, which is what the guide's Re-check button and a finished
+ * install script call.
+ *
+ * The dependency table and the feature -> dependency mapping between the
+ * sync markers are kept byte-for-byte in sync with the logic-only double
+ * (tests/imports/testservices/PhoneDeps.qml);
+ * tests/test_phone_sessions_contract.py enforces it.
+ */
+Singleton {
+    id: root
+
+    property bool scrcpy: false
+    property bool adb: false
+    property bool droidcamCli: false
+    property bool v4l2Ctl: false
+    property bool pactl: false
+    property bool mpv: false
+    property bool ffplay: false
+    property bool vlc: false
+    property bool kdialog: false
+    property bool wlPaste: false
+    property bool v4l2loopbackLoaded: false
+    property bool v4l2loopbackInstalled: false
+    property string scrcpyVersion: ""
+    property int scrcpyMajor: 0
+    property int scrcpyMinor: 0
+    property string distro: "unknown" // arch | fedora | debian | unknown
+
+    readonly property bool appModeSupported: root.scrcpy && root.scrcpyMajor >= 4
+
+    // Probes still in flight. `ready` is false until the first sweep has
+    // answered, so a card reads "checking" rather than "install" while the
+    // probes run.
+    property int probesPending: 0
+    property bool probed: false
+    readonly property bool ready: root.probed && root.probesPending === 0
+
+    // BEGIN phone-deps logic (synced with tests/imports/testservices/PhoneDeps.qml)
+    // `scrcpy --version` prints "scrcpy 4.1 <url>" on its first line.
+    function parseScrcpyVersion(line: string): var {
+        const match = /^scrcpy\s+v?(\d+)\.(\d+)(?:\.(\d+))?/.exec((line ?? "").trim());
+        if (!match) return null;
+        return {
+            major: parseInt(match[1]),
+            minor: parseInt(match[2]),
+            version: match[1] + "." + match[2] + (match[3] ? "." + match[3] : "")
+        };
+    }
+
+    // The distro probe prints every marker file that exists, one per line;
+    // the first one names the distro.
+    function parseDistro(text: string): string {
+        for (const line of (text ?? "").split("\n")) {
+            const file = line.trim();
+            if (file === "/etc/arch-release") return "arch";
+            if (file === "/etc/fedora-release") return "fedora";
+            if (file === "/etc/debian_version") return "debian";
+        }
+        return "unknown";
+    }
+
+    // `lsmod` lists one module per line, name first. DroidCam's own build of
+    // the module is `v4l2loopback_dc`, which counts.
+    function parseLsmod(text: string): bool {
+        return (text ?? "").split("\n").some(line => /^v4l2loopback(\b|_)/.test(line.trim()));
+    }
+
+    // The install guide's rows: the sibling fork's table, verbatim.
+    function dependency(key: string): var {
+        const table = {
+            "scrcpy": {
+                name: Translation.tr("scrcpy"),
+                description: Translation.tr("Mirrors your phone screen in a floating SDL window. The main binary for screen mirroring."),
+                commands: {
+                    arch: "sudo pacman -S scrcpy",
+                    fedora: "sudo dnf install scrcpy",
+                    debian: "sudo apt install scrcpy"
+                }
+            },
+            "android-tools": {
+                name: Translation.tr("android-tools (adb)"),
+                description: Translation.tr("Required for USB connection, quick actions (screenshot, power button) and opening apps from notifications."),
+                commands: {
+                    arch: "sudo pacman -S android-tools",
+                    fedora: "sudo dnf install android-tools",
+                    debian: "sudo apt install android-tools-adb"
+                }
+            },
+            "droidcam-cli": {
+                name: Translation.tr("DroidCam CLI"),
+                description: Translation.tr("Connects to the DroidCam app on your phone and streams video to /dev/videoN"),
+                commands: {
+                    arch: "yay -S droidcam",
+                    fedora: "# Enable RPM Fusion first, then:\nsudo dnf install android-tools\n# Download from https://www.dev47apps.com/droidcam/linux/",
+                    debian: "# Download from https://www.dev47apps.com/droidcam/linux/\n# Or: sudo apt install droidcam"
+                }
+            },
+            "v4l2loopback": {
+                name: Translation.tr("v4l2loopback kernel module"),
+                description: Translation.tr("Creates virtual /dev/videoN devices that DroidCam writes to. Without it, droidcam-cli has nowhere to stream."),
+                commands: {
+                    arch: "yay -S v4l2loopback-dkms\nsudo modprobe v4l2loopback\necho v4l2loopback | sudo tee /etc/modules-load.d/v4l2loopback.conf",
+                    fedora: "sudo dnf install akmod-v4l2loopback\nsudo modprobe v4l2loopback\necho v4l2loopback | sudo tee /etc/modules-load.d/v4l2loopback.conf",
+                    debian: "sudo apt install v4l2loopback-dkms\nsudo modprobe v4l2loopback\necho v4l2loopback | sudo tee /etc/modules-load.d/v4l2loopback.conf"
+                }
+            },
+            "v4l-utils": {
+                name: Translation.tr("v4l-utils (v4l2-ctl)"),
+                description: Translation.tr("Recommended for device detection and live mirror/flip controls"),
+                commands: {
+                    arch: "sudo pacman -S v4l-utils",
+                    fedora: "sudo dnf install v4l-utils",
+                    debian: "sudo apt install v4l-utils"
+                }
+            },
+            "mpv": {
+                name: Translation.tr("mpv (optional)"),
+                description: Translation.tr("Recommended for the webcam preview window. Falls back to ffplay/vlc if absent."),
+                commands: {
+                    arch: "sudo pacman -S mpv",
+                    fedora: "sudo dnf install mpv",
+                    debian: "sudo apt install mpv"
+                }
+            },
+            "pactl": {
+                name: Translation.tr("pactl (PulseAudio/PipeWire CLI)"),
+                description: Translation.tr("Required for audio routing — creates a virtual null-sink that turns the phone mic stream into a recordable source."),
+                commands: {
+                    arch: "sudo pacman -S pulseaudio-utils",
+                    fedora: "sudo dnf install pulseaudio-utils",
+                    debian: "sudo apt install pulseaudio-utils"
+                }
+            },
+            "audio-backend": {
+                name: Translation.tr("scrcpy or DroidCam CLI"),
+                description: Translation.tr("At least one audio backend is needed. scrcpy is preferred (no extra app on phone). DroidCam CLI is the fallback."),
+                commands: {
+                    arch: "# Option 1 (preferred):\nsudo pacman -S scrcpy\n# Option 2:\nyay -S droidcam",
+                    fedora: "# Option 1 (preferred):\nsudo dnf install scrcpy\n# Option 2: install from https://www.dev47apps.com/droidcam/linux/",
+                    debian: "# Option 1 (preferred):\nsudo apt install scrcpy\n# Option 2:\nsudo apt install droidcam"
+                }
+            }
+        };
+        const entry = table[key];
+        if (!entry) return null;
+        return { key: key, name: entry.name, description: entry.description, commands: entry.commands };
+    }
+
+    // Which dependencies a feature is missing, given the presence flags.
+    // "mirror" is scrcpy + adb; "webcam" is DroidCam + the loopback module
+    // (loaded or merely installed), with v4l-utils and mpv recommended;
+    // "microphone" is pactl + either audio backend.
+    function missingDeps(feature: string, flags: var): var {
+        const f = flags ?? {};
+        const missing = [];
+        const need = (key, present) => { if (!present) missing.push(root.dependency(key)); };
+        if (feature === "mirror") {
+            need("scrcpy", f.scrcpy === true);
+            need("android-tools", f.adb === true);
+        } else if (feature === "webcam") {
+            need("droidcam-cli", f.droidcamCli === true);
+            need("v4l2loopback", f.v4l2loopbackLoaded === true || f.v4l2loopbackInstalled === true);
+            need("v4l-utils", f.v4l2Ctl === true);
+            need("mpv", f.mpv === true);
+        } else if (feature === "microphone") {
+            need("pactl", f.pactl === true);
+            need("audio-backend", f.scrcpy === true || f.droidcamCli === true);
+        }
+        return missing;
+    }
+    // END phone-deps logic
+
+    function flags(): var {
+        return {
+            scrcpy: root.scrcpy, adb: root.adb, droidcamCli: root.droidcamCli,
+            v4l2Ctl: root.v4l2Ctl, pactl: root.pactl, mpv: root.mpv, ffplay: root.ffplay,
+            vlc: root.vlc, kdialog: root.kdialog, wlPaste: root.wlPaste,
+            v4l2loopbackLoaded: root.v4l2loopbackLoaded,
+            v4l2loopbackInstalled: root.v4l2loopbackInstalled
+        };
+    }
+
+    function missingFor(feature: string): var {
+        return root.missingDeps(feature, root.flags());
+    }
+
+    // Starts one probe and counts it; ready() waits for the count to return
+    // to zero. Accounting hangs off `running` rather than `exited`, because a
+    // binary that is not there fails to start without ever exiting.
+    function startProbe(probe: var): void {
+        if (probe.running) return;
+        root.probesPending++;
+        probe.running = true;
+    }
+
+    function recheck(): void {
+        for (const probe of [scrcpyProbe, adbProbe, droidcamProbe, v4l2CtlProbe, pactlProbe,
+                             mpvProbe, ffplayProbe, vlcProbe, kdialogProbe, wlPasteProbe,
+                             lsmodProbe, modinfoProbe, distroProbe])
+            root.startProbe(probe);
+    }
+
+    function probeAnswered(): void {
+        root.probesPending = Math.max(0, root.probesPending - 1);
+    }
+
+    Component.onCompleted: root.probed = true
+
+    // One constant `command -v` per tool. Each starts itself at construction
+    // (the capability-probe lint's rule) and again from recheck(). The flag
+    // is written from onExited; the pending count from onRunningChanged.
+    Process {
+        id: scrcpyProbe
+        command: ["sh", "-c", "command -v scrcpy"]
+        Component.onCompleted: root.startProbe(this)
+        onRunningChanged: if (!running) root.probeAnswered()
+        onExited: (exitCode, exitStatus) => {
+            root.scrcpy = exitCode === 0;
+            if (root.scrcpy) {
+                root.startProbe(versionProbe);
+            } else {
+                root.scrcpyVersion = "";
+                root.scrcpyMajor = 0;
+                root.scrcpyMinor = 0;
+            }
+        }
+    }
+
+    Process {
+        id: versionProbe
+        command: ["scrcpy", "--version"]
+        stdout: StdioCollector { id: versionOut }
+        onRunningChanged: if (!running) root.probeAnswered()
+        onExited: (exitCode, exitStatus) => {
+            const parsed = root.parseScrcpyVersion(versionOut.text.split("\n")[0] ?? "");
+            root.scrcpyVersion = parsed?.version ?? "";
+            root.scrcpyMajor = parsed?.major ?? 0;
+            root.scrcpyMinor = parsed?.minor ?? 0;
+        }
+    }
+
+    Process {
+        id: adbProbe
+        command: ["sh", "-c", "command -v adb"]
+        Component.onCompleted: root.startProbe(this)
+        onRunningChanged: if (!running) root.probeAnswered()
+        onExited: (exitCode, exitStatus) => { root.adb = exitCode === 0; }
+    }
+
+    Process {
+        id: droidcamProbe
+        command: ["sh", "-c", "command -v droidcam-cli"]
+        Component.onCompleted: root.startProbe(this)
+        onRunningChanged: if (!running) root.probeAnswered()
+        onExited: (exitCode, exitStatus) => { root.droidcamCli = exitCode === 0; }
+    }
+
+    Process {
+        id: v4l2CtlProbe
+        command: ["sh", "-c", "command -v v4l2-ctl"]
+        Component.onCompleted: root.startProbe(this)
+        onRunningChanged: if (!running) root.probeAnswered()
+        onExited: (exitCode, exitStatus) => { root.v4l2Ctl = exitCode === 0; }
+    }
+
+    Process {
+        id: pactlProbe
+        command: ["sh", "-c", "command -v pactl"]
+        Component.onCompleted: root.startProbe(this)
+        onRunningChanged: if (!running) root.probeAnswered()
+        onExited: (exitCode, exitStatus) => { root.pactl = exitCode === 0; }
+    }
+
+    Process {
+        id: mpvProbe
+        command: ["sh", "-c", "command -v mpv"]
+        Component.onCompleted: root.startProbe(this)
+        onRunningChanged: if (!running) root.probeAnswered()
+        onExited: (exitCode, exitStatus) => { root.mpv = exitCode === 0; }
+    }
+
+    Process {
+        id: ffplayProbe
+        command: ["sh", "-c", "command -v ffplay"]
+        Component.onCompleted: root.startProbe(this)
+        onRunningChanged: if (!running) root.probeAnswered()
+        onExited: (exitCode, exitStatus) => { root.ffplay = exitCode === 0; }
+    }
+
+    Process {
+        id: vlcProbe
+        command: ["sh", "-c", "command -v vlc"]
+        Component.onCompleted: root.startProbe(this)
+        onRunningChanged: if (!running) root.probeAnswered()
+        onExited: (exitCode, exitStatus) => { root.vlc = exitCode === 0; }
+    }
+
+    Process {
+        id: kdialogProbe
+        command: ["sh", "-c", "command -v kdialog"]
+        Component.onCompleted: root.startProbe(this)
+        onRunningChanged: if (!running) root.probeAnswered()
+        onExited: (exitCode, exitStatus) => { root.kdialog = exitCode === 0; }
+    }
+
+    Process {
+        id: wlPasteProbe
+        command: ["sh", "-c", "command -v wl-paste"]
+        Component.onCompleted: root.startProbe(this)
+        onRunningChanged: if (!running) root.probeAnswered()
+        onExited: (exitCode, exitStatus) => { root.wlPaste = exitCode === 0; }
+    }
+
+    Process {
+        id: lsmodProbe
+        command: ["lsmod"]
+        stdout: StdioCollector { id: lsmodOut }
+        Component.onCompleted: root.startProbe(this)
+        onRunningChanged: if (!running) root.probeAnswered()
+        onExited: (exitCode, exitStatus) => {
+            root.v4l2loopbackLoaded = exitCode === 0 && root.parseLsmod(lsmodOut.text);
+        }
+    }
+
+    Process {
+        id: modinfoProbe
+        command: ["modinfo", "v4l2loopback"]
+        stdout: StdioCollector {}
+        stderr: StdioCollector {}
+        Component.onCompleted: root.startProbe(this)
+        onRunningChanged: if (!running) root.probeAnswered()
+        onExited: (exitCode, exitStatus) => {
+            root.v4l2loopbackInstalled = exitCode === 0;
+        }
+    }
+
+    Process {
+        id: distroProbe
+        command: ["sh", "-c", "for f in /etc/arch-release /etc/fedora-release /etc/debian_version; do [ -f \"$f\" ] && echo \"$f\"; done; true"]
+        stdout: StdioCollector { id: distroOut }
+        Component.onCompleted: root.startProbe(this)
+        onRunningChanged: if (!running) root.probeAnswered()
+        onExited: (exitCode, exitStatus) => {
+            root.distro = root.parseDistro(distroOut.text);
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/services/PhoneMic.qml
+++ b/dots/.config/quickshell/imi/services/PhoneMic.qml
@@ -1,0 +1,572 @@
+pragma Singleton
+pragma ComponentBehavior: Bound
+
+import Quickshell
+import Quickshell.Io
+import QtQuick
+import qs.modules.common
+
+/**
+ * The phone as a microphone
+ * (docs/superpowers/specs/2026-08-27-phone-tab-design.md, W3).
+ *
+ * The stream lands on a null sink named DroidCam-Mic, whose `.monitor`
+ * source is what applications record from - the routing the sibling fork
+ * arrived at, kept exactly:
+ *
+ *   scrcpy backend (preferred, no app on the phone): scrcpy --no-video
+ *   --no-window --audio-source=mic plays through SDL, which opens its
+ *   stream on the DEFAULT sink and ignores PULSE_SINK on PipeWire. So the
+ *   default sink is swapped to DroidCam-Mic for exactly as long as the
+ *   stream takes to appear (`pactl list sink-inputs` polled every 250 ms,
+ *   3 s ceiling) and then put back. The original sink is persisted in
+ *   Persistent.states.phone.mic.originalDefaultSink so a shell restart
+ *   mid-swap still restores it - the boot reconciliation below does that.
+ *
+ *   droidcam backend: `env PULSE_SINK=DroidCam-Mic droidcam-cli -a`, which
+ *   does honour the variable.
+ *
+ * scripts/phone/setup_droidcam_input.sh loads the null sink (idempotent)
+ * and prints the monitor source; teardown_droidcam_input.sh unloads it.
+ * Both audio processes are launched DETACHED through droidcam_session.sh
+ * so they survive a shell restart and are re-adopted at boot. No streaming
+ * Process lives here: every command is a one-shot argv through one
+ * serialized queue.
+ *
+ * Everything between the sync markers is kept byte-for-byte in sync with
+ * the logic-only double (tests/imports/testservices/PhoneMic.qml);
+ * tests/test_phone_sessions_contract.py enforces it.
+ */
+Singleton {
+    id: root
+
+    readonly property bool available: PhoneDeps.pactl && (PhoneDeps.scrcpy || PhoneDeps.droidcamCli)
+    readonly property string preferredBackend: PhoneDeps.scrcpy ? "scrcpy" : (PhoneDeps.droidcamCli ? "droidcam" : "")
+    readonly property bool deviceReachable: PhoneConnect.activeDevice?.reachable === true
+    readonly property string activeDeviceId: String(PhoneConnect.activeDevice?.id ?? "")
+
+    property bool connecting: false
+    property bool active: false
+    // unavailable | offline | connecting | ready | active
+    readonly property string state: root.stateFor(root.available, root.deviceReachable, root.connecting, root.active)
+
+    property string backend: "" // scrcpy | droidcam, while a session is up
+    property bool muted: false
+    property int gain: 100
+    property bool isDefaultInput: false
+    property string previousDefaultSource: ""
+    property string pulseSource: "" // the null sink's monitor source
+    property string activeMode: "" // usb | wifi | scrcpy
+    property string activeIp: ""
+    property int activePort: 0
+    property int sessionPid: 0
+    property int startedAt: 0
+    property string lastError: ""
+    property bool userStopped: false
+    // The user's default sink while it is swapped to DroidCam-Mic; "" when
+    // it is not. Mirrors Persistent so a restart can undo the swap.
+    property string swappedSink: Persistent.states.phone.mic.originalDefaultSink
+
+    readonly property string sinkName: "DroidCam-Mic"
+    readonly property string sessionScript: `${Directories.scriptPath}/phone/droidcam_session.sh`
+    readonly property string statusScript: `${Directories.scriptPath}/phone/droidcam_status.sh`
+    readonly property string setupScript: `${Directories.scriptPath}/phone/setup_droidcam_input.sh`
+    readonly property string teardownScript: `${Directories.scriptPath}/phone/teardown_droidcam_input.sh`
+    readonly property int connectTimeoutMs: 10000
+    readonly property int verifyAfterMs: 5000
+    readonly property int swapPollMs: 250
+    readonly property int swapCeilingMs: 3000
+
+    signal errorOccurred(string message)
+
+    // BEGIN phone-mic logic (synced with tests/imports/testservices/PhoneMic.qml)
+    function stateFor(available: bool, reachable: bool, connecting: bool, active: bool): string {
+        if (!available) return "unavailable";
+        if (active) return "active";
+        if (connecting) return "connecting";
+        if (!reachable) return "offline";
+        return "ready";
+    }
+
+    function sessionFor(backend: string): string {
+        return backend === "scrcpy" ? "scrcpy-mic" : "audio";
+    }
+
+    // scrcpy's mic capture, audio only, no window. Routing is the default
+    // sink swap, not a flag - there is none.
+    function scrcpyMicArgs(targetArgs: var): var {
+        return ["scrcpy", "--no-video", "--no-window", "--audio-source=mic", "--audio-buffer=50"]
+            .concat(targetArgs ?? []);
+    }
+
+    function droidcamAudioArgs(mode: string, ip: string, port: int): var {
+        const args = ["env", "PULSE_SINK=" + root.sinkName, "droidcam-cli", "-a", "-nocontrols"];
+        if (mode === "usb") args.push("adb", String(port));
+        else args.push(String(ip), String(port));
+        return args;
+    }
+
+    // Same rule as the webcam's: usb when asked, a configured address when
+    // given, else adb's answer, else KDE Connect's address.
+    function connectionPlan(conf: var, adbState: string, addresses: var): var {
+        const c = conf ?? {};
+        const port = Number(c.port) > 0 ? Number(c.port) : 4748;
+        if (c.connection === "usb") return { mode: "usb", ip: "", port: port };
+        const configured = String(c.wifiIp ?? "").trim();
+        if (configured.length > 0) return { mode: "wifi", ip: configured, port: port };
+        if (String(adbState ?? "").trim() === "device") return { mode: "usb", ip: "", port: port };
+        for (let i = 0; i < (addresses?.length ?? 0); i++) {
+            const address = String(addresses[i] ?? "").trim();
+            if (address.length > 0) return { mode: "wifi", ip: address, port: port };
+        }
+        return { error: "Could not detect USB or Wi-Fi IP. Plug the phone in with USB debugging on, or set the phone's Wi-Fi IP from the DroidCam app in the microphone settings." };
+    }
+
+    // `pactl list sink-inputs` names the application in several properties;
+    // any mention of scrcpy is its stream.
+    function streamPresent(sinkInputsText: string): bool {
+        return /scrcpy/i.test(sinkInputsText ?? "");
+    }
+
+    // One droidcam_status.sh reply, the two audio facts.
+    function parseStatus(text: string): var {
+        try {
+            const doc = JSON.parse((text ?? "").trim());
+            if (!doc || typeof doc !== "object") return null;
+            return {
+                audioRunning: doc.audio_running === true,
+                audioHasSinkInput: doc.audio_has_sink_input === true,
+                audioSource: String(doc.audio_source ?? "")
+            };
+        } catch (e) {
+            return null;
+        }
+    }
+
+    function parseSessionStatus(text: string): var {
+        try {
+            const doc = JSON.parse((text ?? "").trim());
+            if (!doc || typeof doc !== "object") return null;
+            return {
+                session: String(doc.session ?? ""),
+                alive: doc.alive === true || doc.alive === "true",
+                pid: parseInt(doc.pid) || 0,
+                started: parseInt(doc.started) || 0,
+                port: parseInt(doc.port) || 0,
+                mode: String(doc.mode ?? ""),
+                ip: String(doc.ip ?? "")
+            };
+        } catch (e) {
+            return null;
+        }
+    }
+
+    // What to do about the default sink at boot: a default of DroidCam-Mic
+    // with no live mic session is a swap the previous shell never undid.
+    function restorePlan(defaultSink: string, savedSink: string, sessionAlive: bool): string {
+        if (String(defaultSink ?? "").trim() !== root.sinkName) return "";
+        if (sessionAlive) return "";
+        const saved = String(savedSink ?? "").trim();
+        return (saved.length > 0 && saved !== root.sinkName) ? saved : "@DEFAULT_SINK@";
+    }
+
+    function muteArgs(source: string, muted: bool): var {
+        return ["pactl", "set-source-mute", source, muted ? "1" : "0"];
+    }
+
+    function gainArgs(source: string, percent: int): var {
+        return ["pactl", "set-source-volume", source, String(Math.max(0, Math.min(200, percent))) + "%"];
+    }
+
+    // A launch that went wrong: report it and undo whatever it had done.
+    function fail(message: string): void {
+        root.connecting = false;
+        root.active = false;
+        root.lastError = message;
+        root.errorOccurred(message);
+        root.restoreDefaultSink();
+        root.cleanupSession();
+    }
+
+    // A launch that never began: nothing to undo.
+    function refuse(message: string): void {
+        root.lastError = message;
+        root.errorOccurred(message);
+    }
+
+    function start(): void {
+        if (!root.available || root.connecting || root.active) return;
+        if (!root.deviceReachable) {
+            root.refuse("No reachable phone - pair a device first");
+            return;
+        }
+        root.connecting = true;
+        root.userStopped = false;
+        root.lastError = "";
+        root.backend = root.preferredBackend;
+        Persistent.states.phone.mic.lastBackend = root.backend;
+        // A loopback left by a previous "hear yourself" would otherwise
+        // stay for the whole session.
+        root.run(["pactl", "unload-module", "module-loopback"], null);
+        root.run(["bash", root.setupScript], (text, code) => {
+            if (!root.connecting) return;
+            const source = (text ?? "").trim().split("\n")[0] ?? "";
+            if (code !== 0 || source.length === 0) {
+                root.fail("Failed to create the DroidCam-Mic null sink - pactl may not have permission");
+                return;
+            }
+            root.pulseSource = source;
+            if (root.backend === "scrcpy") root.startScrcpy();
+            else root.startDroidcam();
+        });
+        root.armConnectTimers();
+    }
+
+    function startScrcpy(): void {
+        root.run(["pactl", "get-default-sink"], (text, code) => {
+            if (!root.connecting) return;
+            const original = (text ?? "").trim();
+            if (code !== 0 || original.length === 0) {
+                root.fail("Could not read the current default audio sink - audio routing aborted");
+                return;
+            }
+            if (original !== root.sinkName) root.rememberSwap(original);
+            root.run(["pactl", "set-default-sink", root.sinkName], (t, c) => {
+                if (!root.connecting) return;
+                root.activeMode = "scrcpy";
+                root.activeIp = "";
+                root.activePort = 0;
+                const target = PhoneScrcpy.targetArgs(Config.options.phone.scrcpy, PhoneConnect.activeDevice);
+                root.run(["bash", root.sessionScript, "launch", "scrcpy-mic"].concat(root.scrcpyMicArgs(target)),
+                    (out, rc) => {
+                        if (!root.connecting) return;
+                        root.sessionPid = parseInt(out) || 0;
+                        root.armSwapRestore();
+                        root.armVerify();
+                    });
+            });
+        });
+    }
+
+    function startDroidcam(): void {
+        const conf = Config.options.phone.microphone;
+        const direct = root.connectionPlan(conf, "", []);
+        if (!direct.error) {
+            root.launchDroidcam(direct);
+            return;
+        }
+        root.run(["adb", "get-state"], (text, code) => {
+            if (!root.connecting) return;
+            const plan = root.connectionPlan(conf, code === 0 ? text : "",
+                PhoneConnect.activeDevice?.reachableAddresses ?? []);
+            if (plan.error) {
+                root.fail(plan.error);
+                return;
+            }
+            root.launchDroidcam(plan);
+        });
+    }
+
+    function launchDroidcam(plan: var): void {
+        root.activeMode = plan.mode;
+        root.activeIp = plan.ip;
+        root.activePort = plan.port;
+        Persistent.states.phone.mic.lastMode = plan.mode;
+        Persistent.states.phone.mic.lastIp = plan.ip;
+        Persistent.states.phone.mic.lastPort = plan.port;
+        root.run(["bash", root.sessionScript, "launch", "audio"]
+            .concat(root.droidcamAudioArgs(plan.mode, plan.ip, plan.port)), (out, rc) => {
+                if (!root.connecting) return;
+                if (rc !== 0) {
+                    root.fail("DroidCam did not start - is the DroidCam app open on the phone?");
+                    return;
+                }
+                root.sessionPid = parseInt(out) || 0;
+                root.armVerify();
+            });
+    }
+
+    function rememberSwap(original: string): void {
+        root.swappedSink = original;
+        Persistent.states.phone.mic.originalDefaultSink = original;
+    }
+
+    function restoreDefaultSink(): void {
+        root.disarmSwapRestore();
+        const original = root.swappedSink;
+        if (!original) return;
+        root.swappedSink = "";
+        Persistent.states.phone.mic.originalDefaultSink = "";
+        root.run(["pactl", "set-default-sink", original], null);
+    }
+
+    // The swap has done its job the moment scrcpy's stream exists.
+    function pollSwap(): void {
+        root.run(["pactl", "list", "sink-inputs"], (text, code) => {
+            if (root.streamPresent(text)) root.restoreDefaultSink();
+        });
+    }
+
+    // Success is evidence, not a timer: the process is alive AND the null
+    // sink reports a running input, which droidcam_status.sh answers.
+    function verify(): void {
+        root.run(["bash", root.statusScript], (text, code) => {
+            if (!root.connecting) return;
+            const status = root.parseStatus(text);
+            if (status && status.audioRunning && status.audioHasSinkInput) {
+                root.becomeActive();
+            } else if (status && status.audioRunning) {
+                if (root.connectDeadlinePassed())
+                    root.fail("The phone microphone started but no audio reached the DroidCam-Mic sink - another audio processor may have claimed the stream");
+                else root.armVerifyRetry();
+            } else {
+                root.fail("Phone microphone process exited - check the phone connection and that USB or Wireless debugging is still on");
+            }
+        });
+    }
+
+    function becomeActive(): void {
+        root.connecting = false;
+        root.active = true;
+        root.lastError = "";
+        root.startedAt = Math.floor(Date.now() / 1000);
+        root.disarmConnectTimers();
+        // The stream is on the null sink, so the swap has done its job even
+        // if the poll never saw the sink-input appear.
+        root.restoreDefaultSink();
+        root.applyInitialState();
+        root.armWatchdog();
+    }
+
+    function applyInitialState(): void {
+        const conf = Config.options.phone.microphone;
+        root.muted = false;
+        root.gain = Number(conf.micGain) > 0 ? Number(conf.micGain) : 100;
+        if (root.gain !== 100) root.setGain(root.gain);
+        if (conf.setAsDefault) root.setAsDefaultInput();
+    }
+
+    function adoptSession(status: var): void {
+        root.backend = status.session === "scrcpy-mic" ? "scrcpy" : "droidcam";
+        root.sessionPid = status.pid;
+        root.startedAt = status.started;
+        root.activeMode = root.backend === "scrcpy" ? "scrcpy" : status.mode;
+        root.activeIp = status.ip;
+        root.activePort = status.port;
+        root.run(["bash", root.setupScript], (text, code) => {
+            root.pulseSource = (text ?? "").trim().split("\n")[0] ?? "";
+            root.connecting = false;
+            root.active = true;
+            root.lastError = "";
+            root.armWatchdog();
+        });
+    }
+
+    // Boot: adopt a live session, and undo a swap the last shell left behind.
+    function reconcile(): void {
+        root.run(["bash", root.sessionScript, "status", "scrcpy-mic"], (scrcpyText, c1) => {
+            const scrcpyStatus = root.parseSessionStatus(scrcpyText);
+            root.run(["bash", root.sessionScript, "status", "audio"], (audioText, c2) => {
+                const audioStatus = root.parseSessionStatus(audioText);
+                const live = (scrcpyStatus && scrcpyStatus.alive) ? scrcpyStatus
+                    : ((audioStatus && audioStatus.alive) ? audioStatus : null);
+                if (live && !root.active && !root.connecting) root.adoptSession(live);
+                root.run(["pactl", "get-default-sink"], (sinkText, c3) => {
+                    const target = root.restorePlan(sinkText, Persistent.states.phone.mic.originalDefaultSink, live !== null);
+                    if (!target) return;
+                    root.swappedSink = "";
+                    Persistent.states.phone.mic.originalDefaultSink = "";
+                    root.run(["pactl", "set-default-sink", target], null);
+                });
+            });
+        });
+    }
+
+    function checkSession(): void {
+        root.run(["bash", root.sessionScript, "status", root.sessionFor(root.backend)], (text, code) => {
+            const status = root.parseSessionStatus(text);
+            if (status && status.alive) return;
+            if (root.active) {
+                root.active = false;
+                root.disarmWatchdog();
+                if (!root.userStopped) root.fail("Microphone connection lost - the audio process exited");
+            }
+        });
+    }
+
+    function cleanupSession(): void {
+        root.run(["bash", root.sessionScript, "stop", "audio"], null);
+        root.run(["bash", root.sessionScript, "stop", "scrcpy-mic"], null);
+        root.run(["pactl", "unload-module", "module-loopback"], null);
+        root.run(["bash", root.teardownScript], null);
+        root.pulseSource = "";
+        root.sessionPid = 0;
+        root.startedAt = 0;
+    }
+
+    function stop(): void {
+        if (!root.connecting && !root.active) return;
+        root.userStopped = true;
+        root.disarmConnectTimers();
+        root.disarmWatchdog();
+        if (root.isDefaultInput) root.restoreDefaultInput();
+        root.restoreDefaultSink();
+        root.connecting = false;
+        root.active = false;
+        root.muted = false;
+        root.cleanupSession();
+    }
+
+    function toggle(): void {
+        if (root.connecting || root.active) root.stop();
+        else root.start();
+    }
+
+    function toggleMute(): void {
+        root.muted = !root.muted;
+        if (root.active && root.pulseSource)
+            root.run(root.muteArgs(root.pulseSource, root.muted), null);
+    }
+
+    function setGain(percent: int): void {
+        root.gain = Math.max(0, Math.min(200, percent));
+        Config.options.phone.microphone.micGain = root.gain;
+        if (root.active && root.pulseSource)
+            root.run(root.gainArgs(root.pulseSource, root.gain), null);
+    }
+
+    function setAsDefaultInput(): void {
+        if (!root.active || !root.pulseSource || root.isDefaultInput) return;
+        root.run(["pactl", "get-default-source"], (text, code) => {
+            const previous = (text ?? "").trim();
+            if (!root.active || !root.pulseSource) return;
+            root.previousDefaultSource = previous;
+            root.isDefaultInput = true;
+            root.run(["pactl", "set-default-source", root.pulseSource], null);
+        });
+    }
+
+    function restoreDefaultInput(): void {
+        if (!root.isDefaultInput) return;
+        root.isDefaultInput = false;
+        if (root.previousDefaultSource)
+            root.run(["pactl", "set-default-source", root.previousDefaultSource], null);
+        root.previousDefaultSource = "";
+    }
+    // END phone-mic logic
+
+    // ---- timers ----
+
+    property real connectStartedAt: 0
+
+    function connectDeadlinePassed(): bool {
+        return Date.now() - root.connectStartedAt >= root.connectTimeoutMs;
+    }
+
+    function armConnectTimers(): void {
+        root.connectStartedAt = Date.now();
+        failTimer.restart();
+    }
+
+    function disarmConnectTimers(): void {
+        failTimer.stop();
+        verifyTimer.stop();
+        verifyRetryTimer.stop();
+    }
+
+    function armVerify(): void { verifyTimer.restart(); }
+    function armVerifyRetry(): void { verifyRetryTimer.restart(); }
+
+    function armSwapRestore(): void {
+        swapTimer.elapsedMs = 0;
+        swapTimer.restart();
+    }
+
+    function disarmSwapRestore(): void { swapTimer.stop(); }
+    function armWatchdog(): void { watchdog.restart(); }
+    function disarmWatchdog(): void { watchdog.stop(); }
+
+    Timer {
+        id: failTimer
+        interval: root.connectTimeoutMs
+        onTriggered: {
+            if (!root.connecting) return;
+            root.fail("Could not connect within " + Math.round(root.connectTimeoutMs / 1000)
+                + "s - verify the phone is reachable and the DroidCam/scrcpy app is open");
+        }
+    }
+
+    Timer {
+        id: verifyTimer
+        interval: root.verifyAfterMs
+        onTriggered: if (root.connecting) root.verify()
+    }
+
+    Timer {
+        id: verifyRetryTimer
+        interval: 2000
+        onTriggered: if (root.connecting) root.verify()
+    }
+
+    // Every millisecond past the stream's creation is silence on the user's
+    // speakers, so the swap is polled rather than waited out.
+    Timer {
+        id: swapTimer
+        property int elapsedMs: 0
+        interval: root.swapPollMs
+        repeat: true
+        onTriggered: {
+            swapTimer.elapsedMs += swapTimer.interval;
+            if (swapTimer.elapsedMs >= root.swapCeilingMs) {
+                swapTimer.stop();
+                root.restoreDefaultSink();
+                return;
+            }
+            root.pollSwap();
+        }
+    }
+
+    Timer {
+        id: watchdog
+        interval: 5000
+        repeat: true
+        onTriggered: {
+            if (!root.active) { watchdog.stop(); return; }
+            root.checkSession();
+        }
+    }
+
+    // ---- the serialized command queue ----
+
+    property var callQueue: []
+    property var activeCallback: null
+
+    function run(argv: var, callback: var): void {
+        root.callQueue.push({ argv: argv, callback: callback });
+        root.pump();
+    }
+
+    function pump(): void {
+        if (cmdProc.running || root.callQueue.length === 0) return;
+        const next = root.callQueue.shift();
+        root.activeCallback = next.callback;
+        cmdProc.exec(next.argv);
+    }
+
+    Process {
+        id: cmdProc
+        environment: ({ LANG: "C", LC_ALL: "C" })
+        stdout: StdioCollector { id: cmdOut }
+        stderr: StdioCollector {}
+        onExited: (exitCode, exitStatus) => {
+            const callback = root.activeCallback;
+            root.activeCallback = null;
+            callback?.(cmdOut.text, exitCode);
+            root.pump();
+        }
+    }
+
+    Component.onCompleted: root.reconcile()
+
+    onActiveDeviceIdChanged: if (root.active || root.connecting) root.stop()
+}

--- a/dots/.config/quickshell/imi/services/PhoneScrcpy.qml
+++ b/dots/.config/quickshell/imi/services/PhoneScrcpy.qml
@@ -1,0 +1,437 @@
+pragma Singleton
+pragma ComponentBehavior: Bound
+
+import Quickshell
+import Quickshell.Io
+import QtQuick
+import qs.modules.common
+
+/**
+ * scrcpy for the Phone tab: the screen mirror and app mode
+ * (docs/superpowers/specs/2026-08-27-phone-tab-design.md, W3).
+ *
+ * QML holds no scrcpy process handle. One supervisor -
+ * scripts/phone/scrcpy_session_manager.py, NDJSON on stdin/stdout - owns
+ * every scrcpy child, its `imi-phone-<type>-<id>` window title and its
+ * exit; this service sends launch/stop/focus/list_apps and applies the
+ * started/exited/error/apps_list/apps_error events to the model. The
+ * supervisor is started on demand by the first command and stopped by a
+ * 10 s idle timer once no session is live and nothing is loading; a
+ * supervisor that dies with commands still queued is restarted on the
+ * DiscordVoice ladder (capped exponential backoff, five attempts), and one
+ * that dies with nothing queued is simply gone until the next command.
+ *
+ * `mirrorArgs()` and `appModeArgs()` are the flag tables, pure: the mirror
+ * takes Config.options.phone.scrcpy.*, app mode adds --start-app and the
+ * virtual display. `targetArgs()` names a wireless target when the user
+ * asked for one; the supervisor still prefers a USB serial over it.
+ *
+ * Everything between the sync markers is kept byte-for-byte in sync with
+ * the logic-only double (tests/imports/testservices/PhoneScrcpy.qml);
+ * tests/test_phone_sessions_contract.py enforces it.
+ */
+Singleton {
+    id: root
+
+    readonly property bool available: PhoneDeps.scrcpy
+    readonly property bool appModeSupported: PhoneDeps.appModeSupported
+    readonly property var activeDevice: PhoneConnect.activeDevice
+    // Tracked by id: the device OBJECT is rebuilt on every sweep, so a
+    // change handler on it would fire once a poll.
+    readonly property string activeDeviceId: String(PhoneConnect.activeDevice?.id ?? "")
+
+    property bool mirrorRunning: false
+    property bool mirrorLaunching: false
+    property string lastError: ""
+
+    // [{ name, package, system }]
+    property var apps: []
+    property bool appsLoading: false
+    property string appsError: ""
+
+    // One row per live scrcpy window: { id, type, title, pid, package, startedAt }.
+    readonly property alias sessions: sessionsModel
+    readonly property int sessionCount: sessionsModel.count
+
+    readonly property var favorites: Config.options.phone.scrcpy.appMode.favoritePackages
+    readonly property var recents: Persistent.states.phone.scrcpy.recentPackages
+    readonly property int maxRecents: 20
+
+    // idle | starting | running | restarting | stopped
+    property string managerState: "idle"
+    property int restartAttempts: 0
+    readonly property int maxRestartAttempts: 5
+    property var pendingMessages: []
+
+    signal feedback(string message, bool ok)
+
+    ListModel {
+        id: sessionsModel
+        dynamicRoles: true
+    }
+
+    // BEGIN phone-scrcpy logic (synced with tests/imports/testservices/PhoneScrcpy.qml)
+    // The mirror's flags, from Config.options.phone.scrcpy - the sibling
+    // fork's table. `--video-buffer` is scrcpy >= 2's name for the display
+    // buffer.
+    function mirrorArgs(opts: var): var {
+        const o = opts ?? {};
+        const args = [];
+        if (o.stayAwake) args.push("--stay-awake");
+        if (o.turnScreenOff) args.push("--turn-screen-off");
+        if (o.noPowerOn) args.push("--no-power-on");
+        if (o.noAudio) args.push("--no-audio");
+        if (o.showTouches) args.push("--show-touches");
+        if (o.fullscreen) args.push("--fullscreen");
+        if (o.alwaysOnTop) args.push("--always-on-top");
+        if (Number(o.maxFps) > 0) args.push("--max-fps=" + Number(o.maxFps));
+        if (typeof o.bitRate === "string" && o.bitRate.trim() !== "") args.push("--video-bit-rate=" + o.bitRate.trim());
+        if (Number(o.maxSize) > 0) args.push("--max-size=" + Number(o.maxSize));
+        if (Number(o.videoBuffer) > 0) args.push("--video-buffer=" + Number(o.videoBuffer));
+        return args;
+    }
+
+    // App mode: one app on a virtual display of its own when flexDisplay is
+    // on, otherwise started on the phone's screen and mirrored.
+    function appModeArgs(packageName: string, appOpts: var): var {
+        const o = appOpts ?? {};
+        const args = ["--start-app=" + packageName];
+        if (o.flexDisplay) {
+            const w = Number(o.displayWidth) > 0 ? Number(o.displayWidth) : 1280;
+            const h = Number(o.displayHeight) > 0 ? Number(o.displayHeight) : 960;
+            const density = Number(o.density) > 0 ? Number(o.density) : 160;
+            args.push("--new-display=" + w + "x" + h + "/" + density);
+            args.push("--flex-display");
+            if (o.keepActive) args.push("--keep-active");
+            if (o.systemDecorations === false) args.push("--no-vd-system-decorations");
+        }
+        return args;
+    }
+
+    // The `-s` target for a wireless phone: the address KDE Connect reaches
+    // it on (autoWirelessIp) or the configured one, with the configured
+    // port. Empty when the user did not ask for wireless or no address is
+    // known - the supervisor then lets adb pick, USB first.
+    function targetArgs(opts: var, device: var): var {
+        const o = opts ?? {};
+        if (!o.useWireless) return [];
+        let ip = "";
+        if (o.autoWirelessIp) {
+            const addresses = device?.reachableAddresses ?? [];
+            for (let i = 0; i < addresses.length; i++) {
+                const address = String(addresses[i] ?? "").trim();
+                if (address.length > 0) { ip = address; break; }
+            }
+        }
+        if (!ip) ip = String(o.wirelessIp ?? "").trim();
+        if (!ip) return [];
+        const port = String(o.wirelessPort ?? "").trim() || "5555";
+        return ["-s", ip.indexOf(":") >= 0 ? ip : ip + ":" + port];
+    }
+
+    function sessionIdFor(packageName: string): string {
+        return "app:" + packageName;
+    }
+
+    // MRU: the package moves to the front, the list is capped.
+    function pushRecent(list: var, packageName: string, max: int): var {
+        const out = [];
+        for (let i = 0; i < (list?.length ?? 0); i++) {
+            const entry = String(list[i]);
+            if (entry !== packageName) out.push(entry);
+        }
+        out.unshift(packageName);
+        return out.slice(0, max);
+    }
+
+    function toggleInList(list: var, packageName: string): var {
+        const out = [];
+        let found = false;
+        for (let i = 0; i < (list?.length ?? 0); i++) {
+            const entry = String(list[i]);
+            if (entry === packageName) { found = true; continue; }
+            out.push(entry);
+        }
+        if (!found) out.push(packageName);
+        return out;
+    }
+
+    function isFavorite(packageName: string): bool {
+        const list = root.favorites ?? [];
+        for (let i = 0; i < list.length; i++)
+            if (String(list[i]) === packageName) return true;
+        return false;
+    }
+
+    function sessionIndex(id: string): int {
+        for (let i = 0; i < sessionsModel.count; i++)
+            if (sessionsModel.get(i).id === id) return i;
+        return -1;
+    }
+
+    function isAppRunning(packageName: string): bool {
+        return root.sessionIndex(root.sessionIdFor(packageName)) >= 0;
+    }
+
+    // Delay before the Nth restart of the supervisor: 1s, 2s, 4s, ... 30s.
+    function backoffDelay(attempt: int): int {
+        return Math.min(30000, 1000 * Math.pow(2, Math.max(1, attempt) - 1));
+    }
+
+    // The supervisor is wanted while anything is live or pending - the
+    // idle timer stops it otherwise.
+    function managerWanted(): bool {
+        return sessionsModel.count > 0 || root.mirrorLaunching || root.appsLoading
+            || (root.pendingMessages?.length ?? 0) > 0;
+    }
+
+    function parseManagerLine(line: string): var {
+        const trimmed = (line ?? "").trim();
+        if (trimmed.length === 0) return null;
+        try {
+            const doc = JSON.parse(trimmed);
+            return (doc && typeof doc === "object" && typeof doc.event === "string") ? doc : null;
+        } catch (e) {
+            return null;
+        }
+    }
+
+    // One supervisor event onto the model.
+    function applyEvent(msg: var): void {
+        if (!msg) return;
+        const id = String(msg.id ?? "");
+        if (msg.event === "started") {
+            const row = {
+                id: id,
+                type: String(msg.type ?? (id === "mirror" ? "mirror" : "app")),
+                title: String(msg.title ?? ""),
+                pid: Number(msg.pid ?? 0),
+                package: id.startsWith("app:") ? id.substring(4) : "",
+                startedAt: Date.now()
+            };
+            const index = root.sessionIndex(id);
+            if (index >= 0) {
+                for (const key in row) if (key !== "startedAt") sessionsModel.setProperty(index, key, row[key]);
+            } else {
+                sessionsModel.append(row);
+            }
+            if (id === "mirror") {
+                root.mirrorRunning = true;
+                root.mirrorLaunching = false;
+            }
+        } else if (msg.event === "exited") {
+            const index = root.sessionIndex(id);
+            if (index >= 0) sessionsModel.remove(index);
+            if (id === "mirror") {
+                root.mirrorRunning = false;
+                root.mirrorLaunching = false;
+            }
+            if (Number(msg.code ?? 0) !== 0 && String(msg.error ?? "").length > 0) {
+                root.lastError = String(msg.error);
+                root.feedback(root.lastError, false);
+            }
+        } else if (msg.event === "error") {
+            if (id === "mirror") root.mirrorLaunching = false;
+            root.lastError = String(msg.message ?? "scrcpy error");
+            root.feedback(root.lastError, false);
+        } else if (msg.event === "apps_list") {
+            root.apps = Array.isArray(msg.apps) ? msg.apps : [];
+            // A cached list is served before the live one; loading stays on
+            // until the live one lands.
+            if (msg.cached !== true) {
+                root.appsLoading = false;
+                root.appsError = "";
+            }
+        } else if (msg.event === "apps_error") {
+            root.appsLoading = false;
+            root.appsError = String(msg.message ?? "Failed to list apps");
+        }
+    }
+
+    function handleLine(line: string): void {
+        root.applyEvent(root.parseManagerLine(line));
+    }
+
+    function deviceId(): string {
+        return root.activeDeviceId || "default";
+    }
+
+    function scrcpyTarget(): var {
+        return root.targetArgs(Config.options.phone.scrcpy, root.activeDevice);
+    }
+
+    function launchMirror(): void {
+        if (!root.available) {
+            root.lastError = "scrcpy is not installed";
+            return;
+        }
+        if (root.mirrorRunning) {
+            root.focusMirror();
+            return;
+        }
+        root.mirrorLaunching = true;
+        root.lastError = "";
+        root.send({
+            cmd: "launch", id: "mirror", type: "mirror",
+            target_args: root.scrcpyTarget(),
+            extra_args: root.mirrorArgs(Config.options.phone.scrcpy)
+        });
+    }
+
+    function stopMirror(): void {
+        root.send({ cmd: "stop", id: "mirror" });
+    }
+
+    function focusMirror(): void {
+        root.send({ cmd: "focus", id: "mirror" });
+    }
+
+    function refreshApps(): void {
+        if (!root.appModeSupported) return;
+        root.appsLoading = true;
+        root.appsError = "";
+        root.send({ cmd: "list_apps", target_args: root.scrcpyTarget(), deviceId: root.deviceId() });
+    }
+
+    function launchApp(packageName: string): void {
+        if (!packageName) return;
+        if (!root.appModeSupported) {
+            root.lastError = "scrcpy 4.0+ is required for App Mode";
+            root.feedback(root.lastError, false);
+            return;
+        }
+        if (root.isAppRunning(packageName)) {
+            root.focusApp(packageName);
+            return;
+        }
+        root.send({
+            cmd: "launch", id: root.sessionIdFor(packageName), type: "app",
+            target_args: root.scrcpyTarget(),
+            extra_args: root.appModeArgs(packageName, Config.options.phone.scrcpy.appMode)
+        });
+        Persistent.states.phone.scrcpy.recentPackages =
+            root.pushRecent(Persistent.states.phone.scrcpy.recentPackages, packageName, root.maxRecents);
+    }
+
+    function stopApp(packageName: string): void {
+        if (!packageName) return;
+        root.send({ cmd: "stop", id: root.sessionIdFor(packageName) });
+    }
+
+    function focusApp(packageName: string): void {
+        if (!packageName) return;
+        root.send({ cmd: "focus", id: root.sessionIdFor(packageName) });
+    }
+
+    function stopAllApps(): void {
+        root.send({ cmd: "stop_all" });
+    }
+
+    function toggleFavorite(packageName: string): void {
+        if (!packageName) return;
+        Config.options.phone.scrcpy.appMode.favoritePackages =
+            root.toggleInList(Config.options.phone.scrcpy.appMode.favoritePackages, packageName);
+    }
+    // END phone-scrcpy logic
+
+    // ---- the supervisor's lifetime ----
+
+    function send(message: var): void {
+        managerIdleTimer.restart();
+        if (!manager.running) {
+            root.pendingMessages = root.pendingMessages.concat([message]);
+            root.startManager(true);
+            return;
+        }
+        manager.write(JSON.stringify(message) + "\n");
+    }
+
+    function startManager(manual: bool): void {
+        if (manager.running) return;
+        if (manual) root.restartAttempts = 0;
+        restartTimer.stop();
+        root.managerState = "starting";
+        manager.running = true;
+    }
+
+    function flushPending(): void {
+        const queued = root.pendingMessages;
+        root.pendingMessages = [];
+        for (const message of queued)
+            manager.write(JSON.stringify(message) + "\n");
+    }
+
+    // The supervisor stops every session when its stdin closes, so this is
+    // only ever called with nothing live (managerWanted() false).
+    function stopManager(): void {
+        if (!manager.running) return;
+        root.managerState = "idle";
+        manager.running = false;
+    }
+
+    function clearLive(): void {
+        sessionsModel.clear();
+        root.mirrorRunning = false;
+        root.mirrorLaunching = false;
+        root.appsLoading = false;
+    }
+
+    onSessionCountChanged: managerIdleTimer.restart()
+    onAppsLoadingChanged: managerIdleTimer.restart()
+    onMirrorLaunchingChanged: managerIdleTimer.restart()
+
+    Timer {
+        id: managerIdleTimer
+        interval: 10000
+        onTriggered: {
+            if (root.managerWanted()) {
+                managerIdleTimer.restart();
+                return;
+            }
+            root.stopManager();
+        }
+    }
+
+    Timer {
+        id: restartTimer
+        onTriggered: root.startManager(false)
+    }
+
+    Process {
+        id: manager
+        // process-lifecycle: restart-safe -- capped exponential backoff; no running binding.
+        command: ["python3", `${Directories.scriptPath}/phone/scrcpy_session_manager.py`]
+        stdinEnabled: true
+        onStarted: {
+            root.managerState = "running";
+            root.flushPending();
+        }
+        stdout: SplitParser { onRead: data => root.handleLine(data) }
+        stderr: SplitParser { onRead: data => console.warn("[PhoneScrcpy]", data) }
+        onExited: (exitCode, exitStatus) => {
+            const wasDeliberate = root.managerState === "idle";
+            root.clearLive();
+            if (wasDeliberate || root.pendingMessages.length === 0) {
+                root.managerState = "idle";
+                return;
+            }
+            if (root.restartAttempts >= root.maxRestartAttempts) {
+                root.managerState = "stopped";
+                root.pendingMessages = [];
+                root.lastError = "scrcpy session manager stopped after repeated failures";
+                root.feedback(root.lastError, false);
+                return;
+            }
+            root.restartAttempts++;
+            root.managerState = "restarting";
+            restartTimer.interval = root.backoffDelay(root.restartAttempts);
+            restartTimer.restart();
+        }
+    }
+
+    // A device change is a different phone: what was mirrored is not what
+    // the tab is about any more.
+    onActiveDeviceIdChanged: {
+        if (sessionsModel.count > 0) root.send({ cmd: "stop_all" });
+    }
+}

--- a/dots/.config/quickshell/imi/tests/imports/testservices/PhoneCamera.qml
+++ b/dots/.config/quickshell/imi/tests/imports/testservices/PhoneCamera.qml
@@ -1,0 +1,303 @@
+pragma Singleton
+pragma ComponentBehavior: Bound
+
+import Quickshell
+import QtQuick
+import qs.modules.common
+
+// Logic-only double of services/PhoneCamera.qml: the serialized command
+// queue is `run()` answering synchronously from `responder`, recording
+// every argv in `ranCommands`; timers are inert. Everything between the
+// sync markers is byte-for-byte the real service's
+// (tests/test_phone_sessions_contract.py enforces it).
+Singleton {
+    id: root
+
+    property bool available: false
+    property bool deviceReachable: PhoneConnect.activeDevice?.reachable === true
+    readonly property string activeDeviceId: String(PhoneConnect.activeDevice?.id ?? "")
+
+    property bool connecting: false
+    property bool active: false
+    readonly property string state: root.stateFor(root.available, root.deviceReachable, root.connecting, root.active)
+
+    property string device: ""
+    property string activeMode: ""
+    property string activeIp: ""
+    property int activePort: 0
+    property int sessionPid: 0
+    property int startedAt: 0
+    property string lastError: ""
+    property bool userStopped: false
+
+    readonly property string sessionScript: "/mock/phone/droidcam_session.sh"
+    readonly property int connectTimeoutMs: 9000
+    readonly property int successAfterMs: 6000
+
+    signal errorOccurred(string message)
+
+    // BEGIN phone-camera logic (synced with services/PhoneCamera.qml)
+    function stateFor(available: bool, reachable: bool, connecting: bool, active: bool): string {
+        if (!available) return "unavailable";
+        if (active) return "active";
+        if (connecting) return "connecting";
+        if (!reachable) return "offline";
+        return "ready";
+    }
+
+    // `v4l2-ctl --list-devices` prints a name line per device followed by
+    // its indented nodes. The first node under a DroidCam block wins; a
+    // loopback block is the fallback.
+    function parseV4l2Devices(text: string): string {
+        const lines = (text ?? "").split("\n");
+        const firstNodeUnder = (matcher) => {
+            let inBlock = false;
+            for (const raw of lines) {
+                const line = raw.replace(/\s+$/, "");
+                if (line.length === 0) continue;
+                const isNode = /^\s+\/dev\/video\d+/.test(line);
+                if (!isNode) {
+                    inBlock = matcher.test(line);
+                    continue;
+                }
+                if (inBlock) return line.trim();
+            }
+            return "";
+        };
+        return firstNodeUnder(/droid\s*cam/i) || firstNodeUnder(/loopback|dummy/i);
+    }
+
+    // droidcam-cli 2.1.5: single-dash flags, `-size=WxH`, then either
+    // `adb <port>` or `<ip> <port>`. Facing is not a flag (the app decides);
+    // 180 degrees is both flips.
+    function droidcamArgs(conf: var, mode: string, ip: string, port: int): var {
+        const c = conf ?? {};
+        const args = ["droidcam-cli", "-nocontrols"];
+        const size = String(c.resolution ?? "").trim();
+        if (size.length > 0) args.push("-size=" + size);
+        const rotate180 = Number(c.rotateDegrees) === 180;
+        if (c.mirrorHorizontally || rotate180) args.push("-hflip");
+        if (rotate180) args.push("-vflip");
+        if (mode === "usb") args.push("adb", String(port));
+        else args.push(String(ip), String(port));
+        return args;
+    }
+
+    // Where to connect, USB first. `adbState` is `adb get-state`'s answer
+    // (or "" when adb is absent); `addresses` is what KDE Connect reports.
+    function connectionPlan(conf: var, adbState: string, addresses: var): var {
+        const c = conf ?? {};
+        const port = Number(c.port) > 0 ? Number(c.port) : 4747;
+        if (c.connection === "usb") return { mode: "usb", ip: "", port: port };
+        const configured = String(c.wifiIp ?? "").trim();
+        if (configured.length > 0) return { mode: "wifi", ip: configured, port: port };
+        if (String(adbState ?? "").trim() === "device") return { mode: "usb", ip: "", port: port };
+        for (let i = 0; i < (addresses?.length ?? 0); i++) {
+            const address = String(addresses[i] ?? "").trim();
+            if (address.length > 0) return { mode: "wifi", ip: address, port: port };
+        }
+        return { error: "Could not detect USB or Wi-Fi IP. Plug the phone in with USB debugging on, or set the phone's Wi-Fi IP from the DroidCam app in the webcam settings." };
+    }
+
+    // The preview player: mpv, else ffplay, else vlc. Empty when none is there.
+    function previewCommand(device: string, deps: var): var {
+        const d = deps ?? {};
+        if (!device) return [];
+        if (d.mpv) return ["mpv", "--profile=low-latency", "--no-fullscreen", "--no-osc",
+                           "--title=imi webcam preview", "av://v4l2:" + device];
+        if (d.ffplay) return ["ffplay", "-fflags", "nobuffer", "-framedrop",
+                              "-window_title", "imi webcam preview", "-f", "v4l2", "-i", device];
+        if (d.vlc) return ["vlc", "--no-video-title-show", "--no-fullscreen", "v4l2://" + device];
+        return [];
+    }
+
+    // One `droidcam_session.sh status video` reply.
+    function parseSessionStatus(text: string): var {
+        try {
+            const doc = JSON.parse((text ?? "").trim());
+            if (!doc || typeof doc !== "object") return null;
+            return {
+                alive: doc.alive === true || doc.alive === "true",
+                pid: parseInt(doc.pid) || 0,
+                started: parseInt(doc.started) || 0,
+                port: parseInt(doc.port) || 0,
+                mode: String(doc.mode ?? ""),
+                ip: String(doc.ip ?? ""),
+                device: String(doc.device ?? "")
+            };
+        } catch (e) {
+            return null;
+        }
+    }
+
+    function fail(message: string): void {
+        root.connecting = false;
+        root.active = false;
+        root.lastError = message;
+        root.errorOccurred(message);
+    }
+
+    function start(): void {
+        if (!root.available || root.connecting || root.active) return;
+        if (!root.deviceReachable) {
+            root.fail("No reachable phone - pair a device first");
+            return;
+        }
+        root.connecting = true;
+        root.userStopped = false;
+        root.lastError = "";
+        const conf = Config.options.phone.webcam;
+        const direct = root.connectionPlan(conf, "", []);
+        if (!direct.error) {
+            root.launch(direct);
+            return;
+        }
+        root.run(["adb", "get-state"], (text, code) => {
+            const plan = root.connectionPlan(conf, code === 0 ? text : "",
+                PhoneConnect.activeDevice?.reachableAddresses ?? []);
+            if (plan.error) {
+                root.fail(plan.error);
+                return;
+            }
+            root.launch(plan);
+        });
+    }
+
+    function launch(plan: var): void {
+        const conf = Config.options.phone.webcam;
+        root.activeMode = plan.mode;
+        root.activeIp = plan.ip;
+        root.activePort = plan.port;
+        Persistent.states.phone.camera.lastMode = plan.mode;
+        Persistent.states.phone.camera.lastIp = plan.ip;
+        Persistent.states.phone.camera.lastPort = plan.port;
+        const argv = ["bash", root.sessionScript, "launch", "video"]
+            .concat(root.droidcamArgs(conf, plan.mode, plan.ip, plan.port));
+        root.run(argv, (text, code) => {
+            if (!root.connecting) return;
+            if (code !== 0) {
+                root.fail("DroidCam did not start - is the DroidCam app open on the phone?");
+                return;
+            }
+            root.sessionPid = parseInt(text) || 0;
+            root.armConnectTimers();
+        });
+    }
+
+    function adoptStatus(status: var): void {
+        root.sessionPid = status.pid;
+        root.startedAt = status.started;
+        root.activeMode = status.mode;
+        root.activeIp = status.ip;
+        root.activePort = status.port;
+        if (status.device) root.device = status.device;
+        root.connecting = false;
+        root.active = true;
+        root.lastError = "";
+        if (!status.device) root.detectDevice();
+        root.armWatchdog();
+    }
+
+    function checkSession(): void {
+        root.run(["bash", root.sessionScript, "status", "video"], (text, code) => {
+            const status = root.parseSessionStatus(text);
+            if (status && status.alive) {
+                if (!root.active) root.adoptStatus(status);
+                return;
+            }
+            if (root.active) {
+                root.active = false;
+                root.device = "";
+                root.disarmWatchdog();
+                if (!root.userStopped) root.fail("The webcam stream ended");
+            } else if (root.connecting && root.connectDeadlinePassed()) {
+                root.fail("Could not connect within " + Math.round(root.connectTimeoutMs / 1000)
+                    + "s - check that the DroidCam app is open and in Start mode");
+            }
+        });
+    }
+
+    function detectDevice(): void {
+        if (!PhoneDeps.v4l2Ctl) return;
+        root.run(["v4l2-ctl", "--list-devices"], (text, code) => {
+            const found = root.parseV4l2Devices(text);
+            if (found) root.device = found;
+        });
+    }
+
+    function stop(): void {
+        if (!root.connecting && !root.active) return;
+        root.userStopped = true;
+        root.disarmWatchdog();
+        root.connecting = false;
+        root.active = false;
+        root.device = "";
+        root.sessionPid = 0;
+        root.run(["bash", root.sessionScript, "stop", "video"], null);
+    }
+
+    function toggle(): void {
+        if (root.connecting || root.active) root.stop();
+        else root.start();
+    }
+
+    // Facing is the DroidCam app's setting; the shell only records the
+    // choice for the card.
+    function flip(): void {
+        const conf = Config.options.phone.webcam;
+        conf.cameraFacing = conf.cameraFacing === "front" ? "back" : "front";
+    }
+
+    function mirror(on: bool): void {
+        Config.options.phone.webcam.mirrorHorizontally = on;
+        if (root.active && root.device && PhoneDeps.v4l2Ctl)
+            root.run(["v4l2-ctl", "-d", root.device, "--set-ctrl=horizontal_flip=" + (on ? "1" : "0")], null);
+    }
+
+    function openPreview(): void {
+        const argv = root.previewCommand(root.device, PhoneDeps);
+        if (argv.length === 0) {
+            root.lastError = "No preview player found - install mpv";
+            root.errorOccurred(root.lastError);
+            return;
+        }
+        Quickshell.execDetached(argv);
+    }
+    // END phone-camera logic
+    property real connectStartedAt: 0
+    property bool deadlinePassed: false
+    function connectDeadlinePassed(): bool { return root.deadlinePassed; }
+    property int connectTimersArmed: 0
+    property int watchdogArmed: 0
+    function armConnectTimers(): void { root.connectTimersArmed++; }
+    function armWatchdog(): void { root.watchdogArmed++; }
+    function disarmWatchdog(): void { root.watchdogArmed = 0; }
+
+    // responder(argv) -> { text, code } or null (empty output, exit 0)
+    property var responder: null
+    property var ranCommands: []
+
+    function run(argv: var, callback: var): void {
+        root.ranCommands = root.ranCommands.concat([argv]);
+        const reply = root.responder ? root.responder(argv) : null;
+        callback?.(reply?.text ?? "", reply?.code ?? 0);
+    }
+
+    function reset(): void {
+        root.connecting = false;
+        root.active = false;
+        root.device = "";
+        root.activeMode = "";
+        root.activeIp = "";
+        root.activePort = 0;
+        root.sessionPid = 0;
+        root.startedAt = 0;
+        root.lastError = "";
+        root.userStopped = false;
+        root.deadlinePassed = false;
+        root.connectTimersArmed = 0;
+        root.watchdogArmed = 0;
+        root.responder = null;
+        root.ranCommands = [];
+    }
+}

--- a/dots/.config/quickshell/imi/tests/imports/testservices/PhoneDeps.qml
+++ b/dots/.config/quickshell/imi/tests/imports/testservices/PhoneDeps.qml
@@ -1,0 +1,190 @@
+pragma Singleton
+pragma ComponentBehavior: Bound
+
+import Quickshell
+import QtQuick
+import qs.services
+
+// Logic-only double of services/PhoneDeps.qml: the flags are plain
+// properties a test sets, the dependency table and the feature mapping
+// between the sync markers are byte-for-byte the real service's
+// (tests/test_phone_sessions_contract.py enforces it), and no probe runs.
+Singleton {
+    id: root
+
+    property bool scrcpy: false
+    property bool adb: false
+    property bool droidcamCli: false
+    property bool v4l2Ctl: false
+    property bool pactl: false
+    property bool mpv: false
+    property bool ffplay: false
+    property bool vlc: false
+    property bool kdialog: false
+    property bool wlPaste: false
+    property bool v4l2loopbackLoaded: false
+    property bool v4l2loopbackInstalled: false
+    property string scrcpyVersion: ""
+    property int scrcpyMajor: 0
+    property int scrcpyMinor: 0
+    property string distro: "unknown"
+
+    readonly property bool appModeSupported: root.scrcpy && root.scrcpyMajor >= 4
+
+    property int probesPending: 0
+    property bool probed: true
+    readonly property bool ready: root.probed && root.probesPending === 0
+    property int rechecks: 0
+
+    // BEGIN phone-deps logic (synced with services/PhoneDeps.qml)
+    // `scrcpy --version` prints "scrcpy 4.1 <url>" on its first line.
+    function parseScrcpyVersion(line: string): var {
+        const match = /^scrcpy\s+v?(\d+)\.(\d+)(?:\.(\d+))?/.exec((line ?? "").trim());
+        if (!match) return null;
+        return {
+            major: parseInt(match[1]),
+            minor: parseInt(match[2]),
+            version: match[1] + "." + match[2] + (match[3] ? "." + match[3] : "")
+        };
+    }
+
+    // The distro probe prints every marker file that exists, one per line;
+    // the first one names the distro.
+    function parseDistro(text: string): string {
+        for (const line of (text ?? "").split("\n")) {
+            const file = line.trim();
+            if (file === "/etc/arch-release") return "arch";
+            if (file === "/etc/fedora-release") return "fedora";
+            if (file === "/etc/debian_version") return "debian";
+        }
+        return "unknown";
+    }
+
+    // `lsmod` lists one module per line, name first. DroidCam's own build of
+    // the module is `v4l2loopback_dc`, which counts.
+    function parseLsmod(text: string): bool {
+        return (text ?? "").split("\n").some(line => /^v4l2loopback(\b|_)/.test(line.trim()));
+    }
+
+    // The install guide's rows: the sibling fork's table, verbatim.
+    function dependency(key: string): var {
+        const table = {
+            "scrcpy": {
+                name: Translation.tr("scrcpy"),
+                description: Translation.tr("Mirrors your phone screen in a floating SDL window. The main binary for screen mirroring."),
+                commands: {
+                    arch: "sudo pacman -S scrcpy",
+                    fedora: "sudo dnf install scrcpy",
+                    debian: "sudo apt install scrcpy"
+                }
+            },
+            "android-tools": {
+                name: Translation.tr("android-tools (adb)"),
+                description: Translation.tr("Required for USB connection, quick actions (screenshot, power button) and opening apps from notifications."),
+                commands: {
+                    arch: "sudo pacman -S android-tools",
+                    fedora: "sudo dnf install android-tools",
+                    debian: "sudo apt install android-tools-adb"
+                }
+            },
+            "droidcam-cli": {
+                name: Translation.tr("DroidCam CLI"),
+                description: Translation.tr("Connects to the DroidCam app on your phone and streams video to /dev/videoN"),
+                commands: {
+                    arch: "yay -S droidcam",
+                    fedora: "# Enable RPM Fusion first, then:\nsudo dnf install android-tools\n# Download from https://www.dev47apps.com/droidcam/linux/",
+                    debian: "# Download from https://www.dev47apps.com/droidcam/linux/\n# Or: sudo apt install droidcam"
+                }
+            },
+            "v4l2loopback": {
+                name: Translation.tr("v4l2loopback kernel module"),
+                description: Translation.tr("Creates virtual /dev/videoN devices that DroidCam writes to. Without it, droidcam-cli has nowhere to stream."),
+                commands: {
+                    arch: "yay -S v4l2loopback-dkms\nsudo modprobe v4l2loopback\necho v4l2loopback | sudo tee /etc/modules-load.d/v4l2loopback.conf",
+                    fedora: "sudo dnf install akmod-v4l2loopback\nsudo modprobe v4l2loopback\necho v4l2loopback | sudo tee /etc/modules-load.d/v4l2loopback.conf",
+                    debian: "sudo apt install v4l2loopback-dkms\nsudo modprobe v4l2loopback\necho v4l2loopback | sudo tee /etc/modules-load.d/v4l2loopback.conf"
+                }
+            },
+            "v4l-utils": {
+                name: Translation.tr("v4l-utils (v4l2-ctl)"),
+                description: Translation.tr("Recommended for device detection and live mirror/flip controls"),
+                commands: {
+                    arch: "sudo pacman -S v4l-utils",
+                    fedora: "sudo dnf install v4l-utils",
+                    debian: "sudo apt install v4l-utils"
+                }
+            },
+            "mpv": {
+                name: Translation.tr("mpv (optional)"),
+                description: Translation.tr("Recommended for the webcam preview window. Falls back to ffplay/vlc if absent."),
+                commands: {
+                    arch: "sudo pacman -S mpv",
+                    fedora: "sudo dnf install mpv",
+                    debian: "sudo apt install mpv"
+                }
+            },
+            "pactl": {
+                name: Translation.tr("pactl (PulseAudio/PipeWire CLI)"),
+                description: Translation.tr("Required for audio routing — creates a virtual null-sink that turns the phone mic stream into a recordable source."),
+                commands: {
+                    arch: "sudo pacman -S pulseaudio-utils",
+                    fedora: "sudo dnf install pulseaudio-utils",
+                    debian: "sudo apt install pulseaudio-utils"
+                }
+            },
+            "audio-backend": {
+                name: Translation.tr("scrcpy or DroidCam CLI"),
+                description: Translation.tr("At least one audio backend is needed. scrcpy is preferred (no extra app on phone). DroidCam CLI is the fallback."),
+                commands: {
+                    arch: "# Option 1 (preferred):\nsudo pacman -S scrcpy\n# Option 2:\nyay -S droidcam",
+                    fedora: "# Option 1 (preferred):\nsudo dnf install scrcpy\n# Option 2: install from https://www.dev47apps.com/droidcam/linux/",
+                    debian: "# Option 1 (preferred):\nsudo apt install scrcpy\n# Option 2:\nsudo apt install droidcam"
+                }
+            }
+        };
+        const entry = table[key];
+        if (!entry) return null;
+        return { key: key, name: entry.name, description: entry.description, commands: entry.commands };
+    }
+
+    // Which dependencies a feature is missing, given the presence flags.
+    // "mirror" is scrcpy + adb; "webcam" is DroidCam + the loopback module
+    // (loaded or merely installed), with v4l-utils and mpv recommended;
+    // "microphone" is pactl + either audio backend.
+    function missingDeps(feature: string, flags: var): var {
+        const f = flags ?? {};
+        const missing = [];
+        const need = (key, present) => { if (!present) missing.push(root.dependency(key)); };
+        if (feature === "mirror") {
+            need("scrcpy", f.scrcpy === true);
+            need("android-tools", f.adb === true);
+        } else if (feature === "webcam") {
+            need("droidcam-cli", f.droidcamCli === true);
+            need("v4l2loopback", f.v4l2loopbackLoaded === true || f.v4l2loopbackInstalled === true);
+            need("v4l-utils", f.v4l2Ctl === true);
+            need("mpv", f.mpv === true);
+        } else if (feature === "microphone") {
+            need("pactl", f.pactl === true);
+            need("audio-backend", f.scrcpy === true || f.droidcamCli === true);
+        }
+        return missing;
+    }
+    // END phone-deps logic
+    function flags(): var {
+        return {
+            scrcpy: root.scrcpy, adb: root.adb, droidcamCli: root.droidcamCli,
+            v4l2Ctl: root.v4l2Ctl, pactl: root.pactl, mpv: root.mpv, ffplay: root.ffplay,
+            vlc: root.vlc, kdialog: root.kdialog, wlPaste: root.wlPaste,
+            v4l2loopbackLoaded: root.v4l2loopbackLoaded,
+            v4l2loopbackInstalled: root.v4l2loopbackInstalled
+        };
+    }
+
+    function missingFor(feature: string): var {
+        return root.missingDeps(feature, root.flags());
+    }
+
+    function recheck(): void {
+        root.rechecks++;
+    }
+}

--- a/dots/.config/quickshell/imi/tests/imports/testservices/PhoneMic.qml
+++ b/dots/.config/quickshell/imi/tests/imports/testservices/PhoneMic.qml
@@ -1,0 +1,478 @@
+pragma Singleton
+pragma ComponentBehavior: Bound
+
+import Quickshell
+import QtQuick
+import qs.modules.common
+
+// Logic-only double of services/PhoneMic.qml: the serialized command queue
+// is `run()` answering synchronously from `responder`, recording every
+// argv in `ranCommands`; timers are inert. Everything between the sync
+// markers is byte-for-byte the real service's
+// (tests/test_phone_sessions_contract.py enforces it).
+Singleton {
+    id: root
+
+    property bool available: false
+    property string preferredBackend: "scrcpy"
+    property bool deviceReachable: PhoneConnect.activeDevice?.reachable === true
+    readonly property string activeDeviceId: String(PhoneConnect.activeDevice?.id ?? "")
+
+    property bool connecting: false
+    property bool active: false
+    readonly property string state: root.stateFor(root.available, root.deviceReachable, root.connecting, root.active)
+
+    property string backend: ""
+    property bool muted: false
+    property int gain: 100
+    property bool isDefaultInput: false
+    property string previousDefaultSource: ""
+    property string pulseSource: ""
+    property string activeMode: ""
+    property string activeIp: ""
+    property int activePort: 0
+    property int sessionPid: 0
+    property int startedAt: 0
+    property string lastError: ""
+    property bool userStopped: false
+    property string swappedSink: Persistent.states.phone.mic.originalDefaultSink
+
+    readonly property string sinkName: "DroidCam-Mic"
+    readonly property string sessionScript: "/mock/phone/droidcam_session.sh"
+    readonly property string statusScript: "/mock/phone/droidcam_status.sh"
+    readonly property string setupScript: "/mock/phone/setup_droidcam_input.sh"
+    readonly property string teardownScript: "/mock/phone/teardown_droidcam_input.sh"
+    readonly property int connectTimeoutMs: 10000
+    readonly property int verifyAfterMs: 5000
+    readonly property int swapPollMs: 250
+    readonly property int swapCeilingMs: 3000
+
+    signal errorOccurred(string message)
+
+    // BEGIN phone-mic logic (synced with services/PhoneMic.qml)
+    function stateFor(available: bool, reachable: bool, connecting: bool, active: bool): string {
+        if (!available) return "unavailable";
+        if (active) return "active";
+        if (connecting) return "connecting";
+        if (!reachable) return "offline";
+        return "ready";
+    }
+
+    function sessionFor(backend: string): string {
+        return backend === "scrcpy" ? "scrcpy-mic" : "audio";
+    }
+
+    // scrcpy's mic capture, audio only, no window. Routing is the default
+    // sink swap, not a flag - there is none.
+    function scrcpyMicArgs(targetArgs: var): var {
+        return ["scrcpy", "--no-video", "--no-window", "--audio-source=mic", "--audio-buffer=50"]
+            .concat(targetArgs ?? []);
+    }
+
+    function droidcamAudioArgs(mode: string, ip: string, port: int): var {
+        const args = ["env", "PULSE_SINK=" + root.sinkName, "droidcam-cli", "-a", "-nocontrols"];
+        if (mode === "usb") args.push("adb", String(port));
+        else args.push(String(ip), String(port));
+        return args;
+    }
+
+    // Same rule as the webcam's: usb when asked, a configured address when
+    // given, else adb's answer, else KDE Connect's address.
+    function connectionPlan(conf: var, adbState: string, addresses: var): var {
+        const c = conf ?? {};
+        const port = Number(c.port) > 0 ? Number(c.port) : 4748;
+        if (c.connection === "usb") return { mode: "usb", ip: "", port: port };
+        const configured = String(c.wifiIp ?? "").trim();
+        if (configured.length > 0) return { mode: "wifi", ip: configured, port: port };
+        if (String(adbState ?? "").trim() === "device") return { mode: "usb", ip: "", port: port };
+        for (let i = 0; i < (addresses?.length ?? 0); i++) {
+            const address = String(addresses[i] ?? "").trim();
+            if (address.length > 0) return { mode: "wifi", ip: address, port: port };
+        }
+        return { error: "Could not detect USB or Wi-Fi IP. Plug the phone in with USB debugging on, or set the phone's Wi-Fi IP from the DroidCam app in the microphone settings." };
+    }
+
+    // `pactl list sink-inputs` names the application in several properties;
+    // any mention of scrcpy is its stream.
+    function streamPresent(sinkInputsText: string): bool {
+        return /scrcpy/i.test(sinkInputsText ?? "");
+    }
+
+    // One droidcam_status.sh reply, the two audio facts.
+    function parseStatus(text: string): var {
+        try {
+            const doc = JSON.parse((text ?? "").trim());
+            if (!doc || typeof doc !== "object") return null;
+            return {
+                audioRunning: doc.audio_running === true,
+                audioHasSinkInput: doc.audio_has_sink_input === true,
+                audioSource: String(doc.audio_source ?? "")
+            };
+        } catch (e) {
+            return null;
+        }
+    }
+
+    function parseSessionStatus(text: string): var {
+        try {
+            const doc = JSON.parse((text ?? "").trim());
+            if (!doc || typeof doc !== "object") return null;
+            return {
+                session: String(doc.session ?? ""),
+                alive: doc.alive === true || doc.alive === "true",
+                pid: parseInt(doc.pid) || 0,
+                started: parseInt(doc.started) || 0,
+                port: parseInt(doc.port) || 0,
+                mode: String(doc.mode ?? ""),
+                ip: String(doc.ip ?? "")
+            };
+        } catch (e) {
+            return null;
+        }
+    }
+
+    // What to do about the default sink at boot: a default of DroidCam-Mic
+    // with no live mic session is a swap the previous shell never undid.
+    function restorePlan(defaultSink: string, savedSink: string, sessionAlive: bool): string {
+        if (String(defaultSink ?? "").trim() !== root.sinkName) return "";
+        if (sessionAlive) return "";
+        const saved = String(savedSink ?? "").trim();
+        return (saved.length > 0 && saved !== root.sinkName) ? saved : "@DEFAULT_SINK@";
+    }
+
+    function muteArgs(source: string, muted: bool): var {
+        return ["pactl", "set-source-mute", source, muted ? "1" : "0"];
+    }
+
+    function gainArgs(source: string, percent: int): var {
+        return ["pactl", "set-source-volume", source, String(Math.max(0, Math.min(200, percent))) + "%"];
+    }
+
+    // A launch that went wrong: report it and undo whatever it had done.
+    function fail(message: string): void {
+        root.connecting = false;
+        root.active = false;
+        root.lastError = message;
+        root.errorOccurred(message);
+        root.restoreDefaultSink();
+        root.cleanupSession();
+    }
+
+    // A launch that never began: nothing to undo.
+    function refuse(message: string): void {
+        root.lastError = message;
+        root.errorOccurred(message);
+    }
+
+    function start(): void {
+        if (!root.available || root.connecting || root.active) return;
+        if (!root.deviceReachable) {
+            root.refuse("No reachable phone - pair a device first");
+            return;
+        }
+        root.connecting = true;
+        root.userStopped = false;
+        root.lastError = "";
+        root.backend = root.preferredBackend;
+        Persistent.states.phone.mic.lastBackend = root.backend;
+        // A loopback left by a previous "hear yourself" would otherwise
+        // stay for the whole session.
+        root.run(["pactl", "unload-module", "module-loopback"], null);
+        root.run(["bash", root.setupScript], (text, code) => {
+            if (!root.connecting) return;
+            const source = (text ?? "").trim().split("\n")[0] ?? "";
+            if (code !== 0 || source.length === 0) {
+                root.fail("Failed to create the DroidCam-Mic null sink - pactl may not have permission");
+                return;
+            }
+            root.pulseSource = source;
+            if (root.backend === "scrcpy") root.startScrcpy();
+            else root.startDroidcam();
+        });
+        root.armConnectTimers();
+    }
+
+    function startScrcpy(): void {
+        root.run(["pactl", "get-default-sink"], (text, code) => {
+            if (!root.connecting) return;
+            const original = (text ?? "").trim();
+            if (code !== 0 || original.length === 0) {
+                root.fail("Could not read the current default audio sink - audio routing aborted");
+                return;
+            }
+            if (original !== root.sinkName) root.rememberSwap(original);
+            root.run(["pactl", "set-default-sink", root.sinkName], (t, c) => {
+                if (!root.connecting) return;
+                root.activeMode = "scrcpy";
+                root.activeIp = "";
+                root.activePort = 0;
+                const target = PhoneScrcpy.targetArgs(Config.options.phone.scrcpy, PhoneConnect.activeDevice);
+                root.run(["bash", root.sessionScript, "launch", "scrcpy-mic"].concat(root.scrcpyMicArgs(target)),
+                    (out, rc) => {
+                        if (!root.connecting) return;
+                        root.sessionPid = parseInt(out) || 0;
+                        root.armSwapRestore();
+                        root.armVerify();
+                    });
+            });
+        });
+    }
+
+    function startDroidcam(): void {
+        const conf = Config.options.phone.microphone;
+        const direct = root.connectionPlan(conf, "", []);
+        if (!direct.error) {
+            root.launchDroidcam(direct);
+            return;
+        }
+        root.run(["adb", "get-state"], (text, code) => {
+            if (!root.connecting) return;
+            const plan = root.connectionPlan(conf, code === 0 ? text : "",
+                PhoneConnect.activeDevice?.reachableAddresses ?? []);
+            if (plan.error) {
+                root.fail(plan.error);
+                return;
+            }
+            root.launchDroidcam(plan);
+        });
+    }
+
+    function launchDroidcam(plan: var): void {
+        root.activeMode = plan.mode;
+        root.activeIp = plan.ip;
+        root.activePort = plan.port;
+        Persistent.states.phone.mic.lastMode = plan.mode;
+        Persistent.states.phone.mic.lastIp = plan.ip;
+        Persistent.states.phone.mic.lastPort = plan.port;
+        root.run(["bash", root.sessionScript, "launch", "audio"]
+            .concat(root.droidcamAudioArgs(plan.mode, plan.ip, plan.port)), (out, rc) => {
+                if (!root.connecting) return;
+                if (rc !== 0) {
+                    root.fail("DroidCam did not start - is the DroidCam app open on the phone?");
+                    return;
+                }
+                root.sessionPid = parseInt(out) || 0;
+                root.armVerify();
+            });
+    }
+
+    function rememberSwap(original: string): void {
+        root.swappedSink = original;
+        Persistent.states.phone.mic.originalDefaultSink = original;
+    }
+
+    function restoreDefaultSink(): void {
+        root.disarmSwapRestore();
+        const original = root.swappedSink;
+        if (!original) return;
+        root.swappedSink = "";
+        Persistent.states.phone.mic.originalDefaultSink = "";
+        root.run(["pactl", "set-default-sink", original], null);
+    }
+
+    // The swap has done its job the moment scrcpy's stream exists.
+    function pollSwap(): void {
+        root.run(["pactl", "list", "sink-inputs"], (text, code) => {
+            if (root.streamPresent(text)) root.restoreDefaultSink();
+        });
+    }
+
+    // Success is evidence, not a timer: the process is alive AND the null
+    // sink reports a running input, which droidcam_status.sh answers.
+    function verify(): void {
+        root.run(["bash", root.statusScript], (text, code) => {
+            if (!root.connecting) return;
+            const status = root.parseStatus(text);
+            if (status && status.audioRunning && status.audioHasSinkInput) {
+                root.becomeActive();
+            } else if (status && status.audioRunning) {
+                if (root.connectDeadlinePassed())
+                    root.fail("The phone microphone started but no audio reached the DroidCam-Mic sink - another audio processor may have claimed the stream");
+                else root.armVerifyRetry();
+            } else {
+                root.fail("Phone microphone process exited - check the phone connection and that USB or Wireless debugging is still on");
+            }
+        });
+    }
+
+    function becomeActive(): void {
+        root.connecting = false;
+        root.active = true;
+        root.lastError = "";
+        root.startedAt = Math.floor(Date.now() / 1000);
+        root.disarmConnectTimers();
+        // The stream is on the null sink, so the swap has done its job even
+        // if the poll never saw the sink-input appear.
+        root.restoreDefaultSink();
+        root.applyInitialState();
+        root.armWatchdog();
+    }
+
+    function applyInitialState(): void {
+        const conf = Config.options.phone.microphone;
+        root.muted = false;
+        root.gain = Number(conf.micGain) > 0 ? Number(conf.micGain) : 100;
+        if (root.gain !== 100) root.setGain(root.gain);
+        if (conf.setAsDefault) root.setAsDefaultInput();
+    }
+
+    function adoptSession(status: var): void {
+        root.backend = status.session === "scrcpy-mic" ? "scrcpy" : "droidcam";
+        root.sessionPid = status.pid;
+        root.startedAt = status.started;
+        root.activeMode = root.backend === "scrcpy" ? "scrcpy" : status.mode;
+        root.activeIp = status.ip;
+        root.activePort = status.port;
+        root.run(["bash", root.setupScript], (text, code) => {
+            root.pulseSource = (text ?? "").trim().split("\n")[0] ?? "";
+            root.connecting = false;
+            root.active = true;
+            root.lastError = "";
+            root.armWatchdog();
+        });
+    }
+
+    // Boot: adopt a live session, and undo a swap the last shell left behind.
+    function reconcile(): void {
+        root.run(["bash", root.sessionScript, "status", "scrcpy-mic"], (scrcpyText, c1) => {
+            const scrcpyStatus = root.parseSessionStatus(scrcpyText);
+            root.run(["bash", root.sessionScript, "status", "audio"], (audioText, c2) => {
+                const audioStatus = root.parseSessionStatus(audioText);
+                const live = (scrcpyStatus && scrcpyStatus.alive) ? scrcpyStatus
+                    : ((audioStatus && audioStatus.alive) ? audioStatus : null);
+                if (live && !root.active && !root.connecting) root.adoptSession(live);
+                root.run(["pactl", "get-default-sink"], (sinkText, c3) => {
+                    const target = root.restorePlan(sinkText, Persistent.states.phone.mic.originalDefaultSink, live !== null);
+                    if (!target) return;
+                    root.swappedSink = "";
+                    Persistent.states.phone.mic.originalDefaultSink = "";
+                    root.run(["pactl", "set-default-sink", target], null);
+                });
+            });
+        });
+    }
+
+    function checkSession(): void {
+        root.run(["bash", root.sessionScript, "status", root.sessionFor(root.backend)], (text, code) => {
+            const status = root.parseSessionStatus(text);
+            if (status && status.alive) return;
+            if (root.active) {
+                root.active = false;
+                root.disarmWatchdog();
+                if (!root.userStopped) root.fail("Microphone connection lost - the audio process exited");
+            }
+        });
+    }
+
+    function cleanupSession(): void {
+        root.run(["bash", root.sessionScript, "stop", "audio"], null);
+        root.run(["bash", root.sessionScript, "stop", "scrcpy-mic"], null);
+        root.run(["pactl", "unload-module", "module-loopback"], null);
+        root.run(["bash", root.teardownScript], null);
+        root.pulseSource = "";
+        root.sessionPid = 0;
+        root.startedAt = 0;
+    }
+
+    function stop(): void {
+        if (!root.connecting && !root.active) return;
+        root.userStopped = true;
+        root.disarmConnectTimers();
+        root.disarmWatchdog();
+        if (root.isDefaultInput) root.restoreDefaultInput();
+        root.restoreDefaultSink();
+        root.connecting = false;
+        root.active = false;
+        root.muted = false;
+        root.cleanupSession();
+    }
+
+    function toggle(): void {
+        if (root.connecting || root.active) root.stop();
+        else root.start();
+    }
+
+    function toggleMute(): void {
+        root.muted = !root.muted;
+        if (root.active && root.pulseSource)
+            root.run(root.muteArgs(root.pulseSource, root.muted), null);
+    }
+
+    function setGain(percent: int): void {
+        root.gain = Math.max(0, Math.min(200, percent));
+        Config.options.phone.microphone.micGain = root.gain;
+        if (root.active && root.pulseSource)
+            root.run(root.gainArgs(root.pulseSource, root.gain), null);
+    }
+
+    function setAsDefaultInput(): void {
+        if (!root.active || !root.pulseSource || root.isDefaultInput) return;
+        root.run(["pactl", "get-default-source"], (text, code) => {
+            const previous = (text ?? "").trim();
+            if (!root.active || !root.pulseSource) return;
+            root.previousDefaultSource = previous;
+            root.isDefaultInput = true;
+            root.run(["pactl", "set-default-source", root.pulseSource], null);
+        });
+    }
+
+    function restoreDefaultInput(): void {
+        if (!root.isDefaultInput) return;
+        root.isDefaultInput = false;
+        if (root.previousDefaultSource)
+            root.run(["pactl", "set-default-source", root.previousDefaultSource], null);
+        root.previousDefaultSource = "";
+    }
+    // END phone-mic logic
+    property real connectStartedAt: 0
+    property bool deadlinePassed: false
+    function connectDeadlinePassed(): bool { return root.deadlinePassed; }
+    property int verifyArmed: 0
+    property int verifyRetryArmed: 0
+    property int swapRestoreArmed: 0
+    property int watchdogArmed: 0
+    function armConnectTimers(): void {}
+    function disarmConnectTimers(): void {}
+    function armVerify(): void { root.verifyArmed++; }
+    function armVerifyRetry(): void { root.verifyRetryArmed++; }
+    function armSwapRestore(): void { root.swapRestoreArmed++; }
+    function disarmSwapRestore(): void { root.swapRestoreArmed = 0; }
+    function armWatchdog(): void { root.watchdogArmed++; }
+    function disarmWatchdog(): void { root.watchdogArmed = 0; }
+
+    // responder(argv) -> { text, code } or null (empty output, exit 0)
+    property var responder: null
+    property var ranCommands: []
+
+    function run(argv: var, callback: var): void {
+        root.ranCommands = root.ranCommands.concat([argv]);
+        const reply = root.responder ? root.responder(argv) : null;
+        callback?.(reply?.text ?? "", reply?.code ?? 0);
+    }
+
+    function reset(): void {
+        root.connecting = false;
+        root.active = false;
+        root.backend = "";
+        root.muted = false;
+        root.gain = 100;
+        root.isDefaultInput = false;
+        root.previousDefaultSource = "";
+        root.pulseSource = "";
+        root.activeMode = "";
+        root.activeIp = "";
+        root.activePort = 0;
+        root.sessionPid = 0;
+        root.startedAt = 0;
+        root.lastError = "";
+        root.userStopped = false;
+        root.swappedSink = "";
+        root.deadlinePassed = false;
+        root.verifyArmed = 0;
+        root.verifyRetryArmed = 0;
+        root.swapRestoreArmed = 0;
+        root.watchdogArmed = 0;
+        root.responder = null;
+        root.ranCommands = [];
+    }
+}

--- a/dots/.config/quickshell/imi/tests/imports/testservices/PhoneScrcpy.qml
+++ b/dots/.config/quickshell/imi/tests/imports/testservices/PhoneScrcpy.qml
@@ -1,0 +1,331 @@
+pragma Singleton
+pragma ComponentBehavior: Bound
+
+import Quickshell
+import QtQuick
+import qs.modules.common
+
+// Logic-only double of services/PhoneScrcpy.qml: the supervisor Process
+// and its timers are replaced by `sentMessages`, which records what
+// `send()` would have written; everything between the sync markers is
+// byte-for-byte the real service's (tests/test_phone_sessions_contract.py
+// enforces it).
+Singleton {
+    id: root
+
+    property bool available: false
+    property bool appModeSupported: false
+    readonly property var activeDevice: PhoneConnect.activeDevice
+    readonly property string activeDeviceId: String(PhoneConnect.activeDevice?.id ?? "")
+
+    property bool mirrorRunning: false
+    property bool mirrorLaunching: false
+    property string lastError: ""
+
+    property var apps: []
+    property bool appsLoading: false
+    property string appsError: ""
+
+    readonly property alias sessions: sessionsModel
+    readonly property int sessionCount: sessionsModel.count
+
+    readonly property var favorites: Config.options.phone.scrcpy.appMode.favoritePackages
+    readonly property var recents: Persistent.states.phone.scrcpy.recentPackages
+    readonly property int maxRecents: 20
+
+    property string managerState: "idle"
+    property int restartAttempts: 0
+    readonly property int maxRestartAttempts: 5
+    property var pendingMessages: []
+
+    signal feedback(string message, bool ok)
+
+    ListModel {
+        id: sessionsModel
+        dynamicRoles: true
+    }
+
+    // BEGIN phone-scrcpy logic (synced with services/PhoneScrcpy.qml)
+    // The mirror's flags, from Config.options.phone.scrcpy - the sibling
+    // fork's table. `--video-buffer` is scrcpy >= 2's name for the display
+    // buffer.
+    function mirrorArgs(opts: var): var {
+        const o = opts ?? {};
+        const args = [];
+        if (o.stayAwake) args.push("--stay-awake");
+        if (o.turnScreenOff) args.push("--turn-screen-off");
+        if (o.noPowerOn) args.push("--no-power-on");
+        if (o.noAudio) args.push("--no-audio");
+        if (o.showTouches) args.push("--show-touches");
+        if (o.fullscreen) args.push("--fullscreen");
+        if (o.alwaysOnTop) args.push("--always-on-top");
+        if (Number(o.maxFps) > 0) args.push("--max-fps=" + Number(o.maxFps));
+        if (typeof o.bitRate === "string" && o.bitRate.trim() !== "") args.push("--video-bit-rate=" + o.bitRate.trim());
+        if (Number(o.maxSize) > 0) args.push("--max-size=" + Number(o.maxSize));
+        if (Number(o.videoBuffer) > 0) args.push("--video-buffer=" + Number(o.videoBuffer));
+        return args;
+    }
+
+    // App mode: one app on a virtual display of its own when flexDisplay is
+    // on, otherwise started on the phone's screen and mirrored.
+    function appModeArgs(packageName: string, appOpts: var): var {
+        const o = appOpts ?? {};
+        const args = ["--start-app=" + packageName];
+        if (o.flexDisplay) {
+            const w = Number(o.displayWidth) > 0 ? Number(o.displayWidth) : 1280;
+            const h = Number(o.displayHeight) > 0 ? Number(o.displayHeight) : 960;
+            const density = Number(o.density) > 0 ? Number(o.density) : 160;
+            args.push("--new-display=" + w + "x" + h + "/" + density);
+            args.push("--flex-display");
+            if (o.keepActive) args.push("--keep-active");
+            if (o.systemDecorations === false) args.push("--no-vd-system-decorations");
+        }
+        return args;
+    }
+
+    // The `-s` target for a wireless phone: the address KDE Connect reaches
+    // it on (autoWirelessIp) or the configured one, with the configured
+    // port. Empty when the user did not ask for wireless or no address is
+    // known - the supervisor then lets adb pick, USB first.
+    function targetArgs(opts: var, device: var): var {
+        const o = opts ?? {};
+        if (!o.useWireless) return [];
+        let ip = "";
+        if (o.autoWirelessIp) {
+            const addresses = device?.reachableAddresses ?? [];
+            for (let i = 0; i < addresses.length; i++) {
+                const address = String(addresses[i] ?? "").trim();
+                if (address.length > 0) { ip = address; break; }
+            }
+        }
+        if (!ip) ip = String(o.wirelessIp ?? "").trim();
+        if (!ip) return [];
+        const port = String(o.wirelessPort ?? "").trim() || "5555";
+        return ["-s", ip.indexOf(":") >= 0 ? ip : ip + ":" + port];
+    }
+
+    function sessionIdFor(packageName: string): string {
+        return "app:" + packageName;
+    }
+
+    // MRU: the package moves to the front, the list is capped.
+    function pushRecent(list: var, packageName: string, max: int): var {
+        const out = [];
+        for (let i = 0; i < (list?.length ?? 0); i++) {
+            const entry = String(list[i]);
+            if (entry !== packageName) out.push(entry);
+        }
+        out.unshift(packageName);
+        return out.slice(0, max);
+    }
+
+    function toggleInList(list: var, packageName: string): var {
+        const out = [];
+        let found = false;
+        for (let i = 0; i < (list?.length ?? 0); i++) {
+            const entry = String(list[i]);
+            if (entry === packageName) { found = true; continue; }
+            out.push(entry);
+        }
+        if (!found) out.push(packageName);
+        return out;
+    }
+
+    function isFavorite(packageName: string): bool {
+        const list = root.favorites ?? [];
+        for (let i = 0; i < list.length; i++)
+            if (String(list[i]) === packageName) return true;
+        return false;
+    }
+
+    function sessionIndex(id: string): int {
+        for (let i = 0; i < sessionsModel.count; i++)
+            if (sessionsModel.get(i).id === id) return i;
+        return -1;
+    }
+
+    function isAppRunning(packageName: string): bool {
+        return root.sessionIndex(root.sessionIdFor(packageName)) >= 0;
+    }
+
+    // Delay before the Nth restart of the supervisor: 1s, 2s, 4s, ... 30s.
+    function backoffDelay(attempt: int): int {
+        return Math.min(30000, 1000 * Math.pow(2, Math.max(1, attempt) - 1));
+    }
+
+    // The supervisor is wanted while anything is live or pending - the
+    // idle timer stops it otherwise.
+    function managerWanted(): bool {
+        return sessionsModel.count > 0 || root.mirrorLaunching || root.appsLoading
+            || (root.pendingMessages?.length ?? 0) > 0;
+    }
+
+    function parseManagerLine(line: string): var {
+        const trimmed = (line ?? "").trim();
+        if (trimmed.length === 0) return null;
+        try {
+            const doc = JSON.parse(trimmed);
+            return (doc && typeof doc === "object" && typeof doc.event === "string") ? doc : null;
+        } catch (e) {
+            return null;
+        }
+    }
+
+    // One supervisor event onto the model.
+    function applyEvent(msg: var): void {
+        if (!msg) return;
+        const id = String(msg.id ?? "");
+        if (msg.event === "started") {
+            const row = {
+                id: id,
+                type: String(msg.type ?? (id === "mirror" ? "mirror" : "app")),
+                title: String(msg.title ?? ""),
+                pid: Number(msg.pid ?? 0),
+                package: id.startsWith("app:") ? id.substring(4) : "",
+                startedAt: Date.now()
+            };
+            const index = root.sessionIndex(id);
+            if (index >= 0) {
+                for (const key in row) if (key !== "startedAt") sessionsModel.setProperty(index, key, row[key]);
+            } else {
+                sessionsModel.append(row);
+            }
+            if (id === "mirror") {
+                root.mirrorRunning = true;
+                root.mirrorLaunching = false;
+            }
+        } else if (msg.event === "exited") {
+            const index = root.sessionIndex(id);
+            if (index >= 0) sessionsModel.remove(index);
+            if (id === "mirror") {
+                root.mirrorRunning = false;
+                root.mirrorLaunching = false;
+            }
+            if (Number(msg.code ?? 0) !== 0 && String(msg.error ?? "").length > 0) {
+                root.lastError = String(msg.error);
+                root.feedback(root.lastError, false);
+            }
+        } else if (msg.event === "error") {
+            if (id === "mirror") root.mirrorLaunching = false;
+            root.lastError = String(msg.message ?? "scrcpy error");
+            root.feedback(root.lastError, false);
+        } else if (msg.event === "apps_list") {
+            root.apps = Array.isArray(msg.apps) ? msg.apps : [];
+            // A cached list is served before the live one; loading stays on
+            // until the live one lands.
+            if (msg.cached !== true) {
+                root.appsLoading = false;
+                root.appsError = "";
+            }
+        } else if (msg.event === "apps_error") {
+            root.appsLoading = false;
+            root.appsError = String(msg.message ?? "Failed to list apps");
+        }
+    }
+
+    function handleLine(line: string): void {
+        root.applyEvent(root.parseManagerLine(line));
+    }
+
+    function deviceId(): string {
+        return root.activeDeviceId || "default";
+    }
+
+    function scrcpyTarget(): var {
+        return root.targetArgs(Config.options.phone.scrcpy, root.activeDevice);
+    }
+
+    function launchMirror(): void {
+        if (!root.available) {
+            root.lastError = "scrcpy is not installed";
+            return;
+        }
+        if (root.mirrorRunning) {
+            root.focusMirror();
+            return;
+        }
+        root.mirrorLaunching = true;
+        root.lastError = "";
+        root.send({
+            cmd: "launch", id: "mirror", type: "mirror",
+            target_args: root.scrcpyTarget(),
+            extra_args: root.mirrorArgs(Config.options.phone.scrcpy)
+        });
+    }
+
+    function stopMirror(): void {
+        root.send({ cmd: "stop", id: "mirror" });
+    }
+
+    function focusMirror(): void {
+        root.send({ cmd: "focus", id: "mirror" });
+    }
+
+    function refreshApps(): void {
+        if (!root.appModeSupported) return;
+        root.appsLoading = true;
+        root.appsError = "";
+        root.send({ cmd: "list_apps", target_args: root.scrcpyTarget(), deviceId: root.deviceId() });
+    }
+
+    function launchApp(packageName: string): void {
+        if (!packageName) return;
+        if (!root.appModeSupported) {
+            root.lastError = "scrcpy 4.0+ is required for App Mode";
+            root.feedback(root.lastError, false);
+            return;
+        }
+        if (root.isAppRunning(packageName)) {
+            root.focusApp(packageName);
+            return;
+        }
+        root.send({
+            cmd: "launch", id: root.sessionIdFor(packageName), type: "app",
+            target_args: root.scrcpyTarget(),
+            extra_args: root.appModeArgs(packageName, Config.options.phone.scrcpy.appMode)
+        });
+        Persistent.states.phone.scrcpy.recentPackages =
+            root.pushRecent(Persistent.states.phone.scrcpy.recentPackages, packageName, root.maxRecents);
+    }
+
+    function stopApp(packageName: string): void {
+        if (!packageName) return;
+        root.send({ cmd: "stop", id: root.sessionIdFor(packageName) });
+    }
+
+    function focusApp(packageName: string): void {
+        if (!packageName) return;
+        root.send({ cmd: "focus", id: root.sessionIdFor(packageName) });
+    }
+
+    function stopAllApps(): void {
+        root.send({ cmd: "stop_all" });
+    }
+
+    function toggleFavorite(packageName: string): void {
+        if (!packageName) return;
+        Config.options.phone.scrcpy.appMode.favoritePackages =
+            root.toggleInList(Config.options.phone.scrcpy.appMode.favoritePackages, packageName);
+    }
+    // END phone-scrcpy logic
+    property var sentMessages: []
+    property var feedbackLog: []
+    onFeedback: (message, ok) => { root.feedbackLog = root.feedbackLog.concat([{ message: message, ok: ok }]); }
+
+    function send(message: var): void {
+        root.sentMessages = root.sentMessages.concat([message]);
+    }
+
+    function reset(): void {
+        sessionsModel.clear();
+        root.mirrorRunning = false;
+        root.mirrorLaunching = false;
+        root.lastError = "";
+        root.apps = [];
+        root.appsLoading = false;
+        root.appsError = "";
+        root.pendingMessages = [];
+        root.sentMessages = [];
+        root.feedbackLog = [];
+    }
+}

--- a/dots/.config/quickshell/imi/tests/imports/testservices/qmldir
+++ b/dots/.config/quickshell/imi/tests/imports/testservices/qmldir
@@ -5,6 +5,7 @@ singleton MediaCapture MediaCapture.qml
 singleton OpenRgb OpenRgb.qml
 singleton PhoneConnect PhoneConnect.qml
 singleton PhoneNotifications PhoneNotifications.qml
+singleton PhoneDeps PhoneDeps.qml
 singleton PluginStore PluginStore.qml
 singleton Tailscale Tailscale.qml
 singleton Vpn Vpn.qml

--- a/dots/.config/quickshell/imi/tests/imports/testservices/qmldir
+++ b/dots/.config/quickshell/imi/tests/imports/testservices/qmldir
@@ -7,6 +7,7 @@ singleton PhoneCamera PhoneCamera.qml
 singleton PhoneConnect PhoneConnect.qml
 singleton PhoneNotifications PhoneNotifications.qml
 singleton PhoneDeps PhoneDeps.qml
+singleton PhoneMic PhoneMic.qml
 singleton PhoneScrcpy PhoneScrcpy.qml
 singleton PluginStore PluginStore.qml
 singleton Tailscale Tailscale.qml

--- a/dots/.config/quickshell/imi/tests/imports/testservices/qmldir
+++ b/dots/.config/quickshell/imi/tests/imports/testservices/qmldir
@@ -3,6 +3,7 @@ singleton Battery Battery.qml
 singleton BluetoothStatus BluetoothStatus.qml
 singleton MediaCapture MediaCapture.qml
 singleton OpenRgb OpenRgb.qml
+singleton PhoneCamera PhoneCamera.qml
 singleton PhoneConnect PhoneConnect.qml
 singleton PhoneNotifications PhoneNotifications.qml
 singleton PhoneDeps PhoneDeps.qml

--- a/dots/.config/quickshell/imi/tests/imports/testservices/qmldir
+++ b/dots/.config/quickshell/imi/tests/imports/testservices/qmldir
@@ -6,6 +6,7 @@ singleton OpenRgb OpenRgb.qml
 singleton PhoneConnect PhoneConnect.qml
 singleton PhoneNotifications PhoneNotifications.qml
 singleton PhoneDeps PhoneDeps.qml
+singleton PhoneScrcpy PhoneScrcpy.qml
 singleton PluginStore PluginStore.qml
 singleton Tailscale Tailscale.qml
 singleton Vpn Vpn.qml

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -1636,6 +1636,16 @@ if ! python3 "$SCRIPT_DIR/test_phone_contacts_contract.py"; then
     exit 1
 fi
 
+# The scrcpy supervisor over its real stdin/stdout, with fake scrcpy/adb/
+# hyprctl first on PATH: the exact argv, the events, focus by window title,
+# the USB-over-wireless rule, the app-list parse and its fallback, the cache
+# file, and stop-on-EOF.
+echo "Running Phone scrcpy session manager tests..."
+if ! python3 "$SCRIPT_DIR/test_phone_scrcpy_manager.py"; then
+    echo "Phone scrcpy session manager tests failed."
+    exit 1
+fi
+
 echo "Running registry entry validator tests..."
 if ! python3 "$SCRIPT_DIR/test_registry_validate.py"; then
     echo "Registry entry validator tests failed."

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -1646,6 +1646,17 @@ if ! python3 "$SCRIPT_DIR/test_phone_scrcpy_manager.py"; then
     exit 1
 fi
 
+# The four session services' process I/O, which their doubles omit: the
+# synced regions byte-identical, argv only (the constant probes are the one
+# shell), no running binding anywhere, the supervisor's marker, ladder and
+# idle timer, detached DroidCam launches, and the mic's swap undone on
+# every exit path.
+echo "Running Phone sessions contract tests..."
+if ! python3 "$SCRIPT_DIR/test_phone_sessions_contract.py"; then
+    echo "Phone sessions contract tests failed."
+    exit 1
+fi
+
 echo "Running registry entry validator tests..."
 if ! python3 "$SCRIPT_DIR/test_registry_validate.py"; then
     echo "Registry entry validator tests failed."

--- a/dots/.config/quickshell/imi/tests/test_phone_notifications_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_notifications_runtime.py
@@ -160,8 +160,12 @@ class PhoneNotificationsRuntimeTest(unittest.TestCase):
         # the device model (the timer fires on start) and nothing re-sweeps
         # on a schedule, so the second notification can only arrive through
         # the signal.
+        # sidebar.phone.enable ships false until the tab exists (it gates the
+        # dedupe, not just the tab), and the mirror reads it as mirrorActive -
+        # so the harness turns it on explicitly rather than riding the default.
         (shell_config / "config.json").write_text(json.dumps({
             "networking": {"phoneConnect": {"enable": True, "pollInterval": 600000}},
+            "sidebar": {"phone": {"enable": True}},
         }, indent=2))
 
     def invocations(self):

--- a/dots/.config/quickshell/imi/tests/test_phone_scrcpy_manager.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_scrcpy_manager.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""Drives scripts/phone/scrcpy_session_manager.py over its real stdin/stdout
+with fake `scrcpy`, `adb` and `hyprctl` binaries first on PATH.
+
+The supervisor is the one process that owns scrcpy children for the Phone
+tab, so what is pinned here is the protocol the QML side is written against:
+the exact scrcpy argv (target first, then the imi-phone-<type>-<id> window
+title, then the caller's flags), the started/exited/error events, focus by
+window title through hyprctl, the USB-over-wireless target rule, the app-list
+parse with its system marker and its `pm list packages -3` fallback, the
+apps_error that keeps a dropped phone from wiping the list on screen, the
+cache file the next launch reads back, and the stop-everything-on-EOF that
+keeps a shell restart from stranding headless scrcpy windows.
+"""
+import json
+import os
+import queue
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+MANAGER = ROOT / "scripts" / "phone" / "scrcpy_session_manager.py"
+
+FAKE_SCRCPY = r"""#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$FAKE_LOG/scrcpy.argv"
+case " $* " in
+  *" --version "*) echo "scrcpy 4.1 <https://github.com/Genymobile/scrcpy>"; exit 0 ;;
+  *" --list-apps "*)
+    if [ -n "${FAKE_LIST_APPS:-}" ]; then cat "$FAKE_LIST_APPS"; fi
+    exit 0 ;;
+esac
+if [ -n "${FAKE_SCRCPY_FAIL:-}" ]; then
+  echo "WARN: something minor" >&2
+  echo "ERROR: Could not find ADB device" >&2
+  exit 1
+fi
+exec sleep 60
+"""
+
+FAKE_ADB = r"""#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$FAKE_LOG/adb.argv"
+case "$1" in
+  devices)
+    echo "List of devices attached"
+    if [ -n "${FAKE_ADB_DEVICES:-}" ]; then printf '%b\n' "$FAKE_ADB_DEVICES"; fi
+    exit 0 ;;
+  connect) echo "connected to $2"; exit 0 ;;
+  get-state) echo device; exit 0 ;;
+esac
+case " $* " in
+  *" shell pm list packages -3 "*)
+    if [ -n "${FAKE_ADB_PM_FAIL:-}" ]; then echo "error: no devices/emulators found" >&2; exit 1; fi
+    printf 'package:org.mozilla.firefox\npackage:com.example.second\npackage:org.mozilla.firefox\n'
+    exit 0 ;;
+esac
+exit 0
+"""
+
+FAKE_HYPRCTL = r"""#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$FAKE_LOG/hyprctl.argv"
+exit 0
+"""
+
+LIST_APPS_OUTPUT = """INFO: [server] INFO: List of apps:
+ * Settings                    com.android.settings
+ - Firefox                     org.mozilla.firefox
+ - Signal Private Messenger    org.thoughtcrime.securesms
+ * Firefox                     org.mozilla.firefox
+this line is not an app
+"""
+
+
+class Supervisor:
+    def __init__(self, tmp, env_extra=None):
+        self.tmp = Path(tmp)
+        self.bin = self.tmp / "bin"
+        self.bin.mkdir()
+        self.log = self.tmp / "log"
+        self.log.mkdir()
+        for name, body in (("scrcpy", FAKE_SCRCPY), ("adb", FAKE_ADB), ("hyprctl", FAKE_HYPRCTL)):
+            path = self.bin / name
+            path.write_text(body)
+            path.chmod(0o755)
+        env = dict(os.environ)
+        env["PATH"] = f"{self.bin}:{env.get('PATH', '')}"
+        env["FAKE_LOG"] = str(self.log)
+        env["XDG_CACHE_HOME"] = str(self.tmp / "cache")
+        env["HOME"] = str(self.tmp)
+        env.update(env_extra or {})
+        self.proc = subprocess.Popen(
+            [sys.executable, str(MANAGER)], stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE, text=True, env=env, bufsize=1)
+        self.events = queue.Queue()
+        threading.Thread(target=self._pump, daemon=True).start()
+
+    def _pump(self):
+        for line in self.proc.stdout:
+            line = line.strip()
+            if line:
+                self.events.put(json.loads(line))
+
+    def send(self, **msg):
+        self.proc.stdin.write(json.dumps(msg) + "\n")
+        self.proc.stdin.flush()
+
+    def expect(self, event, timeout=8.0, **fields):
+        deadline = time.monotonic() + timeout
+        seen = []
+        while time.monotonic() < deadline:
+            try:
+                msg = self.events.get(timeout=max(0.01, deadline - time.monotonic()))
+            except queue.Empty:
+                break
+            seen.append(msg)
+            if msg.get("event") == event and all(msg.get(k) == v for k, v in fields.items()):
+                return msg
+        raise AssertionError(f"no {event} {fields} within {timeout}s; saw {seen}")
+
+    def argv(self, binary, at_least=1, timeout=5.0):
+        """The fake's recorded argv lines. A `started` event is emitted as
+        soon as the child is spawned, before the fake has written its log
+        line, so this waits for the count the caller expects."""
+        path = self.log / f"{binary}.argv"
+        deadline = time.monotonic() + timeout
+        while True:
+            lines = path.read_text().splitlines() if path.exists() else []
+            if len(lines) >= at_least or time.monotonic() >= deadline:
+                return lines
+            time.sleep(0.02)
+
+    def close(self):
+        if self.proc.stdin and not self.proc.stdin.closed:
+            self.proc.stdin.close()
+        try:
+            self.proc.wait(timeout=8)
+        except subprocess.TimeoutExpired:
+            self.proc.kill()
+            self.proc.wait()
+        stderr = self.proc.stderr.read()
+        self.proc.stderr.close()
+        self.proc.stdout.close()
+        return stderr
+
+
+class ScrcpySessionManagerTests(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+
+    def _start(self, **env):
+        sup = Supervisor(self.tmpdir.name, env)
+        self.addCleanup(sup.close)
+        return sup
+
+    def test_launch_builds_target_then_title_then_flags_and_reports_started(self):
+        sup = self._start(FAKE_ADB_DEVICES="ABC123\\tdevice")
+        sup.send(cmd="launch", id="mirror", type="mirror", target_args=[],
+                 extra_args=["--stay-awake", "--max-fps=60"])
+        started = sup.expect("started", id="mirror")
+        self.assertEqual(started["title"], "imi-phone-mirror-mirror")
+        self.assertGreater(started["pid"], 0)
+        argv = sup.argv("scrcpy")
+        self.assertEqual(argv, ["-s ABC123 --window-title=imi-phone-mirror-mirror --stay-awake --max-fps=60"])
+
+    def test_a_usb_serial_wins_over_a_wireless_one(self):
+        sup = self._start(FAKE_ADB_DEVICES="192.168.1.20:5555\\tdevice\\nUSB42\\tdevice")
+        sup.send(cmd="launch", id="mirror", type="mirror", target_args=["-s", "192.168.1.20:5555"])
+        sup.expect("started", id="mirror")
+        self.assertTrue(sup.argv("scrcpy")[0].startswith("-s USB42 "))
+
+    def test_a_wireless_target_is_connected_first_and_stands_when_adb_lists_nothing(self):
+        sup = self._start()
+        sup.send(cmd="launch", id="mirror", type="mirror", target_args=["-s", "10.0.0.7:5555"])
+        sup.expect("started", id="mirror")
+        self.assertIn("connect 10.0.0.7:5555", sup.argv("adb"))
+        self.assertTrue(sup.argv("scrcpy")[0].startswith("-s 10.0.0.7:5555 --window-title="))
+
+    def test_an_app_session_title_carries_the_package_with_colons_replaced(self):
+        sup = self._start()
+        sup.send(cmd="launch", id="app:org.mozilla.firefox", type="app",
+                 extra_args=["--start-app=org.mozilla.firefox"])
+        started = sup.expect("started", id="app:org.mozilla.firefox")
+        self.assertEqual(started["title"], "imi-phone-app-app_org.mozilla.firefox")
+
+    def test_launching_a_live_session_again_focuses_it_instead_of_a_second_scrcpy(self):
+        sup = self._start()
+        sup.send(cmd="launch", id="mirror", type="mirror")
+        sup.expect("started", id="mirror")
+        sup.send(cmd="launch", id="mirror", type="mirror")
+        again = sup.expect("started", id="mirror", alreadyRunning=True)
+        self.assertEqual(again["title"], "imi-phone-mirror-mirror")
+        self.assertEqual(sup.argv("hyprctl"), ["dispatch focuswindow title:^imi-phone-mirror-mirror$"])
+        self.assertEqual(len(sup.argv("scrcpy", at_least=2, timeout=1.0)), 1)
+
+    def test_focus_addresses_the_window_by_its_title(self):
+        sup = self._start()
+        sup.send(cmd="launch", id="mirror", type="mirror")
+        sup.expect("started", id="mirror")
+        sup.send(cmd="focus", id="mirror")
+        self.assertEqual(sup.argv("hyprctl"), ["dispatch focuswindow title:^imi-phone-mirror-mirror$"])
+
+    def test_stop_ends_the_session_and_reports_exited(self):
+        sup = self._start()
+        sup.send(cmd="launch", id="mirror", type="mirror")
+        started = sup.expect("started", id="mirror")
+        sup.send(cmd="stop", id="mirror")
+        exited = sup.expect("exited", id="mirror")
+        self.assertNotEqual(exited["code"], None)
+        self.assertFalse(Path(f"/proc/{started['pid']}").exists() and
+                         "sleep" in (Path(f"/proc/{started['pid']}/comm").read_text()
+                                     if Path(f"/proc/{started['pid']}/comm").exists() else ""))
+
+    def test_stop_all_ends_every_session(self):
+        sup = self._start()
+        sup.send(cmd="launch", id="mirror", type="mirror")
+        sup.send(cmd="launch", id="app:com.a", type="app")
+        sup.expect("started", id="mirror")
+        sup.expect("started", id="app:com.a")
+        sup.send(cmd="stop_all")
+        sup.expect("exited", id="mirror")
+        sup.expect("exited", id="app:com.a")
+
+    def test_a_failing_scrcpy_reports_its_last_stderr_line(self):
+        sup = self._start(FAKE_SCRCPY_FAIL="1")
+        sup.send(cmd="launch", id="mirror", type="mirror")
+        sup.expect("started", id="mirror")
+        exited = sup.expect("exited", id="mirror")
+        self.assertEqual(exited["code"], 1)
+        self.assertEqual(exited["error"], "ERROR: Could not find ADB device")
+
+    def test_closing_stdin_stops_every_session(self):
+        sup = self._start()
+        sup.send(cmd="launch", id="mirror", type="mirror")
+        started = sup.expect("started", id="mirror")
+        sup.close()
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline:
+            comm = Path(f"/proc/{started['pid']}/comm")
+            if not comm.exists():
+                break
+            try:
+                if comm.read_text().strip() != "sleep":
+                    break
+            except OSError:
+                break
+            time.sleep(0.05)
+        else:
+            self.fail("the scrcpy child outlived the supervisor's stdin")
+
+    def test_list_apps_parses_the_system_marker_dedupes_and_sorts(self):
+        listing = Path(self.tmpdir.name) / "apps.txt"
+        listing.write_text(LIST_APPS_OUTPUT)
+        sup = self._start(FAKE_LIST_APPS=str(listing), FAKE_ADB_DEVICES="ABC123\\tdevice")
+        sup.send(cmd="list_apps", target_args=[], deviceId="dev_1")
+        apps = sup.expect("apps_list", deviceId="dev_1")
+        self.assertNotIn("cached", apps)
+        self.assertEqual(
+            apps["apps"],
+            [{"package": "org.mozilla.firefox", "name": "Firefox", "system": False},
+             {"package": "com.android.settings", "name": "Settings", "system": True},
+             {"package": "org.thoughtcrime.securesms", "name": "Signal Private Messenger", "system": False}])
+        self.assertIn("-s ABC123 --list-apps", sup.argv("scrcpy"))
+
+    def test_list_apps_falls_back_to_pm_list_when_scrcpy_prints_nothing(self):
+        sup = self._start(FAKE_ADB_DEVICES="ABC123\\tdevice")
+        sup.send(cmd="list_apps", deviceId="dev_1")
+        apps = sup.expect("apps_list", deviceId="dev_1")
+        self.assertEqual(
+            apps["apps"],
+            [{"package": "org.mozilla.firefox", "name": "Firefox", "system": False},
+             {"package": "com.example.second", "name": "Second", "system": False}])
+        self.assertIn("-s ABC123 shell pm list packages -3", sup.argv("adb"))
+
+    def test_a_phone_off_adb_is_an_error_not_an_empty_list(self):
+        sup = self._start(FAKE_ADB_PM_FAIL="1")
+        sup.send(cmd="list_apps", deviceId="dev_1")
+        error = sup.expect("apps_error")
+        self.assertEqual(error["message"], "Phone not reachable over ADB")
+        self.assertTrue(all(m.get("event") != "apps_list" for m in list(sup.events.queue)))
+
+    def test_the_app_list_is_cached_per_device_and_served_before_the_next_fetch(self):
+        listing = Path(self.tmpdir.name) / "apps.txt"
+        listing.write_text(LIST_APPS_OUTPUT)
+        sup = self._start(FAKE_LIST_APPS=str(listing))
+        sup.send(cmd="list_apps", deviceId="dev_1")
+        fresh = sup.expect("apps_list", deviceId="dev_1")
+        cache = Path(self.tmpdir.name) / "cache" / "immaterial-impulse" / "phone" / "apps" / "dev_1.json"
+        self.assertTrue(cache.exists(), f"no cache at {cache}")
+        data = json.loads(cache.read_text())
+        self.assertEqual(data["deviceId"], "dev_1")
+        self.assertEqual(data["apps"], fresh["apps"])
+        self.assertIsInstance(data["generatedAt"], int)
+
+        sup.send(cmd="list_apps", deviceId="dev_1")
+        cached = sup.expect("apps_list", deviceId="dev_1", cached=True)
+        self.assertEqual(cached["apps"], fresh["apps"])
+        sup.expect("apps_list", deviceId="dev_1")
+
+    def test_an_unknown_command_and_a_malformed_line_do_not_end_the_loop(self):
+        sup = self._start()
+        sup.proc.stdin.write("this is not json\n")
+        sup.send(cmd="nonsense")
+        sup.send(cmd="launch", id="mirror", type="mirror")
+        sup.expect("started", id="mirror")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dots/.config/quickshell/imi/tests/test_phone_scrcpy_manager.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_scrcpy_manager.py
@@ -134,6 +134,10 @@ class Supervisor:
             time.sleep(0.02)
 
     def close(self):
+        # Idempotent: a test that closes stdin itself is closed again by
+        # the cleanup, and the pipes may only be read once.
+        if self.proc.stderr.closed:
+            return ""
         if self.proc.stdin and not self.proc.stdin.closed:
             self.proc.stdin.close()
         try:

--- a/dots/.config/quickshell/imi/tests/test_phone_sessions_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_sessions_contract.py
@@ -317,9 +317,22 @@ def test_the_config_and_persistent_blocks_carry_every_key_the_services_read():
         assert re.search(rf"property \S+ {key}:", phone), f"Config.options.phone lacks {key}"
     assert config.rstrip().endswith("}\n        }\n    }\n}") or config.rstrip().endswith("}"), "Config.qml shape"
     sidebar = re.search(r"property JsonObject sidebar: JsonObject \{(.*?)\n            \}", config, re.S)
-    assert sidebar and re.search(r"property JsonObject phone: JsonObject \{\s*property bool enable: true", sidebar.group(1)), (
-        "sidebar.phone.enable is not declared beside sidebar.media"
-    )
+    assert sidebar, "Config.options.sidebar not found"
+    tab_key = re.search(r"property JsonObject phone: JsonObject \{(.*?)\n                \}", sidebar.group(1), re.S)
+    assert tab_key, "sidebar.phone.enable is not declared beside sidebar.media"
+    enabled = re.search(r"property bool enable: (true|false)", tab_key.group(1))
+    assert enabled, "sidebar.phone lacks an enable property"
+    # The key gates more than a tab: PhoneNotifications reads it as
+    # mirrorActive, and that is what drops kdeconnectd's desktop copy of a
+    # phone notification. True before a list exists to read them in and the
+    # phone's notifications stop arriving anywhere at all - so the default
+    # follows the tab into the tree, and this releases itself when W5 lands.
+    tab_exists = (ROOT / "modules/imi/sidebarLeft/phone").is_dir()
+    if not tab_exists:
+        assert enabled.group(1) == "false", (
+            "sidebar.phone.enable is true but modules/imi/sidebarLeft/phone does not exist: "
+            "the notification dedupe would drop the phone's notifications with nothing drawing them"
+        )
     states = persistent[persistent.index("property JsonObject phone: JsonObject {"):]
     for key in ("activeDeviceId", "recentDeviceIds", "cachedNotificationsJson", "recentPackages",
                 "originalDefaultSink", "lastBackend", "lastMode", "lastIp", "lastPort"):

--- a/dots/.config/quickshell/imi/tests/test_phone_sessions_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_sessions_contract.py
@@ -1,0 +1,346 @@
+"""Contract checks for the Phone tab's four session services:
+services/PhoneDeps.qml, PhoneScrcpy.qml, PhoneCamera.qml, PhoneMic.qml.
+
+The QML suite (tst_phone_scrcpy.qml) drives logic-only doubles under
+tests/imports/testservices, so the doubles proving something transfers to
+the real services only while the regions between the `BEGIN/END <name>
+logic` markers are byte-for-byte identical - the first check here. The
+rest pins the process I/O the doubles deliberately omit, which is the half
+CONTRIBUTING.md names outright:
+
+- every command is an argv array. The only shell strings are PhoneDeps'
+  constant probes (`command -v <tool>` and the distro marker walk), with
+  nothing interpolated into any of them;
+- no Process in any of the four files carries a `running:` binding. The
+  scrcpy supervisor is started imperatively, carries the restart-safe
+  marker, and every restart goes through the backoff ladder; the
+  capability probes start themselves from Component.onCompleted (the
+  capability-probe lint's rule) and again from recheck();
+- the supervisor's idle timer is declared at its ten seconds and consults
+  managerWanted() before stopping anything;
+- the DroidCam sessions are launched detached through droidcam_session.sh
+  rather than held by a Process, and the microphone's default-sink swap is
+  both persisted and undone on every exit path.
+"""
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SERVICES = ROOT / "services"
+DOUBLES = ROOT / "tests" / "imports" / "testservices"
+
+SYNCED = {
+    "PhoneDeps": "phone-deps",
+    "PhoneScrcpy": "phone-scrcpy",
+    "PhoneCamera": "phone-camera",
+    "PhoneMic": "phone-mic",
+}
+
+
+def _source(name: str) -> str:
+    return (SERVICES / f"{name}.qml").read_text()
+
+
+def _synced_region(path: Path, tag: str) -> str:
+    text = path.read_text()
+    begin = f"    // BEGIN {tag} logic"
+    end = f"    // END {tag} logic"
+    assert text.count(begin) == 1, f"{path}: expected exactly one BEGIN marker"
+    assert text.count(end) == 1, f"{path}: expected exactly one END marker"
+    start = text.index("\n", text.index(begin)) + 1
+    return text[start:text.index(end)]
+
+
+def _process_blocks(source: str):
+    """Every `Process { ... }` block, brace-counted with string literals
+    skipped, so a `}` inside a shell string cannot end a block early."""
+    for match in re.finditer(r"\bProcess\s*\{", source):
+        depth, index, quote = 1, match.end(), None
+        while index < len(source) and depth:
+            char = source[index]
+            if quote:
+                if char == "\\":
+                    index += 1
+                elif char == quote:
+                    quote = None
+            elif char in "\"'`":
+                quote = char
+            elif char == "{":
+                depth += 1
+            elif char == "}":
+                depth -= 1
+            index += 1
+        yield source[match.start():index]
+
+
+def _process_block(source: str, process_id: str) -> str:
+    for block in _process_blocks(source):
+        if re.search(rf"\bid:\s*{process_id}\b", block):
+            return block
+    raise AssertionError(f"Process block for id {process_id} not found")
+
+
+def _shell_strings(source: str):
+    """Every `["sh"|"bash", "-c", <expr>]` literal's third element, up to the
+    closing bracket of the argv - a JS string literal is read whole, so a
+    `]` inside it (the distro probe's `[ -f "$f" ]`) does not end it."""
+    out = []
+    for match in re.finditer(r'\["(?:sh|bash)",\s*"-c",\s*', source):
+        index, depth, quote = match.end(), 0, None
+        while index < len(source):
+            char = source[index]
+            if quote:
+                if char == "\\":
+                    index += 1
+                elif char == quote:
+                    quote = None
+            elif char in "\"'`":
+                quote = char
+            elif char == "[":
+                depth += 1
+            elif char == "]":
+                if depth == 0:
+                    break
+                depth -= 1
+            index += 1
+        out.append(source[match.end():index].strip())
+    return out
+
+
+# ---- the doubles -------------------------------------------------------------
+
+
+def test_every_synced_region_is_byte_identical_between_service_and_double():
+    for name, tag in SYNCED.items():
+        service_region = _synced_region(SERVICES / f"{name}.qml", tag)
+        double_region = _synced_region(DOUBLES / f"{name}.qml", tag)
+        assert service_region.strip(), f"{name}: synced region is empty"
+        assert service_region == double_region, (
+            f"services/{name}.qml and tests/imports/testservices/{name}.qml have "
+            f"drifted between the {tag} logic markers; edit both sides identically"
+        )
+
+
+def test_the_doubles_are_registered_for_the_qml_suite():
+    qmldir = (DOUBLES / "qmldir").read_text().splitlines()
+    for name in SYNCED:
+        assert f"singleton {name} {name}.qml" in qmldir, f"{name} is not in testservices/qmldir"
+
+
+def test_the_doubles_hold_no_process():
+    for name in SYNCED:
+        text = (DOUBLES / f"{name}.qml").read_text()
+        assert not re.search(r"\bProcess\s*\{", text), f"the {name} double declares a Process"
+        assert "Quickshell.Io" not in text, f"the {name} double imports Quickshell.Io"
+
+
+# ---- argv only ---------------------------------------------------------------
+
+
+def test_the_only_shell_strings_are_phone_deps_constant_probes():
+    for name in ("PhoneScrcpy", "PhoneCamera", "PhoneMic"):
+        assert _shell_strings(_source(name)) == [], (
+            f"{name}.qml carries a shell string: {_shell_strings(_source(name))}"
+        )
+    deps = _shell_strings(_source("PhoneDeps"))
+    probes = [s for s in deps if s.startswith('"command -v ')]
+    assert len(probes) == 10, f"expected ten `command -v` probes, found {probes}"
+    for string in deps:
+        assert string.startswith('"') and string.endswith('"'), f"not a plain literal: {string}"
+        assert "${" not in string and "+" not in string, f"interpolation into a shell string: {string}"
+    others = [s for s in deps if s not in probes]
+    assert len(others) == 1 and "/etc/arch-release /etc/fedora-release /etc/debian_version" in others[0], (
+        f"unexpected shell strings beside the probes: {others}"
+    )
+
+
+def test_no_service_interpolates_into_a_shell_command_line():
+    for name in SYNCED:
+        for line in _source(name).splitlines():
+            if re.search(r'"(?:sh|bash)",\s*"-c"', line) and "${" in line:
+                raise AssertionError(f"{name}.qml interpolates into a shell command: {line.strip()}")
+
+
+def _run_argvs(source: str):
+    """The first argument of every `root.run(` call, bracket-balanced."""
+    out = []
+    for match in re.finditer(r"root\.run\(", source):
+        index, depth, quote = match.end(), 0, None
+        while index < len(source):
+            char = source[index]
+            if quote:
+                if char == "\\":
+                    index += 1
+                elif char == quote:
+                    quote = None
+            elif char in "\"'`":
+                quote = char
+            elif char in "([{":
+                depth += 1
+            elif char in ")]}":
+                if depth == 0:
+                    break
+                depth -= 1
+            elif char == "," and depth == 0:
+                break
+            index += 1
+        out.append(source[match.end():index].strip())
+    return out
+
+
+def test_every_exec_and_run_takes_an_argv_array():
+    """The one-shot queue only ever sees a literal array or an array a
+    builder returned - never a joined string."""
+    for name in ("PhoneCamera", "PhoneMic"):
+        source = _source(name)
+        argvs = _run_argvs(source)
+        assert len(argvs) > 5, f"{name}.qml never runs a command"
+        for argv in argvs:
+            # A local named `argv` is fine while it is declared as an array.
+            local = argv == "argv" and "const argv = [" in source
+            assert local or argv.startswith("[") or argv.startswith("root.") or argv.startswith("PhoneScrcpy."), (
+                f"{name}.qml runs something that is not an argv array: {argv[:80]}"
+            )
+        assert "cmdProc.exec(next.argv)" in source, f"{name}.qml's queue does not exec the argv"
+
+
+def test_droidcam_sessions_are_launched_detached_through_the_session_script():
+    """No Process here holds a droidcam-cli or a scrcpy mic stream: both go
+    through droidcam_session.sh launch, whose pidfile is the binary's, so
+    the stream outlives the shell and is re-adopted at boot."""
+    camera = _source("PhoneCamera")
+    mic = _source("PhoneMic")
+    assert '"launch", "video"' in camera, "the webcam is not launched through the session script"
+    assert '"launch", "scrcpy-mic"' in mic and '"launch", "audio"' in mic, (
+        "a microphone backend is not launched through the session script"
+    )
+    for name, source in (("PhoneCamera", camera), ("PhoneMic", mic)):
+        for block in _process_blocks(source):
+            assert "droidcam-cli" not in block and "scrcpy" not in block.replace("PhoneScrcpy", ""), (
+                f"{name}.qml holds a stream in a Process block"
+            )
+        assert 'root.checkSession()' in source or 'root.reconcile()' in source
+        assert "Component.onCompleted" in source, f"{name}.qml never re-adopts a session at boot"
+
+
+# ---- process lifetimes -------------------------------------------------------
+
+
+def test_no_process_in_the_four_services_has_a_running_binding():
+    for name in SYNCED:
+        for block in _process_blocks(_source(name)):
+            bindings = re.findall(r"^\s*running\s*:", block, re.M)
+            assert bindings == [], f"{name}.qml declares a running binding in {block[:120]!r}"
+
+
+def test_the_supervisor_carries_the_marker_and_restarts_on_the_ladder():
+    source = _source("PhoneScrcpy")
+    block = _process_block(source, "manager")
+    assert "process-lifecycle: restart-safe" in block, "the supervisor lacks the restart-safe marker"
+    assert "stdinEnabled: true" in block, "the supervisor is not written to over stdin"
+    assert "scrcpy_session_manager.py" in block, "the supervisor is not the session manager script"
+    assert "root.restartAttempts >= root.maxRestartAttempts" in block, "no ceiling in the exit handler"
+    assert "restartTimer.interval = root.backoffDelay(root.restartAttempts)" in block, (
+        "the restart timer is armed with something other than the ladder's delay"
+    )
+    assert re.search(r"readonly property int maxRestartAttempts:\s*5", source), "no declared ceiling"
+    assert "manager.running = true" in source and "manager.running = false" in source, (
+        "the supervisor must be started and stopped imperatively"
+    )
+    starts = [line.strip() for line in source.splitlines()
+              if "startManager(" in line and "function startManager" not in line]
+    assert starts and all("root.startManager(" in line for line in starts), starts
+
+
+def test_the_supervisor_idle_timer_is_ten_seconds_and_asks_before_stopping():
+    source = _source("PhoneScrcpy")
+    timer = re.search(r"Timer \{\n\s*id: managerIdleTimer(.*?)\n    \}", source, re.S)
+    assert timer, "managerIdleTimer missing"
+    body = timer.group(1)
+    assert re.search(r"interval:\s*10000", body), "the idle timer is not ten seconds"
+    assert "root.managerWanted()" in body and "root.stopManager()" in body, (
+        "the idle timer stops the supervisor without asking managerWanted()"
+    )
+    assert "managerIdleTimer.restart()" in re.search(r"function send\(.*?\n    \}", source, re.S).group(0), (
+        "a command does not re-arm the idle timer"
+    )
+    for handler in ("onSessionCountChanged", "onAppsLoadingChanged", "onMirrorLaunchingChanged"):
+        assert f"{handler}: managerIdleTimer.restart()" in source, f"{handler} does not re-arm the idle timer"
+
+
+def test_the_capability_probes_start_themselves_and_again_from_recheck():
+    source = _source("PhoneDeps")
+    probes = [block for block in _process_blocks(source) if '"command -v ' in block]
+    assert len(probes) == 10, f"expected ten probes, found {len(probes)}"
+    for block in probes:
+        assert "Component.onCompleted: root.startProbe(this)" in block, f"a probe does not start itself: {block[:80]}"
+        assert "onRunningChanged: if (!running) root.probeAnswered()" in block, (
+            "a probe's accounting hangs off exited, which a missing binary never emits"
+        )
+    recheck = re.search(r"function recheck\(\): void \{(.*?)\n    \}", source, re.S)
+    assert recheck, "recheck() missing"
+    for probe_id in ("scrcpyProbe", "adbProbe", "droidcamProbe", "v4l2CtlProbe", "pactlProbe",
+                     "mpvProbe", "ffplayProbe", "vlcProbe", "kdialogProbe", "wlPasteProbe",
+                     "lsmodProbe", "modinfoProbe", "distroProbe"):
+        assert probe_id in recheck.group(1), f"recheck() does not restart {probe_id}"
+    assert '["scrcpy", "--version"]' in source, "the version probe is not the argv scrcpy --version"
+
+
+def test_the_microphone_swap_is_persisted_and_undone_on_every_exit_path():
+    source = _source("PhoneMic")
+    remember = re.search(r"function rememberSwap\(.*?\n    \}", source, re.S).group(0)
+    assert "Persistent.states.phone.mic.originalDefaultSink = original" in remember
+    restore = re.search(r"function restoreDefaultSink\(.*?\n    \}", source, re.S).group(0)
+    assert 'Persistent.states.phone.mic.originalDefaultSink = ""' in restore
+    assert '["pactl", "set-default-sink", original]' in restore
+    for fn in ("fail", "stop", "becomeActive"):
+        body = re.search(rf"function {fn}\(.*?\n    \}}", source, re.S).group(0)
+        assert "root.restoreDefaultSink()" in body, f"{fn}() leaves the default sink swapped"
+    reconcile = re.search(r"function reconcile\(.*?\n    \}", source, re.S).group(0)
+    assert "root.restorePlan(" in reconcile, "boot reconciliation does not consult restorePlan"
+    assert "Component.onCompleted: root.reconcile()" in source, "reconciliation does not run at boot"
+    swap = re.search(r"Timer \{\n\s*id: swapTimer(.*?)\n    \}", source, re.S)
+    assert swap and "root.restoreDefaultSink()" in swap.group(1), "the swap poll has no ceiling restore"
+
+
+def test_the_config_and_persistent_blocks_carry_every_key_the_services_read():
+    config = (ROOT / "modules" / "common" / "Config.qml").read_text()
+    persistent = (ROOT / "modules" / "common" / "Persistent.qml").read_text()
+    phone = config[config.index("property JsonObject phone: JsonObject {"):]
+    for key in ("showPeripheralCards", "stayAwake", "turnScreenOff", "noPowerOn", "noAudio", "showTouches",
+                "fullscreen", "alwaysOnTop", "maxFps", "bitRate", "maxSize", "videoBuffer", "useWireless",
+                "autoWirelessIp", "wirelessIp", "wirelessPort", "flexDisplay", "displayWidth", "displayHeight",
+                "density", "keepActive", "systemDecorations", "favoritePackages", "cameraFacing", "resolution",
+                "mirrorHorizontally", "rotateDegrees", "connection", "wifiIp", "micGain", "setAsDefault",
+                "favoriteIds", "sortBy", "hideUnnamed"):
+        assert re.search(rf"property \S+ {key}:", phone), f"Config.options.phone lacks {key}"
+    assert config.rstrip().endswith("}\n        }\n    }\n}") or config.rstrip().endswith("}"), "Config.qml shape"
+    sidebar = re.search(r"property JsonObject sidebar: JsonObject \{(.*?)\n            \}", config, re.S)
+    assert sidebar and re.search(r"property JsonObject phone: JsonObject \{\s*property bool enable: true", sidebar.group(1)), (
+        "sidebar.phone.enable is not declared beside sidebar.media"
+    )
+    states = persistent[persistent.index("property JsonObject phone: JsonObject {"):]
+    for key in ("activeDeviceId", "recentDeviceIds", "cachedNotificationsJson", "recentPackages",
+                "originalDefaultSink", "lastBackend", "lastMode", "lastIp", "lastPort"):
+        assert re.search(rf"property \S+ {key}:", states), f"Persistent.states.phone lacks {key}"
+
+
+def test_the_supervisor_script_writes_the_titles_and_the_cache_the_service_expects():
+    script = (ROOT / "scripts" / "phone" / "scrcpy_session_manager.py").read_text()
+    assert 'TITLE_PREFIX = "imi-phone-"' in script
+    assert '"immaterial-impulse" / "phone" / "apps"' in script
+    assert 'self.stop_all()' in re.search(r"def run\(self\):.*?\n\n", script, re.S).group(0), (
+        "stdin closing does not stop every session"
+    )
+    session = (ROOT / "scripts" / "phone" / "droidcam_session.sh").read_text()
+    assert "quickshell/imi/phone" in session, "the session state dir is not the shell's"
+    for name in ("droidcam_session.sh", "droidcam_status.sh"):
+        text = (ROOT / "scripts" / "phone" / name).read_text()
+        assert "pgrep -" + "f" not in text, f"{name} matches its own caller"
+
+
+if __name__ == "__main__":
+    import sys
+    from contract_runner import run
+    sys.exit(run(globals()))

--- a/dots/.config/quickshell/imi/tests/tst_phone_scrcpy.qml
+++ b/dots/.config/quickshell/imi/tests/tst_phone_scrcpy.qml
@@ -50,6 +50,9 @@ TestCase {
         PhoneScrcpy.appModeSupported = true
         PhoneCamera.reset()
         PhoneCamera.available = true
+        PhoneMic.reset()
+        PhoneMic.available = true
+        PhoneMic.preferredBackend = "scrcpy"
         Config.options.phone.scrcpy.appMode.favoritePackages = []
         Config.options.phone.scrcpy.useWireless = false
         Config.options.phone.scrcpy.autoWirelessIp = true
@@ -58,7 +61,12 @@ TestCase {
         Config.options.phone.webcam.wifiIp = ""
         Config.options.phone.webcam.mirrorHorizontally = false
         Config.options.phone.webcam.rotateDegrees = 0
+        Config.options.phone.microphone.connection = "wifi"
+        Config.options.phone.microphone.wifiIp = ""
+        Config.options.phone.microphone.micGain = 100
+        Config.options.phone.microphone.setAsDefault = false
         Persistent.states.phone.scrcpy.recentPackages = []
+        Persistent.states.phone.mic.originalDefaultSink = ""
     }
 
     // ================================================================
@@ -566,5 +574,311 @@ TestCase {
         compare(s.ip, "1.2.3.4")
         compare(PhoneCamera.parseSessionStatus("not json"), null)
         compare(PhoneCamera.parseSessionStatus(""), null)
+    }
+
+    // ================================================================
+    // PhoneMic
+    // ================================================================
+
+    function test_mic_argv_builders() {
+        compare(PhoneMic.scrcpyMicArgs(["-s", "ABC"]),
+                ["scrcpy", "--no-video", "--no-window", "--audio-source=mic", "--audio-buffer=50", "-s", "ABC"])
+        compare(PhoneMic.scrcpyMicArgs([]).length, 5)
+        compare(PhoneMic.droidcamAudioArgs("usb", "", 4748),
+                ["env", "PULSE_SINK=DroidCam-Mic", "droidcam-cli", "-a", "-nocontrols", "adb", "4748"])
+        compare(PhoneMic.droidcamAudioArgs("wifi", "10.0.0.2", 4748),
+                ["env", "PULSE_SINK=DroidCam-Mic", "droidcam-cli", "-a", "-nocontrols", "10.0.0.2", "4748"])
+        compare(PhoneMic.muteArgs("DroidCam-Mic.monitor", true), ["pactl", "set-source-mute", "DroidCam-Mic.monitor", "1"])
+        compare(PhoneMic.gainArgs("DroidCam-Mic.monitor", 250), ["pactl", "set-source-volume", "DroidCam-Mic.monitor", "200%"])
+        compare(PhoneMic.sessionFor("scrcpy"), "scrcpy-mic")
+        compare(PhoneMic.sessionFor("droidcam"), "audio")
+        compare(PhoneMic.connectionPlan({ connection: "wifi" }, "device", []), { mode: "usb", ip: "", port: 4748 })
+    }
+
+    function test_mic_stream_evidence_and_the_restore_plan() {
+        verify(PhoneMic.streamPresent("Sink Input #57\n\tapplication.name = \"scrcpy\"\n"))
+        verify(!PhoneMic.streamPresent("Sink Input #57\n\tapplication.name = \"Firefox\"\n"))
+        compare(PhoneMic.restorePlan("Arctis_Media", "alsa_output.x", false), "")
+        compare(PhoneMic.restorePlan("DroidCam-Mic", "alsa_output.x", true), "")
+        compare(PhoneMic.restorePlan("DroidCam-Mic\n", "alsa_output.x", false), "alsa_output.x")
+        compare(PhoneMic.restorePlan("DroidCam-Mic", "", false), "@DEFAULT_SINK@")
+        compare(PhoneMic.restorePlan("DroidCam-Mic", "DroidCam-Mic", false), "@DEFAULT_SINK@")
+        const status = PhoneMic.parseStatus('{"installed":true,"audio_source":"DroidCam-Mic.monitor","audio_has_sink_input":true,"audio_running":true}')
+        compare(status.audioRunning, true)
+        compare(status.audioHasSinkInput, true)
+        compare(PhoneMic.parseStatus("nope"), null)
+    }
+
+    function scrcpyMicResponder(sinkInputs) {
+        return argv => {
+            const line = argv.join(" ")
+            if (line === "bash " + setupScript) return { text: "DroidCam-Mic.monitor\n", code: 0 }
+            if (line === "pactl get-default-sink") return { text: "alsa_output.arctis\n", code: 0 }
+            if (argv[2] === "launch") return { text: "777\n", code: 0 }
+            if (line === "pactl list sink-inputs") return { text: sinkInputs || "", code: 0 }
+            if (line === "pactl get-default-source") return { text: "alsa_input.laptop\n", code: 0 }
+            return null
+        }
+    }
+
+    function test_mic_start_on_scrcpy_swaps_the_default_sink_and_launches_detached() {
+        PhoneMic.responder = scrcpyMicResponder("")
+        PhoneMic.start()
+        verify(PhoneMic.connecting)
+        compare(PhoneMic.state, "connecting")
+        compare(PhoneMic.backend, "scrcpy")
+        compare(PhoneMic.pulseSource, "DroidCam-Mic.monitor")
+        compare(argvJoined(PhoneMic.ranCommands), [
+            "pactl unload-module module-loopback",
+            "bash " + setupScript,
+            "pactl get-default-sink",
+            "pactl set-default-sink DroidCam-Mic",
+            "bash " + sessionScript + " launch scrcpy-mic scrcpy --no-video --no-window --audio-source=mic --audio-buffer=50"
+        ])
+        compare(PhoneMic.swappedSink, "alsa_output.arctis")
+        compare(Persistent.states.phone.mic.originalDefaultSink, "alsa_output.arctis")
+        compare(Persistent.states.phone.mic.lastBackend, "scrcpy")
+        compare(PhoneMic.sessionPid, 777)
+        compare(PhoneMic.swapRestoreArmed, 1)
+        compare(PhoneMic.verifyArmed, 1)
+    }
+
+    function test_mic_the_swap_is_undone_the_moment_the_stream_appears() {
+        PhoneMic.responder = scrcpyMicResponder("")
+        PhoneMic.start()
+        PhoneMic.ranCommands = []
+        PhoneMic.pollSwap()
+        compare(argvJoined(PhoneMic.ranCommands), ["pactl list sink-inputs"])
+        compare(PhoneMic.swappedSink, "alsa_output.arctis")
+        PhoneMic.responder = scrcpyMicResponder("Sink Input #57\n\tapplication.name = \"scrcpy\"\n")
+        PhoneMic.pollSwap()
+        compare(argvJoined(PhoneMic.ranCommands)[2], "pactl set-default-sink alsa_output.arctis")
+        compare(PhoneMic.swappedSink, "")
+        compare(Persistent.states.phone.mic.originalDefaultSink, "")
+        compare(PhoneMic.swapRestoreArmed, 0)
+        // Restoring twice is a no-op.
+        PhoneMic.restoreDefaultSink()
+        compare(PhoneMic.ranCommands.length, 3)
+    }
+
+    function test_mic_a_default_sink_that_is_already_the_null_sink_is_not_remembered() {
+        PhoneMic.responder = argv => {
+            const line = argv.join(" ")
+            if (line === "bash " + setupScript) return { text: "DroidCam-Mic.monitor\n", code: 0 }
+            if (line === "pactl get-default-sink") return { text: "DroidCam-Mic\n", code: 0 }
+            return { text: "1\n", code: 0 }
+        }
+        PhoneMic.start()
+        compare(PhoneMic.swappedSink, "")
+        compare(Persistent.states.phone.mic.originalDefaultSink, "")
+    }
+
+    function test_mic_verify_needs_the_process_and_the_stream() {
+        PhoneMic.responder = scrcpyMicResponder("")
+        PhoneMic.start()
+        PhoneMic.ranCommands = []
+        PhoneMic.responder = argv => ({ text: '{"audio_running":true,"audio_has_sink_input":false}', code: 0 })
+        PhoneMic.verify()
+        verify(PhoneMic.connecting)
+        compare(PhoneMic.verifyRetryArmed, 1)
+        compare(argvJoined(PhoneMic.ranCommands), ["bash " + statusScript])
+        PhoneMic.responder = argv => ({ text: '{"audio_running":true,"audio_has_sink_input":true}', code: 0 })
+        PhoneMic.verify()
+        verify(PhoneMic.active)
+        verify(!PhoneMic.connecting)
+        compare(PhoneMic.state, "active")
+        compare(PhoneMic.gain, 100)
+        verify(!PhoneMic.muted)
+        compare(PhoneMic.watchdogArmed, 1)
+        verify(PhoneMic.startedAt > 0)
+    }
+
+    function test_mic_verify_with_a_dead_process_fails_and_tears_down() {
+        PhoneMic.responder = scrcpyMicResponder("")
+        PhoneMic.start()
+        PhoneMic.ranCommands = []
+        PhoneMic.responder = argv => ({ text: '{"audio_running":false,"audio_has_sink_input":false}', code: 0 })
+        PhoneMic.verify()
+        verify(!PhoneMic.connecting)
+        verify(!PhoneMic.active)
+        verify(PhoneMic.lastError.indexOf("exited") >= 0)
+        const ran = argvJoined(PhoneMic.ranCommands)
+        compare(ran[0], "bash " + statusScript)
+        verify(ran.indexOf("pactl set-default-sink alsa_output.arctis") > 0)
+        verify(ran.indexOf("bash " + sessionScript + " stop audio") > 0)
+        verify(ran.indexOf("bash " + sessionScript + " stop scrcpy-mic") > 0)
+        verify(ran.indexOf("bash " + teardownScript) > 0)
+        compare(PhoneMic.swappedSink, "")
+    }
+
+    function test_mic_verify_past_the_deadline_with_no_stream_names_the_hijack() {
+        PhoneMic.responder = scrcpyMicResponder("")
+        PhoneMic.start()
+        PhoneMic.deadlinePassed = true
+        PhoneMic.responder = argv => ({ text: '{"audio_running":true,"audio_has_sink_input":false}', code: 0 })
+        PhoneMic.verify()
+        verify(!PhoneMic.connecting)
+        verify(PhoneMic.lastError.indexOf("another audio processor") >= 0)
+    }
+
+    function activeScrcpyMic() {
+        PhoneMic.responder = scrcpyMicResponder("")
+        PhoneMic.start()
+        PhoneMic.responder = argv => ({ text: '{"audio_running":true,"audio_has_sink_input":true}', code: 0 })
+        PhoneMic.verify()
+        PhoneMic.responder = scrcpyMicResponder("")
+        PhoneMic.ranCommands = []
+    }
+
+    function test_mic_mute_and_gain_reach_the_monitor_source() {
+        activeScrcpyMic()
+        PhoneMic.toggleMute()
+        verify(PhoneMic.muted)
+        PhoneMic.setGain(150)
+        compare(PhoneMic.gain, 150)
+        compare(Config.options.phone.microphone.micGain, 150)
+        compare(argvJoined(PhoneMic.ranCommands), [
+            "pactl set-source-mute DroidCam-Mic.monitor 1",
+            "pactl set-source-volume DroidCam-Mic.monitor 150%"
+        ])
+    }
+
+    function test_mic_default_input_is_taken_and_given_back() {
+        activeScrcpyMic()
+        PhoneMic.setAsDefaultInput()
+        verify(PhoneMic.isDefaultInput)
+        compare(PhoneMic.previousDefaultSource, "alsa_input.laptop")
+        compare(argvJoined(PhoneMic.ranCommands), [
+            "pactl get-default-source",
+            "pactl set-default-source DroidCam-Mic.monitor"
+        ])
+        PhoneMic.setAsDefaultInput()
+        compare(PhoneMic.ranCommands.length, 2)
+        PhoneMic.restoreDefaultInput()
+        verify(!PhoneMic.isDefaultInput)
+        compare(argvJoined(PhoneMic.ranCommands)[2], "pactl set-default-source alsa_input.laptop")
+        compare(PhoneMic.previousDefaultSource, "")
+    }
+
+    function test_mic_a_configured_gain_and_default_apply_when_the_stream_is_up() {
+        Config.options.phone.microphone.micGain = 80
+        Config.options.phone.microphone.setAsDefault = true
+        activeScrcpyMic()
+        compare(PhoneMic.gain, 80)
+        verify(PhoneMic.isDefaultInput)
+    }
+
+    function test_mic_stop_restores_everything_and_tears_the_sink_down() {
+        activeScrcpyMic()
+        PhoneMic.setAsDefaultInput()
+        PhoneMic.ranCommands = []
+        PhoneMic.stop()
+        verify(!PhoneMic.active)
+        verify(PhoneMic.userStopped)
+        verify(!PhoneMic.isDefaultInput)
+        compare(PhoneMic.pulseSource, "")
+        compare(argvJoined(PhoneMic.ranCommands), [
+            "pactl set-default-source alsa_input.laptop",
+            "bash " + sessionScript + " stop audio",
+            "bash " + sessionScript + " stop scrcpy-mic",
+            "pactl unload-module module-loopback",
+            "bash " + teardownScript
+        ])
+        PhoneMic.stop()
+        compare(PhoneMic.ranCommands.length, 5)
+    }
+
+    function test_mic_start_on_droidcam_routes_through_pulse_sink() {
+        PhoneMic.preferredBackend = "droidcam"
+        Config.options.phone.microphone.connection = "usb"
+        PhoneMic.responder = argv => {
+            const line = argv.join(" ")
+            if (line === "bash " + setupScript) return { text: "DroidCam-Mic.monitor\n", code: 0 }
+            if (argv[2] === "launch") return { text: "888\n", code: 0 }
+            return null
+        }
+        PhoneMic.start()
+        compare(PhoneMic.backend, "droidcam")
+        compare(argvJoined(PhoneMic.ranCommands), [
+            "pactl unload-module module-loopback",
+            "bash " + setupScript,
+            "bash " + sessionScript + " launch audio env PULSE_SINK=DroidCam-Mic droidcam-cli -a -nocontrols adb 4748"
+        ])
+        compare(PhoneMic.swappedSink, "")
+        compare(PhoneMic.sessionPid, 888)
+        compare(PhoneMic.verifyArmed, 1)
+        compare(Persistent.states.phone.mic.lastMode, "usb")
+        compare(Persistent.states.phone.mic.lastPort, 4748)
+    }
+
+    function test_mic_start_fails_when_the_null_sink_cannot_be_made() {
+        PhoneMic.responder = argv => argv[0] === "bash" ? { text: "", code: 1 } : null
+        PhoneMic.start()
+        verify(!PhoneMic.connecting)
+        verify(PhoneMic.lastError.indexOf("null sink") >= 0)
+    }
+
+    function test_mic_start_is_refused_without_a_reachable_phone() {
+        PhoneConnect.devices = [phone({ reachable: false })]
+        PhoneMic.start()
+        verify(!PhoneMic.connecting)
+        compare(PhoneMic.ranCommands, [])
+        compare(PhoneMic.state, "offline")
+    }
+
+    function test_mic_boot_reconciliation_restores_a_leftover_swap() {
+        Persistent.states.phone.mic.originalDefaultSink = "alsa_output.arctis"
+        PhoneMic.swappedSink = "alsa_output.arctis"
+        PhoneMic.responder = argv => {
+            const line = argv.join(" ")
+            if (argv[2] === "status") return { text: '{"session":"' + argv[3] + '","alive":false}', code: 0 }
+            if (line === "pactl get-default-sink") return { text: "DroidCam-Mic\n", code: 0 }
+            return null
+        }
+        PhoneMic.reconcile()
+        verify(!PhoneMic.active)
+        compare(argvJoined(PhoneMic.ranCommands), [
+            "bash " + sessionScript + " status scrcpy-mic",
+            "bash " + sessionScript + " status audio",
+            "pactl get-default-sink",
+            "pactl set-default-sink alsa_output.arctis"
+        ])
+        compare(Persistent.states.phone.mic.originalDefaultSink, "")
+        compare(PhoneMic.swappedSink, "")
+    }
+
+    function test_mic_boot_reconciliation_adopts_a_live_session_and_leaves_the_sink() {
+        PhoneMic.responder = argv => {
+            const line = argv.join(" ")
+            if (argv[2] === "status" && argv[3] === "scrcpy-mic")
+                return { text: '{"session":"scrcpy-mic","pid":"777","alive":true,"started":"1700000000","port":"","mode":"wifi","ip":""}', code: 0 }
+            if (argv[2] === "status") return { text: '{"session":"audio","alive":false}', code: 0 }
+            if (line === "bash " + setupScript) return { text: "DroidCam-Mic.monitor\n", code: 0 }
+            if (line === "pactl get-default-sink") return { text: "DroidCam-Mic\n", code: 0 }
+            return null
+        }
+        PhoneMic.reconcile()
+        verify(PhoneMic.active)
+        compare(PhoneMic.backend, "scrcpy")
+        compare(PhoneMic.sessionPid, 777)
+        compare(PhoneMic.startedAt, 1700000000)
+        compare(PhoneMic.pulseSource, "DroidCam-Mic.monitor")
+        compare(PhoneMic.watchdogArmed, 1)
+        verify(argvJoined(PhoneMic.ranCommands).indexOf("pactl set-default-sink @DEFAULT_SINK@") < 0)
+    }
+
+    function test_mic_boot_reconciliation_leaves_a_normal_default_alone() {
+        PhoneMic.responder = argv => argv[0] === "pactl" ? { text: "Arctis_Media\n", code: 0 } : { text: '{"alive":false}', code: 0 }
+        PhoneMic.reconcile()
+        compare(PhoneMic.ranCommands.length, 3)
+    }
+
+    function test_mic_watchdog_reports_a_lost_stream() {
+        activeScrcpyMic()
+        PhoneMic.responder = argv => ({ text: '{"session":"scrcpy-mic","alive":false}', code: 0 })
+        PhoneMic.checkSession()
+        verify(!PhoneMic.active)
+        verify(PhoneMic.lastError.indexOf("lost") >= 0)
+        compare(argvJoined(PhoneMic.ranCommands)[0], "bash " + sessionScript + " status scrcpy-mic")
     }
 }

--- a/dots/.config/quickshell/imi/tests/tst_phone_scrcpy.qml
+++ b/dots/.config/quickshell/imi/tests/tst_phone_scrcpy.qml
@@ -1,0 +1,130 @@
+import QtQuick
+import QtTest
+import testservices
+import qs.modules.common
+
+// The Phone tab's four session services - PhoneDeps, PhoneScrcpy,
+// PhoneCamera, PhoneMic - driven through their logic-only doubles in
+// tests/imports/testservices. Every argv, flag table and state ladder is
+// exercised here; the process I/O the doubles omit is pinned by
+// tests/test_phone_sessions_contract.py, and the supervisor itself by
+// tests/test_phone_scrcpy_manager.py.
+TestCase {
+    name: "PhoneSessionsTest"
+
+    readonly property string sessionScript: "/mock/phone/droidcam_session.sh"
+    readonly property string statusScript: "/mock/phone/droidcam_status.sh"
+    readonly property string setupScript: "/mock/phone/setup_droidcam_input.sh"
+    readonly property string teardownScript: "/mock/phone/teardown_droidcam_input.sh"
+
+    function phone(extra) {
+        return Object.assign({
+            id: "dev_1", name: "Phone", type: "phone", reachable: true, paired: true,
+            hasPairingRequest: false, reachableAddresses: ["192.168.1.50"],
+            cellularNetworkType: "LTE", cellularNetworkStrength: 3,
+            batteryAvailable: true, batteryCharge: 80, batteryCharging: false
+        }, extra || {})
+    }
+
+    function argvJoined(list) {
+        return list.map(a => a.join(" "))
+    }
+
+    function init() {
+        PhoneConnect.installed = true
+        PhoneConnect.backend = "kdeconnect"
+        PhoneConnect.devices = [phone()]
+        PhoneDeps.scrcpy = false
+        PhoneDeps.adb = false
+        PhoneDeps.droidcamCli = false
+        PhoneDeps.v4l2Ctl = false
+        PhoneDeps.pactl = false
+        PhoneDeps.mpv = false
+        PhoneDeps.ffplay = false
+        PhoneDeps.vlc = false
+        PhoneDeps.v4l2loopbackLoaded = false
+        PhoneDeps.v4l2loopbackInstalled = false
+        PhoneDeps.scrcpyMajor = 0
+    }
+
+    // ================================================================
+    // PhoneDeps
+    // ================================================================
+
+    function test_deps_parses_the_scrcpy_version_line() {
+        const v = PhoneDeps.parseScrcpyVersion("scrcpy 4.1 <https://github.com/Genymobile/scrcpy>")
+        compare(v.major, 4)
+        compare(v.minor, 1)
+        compare(v.version, "4.1")
+        compare(PhoneDeps.parseScrcpyVersion("scrcpy v2.7.1").version, "2.7.1")
+        compare(PhoneDeps.parseScrcpyVersion("Dependencies (compiled / linked):"), null)
+        compare(PhoneDeps.parseScrcpyVersion(""), null)
+    }
+
+    function test_deps_app_mode_needs_scrcpy_four() {
+        PhoneDeps.scrcpy = true
+        PhoneDeps.scrcpyMajor = 3
+        verify(!PhoneDeps.appModeSupported)
+        PhoneDeps.scrcpyMajor = 4
+        verify(PhoneDeps.appModeSupported)
+        PhoneDeps.scrcpy = false
+        verify(!PhoneDeps.appModeSupported)
+    }
+
+    function test_deps_reads_the_distro_off_the_marker_files() {
+        compare(PhoneDeps.parseDistro("/etc/arch-release\n"), "arch")
+        compare(PhoneDeps.parseDistro("/etc/fedora-release\n"), "fedora")
+        compare(PhoneDeps.parseDistro("/etc/debian_version\n"), "debian")
+        compare(PhoneDeps.parseDistro(""), "unknown")
+        compare(PhoneDeps.parseDistro("/etc/os-release\n"), "unknown")
+    }
+
+    function test_deps_counts_droidcams_own_loopback_module_as_loaded() {
+        compare(PhoneDeps.parseLsmod("Module                  Size  Used by\nsnd_aloop              45056  1\nv4l2loopback_dc        45056  0\n"), true)
+        compare(PhoneDeps.parseLsmod("v4l2loopback           53248  0\n"), true)
+        compare(PhoneDeps.parseLsmod("snd_aloop              45056  1\nvideodev              421888  1\n"), false)
+        compare(PhoneDeps.parseLsmod(""), false)
+    }
+
+    function test_deps_dependency_table_carries_the_forks_commands() {
+        const scrcpy = PhoneDeps.dependency("scrcpy")
+        compare(scrcpy.key, "scrcpy")
+        compare(scrcpy.commands.arch, "sudo pacman -S scrcpy")
+        compare(scrcpy.commands.fedora, "sudo dnf install scrcpy")
+        compare(scrcpy.commands.debian, "sudo apt install scrcpy")
+        compare(PhoneDeps.dependency("android-tools").commands.debian, "sudo apt install android-tools-adb")
+        compare(PhoneDeps.dependency("droidcam-cli").commands.arch, "yay -S droidcam")
+        verify(PhoneDeps.dependency("v4l2loopback").commands.fedora.startsWith("sudo dnf install akmod-v4l2loopback"))
+        compare(PhoneDeps.dependency("pactl").commands.arch, "sudo pacman -S pulseaudio-utils")
+        verify(PhoneDeps.dependency("audio-backend").commands.arch.indexOf("yay -S droidcam") > 0)
+        verify(PhoneDeps.dependency("scrcpy").description.length > 0)
+        compare(PhoneDeps.dependency("python-dbus"), null)
+    }
+
+    function test_deps_missing_for_mirror_is_scrcpy_and_adb() {
+        compare(PhoneDeps.missingDeps("mirror", {}).map(d => d.key), ["scrcpy", "android-tools"])
+        compare(PhoneDeps.missingDeps("mirror", { scrcpy: true }).map(d => d.key), ["android-tools"])
+        compare(PhoneDeps.missingDeps("mirror", { scrcpy: true, adb: true }), [])
+    }
+
+    function test_deps_missing_for_webcam_accepts_an_installed_but_unloaded_module() {
+        compare(PhoneDeps.missingDeps("webcam", {}).map(d => d.key),
+                ["droidcam-cli", "v4l2loopback", "v4l-utils", "mpv"])
+        compare(PhoneDeps.missingDeps("webcam", { droidcamCli: true, v4l2loopbackInstalled: true, v4l2Ctl: true, mpv: true }), [])
+        compare(PhoneDeps.missingDeps("webcam", { droidcamCli: true, v4l2loopbackLoaded: true, v4l2Ctl: true }).map(d => d.key), ["mpv"])
+    }
+
+    function test_deps_missing_for_microphone_needs_pactl_and_one_backend() {
+        compare(PhoneDeps.missingDeps("microphone", {}).map(d => d.key), ["pactl", "audio-backend"])
+        compare(PhoneDeps.missingDeps("microphone", { pactl: true, droidcamCli: true }), [])
+        compare(PhoneDeps.missingDeps("microphone", { scrcpy: true }).map(d => d.key), ["pactl"])
+        compare(PhoneDeps.missingDeps("nonsense", {}), [])
+    }
+
+    function test_deps_missing_for_reads_the_live_flags() {
+        PhoneDeps.scrcpy = true
+        compare(PhoneDeps.missingFor("mirror").map(d => d.key), ["android-tools"])
+        PhoneDeps.adb = true
+        compare(PhoneDeps.missingFor("mirror"), [])
+    }
+}

--- a/dots/.config/quickshell/imi/tests/tst_phone_scrcpy.qml
+++ b/dots/.config/quickshell/imi/tests/tst_phone_scrcpy.qml
@@ -45,6 +45,14 @@ TestCase {
         PhoneDeps.v4l2loopbackLoaded = false
         PhoneDeps.v4l2loopbackInstalled = false
         PhoneDeps.scrcpyMajor = 0
+        PhoneScrcpy.reset()
+        PhoneScrcpy.available = true
+        PhoneScrcpy.appModeSupported = true
+        Config.options.phone.scrcpy.appMode.favoritePackages = []
+        Config.options.phone.scrcpy.useWireless = false
+        Config.options.phone.scrcpy.autoWirelessIp = true
+        Config.options.phone.scrcpy.wirelessIp = ""
+        Persistent.states.phone.scrcpy.recentPackages = []
     }
 
     // ================================================================
@@ -126,5 +134,238 @@ TestCase {
         compare(PhoneDeps.missingFor("mirror").map(d => d.key), ["android-tools"])
         PhoneDeps.adb = true
         compare(PhoneDeps.missingFor("mirror"), [])
+    }
+
+    // ================================================================
+    // PhoneScrcpy - the flag tables
+    // ================================================================
+
+    function test_scrcpy_mirror_args_from_the_defaults_is_the_bit_rate_alone() {
+        compare(PhoneScrcpy.mirrorArgs(Config.options.phone.scrcpy), ["--video-bit-rate=8M"])
+        compare(PhoneScrcpy.mirrorArgs({}), [])
+        compare(PhoneScrcpy.mirrorArgs(null), [])
+    }
+
+    function test_scrcpy_mirror_args_carries_every_flag_in_the_forks_order() {
+        const args = PhoneScrcpy.mirrorArgs({
+            stayAwake: true, turnScreenOff: true, noPowerOn: true, noAudio: true, showTouches: true,
+            fullscreen: true, alwaysOnTop: true, maxFps: 60, bitRate: "4M", maxSize: 1080, videoBuffer: 50
+        })
+        compare(args, ["--stay-awake", "--turn-screen-off", "--no-power-on", "--no-audio", "--show-touches",
+                       "--fullscreen", "--always-on-top", "--max-fps=60", "--video-bit-rate=4M",
+                       "--max-size=1080", "--video-buffer=50"])
+        compare(PhoneScrcpy.mirrorArgs({ maxFps: 0, bitRate: "  ", maxSize: -1, videoBuffer: 0 }), [])
+    }
+
+    function test_scrcpy_app_mode_args_opens_a_virtual_display_when_flex_is_on() {
+        compare(PhoneScrcpy.appModeArgs("org.mozilla.firefox", Config.options.phone.scrcpy.appMode),
+                ["--start-app=org.mozilla.firefox", "--new-display=1280x960/160", "--flex-display", "--keep-active"])
+        compare(PhoneScrcpy.appModeArgs("com.a", { flexDisplay: false }), ["--start-app=com.a"])
+        compare(PhoneScrcpy.appModeArgs("com.a", { flexDisplay: true, displayWidth: 1920, displayHeight: 1080, density: 240, keepActive: false, systemDecorations: false }),
+                ["--start-app=com.a", "--new-display=1920x1080/240", "--flex-display", "--no-vd-system-decorations"])
+        compare(PhoneScrcpy.appModeArgs("com.a", { flexDisplay: true, displayWidth: 0 }),
+                ["--start-app=com.a", "--new-display=1280x960/160", "--flex-display"])
+    }
+
+    function test_scrcpy_target_args_names_a_wireless_phone_only_when_asked() {
+        compare(PhoneScrcpy.targetArgs({ useWireless: false }, phone()), [])
+        compare(PhoneScrcpy.targetArgs({ useWireless: true, autoWirelessIp: true, wirelessPort: "5555" }, phone()),
+                ["-s", "192.168.1.50:5555"])
+        compare(PhoneScrcpy.targetArgs({ useWireless: true, autoWirelessIp: true, wirelessPort: "" }, phone({ reachableAddresses: ["", " 10.0.0.9 "] })),
+                ["-s", "10.0.0.9:5555"])
+        compare(PhoneScrcpy.targetArgs({ useWireless: true, autoWirelessIp: false, wirelessIp: "10.0.0.3", wirelessPort: "40001" }, phone()),
+                ["-s", "10.0.0.3:40001"])
+        compare(PhoneScrcpy.targetArgs({ useWireless: true, autoWirelessIp: false, wirelessIp: "10.0.0.3:41234" }, phone()),
+                ["-s", "10.0.0.3:41234"])
+        compare(PhoneScrcpy.targetArgs({ useWireless: true, autoWirelessIp: true }, phone({ reachableAddresses: [] })), [])
+        compare(PhoneScrcpy.targetArgs({ useWireless: true, autoWirelessIp: true }, null), [])
+    }
+
+    function test_scrcpy_recents_are_mru_and_capped() {
+        compare(PhoneScrcpy.pushRecent([], "a", 3), ["a"])
+        compare(PhoneScrcpy.pushRecent(["a", "b"], "b", 3), ["b", "a"])
+        compare(PhoneScrcpy.pushRecent(["a", "b", "c"], "d", 3), ["d", "a", "b"])
+        compare(PhoneScrcpy.toggleInList(["a"], "b"), ["a", "b"])
+        compare(PhoneScrcpy.toggleInList(["a", "b"], "a"), ["b"])
+    }
+
+    function test_scrcpy_backoff_doubles_from_one_second_to_a_thirty_second_cap() {
+        compare(PhoneScrcpy.backoffDelay(1), 1000)
+        compare(PhoneScrcpy.backoffDelay(2), 2000)
+        compare(PhoneScrcpy.backoffDelay(5), 16000)
+        compare(PhoneScrcpy.backoffDelay(6), 30000)
+        compare(PhoneScrcpy.backoffDelay(40), 30000)
+    }
+
+    // ================================================================
+    // PhoneScrcpy - the event ladder
+    // ================================================================
+
+    function test_scrcpy_started_and_exited_move_the_mirror_and_the_session_list() {
+        PhoneScrcpy.mirrorLaunching = true
+        PhoneScrcpy.handleLine('{"event":"started","id":"mirror","pid":4242,"title":"imi-phone-mirror-mirror"}')
+        verify(PhoneScrcpy.mirrorRunning)
+        verify(!PhoneScrcpy.mirrorLaunching)
+        compare(PhoneScrcpy.sessionCount, 1)
+        compare(PhoneScrcpy.sessions.get(0).title, "imi-phone-mirror-mirror")
+        compare(PhoneScrcpy.sessions.get(0).pid, 4242)
+        compare(PhoneScrcpy.sessions.get(0).package, "")
+        PhoneScrcpy.handleLine('{"event":"started","id":"app:org.mozilla.firefox","pid":4300,"title":"imi-phone-app-app_org.mozilla.firefox"}')
+        compare(PhoneScrcpy.sessionCount, 2)
+        compare(PhoneScrcpy.sessions.get(1).package, "org.mozilla.firefox")
+        verify(PhoneScrcpy.isAppRunning("org.mozilla.firefox"))
+        // A repeat `started` (alreadyRunning) updates the row in place.
+        PhoneScrcpy.handleLine('{"event":"started","id":"mirror","pid":4242,"title":"imi-phone-mirror-mirror","alreadyRunning":true}')
+        compare(PhoneScrcpy.sessionCount, 2)
+        PhoneScrcpy.handleLine('{"event":"exited","id":"mirror","code":0,"error":""}')
+        verify(!PhoneScrcpy.mirrorRunning)
+        compare(PhoneScrcpy.sessionCount, 1)
+        compare(PhoneScrcpy.lastError, "")
+        PhoneScrcpy.handleLine('{"event":"exited","id":"app:org.mozilla.firefox","code":1,"error":"ERROR: Could not find ADB device"}')
+        compare(PhoneScrcpy.sessionCount, 0)
+        compare(PhoneScrcpy.lastError, "ERROR: Could not find ADB device")
+        compare(PhoneScrcpy.feedbackLog.length, 1)
+        compare(PhoneScrcpy.feedbackLog[0].ok, false)
+    }
+
+    function test_scrcpy_an_error_event_ends_the_launch_and_names_the_cause() {
+        PhoneScrcpy.mirrorLaunching = true
+        PhoneScrcpy.handleLine('{"event":"error","id":"mirror","message":"Failed to launch scrcpy: [Errno 2]"}')
+        verify(!PhoneScrcpy.mirrorLaunching)
+        verify(!PhoneScrcpy.mirrorRunning)
+        compare(PhoneScrcpy.lastError, "Failed to launch scrcpy: [Errno 2]")
+    }
+
+    function test_scrcpy_a_cached_app_list_shows_but_keeps_loading_until_the_live_one() {
+        PhoneScrcpy.appsLoading = true
+        PhoneScrcpy.handleLine('{"event":"apps_list","deviceId":"dev_1","apps":[{"package":"com.a","name":"A","system":false}],"cached":true}')
+        compare(PhoneScrcpy.apps.length, 1)
+        verify(PhoneScrcpy.appsLoading)
+        PhoneScrcpy.handleLine('{"event":"apps_list","deviceId":"dev_1","apps":[{"package":"com.a","name":"A","system":false},{"package":"com.b","name":"B","system":true}]}')
+        compare(PhoneScrcpy.apps.length, 2)
+        verify(!PhoneScrcpy.appsLoading)
+        compare(PhoneScrcpy.appsError, "")
+    }
+
+    function test_scrcpy_an_apps_error_keeps_the_list_on_screen() {
+        PhoneScrcpy.apps = [{ package: "com.a", name: "A", system: false }]
+        PhoneScrcpy.appsLoading = true
+        PhoneScrcpy.handleLine('{"event":"apps_error","message":"Phone not reachable over ADB"}')
+        verify(!PhoneScrcpy.appsLoading)
+        compare(PhoneScrcpy.appsError, "Phone not reachable over ADB")
+        compare(PhoneScrcpy.apps.length, 1)
+    }
+
+    function test_scrcpy_ignores_lines_that_are_not_events() {
+        PhoneScrcpy.handleLine("")
+        PhoneScrcpy.handleLine("not json")
+        PhoneScrcpy.handleLine('{"cmd":"launch"}')
+        PhoneScrcpy.handleLine('[1,2]')
+        compare(PhoneScrcpy.sessionCount, 0)
+        compare(PhoneScrcpy.lastError, "")
+    }
+
+    // ================================================================
+    // PhoneScrcpy - the commands
+    // ================================================================
+
+    function test_scrcpy_launch_mirror_sends_the_flags_and_the_target() {
+        Config.options.phone.scrcpy.useWireless = true
+        PhoneScrcpy.launchMirror()
+        verify(PhoneScrcpy.mirrorLaunching)
+        compare(PhoneScrcpy.sentMessages.length, 1)
+        const msg = PhoneScrcpy.sentMessages[0]
+        compare(msg.cmd, "launch")
+        compare(msg.id, "mirror")
+        compare(msg.type, "mirror")
+        compare(msg.target_args, ["-s", "192.168.1.50:5555"])
+        compare(msg.extra_args, ["--video-bit-rate=8M"])
+    }
+
+    function test_scrcpy_launch_mirror_while_running_focuses_instead() {
+        PhoneScrcpy.handleLine('{"event":"started","id":"mirror","pid":1,"title":"t"}')
+        PhoneScrcpy.launchMirror()
+        compare(PhoneScrcpy.sentMessages, [{ cmd: "focus", id: "mirror" }])
+        PhoneScrcpy.stopMirror()
+        compare(PhoneScrcpy.sentMessages[1], { cmd: "stop", id: "mirror" })
+    }
+
+    function test_scrcpy_launch_mirror_without_scrcpy_is_refused() {
+        PhoneScrcpy.available = false
+        PhoneScrcpy.launchMirror()
+        verify(!PhoneScrcpy.mirrorLaunching)
+        compare(PhoneScrcpy.sentMessages, [])
+        compare(PhoneScrcpy.lastError, "scrcpy is not installed")
+    }
+
+    function test_scrcpy_refresh_apps_is_gated_on_app_mode_and_keyed_on_the_device() {
+        PhoneScrcpy.appModeSupported = false
+        PhoneScrcpy.refreshApps()
+        compare(PhoneScrcpy.sentMessages, [])
+        PhoneScrcpy.appModeSupported = true
+        PhoneScrcpy.refreshApps()
+        verify(PhoneScrcpy.appsLoading)
+        compare(PhoneScrcpy.sentMessages, [{ cmd: "list_apps", target_args: [], deviceId: "dev_1" }])
+        PhoneConnect.devices = []
+        compare(PhoneScrcpy.deviceId(), "default")
+    }
+
+    function test_scrcpy_launch_app_sends_app_mode_and_records_the_recent() {
+        PhoneScrcpy.launchApp("org.mozilla.firefox")
+        compare(PhoneScrcpy.sentMessages.length, 1)
+        const msg = PhoneScrcpy.sentMessages[0]
+        compare(msg.cmd, "launch")
+        compare(msg.id, "app:org.mozilla.firefox")
+        compare(msg.type, "app")
+        compare(msg.extra_args[0], "--start-app=org.mozilla.firefox")
+        compare(msg.extra_args[1], "--new-display=1280x960/160")
+        compare(Persistent.states.phone.scrcpy.recentPackages.length, 1)
+        compare(String(Persistent.states.phone.scrcpy.recentPackages[0]), "org.mozilla.firefox")
+        compare(String(PhoneScrcpy.recents[0]), "org.mozilla.firefox")
+        // Launching a running app focuses it.
+        PhoneScrcpy.handleLine('{"event":"started","id":"app:org.mozilla.firefox","pid":9,"title":"t"}')
+        PhoneScrcpy.launchApp("org.mozilla.firefox")
+        compare(PhoneScrcpy.sentMessages[1], { cmd: "focus", id: "app:org.mozilla.firefox" })
+        PhoneScrcpy.stopApp("org.mozilla.firefox")
+        compare(PhoneScrcpy.sentMessages[2], { cmd: "stop", id: "app:org.mozilla.firefox" })
+        PhoneScrcpy.stopAllApps()
+        compare(PhoneScrcpy.sentMessages[3], { cmd: "stop_all" })
+        PhoneScrcpy.launchApp("")
+        compare(PhoneScrcpy.sentMessages.length, 4)
+    }
+
+    function test_scrcpy_launch_app_needs_scrcpy_four() {
+        PhoneScrcpy.appModeSupported = false
+        PhoneScrcpy.launchApp("com.a")
+        compare(PhoneScrcpy.sentMessages, [])
+        compare(PhoneScrcpy.lastError, "scrcpy 4.0+ is required for App Mode")
+        compare(PhoneScrcpy.feedbackLog.length, 1)
+    }
+
+    function test_scrcpy_favorites_live_in_config() {
+        verify(!PhoneScrcpy.isFavorite("com.a"))
+        PhoneScrcpy.toggleFavorite("com.a")
+        verify(PhoneScrcpy.isFavorite("com.a"))
+        compare(Config.options.phone.scrcpy.appMode.favoritePackages.length, 1)
+        PhoneScrcpy.toggleFavorite("com.a")
+        verify(!PhoneScrcpy.isFavorite("com.a"))
+        compare(Config.options.phone.scrcpy.appMode.favoritePackages.length, 0)
+    }
+
+    function test_scrcpy_the_supervisor_is_wanted_while_anything_is_live_or_pending() {
+        verify(!PhoneScrcpy.managerWanted())
+        PhoneScrcpy.mirrorLaunching = true
+        verify(PhoneScrcpy.managerWanted())
+        PhoneScrcpy.mirrorLaunching = false
+        PhoneScrcpy.appsLoading = true
+        verify(PhoneScrcpy.managerWanted())
+        PhoneScrcpy.appsLoading = false
+        PhoneScrcpy.pendingMessages = [{ cmd: "focus", id: "mirror" }]
+        verify(PhoneScrcpy.managerWanted())
+        PhoneScrcpy.pendingMessages = []
+        PhoneScrcpy.handleLine('{"event":"started","id":"mirror","pid":1,"title":"t"}')
+        verify(PhoneScrcpy.managerWanted())
+        PhoneScrcpy.handleLine('{"event":"exited","id":"mirror","code":0,"error":""}')
+        verify(!PhoneScrcpy.managerWanted())
     }
 }

--- a/dots/.config/quickshell/imi/tests/tst_phone_scrcpy.qml
+++ b/dots/.config/quickshell/imi/tests/tst_phone_scrcpy.qml
@@ -48,10 +48,16 @@ TestCase {
         PhoneScrcpy.reset()
         PhoneScrcpy.available = true
         PhoneScrcpy.appModeSupported = true
+        PhoneCamera.reset()
+        PhoneCamera.available = true
         Config.options.phone.scrcpy.appMode.favoritePackages = []
         Config.options.phone.scrcpy.useWireless = false
         Config.options.phone.scrcpy.autoWirelessIp = true
         Config.options.phone.scrcpy.wirelessIp = ""
+        Config.options.phone.webcam.connection = "wifi"
+        Config.options.phone.webcam.wifiIp = ""
+        Config.options.phone.webcam.mirrorHorizontally = false
+        Config.options.phone.webcam.rotateDegrees = 0
         Persistent.states.phone.scrcpy.recentPackages = []
     }
 
@@ -367,5 +373,198 @@ TestCase {
         verify(PhoneScrcpy.managerWanted())
         PhoneScrcpy.handleLine('{"event":"exited","id":"mirror","code":0,"error":""}')
         verify(!PhoneScrcpy.managerWanted())
+    }
+
+    // ================================================================
+    // PhoneCamera
+    // ================================================================
+
+    function test_camera_state_ladder() {
+        compare(PhoneCamera.stateFor(false, true, true, true), "unavailable")
+        compare(PhoneCamera.stateFor(true, false, false, false), "offline")
+        compare(PhoneCamera.stateFor(true, true, false, false), "ready")
+        compare(PhoneCamera.stateFor(true, true, true, false), "connecting")
+        compare(PhoneCamera.stateFor(true, true, false, true), "active")
+        compare(PhoneCamera.stateFor(true, false, false, true), "active")
+        compare(PhoneCamera.state, "ready")
+        PhoneCamera.available = false
+        compare(PhoneCamera.state, "unavailable")
+        PhoneCamera.available = true
+        PhoneConnect.devices = [phone({ reachable: false })]
+        compare(PhoneCamera.state, "offline")
+    }
+
+    function test_camera_finds_the_droidcam_node_in_v4l2_ctl_output() {
+        // Captured on the development machine, DroidCam's own module.
+        compare(PhoneCamera.parseV4l2Devices("Droidcam (platform:v4l2loopback_dc-000):\n\t/dev/video0\n"), "/dev/video0")
+        const mixed = "Integrated Camera (usb-0000:00:14.0-8):\n\t/dev/video1\n\t/dev/video2\n\nDroidCam (platform:v4l2loopback-000):\n\t/dev/video10\n\t/dev/video11\n"
+        compare(PhoneCamera.parseV4l2Devices(mixed), "/dev/video10")
+        const loopbackOnly = "Integrated Camera (usb-0000:00:14.0-8):\n\t/dev/video1\n\nDummy video device (0x0000) (platform:v4l2loopback-000):\n\t/dev/video10\n"
+        compare(PhoneCamera.parseV4l2Devices(loopbackOnly), "/dev/video10")
+        compare(PhoneCamera.parseV4l2Devices("Integrated Camera (usb-0000:00:14.0-8):\n\t/dev/video1\n"), "")
+        compare(PhoneCamera.parseV4l2Devices(""), "")
+    }
+
+    function test_camera_droidcam_args_single_dash_size_and_flips() {
+        compare(PhoneCamera.droidcamArgs({ resolution: "1280x720" }, "usb", "", 4747),
+                ["droidcam-cli", "-nocontrols", "-size=1280x720", "adb", "4747"])
+        compare(PhoneCamera.droidcamArgs({ resolution: "640x480", mirrorHorizontally: true }, "wifi", "192.168.1.50", 4747),
+                ["droidcam-cli", "-nocontrols", "-size=640x480", "-hflip", "192.168.1.50", "4747"])
+        compare(PhoneCamera.droidcamArgs({ resolution: "", rotateDegrees: 180 }, "wifi", "10.0.0.2", 4748),
+                ["droidcam-cli", "-nocontrols", "-hflip", "-vflip", "10.0.0.2", "4748"])
+        compare(PhoneCamera.droidcamArgs({ mirrorHorizontally: true, rotateDegrees: 180 }, "usb", "", 4747),
+                ["droidcam-cli", "-nocontrols", "-hflip", "-vflip", "adb", "4747"])
+    }
+
+    function test_camera_connection_plan_is_usb_first() {
+        compare(PhoneCamera.connectionPlan({ connection: "usb" }, "", []), { mode: "usb", ip: "", port: 4747 })
+        compare(PhoneCamera.connectionPlan({ connection: "wifi", wifiIp: " 10.0.0.5 ", port: 4750 }, "device", ["1.2.3.4"]),
+                { mode: "wifi", ip: "10.0.0.5", port: 4750 })
+        compare(PhoneCamera.connectionPlan({ connection: "wifi" }, "device\n", ["1.2.3.4"]), { mode: "usb", ip: "", port: 4747 })
+        compare(PhoneCamera.connectionPlan({ connection: "wifi" }, "offline", ["", "1.2.3.4"]), { mode: "wifi", ip: "1.2.3.4", port: 4747 })
+        verify(PhoneCamera.connectionPlan({ connection: "wifi" }, "", []).error.length > 0)
+    }
+
+    function test_camera_preview_falls_back_from_mpv_to_ffplay_to_vlc() {
+        compare(PhoneCamera.previewCommand("/dev/video0", { mpv: true, ffplay: true, vlc: true }),
+                ["mpv", "--profile=low-latency", "--no-fullscreen", "--no-osc", "--title=imi webcam preview", "av://v4l2:/dev/video0"])
+        compare(PhoneCamera.previewCommand("/dev/video0", { ffplay: true, vlc: true })[0], "ffplay")
+        compare(PhoneCamera.previewCommand("/dev/video0", { vlc: true }), ["vlc", "--no-video-title-show", "--no-fullscreen", "v4l2:///dev/video0"])
+        compare(PhoneCamera.previewCommand("/dev/video0", {}), [])
+        compare(PhoneCamera.previewCommand("", { mpv: true }), [])
+    }
+
+    function test_camera_start_probes_usb_then_launches_detached() {
+        PhoneCamera.responder = argv => {
+            if (argv[0] === "adb") return { text: "device\n", code: 0 }
+            if (argv[2] === "launch") return { text: "31337\n", code: 0 }
+            return null
+        }
+        PhoneCamera.start()
+        verify(PhoneCamera.connecting)
+        compare(PhoneCamera.state, "connecting")
+        compare(argvJoined(PhoneCamera.ranCommands), [
+            "adb get-state",
+            "bash " + sessionScript + " launch video droidcam-cli -nocontrols -size=1280x720 adb 4747"
+        ])
+        compare(PhoneCamera.activeMode, "usb")
+        compare(PhoneCamera.sessionPid, 31337)
+        compare(PhoneCamera.connectTimersArmed, 1)
+        compare(Persistent.states.phone.camera.lastMode, "usb")
+        compare(Persistent.states.phone.camera.lastPort, 4747)
+    }
+
+    function test_camera_start_takes_a_configured_address_without_probing() {
+        Config.options.phone.webcam.wifiIp = "10.0.0.7"
+        Config.options.phone.webcam.mirrorHorizontally = true
+        PhoneCamera.responder = argv => ({ text: "1\n", code: 0 })
+        PhoneCamera.start()
+        compare(argvJoined(PhoneCamera.ranCommands), [
+            "bash " + sessionScript + " launch video droidcam-cli -nocontrols -size=1280x720 -hflip 10.0.0.7 4747"
+        ])
+        compare(PhoneCamera.activeIp, "10.0.0.7")
+        compare(Persistent.states.phone.camera.lastIp, "10.0.0.7")
+    }
+
+    function test_camera_start_falls_back_to_kde_connects_address() {
+        PhoneCamera.responder = argv => argv[0] === "adb" ? { text: "", code: 1 } : { text: "5\n", code: 0 }
+        PhoneCamera.start()
+        compare(PhoneCamera.activeMode, "wifi")
+        compare(PhoneCamera.activeIp, "192.168.1.50")
+    }
+
+    function test_camera_start_with_nothing_to_connect_to_fails_with_a_reason() {
+        PhoneConnect.devices = [phone({ reachableAddresses: [] })]
+        PhoneCamera.responder = argv => ({ text: "", code: 1 })
+        PhoneCamera.start()
+        verify(!PhoneCamera.connecting)
+        verify(PhoneCamera.lastError.indexOf("USB or Wi-Fi IP") >= 0)
+        compare(PhoneCamera.ranCommands.length, 1)
+    }
+
+    function test_camera_start_is_refused_without_a_reachable_phone() {
+        PhoneConnect.devices = [phone({ reachable: false })]
+        PhoneCamera.start()
+        verify(!PhoneCamera.connecting)
+        compare(PhoneCamera.ranCommands, [])
+        verify(PhoneCamera.lastError.length > 0)
+        PhoneCamera.available = false
+        PhoneConnect.devices = [phone()]
+        PhoneCamera.start()
+        compare(PhoneCamera.ranCommands, [])
+    }
+
+    function test_camera_a_live_status_makes_it_active_and_arms_the_watchdog() {
+        PhoneCamera.connecting = true
+        PhoneCamera.responder = argv => argv[2] === "status"
+            ? { text: '{"session":"video","pid":"31337","alive":true,"started":"1787811446","port":"4747","mode":"usb","ip":"adb","device":"/dev/video0","video_running":true,"audio_running":false}\n', code: 0 }
+            : null
+        PhoneCamera.checkSession()
+        verify(PhoneCamera.active)
+        verify(!PhoneCamera.connecting)
+        compare(PhoneCamera.state, "active")
+        compare(PhoneCamera.device, "/dev/video0")
+        compare(PhoneCamera.sessionPid, 31337)
+        compare(PhoneCamera.startedAt, 1787811446)
+        compare(PhoneCamera.watchdogArmed, 1)
+        compare(argvJoined(PhoneCamera.ranCommands), ["bash " + sessionScript + " status video"])
+    }
+
+    function test_camera_a_dead_status_while_active_reports_the_loss() {
+        PhoneCamera.active = true
+        PhoneCamera.device = "/dev/video0"
+        PhoneCamera.responder = argv => ({ text: '{"session":"video","pid":"","alive":false}', code: 0 })
+        PhoneCamera.checkSession()
+        verify(!PhoneCamera.active)
+        compare(PhoneCamera.device, "")
+        compare(PhoneCamera.lastError, "The webcam stream ended")
+    }
+
+    function test_camera_a_dead_status_past_the_deadline_fails_the_connect() {
+        PhoneCamera.connecting = true
+        PhoneCamera.responder = argv => ({ text: '{"alive":false}', code: 0 })
+        PhoneCamera.checkSession()
+        verify(PhoneCamera.connecting)
+        PhoneCamera.deadlinePassed = true
+        PhoneCamera.checkSession()
+        verify(!PhoneCamera.connecting)
+        verify(PhoneCamera.lastError.indexOf("9s") >= 0)
+    }
+
+    function test_camera_stop_goes_through_the_session_script() {
+        PhoneCamera.active = true
+        PhoneCamera.device = "/dev/video0"
+        PhoneCamera.stop()
+        verify(!PhoneCamera.active)
+        verify(PhoneCamera.userStopped)
+        compare(PhoneCamera.device, "")
+        compare(argvJoined(PhoneCamera.ranCommands), ["bash " + sessionScript + " stop video"])
+        PhoneCamera.stop()
+        compare(PhoneCamera.ranCommands.length, 1)
+    }
+
+    function test_camera_mirror_writes_the_config_and_flips_the_live_device() {
+        PhoneDeps.v4l2Ctl = true
+        PhoneCamera.mirror(true)
+        compare(Config.options.phone.webcam.mirrorHorizontally, true)
+        compare(PhoneCamera.ranCommands, [])
+        PhoneCamera.active = true
+        PhoneCamera.device = "/dev/video0"
+        PhoneCamera.mirror(false)
+        compare(argvJoined(PhoneCamera.ranCommands), ["v4l2-ctl -d /dev/video0 --set-ctrl=horizontal_flip=0"])
+        PhoneCamera.flip()
+        compare(Config.options.phone.webcam.cameraFacing, "back")
+        PhoneCamera.flip()
+        compare(Config.options.phone.webcam.cameraFacing, "front")
+    }
+
+    function test_camera_parse_session_status_tolerates_the_scripts_strings() {
+        const s = PhoneCamera.parseSessionStatus('{"session":"video","pid":"12","alive":"true","started":"7","port":"4747","mode":"wifi","ip":"1.2.3.4","device":""}')
+        compare(s.alive, true)
+        compare(s.pid, 12)
+        compare(s.port, 4747)
+        compare(s.ip, "1.2.3.4")
+        compare(PhoneCamera.parseSessionStatus("not json"), null)
+        compare(PhoneCamera.parseSessionStatus(""), null)
     }
 }

--- a/sdata/deps-info.md
+++ b/sdata/deps-info.md
@@ -196,6 +196,23 @@ Tips:
   - Note that `qalc` is the needed executable. In Arch Linux [libqalculate](https://archlinux.org/packages/extra/x86_64/libqalculate) provides it, but in Fedora [qalculate](https://packages.fedoraproject.org/pkgs/libqalculate/qalculate/fedora-43.html#files) does and [libqalculate](https://packages.fedoraproject.org/pkgs/libqalculate/libqalculate/fedora-43.html#files) does not.
 
 
+## Phone (optional)
+None of these is in any `PKGBUILD` or install list, on purpose: the Phone tab probes each one
+at shell start (`quickshell/imi/services/PhoneDeps.qml`, a constant `command -v` per tool) and
+shows the install command for Arch, Fedora and Debian when one is missing. Install what you use.
+- `scrcpy` — the screen mirror and App Mode (`--start-app`, needs scrcpy 4+); also the
+  preferred microphone backend (`--audio-source=mic`). Arch: `scrcpy`.
+- `android-tools` — `adb`, which scrcpy and the USB connection paths need.
+- `droidcam` (AUR, bundles `droidcam-cli` and the `v4l2loopback-dc` module) or `droidcam-cli` with
+  `v4l2loopback-dkms` — the webcam, and the fallback microphone backend.
+  `quickshell/imi/scripts/phone/install_droidcam.sh` is the per-distro installer the guide offers.
+- `v4l-utils` — `v4l2-ctl`, recommended: finds the webcam's `/dev/videoN` and flips it live.
+- `pulseaudio-utils` (or `pipewire-pulse`) — `pactl`, required for the microphone: loads the
+  `DroidCam-Mic` null sink whose monitor is the recordable source.
+- `mpv` (recommended), else `ffplay` (`ffmpeg`) or `vlc` — the webcam preview window.
+- `kdialog` (already in `immaterial-impulse-quickshell-git`) and `wl-clipboard` (already in
+  `immaterial-impulse-hyprland`) — the Send file picker and the clipboard share.
+
 # Actual packages
 ## immaterial-impulse-quickshell-git
 - Pinned commit.


### PR DESCRIPTION
W3 of the Phone tab: the scrcpy mirror, App Mode, the DroidCam webcam and the phone microphone — services and scripts. No UI; W5 draws it.

Stacked on 314 — review the last commits only.

QML holds no scrcpy process handle. One supervisor, `scripts/phone/scrcpy_session_manager.py`, speaks NDJSON on stdin/stdout and owns every scrcpy child and its `imi-phone-<type>-<id>` window title; `services/PhoneScrcpy.qml` sends launch/stop/focus/list_apps and applies the events. Started by the first command, stopped by a ten-second idle timer, restarted on the DiscordVoice ladder — marker, backoff, ceiling, no `running` binding.

The webcam and microphone launch **detached** through `scripts/phone/droidcam_session.sh` so they outlive a shell restart and are re-adopted at boot. The microphone's routing is the fork's, kept exactly: the stream lands on a `DroidCam-Mic` null sink whose monitor is the recordable source, and because scrcpy's SDL audio ignores `PULSE_SINK` on PipeWire, the default sink is swapped for exactly as long as the stream takes to appear — persisted, so a restart mid-swap still undoes it.

`services/PhoneDeps.qml` probes every optional tool with a constant `command -v` at construction and answers `missingFor(feature)` with the fork's per-distro install commands. **Nothing is added to the installer.**

Three things measured rather than assumed: scrcpy 4.1's flag names (`--video-buffer`, not the fork's stale `--display-buffer`); that a Process whose binary is absent never emits `exited` (which is what PhoneDeps' pending count hangs off); and a live construction of all four singletons under headless weston with an isolated bus.

Divergences worth naming: every `pgrep -f` became `pgrep -x` on the binary with the signature checked on the cmdline; the vestigial `python-dbus` dependency row is gone (our transport is busctl); and there is no mDNS wireless-debugging discovery yet — the wireless target is KDE Connect's address plus the configured port, `adb connect`ed before use.

Also in this PR: `sidebar.phone.enable` ships **false**. It gates the notification mirror's dedupe as well as the tab, and true before a list exists to read them in would stop the phone's notifications arriving anywhere. `test_phone_sessions_contract.py` pins that to the tab's existence, so W5 flips it without a test edit.

Not verified against a real phone, by design — the live checks are the mirror, the app list over USB adb, `/dev/videoN` appearing and `DroidCam-Mic` in `pactl list sources short`. Note `droidcam-cli` on the development machine is currently broken by a missing `libswscale.so.9`, which a `command -v` probe cannot and should not see.

Tests: `test_phone_scrcpy_manager.py` drives the real supervisor with fake scrcpy/adb/hyprctl on PATH; `tst_phone_scrcpy.qml` drives all four services through logic-only doubles (65 checks, whole launches compared as argv lists); `test_phone_sessions_contract.py` pins the process I/O the doubles omit and the byte-identity of the four synced regions.

Docs: updated AGENT.md §Directory map (scripts/phone, the four services) and §External binaries the shell drives; sdata/deps-info.md gains "Phone (optional)"
Changelog: updated
