### PR TITLE
fix(config): the settings window stops undebouncing the whole shell's writes

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -438,6 +438,9 @@ ReloadPopup.qml, welcome.qml, killDialog.qml   Misc top-level overlays
 
 modules/common/             Shared, feature-agnostic building blocks
   Config.qml                 Singleton: the entire settings schema + JSON persistence (see below)
+  ConfigWriteDelayRef.qml    A surface's claim on an undebounced config write. Config.readWriteDelay
+                              is a readonly RESOLUTION over the live claims - nothing assigns it,
+                              and a claim's release is its own lifetime. See the Config section
   Appearance.qml              Singleton: design tokens - colors (M3 color roles), font sizes,
                               rounding, spacing, border widths, animation curves/durations, sizes.
                               Every widget reads from here rather than hardcoding values.
@@ -745,7 +748,8 @@ assets/                    Static images/fonts bundled with the shell
 `JsonAdapter`/`JsonObject` machinery automatically:
 
 1. Loads `~/.config/immaterial-impulse/config.json` into `Config.options` on startup.
-2. Persists any property write back to that file (debounced by `Config.readWriteDelay`, 50ms).
+2. Persists any property write back to that file (debounced by `Config.readWriteDelay`, 50ms by
+   default — see the claim entry below for what that debounce is for and who may shorten it).
 
 Consequences for making changes:
 
