### PR TITLE
fix(phone): the sub-pages' content slot is a layout, and cards draw the app icon

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -616,7 +616,10 @@ services/                  Singletons wrapping external state/processes - one pe
                               whose call the service does not answer is a fake action, and
                               a button past Ring needs the BACKEND gate too, since Valent
                               answers none of them). The tab itself is driven end to end by
-                              tests/test_phone_tab_runtime.py
+                              tests/test_phone_tab_runtime.py, and what its sub-pages
+                              DRAW - the lists' and the empty states' geometry, and a
+                              notification card's app icon - by
+                              tests/test_phone_tab_layout_runtime.py
   PhoneNotifications.qml       The paired phone's notifications, mirrored off KDE Connect on
                               the same busctl transport through a serialized queue of its
                               own. No monitor of its own: the four notification signals sit
@@ -1821,6 +1824,43 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   keyboard's rows agreed before there was anything to the right of the spacebar.
   afd3bf661 ("fix(osk): make the key pitch a multiple of four, so a quarter unit is whole pixels"),
   e119c7b1d ("refactor(osk): no key fills the row any more").
+- **`Layout.*` is inert in an item no layout manages, and the failure is a page that draws
+  its header and nothing else.** A component whose `default property alias` points at a plain
+  `Item` invites every caller to state `Layout.fillWidth`/`fillHeight` on the child it puts
+  there - the attached properties exist on every Item, they are accepted, they are never read,
+  and nothing is logged. `PhoneSubPage` was that shape: measured in a real window, the Contacts
+  page's root column sat at its IMPLICIT height, **73px inside an 836px slot**, so the region
+  holding the list was handed 0 while the list itself reported `count` 2, `contentHeight` 110
+  and a first delegate 52px tall. On screen that is "147 of 150 contacts" over an empty body.
+  Its sibling is the same defect on the page whose list happens to be *empty*: `PagePlaceholder`
+  centres its column in itself and clips nothing, so a zero-height region at y=117 drew that
+  column from y=32 to y=202 - over the search field at 44-86 and the status line at 94-109,
+  which reads as an empty state painted on top of its own header rather than as a missing
+  height. If a slot's callers are meant to fill it, the slot is a layout.
+  da09d103b ("fix(phone): the sub-page's content slot is a layout, not a plain Item").
+- **...and making it a layout is only half of it, because a nested layout holding a filling
+  child grows to whatever is going.** `Layout.fillHeight` defaults to **true** for an item that
+  is itself a layout, and a `RowLayout`'s own maximum height is derived from its children - so a
+  row whose only children are content-sized cannot grow and needs nothing said about it, while
+  the same row holding one `Layout.fillHeight: true` child becomes unbounded and takes the
+  column's entire leftover. `ToolbarTextField` declares that flag **in the shared widget**, so
+  every search row in this tree is the second case and looks exactly like the first. Probed with
+  `qml6` against the same skeleton rather than reasoned about: 35px for the row and 286 for the
+  region below it, against **313 and 8** with one filling child, and back to 35/286 with
+  `Layout.fillHeight: false` stated on the row. Watch the direction of the failure - the list
+  does not disappear, it comes back eighteen pixels tall, which reads as a scroll bug.
+  f29079c51 ("fix(phone): the search row is content-height, so the list keeps the leftover").
+- **Neither of those is reachable from a source check, and the source check that existed was
+  green over the first one.** `test_phone_tab_surface_contract.py` already required that slot to
+  be a `ColumnLayout` and said why; it asked `assertRegex(host, r"ColumnLayout \{")`, which is
+  "does a ColumnLayout appear anywhere in this file", and the file has one - the title bar's.
+  A check about ONE object has to resolve that object: it reads the id the default alias names
+  and then that declaration's type. The consequence is measured separately
+  (`PhoneTabLayoutRuntimeTest.qml` reads the drawn boxes back out of a real window under
+  headless weston), because a height is not in the source and a rule about the source is a long
+  way from the pixel it protects.
+  b0e8f8af6 ("test(phone): the host check reads the slot's own type, not any ColumnLayout"),
+  1a2e39ee4 ("test(phone): measure what the tab's sub-pages actually draw").
 - **A keyboard is a LATTICE, not a stack of rows, and a `GridLayout` does not
   hand out equal columns on its own.** The numpad's `+` and its Enter are one
   key two rows tall, which a `RowLayout` cannot say — so each of them shipped
@@ -4320,6 +4360,20 @@ across daemon restarts. Four more things about that path, each of which cost a m
   5cad7ad40 ("feat(phoneNotifications): mirror the phone's notifications off KDE Connect over
   busctl"), dbe6e73d5 ("test(phoneNotifications): drive the sweep, a signal, dismiss and reply
   against a fake busctl").
+- **A mirrored notification's `iconPath` is a PATH the daemon wrote, so it is the picture slot
+  and never the icon-theme one.** kdeconnectd saves the posting app's icon payload to a file -
+  40 of them under `/tmp/kdeconnect_<user>/` on this machine, PNGs at 90-128px - and hands the
+  absolute path over as `iconPath`; `PhoneNotifications.groupsForList` already carried it as
+  each group's `appIcon`, the same derivation `services/Notifications.qml` makes for a desktop
+  group, and the tab's card simply never drew it. It goes through
+  `modules/common/widgets/NotificationAppIcon.qml`, which is the shell's own notification icon,
+  through `image` (a URL to a file) rather than `appIcon` - that slot resolves through
+  `Quickshell.iconPath`, i.e. the icon THEME, which knows nothing about a path a daemon wrote
+  and would answer `image-missing` for every notification. An empty `iconPath` leaves the slot
+  empty and the widget falls back to the glyph it guesses from the title, which is the fallback
+  the desktop cards have always had. What separates "the icon is not drawn" from "the file did
+  not load" is `Image.status`, and nothing else, so the check for it is a runtime one.
+  9cc805f9b ("feat(phone): a phone notification card draws the posting app's icon").
 - **kdeconnectd's desktop copy of a mirrored notification is dropped at ingestion, behind the
   mirror gate.** `services/Notifications.qml`'s `onNotification` asks
   `PhoneNotifications.mirrorsDesktopNotification(appName)` before tracking - the daemon posts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,19 @@ own repo; the installer pins which revision it builds.
   the rest of this release's phone work is reached.
 
 ### Fixed
+- **The Phone tab's Contacts and Android Apps pages draw their contents
+  again.** Contacts showed its count — "147 of 150 contacts" — and then an
+  empty page, and Android Apps drew its big empty-state icon on top of its
+  own search box, hiding the line explaining that the phone was not
+  reachable. Both pages were being given no height to draw into, so a full
+  list showed nothing and an empty one spilled over the header above it.
+  Each page now fills the room under its title bar: the list runs to the
+  bottom of the panel, and an empty state centres in what is left.
+- **Phone notifications show the app's icon.** A mirrored notification drew
+  the app's name and its text but never the icon KDE Connect sends with it.
+  The icon is now on the card, beside the app name, with the same
+  guessed-glyph fallback the shell's own notifications use for an app that
+  sends none.
 - **Settings stops switching off the debounce on every config write in the
   shell.** Opening the settings window was never actually required: the
   settings page host is built while the shell starts, and it asked for its

--- a/dots/.config/quickshell/imi/PhoneTabLayoutRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/PhoneTabLayoutRuntimeTest.qml
@@ -296,6 +296,34 @@ ShellRoot {
                           statusBox.left >= 0 && statusBox.right <= page.width + 1);
         },
 
