### PR TITLE
fix(phone): the card stack's stale pairing card, and the tab in the compile sweep

### DIFF
--- a/dots/.config/quickshell/imi/DesignSystemCompile.qml
+++ b/dots/.config/quickshell/imi/DesignSystemCompile.qml
@@ -69,6 +69,23 @@ ShellRoot {
                 // wallpaper selector, so it compiles for the first time when
                 // someone clicks its toolbar button - which on a shell where
                 // nobody has is never.
+                // The Phone tab's own pieces. Nothing else in this sweep
+                // reaches them: the tab is one of four in a SwipeView, its
+                // sub-pages and its card stack are resolved BY URL through
+                // Loaders (deliberately, so a missing file degrades instead of
+                // taking the tab down), and a Loader that never activates
+                // never compiles what it points at. That is exactly how
+                // PhoneFeatureCards.qml shipped naming PhoneConnectPairingCard
+                // - a type renamed when the shared pieces moved to
+                // qs.modules.imi.phone - through a green suite, and said so
+                // only on a live shell.
+                Quickshell.shellPath("modules/imi/sidebarLeft/phone/Phone.qml"),
+                Quickshell.shellPath("modules/imi/sidebarLeft/phone/PhoneFeatureCards.qml"),
+                Quickshell.shellPath("modules/imi/sidebarLeft/phone/PhoneContactsPage.qml"),
+                Quickshell.shellPath("modules/imi/sidebarLeft/phone/PhoneAppsPage.qml"),
+                Quickshell.shellPath("modules/imi/sidebarLeft/phone/PhoneWebcamPage.qml"),
+                Quickshell.shellPath("modules/imi/sidebarLeft/phone/PhoneMicPage.qml"),
+                Quickshell.shellPath("modules/imi/sidebarLeft/phone/InstallGuidePopup.qml"),
                 Quickshell.shellPath("modules/imi/wallpaperSelector/ClockDepthPicker.qml"),
                 // Same shape one step on: the desktop subject selector's
                 // surface is behind a Loader that stays inactive until somebody

--- a/dots/.config/quickshell/imi/modules/common/widgets/MaterialShapeWrappedMaterialSymbol.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/MaterialShapeWrappedMaterialSymbol.qml
@@ -9,6 +9,12 @@ MaterialShape {
     property alias iconSize: symbol.iconSize
     property alias font: symbol.font
     property alias colSymbol: symbol.color
+    // The designsystem plugin's copy of this widget has always carried
+    // this alias and this one had not, so a call site written against
+    // that one assigns a property this component does not have. QML
+    // reports that only when the file is COMPILED, which for the Phone
+    // tab's cards is the first time someone opens the tab.
+    property alias animateChange: symbol.animateChange
     property real padding: Appearance.spacing.space100
     property var wrappedShape: MaterialShape.Shape.Clover4Leaf
 

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneFeatureCards.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneFeatureCards.qml
@@ -330,16 +330,12 @@ Item {
             onStopClicked: PhoneMic.stop()
         }
 
-        // ---- 4. a card per peer asking to pair ----
-        Repeater {
-            model: PhoneConnect.pairingRequests
-
-            delegate: PhoneConnectPairingCard {
-                required property var modelData
-                Layout.fillWidth: true
-                device: modelData
-            }
-        }
+        // No pairing cards here, though the spec groups them into this stack:
+        // Phone.qml draws them itself, because answering a request is the only
+        // way an unpaired phone gets into the shell and this file is loaded by
+        // URL - a stack that failed to load would take pairing with it. The
+        // type also moved to qs.modules.imi.phone as PhonePairingCard; the
+        // name that used to be here was the dialog's.
     }
 
     // The guide covers the phone panel rather than the three cards it was


### PR DESCRIPTION
Two defects the suite could not see, both found on the Phone tab's first live load.

**The card stack drew a second pairing card, by a name that no longer exists.** `PhoneFeatureCards.qml` carried its own `Repeater` over `PhoneConnectPairingCard` — what that type was called inside the dialog #317 deleted, before the shared pieces moved to `qs.modules.imi.phone` as `PhonePairingCard`. The copy is removed rather than renamed: `Phone.qml` draws pairing cards itself, deliberately, because it is loaded directly while the stack is resolved BY URL, and a stack that failed to load would take answering a pairing request with it.

**A card assigned a property its widget does not have.** `PhoneFeatureCard.qml` sets `animateChange` on `MaterialShapeWrappedMaterialSymbol`. The designsystem plugin's copy of that widget has always aliased it through; the one under `modules/common/widgets` had not, so the assignment named nothing. The alias is there now, pointing at the property `StyledText` already declares — the two copies agree again.

**Why a green suite missed both.** The tab is one of four in a `SwipeView`, and its card stack and four sub-pages resolve by URL through `Loader`s — on purpose, so a file that has not landed degrades instead of taking the tab down with `Type unavailable`. A `Loader` that never activates never compiles what it points at, so nothing in the suite had ever built these files. `DesignSystemCompile.qml` lists all seven now; it reddens on both defects and passes at `checked=194 failures=0`.

Suite: 1402 passed, 0 failed.

Docs: not needed - the sweep's own comment carries the reason, beside the entries for the other files nothing else compiles
Changelog: not user-visible - both defects landed and are fixed inside the same unreleased tab, so no released behaviour changed
