### PR TITLE
test(suite): serialize the compositor harnesses behind one flock

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -429,6 +429,53 @@ finding). A check that reads the `.in` is checking the wrong file and stays gree
 for the whole life of the bug; `tests/test_clock_depth_cache.py` reads both now.
 (fix(install): put onnxruntime in the lock the installer actually installs.)
 
+## Running the suite while another agent is running one
+
+**`tests/run_tests.sh` serializes itself — do not check `ps` for a running suite
+before starting one, and do not stagger runs by hand.** Everything up to the
+first runtime harness is pure (source-text lints, contract checks that parse QML
+and Python) and overlaps freely; from the first harness to the end of the run
+the script holds one exclusive `flock` on
+`${XDG_RUNTIME_DIR}/immaterial-impulse-test-suite.lock` — one fixed name per
+user, so every worktree and every clone on this machine contends for the same
+one. A second suite reaching that point prints which checkout is ahead of it and
+waits.
+
+That waiting used to be the caller's rule, and callers forgot it, the maintainer
+twice. What it costs is not a red test: forty of the checks start a nested
+weston and a `dbus-run-session`, and two of those up at once takes the loser's
+compositor away, so what it prints is `The Wayland connection broke. Did the
+Wayland compositor die?` — indistinguishable from a real regression in whatever
+it was testing. Five times in one day, three full re-runs, and one agent
+"fixing" code that was never broken.
+
+Four properties to know before changing any of it.
+
+- **The lock lives on a file descriptor the shell holds open**, so the kernel
+  drops it however the run ends — a failing check's `exit 1`, a Ctrl-C, a
+  SIGKILL. There is no lockfile to clean up and no stale marker to clear.
+- **What the kernel cannot drop is a descendant that inherited the
+  descriptor**: bash sets no close-on-exec on a `{fd}<>` redirection. Measured —
+  a backgrounded holder SIGKILLed while its child was alive left the lock held
+  with no suite running. So the wait gives up on the lock (not on the run) after
+  two consecutive minutes with the record naming a pid that is gone and not
+  moving, and says so.
+- **There is exactly ONE acquire point**, which is what makes the boundary cheap
+  and is also the thing that can silently break: a harness wired in above it
+  would run unserialized. `tests/lint_suite_lock_scope.py` fails the suite on
+  that, classifying "a harness that nests a compositor" with
+  `lint_display_isolation`'s own rule rather than a list of its own.
+- **CI never contends** — one job, a fresh runner, nothing else holding it — so
+  `flock -n` succeeds on its first try and the whole mechanism costs an `open()`
+  and one ioctl. It cannot turn a CI failure into a hang.
+
+The `run_*_probe.sh` scripts are **not** covered. They are run by hand, each
+nests its own weston, and two of those still collide with each other and with a
+suite's harnesses; `docs/handoff-2026-08-17-edit-mode.md`'s "re-run in
+isolation" is still the rule there.
+8b5f04d6e ("test(suite): serialize a run's compositor harnesses behind one flock"),
+d8ba5738b ("test(lint): fail on a compositor harness wired in above the suite lock").
+
 ## Directory map
 
 ```

--- a/AGENT.md
+++ b/AGENT.md
@@ -458,8 +458,8 @@ Four properties to know before changing any of it.
   descriptor**: bash sets no close-on-exec on a `{fd}<>` redirection. Measured —
   a backgrounded holder SIGKILLed while its child was alive left the lock held
   with no suite running. So the wait gives up on the lock (not on the run) after
-  two consecutive minutes with the record naming a pid that is gone and not
-  moving, and says so.
+  two consecutive minutes with the holder's record unchanged and naming no live
+  process, and says so.
 - **There is exactly ONE acquire point**, which is what makes the boundary cheap
   and is also the thing that can silently break: a harness wired in above it
   would run unserialized. `tests/lint_suite_lock_scope.py` fails the suite on

--- a/AGENT.md
+++ b/AGENT.md
@@ -449,6 +449,14 @@ Wayland compositor die?` — indistinguishable from a real regression in whateve
 it was testing. Five times in one day, three full re-runs, and one agent
 "fixing" code that was never broken.
 
