### PR TITLE
fix(phone): the footer spells notifications out, and a card says why it cannot start

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -651,7 +651,13 @@ services/                  Singletons wrapping external state/processes - one pe
                               feature's own activation (lint_capability_probe_gating.py).
                               missingFor(feature) is the install guide's rows with the
                               sibling fork's per-distro commands verbatim; nothing here is
-                              an installer dependency (sdata/deps-info.md "Phone (optional)")
+                              an installer dependency (sdata/deps-info.md "Phone (optional)").
+                              `adbDevice` is the one LIVE fact in the file - whether
+                              `adb devices` lists a phone in the `device` state, started by
+                              the adb presence probe's own exit and re-asked through
+                              refreshAdbDevices(), so a card can say "no device over ADB"
+                              before it is clicked
+                              b591575c4 ("fix(phone): a card that cannot start over ADB says so before the click")
   PhoneScrcpy.qml              The screen mirror and app mode. QML holds no scrcpy handle:
                               scripts/phone/scrcpy_session_manager.py is ONE supervisor
                               speaking NDJSON on stdin/stdout that owns every scrcpy child
@@ -1618,6 +1624,19 @@ of the range, and on `visualizerPoints` coming back.
 ce41c4f9c ("feat(cava): give CavaService the producer it always implied"),
 bcf5f9ca1 ("refactor(cava): move every band consumer onto the one service"),
 004a17745 ("test(cava): pin the producer, the gate and the band contract").
+
+**A signal nothing connects to is that same hole from the other side, and only a surface can
+find it.** `PhoneScrcpy.feedback(message, ok)`, `PhoneCamera.errorOccurred(message)` and
+`PhoneMic.errorOccurred(message)` have been raised on every failure since those services landed,
+and the Phone tab's toast was connected to `PhoneConnect.actionFeedback` and to nothing else — so
+a scrcpy that could not attach, a webcam that never connected and a microphone whose routing
+failed all reported themselves into a channel with no other end. Nothing errors: a signal with no
+connections is a perfectly legal signal, and there is no log line, no warning and no failing test.
+What it looks like on screen is the feature ignoring the click, which is how it was reported.
+Note which direction the existing check runs: `tests/test_phone_tab_surface_contract.py` derives
+its allowlist from what the services declare, so it answers "does this call reach a service" —
+the half that needed a harness is "does this signal reach a surface".
+85df64825 ("fix(phone): the tab hears the three session services' failures").
 
 **Resampling a spectrum by picking one index per bar drops most of it.**
 `Math.floor(i * source.length / barCount)` reads like the obvious way to fit 50 bands into 20 dots
@@ -2814,6 +2833,29 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   and `tests/lint_icon_glyph_alignment.py` fails any `contentItem: MaterialSymbol` block without
   both. (fix(widgets): every contentItem glyph is centred by alignment, not by an anchor the
   Control ignores.)
+- **An icon-only button written as a labelled one sizes itself from the label it has not
+  got.** `RippleButtonWithIcon`'s contentItem is a glyph slot beside a `Layout.fillWidth: true`
+  slot for the label, so `mainText: ""` does not make it an icon button — it makes it a button
+  whose empty label absorbs whatever width its ROW has left, from inside. The Phone tab's footer
+  is where that bites, because its two actions flank a `Layout.fillWidth` count pill: measured
+  at the sidebar's 460px they came out 44x35, near enough square to read as a circle under
+  `rounding.full`, with the drawn glyph **1.5px left of the button's own centre** — so widening
+  them would have moved the glyph further off rather than centring it. An icon-only button is a
+  `RippleButton` whose `contentItem` is a `MaterialSymbol` declaring both alignments (the entry
+  above), with both dimensions stated, since nothing about its content can decide them. None of
+  this is visible from the source and none of it is reachable from `qmltestrunner`, which builds
+  neither a laid-out box nor a `RippleButton`; `PhoneTabRuntimeTest.qml` measures the drawn
+  glyph's centre through `mapToItem`. It was the only `mainText: ""` call site in the tree, so
+  this is a note rather than a check.
+  bd35286c3 ("fix(phone): the footer's two actions become soft rectangles, glyphs centred").
+- **A `Text` positioned with `anchors.centerIn` has no box, so `elide` cannot fire and the
+  label paints over its neighbours instead.** Eliding needs a width, and `centerIn` gives a Text
+  its implicit one — which is however wide the string happens to be, drawn straight out past its
+  parent's edges. The Phone tab's count pill was written that way: it is the only
+  `Layout.fillWidth` item in its row, so it could never push the two buttons off, and a longer
+  string (a translation, a count in the hundreds) would simply have been drawn on top of them.
+  `anchors.fill` plus `horizontalAlignment` is the spelling that both centres and bounds.
+  8f8f14c8c ("fix(phone): the footer's count pill spells \"notifications\" out").
 - **The two bars load the same widget files out of `modules/imi/bar/`, and each used to decide
   which file for itself.** `Config.options.bar.layouts.*` is shared and Settings > Bar offers a
   plugin's bar widget whatever the orientation, but only `BarContent.qml` ever learned the
@@ -4487,6 +4529,42 @@ singletons (`PhoneConnect.activeDevice`, `PhoneScrcpy.targetArgs`) - the doubles
 them too. The one-shot serialized queue (`run`/`pump`/one `Process` with `exec`) is
 `PhoneConnect`'s busctl queue, reused rather than one Process per command.
 ("test(phone): pin the four session services' process I/O to their doubles").