+        // ---- and it still does at a page height that has nothing to spare -
+        () => {
+            window.implicitHeight = 380;
+        },
+        () => {},
+        () => {
+            const page = harness.first("PhoneAppsPage");
+            const placeholder = harness.findAll(page, "PagePlaceholder", [])[0] ?? null;
+            const region = placeholder?.parent ?? null;
+            const column = region?.parent ?? null;
+            const status = column?.children[1] ?? null;
+            const drawn = placeholder?.children[0] ?? null;
+            const statusBox = harness.boxIn(status, page);
+            const regionBox = harness.boxIn(placeholder, page);
+            const drawnBox = harness.boxIn(drawn, page);
+            console.log(`[PhoneTabLayout] cramped: status ${statusBox.top}-${statusBox.bottom}`
+                        + ` region ${regionBox.top}-${regionBox.bottom}`
+                        + ` drawn ${drawnBox.top}-${drawnBox.bottom} of page ${page.height}`);
+            // `dropIconWhenCramped` is what makes this hold: the glyph gives
+            // way and the two labels fit, rather than the column growing past
+            // the region and painting over the header again.
+            harness.check(`a short page still keeps the empty state under the status line,`
+                          + ` got ${drawnBox.top} against ${statusBox.bottom}`,
+                          drawnBox.top >= statusBox.bottom);
+            harness.check(`...and inside the page, got ${drawnBox.bottom} of ${page.height}`,
+                          drawnBox.bottom <= page.height + 1);
+        },
+
         () => harness.finish()
     ]
 