+**The queueing is inherent, not a cost of where the boundary sits**, and that
+was measured before it was argued about: on one full green run here, of 16m40s
+of work the compositor harnesses are **15m19s**, the free head above the acquire
+is **23s**, and everything else inside the lock is **1m21s**. So even a
+per-harness lock — forty acquire/release pairs and a rule every new harness has
+to remember — could overlap about a hundred seconds of a seventeen-minute run.
+Do not re-open that trade on the assumption that most of a run is static.
+
 Four properties to know before changing any of it.
 
 - **The lock lives on a file descriptor the shell holds open**, so the kernel

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -243,6 +243,15 @@ bug in anything that qualifies:
 - **Run `./tests/run_tests.sh` before committing** and confirm it's green. A change that breaks an
   existing test is a regression, full stop - fix the change, don't loosen or delete the test to
   make it pass, unless the test itself was wrong (and if so, say so explicitly in the commit).
+  **Start it whenever you are ready: do not check `ps` for a suite already running and do not
+  stagger runs by hand.** The script takes an exclusive `flock` before its first runtime harness,
+  says which checkout is ahead of it, and waits - the static half of the run overlaps freely and
+  only the compositor harnesses queue. That used to be the caller's rule and callers forgot it;
+  what it costs is `The Wayland connection broke. Did the Wayland compositor die?` in the losing
+  run, which is what a real regression looks like too. See
+  [AGENT.md → Running the suite while another agent is running one](AGENT.md#running-the-suite-while-another-agent-is-running-one)
+  for the boundary, the release, and why `run_*_probe.sh` is not covered.
+  8b5f04d6e ("test(suite): serialize a run's compositor harnesses behind one flock").
 - **A green suite does not mean the shell loads.** The QML tests only instantiate pure-logic
   singletons, so any widget that fails to *compile* (a `FINAL` property override, a bad type name, a
   missing `import qs.modules.common`) passes every test while taking down every panel that reaches
@@ -419,6 +428,14 @@ once:
 - **Small, single-purpose commits (see below) are what make parallel branches mergeable at all.** A
   worktree whose entire session is one giant commit is much more likely to conflict messily on merge
   than one with granular commits a reviewer (human or agent) can cherry-pick or rebase around.
+- **Two worktrees may run `./tests/run_tests.sh` at the same time; the script queues them.** It
+  holds one `flock` shared by every worktree and clone on the machine, across the section where
+  its harnesses each bring up a nested weston. Before 8b5f04d6e ("test(suite): serialize a run's
+  compositor harnesses behind one flock") the losing run reported a broken Wayland connection,
+  which reads as a regression in whatever it was testing rather than as contention - and the rule
+  that was supposed to prevent it ("check for a running suite first") was forgotten by every kind
+  of caller including the maintainer. Do not add a hand check back; if a run is waiting it says
+  which checkout it is waiting for.
 - **Re-run the live-verification loop against the primary checkout after merging**, even if each
   worktree "passed" its own review - the merge itself, and the fact that the changes were never
   actually hot-reloaded together until now, are both new sources of breakage.

--- a/dots/.config/quickshell/imi/tests/lint_suite_lock_scope.py
+++ b/dots/.config/quickshell/imi/tests/lint_suite_lock_scope.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+#
+# Regression guard: every compositor-nesting harness runs inside the suite lock.
+#
+# `run_tests.sh` takes one exclusive `flock` before its first runtime harness
+# and holds it to the end of the run, so two suites started in two git
+# worktrees cannot have their nested westons up at the same time. That
+# collision is not a red test - it is `The Wayland connection broke. Did the
+# Wayland compositor die?` in whichever run lost, which reads exactly like a
+# regression in the code under test and has cost three full re-runs and one
+# agent "fixing" code that was never broken.
+#
+# One acquire point is deliberate (the reasoning is written out in
+# `run_tests.sh`): forty acquire/release pairs would overlap more and would be
+# a rule every future harness has to remember. What makes the single boundary
+# safe is that nothing may be wired in above it, and THAT is a rule a check can
+# hold. A harness added to the top half of the file would run unprotected,
+# silently, and its collisions would look like flakes.
+#
+# "A harness that nests a compositor" is not a list kept here: it is
+# `lint_display_isolation.launches_qs`, the same classifier that already
+# decides which harnesses must bring their own display. One definition, so a
+# harness cannot be a compositor harness for one check and not the other.
+#
+# Exits non-zero. Wired into run_tests.sh / CI.
+
+import ast
+import sys
+from pathlib import Path
+
+import lint_display_isolation
+
+TESTS = Path(__file__).resolve().parent
+RUNNER = TESTS / "run_tests.sh"
+
+# The invocation form, never a mention: several blocks name a sibling harness
+# in their comment, and a comment above the boundary is not a harness running
+# above it.
+INVOCATION = 'python3 "$SCRIPT_DIR/{name}"'
+ACQUIRE = "acquire_suite_lock"
+
+
+def acquire_lines(runner: str):
+    """Line numbers of the top-level `acquire_suite_lock` call.
+
+    The definition (`acquire_suite_lock() {`) and every mention inside a
+    comment are excluded, so the answer is where the lock is actually taken.
+    """
+    found = []
+    for number, line in enumerate(runner.splitlines(), 1):
+        stripped = line.strip()
+        if stripped == ACQUIRE:
+            found.append(number)
+    return found
+
+
+def invocation_lines(runner: str, name: str):
+    needle = INVOCATION.format(name=name)
+    return [number for number, line in enumerate(runner.splitlines(), 1)
+            if needle in line and not line.lstrip().startswith("#")]
+
+
+def compositor_harnesses():
+    """Every `test_*.py` that ends up with a compositor of its own running.
+
+    Three spellings, all of them the sibling lint's: the harness builds a `qs`
+    argv itself, it starts weston itself, or it hands off to a `run_*_probe.sh`
+    that does (test_edit_mode_chrome.py and test_bar_exclusive_zone_reserver.py
+    are the two that delegate, and a check that asked only about `qs` argv
+    lists would have placed neither).
+    """
+    names = []
+    for path in sorted(TESTS.glob("test_*.py")):
+        text = path.read_text(encoding="utf-8")
+        try:
+            tree = ast.parse(text)
+        except SyntaxError:
+            continue
+        if (lint_display_isolation.launches_qs(tree)
+                or lint_display_isolation.starts_weston(tree)
+                or lint_display_isolation.delegates_to_nested_probe(text)):
+            names.append(path.name)
+    return names
+
+
+def check(runner: str, harnesses):
+    """Failures for one runner text and one set of harness file names."""
+    failures = []
+    acquires = acquire_lines(runner)
+    if not acquires:
+        return [f"run_tests.sh never calls {ACQUIRE}: the runtime harnesses "
+                f"run unserialized, so a suite in another worktree can break "
+                f"this one mid-harness."]
+    if len(acquires) > 1:
+        failures.append(
+            f"run_tests.sh calls {ACQUIRE} {len(acquires)} times (lines "
+            f"{', '.join(str(n) for n in acquires)}). One boundary is the "
+            f"whole design - a second one means part of the run is outside a "
+            f"section that reads as inside it.")
+    boundary = acquires[0]
+
+    registered = 0
+    for name in harnesses:
+        lines = invocation_lines(runner, name)
+        if not lines:
+            # Not this check's business: lint_suite_registration.py owns
+            # "wired in at all", and a harness reached some other way is not
+            # something this one can place.
+            continue
+        registered += 1
+        early = [n for n in lines if n < boundary]
+        if early:
+            failures.append(
+                f"{name}: invoked at line {early[0]}, above the "
+                f"{ACQUIRE} at line {boundary}. It starts a nested "
+                f"compositor, so it has to run inside the lock - move the "
+                f"block below the boundary rather than moving the boundary "
+                f"up, which would serialize the static lints for nothing.")
+
+    if not registered:
+        failures.append(
+            "no compositor harness found in run_tests.sh - the sweep covers "
+            "nothing, which is what it looks like when the invocation spelling "
+            "changes.")
+    return failures
+
+
+GOOD = """\
+echo "a static lint"
+python3 "$SCRIPT_DIR/lint_spacing.py"
+acquire_suite_lock
+python3 "$SCRIPT_DIR/test_edit_mode_runtime.py"
+"""
+
+EARLY = """\
+python3 "$SCRIPT_DIR/test_edit_mode_runtime.py"
+acquire_suite_lock
+python3 "$SCRIPT_DIR/test_phone_tab_runtime.py"
+"""
+
+MENTIONED_ONLY = """\
+# test_edit_mode_runtime.py is the sibling of the one below
+acquire_suite_lock
+python3 "$SCRIPT_DIR/test_edit_mode_runtime.py"
+"""
+
+NO_ACQUIRE = """\
+python3 "$SCRIPT_DIR/test_edit_mode_runtime.py"
+"""
+
+TWICE = """\
+acquire_suite_lock
+python3 "$SCRIPT_DIR/test_edit_mode_runtime.py"
+acquire_suite_lock
+"""
+
+
+def self_check():
+    """The check proved against fixtures, independently of the real tree.
+
+    A source-text check is code with nothing testing it, and this repo's
+    silent failures are checks that were green over the thing they exist to
+    refuse. Each fixture is one way the boundary breaks.
+    """
+    cases = [
+        (GOOD, ["test_edit_mode_runtime.py"], 0, "a harness below the boundary"),
+        (EARLY, ["test_edit_mode_runtime.py", "test_phone_tab_runtime.py"], 1,
+         "a harness above the boundary"),
+        (MENTIONED_ONLY, ["test_edit_mode_runtime.py"], 0,
+         "a harness NAMED above the boundary and invoked below it"),
+        (NO_ACQUIRE, ["test_edit_mode_runtime.py"], 1, "no boundary at all"),
+        (TWICE, ["test_edit_mode_runtime.py"], 1, "two boundaries"),
+    ]
+    problems = []
+    for runner, harnesses, expected, description in cases:
+        found = len(check(runner, harnesses))
+        if found != expected:
+            problems.append(
+                f"self-check: {description} produced {found} failures, "
+                f"expected {expected}")
+    # And the vacuity guard, which is the one that keeps a spelling change
+    # from turning this whole lint into a no-op.
+    if len(check(GOOD, [])) != 1:
+        problems.append("self-check: an empty harness set did not report the "
+                        "sweep as covering nothing")
+    return problems
+
+
+def main() -> int:
+    problems = self_check()
+    for problem in problems:
+        print(f"suite lock scope: {problem}", file=sys.stderr)
+    if problems:
+        return 1
+
+    runner = RUNNER.read_text(encoding="utf-8")
+    harnesses = compositor_harnesses()
+    failures = check(runner, harnesses)
+    for failure in failures:
+        print(f"suite lock scope: {failure}", file=sys.stderr)
+    if failures:
+        return 1
+
+    inside = sum(1 for name in harnesses if invocation_lines(runner, name))
+    print(f"Suite lock scope lint passed: {inside} compositor harnesses, all "
+          f"inside the lock")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -16,6 +16,167 @@ cd "$PROJECT_ROOT" || exit 1
 # explicit value still wins, for anyone who needs a real platform plugin.
 export QT_QPA_PLATFORM="${QT_QPA_PLATFORM:-offscreen}"
 
+# ---------------------------------------------------------------------------
+# Serializing concurrent suite runs
+#
+# Several agents work this repo in parallel git worktrees and every worktree
+# runs this same script. Forty of the checks below are runtime harnesses -
+# test_edit_mode_runtime.py, test_widget_interaction_runtime.py,
+# test_phone_tab_runtime.py, test_settings_page_incubation_runtime.py, the
+# phone-connect pair, and the rest - and each one starts a nested weston and a
+# `dbus-run-session`. Two suites overlapping there costs the loser its
+# compositor mid-run, and what it reports is `The Wayland connection broke. Did
+# the Wayland compositor die?`, which is indistinguishable from a real
+# regression: five times in one day, three full re-runs, and one agent
+# "fixing" code that was never broken. Waiting used to be the caller's job -
+# `ps` for a running suite before starting one - and a rule every caller has to
+# remember is a rule that gets forgotten, including by the maintainer twice.
+#
+# So the waiting is the script's job now. `acquire_suite_lock` blocks until it
+# can have the machine to itself, says whose run it is waiting for, and never
+# fails: an agent handed a hard error retries in a loop, which is worse than
+# the collision.
+#
+# WHERE the lock is taken, and why it is not the whole run:
+#
+#   - Everything above the acquire is pure. Source-text lints, contract checks
+#     that parse QML and Python, unit tests: none of them start a process that
+#     competes for anything, so two suites are free to overlap there.
+#   - The harnesses are interleaved with more static checks all the way to the
+#     end of the file rather than grouped, so the honest contiguous critical
+#     section is "the first harness to the end of the run".
+#   - A lock taken and released around each harness would overlap more, and it
+#     is forty acquire/release pairs plus a rule every future harness has to
+#     remember. The failure mode is one unwrapped harness and a collision that
+#     looks exactly like the one this exists to remove. One acquire point
+#     cannot be forgotten, and `lint_suite_lock_scope.py` fails the suite if a
+#     harness is ever wired in above it.
+#   - The tail past the last harness is held too: a handful of contract checks,
+#     the DesignSystemCompile probe (which starts a real `qs` on the session's
+#     OWN display) and qmltestrunner. Releasing early would reclaim under a
+#     minute and add a second boundary that a harness appended below it would
+#     silently escape.
+#
+# WHICH lock: one fixed name per user, never a hash of the checkout. What is
+# being serialized is this machine's ability to run a nested compositor, not a
+# repository - so every worktree and every clone has to contend for the same
+# one, which is exactly what "keyed to the repo, not the worktree" needs. On CI
+# it is uncontended by construction (one job, a fresh runner, nothing else
+# holding it), so `flock -n` succeeds on its first try and the whole mechanism
+# costs an open() and one ioctl. It can never turn a CI failure into a hang.
+#
+# HOW it is released: the lock lives on a file descriptor this shell holds
+# open, so the kernel drops it when the process ends for any reason - a failing
+# check's `exit 1`, a Ctrl-C, a SIGKILL. There is no lockfile to clean up and
+# no stale marker that can wedge the next run.
+#
+# The one residual is a DESCENDANT that inherits the descriptor and outlives
+# the suite - bash sets no close-on-exec on a `{fd}<>` redirection, so every
+# child has a copy. Measured while building this: a backgrounded holder
+# SIGKILLed while its child was still alive left the lock held with no suite
+# running. So the wait has a second strike - two consecutive minutes with the
+# record naming a pid that is gone and not moving - after which it says so and
+# runs unserialized rather than waiting on nothing for ever.
+if [[ "${XDG_RUNTIME_DIR:-}" ]]; then
+    SUITE_LOCK_FILE="$XDG_RUNTIME_DIR/immaterial-impulse-test-suite.lock"
+else
+    # /tmp is shared between users; another account's file would be
+    # unopenable, which would read as "no lock available" rather than as a
+    # permission problem.
+    SUITE_LOCK_FILE="/tmp/immaterial-impulse-test-suite.$(id -u).lock"
+fi
+
+# Named in the record so a waiting run can say which checkout is ahead of it.
+SUITE_LOCK_WORKTREE="$(git -C "$PROJECT_ROOT" rev-parse --show-toplevel 2>/dev/null)"
+[[ -n "$SUITE_LOCK_WORKTREE" ]] || SUITE_LOCK_WORKTREE="$PROJECT_ROOT"
+
+if ! command -v flock >/dev/null 2>&1; then
+    echo "Warning: flock not found (it ships in util-linux)." >&2
+    echo "  Running without suite serialization: a suite started in another" >&2
+    echo "  worktree while this one is in its runtime harnesses can break both" >&2
+    echo "  with 'The Wayland connection broke'. Check by hand instead." >&2
+fi
+
+# The holder's own record, read by a waiter. It is written into the lock file
+# itself rather than a sidecar, which is why the descriptor below is opened
+# read-write (`<>`) and not `>`: a waiter opening with `>` would truncate the
+# record it is about to read.
+suite_lock_record() {
+    local record
+    record="$(head -n 1 "$SUITE_LOCK_FILE" 2>/dev/null)"
+    if [[ -z "$record" ]]; then
+        record="an unidentified run (it left no record)"
+    fi
+    printf '%s' "$record"
+}
+
+acquire_suite_lock() {
+    if ! command -v flock >/dev/null 2>&1; then
+        return 0
+    fi
+    # Re-entry: a run_tests.sh invoked from inside another one is a descendant
+    # of the holder, so blocking here would be blocking on ourselves. The outer
+    # run already owns the machine on this one's behalf.
+    if [[ -n "${IMI_SUITE_LOCK_HELD:-}" ]]; then
+        echo "[suite-lock] already held by this run's parent (pid ${IMI_SUITE_LOCK_HELD}); not re-taking it"
+        return 0
+    fi
+
+    if ! exec {SUITE_LOCK_FD}<>"$SUITE_LOCK_FILE"; then
+        echo "Warning: cannot open $SUITE_LOCK_FILE; running without suite serialization." >&2
+        return 0
+    fi
+
+    local start=$SECONDS
+    if ! flock -n "$SUITE_LOCK_FD"; then
+        echo "[suite-lock] another suite is running in $(suite_lock_record)"
+        echo "[suite-lock] waiting for it to finish - the runtime harnesses below each start a nested weston and cannot share this machine."
+        # -w rather than a bare blocking wait so the wait is not silent: a run
+        # queued behind a wedged one should say so every minute instead of
+        # looking hung itself. It still never gives up on a live holder,
+        # because a hard failure here is a retry loop in whatever started it.
+        local record="" previous="" abandoned=0
+        until flock -w 60 "$SUITE_LOCK_FD"; do
+            local note pid
+            previous="$record"
+            record="$(suite_lock_record)"
+            note=""
+            pid="$(printf '%s' "$record" | sed -n 's/.*pid \([0-9][0-9]*\).*/\1/p')"
+            # A descendant that inherits this descriptor keeps the lock after
+            # the run that took it has gone - measured: a backgrounded holder
+            # SIGKILLed while its `sleep` child was still alive left the lock
+            # held with nothing running the suite. That is the one way this can
+            # wedge, so it is the one case that gives up on the lock rather
+            # than on the run. Two strikes a minute apart, and only while the
+            # record has not moved: a real handoff writes a new record within
+            # milliseconds of taking the lock, so an unchanged record naming a
+            # dead pid sixty seconds later is a leak and not a race with
+            # somebody else's acquire.
+            if [[ -n "$pid" ]] && ! kill -0 "$pid" 2>/dev/null; then
+                if [[ "$record" == "$previous" ]]; then
+                    abandoned=1
+                    break
+                fi
+                note=" - that pid has exited; if the lock is still held a minute from now, something it spawned is holding this descriptor open"
+            fi
+            echo "[suite-lock] still waiting after $((SECONDS - start))s for $record$note"
+        done
+        if (( abandoned )); then
+            echo "[suite-lock] giving up on the lock after $((SECONDS - start))s: it is held by something that outlived $record." >&2
+            echo "[suite-lock] no suite is running under that pid, so this run continues unserialized. Check for a stray weston or qs if the harnesses below misbehave." >&2
+            # Deliberately no record and no IMI_SUITE_LOCK_HELD: this run does
+            # not hold the lock, and saying it does would tell the next waiter
+            # to wait for a run that is not the one blocking it.
+            return 0
+        fi
+        echo "[suite-lock] acquired after $((SECONDS - start))s"
+    fi
+
+    printf '%s (pid %s, started %s)\n' \
+        "$SUITE_LOCK_WORKTREE" "$$" "$(date -Is)" > "$SUITE_LOCK_FILE"
+    export IMI_SUITE_LOCK_HELD=$$
+}
+
 # Find Qt6 qmltestrunner
 QMLTESTRUNNER=""
 POSSIBLE_PATHS=(
@@ -525,6 +686,11 @@ if ! python3 "$SCRIPT_DIR/test_polkit_dialog_contract.py"; then
     echo "Polkit dialog contract tests failed."
     exit 1
 fi
+
+# Everything from here down may start a nested compositor, so this is where the
+# run stops sharing the machine. See "Serializing concurrent suite runs" at the
+# top of this file for why the boundary is here and not around each harness.
+acquire_suite_lock
 
 # ...and the half the source cannot state: where the action row lands in the
 # card, whether the two buttons answer a real pointer, and whether the field

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -57,6 +57,17 @@ export QT_QPA_PLATFORM="${QT_QPA_PLATFORM:-offscreen}"
 #     minute and add a second boundary that a harness appended below it would
 #     silently escape.
 #
+# Measured on this machine (2026-08-28, one full green run, every block timed
+# from the run's own output), because "how much could narrowing possibly buy"
+# is the load-bearing number and it is not what it looks like: of 16m40s of
+# work, the compositor harnesses are 15m19s, the free head above the acquire is
+# 23s, and everything else inside the lock is 1m21s. The run is harness-bound,
+# so even a per-harness lock could overlap only about a hundred seconds of a
+# seventeen-minute run. That is what settles the trade above, rather than the
+# argument about forty call sites on its own - and it is why the boundary is
+# not worth moving on the assumption that most of a run is static. On this tree
+# it is not.
+#
 # WHICH lock: one fixed name per user, never a hash of the checkout. What is
 # being serialized is this machine's ability to run a nested compositor, not a
 # repository - so every worktree and every clone has to contend for the same

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -335,6 +335,17 @@ if ! python3 "$SCRIPT_DIR/lint_display_isolation.py"; then
     exit 1
 fi
 
+# ...and its sibling: a harness with a compositor of its own must also run
+# INSIDE the suite lock taken below, or two worktrees' suites still bring two
+# westons up at once and the loser reports a broken Wayland connection that
+# looks like a regression. One acquire point is what makes that rule simple;
+# this is what keeps a harness from being wired in above it.
+echo "Running suite lock scope lint..."
+if ! python3 "$SCRIPT_DIR/lint_suite_lock_scope.py"; then
+    echo "Suite lock scope lint failed."
+    exit 1
+fi
+
 echo "Running key monitor tests..."
 if ! python3 "$SCRIPT_DIR/test_key_monitor.py"; then
     echo "Key monitor tests failed."

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -39,9 +39,9 @@ export QT_QPA_PLATFORM="${QT_QPA_PLATFORM:-offscreen}"
 #
 # WHERE the lock is taken, and why it is not the whole run:
 #
-#   - Everything above the acquire is pure. Source-text lints, contract checks
-#     that parse QML and Python, unit tests: none of them start a process that
-#     competes for anything, so two suites are free to overlap there.
+#   - Everything above the acquire is pure. Source-text lints and contract
+#     checks that parse QML, Python and shell: none of them start a process
+#     that competes for anything, so two suites are free to overlap there.
 #   - The harnesses are interleaved with more static checks all the way to the
 #     end of the file rather than grouped, so the honest contiguous critical
 #     section is "the first harness to the end of the run".
@@ -75,8 +75,8 @@ export QT_QPA_PLATFORM="${QT_QPA_PLATFORM:-offscreen}"
 # child has a copy. Measured while building this: a backgrounded holder
 # SIGKILLed while its child was still alive left the lock held with no suite
 # running. So the wait has a second strike - two consecutive minutes with the
-# record naming a pid that is gone and not moving - after which it says so and
-# runs unserialized rather than waiting on nothing for ever.
+# record unchanged and naming no live process - after which it says so and runs
+# unserialized rather than waiting on nothing for ever.
 if [[ "${XDG_RUNTIME_DIR:-}" ]]; then
     SUITE_LOCK_FILE="$XDG_RUNTIME_DIR/immaterial-impulse-test-suite.lock"
 else
@@ -151,19 +151,23 @@ acquire_suite_lock() {
             # record has not moved: a real handoff writes a new record within
             # milliseconds of taking the lock, so an unchanged record naming a
             # dead pid sixty seconds later is a leak and not a race with
-            # somebody else's acquire.
-            if [[ -n "$pid" ]] && ! kill -0 "$pid" 2>/dev/null; then
+            # somebody else's acquire. A record with no pid in it at all
+            # counts the same way and for the same reason: the only moment
+            # the file is empty is between one `flock` returning and the
+            # `printf` a few microseconds later, so an empty one that is
+            # still empty a minute on is not a suite either.
+            if [[ -z "$pid" ]] || ! kill -0 "$pid" 2>/dev/null; then
                 if [[ "$record" == "$previous" ]]; then
                     abandoned=1
                     break
                 fi
-                note=" - that pid has exited; if the lock is still held a minute from now, something it spawned is holding this descriptor open"
+                note=" - no live suite is running under that record; if the lock is still held a minute from now, something a finished run spawned is holding this descriptor open"
             fi
             echo "[suite-lock] still waiting after $((SECONDS - start))s for $record$note"
         done
         if (( abandoned )); then
-            echo "[suite-lock] giving up on the lock after $((SECONDS - start))s: it is held by something that outlived $record." >&2
-            echo "[suite-lock] no suite is running under that pid, so this run continues unserialized. Check for a stray weston or qs if the harnesses below misbehave." >&2
+            echo "[suite-lock] giving up on the lock after $((SECONDS - start))s: it is held by something that outlived the run recorded as $record." >&2
+            echo "[suite-lock] no live suite matches that record, so this run continues unserialized. Check for a stray weston or qs if the harnesses below misbehave." >&2
             # Deliberately no record and no IMI_SUITE_LOCK_HELD: this run does
             # not hold the lock, and saying it does would tell the next waiter
             # to wait for a run that is not the one blocking it.


### PR DESCRIPTION
Several agents work this repo in parallel git worktrees, and every worktree runs the same `tests/run_tests.sh`. Forty-two of its checks are runtime harnesses that each start a nested weston and a `dbus-run-session`; two suites overlapping there costs the loser its compositor mid-run, and what it prints is `The Wayland connection broke. Did the Wayland compositor die?` — indistinguishable from a real regression. Five times in one day, three full re-runs, and one agent "fixing" code that was never broken. Waiting was the caller's rule, and callers forget it, the maintainer twice.

The waiting is the script's job now. It takes an exclusive `flock` before its first runtime harness, names the checkout that is ahead of it, and waits; it never fails on a busy lock, because an agent handed a hard error retries in a loop.

## Where the boundary is, and the measurement behind it

The lock is taken at the first harness and held to the end of the run. Everything above it is pure and overlaps freely; the harnesses are interleaved with static checks all the way down, so that is the honest contiguous critical section.

How much a narrower one could buy was measured rather than assumed, and it inverts the intuition: of 16m40s of work, the compositor harnesses are 15m19s, the free head above the acquire is 23s, and everything else inside the lock is 1m21s. A per-harness lock — forty acquire/release pairs and a rule every new harness has to remember — could overlap about a hundred seconds of a seventeen-minute run. One acquire point cannot be forgotten, and `lint_suite_lock_scope.py` fails the suite if a compositor harness is ever wired in above it.

The path is one fixed name per user, never a hash of the checkout: what is serialized is this machine's nested compositor, not a repository, so every worktree and every clone contends for the same one. On CI it is uncontended by construction — one job, a fresh runner — so `flock -n` succeeds on its first try. It cannot turn a CI failure into a hang.

Release is the kernel's: the lock lives on a descriptor the shell holds open, so it goes when the process does — an `exit 1`, a Ctrl-C, a SIGKILL. The residual is a descendant that inherits the descriptor, which was measured rather than supposed, so the wait gives up after two consecutive minutes with the record unchanged and naming no live process.

## Driven, not asserted

Against the real script or a byte-identical extract of its acquire: an uncontended take (5 ms); a contended one that waited 640s behind a real concurrent run, printed the holder's worktree and pid, heartbeat every minute, then acquired and finished green; a SIGKILLed holder released instantly; a leaked descendant and a holder that wrote no record both gave up after 120s with a reason; re-entry proceeded without re-taking; and with `flock` hidden from PATH the real script warned and carried on. `lint_suite_lock_scope.py` is proved against in-memory fixtures and planted against the real tree.

Not covered, and said so in AGENT.md: the `run_*_probe.sh` scripts are hand-run, nest their own weston, and still collide.

One thing left open: the collision's *mechanism* is not established. `nested_display.py` already gives each harness its own `XDG_RUNTIME_DIR` and socket name, so it is not a socket clash — it is contention over something shared (seat, portal, CPU). The lock removes the overlap either way, but a future fix rather than a serialization would start there.

Docs: updated AGENT.md §"Running the suite while another agent is running one" and CONTRIBUTING.md §"New features and bugfixes need tests" / §"Multi-agent / parallel workflows (git worktrees)"
Changelog: not user-visible - a test-suite tooling change; nothing the shell draws or persists is touched