@@ -854,6 +858,48 @@ Consequences for making changes:
   add a local `Timer` (600ms is the convention already used, see `BarConfig.qml`'s
   `mediaDebounceTimer` and `BackgroundConfig.qml`'s `quoteDebounceTimer`) that assigns to
   `Config.options.x.y` only after typing pauses, instead of assigning directly in `onValueChanged`.
+- **...and that debounce is not a nicety, it is what keeps `watchChanges` from feeding the shell's
+  own write back at it — so `readWriteDelay` is a RESOLUTION over declared claims now, and nothing
+  assigns it.** `writeAdapter()` serializes the *whole* schema and `configFileView` watches the file
+  it just wrote, so one property write is a full serialization, an inotify event, a full re-read and
+  a full deserialize; the two timers coalesce a burst into one of each. At a delay of 0 the write
+  comes straight back as a reload, and a second property written in between is deserialized away by
+  a file that does not carry it yet.
+  Three surfaces used to set the delay to 0 by assignment. Two of them (`welcome.qml`,
+  `killDialog.qml`) are standalone `qs -p` processes whose whole life is one window, so the global
+  they mutated was their own; the third was `SettingsContent.qml`, inside the shell, and it never
+  restored it — **every config write from anywhere in the shell had been undebounced for the whole
+  session**. Worse than "once Settings has been opened", which is how the line reads: the panel
+  family loads `Settings` behind a `LazyLoader` gated on `Config.ready` and declares the content
+  statically inside the window, so `Component.onCompleted` ran at startup. Measured with the window
+  never opened, the delay read 0. The premise was true where it was written — 50e73d4a3 ("set config
+  read/write delay to 0 where delay is unnecessary") put it in a standalone `settings.qml` — and
+  came along unchanged when Settings became an in-shell panel with bb6e174be ("Supersede
+  dots-hyprland ii with the pC theme").
+  A surface that wants an undebounced write declares a `ConfigWriteDelayRef` (in `modules/common/`,
+  beside `Config`, so anything that can say `Config` can say it with no new import) bound to the
+  condition under which that is really true; `Config.readWriteDelay` is a readonly derivation over
+  the live claims. **"Restore the previous value" is the shape to refuse here**: a saved value is a
+  second thing to keep in sync, it has no answer when two surfaces want the delay at once, and it
+  still needs somebody alive to run the restore — which a destroyed surface has not got. A claim's
+  release is its own lifetime, which is the same reasoning as the derived idle inhibitor in
+  83544dedb ("feat(idle): a deliberately blanked monitor holds the keep-awake"). It is a count
+  rather than a list of per-claim values because every claimant wants the same thing.
+  `active` is `required` and defaults to nothing, because the defect was a claim whose condition was
+  "the surface exists" written where the real condition was "the window is on screen": the settings
+  claim is `active: settingsWindow.visible` in `Settings.qml` — the window, not the host, since the
+  host lives for the session. `tests/lint_config_write_delay_claims.py` fails on an assignment, on a
+  second writer of the claim count, on a claim with no stated condition, and on a claim held
+  unconditionally inside `modules/`, `services/` or `panelFamilies/` — that last rule is the one
+  that would have caught this. `ConfigWriteDelayRuntimeTest.qml` builds the real `Settings` scope
+  **without opening its window** and reads the delay back across an open, a close, a second open,
+  two claimants at once and a claim whose declaring object is destroyed under it (a hot reload);
+  the source contract can say the claim is in the wrong file, only the harness can say what the
+  delay actually was.
+  8de9c2cdd ("fix(config): resolve the write delay from claims instead of a global assignment"),
+  2fa736625 ("fix(settings): the faster config flush lasts as long as the window, not the session"),
+  24ff433f4 ("test(lint): fail on an assigned config write delay, and on a claim held for the session"),
+  e7c5e7a9f ("test(config): drive how long the settings window's faster flush lasts").
 
 `GlobalStates.qml` is the sibling singleton for state that should **not** persist (is this sidebar
 currently open, is the bar in autoHide-triggered-show state, etc.) - don't add ephemeral UI state to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,14 @@ own repo; the installer pins which revision it builds.
   the rest of this release's phone work is reached.
 
 ### Fixed
+- **Settings stops switching off the debounce on every config write in the
+  shell.** Opening the settings window was never actually required: the
+  settings page host is built while the shell starts, and it asked for its
+  config writes to be flushed immediately and never asked for that to stop —
+  so from startup onward every setting written anywhere in the shell, by any
+  panel, rewrote the whole of `config.json` and read it straight back, once
+  per value instead of once per burst. Settings still writes immediately while
+  its window is open, and only while its window is open.
 - **Both sidebars open on the monitor you are using again.** On a multi-monitor
   setup the left and right sidebars had started opening on whichever screen was
   focused when the shell started, wherever you actually were — the same thing

--- a/dots/.config/quickshell/imi/ConfigWriteDelayRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/ConfigWriteDelayRuntimeTest.qml
@@ -1,0 +1,178 @@
+import QtQuick
+import Quickshell
+import qs
+import qs.services
+import qs.modules.common
+import qs.modules.imi.settings
+
+/**
+ * How long `Config.readWriteDelay` stays 0, driven against the real settings
+ * window.
+ *
+ * What this exists to refuse, in the shape it was found:
+ * `SettingsContent.qml` set `Config.readWriteDelay = 0` from its own
+ * `Component.onCompleted` and never restored it. `Config` is a singleton and
+ * the settings host is built at `Config.ready` - not when its window opens -
+ * so from startup onward EVERY config write anywhere in the shell was flushed
+ * on the next turn instead of being debounced, for the rest of the session, on
+ * every machine, whether or not Settings was ever opened. The first check
+ * below is that sentence: the real `Settings` scope is built and the delay is
+ * still the default.
+ *
+ * The rest are the lifetime questions a saved-and-restored value gets wrong
+ * and a resolution does not: opened and closed repeatedly, two claimants at
+ * once, and a claim whose declaring object is destroyed under it - which is
+ * what a hot reload does to a surface holding one, and the case where "restore
+ * the previous value" has nobody left to run the restore.
+ *
+ * The claim is read through `Config.readWriteDelay` rather than through the
+ * claim count, because the delay is what the two timers in `Config.qml`
+ * actually use: a count that moves while the resolution is broken would agree
+ * with itself.
+ *
+ * Brings its own weston and its own session bus through
+ * tests/test_config_write_delay_runtime.py, which is what runs it.
+ *
+ *   qs -p ConfigWriteDelayRuntimeTest.qml
+ */
+ShellRoot {
+    id: harness
+
+    property int failures: 0
+    property int checksRun: 0
+
+    function check(label, ok) {
+        harness.checksRun++;
+        console.log(`[ConfigWriteDelay] ${label}: ${ok ? "ok" : "FAIL"}`);
+        if (!ok)
+            harness.failures++;
+    }
+
+    function finish() {
+        console.log(`[ConfigWriteDelay] checks: ${harness.checksRun} failures: ${harness.failures}`);
+        Qt.exit(harness.failures === 0 ? 0 : 1);
+    }
+
+    readonly property int debounced: Config.defaultReadWriteDelay
+    readonly property int immediate: 0
+
+    // The real thing, not a re-declaration of its wiring: this is the scope
+    // the panel family loads, carrying its own window and its own claim.
+    Settings {}
+
+    // A second claimant, so "two things want it at once" is driven rather than
+    // reasoned about. Toggled by the steps below.
+    property bool secondWanted: false
+    ConfigWriteDelayRef {
+        active: harness.secondWanted
+    }
+
+    // A claim whose declaring object goes away under it. `Loader.active =
+    // false` destroys the object, which is what a hot reload does to a surface
+    // holding a claim - and the case a saved previous value cannot recover
+    // from, because whoever would restore it has been destroyed too.
+    Loader {
+        id: doomedClaim
+        active: false
+        sourceComponent: ConfigWriteDelayRef {
+            active: true
+        }
+    }
+
+    property int elapsed: 0
+    Timer {
+        id: waitForReady
+        interval: 250
+        repeat: true
+        running: true
+        onTriggered: {
+            harness.elapsed += waitForReady.interval;
+            if (!Config.ready) {
+                if (harness.elapsed >= 20000) {
+                    harness.check("Config became ready", false);
+                    harness.finish();
+                }
+                return;
+            }
+            waitForReady.running = false;
+            steps.running = true;
+        }
+    }
+
+    property var stepList: [
+        () => {
+            harness.check(`the settings host is built and the shell's writes are still`
+                          + ` debounced, got ${Config.readWriteDelay}ms`,
+                          Config.readWriteDelay === harness.debounced);
+            GlobalStates.settingsOpen = true;
+        },
+
+        () => {
+            harness.check(`the open window flushes immediately, got ${Config.readWriteDelay}ms`,
+                          Config.readWriteDelay === harness.immediate);
+            GlobalStates.settingsOpen = false;
+        },
+
+        () => {
+            harness.check(`closing it restores the debounce, got ${Config.readWriteDelay}ms`,
+                          Config.readWriteDelay === harness.debounced);
+            GlobalStates.settingsOpen = true;
+        },
+
+        () => {
+            harness.check(`...and a second open claims it again rather than having spent`
+                          + ` the claim, got ${Config.readWriteDelay}ms`,
+                          Config.readWriteDelay === harness.immediate);
+            harness.secondWanted = true;
+        },
+
+        () => {
+            harness.check(`two claimants at once is still one answer, got ${Config.readWriteDelay}ms`,
+                          Config.readWriteDelay === harness.immediate);
+            GlobalStates.settingsOpen = false;
+        },
+
+        () => {
+            harness.check(`the window closing under the other claimant does not take the`
+                          + ` faster flush with it, got ${Config.readWriteDelay}ms`,
+                          Config.readWriteDelay === harness.immediate);
+            harness.secondWanted = false;
+        },
+
+        () => {
+            harness.check(`...and the last claimant releasing restores the debounce, got`
+                          + ` ${Config.readWriteDelay}ms`,
+                          Config.readWriteDelay === harness.debounced);
+            doomedClaim.active = true;
+        },
+
+        () => {
+            harness.check(`a claim declared inside a Loader is held, got ${Config.readWriteDelay}ms`,
+                          Config.readWriteDelay === harness.immediate);
+            doomedClaim.active = false;
+        },
+
+        () => {
+            harness.check(`destroying the object that made a claim releases it, got`
+                          + ` ${Config.readWriteDelay}ms`,
+                          Config.readWriteDelay === harness.debounced);
+            harness.check(`...and the claim count is back to nothing rather than merely`
+                          + ` resolving to the default, got ${Config.immediateWriteClaims}`,
+                          Config.immediateWriteClaims === 0);
+        },
+
+        () => harness.finish()
+    ]
+
+    property int stepIndex: 0
+    Timer {
+        id: steps
+        interval: 300
+        repeat: true
+        onTriggered: {
+            if (harness.stepIndex >= harness.stepList.length)
+                return;
+            harness.stepList[harness.stepIndex++]();
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/killDialog.qml
+++ b/dots/.config/quickshell/imi/killDialog.qml
@@ -36,13 +36,20 @@ ApplicationWindow {
     // This dialog is its own short-lived Quickshell process and it *does* write
     // config: the "Always" buttons below persist conflictKiller.autoKill*. It
     // then quits as soon as it is closed, so a debounced or backgrounded write
-    // would be lost with the process. Hence no delay and a blocking write -
-    // `blockWrites` is FileView's threading mode ("block until the write
-    // completes"), not a permission switch, which is the behaviour wanted here.
+    // would be lost with the process. Hence the claim below and a blocking
+    // write - `blockWrites` is FileView's threading mode ("block until the
+    // write completes"), not a permission switch, which is the behaviour
+    // wanted here.
     Component.onCompleted: {
-        Config.readWriteDelay = 0;
         Config.blockWrites = true;
         MaterialThemeLoader.reapplyTheme();
+    }
+
+    // `active: true` - this process IS this window, so existing really is the
+    // condition. Stated rather than defaulted, for the reason the component's
+    // own header gives.
+    ConfigWriteDelayRef {
+        active: true
     }
 
     minimumWidth: 400

--- a/dots/.config/quickshell/imi/modules/common/Config.qml
+++ b/dots/.config/quickshell/imi/modules/common/Config.qml
@@ -16,7 +16,39 @@ Singleton {
     property string filePath: Directories.shellConfigPath
     property alias options: configOptionsJsonAdapter
     property bool ready: false
-    property int readWriteDelay: 50 // milliseconds
+
+    // What the debounce below is for, because it is not "saving is slow".
+    //
+    // `writeAdapter()` serializes the WHOLE schema, and `configFileView`
+    // watches the file it just wrote - so one property write is a full
+    // serialization, an inotify event, a full re-read and a full deserialize.
+    // The two timers coalesce a burst of those into one of each: a settings
+    // page whose control writes per keystroke, a migration calling
+    // `setNestedValue` five times in a row, a drag - all of them cost one
+    // round trip instead of N. The reload timer is the half that matters most
+    // with `watchChanges: true`: at a delay of 0 the shell's own write comes
+    // straight back as a reload, so a second property written in between is
+    // deserialized away by a file that does not have it yet.
+    //
+    // A surface that genuinely wants its writes flushed immediately declares a
+    // `ConfigWriteDelayRef` instead of assigning here. The delay is RESOLVED
+    // from the live claims rather than saved and restored by whoever changed
+    // it: a claimant states what it needs and nothing states what the value
+    // was, so repeated claims, two claimants at once, and a claim destroyed
+    // with the surface that made it all come out right - and there is no
+    // restore path anyone can forget. That forgotten restore is exactly what
+    // this replaced: `SettingsContent.qml` set the delay to 0 from its own
+    // `Component.onCompleted` and never put it back, and since the settings
+    // host is built at `Config.ready` rather than when its window opens, every
+    // config write in the shell had been undebounced from startup, for the
+    // whole session, on every machine.
+    //
+    // Every claimant wants the same thing - flush now - so a count resolves
+    // it. A per-claim value would be plumbing for a second delay nobody asks
+    // for.
+    readonly property int defaultReadWriteDelay: 50 // milliseconds
+    property int immediateWriteClaims: 0
+    readonly property int readWriteDelay: root.immediateWriteClaims > 0 ? 0 : root.defaultReadWriteDelay
 
     // Forwarded to FileView.blockWrites, which means "block the calling thread
     // until the write completes" - NOT "do not write". The whole block* family

--- a/dots/.config/quickshell/imi/modules/common/ConfigWriteDelayRef.qml
+++ b/dots/.config/quickshell/imi/modules/common/ConfigWriteDelayRef.qml
@@ -1,0 +1,51 @@
+import QtQuick
+
+// A surface's claim on an undebounced config write.
+//
+// `Config` debounces `writeAdapter()` and the reload that its own write
+// provokes (see the comment on `readWriteDelay` there). A surface that wants
+// its writes flushed on the next turn instead - because it is about to quit,
+// or because the user is sitting in it making one deliberate change at a time
+// - declares one of these and binds `active` to the condition under which that
+// is really true. `Config.readWriteDelay` is resolved from the live claims.
+//
+// It is a component rather than a `Config.readWriteDelay = 0` line at the call
+// site for the reason CavaRef is one, plus a sharper one. An assignment has no
+// release path at all: `SettingsContent.qml` carried exactly that assignment,
+// never restored it, and left the whole shell's config writes undebounced from
+// startup for the rest of the session. "Restore the previous value" is not the
+// repair - a saved value is a second thing to keep in sync, it is wrong the
+// moment two surfaces want the delay at once, and it still has to be put back
+// by somebody. A claim states a need and its release IS its own lifetime.
+//
+// `active` has no default on purpose. The defect above was a claim whose
+// condition was "the surface exists" written where the real condition was "the
+// window is on screen", and the settings host exists from `Config.ready`
+// onward. Stating the condition does not force any particular answer; it
+// forces the author to have one. It is `required`, so a bare
+// `ConfigWriteDelayRef {}` is a compile failure - and
+// tests/lint_config_write_delay_claims.py refuses one as well, because a
+// widget that fails to compile leaves this repo's suite fully green and only a
+// live load surfaces it.
+QtObject {
+    id: root
+
+    required property bool active
+    property bool held: false
+
+    function sync() {
+        if (root.active === root.held)
+            return;
+        Config.immediateWriteClaims += root.active ? 1 : -1;
+        root.held = root.active;
+    }
+
+    onActiveChanged: root.sync()
+    Component.onCompleted: root.sync()
+    Component.onDestruction: {
+        if (!root.held)
+            return;
+        Config.immediateWriteClaims--;
+        root.held = false;
+    }
+}

--- a/dots/.config/quickshell/imi/modules/imi/settings/Settings.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/Settings.qml
@@ -20,6 +20,17 @@ Scope {
         GlobalStates.settingsOpen = false;
     }
 
+    // The settings window is where the user sits making one deliberate change
+    // at a time, so while it is up its writes are flushed on the next turn
+    // rather than debounced. The claim is bound to the WINDOW being on screen:
+    // this scope and the content inside it are built at `Config.ready` and
+    // outlive every open, so a claim tied to their existence is the whole
+    // session's - which is precisely what SettingsContent's old
+    // `Config.readWriteDelay = 0` turned out to be.
+    ConfigWriteDelayRef {
+        active: settingsWindow.visible
+    }
+
     // A real toplevel rather than an overlay layer: Settings is a place you sit
     // in and alt-tab back to, so it should be movable and managed by the
     // compositor like any other window.

--- a/dots/.config/quickshell/imi/modules/imi/settings/SettingsContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/SettingsContent.qml
@@ -195,9 +195,11 @@ Item {
         return list
     }
 
-    Component.onCompleted: {
-        Config.readWriteDelay = 0
-    }
+    // The undebounced write this host used to ask for from here belongs to the
+    // WINDOW, not to the host: `Settings.qml` holds the claim for as long as
+    // its window is on screen. This object is built at `Config.ready` and
+    // lives for the session (see the warm-up's gate below), so a claim made
+    // here is a claim nobody ever releases.
 
     // Every page up to here has been asked for, so it is built and kept. This
     // only grows: a page built once stays built (`built` below).

--- a/dots/.config/quickshell/imi/tests/lint_config_write_delay_claims.py
+++ b/dots/.config/quickshell/imi/tests/lint_config_write_delay_claims.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Nobody assigns `Config.readWriteDelay`, and a claim on it states its condition.
+
+`Config` debounces `writeAdapter()` and the reload its own write provokes, at
+`readWriteDelay`. `modules/imi/settings/SettingsContent.qml` set that global to
+0 from its own `Component.onCompleted` and never restored it - and the settings
+host is built at `Config.ready` rather than when its window opens, so every
+config write in the shell had been undebounced from startup, for the whole
+session, whether or not anyone ever opened Settings. One window's preference,
+leaked into a global, with no release path in the code at all.
+
+The repair is a resolution rather than a saved value: a surface declares a
+`ConfigWriteDelayRef`, `Config.readWriteDelay` is derived from the live claims,
+and a claim's release IS its own lifetime. Five things hold that shape, and
+each of them is a way the old defect could come back:
+
+  A. nothing assigns `Config.readWriteDelay`. That is the defect verbatim, and
+     it is also #158's shape - the property is a binding now, so an assignment
+     would destroy the derivation rather than merely mis-set it once.
+  B. `immediateWriteClaims` has exactly one writer, the claim component. Two
+     places counting is how the hand-written `refCount++`/`--` pairs this
+     replaced came to disagree (see CavaRef).
+  C. every claim states `active:`. A bare `ConfigWriteDelayRef {}` would mean
+     "for as long as I exist", which is the sentence that was wrong.
+  D. a claim made from inside the shell's own tree (`modules/`, `services/`)
+     may not be `active: true`. Those objects outlive the gesture that wants
+     the faster flush - the settings host outlives every open of its window -
+     so the condition has to name the gesture. `welcome.qml` and
+     `killDialog.qml` are separate `qs -p` processes whose whole life IS the
+     window, which is why they sit outside those directories and may say so.
+  E. `Config.qml` still derives `readWriteDelay`, readonly, from the claims.
+     Turning it back into a settable `property int` re-opens A silently: every
+     other check here would stay green over it.
+
+Answerable by reading the text, so it needs no compositor. The self-check runs
+first, on fixtures held in this file, so the machinery is proven independently
+of what the tree contains - a source-text check is code with no tests of its
+own, and this repo's static checks have shipped green over the thing they exist
+to refuse before.
+
+Run from `tests/run_tests.sh`.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SKIP_DIRS = {".git", "node_modules", "__pycache__", "tests"}
+
+CONFIG = ROOT / "modules/common/Config.qml"
+CLAIM = ROOT / "modules/common/ConfigWriteDelayRef.qml"
+
+# The directories that are the one long-lived `qs -c imi` process. A claim
+# declared in one of them belongs to an object that outlives whatever gesture
+# wanted the faster flush.
+SHELL_TREE = ("modules/", "services/", "panelFamilies/")
+
+# `Config.readWriteDelay = ...`, and the bare `readWriteDelay = ...` a file
+# inside modules/common could write without the prefix. `==`/`===` are
+# comparisons and `:` is a declaration, so both are excluded.
+ASSIGN_DELAY = re.compile(r"(?:\bConfig\.)?\breadWriteDelay\s*=(?!=)")
+
+# The claim count. Only the component may move it.
+WRITE_CLAIMS = re.compile(r"\bimmediateWriteClaims\s*(?:=(?!=)|\+\+|--|\+=|-=)")
+
+# A claim's whole declaration, up to the closing brace of its (never nested)
+# body, so `active:` can be looked for inside it.
+CLAIM_BLOCK = re.compile(r"\bConfigWriteDelayRef\s*\{([^{}]*)\}")
+
+ACTIVE_TERM = re.compile(r"^\s*active\s*:\s*(.+?)\s*$", re.M)
+
+# The derivation, spelled loosely enough to survive reformatting and tightly
+# enough that a settable `property int readWriteDelay: 50` fails.
+DERIVED_DELAY = re.compile(
+    r"readonly\s+property\s+int\s+readWriteDelay\s*:[^\n]*immediateWriteClaims")
+
+
+def strip_comments(text):
+    """Line and block comments out, so a paragraph quoting the old spelling is
+    prose rather than an offence. Every other check in this tree that reads
+    source does this first, and the one that did not was kept green by a header
+    comment describing the interface it was checking."""
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.S)
+    return re.sub(r"//[^\n]*", "", text)
+
+
+def line_of(text, index):
+    return text.count("\n", 0, index) + 1
+
+
+def offences_for(rel, source):
+    """rel is the path as written in a message; source is raw QML."""
+    text = strip_comments(source)
+    out = []
+
+    for match in ASSIGN_DELAY.finditer(text):
+        out.append(
+            f"{rel}:{line_of(text, match.start())}: assigns `readWriteDelay`. "
+            f"It is a readonly derivation over the live claims now, so this "
+            f"destroys the derivation rather than setting a value - and an "
+            f"assignment has no release path, which is how one window's "
+            f"preference became the whole session's. Declare a "
+            f"`ConfigWriteDelayRef` with the condition under which the faster "
+            f"flush is really wanted.")
+
+    if rel != "modules/common/ConfigWriteDelayRef.qml":
+        for match in WRITE_CLAIMS.finditer(text):
+            out.append(
+                f"{rel}:{line_of(text, match.start())}: writes "
+                f"`immediateWriteClaims`. The count has one writer, "
+                f"`ConfigWriteDelayRef`; a second place counting is how the "
+                f"hand-written refCount pairs it replaced came to disagree.")
+
+    for match in CLAIM_BLOCK.finditer(text):
+        line = line_of(text, match.start())
+        active = ACTIVE_TERM.search(match.group(1))
+        if active is None:
+            out.append(
+                f"{rel}:{line}: `ConfigWriteDelayRef` states no `active:`. "
+                f"An unstated condition reads as \"for as long as I exist\", "
+                f"which is the sentence that left the shell undebounced for "
+                f"whole sessions. Name the condition under which this surface "
+                f"really wants its writes flushed immediately.")
+        elif (any(rel.startswith(prefix) for prefix in SHELL_TREE)
+                and active.group(1).rstrip(";") == "true"):
+            out.append(
+                f"{rel}:{line}: `ConfigWriteDelayRef` is held unconditionally "
+                f"inside the shell's own tree, so it is held for the session. "
+                f"Objects here outlive the gesture that wants the faster flush "
+                f"- the settings host is built at `Config.ready` and outlives "
+                f"every open of its window. Bind `active` to the gesture. "
+                f"(A standalone `qs -p` entry point whose whole process is one "
+                f"window may say `true`; it does not live in these "
+                f"directories.)")
+
+    return out
+
+
+FIXTURES = [
+    ("modules/imi/settings/SettingsContent.qml",
+     "Item {\n    Component.onCompleted: {\n        Config.readWriteDelay = 0\n    }\n}\n",
+     ["assigns `readWriteDelay`"]),
+    ("modules/imi/settings/Settings.qml",
+     "Scope {\n    ConfigWriteDelayRef {\n        active: settingsWindow.visible\n    }\n}\n",
+     []),
+    ("modules/imi/settings/Settings.qml",
+     "Scope {\n    ConfigWriteDelayRef {\n    }\n}\n",
+     ["states no `active:`"]),
+    ("modules/imi/settings/Settings.qml",
+     "Scope {\n    ConfigWriteDelayRef {\n        active: true\n    }\n}\n",
+     ["held unconditionally"]),
+    # The two standalone processes may: their whole life is the one window.
+    ("welcome.qml",
+     "ApplicationWindow {\n    ConfigWriteDelayRef {\n        active: true\n    }\n}\n",
+     []),
+    # A comment quoting the old spelling is prose, not an offence.
+    ("modules/common/ConfigWriteDelayRef.qml",
+     "// a `Config.readWriteDelay = 0` line at the call site\n"
+     "QtObject {\n    function sync() { Config.immediateWriteClaims += 1; }\n}\n",
+     []),
+    # ...but a second counter is one, wherever it lives.
+    ("services/Something.qml",
+     "Singleton {\n    function f() { Config.immediateWriteClaims++; }\n}\n",
+     ["writes `immediateWriteClaims`"]),
+    # A comparison is not an assignment.
+    ("modules/common/Config.qml",
+     "Singleton {\n    readonly property bool fast: readWriteDelay === 0\n}\n",
+     []),
+]
+
+
+def self_check():
+    """Every fixture's expected offences, and only those."""
+    failures = []
+    for rel, source, expected in FIXTURES:
+        found = offences_for(rel, source)
+        for needle in expected:
+            if not any(needle in offence for offence in found):
+                failures.append(
+                    f"self-check: {rel} fixture should have reported {needle!r}, got {found}")
+        if len(found) != len(expected):
+            failures.append(
+                f"self-check: {rel} fixture expected {len(expected)} offence(s), got {found}")
+    return failures
+
+
+def main() -> int:
+    failures = self_check()
+
+    swept = 0
+    for path in sorted(ROOT.rglob("*.qml")):
+        rel = path.relative_to(ROOT)
+        if any(part in SKIP_DIRS for part in rel.parts):
+            continue
+        try:
+            source = path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+        swept += 1
+        failures.extend(offences_for(rel.as_posix(), source))
+
+    if not swept:
+        failures.append(
+            "the sweep found no QML at all, so a clean run says nothing - "
+            "check the tree layout rather than trusting this result")
+
+    if not CLAIM.exists():
+        failures.append(
+            "modules/common/ConfigWriteDelayRef.qml is gone. It is the only "
+            "sanctioned way to ask for an undebounced config write; without it "
+            "the next surface that wants one assigns the global again.")
+
+    if CONFIG.exists():
+        config_text = strip_comments(CONFIG.read_text(encoding="utf-8"))
+        if not DERIVED_DELAY.search(config_text):
+            failures.append(
+                "modules/common/Config.qml no longer derives `readWriteDelay` "
+                "readonly from `immediateWriteClaims`. A settable property here "
+                "re-opens the leak silently: every other check in this file "
+                "would stay green over it.")
+    else:
+        failures.append("modules/common/Config.qml is missing")
+
+    if failures:
+        print("config write delay claim lint failed:\n", file=sys.stderr)
+        for failure in failures:
+            print(f"  {failure}", file=sys.stderr)
+        return 1
+
+    print(f"config write delay claim lint passed ({swept} QML files): the delay is "
+          f"resolved from claims, every claim states its condition, and no claim "
+          f"inside the shell is held for the session")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -281,6 +281,19 @@ if ! python3 "$SCRIPT_DIR/lint_cava_claims.py"; then
     exit 1
 fi
 
+# Config.readWriteDelay debounces the write of the whole schema and the reload
+# the shell's own write provokes. SettingsContent set it to 0 and never put it
+# back, and the settings host is built at Config.ready rather than at window
+# open - so every config write in the shell was undebounced from startup, for
+# the session, on every machine. The delay is resolved from declared claims now;
+# this refuses an assignment, a second writer of the count, a claim with no
+# stated condition, and a claim held unconditionally inside the shell's own tree.
+echo "Running config write delay claim lint..."
+if ! python3 "$SCRIPT_DIR/lint_config_write_delay_claims.py"; then
+    echo "Config write delay claim lint failed."
+    exit 1
+fi
+
 echo "Running process pattern lint..."
 if ! python3 "$SCRIPT_DIR/lint_self_matching_process_patterns.py"; then
     echo "Process pattern lint failed."

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -1115,6 +1115,16 @@ if ! python3 "$SCRIPT_DIR/test_settings_page_incubation_runtime.py"; then
     exit 1
 fi
 
+# How long the settings window's faster config flush lasts, driven against the
+# real Settings scope: an open, a close, a second open, two claimants, and a
+# claim whose declaring object is destroyed under it. Brings its own headless
+# weston and session bus.
+echo "Running config write delay runtime tests..."
+if ! python3 "$SCRIPT_DIR/test_config_write_delay_runtime.py"; then
+    echo "Config write delay runtime tests failed."
+    exit 1
+fi
+
 echo "Running expressive design system tests..."
 if ! python3 "$SCRIPT_DIR/test_expressive_design_system.py"; then
     echo "Expressive design system tests failed."

--- a/dots/.config/quickshell/imi/tests/test_config_write_delay_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_config_write_delay_runtime.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""How long the settings window's faster config flush lasts.
+
+`ConfigWriteDelayRuntimeTest.qml` builds the real `Settings` scope - the same
+one the panel family loads - under this harness's own headless weston and
+session bus, and reads `Config.readWriteDelay` back across an open, a close, a
+second open, a second claimant, and a claim whose declaring object is destroyed
+under it.
+
+The defect it exists to refuse: `modules/imi/settings/SettingsContent.qml` set
+`Config.readWriteDelay = 0` from its own `Component.onCompleted` and never
+restored it. `Config` is a singleton, and the settings host is built at
+`Config.ready` rather than when its window opens (the warm-up's gate - see
+2581cafae ("fix(settings): the warm-up is gated on Config.ready, not on the
+window")), so the shell's config writes had been undebounced from startup for
+the whole session on every machine, whether or not anyone opened Settings.
+
+What the debounce is for is in `Config.qml`'s own comment: `writeAdapter()`
+serializes the whole schema and `configFileView` watches the file it just
+wrote, so an undebounced write is a full serialize, an inotify event, a full
+re-read and a full deserialize per property - and with the reload landing
+immediately, a second property written in between is deserialized away by a
+file that does not carry it yet.
+
+The first check is the leak verbatim: the host is built and the delay is still
+the default. The rest are the lifetime questions "save the previous value and
+put it back" gets wrong - repeated opens, two claimants, and a claim whose
+owner is destroyed, which is what a hot reload does to a surface holding one
+and is the case where nobody is left to run a restore.
+
+Brings its own headless weston (tests/nested_display.py) and its own session
+bus (`dbus-run-session`). Skips when weston, qs or dbus-run-session are
+missing, as in CI.
+"""
+
+import json
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+import nested_display
+
+ROOT = Path(__file__).resolve().parents[1]
+HARNESS = ROOT / "ConfigWriteDelayRuntimeTest.qml"
+
+# A literal, never read back out of the harness's own output: a step list that
+# loses an entry must redden here instead of reporting `failures: 0` for a
+# shorter run.
+EXPECTED_CHECKS = 10
+
+
+@unittest.skipUnless(nested_display.available(),
+                     "needs qs, weston and dbus-run-session on PATH")
+class ConfigWriteDelayRuntimeTest(unittest.TestCase):
+    def setUp(self):
+        self.home = Path(tempfile.mkdtemp(prefix="imi-config-write-delay-"))
+        self.addCleanup(shutil.rmtree, self.home, ignore_errors=True)
+        shell_config = self.home / "config" / "immaterial-impulse"
+        shell_config.mkdir(parents=True)
+        # An empty config on purpose: the delay under test is the QML default,
+        # and nothing here may depend on the maintainer's own settings.
+        (shell_config / "config.json").write_text(json.dumps({}, indent=2))
+
+    def test_the_faster_flush_lasts_exactly_as_long_as_the_window(self):
+        env = nested_display.start(self, "config-write-delay", width=1200, height=800)
+        env["XDG_CONFIG_HOME"] = str(self.home / "config")
+        env["XDG_STATE_HOME"] = str(self.home / "state")
+        env["XDG_CACHE_HOME"] = str(self.home / "cache")
+        env["XDG_DATA_HOME"] = str(self.home / "data")
+
+        # dbus-run-session, not the inherited bus: nothing this harness reads
+        # may depend on what the developer happens to be running.
+        proc = subprocess.run(
+            ["dbus-run-session", "--", "qs", "-p", str(HARNESS)],
+            cwd=str(ROOT), env=env, capture_output=True, text=True, timeout=300)
+        output = proc.stdout + proc.stderr
+
+        failed = [line for line in output.splitlines() if "FAIL" in line]
+        self.assertEqual(failed, [], f"harness reported failures:\n{output}")
+        self.assertIn(f"[ConfigWriteDelay] checks: {EXPECTED_CHECKS} failures: 0", output,
+                      f"harness did not finish cleanly:\n{output}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dots/.config/quickshell/imi/welcome.qml
+++ b/dots/.config/quickshell/imi/welcome.qml
@@ -32,7 +32,16 @@ ApplicationWindow {
 
     Component.onCompleted: {
         MaterialThemeLoader.reapplyTheme();
-        Config.readWriteDelay = 0 // Welcome app always only sets one var at a time so delay isn't needed
+    }
+
+    // The welcome app is its own short-lived Quickshell process with its own
+    // Config singleton, and it sets one var at a time, so the debounce buys it
+    // nothing. `active: true` - existing really is the condition here, since
+    // the process is this window - stated rather than defaulted, because a
+    // claim that reads "for as long as I exist" written where the surface
+    // outlives the gesture is the defect this component replaced.
+    ConfigWriteDelayRef {
+        active: true
     }
 
     minimumWidth: 600


### PR DESCRIPTION
The settings window set `Config.readWriteDelay = 0` and never restored it. `Config` is a singleton, so that was not the settings window's preference — it was every config write in the shell, undebounced, for the rest of the session.

And not "once Settings has been opened", which is how the line reads: the panel family loads `Settings` behind a `LazyLoader` gated on `Config.ready` and declares the content statically inside the window, so `Component.onCompleted` ran during startup. Measured in the new harness with the window never opened, the delay reads 0 — every machine, every session.

What the debounce is for is now written where it lives. `writeAdapter()` serializes the whole schema and `configFileView` watches the file it just wrote, so one property write is a full serialization, an inotify event, a full re-read and a full deserialize; the two timers coalesce a burst into one of each. At a delay of 0 the write comes straight back as a reload, and a second property written in between is deserialized away by a file that does not carry it yet.

The premise was true where it was written: 50e73d4a3 ("set config read/write delay to 0 where delay is unnecessary") put it in a standalone `settings.qml` whose whole process was that window, and it came along unchanged when Settings became an in-shell panel with bb6e174be ("Supersede dots-hyprland ii with the pC theme").

The faster flush is kept, because it is wanted — the settings window is where you sit making one deliberate change at a time — and it is now scoped to the window. `readWriteDelay` is a readonly RESOLUTION over declared `ConfigWriteDelayRef` claims, not a value somebody saves and puts back: a saved value is a second thing to keep in sync, it has no answer when two surfaces want the delay at once, and it still needs somebody alive to run the restore, which a destroyed surface has not got. `Settings.qml` claims on `settingsWindow.visible` — the window, not the host, since the host lives for the session. `welcome.qml` and `killDialog.qml` are converted too: their assignments never leaked (separate `qs -p` processes) but an assignment to a derived property is #158's defect, and their `active: true` is what makes the settings host's version visibly a different claim.

Checks, both proven to fail against the planted defect:

- `tests/lint_config_write_delay_claims.py` — no assignment, one writer of the claim count, every claim states `active:`, and no claim held unconditionally inside `modules/`/`services/`/`panelFamilies/`. That last rule is the one that would have caught this.
- `ConfigWriteDelayRuntimeTest.qml` + its driver — the real `Settings` scope under its own weston and session bus, read across the host being built with the window never opened, an open, a close, a second open, two claimants, and a claim whose declaring object is destroyed under it.

Suite green in both locales: 1402 passed, 0 failed (default and `LC_ALL=C LANG=C`).

Docs: updated AGENT.md §The Config system (settings page ↔ persisted JSON) and the directory map
Changelog: updated