--- a/dots/.config/quickshell/imi/PhoneTabLayoutRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/PhoneTabLayoutRuntimeTest.qml
@@ -1,0 +1,313 @@
+import QtQuick
+import QtTest
+import Quickshell
+import qs
+import qs.services
+import qs.modules.common
+import qs.modules.common.widgets
+import qs.modules.imi.phone
+import qs.modules.imi.sidebarLeft.phone
+
+/**
+ * What the Phone tab and its sub-pages actually DRAW, measured in a real
+ * window rather than read off the source.
+ *
+ * Three classes of defect live here and none of them is reachable from
+ * `qmltestrunner` or from a source check: a page whose content resolves to
+ * zero height renders a header and nothing else, an empty state centred on
+ * the wrong region paints itself over the header above it, and an icon that
+ * is never drawn is indistinguishable in the source from one whose file
+ * failed to load. Every check below is a number read back off an item that
+ * is on screen.
+ *
+ * The tab is built over the REAL services, fed by a fake `busctl` on PATH
+ * (one paired, reachable phone; two mirrored notifications, one carrying an
+ * `iconPath` and one with none) and by a real `kpeoplevcard` fixture tree
+ * that the real contacts monitor reads - so the Contacts page has rows to
+ * lay out and the notification cards have an icon to resolve.
+ *
+ * Driven by tests/test_phone_tab_layout_runtime.py, which brings the weston
+ * and the session bus.
+ *
+ *   PATH=<dir with fake busctl>:$PATH qs -p PhoneTabLayoutRuntimeTest.qml
+ */
+ShellRoot {
+    id: harness
+
+    property int failures: 0
+    property int checksRun: 0
+    property int elapsed: 0
+
+    readonly property string phoneId: Quickshell.env("PHONE_ID") ?? ""
+    // The file the fake daemon reports as the first notification's iconPath.
+    readonly property string iconPath: Quickshell.env("PHONE_ICON_PATH") ?? ""
+
+    function check(label, ok) {
+        harness.checksRun++;
+        console.log(`[PhoneTabLayout] ${label}: ${ok ? "ok" : "FAIL"}`);
+        if (!ok)
+            harness.failures++;
+    }
+
+    function typeName(obj) {
+        return `${obj}`.split("(")[0].split("_QML")[0].trim();
+    }
+
+    function findAll(item, type, out) {
+        if (!item)
+            return out;
+        for (const child of item.children) {
+            if (harness.typeName(child) === type)
+                out.push(child);
+            harness.findAll(child, type, out);
+        }
+        return out;
+    }
+
+    function all(type) {
+        return harness.findAll(loader.item, type, []);
+    }
+
+    function first(type) {
+        return harness.all(type)[0] ?? null;
+    }
+
+    // Where an item is DRAWN, in another item's coordinates. Everything about
+    // both defects is a comparison between two of these.
+    function boxIn(item, reference) {
+        const origin = item.mapToItem(reference, 0, 0);
+        return {
+            top: origin.y,
+            left: origin.x,
+            bottom: origin.y + item.height,
+            right: origin.x + item.width
+        };
+    }
+
+    FloatingWindow {
+        id: window
+        visible: true
+        implicitWidth: 460
+        implicitHeight: 900
+        color: "black"
+
+        TestCase {
+            id: driver
+            when: false
+            name: "PhoneTabLayoutDriver"
+        }
+
+        Loader {
+            id: loader
+            anchors.fill: parent
+            active: false
+            sourceComponent: Phone {}
+        }
+    }
+
+    Component.onCompleted: {
+        // A singleton is constructed on first use; these reads start the
+        // presence probe, the first sweep and the contacts monitor.
+        console.log(`[PhoneTabLayout] services constructed, installed=${PhoneConnect.installed}`
+                    + ` contacts=${PhoneContacts.enabled}`);
+    }
+
+    Timer {
+        id: waitForReady
+        interval: 250
+        repeat: true
+        running: true
+        onTriggered: {
+            harness.elapsed += waitForReady.interval;
+            const ready = Config.ready && PhoneConnect.installed
+                && PhoneConnect.devices.length === 1
+                && PhoneNotifications.count === 2
+                && PhoneContacts.ready && PhoneContacts.count > 0;
+            if (!ready) {
+                if (harness.elapsed >= 40000) {
+                    harness.check(`the fake daemon and the contacts fixture both answered`
+                                  + ` (devices ${PhoneConnect.devices.length},`
+                                  + ` notifications ${PhoneNotifications.count},`
+                                  + ` contacts ${PhoneContacts.count})`, false);
+                    harness.finish();
+                }
+                return;
+            }
+            waitForReady.running = false;
+            steps.running = true;
+        }
+    }
+
+    function finish() {
+        console.log(`[PhoneTabLayout] checks: ${harness.checksRun} failures: ${harness.failures}`);
+        Qt.exit(harness.failures === 0 ? 0 : 1);
+    }
+
+    property var stepList: [
+        () => {
+            loader.active = true;
+        },
+        () => {},
+
+        // ---- a notification card draws the posting app's icon -------------
+        () => {
+            const list = harness.first("PhoneNotificationList");
+            const icons = harness.findAll(list, "NotificationAppIcon", []);
+            harness.check(`every notification card carries an app icon, got ${icons.length} for`
+                          + ` ${PhoneNotifications.appNameList.length} cards`,
+                          icons.length === PhoneNotifications.appNameList.length && icons.length === 2);
+
+            // The one whose group carries an iconPath must have RESOLVED it:
+            // a card drawing a broken Image is the same source as one drawing
+            // a good one, and only the status tells them apart.
+            const withIcon = icons.find(i => String(i.image ?? "") !== "") ?? null;
+            harness.check("the card for an app that sent an icon points at that file",
+                          withIcon !== null
+                          && String(withIcon.image).indexOf(harness.iconPath) >= 0);
+            const drawn = withIcon === null ? [] : harness.findAll(withIcon, "QQuickImage", [])
+                .filter(i => i.status === Image.Ready && i.width > 0);
+            harness.check(`...and the picture loaded, got ${drawn.length} ready images`,
+                          drawn.length >= 1);
+
+            // The other one has no iconPath at all, and must fall back rather
+            // than draw an empty box.
+            const without = icons.find(i => String(i.image ?? "") === "") ?? null;
+            const glyphs = without === null ? [] : harness.findAll(without, "MaterialSymbol", [])
+                .filter(g => g.visible && String(g.text).length > 0);
+            harness.check(`a notification with no icon falls back to a glyph, got ${glyphs.length}`,
+                          without !== null && glyphs.length >= 1);
+        },
+
+        // ---- the Contacts page's list owns the room under the header ------
+        () => loader.item.openSubPage("contacts"),
+        () => {},
+        () => {
+            const page = harness.first("PhoneContactsPage");
+            const list = harness.findAll(page, "StyledListView", [])[0] ?? null;
+            // Structural, not by text: the region the list is anchored into,
+            // the page's own content column above it, and the SLOT that
+            // column sits in - which is what decides whether it fills.
+            const region = list?.parent ?? null;
+            const column = region?.parent ?? null;
+            const slot = column?.parent ?? null;
+            const field = harness.findAll(page, "ToolbarTextField", [])[0] ?? null;
+            const counts = column?.children[1] ?? null;
+            const delegate = list === null ? null : list.itemAtIndex(0);
+            console.log(`[PhoneTabLayout] page=${page?.height} column=${column?.height}`
+                        + ` slot=${harness.typeName(slot)} h=${slot?.height}`
+                        + ` region=${region?.height} list h=${list?.height}`
+                        + ` contentHeight=${list?.contentHeight} count=${list?.count}`
+                        + ` delegate=${delegate?.height} filtered=${PhoneContacts.filtered.length}`);
+
+            // The defect, stated as the thing that was wrong: the page's own
+            // column sat at its IMPLICIT height (73) inside an 836px slot,
+            // because the slot was a plain Item and `Layout.fillHeight` is
+            // inert in one.
+            harness.check(`the sub-page's content slot is a layout, got`
+                          + ` ${harness.typeName(slot)}`,
+                          harness.typeName(slot) === "QQuickColumnLayout");
+            harness.check(`the page's content column fills that slot, got ${column?.height}`
+                          + ` of ${slot?.height} in a ${page?.height} page`,
+                          column !== null && slot !== null && page !== null
+                          && Math.abs(column.height - slot.height) <= 1
+                          && slot.height > page.height / 2);
+            harness.check(`the contact list has a height to draw into, got ${list?.height}`,
+                          list !== null && list.height > 0);
+            harness.check(`the list holds every filtered contact, got ${list?.count}`
+                          + ` of ${PhoneContacts.filtered.length}`,
+                          list !== null && list.count === PhoneContacts.filtered.length
+                          && list.count > 0);
+            harness.check(`its content is taller than nothing, got ${list?.contentHeight}`,
+                          list !== null && list.contentHeight > 0);
+            harness.check(`and a row draws at a real height, got ${delegate?.height}`,
+                          delegate !== null && delegate.height > 0);
+
+            const listBox = harness.boxIn(list, page);
+            const fieldBox = harness.boxIn(field, page);
+            const countBox = harness.boxIn(counts, page);
+            console.log(`[PhoneTabLayout] field ${fieldBox.top}-${fieldBox.bottom}`
+                        + ` count ${countBox.top}-${countBox.bottom}`
+                        + ` list ${listBox.top}-${listBox.bottom} of page ${page.height}`);
+            harness.check("the list starts below the search row and the count line",
+                          listBox.top >= fieldBox.bottom && listBox.top >= countBox.bottom);
+            harness.check(`...and runs to the bottom of the page, got ${listBox.bottom}`
+                          + ` of ${page.height}`,
+                          Math.abs(listBox.bottom - page.height) <= 1);
+        },
+        () => loader.item.popSubPage(),
+        () => {},
+
+        // ---- the Apps page's empty state stays under its own header -------
+        () => loader.item.openSubPage("apps"),
+        () => {},
+        () => {
+            const page = harness.first("PhoneAppsPage");
+            const placeholder = harness.findAll(page, "PagePlaceholder", [])[0] ?? null;
+            // The same structural walk as the Contacts step: the placeholder
+            // is anchored into the leftover region, whose parent is the
+            // page's content column, whose children are its rows in order.
+            const region = placeholder?.parent ?? null;
+            const column = region?.parent ?? null;
+            const field = harness.findAll(page, "ToolbarTextField", [])[0] ?? null;
+            // Row 0 is the search row; row 1 is the status line - the app
+            // count, or the reason there is no count.
+            const status = column?.children[1] ?? null;
+            // PagePlaceholder centres one column in itself; that column is
+            // what is actually painted, and it is free to reach outside.
+            const drawn = placeholder?.children[0] ?? null;
+
+            harness.check("the page has a search row, a status line and an empty state",
+                          page !== null && field !== null && status !== null
+                          && placeholder !== null && drawn !== null);
+            if (page === null || field === null || status === null || drawn === null) {
+                console.log(`[PhoneTabLayout] apps page=${page} field=${field}`
+                            + ` status=${status} placeholder=${placeholder}`);
+                return;
+            }
+
+            const fieldBox = harness.boxIn(field, page);
+            const statusBox = harness.boxIn(status, page);
+            const regionBox = harness.boxIn(placeholder, page);
+            const drawnBox = harness.boxIn(drawn, page);
+            console.log(`[PhoneTabLayout] status text="${status.text}"`);
+            console.log(`[PhoneTabLayout] field ${fieldBox.top}-${fieldBox.bottom}`
+                        + ` status ${statusBox.top}-${statusBox.bottom}`
+                        + ` placeholder region ${regionBox.top}-${regionBox.bottom}`
+                        + ` drawn ${drawnBox.top}-${drawnBox.bottom}`
+                        + ` of page ${page.height} x ${page.width}`);
+
+            harness.check(`the empty state's region starts below the status line,`
+                          + ` got ${regionBox.top} against ${statusBox.bottom}`,
+                          regionBox.top >= statusBox.bottom);
+            harness.check(`...and it is the leftover height, got ${regionBox.bottom}`
+                          + ` of ${page.height}`,
+                          Math.abs(regionBox.bottom - page.height) <= 1
+                          && regionBox.bottom - regionBox.top > 0);
+            // The one the maintainer saw: the glyph column is centred, so a
+            // region of the wrong height paints it over the rows above.
+            harness.check(`what the empty state DRAWS clears the search row,`
+                          + ` got ${drawnBox.top} against ${fieldBox.bottom}`,
+                          drawnBox.top >= fieldBox.bottom);
+            harness.check(`...and clears the status line, got ${drawnBox.top}`
+                          + ` against ${statusBox.bottom}`,
+                          drawnBox.top >= statusBox.bottom);
+            harness.check(`the status line stays inside the page, got`
+                          + ` ${statusBox.left}-${statusBox.right} of ${page.width}`,
+                          statusBox.left >= 0 && statusBox.right <= page.width + 1);
+        },
+
+        () => harness.finish()
+    ]
+
+    property int stepIndex: 0
+    Timer {
+        id: steps
+        interval: 500
+        repeat: true
+        onTriggered: {
+            if (harness.stepIndex >= harness.stepList.length)
+                return;
+            harness.stepList[harness.stepIndex++]();
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/PhoneTabLayoutRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/PhoneTabLayoutRuntimeTest.qml
@@ -41,6 +41,12 @@ ShellRoot {
     readonly property string phoneId: Quickshell.env("PHONE_ID") ?? ""
     // The file the fake daemon reports as the first notification's iconPath.
     readonly property string iconPath: Quickshell.env("PHONE_ICON_PATH") ?? ""
+    // How tall the tab's host is. The window cannot be resized under headless
+    // weston - measured: assigning `implicitHeight` left the page at 880 and
+    // the "cramped" step scored the tall page a second time - so the host's
+    // own height is what the short-page step moves.
+    property real viewportHeight: 900
+    property real tallPageHeight: 0
 
     function check(label, ok) {
         harness.checksRun++;
@@ -99,7 +105,8 @@ ShellRoot {
 
         Loader {
             id: loader
-            anchors.fill: parent
+            width: parent.width
+            height: harness.viewportHeight
             active: false
             sourceComponent: Phone {}
         }
@@ -294,11 +301,12 @@ ShellRoot {
             harness.check(`the status line stays inside the page, got`
                           + ` ${statusBox.left}-${statusBox.right} of ${page.width}`,
                           statusBox.left >= 0 && statusBox.right <= page.width + 1);
+            harness.tallPageHeight = page.height;
         },
 
         // ---- and it still does at a page height that has nothing to spare -
         () => {
-            window.implicitHeight = 380;
+            harness.viewportHeight = 200;
         },
         () => {},
         () => {
@@ -314,14 +322,28 @@ ShellRoot {
             console.log(`[PhoneTabLayout] cramped: status ${statusBox.top}-${statusBox.bottom}`
                         + ` region ${regionBox.top}-${regionBox.bottom}`
                         + ` drawn ${drawnBox.top}-${drawnBox.bottom} of page ${page.height}`);
+            // Or the step scores the tall page a second time and says nothing.
+            harness.check(`the page really did get shorter, got ${page.height}`
+                          + ` against ${harness.tallPageHeight}`,
+                          page.height < harness.tallPageHeight / 2);
             // `dropIconWhenCramped` is what makes this hold: the glyph gives
             // way and the two labels fit, rather than the column growing past
             // the region and painting over the header again.
             harness.check(`a short page still keeps the empty state under the status line,`
                           + ` got ${drawnBox.top} against ${statusBox.bottom}`,
                           drawnBox.top >= statusBox.bottom);
-            harness.check(`...and inside the page, got ${drawnBox.bottom} of ${page.height}`,
-                          drawnBox.bottom <= page.height + 1);
+            // Centred in what is LEFT, which is the whole of what the empty
+            // state owes and the only form of it that survives a region
+            // smaller than the labels: at 180px the two labels are 70 in a
+            // 63px region, so `dropIconWhenCramped` has already given up the
+            // glyph and the remainder overhangs a few pixels at both ends -
+            // symmetrically, which is what says it is centred on its own
+            // region rather than on the page.
+            harness.check(`...centred in the region it was given, got`
+                          + ` ${(drawnBox.top + drawnBox.bottom) / 2} against`
+                          + ` ${(regionBox.top + regionBox.bottom) / 2}`,
+                          Math.abs((drawnBox.top + drawnBox.bottom) / 2
+                                   - (regionBox.top + regionBox.bottom) / 2) <= 1);
         },
 
         () => harness.finish()

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneAppsPage.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneAppsPage.qml
@@ -58,8 +58,14 @@ PhoneSubPage {
         Layout.fillHeight: true
         spacing: Appearance.spacing.space100
 
+        // The search row is content-height, stated rather than left to the
+        // default: `ToolbarTextField` declares `Layout.fillHeight: true` of
+        // its own, which makes this row's maximum height unbounded, and a
+        // nested layout defaults to filling - so the row would take the
+        // column's whole leftover and leave the list eight pixels.
         RowLayout {
             Layout.fillWidth: true
+            Layout.fillHeight: false
             spacing: Appearance.spacing.space100
 
             MaterialSymbol {

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneContactsPage.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneContactsPage.qml
@@ -40,8 +40,14 @@ PhoneSubPage {
         Layout.fillHeight: true
         spacing: Appearance.spacing.space100
 
+        // The search row is content-height, stated rather than left to the
+        // default: `ToolbarTextField` declares `Layout.fillHeight: true` of
+        // its own, which makes this row's maximum height unbounded, and a
+        // nested layout defaults to filling - so the row would take the
+        // column's whole leftover and leave the list eight pixels.
         RowLayout {
             Layout.fillWidth: true
+            Layout.fillHeight: false
             spacing: Appearance.spacing.space100
 
             MaterialSymbol {

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneNotificationList.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneNotificationList.qml
@@ -89,6 +89,16 @@ Item {
             // Newest first, the way the shell's own group draws them.
             readonly property var notifications: (card.group?.notifications ?? []).slice().reverse()
             readonly property int notificationCount: card.notifications.length
+            // KDE Connect saves the posting app's icon to a file and hands
+            // the absolute PATH over as `iconPath` (the group carries the
+            // first one, the same derivation services/Notifications.qml uses
+            // for a desktop group). NotificationAppIcon takes a URL, so it is
+            // spelled the way every other file source in this tree is; a
+            // notification that arrived without one leaves it empty and the
+            // widget draws its glyph instead.
+            readonly property string appIconPath: FileUtils.trimFileProtocol(card.group?.appIcon ?? "")
+            readonly property string appIconUrl: card.appIconPath.length === 0 ? ""
+                : "file://" + card.appIconPath.split("/").map(encodeURIComponent).join("/")
 
             readonly property real dragConfirmThreshold: 70
             readonly property real dismissOvershoot: 20
@@ -191,6 +201,20 @@ Item {
                     RowLayout {
                         Layout.fillWidth: true
                         spacing: Appearance.spacing.space100
+
+                        // The shell's own notification icon, on this model's
+                        // fields: `image` is the picture slot - a URL to a
+                        // file - and the glyph guessed from the title is what
+                        // it falls back to when the phone sent no icon. No
+                        // second resolution scheme, and no `appIcon`: that
+                        // slot goes through the icon THEME, which knows
+                        // nothing about a path kdeconnectd wrote.
+                        NotificationAppIcon {
+                            Layout.alignment: Qt.AlignVCenter
+                            implicitSize: Appearance.font.pixelSize.huge + Appearance.spacing.space100
+                            image: card.appIconUrl
+                            summary: card.notifications[0]?.title ?? card.appName
+                        }
 
                         StyledText {
                             Layout.fillWidth: true

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneSubPage.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneSubPage.qml
@@ -67,10 +67,19 @@ Item {
             }
         }
 
-        Item {
+        // The content slot is a LAYOUT, because every page states its size
+        // with Layout.* - its own header says so - and those attached
+        // properties are inert in anything that is not one. As a plain Item
+        // this slot left each page's root column at its IMPLICIT height:
+        // measured on the Contacts page at 73px inside an 836px slot, so the
+        // region under the search row was handed 0 and the list drew nothing
+        // while reporting 2 rows and 110px of content.
+        ColumnLayout {
             id: contentHolder
             Layout.fillWidth: true
             Layout.fillHeight: true
+            // The page owns the rhythm between its own rows; this adds none.
+            spacing: 0
         }
     }
 }

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -1644,6 +1644,18 @@ if ! python3 "$SCRIPT_DIR/test_phone_tab_runtime.py"; then
     exit 1
 fi
 
+# What the tab and its sub-pages DRAW, in a real window: the Contacts list
+# owning the room under its header, the Android Apps empty state staying
+# clear of the search row it used to paint over, and a notification card's
+# app icon resolving off the file kdeconnectd wrote. A page whose content
+# resolves to zero height renders its header and nothing else, and the
+# source of that reads perfectly.
+echo "Running Phone tab layout runtime tests..."
+if ! python3 "$SCRIPT_DIR/test_phone_tab_layout_runtime.py"; then
+    echo "Phone tab layout runtime tests failed."
+    exit 1
+fi
+
 # The phone's notification mirror: the parser region synced with its double,
 # argv only, dismiss on the LEAF, the declared reply refetch delay, one
 # stream, the desktop dedupe gate at ingestion, and the cache key declared.

--- a/dots/.config/quickshell/imi/tests/test_phone_tab_layout_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_tab_layout_runtime.py
@@ -53,7 +53,7 @@ PHONE_ADDRESS = "192.168.100.179"
 # A literal, never read back out of the harness's own output: a step list
 # that shrinks must redden here instead of reporting `failures: 0` for a
 # shorter run.
-EXPECTED_CHECKS = 20
+EXPECTED_CHECKS = 21
 
 RECORD = """#!/usr/bin/env bash
 printf '%s %s\\n' "$(date +%s.%N)" "$*" >> "$PHONE_EXEC_LOG"

--- a/dots/.config/quickshell/imi/tests/test_phone_tab_layout_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_tab_layout_runtime.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""What the Phone tab and its sub-pages draw, measured in a real window.
+
+`PhoneTabLayoutRuntimeTest.qml` builds the real tab over the real services,
+opens the Contacts and Android Apps sub-pages and reads the drawn geometry
+back. It exists because three defects the maintainer hit are invisible to
+every other check in this suite:
+
+- a sub-page whose content resolves to ZERO height renders its header and
+  nothing else. `PhoneContactsPage` drew "147 of 150 contacts" over an empty
+  list area, and the source reads perfectly: the list states
+  `Layout.fillHeight`, its parent states `Layout.fillHeight`, and the page's
+  root column states it too. Only the numbers show that the column was never
+  in a layout at all.
+- `PagePlaceholder` centres its column in itself and clips nothing, so an
+  empty state given a zero-height region paints its glyph OVER the search row
+  above it. That is one symptom of the same cause, on the page whose list
+  happens to be empty rather than full.
+- an app icon that is never drawn, and one whose file failed to load, are the
+  same source. Only `Image.status` tells them apart.
+
+The fake `busctl` serves one paired, reachable phone and two mirrored
+notifications: leaf 70 carries an `iconPath` (a PNG this test writes, the way
+kdeconnectd writes one per notification icon into its cache) and leaf 71
+carries none, so both the icon and its fallback are on screen at once. The
+Contacts page is fed by the REAL contacts monitor over a real
+`kpeoplevcard/kdeconnect-<id>/` fixture tree, because a list with no rows
+cannot answer "does a row draw at a real height".
+
+Brings its own headless weston and its own session bus (`dbus-run-session`).
+Skips when weston, qs or dbus-run-session are missing, as in CI.
+"""
+
+import json
+import os
+import shutil
+import struct
+import subprocess
+import tempfile
+import time
+import unittest
+import zlib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HARNESS = ROOT / "PhoneTabLayoutRuntimeTest.qml"
+SOCKET = "wayland-imi-phone-layout"
+
+PHONE_ID = "6131a746_571a_4176_a007_95625ff8e08e"
+PHONE_NAME = "Galaxy S23 Ultra"
+PHONE_ADDRESS = "192.168.100.179"
+
+# A literal, never read back out of the harness's own output: a step list
+# that shrinks must redden here instead of reporting `failures: 0` for a
+# shorter run.
+EXPECTED_CHECKS = 18
+
+RECORD = """#!/usr/bin/env bash
+printf '%s %s\\n' "$(date +%s.%N)" "$*" >> "$PHONE_EXEC_LOG"
+__BODY__
+"""
+
+# --json=short shapes lifted from a real busctl against a live KDE Connect
+# daemon. Leaf 70 is the captured Truecaller notification with its real
+# iconPath shape (an absolute path to a file the daemon wrote); leaf 71 is a
+# WhatsApp message, which arrived with no icon at all.
+BUSCTL_BODY = """\
+case "$*" in
+  *"org.freedesktop.DBus ListNames")
+    printf '{"type":"as","data":[[":1.5","org.freedesktop.DBus","org.kde.kdeconnect.daemon"]]}\\n'
+    ;;
+  *"org.kde.kdeconnect.daemon devices bb false false")
+    printf '{"type":"as","data":[["%(phone)s"]]}\\n'
+    ;;
+  *"/notifications org.kde.kdeconnect.device.notifications activeNotifications")
+    printf '{"type":"as","data":[["70","71"]]}\\n'
+    ;;
+  *"/notifications/70 org.freedesktop.DBus.Properties GetAll s org.kde.kdeconnect.device.notifications.notification")
+    printf '{"type":"a{sv}","data":[{"appName":{"type":"s","data":"Truecaller"},"dismissable":{"type":"b","data":true},"hasIcon":{"type":"b","data":true},"iconPath":{"type":"s","data":"%(icon)s"},"internalId":{"type":"s","data":"0|com.truecaller|2131366136|null|10553"},"replyId":{"type":"s","data":""},"silent":{"type":"b","data":false},"text":{"type":"s","data":"Allow Truecaller to run in the background"},"ticker":{"type":"s","data":"Stay protected"},"title":{"type":"s","data":"Stay protected 24/7"}}]}\\n'
+    ;;
+  *"/notifications/71 org.freedesktop.DBus.Properties GetAll s org.kde.kdeconnect.device.notifications.notification")
+    printf '{"type":"a{sv}","data":[{"appName":{"type":"s","data":"WhatsApp"},"dismissable":{"type":"b","data":true},"hasIcon":{"type":"b","data":false},"iconPath":{"type":"s","data":""},"internalId":{"type":"s","data":"0|com.whatsapp|1|N3JGW5Lg6vbO|10466"},"replyId":{"type":"s","data":"r1"},"silent":{"type":"b","data":false},"text":{"type":"s","data":"see you at 8"},"ticker":{"type":"s","data":"Sam: see you at 8"},"title":{"type":"s","data":"Sam"}}]}\\n'
+    ;;
+  *"devices/%(phone)s/battery org.freedesktop.DBus.Properties GetAll s org.kde.kdeconnect.device.battery")
+    printf '{"type":"a{sv}","data":[{"charge":{"type":"i","data":85},"hasBattery":{"type":"b","data":true},"isCharging":{"type":"b","data":false}}]}\\n'
+    ;;
+  *"devices/%(phone)s/connectivity_report org.freedesktop.DBus.Properties GetAll s org.kde.kdeconnect.device.connectivity_report")
+    printf '{"type":"a{sv}","data":[{"cellularNetworkStrength":{"type":"i","data":4},"cellularNetworkType":{"type":"s","data":"LTE"},"iconName":{"type":"s","data":"network-mobile-100-lte"}}]}\\n'
+    ;;
+  *"devices/%(phone)s org.freedesktop.DBus.Properties GetAll s org.kde.kdeconnect.device")
+    printf '{"type":"a{sv}","data":[{"name":{"type":"s","data":"%(name)s"},"type":{"type":"s","data":"phone"},"isPaired":{"type":"b","data":true},"isReachable":{"type":"b","data":true},"isPairRequestedByPeer":{"type":"b","data":false},"pairState":{"type":"i","data":3},"reachableAddresses":{"type":"as","data":["%(address)s"]}}]}\\n'
+    ;;
+  *monitor*)
+    sleep 3600
+    ;;
+esac
+exit 0
+"""
+
+# Three cards shaped after what Android's exporter writes: two named contacts
+# and one that is nothing but a number, so `hideUnnamed` has something to
+# hide and the list still has rows.
+VCARDS = {
+    "alice.vcf": (
+        "BEGIN:VCARD\n"
+        "VERSION:3.0\n"
+        "UID:alice-uid-1\n"
+        "FN:Alice Rivers\n"
+        "N:Rivers;Alice;;;\n"
+        "TEL;TYPE=CELL,PREF:+1 (555) 010-0001\n"
+        "EMAIL;TYPE=HOME:alice@example.com\n"
+        "END:VCARD\n"
+    ),
+    "bob.vcf": (
+        "BEGIN:VCARD\n"
+        "VERSION:3.0\n"
+        "UID:bob-uid-1\n"
+        "FN:Bob Stone\n"
+        "N:Stone;Bob;;;\n"
+        "TEL;TYPE=HOME:555 010 0002\n"
+        "END:VCARD\n"
+    ),
+    "nameless.vcf": (
+        "BEGIN:VCARD\n"
+        "VERSION:3.0\n"
+        "UID:sim-0003\n"
+        "FN:+15550100003\n"
+        "N:;+15550100003;;;\n"
+        "TEL;TYPE=CELL:+1 (555) 010-0003\n"
+        "END:VCARD\n"
+    ),
+}
+
+
+def _png(width=90, height=90):
+    """A real PNG, because Image.status is the whole point of the icon check."""
+    raw = b"".join(b"\x00" + bytes([220, 60, 60, 255]) * width for _ in range(height))
+
+    def chunk(tag, payload):
+        body = tag + payload
+        return struct.pack(">I", len(payload)) + body + struct.pack(">I", zlib.crc32(body))
+
+    return (b"\x89PNG\r\n\x1a\n"
+            + chunk(b"IHDR", struct.pack(">IIBBBBB", width, height, 8, 6, 0, 0, 0))
+            + chunk(b"IDAT", zlib.compress(raw))
+            + chunk(b"IEND", b""))
+
+
+def _stop(proc):
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+
+
+def _runtime_available():
+    return all(shutil.which(name) for name in ("qs", "weston", "dbus-run-session"))
+
+
+@unittest.skipUnless(_runtime_available(), "needs qs, weston and dbus-run-session on PATH")
+class PhoneTabLayoutRuntimeTest(unittest.TestCase):
+    def setUp(self):
+        self.home = Path(tempfile.mkdtemp(prefix="imi-phone-layout-"))
+        self.addCleanup(shutil.rmtree, self.home, ignore_errors=True)
+        self.exec_log = self.home / "exec.log"
+
+        # The notification icon, where the daemon would have put it.
+        icons = self.home / "cache" / "kdeconnect-icons"
+        icons.mkdir(parents=True)
+        self.icon_path = icons / "eb39605216ceabbbd952b1ab18d00267"
+        self.icon_path.write_bytes(_png())
+
+        self.bin = self.home / "bin"
+        self.bin.mkdir(parents=True)
+        fake = self.bin / "busctl"
+        fake.write_text(RECORD.replace("__BODY__", BUSCTL_BODY % {
+            "phone": PHONE_ID, "name": PHONE_NAME, "address": PHONE_ADDRESS,
+            "icon": self.icon_path,
+        }))
+        fake.chmod(0o755)
+
+        # The vCards KDE Connect writes for KPeople, which the real monitor
+        # reads: a fixture tree, never the machine's own contacts.
+        cards = self.home / "data" / "kpeoplevcard" / f"kdeconnect-{PHONE_ID}"
+        cards.mkdir(parents=True)
+        for name, body in VCARDS.items():
+            (cards / name).write_text(body)
+
+        shell_config = self.home / "config" / "immaterial-impulse"
+        shell_config.mkdir(parents=True)
+        # The poll is ten minutes out: the startup sweep populates the model
+        # and nothing may re-sweep while the harness is measuring geometry.
+        (shell_config / "config.json").write_text(json.dumps({
+            "networking": {"phoneConnect": {"enable": True, "pollInterval": 600000}},
+            "phone": {"contacts": {"enabled": True, "hideUnnamed": True}},
+        }, indent=2))
+
+    def test_the_pages_lay_out_and_a_notification_card_draws_its_icon(self):
+        env = dict(os.environ)
+        # A runtime dir of the harness's own: everything this test starts talks
+        # to its own weston and can never map a surface on the user's display.
+        runtime = self.home / "runtime"
+        runtime.mkdir(mode=0o700)
+        env["XDG_RUNTIME_DIR"] = str(runtime)
+        env["WAYLAND_DISPLAY"] = SOCKET
+        env.pop("DISPLAY", None)
+        env.pop("HYPRLAND_INSTANCE_SIGNATURE", None)
+
+        weston = subprocess.Popen(
+            ["weston", "--backend=headless", "--renderer=pixman",
+             f"--socket={SOCKET}", "--width=900", "--height=1000"],
+            env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        self.addCleanup(_stop, weston)
+
+        socket_path = runtime / SOCKET
+        deadline = time.monotonic() + 15
+        while not socket_path.exists() and time.monotonic() < deadline:
+            time.sleep(0.2)
+        self.assertTrue(socket_path.exists(), "headless weston never came up")
+
+        env["LIBGL_ALWAYS_SOFTWARE"] = "1"
+        env["QT_QUICK_BACKEND"] = "software"
+        env["XDG_CONFIG_HOME"] = str(self.home / "config")
+        env["XDG_STATE_HOME"] = str(self.home / "state")
+        env["XDG_CACHE_HOME"] = str(self.home / "cache")
+        env["XDG_DATA_HOME"] = str(self.home / "data")
+        env["PATH"] = f"{self.bin}{os.pathsep}{env['PATH']}"
+        env["PHONE_EXEC_LOG"] = str(self.exec_log)
+        env["PHONE_ID"] = PHONE_ID
+        env["PHONE_ICON_PATH"] = str(self.icon_path)
+
+        # dbus-run-session, not the inherited bus: the fake busctl is the only
+        # daemon this harness may see.
+        proc = subprocess.run(
+            ["dbus-run-session", "--", "qs", "-p", str(HARNESS)],
+            cwd=str(ROOT), env=env, capture_output=True, text=True, timeout=300)
+        output = proc.stdout + proc.stderr
+        failed = [line for line in output.splitlines() if "FAIL" in line]
+        self.assertEqual(failed, [], f"harness reported failures:\n{output}")
+        self.assertIn(f"[PhoneTabLayout] checks: {EXPECTED_CHECKS} failures: 0", output,
+                      f"harness did not finish cleanly:\n{output}")
+
+        # A layout-managed item carrying anchors is a warning, not an error,
+        # and it means the item is not where the source says it is.
+        self.assertNotIn("Detected anchors on an item that is managed by a layout", output,
+                         f"a sub-page's content fights its own layout:\n{output}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dots/.config/quickshell/imi/tests/test_phone_tab_layout_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_tab_layout_runtime.py
@@ -53,7 +53,7 @@ PHONE_ADDRESS = "192.168.100.179"
 # A literal, never read back out of the harness's own output: a step list
 # that shrinks must redden here instead of reporting `failures: 0` for a
 # shorter run.
-EXPECTED_CHECKS = 18
+EXPECTED_CHECKS = 20
 
 RECORD = """#!/usr/bin/env bash
 printf '%s %s\\n' "$(date +%s.%N)" "$*" >> "$PHONE_EXEC_LOG"

--- a/dots/.config/quickshell/imi/tests/test_phone_tab_surface_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_tab_surface_contract.py
@@ -243,12 +243,24 @@ class SubPageContractTests(unittest.TestCase):
         host = strip_comments((SURFACE / "PhoneSubPage.qml").read_text(encoding="utf-8"))
         self.assertRegex(host, r"property string title", "no `title` on the host")
         self.assertRegex(host, r"signal back\b", "no `back()` on the host")
-        self.assertRegex(host, r"default property alias \w+:",
-                         "the host has no default content slot")
-        self.assertRegex(host, r"ColumnLayout \{",
+        slot = re.search(r"default property alias \w+: (\w+)\.data", host)
+        self.assertIsNotNone(slot, "the host has no default content slot")
+
+        # The slot's OWN type, not "a ColumnLayout appears in this file". The
+        # first version of this check asked the second question and matched
+        # the title bar's column while the slot itself was a plain `Item` -
+        # so `Layout.fillHeight` on every page's root column was inert, the
+        # column sat at its implicit height (73px inside an 836px slot,
+        # measured), and the Contacts page drew its count over an empty list.
+        # PhoneTabLayoutRuntimeTest.qml measures the consequence; this names
+        # the cause, because the two are a long way apart.
+        declaration = re.search(rf"(\w+) \{{\s*id: {slot.group(1)}\b", host)
+        self.assertIsNotNone(declaration,
+                             f"the slot `{slot.group(1)}` the default alias names is not declared")
+        self.assertEqual(declaration.group(1), "ColumnLayout",
                          "the content slot must be a ColumnLayout - the pages state "
-                         "their size with Layout.* and would warn about anchors "
-                         "inside anything else")
+                         "their size with Layout.*, and those attached properties do "
+                         "nothing at all in an item no layout manages")
 
     def test_every_page_is_rooted_on_the_host(self):
         for name in PAGES:


### PR DESCRIPTION
The Phone tab's two sub-pages drew a header and nothing under it, and its notification cards drew no app icon.

The first two are one defect: `PhoneSubPage`'s default content slot was a plain `Item`, so the `Layout.*` every page states — each page's own header comment says it does — was accepted, never read and never logged. Measured in a real window: the Contacts page's root column sat at its implicit height, 73px inside an 836px slot, so the region holding the list was handed 0 while the list itself reported 2 rows, 110px of content and a 52px first delegate. On the Android Apps page the list is empty instead, so what is on screen is `PagePlaceholder` — which centres its column in itself and clips nothing, and given a zero-height region at y=117 drew that column from y=32 to y=202, over the search field at 44-86 and the status line at 94-109.

Making the slot a layout is half of it. `ToolbarTextField` declares `Layout.fillHeight: true` in the shared widget, which makes the row holding it unbounded, and a nested layout defaults to filling — so the row took the whole leftover and the list came back 18px tall. Probed with `qml6` against the same skeleton: 35/286 with no filling child, 313/8 with one, 35/286 again with `Layout.fillHeight: false` on the row. After both: the list runs 117-880 of an 880px page and the empty state draws at 414-584, centred in what is left.

The icon was already in the model — `PhoneNotifications.groupsForList` carries each group's `iconPath` as `appIcon`, the derivation `services/Notifications.qml` makes for a desktop group — and the card simply never drew it. It goes through `NotificationAppIcon`, the shell's own, via `image` rather than `appIcon`: that slot resolves through the icon theme, which knows nothing about a path kdeconnectd wrote. Empty `iconPath` falls back to the widget's guessed glyph.

None of this is reachable from `qmltestrunner` or from a source check, and the source check that existed was green over the first defect — it asked whether a `ColumnLayout` appears anywhere in `PhoneSubPage.qml`, and the title bar has one. It resolves the id the default alias names now. `PhoneTabLayoutRuntimeTest.qml` measures the consequence: the real tab over the real services under headless weston, with a fake busctl and a real `kpeoplevcard` fixture, reading back the list's height, contentHeight, count and first delegate, where each page's rows are drawn against each other at two page heights, and `Image.status` on the icon — the only thing that separates a resolved picture from a broken path.

Suite green in both locales, 1402 QML checks, 0 failed.

Docs: updated AGENT.md §Directory map, §Dynamic/data-driven QML gotchas, §busctl monitor
Changelog: updated