+
+**A feature card reported its TOOLING and nothing else, so "the phone is reachable" was
+answering the wrong question.** The Phone tab's three cards gate on
+`PhoneConnect.activeDevice.reachable` — KDE Connect's link — while the mirror, and the
+microphone's preferred backend, drive the phone over **ADB**, which is a different link
+entirely. On a phone paired over LAN with USB debugging never set up, `adb devices` lists
+nothing and both cards read `ready`: "Opens a floating window for the active phone", "Tap to
+start". `PhoneDeps.adbDevice` answers that now, beside the `command -v` sweep. Three rules from
+wiring it up:
+
+- **it is drawn as `offline`, never as a sixth rung.** The card is not running and cannot be
+  started, which is what offline already means, and the SUBTITLE is what says which of the two
+  links is missing — a rung is a thing the card draws differently, and there is nothing
+  different to draw.
+- **the flag is TRI-STATE.** `undefined` means the probe has not answered yet and must not read
+  as a refusal: every `PhoneDeps` flag starts `false`, so a plain falsy test puts both cards on
+  "no device" for the first frames of every session, and refuses for ever at any call site that
+  forgets to pass it — `undefined` is a value (see the `Appearance` and `Config` entries under
+  [Dynamic/data-driven QML gotchas](#dynamicdata-driven-qml-gotchas)).
+- **the webcam does not ask for it, and that asymmetry is the point.** `droidcam-cli` reaches
+  the phone over Wi-Fi when adb has nothing, so `needsAdbDevice` is a term the caller supplies
+  rather than an assumption; claiming a refusal a service can still work around is the "do not
+  fake a state a service cannot report" rule in reverse.
+
+**And the other half of the same complaint: a failed launch's reason was written where nothing
+drew it.** `PhoneCamera` and `PhoneMic` end a failure by setting `lastError` and dropping back to
+`ready`, and `PhoneFeatureCard` draws `lastError` only inside its `active` rung — so nine seconds
+after a click the card was back on "Tap to start · settings to configure" with the reason sitting
+in a property no binding read. The mirror's own ladder already had that arm (`mirrorSubtitleKey`
+returns `"error"`); the two siblings did not, and the card's own header comment claimed they did.
+Every one of these decisions is a pure function in
+`modules/imi/sidebarLeft/phone/phone_cards.js` precisely so `tests/tst_phone_cards.qml` can drive
+it; what needed the runtime harness is whether the click reaches the service at all, and whether
+the card or its settings chip is what a click at the card's centre lands on.
+b591575c4 ("fix(phone): a card that cannot start over ADB says so before the click"),
+cf945864c ("fix(phone): a failed webcam or microphone launch reaches its card's subtitle").
 
 **And the surfaces that DRIVE those services get their allowlist derived rather than written
 down.** "A button whose call no service answers is a fake action" is stated for the right

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,14 @@ own repo; the installer pins which revision it builds.
   among them — stack as cards at the bottom. It landed as a dialog in the
   right sidebar and ships as the Phone tab in the left one, which is where
   the rest of this release's phone work is reached.
+- **The Phone tab's footer toolbar.** The count under your phone's
+  notifications reads "7 notifications" rather than "7 notif.", and "1
+  notification" for one; it says "Device offline" instead of counting when the
+  device on the chip is not there; and a longer count elides inside its pill
+  rather than being drawn over the buttons beside it. Those two buttons — sync
+  and clear — are a little wider than they are tall now, so the row reads as
+  three soft rectangles rather than two circles around a pill, and their icons
+  sit dead centre instead of a pixel and a half to the left.
 
 ### Fixed
 - **The Phone tab's Contacts and Android Apps pages draw their contents
@@ -141,6 +149,17 @@ own repo; the installer pins which revision it builds.
   panel, rewrote the whole of `config.json` and read it straight back, once
   per value instead of once per burst. Settings still writes immediately while
   its window is open, and only while its window is open.
+- **The Phone tab's Mirror, Webcam and Microphone cards say what is wrong
+  instead of nothing.** Three separate silences, all of which read as the card
+  ignoring the click. A card whose feature drives the phone over ADB — the
+  scrcpy mirror, and the microphone wherever scrcpy is installed — now says "No
+  device over ADB" *before* you click it, if `adb devices` lists nothing,
+  instead of offering to open a window it cannot open; plugging the phone in
+  while the tab is open clears it. A launch that fails puts its reason on the
+  card, where before the webcam and the microphone dropped straight back to
+  "Tap to start" with the reason recorded nowhere you could see. And the three
+  services' own error reports now reach the tab's toast, which had only ever
+  been connected to the phone link's.
 - **Both sidebars open on the monitor you are using again.** On a multi-monitor
   setup the left and right sidebars had started opening on whichever screen was
   focused when the shell started, wherever you actually were — the same thing

--- a/dots/.config/quickshell/imi/PhoneTabRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/PhoneTabRuntimeTest.qml
@@ -27,6 +27,16 @@ import qs.modules.imi.sidebarLeft.phone
  * pairState says the peer asked (2) and which has no battery or report
  * leaf at all - so every branch of the surface is on screen at once.
  *
+ * The driver also puts a fake `adb`, `scrcpy`, `droidcam-cli`, `pactl`,
+ * `v4l2-ctl`, `lsmod`, `modinfo` and `mpv` on PATH, so PhoneDeps answers the
+ * same way on every machine and the three feature cards are in a state other
+ * than `unavailable`. The fake `adb` lists NO device, which is the machine
+ * this branch was written against: KDE Connect reaches the phone over LAN and
+ * adb has never seen it. What is read back here is the click PATH and the
+ * card GEOMETRY, neither of which is reachable from qmltestrunner - the
+ * decisions themselves live in phone_cards.js and are driven by
+ * tests/tst_phone_cards.qml.
+ *
  *   PATH=<dir with fake busctl>:$PATH qs -p PhoneTabRuntimeTest.qml
  */
 ShellRoot {
@@ -87,6 +97,42 @@ ShellRoot {
     function contentColumn() {
         const list = harness.first("PhoneNotificationList");
         return list ? list.parent : null;
+    }
+
+    // Items are found by TYPE everywhere above; the toast is a bare
+    // Rectangle, so it is found by the two properties only it declares.
+    function withProperties(item, names, out) {
+        for (const child of item.children) {
+            if (names.every(name => child[name] !== undefined))
+                out.push(child);
+            harness.withProperties(child, names, out);
+        }
+        return out;
+    }
+
+    function toastCard() {
+        return harness.withProperties(loader.item, ["message", "ok"], [])[0] ?? null;
+    }
+
+    // A glyph a Control positions itself: its centre must land on the
+    // button's, which an anchor cannot do and both alignments can.
+    function glyphOffCentre(button) {
+        const glyph = harness.findAll(button, "MaterialSymbol", [])[0] ?? null;
+        if (!glyph) return Number.NaN;
+        const centre = glyph.mapToItem(button, glyph.width / 2, glyph.height / 2);
+        return Math.abs(centre.x - button.width / 2);
+    }
+
+    function cardTitled(fragment) {
+        return harness.all("PhoneFeatureCard").find(c => `${c.title}`.indexOf(fragment) >= 0) ?? null;
+    }
+
+    // The footer's row, read structurally rather than by type: its three
+    // children ARE the two actions and the pill between them, in that order,
+    // and which of them is which is the whole thing being measured.
+    function footerRow() {
+        const footer = harness.first("PhoneFooterBar");
+        return footer ? (footer.children[0] ?? null) : null;
     }
 
     FloatingWindow {
@@ -284,8 +330,176 @@ ShellRoot {
                           grewBy === harness.cardHeight + harness.columnSpacing);
         },
 
+        // ---- the footer toolbar: the pill's word, and the two actions ----
+        () => {
+            // The roster step above left the unpaired laptop showing, which is
+            // the pill's other branch: a count of zero must not stand in for
+            // "the phone is not here".
+            const label = harness.findAll(harness.first("PhoneFooterBar"), "StyledText", [])[0] ?? null;
+            harness.check(`an offline device says so instead of counting, got "${label?.text}"`,
+                          label !== null && label.text === "Device offline");
+            loader.item.pickedDeviceId = harness.phoneId;
+        },
+        () => {
+            const row = harness.footerRow();
+            const slots = row ? row.children : [];
+            harness.footerButtons = slots.length === 3 ? [slots[0], slots[2]] : [];
+            harness.footerPill = slots.length === 3 ? slots[1] : null;
+            harness.footerLabel = harness.footerPill
+                ? (harness.findAll(harness.footerPill, "StyledText", [])[0] ?? null) : null;
+            const buttons = harness.footerButtons;
+            const pill = harness.footerLabel;
+            console.log(`[PhoneTab] footer w=${row?.width}`
+                + ` buttons=${buttons.map(b => `${b.width}x${b.height}@${b.x}`)}`
+                + ` label="${pill?.text}" w=${pill?.width} in pill ${harness.footerPill?.width}`);
+
+            harness.check(`the footer draws two actions around one pill, got ${slots.length} slots`,
+                          buttons.length === 2 && pill !== null);
+            // The abbreviation is what the maintainer asked to be spelled out.
+            harness.check(`the count pill spells the word out, got "${pill?.text}"`,
+                          pill !== null && pill.text.indexOf("notification") >= 0
+                          && pill.text.indexOf("notif.") < 0);
+            harness.check("...and it is the plural, since the fake daemon mirrors none",
+                          pill !== null && pill.text === "0 notifications");
+        },
+        () => {
+            const buttons = harness.footerButtons;
+            const wider = buttons.every(b => b.width > b.height);
+            harness.check(`each action is wider than it is tall, got ${buttons.map(b => `${b.width}x${b.height}`)}`,
+                          buttons.length === 2 && wider);
+            harness.check("both actions take the same stated width",
+                          buttons.length === 2 && buttons[0].width === buttons[1].width
+                          && buttons[0].width === Appearance.sizes.phoneFooterButtonWidth
+                          && buttons[0].height === Appearance.sizes.phoneFooterButtonHeight);
+            const offsets = buttons.map(b => harness.glyphOffCentre(b));
+            console.log(`[PhoneTab] glyph off centre by ${offsets}`);
+            // A RippleButtonWithIcon's glyph sat 2.5px left of centre here,
+            // because the empty label's Layout.fillWidth slot took the rest.
+            harness.check(`each glyph is centred in its action, off by ${offsets}`,
+                          offsets.every(offset => offset < 1));
+        },
+        () => {
+            // The pill is the row's only fillWidth item, so the label must
+            // elide inside it rather than paint over the two actions.
+            const label = harness.footerLabel;
+            const pill = harness.footerPill;
+            const buttons = harness.footerButtons;
+            const left = label.mapToItem(pill.parent, 0, 0).x;
+            const right = left + label.width;
+            harness.check("the label elides rather than overflowing its pill",
+                          label.elide === Text.ElideRight
+                          && label.width <= pill.width);
+            harness.check(`the label stays clear of both actions (${left}..${right})`,
+                          left >= buttons[0].x + buttons[0].width
+                          && right <= buttons[1].x);
+            harness.check("neither action was squeezed to make room for it",
+                          buttons.every(b => b.width === Appearance.sizes.phoneFooterButtonWidth));
+        },
+
+        // ---- the feature cards: what a click reaches ---------------------
+        () => {
+            const cards = harness.all("PhoneFeatureCard");
+            console.log(`[PhoneTab] cards=${cards.map(c => `"${c.title}" ${c.cardState} @${c.y} ${c.width}x${c.height}`)}`);
+            harness.check(`the three feature cards are drawn, got ${cards.length}`, cards.length === 3);
+            harness.check("PhoneDeps answered every probe before the cards were read",
+                          PhoneDeps.ready);
+            harness.check(`the fake adb lists no device, got adbDevice=${PhoneDeps.adbDevice}`,
+                          PhoneDeps.adb && !PhoneDeps.adbDevice);
+        },
+        () => {
+            // The state a card can know BEFORE the click: the phone is
+            // reachable over KDE Connect and adb cannot see it, so scrcpy has
+            // nothing to attach to and the card says which link is missing.
+            const mirror = harness.cardTitled("scrcpy Mirror");
+            const mic = harness.cardTitled("Microphone");
+            console.log(`[PhoneTab] mirror=${mirror?.cardState} "${mirror?.subtitle}"`
+                + ` mic=${mic?.cardState} "${mic?.subtitle}"`);
+            harness.check("a mirror with no ADB device is offline before it is clicked",
+                          mirror !== null && mirror.cardState === "offline"
+                          && mirror.subtitle.indexOf("No device over ADB") === 0);
+            // The microphone's preferred backend is scrcpy, which drives the
+            // phone over ADB; the webcam's droidcam-cli does not, so it is
+            // deliberately still ready.
+            harness.check("so is a microphone whose backend drives the phone over ADB",
+                          mic !== null && mic.cardState === "offline"
+                          && mic.subtitle.indexOf("No device over ADB") === 0);
+            const webcam = harness.cardTitled("Webcam");
+            harness.check("the webcam, which reaches the phone over Wi-Fi, is not refused",
+                          webcam !== null && webcam.cardState === "ready");
+        },
+        () => {
+            // Does the primary click fire at all, or is it swallowed by the
+            // settings chip or by the status mark beside it? Clicked at the
+            // card's own centre, and scored on the service.
+            const mirror = harness.cardTitled("scrcpy Mirror");
+            harness.check("the mirror is not already launching", !PhoneScrcpy.mirrorLaunching);
+            harness.click(mirror);
+        },
+        () => {
+            harness.check("a click on the card's body reaches launchMirror()",
+                          PhoneScrcpy.mirrorLaunching || PhoneScrcpy.mirrorRunning
+                          || PhoneScrcpy.lastError.length > 0);
+            // Disarmed through the model rather than by stopping the mirror:
+            // this harness has no phone and the supervisor's own exit is not
+            // what is being scored here.
+            PhoneScrcpy.mirrorLaunching = false;
+        },
+        () => {
+            // The settings chip is a SECOND affordance on the same card, and
+            // it must not be what the card's own click reaches.
+            const webcam = harness.cardTitled("Webcam");
+            const chip = harness.findAll(webcam, "RippleButton", [])[0] ?? null;
+            harness.check("the webcam card carries its settings chip", chip !== null);
+            harness.check("the sub-page is closed before the chip is clicked",
+                          loader.item.subPage === "");
+            if (chip) harness.click(chip);
+        },
+        () => {
+            harness.check(`the chip opens the webcam page, got "${loader.item.subPage}"`,
+                          loader.item.subPage === "webcam");
+            loader.item.popSubPage();
+        },
+
+        // ---- a launch that fails says so, on the card and in the toast ----
+        () => {
+            // PhoneCamera leaves lastError set and goes back to `ready`, and
+            // the card draws lastError only while it is ACTIVE - so this is
+            // the path on which a failed webcam looked exactly like a card
+            // that had ignored the click.
+            PhoneCamera.lastError = "DroidCam did not start - is the app open on the phone?";
+            PhoneCamera.errorOccurred(PhoneCamera.lastError);
+        },
+        () => {
+            const webcam = harness.cardTitled("Webcam");
+            console.log(`[PhoneTab] webcam=${webcam?.cardState} "${webcam?.subtitle}"`);
+            harness.check(`a failed launch reaches the card's subtitle, got "${webcam?.subtitle}"`,
+                          webcam !== null
+                          && webcam.subtitle === "DroidCam did not start - is the app open on the phone?");
+            const toast = harness.toastCard();
+            harness.check(`the tab hears the service's own error signal, got "${toast?.message}"`,
+                          toast !== null && toast.message === PhoneCamera.lastError && !toast.ok);
+            PhoneCamera.lastError = "";
+        },
+        () => {
+            const webcam = harness.cardTitled("Webcam");
+            harness.check("clearing the error puts the card back on its ready line",
+                          webcam.cardState === "ready"
+                          && webcam.subtitle.indexOf("Tap to start") === 0);
+            // The mirror's own feedback signal had no listener either.
+            PhoneScrcpy.feedback("scrcpy: no device found", false);
+        },
+        () => {
+            const toast = harness.toastCard();
+            harness.check(`the tab hears PhoneScrcpy.feedback, got "${toast?.message}"`,
+                          toast !== null && toast.message === "scrcpy: no device found" && !toast.ok);
+        },
+
         () => harness.finish()
     ]
+
+    property var footerButtons: []
+    property var footerPill: null
+    property var footerLabel: null
 
     property real listWithCard: 0
     property real cardHeight: 0

--- a/dots/.config/quickshell/imi/PhoneTabRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/PhoneTabRuntimeTest.qml
@@ -373,8 +373,9 @@ ShellRoot {
                           && buttons[0].height === Appearance.sizes.phoneFooterButtonHeight);
             const offsets = buttons.map(b => harness.glyphOffCentre(b));
             console.log(`[PhoneTab] glyph off centre by ${offsets}`);
-            // A RippleButtonWithIcon's glyph sat 2.5px left of centre here,
-            // because the empty label's Layout.fillWidth slot took the rest.
+            // A RippleButtonWithIcon's glyph was drawn 1.5px left of centre
+            // here, because the empty label's Layout.fillWidth slot took the
+            // rest of the row's width from inside the button.
             harness.check(`each glyph is centred in its action, off by ${offsets}`,
                           offsets.every(offset => offset < 1));
         },

--- a/dots/.config/quickshell/imi/modules/common/Appearance.qml
+++ b/dots/.config/quickshell/imi/modules/common/Appearance.qml
@@ -865,6 +865,15 @@ Singleton {
         property real searchWidth: 360
         property real sidebarWidth: 460
         property real sidebarWidthExtended: 750
+        // The Phone tab's footer toolbar. Its two actions flank the count
+        // pill, which is the row's only `Layout.fillWidth` item - so nothing
+        // about an icon-only button's own content can decide how wide it is,
+        // and left to size itself from a glyph plus an empty label each came
+        // out 44x35, near enough square to read as a circle under
+        // `rounding.full`. Both dimensions are stated here so the two buttons
+        // and the pill between them cannot disagree about the row's height.
+        property real phoneFooterButtonHeight: 35
+        property real phoneFooterButtonWidth: 48
         // Edit Mode's viewport is inset by exactly what the drawer will need,
         // so the drawer opens into space that already exists rather than
         // covering the desktop or resizing it (spec §1.2). This is the one

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/Phone.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/Phone.qml
@@ -347,12 +347,47 @@ Item {
         }
     }
 
+    // Every service that can fail a gesture the user made on this tab reports
+    // it here. PhoneConnect was the only one connected, so a scrcpy that could
+    // not attach, a webcam that never connected and a microphone whose routing
+    // failed all raised a signal nothing listened to - three services carrying
+    // a "tell the user" channel with no listener, which is what a card that
+    // "does nothing when clicked" looked like from outside. The cards' own
+    // subtitles say the same thing once the state settles; the toast is what
+    // says it at the moment of the click.
+    function showToast(message: string, ok: bool): void {
+        if (!message)
+            return;
+        toast.message = message;
+        toast.ok = ok;
+        toastTimer.restart();
+    }
+
     Connections {
         target: PhoneConnect
         function onActionFeedback(message: string, ok: bool): void {
-            toast.message = message;
-            toast.ok = ok;
-            toastTimer.restart();
+            root.showToast(message, ok);
+        }
+    }
+
+    Connections {
+        target: PhoneScrcpy
+        function onFeedback(message: string, ok: bool): void {
+            root.showToast(message, ok);
+        }
+    }
+
+    Connections {
+        target: PhoneCamera
+        function onErrorOccurred(message: string): void {
+            root.showToast(message, false);
+        }
+    }
+
+    Connections {
+        target: PhoneMic
+        function onErrorOccurred(message: string): void {
+            root.showToast(message, false);
         }
     }
 

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneFeatureCards.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneFeatureCards.qml
@@ -196,7 +196,8 @@ Item {
                 reachable: root.deviceReachable,
                 connecting: PhoneCamera.connecting,
                 active: PhoneCamera.active,
-                device: PhoneCamera.device
+                device: PhoneCamera.device,
+                error: PhoneCamera.lastError
             })
 
             iconName: "videocam"
@@ -218,6 +219,8 @@ Item {
                     return PhoneCamera.device;
                 case "running":
                     return Translation.tr("Streaming from the phone's camera");
+                case "error":
+                    return PhoneCards.errorHeadline(PhoneCamera.lastError);
                 default:
                     return Translation.tr("Tap to start · settings to configure");
                 }
@@ -271,7 +274,8 @@ Item {
                 // over Wi-Fi, so only the preferred backend decides whether
                 // an empty `adb devices` is a refusal.
                 needsAdbDevice: PhoneMic.preferredBackend === "scrcpy",
-                adbDevice: root.adbDevice
+                adbDevice: root.adbDevice,
+                error: PhoneMic.lastError
             })
 
             iconName: "mic"
@@ -295,6 +299,8 @@ Item {
                     return Translation.tr("Active · click to mute");
                 case "noDevice":
                     return Translation.tr("No device over ADB · turn on USB or wireless debugging");
+                case "error":
+                    return PhoneCards.errorHeadline(PhoneMic.lastError);
                 default:
                     return Translation.tr("Tap to start · uses scrcpy or DroidCam");
                 }

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneFeatureCards.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneFeatureCards.qml
@@ -38,6 +38,10 @@ Item {
     readonly property bool showCards: Config.options.phone?.showPeripheralCards ?? true
     readonly property var activeDevice: PhoneConnect.activeDevice
     readonly property bool deviceReachable: PhoneConnect.activeDevice?.reachable === true
+    // `undefined` while the probes are still running, never `false`: every
+    // PhoneDeps flag starts false, and phone_cards.js reads `false` as a
+    // refusal to draw. One derivation, because two cards ask it.
+    readonly property var adbDevice: PhoneDeps.ready ? PhoneDeps.adbDevice : undefined
 
     // The elapsed clock for whichever cards are running. A Timer rather than
     // DateTime's own: that clock ticks per MINUTE unless the user asked for
@@ -54,6 +58,19 @@ Item {
     }
 
     onAnyActiveChanged: root.nowMs = Date.now()
+
+    // Whether adb can see the phone is live state, and a card that says "no
+    // device over ADB" has to stop saying it once the user plugs the phone in.
+    // The probe answers once at construction like every other one in
+    // PhoneDeps; this re-asks it, and only while this stack is on screen AND
+    // adb has still seen nothing - so it stops the moment it has an answer to
+    // give, and costs nothing at all on a tab nobody has opened.
+    Timer {
+        interval: 5000
+        repeat: true
+        running: root.visible && PhoneDeps.adb && !PhoneDeps.adbDevice
+        onTriggered: PhoneDeps.refreshAdbDevices()
+    }
 
     // PhoneScrcpy's session rows carry `startedAt` in milliseconds (Date.now()
     // at the moment the supervisor reported the window), where PhoneCamera and
@@ -96,6 +113,7 @@ Item {
                 reachable: root.deviceReachable,
                 running: PhoneScrcpy.mirrorRunning,
                 launching: PhoneScrcpy.mirrorLaunching,
+                adbDevice: root.adbDevice,
                 error: PhoneScrcpy.lastError
             })
 
@@ -120,6 +138,8 @@ Item {
                     return Translation.tr("Click to see missing dependencies and install guide");
                 case "offline":
                     return Translation.tr("Pair a reachable device to mirror its screen");
+                case "noDevice":
+                    return Translation.tr("No device over ADB · turn on USB or wireless debugging");
                 case "error":
                     return PhoneCards.errorHeadline(PhoneScrcpy.lastError);
                 case "running":
@@ -246,13 +266,18 @@ Item {
                 reachable: root.deviceReachable,
                 connecting: PhoneMic.connecting,
                 active: PhoneMic.active,
-                muted: PhoneMic.muted
+                muted: PhoneMic.muted,
+                // scrcpy drives the phone over ADB; droidcam-cli reaches it
+                // over Wi-Fi, so only the preferred backend decides whether
+                // an empty `adb devices` is a refusal.
+                needsAdbDevice: PhoneMic.preferredBackend === "scrcpy",
+                adbDevice: root.adbDevice
             })
 
             iconName: "mic"
             iconShape: MaterialShape.Shape.Sunny
             hasSettings: true
-            cardState: PhoneMic.state
+            cardState: PhoneCards.micState(micCard.flags)
             title: PhoneCards.micTitleKey(PhoneMic.available) === "install"
                 ? Translation.tr("Install scrcpy or DroidCam")
                 : Translation.tr("Phone Microphone")
@@ -268,6 +293,8 @@ Item {
                     return Translation.tr("Muted · click to unmute");
                 case "active":
                     return Translation.tr("Active · click to mute");
+                case "noDevice":
+                    return Translation.tr("No device over ADB · turn on USB or wireless debugging");
                 default:
                     return Translation.tr("Tap to start · uses scrcpy or DroidCam");
                 }

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneFooterBar.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneFooterBar.qml
@@ -10,8 +10,17 @@ import QtQuick.Layouts
  *
  * The count pill is deliberately not a button - there is nothing to do to a
  * number - and it says why the count is zero when the reason is the link
- * rather than the phone, so "0 notif." never stands in for "the phone is
- * not here".
+ * rather than the phone, so "0 notifications" never stands in for "the phone
+ * is not here". The word is spelled out rather than abbreviated, in the
+ * spelling `sidebarRight/notifications/NotificationList.qml` already uses for
+ * the same count, so the two surfaces share one translation key - and the
+ * singular is its own key, because `Translation.tr` takes one string and has
+ * no plural form to select.
+ *
+ * The pill is the row's only `Layout.fillWidth` item, so it can never push
+ * the two actions off the row - but its label was centred in it with nothing
+ * bounding it, and a centred label paints straight over its neighbours rather
+ * than eliding. The label is anchored to the pill's own box now.
  */
 Item {
     id: root
@@ -54,12 +63,22 @@ Item {
             color: Appearance.colors.colLayer2
 
             StyledText {
-                anchors.centerIn: parent
+                anchors.fill: parent
+                anchors.leftMargin: Appearance.spacing.space125
+                anchors.rightMargin: Appearance.spacing.space125
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
+                elide: Text.ElideRight
+                maximumLineCount: 1
                 font.pixelSize: Appearance.font.pixelSize.small
                 color: Appearance.colors.colOnLayer2
-                text: root.online
-                    ? Translation.tr("%1 notif.").arg(String(root.count))
-                    : Translation.tr("Device offline")
+                text: {
+                    if (!root.online)
+                        return Translation.tr("Device offline");
+                    return root.count === 1
+                        ? Translation.tr("1 notification")
+                        : Translation.tr("%1 notifications").arg(String(root.count));
+                }
             }
         }
 

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneFooterBar.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneFooterBar.qml
@@ -27,8 +27,10 @@ import QtQuick.Layouts
  * their content. `RippleButtonWithIcon` measures a glyph plus a label, and
  * with the label empty its `Layout.fillWidth` slot still took the row's
  * leftover width - so each button came out 44x35, near enough square to read
- * as a circle under `rounding.full`, with the glyph drawn 2.5px left of the
- * button's own centre. An icon-only button is a `RippleButton` whose
+ * as a circle under `rounding.full`, with the glyph drawn 1.5px left of the
+ * button's own centre (its SLOT was 2.5px off; the glyph sits 1px into it,
+ * and what a reader can check against the harness is the drawn number).
+ * An icon-only button is a `RippleButton` whose
  * contentItem is a `MaterialSymbol` declaring both alignments, which is what
  * centres a Control's content item (an anchor on it is decoration).
  */

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneFooterBar.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneFooterBar.qml
@@ -28,11 +28,12 @@ import QtQuick.Layouts
  * with the label empty its `Layout.fillWidth` slot still took the row's
  * leftover width - so each button came out 44x35, near enough square to read
  * as a circle under `rounding.full`, with the glyph drawn 1.5px left of the
- * button's own centre (its SLOT was 2.5px off; the glyph sits 1px into it,
- * and what a reader can check against the harness is the drawn number).
- * An icon-only button is a `RippleButton` whose
+ * button's own centre (its SLOT was 2.5px off; the glyph sits a pixel into
+ * that slot, and the drawn number is the one a reader can check against
+ * PhoneTabRuntimeTest). An icon-only button is a `RippleButton` whose
  * contentItem is a `MaterialSymbol` declaring both alignments, which is what
- * centres a Control's content item (an anchor on it is decoration).
+ * centres a Control's content item - an anchor on it is decoration, because a
+ * Control sizes and positions its content item itself.
  */
 Item {
     id: root

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneFooterBar.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneFooterBar.qml
@@ -21,6 +21,16 @@ import QtQuick.Layouts
  * the two actions off the row - but its label was centred in it with nothing
  * bounding it, and a centred label paints straight over its neighbours rather
  * than eliding. The label is anchored to the pill's own box now.
+ *
+ * The two actions state BOTH of their dimensions
+ * (`Appearance.sizes.phoneFooterButton*`) rather than sizing themselves from
+ * their content. `RippleButtonWithIcon` measures a glyph plus a label, and
+ * with the label empty its `Layout.fillWidth` slot still took the row's
+ * leftover width - so each button came out 44x35, near enough square to read
+ * as a circle under `rounding.full`, with the glyph drawn 2.5px left of the
+ * button's own centre. An icon-only button is a `RippleButton` whose
+ * contentItem is a `MaterialSymbol` declaring both alignments, which is what
+ * centres a Control's content item (an anchor on it is decoration).
  */
 Item {
     id: root
@@ -39,16 +49,24 @@ Item {
         anchors.verticalCenter: parent.verticalCenter
         spacing: Appearance.spacing.space100
 
-        RippleButtonWithIcon {
+        RippleButton {
             id: syncButton
-            materialIcon: "sync"
-            mainText: ""
+            implicitWidth: Appearance.sizes.phoneFooterButtonWidth
+            implicitHeight: Appearance.sizes.phoneFooterButtonHeight
             enabled: root.online
             buttonRadius: Appearance.rounding.full
             colBackground: Appearance.colors.colSecondaryContainer
             colBackgroundHover: Appearance.colors.colSecondaryContainerHover
             colRipple: Appearance.colors.colSecondaryContainerActive
             onClicked: PhoneNotifications.refresh()
+
+            contentItem: MaterialSymbol {
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
+                text: "sync"
+                iconSize: Appearance.font.pixelSize.larger
+                color: Appearance.colors.colOnSecondaryContainer
+            }
 
             StyledToolTip {
                 text: Translation.tr("Sync notifications")
@@ -58,7 +76,7 @@ Item {
         Rectangle {
             id: countPill
             Layout.fillWidth: true
-            implicitHeight: 35
+            implicitHeight: Appearance.sizes.phoneFooterButtonHeight
             radius: Appearance.rounding.full
             color: Appearance.colors.colLayer2
 
@@ -82,16 +100,25 @@ Item {
             }
         }
 
-        RippleButtonWithIcon {
+        RippleButton {
             id: clearButton
-            materialIcon: root.count > 0 ? "delete_sweep" : "do_not_disturb_on"
-            mainText: ""
+            implicitWidth: Appearance.sizes.phoneFooterButtonWidth
+            implicitHeight: Appearance.sizes.phoneFooterButtonHeight
             enabled: root.online && root.count > 0
             buttonRadius: Appearance.rounding.full
             colBackground: Appearance.colors.colSecondaryContainer
             colBackgroundHover: Appearance.colors.colSecondaryContainerHover
             colRipple: Appearance.colors.colSecondaryContainerActive
             onClicked: PhoneNotifications.dismissAll()
+
+            contentItem: MaterialSymbol {
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
+                text: root.count > 0 ? "delete_sweep" : "do_not_disturb_on"
+                iconSize: Appearance.font.pixelSize.larger
+                color: Appearance.colors.colOnSecondaryContainer
+                animateChange: true
+            }
 
             StyledToolTip {
                 text: root.count > 0

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/phone_cards.js
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/phone_cards.js
@@ -33,14 +33,40 @@ function cardState(available, reachable, connecting, active) {
 // The mirror's own state. A launch error is drawn as `offline` (the sibling
 // fork's choice): the card is not running, and the subtitle carries the
 // error's first line, so a second state would say the same thing twice.
+//
+// The same is true of a phone that is reachable over KDE Connect but that
+// `adb devices` does not list: scrcpy has nothing to attach to, so the card
+// cannot start - and that is knowable BEFORE the click, the way missing
+// tooling already is. It is `offline` for the same reason a launch error is,
+// and the subtitle says which of the two links is the missing one.
+//
+// `adbDevice` is deliberately TRI-STATE. `undefined` means the probe has not
+// answered yet, which must not read as a refusal - PhoneDeps' flags all start
+// false, so a plain falsy test would put every card on "no device" for the
+// first frames of every session, and would silently refuse for ever at any
+// call site that forgot to pass the flag at all.
 function mirrorState(flags) {
     const f = flags || {};
     if (!f.available) return "unavailable";
     if (f.running) return "active";
     if (f.launching) return "connecting";
     if (!f.reachable) return "offline";
+    if (f.adbDevice === false) return "offline";
     if (errorHeadline(f.error).length > 0) return "offline";
     return "ready";
+}
+
+// The microphone's, which the service cannot answer for itself: PhoneMic's
+// own `stateFor` knows whether a phone is reachable and not whether adb can
+// see it, and its scrcpy backend - the preferred one wherever scrcpy is
+// installed - drives the phone over ADB. The droidcam backend does not, so
+// the refusal is asked for rather than assumed (`needsAdbDevice`); the webcam
+// is the case that never asks, since droidcam-cli reaches the phone over
+// Wi-Fi when adb has nothing.
+function micState(flags) {
+    const f = flags || {};
+    const linked = f.reachable && !(f.needsAdbDevice && f.adbDevice === false);
+    return cardState(f.available, linked, f.connecting, f.active);
 }
 
 // A service's lastError is whatever the process wrote; only its first line
@@ -72,6 +98,9 @@ function mirrorSubtitleKey(flags) {
     // the error first put a live mirror's card on a stale line.
     if (f.running) return "running";
     if (f.launching) return "launching";
+    // Asked before the error, because "the phone is not on ADB" is what to do
+    // about the error scrcpy's exit produced.
+    if (f.adbDevice === false) return "noDevice";
     if (errorHeadline(f.error).length > 0) return "error";
     return "ready";
 }
@@ -99,6 +128,7 @@ function micSubtitleKey(flags) {
     if (!f.reachable) return "offline";
     if (f.connecting) return "connecting";
     if (f.active) return f.muted ? "muted" : "active";
+    if (f.needsAdbDevice && f.adbDevice === false) return "noDevice";
     return "ready";
 }
 

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/phone_cards.js
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/phone_cards.js
@@ -115,6 +115,12 @@ function webcamSubtitleKey(flags) {
     if (!f.reachable) return "offline";
     if (f.connecting) return "connecting";
     if (f.active) return String(f.device || "").length > 0 ? "device" : "running";
+    // A launch that failed leaves the service back on `ready` with its
+    // lastError set, and the card draws lastError only while it is ACTIVE -
+    // so without this arm a webcam that could not start was a card that had
+    // gone back to saying "Tap to start", which is what "clicking it does
+    // nothing" looked like.
+    if (errorHeadline(f.error).length > 0) return "error";
     return "ready";
 }
 
@@ -129,6 +135,10 @@ function micSubtitleKey(flags) {
     if (f.connecting) return "connecting";
     if (f.active) return f.muted ? "muted" : "active";
     if (f.needsAdbDevice && f.adbDevice === false) return "noDevice";
+    // The webcam's reasoning, and the same silence: a microphone that failed
+    // to start was a card back on "Tap to start" with the reason in a
+    // property nothing drew.
+    if (errorHeadline(f.error).length > 0) return "error";
     return "ready";
 }
 

--- a/dots/.config/quickshell/imi/services/PhoneDeps.qml
+++ b/dots/.config/quickshell/imi/services/PhoneDeps.qml
@@ -43,6 +43,17 @@ Singleton {
     property int scrcpyMinor: 0
     property string distro: "unknown" // arch | fedora | debian | unknown
 
+    // Whether `adb devices` currently lists a phone in the `device` state,
+    // and the serial a launch would resolve to. The one thing here that is
+    // LIVE rather than a fact about what is installed: a phone is plugged in
+    // and unplugged while the shell runs, so `refreshAdbDevices()` exists and
+    // the card stack calls it while it is on screen and has seen nothing. It
+    // lives beside the tooling because the question a card asks before its
+    // click is the same shape - "can this feature start at all" - and
+    // `unavailable` already answers the other half of it.
+    property bool adbDevice: false
+    property string adbDeviceSerial: ""
+
     readonly property bool appModeSupported: root.scrcpy && root.scrcpyMajor >= 4
 
     // Probes still in flight. `ready` is false until the first sweep has
@@ -80,6 +91,29 @@ Singleton {
     // the module is `v4l2loopback_dc`, which counts.
     function parseLsmod(text: string): bool {
         return (text ?? "").split("\n").some(line => /^v4l2loopback(\b|_)/.test(line.trim()));
+    }
+
+    // `adb devices` prints a header line and then one `<serial>\t<state>` row
+    // per transport. Only a row in the `device` state is a phone the tools can
+    // drive: `unauthorized` is a phone that has not answered the RSA prompt
+    // and `offline` a transport that has dropped, and either is a launch that
+    // fails a second later with nothing on screen having said so. The
+    // supervisor prefers a USB serial over an ip:port, so the USB ones come
+    // first here too and the serial reported is the one a launch would use.
+    function parseAdbDevices(text: string): var {
+        const usb = [];
+        const wireless = [];
+        for (const raw of (text ?? "").split("\n")) {
+            const line = raw.trim();
+            if (line.length === 0) continue;
+            if (line.indexOf("List of devices") === 0) continue;
+            const parts = line.split(/\s+/);
+            if (parts.length < 2 || parts[1] !== "device") continue;
+            if (parts[0].indexOf(":") >= 0) wireless.push(parts[0]);
+            else usb.push(parts[0]);
+        }
+        const serials = usb.concat(wireless);
+        return { present: serials.length > 0, serial: serials.length > 0 ? serials[0] : "" };
     }
 
     // The install guide's rows: the sibling fork's table, verbatim.
@@ -217,6 +251,15 @@ Singleton {
             root.startProbe(probe);
     }
 
+    // Live state, so it is re-asked rather than answered once. Refused while
+    // adb is not installed: a Process whose binary is not on PATH never emits
+    // `exited`, so the flag would keep whatever it had while the probe count
+    // still moved.
+    function refreshAdbDevices(): void {
+        if (!root.adb) return;
+        root.startProbe(adbDevicesProbe);
+    }
+
     function probeAnswered(): void {
         root.probesPending = Math.max(0, root.probesPending - 1);
     }
@@ -261,7 +304,31 @@ Singleton {
         command: ["sh", "-c", "command -v adb"]
         Component.onCompleted: root.startProbe(this)
         onRunningChanged: if (!running) root.probeAnswered()
-        onExited: (exitCode, exitStatus) => { root.adb = exitCode === 0; }
+        onExited: (exitCode, exitStatus) => {
+            root.adb = exitCode === 0;
+            if (root.adb) {
+                root.startProbe(adbDevicesProbe);
+            } else {
+                root.adbDevice = false;
+                root.adbDeviceSerial = "";
+            }
+        }
+    }
+
+    // Not started from Component.onCompleted and not in recheck()'s list: it
+    // is started by the presence probe above, which recheck() does restart, so
+    // a machine without adb never spawns it at all.
+    Process {
+        id: adbDevicesProbe
+        command: ["adb", "devices"]
+        stdout: StdioCollector { id: adbDevicesOut }
+        stderr: StdioCollector {}
+        onRunningChanged: if (!running) root.probeAnswered()
+        onExited: (exitCode, exitStatus) => {
+            const found = root.parseAdbDevices(exitCode === 0 ? adbDevicesOut.text : "");
+            root.adbDevice = found.present;
+            root.adbDeviceSerial = found.serial;
+        }
     }
 
     Process {

--- a/dots/.config/quickshell/imi/services/PhoneDeps.qml
+++ b/dots/.config/quickshell/imi/services/PhoneDeps.qml
@@ -43,16 +43,15 @@ Singleton {
     property int scrcpyMinor: 0
     property string distro: "unknown" // arch | fedora | debian | unknown
 
-    // Whether `adb devices` currently lists a phone in the `device` state,
-    // and the serial a launch would resolve to. The one thing here that is
-    // LIVE rather than a fact about what is installed: a phone is plugged in
-    // and unplugged while the shell runs, so `refreshAdbDevices()` exists and
-    // the card stack calls it while it is on screen and has seen nothing. It
-    // lives beside the tooling because the question a card asks before its
-    // click is the same shape - "can this feature start at all" - and
-    // `unavailable` already answers the other half of it.
+    // Whether `adb devices` currently lists a phone in the `device` state.
+    // The one thing here that is LIVE rather than a fact about what is
+    // installed: a phone is plugged in and unplugged while the shell runs, so
+    // `refreshAdbDevices()` exists and the card stack calls it while it is on
+    // screen and has seen nothing. It lives beside the tooling because the
+    // question a card asks before its click is the same shape - "can this
+    // feature start at all" - and `unavailable` already answers the other
+    // half of it.
     property bool adbDevice: false
-    property string adbDeviceSerial: ""
 
     readonly property bool appModeSupported: root.scrcpy && root.scrcpyMajor >= 4
 
@@ -97,23 +96,19 @@ Singleton {
     // per transport. Only a row in the `device` state is a phone the tools can
     // drive: `unauthorized` is a phone that has not answered the RSA prompt
     // and `offline` a transport that has dropped, and either is a launch that
-    // fails a second later with nothing on screen having said so. The
-    // supervisor prefers a USB serial over an ip:port, so the USB ones come
-    // first here too and the serial reported is the one a launch would use.
-    function parseAdbDevices(text: string): var {
-        const usb = [];
-        const wireless = [];
+    // fails a second later with nothing on screen having said so. WHICH
+    // transport is not answered here - the scrcpy supervisor resolves that
+    // for itself on every launch, and a second answer to it would be a second
+    // answer that can disagree.
+    function parseAdbDevices(text: string): bool {
         for (const raw of (text ?? "").split("\n")) {
             const line = raw.trim();
             if (line.length === 0) continue;
             if (line.indexOf("List of devices") === 0) continue;
             const parts = line.split(/\s+/);
-            if (parts.length < 2 || parts[1] !== "device") continue;
-            if (parts[0].indexOf(":") >= 0) wireless.push(parts[0]);
-            else usb.push(parts[0]);
+            if (parts.length >= 2 && parts[1] === "device") return true;
         }
-        const serials = usb.concat(wireless);
-        return { present: serials.length > 0, serial: serials.length > 0 ? serials[0] : "" };
+        return false;
     }
 
     // The install guide's rows: the sibling fork's table, verbatim.
@@ -310,7 +305,6 @@ Singleton {
                 root.startProbe(adbDevicesProbe);
             } else {
                 root.adbDevice = false;
-                root.adbDeviceSerial = "";
             }
         }
     }
@@ -325,9 +319,7 @@ Singleton {
         stderr: StdioCollector {}
         onRunningChanged: if (!running) root.probeAnswered()
         onExited: (exitCode, exitStatus) => {
-            const found = root.parseAdbDevices(exitCode === 0 ? adbDevicesOut.text : "");
-            root.adbDevice = found.present;
-            root.adbDeviceSerial = found.serial;
+            root.adbDevice = exitCode === 0 && root.parseAdbDevices(adbDevicesOut.text);
         }
     }
 

--- a/dots/.config/quickshell/imi/tests/imports/testservices/PhoneDeps.qml
+++ b/dots/.config/quickshell/imi/tests/imports/testservices/PhoneDeps.qml
@@ -28,6 +28,8 @@ Singleton {
     property int scrcpyMajor: 0
     property int scrcpyMinor: 0
     property string distro: "unknown"
+    property bool adbDevice: false
+    property string adbDeviceSerial: ""
 
     readonly property bool appModeSupported: root.scrcpy && root.scrcpyMajor >= 4
 
@@ -64,6 +66,29 @@ Singleton {
     // the module is `v4l2loopback_dc`, which counts.
     function parseLsmod(text: string): bool {
         return (text ?? "").split("\n").some(line => /^v4l2loopback(\b|_)/.test(line.trim()));
+    }
+
+    // `adb devices` prints a header line and then one `<serial>\t<state>` row
+    // per transport. Only a row in the `device` state is a phone the tools can
+    // drive: `unauthorized` is a phone that has not answered the RSA prompt
+    // and `offline` a transport that has dropped, and either is a launch that
+    // fails a second later with nothing on screen having said so. The
+    // supervisor prefers a USB serial over an ip:port, so the USB ones come
+    // first here too and the serial reported is the one a launch would use.
+    function parseAdbDevices(text: string): var {
+        const usb = [];
+        const wireless = [];
+        for (const raw of (text ?? "").split("\n")) {
+            const line = raw.trim();
+            if (line.length === 0) continue;
+            if (line.indexOf("List of devices") === 0) continue;
+            const parts = line.split(/\s+/);
+            if (parts.length < 2 || parts[1] !== "device") continue;
+            if (parts[0].indexOf(":") >= 0) wireless.push(parts[0]);
+            else usb.push(parts[0]);
+        }
+        const serials = usb.concat(wireless);
+        return { present: serials.length > 0, serial: serials.length > 0 ? serials[0] : "" };
     }
 
     // The install guide's rows: the sibling fork's table, verbatim.
@@ -186,5 +211,12 @@ Singleton {
 
     function recheck(): void {
         root.rechecks++;
+    }
+
+    property int adbDeviceRefreshes: 0
+
+    function refreshAdbDevices(): void {
+        if (!root.adb) return;
+        root.adbDeviceRefreshes++;
     }
 }

--- a/dots/.config/quickshell/imi/tests/imports/testservices/PhoneDeps.qml
+++ b/dots/.config/quickshell/imi/tests/imports/testservices/PhoneDeps.qml
@@ -29,7 +29,6 @@ Singleton {
     property int scrcpyMinor: 0
     property string distro: "unknown"
     property bool adbDevice: false
-    property string adbDeviceSerial: ""
 
     readonly property bool appModeSupported: root.scrcpy && root.scrcpyMajor >= 4
 
@@ -72,23 +71,19 @@ Singleton {
     // per transport. Only a row in the `device` state is a phone the tools can
     // drive: `unauthorized` is a phone that has not answered the RSA prompt
     // and `offline` a transport that has dropped, and either is a launch that
-    // fails a second later with nothing on screen having said so. The
-    // supervisor prefers a USB serial over an ip:port, so the USB ones come
-    // first here too and the serial reported is the one a launch would use.
-    function parseAdbDevices(text: string): var {
-        const usb = [];
-        const wireless = [];
+    // fails a second later with nothing on screen having said so. WHICH
+    // transport is not answered here - the scrcpy supervisor resolves that
+    // for itself on every launch, and a second answer to it would be a second
+    // answer that can disagree.
+    function parseAdbDevices(text: string): bool {
         for (const raw of (text ?? "").split("\n")) {
             const line = raw.trim();
             if (line.length === 0) continue;
             if (line.indexOf("List of devices") === 0) continue;
             const parts = line.split(/\s+/);
-            if (parts.length < 2 || parts[1] !== "device") continue;
-            if (parts[0].indexOf(":") >= 0) wireless.push(parts[0]);
-            else usb.push(parts[0]);
+            if (parts.length >= 2 && parts[1] === "device") return true;
         }
-        const serials = usb.concat(wireless);
-        return { present: serials.length > 0, serial: serials.length > 0 ? serials[0] : "" };
+        return false;
     }
 
     // The install guide's rows: the sibling fork's table, verbatim.

--- a/dots/.config/quickshell/imi/tests/test_phone_tab_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_tab_runtime.py
@@ -12,6 +12,17 @@ the notification list owning the leftover height (measured: take the pairing
 card away and the list grows by exactly that card), the pairing card and the
 roster behind the chip's arrow - and clicks Accept and Decline.
 
+It also puts a fake `adb`, `scrcpy`, `droidcam-cli`, `pactl`, `v4l2-ctl`,
+`lsmod`, `modinfo` and `mpv` on PATH, so `PhoneDeps` answers the same way on
+every machine instead of reading the developer's own. The fake `adb` lists NO
+device - the machine this was written against, where KDE Connect reaches the
+phone over LAN and adb has never seen it - which is what puts the mirror and
+the microphone cards on their "no device over ADB" state before anything is
+clicked. The footer's geometry and the feature cards' click path are read
+back here because neither is reachable from `qmltestrunner`: it can build
+neither a laid-out box nor a RippleButton, which is why the cards' own
+decisions live in `phone_cards.js` and are driven by `tests/tst_phone_cards.qml`.
+
 Those two clicks are scored HERE, off the fake's recorded invocations:
 `acceptPairing` and `cancelPairing` must each have been called once, on the
 laptop's device path, and never on the phone's. A click that reached nothing
@@ -42,7 +53,7 @@ LAPTOP_ADDRESS = "192.168.100.99"
 # A literal, never read back out of the harness's own output: a step list
 # that shrinks must redden here instead of reporting `failures: 0` for a
 # shorter run.
-EXPECTED_CHECKS = 24
+EXPECTED_CHECKS = 49
 
 RECORD = """#!/usr/bin/env bash
 printf '%s %s\\n' "$(date +%s.%N)" "$*" >> "$PHONE_EXEC_LOG"
@@ -82,6 +93,36 @@ exit 0
        "phone_address": PHONE_ADDRESS, "laptop_address": LAPTOP_ADDRESS}
 
 
+# What each optional tool answers. `adb devices` lists nothing on purpose;
+# `scrcpy --version` answers a version so PhoneDeps' version probe has
+# something to parse, and any other scrcpy invocation fails the way a real one
+# does with no device attached.
+TOOL_FAKES = {
+    "adb": r"""case "$1" in
+  devices) printf 'List of devices attached\n\n' ;;
+  get-state) printf 'error: no devices/emulators found\n' >&2; exit 1 ;;
+esac
+exit 0
+""",
+    "scrcpy": r"""case "$1" in
+  --version) printf 'scrcpy 3.1 <https://github.com/Genymobile/scrcpy>\n' ;;
+  *) printf 'ERROR: Could not find any ADB device\n' >&2; exit 1 ;;
+esac
+exit 0
+""",
+    "droidcam-cli": "exit 1\n",
+    "v4l2-ctl": "exit 0\n",
+    "pactl": r"""printf 'alsa_output.fake\n'
+exit 0
+""",
+    "lsmod": r"""printf 'Module Size Used by\nv4l2loopback 53248 0\n'
+exit 0
+""",
+    "modinfo": "exit 0\n",
+    "mpv": "exit 0\n",
+}
+
+
 def _stop(proc):
     proc.terminate()
     try:
@@ -106,6 +147,11 @@ class PhoneTabRuntimeTest(unittest.TestCase):
         fake = self.bin / "busctl"
         fake.write_text(RECORD.replace("__BODY__", BUSCTL_BODY))
         fake.chmod(0o755)
+
+        for name, body in TOOL_FAKES.items():
+            tool = self.bin / name
+            tool.write_text(RECORD.replace("__BODY__", body))
+            tool.chmod(0o755)
 
         shell_config = self.home / "config" / "immaterial-impulse"
         shell_config.mkdir(parents=True)

--- a/dots/.config/quickshell/imi/tests/tst_phone_cards.qml
+++ b/dots/.config/quickshell/imi/tests/tst_phone_cards.qml
@@ -168,6 +168,37 @@ TestCase {
         compare(PhoneCards.micTitleKey(false), "install");
     }
 
+    function test_a_failed_launch_reaches_the_webcam_and_microphone_subtitles() {
+        // Both services leave `lastError` set and go back to `ready`, and the
+        // card draws lastError only while it is ACTIVE - so a webcam that
+        // could not connect was a card back on "Tap to start", which is
+        // exactly what "clicking it does nothing" looked like.
+        compare(PhoneCards.webcamSubtitleKey({
+            available: true, reachable: true, error: "DroidCam did not start"
+        }), "error");
+        compare(PhoneCards.micSubtitleKey({
+            available: true, reachable: true, error: "Phone microphone process exited"
+        }), "error");
+        // Whitespace is not an error: it would replace a usable "Tap to
+        // start" with a blank line.
+        compare(PhoneCards.webcamSubtitleKey({
+            available: true, reachable: true, error: "  \n "
+        }), "ready");
+        compare(PhoneCards.micSubtitleKey({ available: true, reachable: true, error: "" }), "ready");
+    }
+
+    function test_a_live_session_outranks_the_error_it_has_not_hit_yet() {
+        // lastError is cleared by the next start() and by nothing else, so a
+        // stale one must not take a running stream off its own state.
+        compare(PhoneCards.webcamSubtitleKey({
+            available: true, reachable: true, active: true, device: "/dev/video2",
+            error: "an old failure"
+        }), "device");
+        compare(PhoneCards.micSubtitleKey({
+            available: true, reachable: true, connecting: true, error: "an old failure"
+        }), "connecting");
+    }
+
     // ---------------------------------------------------------------------
     // The microphone's own ladder
     // ---------------------------------------------------------------------

--- a/dots/.config/quickshell/imi/tests/tst_phone_cards.qml
+++ b/dots/.config/quickshell/imi/tests/tst_phone_cards.qml
@@ -72,6 +72,45 @@ TestCase {
         }), "running");
     }
 
+    function test_a_phone_adb_cannot_see_is_offline_before_the_click() {
+        // The machine this was found on: KDE Connect reaches the phone over
+        // LAN and `adb devices` lists nothing, so scrcpy has nothing to attach
+        // to - and the card said "Opens a floating window for the active
+        // phone" right up until the click.
+        const away = {
+            available: true, reachable: true, running: false, launching: false,
+            adbDevice: false, error: ""
+        };
+        compare(PhoneCards.mirrorState(away), "offline");
+        compare(PhoneCards.mirrorSubtitleKey(away), "noDevice");
+        // And it says which link is missing rather than which failed: the
+        // error the failed launch left behind is the consequence.
+        compare(PhoneCards.mirrorSubtitleKey(Object.assign({}, away,
+            { error: "ERROR: Could not find any ADB device" })), "noDevice");
+    }
+
+    function test_a_probe_that_has_not_answered_yet_is_not_a_refusal() {
+        // Every PhoneDeps flag starts false, so a plain falsy test would put
+        // every card on "no device" for the first frames of every session -
+        // and would refuse for ever at any call site that forgot the flag.
+        const unknown = { available: true, reachable: true, running: false, launching: false };
+        compare(PhoneCards.mirrorState(unknown), "ready");
+        compare(PhoneCards.mirrorSubtitleKey(unknown), "ready");
+        compare(PhoneCards.mirrorState(Object.assign({}, unknown, { adbDevice: undefined })), "ready");
+        compare(PhoneCards.mirrorState(Object.assign({}, unknown, { adbDevice: true })), "ready");
+    }
+
+    function test_a_running_mirror_outranks_adb_losing_sight_of_the_phone() {
+        // The transport dropping does not stop the window that is already up;
+        // the supervisor's exit event is what does.
+        compare(PhoneCards.mirrorState({
+            available: true, reachable: true, running: true, adbDevice: false
+        }), "active");
+        compare(PhoneCards.mirrorSubtitleKey({
+            available: true, reachable: true, running: true, adbDevice: false
+        }), "running");
+    }
+
     function test_the_mirror_titles_follow_its_ladder() {
         compare(PhoneCards.mirrorTitleKey({ available: false }), "install");
         compare(PhoneCards.mirrorTitleKey({ available: true, running: true }), "running");
@@ -127,6 +166,47 @@ TestCase {
         compare(PhoneCards.micSubtitleKey({ available: false }), "install");
         compare(PhoneCards.micTitleKey(true), "mic");
         compare(PhoneCards.micTitleKey(false), "install");
+    }
+
+    // ---------------------------------------------------------------------
+    // The microphone's own ladder
+    // ---------------------------------------------------------------------
+
+    function test_the_microphone_asks_for_adb_only_on_the_backend_that_uses_it() {
+        // scrcpy --audio-source=mic drives the phone over ADB; droidcam-cli
+        // reaches it over Wi-Fi, so an empty `adb devices` refuses one and
+        // not the other.
+        const base = { available: true, reachable: true, connecting: false, active: false };
+        compare(PhoneCards.micState(Object.assign({}, base,
+            { needsAdbDevice: true, adbDevice: false })), "offline");
+        compare(PhoneCards.micSubtitleKey(Object.assign({}, base,
+            { needsAdbDevice: true, adbDevice: false })), "noDevice");
+        compare(PhoneCards.micState(Object.assign({}, base,
+            { needsAdbDevice: false, adbDevice: false })), "ready");
+        compare(PhoneCards.micSubtitleKey(Object.assign({}, base,
+            { needsAdbDevice: false, adbDevice: false })), "ready");
+        compare(PhoneCards.micState(Object.assign({}, base,
+            { needsAdbDevice: true, adbDevice: true })), "ready");
+    }
+
+    function test_the_microphones_ladder_is_still_the_shared_one() {
+        // micState is the shared ladder with one extra term, not a second
+        // ladder: everything else it answers must match cardState.
+        const base = { available: true, reachable: true, needsAdbDevice: true, adbDevice: true };
+        compare(PhoneCards.micState(Object.assign({}, base, { available: false, active: true })), "unavailable");
+        compare(PhoneCards.micState(Object.assign({}, base, { active: true, reachable: false })), "active");
+        compare(PhoneCards.micState(Object.assign({}, base, { connecting: true })), "connecting");
+        compare(PhoneCards.micState(Object.assign({}, base, { reachable: false })), "offline");
+        compare(PhoneCards.micState(base), "ready");
+        // An unanswered probe is not a refusal here either.
+        compare(PhoneCards.micState({ available: true, reachable: true, needsAdbDevice: true }), "ready");
+        compare(PhoneCards.micState(undefined), "unavailable");
+    }
+
+    function test_an_active_microphone_outranks_adb_losing_sight_of_the_phone() {
+        compare(PhoneCards.micState({
+            available: true, reachable: true, active: true, needsAdbDevice: true, adbDevice: false
+        }), "active");
     }
 
     // ---------------------------------------------------------------------

--- a/dots/.config/quickshell/imi/tests/tst_phone_scrcpy.qml
+++ b/dots/.config/quickshell/imi/tests/tst_phone_scrcpy.qml
@@ -46,7 +46,6 @@ TestCase {
         PhoneDeps.v4l2loopbackInstalled = false
         PhoneDeps.scrcpyMajor = 0
         PhoneDeps.adbDevice = false
-        PhoneDeps.adbDeviceSerial = ""
         PhoneDeps.adbDeviceRefreshes = 0
         PhoneScrcpy.reset()
         PhoneScrcpy.available = true
@@ -112,30 +111,21 @@ TestCase {
     }
 
     function test_deps_reads_adb_devices_and_counts_only_a_device_in_the_device_state() {
-        const usb = PhoneDeps.parseAdbDevices("List of devices attached\nR5CT30ABCDE\tdevice\n\n")
-        compare(usb.present, true)
-        compare(usb.serial, "R5CT30ABCDE")
+        compare(PhoneDeps.parseAdbDevices("List of devices attached\nR5CT30ABCDE\tdevice\n\n"), true)
+        compare(PhoneDeps.parseAdbDevices("List of devices attached\n192.168.1.50:5555\tdevice\n"), true)
         // An empty list is the machine this was found on: the phone is paired
         // over KDE Connect and adb has never seen it.
-        compare(PhoneDeps.parseAdbDevices("List of devices attached\n\n").present, false)
-        compare(PhoneDeps.parseAdbDevices("").present, false)
-        compare(PhoneDeps.parseAdbDevices("").serial, "")
+        compare(PhoneDeps.parseAdbDevices("List of devices attached\n\n"), false)
+        compare(PhoneDeps.parseAdbDevices(""), false)
+        compare(PhoneDeps.parseAdbDevices(undefined), false)
         // A phone that has not answered the RSA prompt, and a transport that
         // has dropped, are both listed - and both are a launch that fails a
         // second later, so neither counts.
-        compare(PhoneDeps.parseAdbDevices("List of devices attached\nR5CT30ABCDE\tunauthorized\n").present, false)
-        compare(PhoneDeps.parseAdbDevices("List of devices attached\n192.168.1.50:5555\toffline\n").present, false)
-    }
-
-    function test_deps_names_the_serial_a_launch_would_actually_resolve_to() {
-        // The supervisor prefers a USB serial over an ip:port, so a card
-        // naming the wireless one would name a transport nothing uses.
-        const both = PhoneDeps.parseAdbDevices(
-            "List of devices attached\n192.168.1.50:5555\tdevice\nR5CT30ABCDE\tdevice\n")
-        compare(both.present, true)
-        compare(both.serial, "R5CT30ABCDE")
-        compare(PhoneDeps.parseAdbDevices("List of devices attached\n192.168.1.50:5555\tdevice\n").serial,
-                "192.168.1.50:5555")
+        compare(PhoneDeps.parseAdbDevices("List of devices attached\nR5CT30ABCDE\tunauthorized\n"), false)
+        compare(PhoneDeps.parseAdbDevices("List of devices attached\n192.168.1.50:5555\toffline\n"), false)
+        // One usable transport among several unusable ones still counts.
+        compare(PhoneDeps.parseAdbDevices(
+            "List of devices attached\n192.168.1.50:5555\toffline\nR5CT30ABCDE\tdevice\n"), true)
     }
 
     function test_deps_refuses_to_re_ask_adb_while_adb_is_not_installed() {

--- a/dots/.config/quickshell/imi/tests/tst_phone_scrcpy.qml
+++ b/dots/.config/quickshell/imi/tests/tst_phone_scrcpy.qml
@@ -45,6 +45,9 @@ TestCase {
         PhoneDeps.v4l2loopbackLoaded = false
         PhoneDeps.v4l2loopbackInstalled = false
         PhoneDeps.scrcpyMajor = 0
+        PhoneDeps.adbDevice = false
+        PhoneDeps.adbDeviceSerial = ""
+        PhoneDeps.adbDeviceRefreshes = 0
         PhoneScrcpy.reset()
         PhoneScrcpy.available = true
         PhoneScrcpy.appModeSupported = true
@@ -106,6 +109,44 @@ TestCase {
         compare(PhoneDeps.parseLsmod("v4l2loopback           53248  0\n"), true)
         compare(PhoneDeps.parseLsmod("snd_aloop              45056  1\nvideodev              421888  1\n"), false)
         compare(PhoneDeps.parseLsmod(""), false)
+    }
+
+    function test_deps_reads_adb_devices_and_counts_only_a_device_in_the_device_state() {
+        const usb = PhoneDeps.parseAdbDevices("List of devices attached\nR5CT30ABCDE\tdevice\n\n")
+        compare(usb.present, true)
+        compare(usb.serial, "R5CT30ABCDE")
+        // An empty list is the machine this was found on: the phone is paired
+        // over KDE Connect and adb has never seen it.
+        compare(PhoneDeps.parseAdbDevices("List of devices attached\n\n").present, false)
+        compare(PhoneDeps.parseAdbDevices("").present, false)
+        compare(PhoneDeps.parseAdbDevices("").serial, "")
+        // A phone that has not answered the RSA prompt, and a transport that
+        // has dropped, are both listed - and both are a launch that fails a
+        // second later, so neither counts.
+        compare(PhoneDeps.parseAdbDevices("List of devices attached\nR5CT30ABCDE\tunauthorized\n").present, false)
+        compare(PhoneDeps.parseAdbDevices("List of devices attached\n192.168.1.50:5555\toffline\n").present, false)
+    }
+
+    function test_deps_names_the_serial_a_launch_would_actually_resolve_to() {
+        // The supervisor prefers a USB serial over an ip:port, so a card
+        // naming the wireless one would name a transport nothing uses.
+        const both = PhoneDeps.parseAdbDevices(
+            "List of devices attached\n192.168.1.50:5555\tdevice\nR5CT30ABCDE\tdevice\n")
+        compare(both.present, true)
+        compare(both.serial, "R5CT30ABCDE")
+        compare(PhoneDeps.parseAdbDevices("List of devices attached\n192.168.1.50:5555\tdevice\n").serial,
+                "192.168.1.50:5555")
+    }
+
+    function test_deps_refuses_to_re_ask_adb_while_adb_is_not_installed() {
+        // A Process whose binary is not on PATH never emits `exited`, so a
+        // refresh there would move the pending count and leave the flag alone.
+        PhoneDeps.adb = false
+        PhoneDeps.refreshAdbDevices()
+        compare(PhoneDeps.adbDeviceRefreshes, 0)
+        PhoneDeps.adb = true
+        PhoneDeps.refreshAdbDevices()
+        compare(PhoneDeps.adbDeviceRefreshes, 1)
     }
 
     function test_deps_dependency_table_carries_the_forks_commands() {


### PR DESCRIPTION
Three defects the maintainer hit on the live Phone tab, and what turned out to
be underneath the third one.

## 1. The count pill spells the word out

"7 notif." is now "7 notifications", and "1 notification" for one —
`Translation.tr` takes a single string and has no plural form to select, so the
singular is its own key. The plural is deliberately spelled the way
`sidebarRight/notifications/NotificationList.qml` already spells the same count:
`"%1 notifications"` is a key all fourteen translation tables already carry,
where `"%1 notif."` was in none of them. The singular `"1 notification"` is a
new key in none of them yet; it is a `Translation.tr("...")` literal, which is
the form `translations/tools/translation-manager.py` extracts, so the next
extract picks it up and until then it falls back to English.

The label also gets a box. It was `anchors.centerIn: parent` with nothing
bounding it, so a longer form would have been drawn straight over the two
buttons rather than eliding — a centred `Text` has no width to elide inside. It
fills the pill now, inset one spacing step, centred by alignment, and elides.

## 2. The two flanking actions are soft rectangles with centred glyphs

Both were `RippleButtonWithIcon` with `mainText: ""`, which is the wrong widget
in two ways that compound. It sizes itself from a glyph plus a label, so with
the label empty each button measured **44x35** — a stadium under
`rounding.full`, but near enough square to read as a circle. And the label's
slot is `Layout.fillWidth: true`, so it absorbed the row's leftover width from
*inside* the button and pushed the drawn glyph **1.5px left of the button's own
centre**: widening it would have moved the glyph further off, not centred it.

Both are a `RippleButton` whose `contentItem` is a `MaterialSymbol` declaring
both alignments — the spelling `IconToolbarButton` already uses, and the one
thing that centres a Control's content item. Their size comes from two new
`Appearance.sizes.phoneFooterButton*` tokens, which the pill's height reads too
so the row cannot disagree with itself.

Measured in `PhoneTabRuntimeTest` at the sidebar's 460px: **48x35** each, both
glyph centres **0.0px** off, the pill 328px wide with its label inside it.

## 3. The three feature cards

**Diagnosed before anything was changed.** Two of the three cannot work on this
machine at all, and the primary click was never the problem:

| card | why it failed here | what was code |
| --- | --- | --- |
| scrcpy Mirror | environmental — `adb devices` lists nothing | no state before the click; the failure toast never fired |
| Phone Webcam | environmental — `droidcam-cli` is broken (`libswscale.so.9`) | the failure's reason was drawn nowhere; no toast |
| Phone Microphone | environmental — its scrcpy backend needs an ADB device | no state before the click; reason drawn nowhere; no toast |

**The click fires.** Driven with a real mouse event at the card's own centre in
the runtime harness, it reaches `PhoneScrcpy.launchMirror()`; a click on the
settings chip on the same card opens the webcam page instead. Neither the chip
nor the status mark swallows the card's own click, and both checks redden when
their handler is removed.

Three code fixes:

- **A card that cannot start over ADB says so before the click.** The cards
  gated on `PhoneConnect.activeDevice.reachable` — KDE Connect's link — while
  the mirror and the microphone's preferred backend drive the phone over ADB.
  `PhoneDeps.adbDevice` answers that now, beside the `command -v` sweep, and it
  is the one live fact in that file, so the card stack re-asks it while it is on
  screen and adb has seen nothing. It is drawn as `offline` rather than a sixth
  rung, the flag is tri-state so an unanswered probe is not a refusal, and the
  webcam deliberately does not ask — droidcam-cli reaches the phone over Wi-Fi.
- **A failed launch reaches the card's subtitle.** `PhoneCamera` and `PhoneMic`
  end a failure by writing `lastError` and dropping back to `ready`, and
  `PhoneFeatureCard` draws `lastError` only inside its `active` rung — so the
  card went straight back to "Tap to start" with the reason in a property
  nothing read. The mirror's ladder already had that arm.
- **The tab hears the three services' own error signals.** `PhoneScrcpy.feedback`
  and `PhoneCamera`/`PhoneMic.errorOccurred` had no listener anywhere in the
  tree; the toast was wired to `PhoneConnect.actionFeedback` and nothing else.

## Tests

- `tests/tst_phone_cards.qml` — the card decisions, which are pure functions in
  `phone_cards.js` for exactly this reason. Every new check reddens on a planted
  mutation (the adb term dropped from `mirrorState`, from `micState`, the error
  arm dropped from `webcamSubtitleKey`).
- `tests/tst_phone_scrcpy.qml` — `parseAdbDevices` through the PhoneDeps double,
  including `unauthorized` and `offline` rows, which are a launch that fails a
  second later.
- `PhoneTabRuntimeTest.qml` + `tests/test_phone_tab_runtime.py` — the footer's
  geometry and the cards' click path, neither reachable from `qmltestrunner`.
  The driver now puts fake tooling on PATH so `PhoneDeps` answers the same way
  on every machine; its fake `adb` lists no device. 25 new checks, every one of
  them shown to redden on a planted mutation.

Docs: updated AGENT.md §Directory map, §State propagation is reactive, §Dynamic/data-driven QML gotchas, §the phone session services
Changelog: updated
