### PR TITLE
fix(phone): a contact card is sized by what it holds, in any script

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1935,6 +1935,49 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   way from the pixel it protects.
   b0e8f8af6 ("test(phone): the host check reads the slot's own type, not any ColumnLayout"),
   1a2e39ee4 ("test(phone): measure what the tab's sub-pages actually draw").
+- **A row sized from a constant fits ONE script, and an aligned layout child
+  answers a cell that is too small by OVERFLOWING it rather than by
+  shrinking.** Third in the same family, on the same page, reported from a
+  screenshot of a real contact list. `PhoneContactsPage`'s row header stated
+  `Layout.preferredHeight: Appearance.font.pixelSize.huge * 2` (44) and a
+  `Control` sizes its content item to the PADDED rect, so the row's contents
+  had 36px. What a row holds is not a constant: measured in a real window with
+  both scripts on screen at once, the name-and-number column is **34px** tall
+  for "Alice Rivers" and **47** for an Arabic name at the same `pixelSize`,
+  because `Google Sans Flex` carries no Arabic and the fallback face sets 32px
+  against the Latin face's 19. Before: the Latin card is 52 tall with its 38px
+  avatar drawn at 8-46 - six pixels short of the card's own edge, under the
+  8px base unit, which is the "flush against the bottom border" in the
+  photograph - and the Arabic card is the same 52, with the avatar at 13-51
+  and the NUMBER at 8-55, three pixels **below** the card. Nothing errors and
+  nothing is logged, because `Layout.alignment` means the layout hands the
+  child its preferred size and aligns it, and a cell smaller than that is
+  simply overflowed. After: 58 and 67, each avatar 10 and 14 pixels clear.
+  The header states no height at all now and says its vertical padding out
+  loud in `Appearance.spacing.*` rather than inheriting whatever the Basic
+  style's `padding` happens to be, and the card's own padding is one
+  `rowPadding` rather than `space50` on the content column's anchors plus
+  `space100` added to the height - two spellings that agree only while one is
+  twice the other, which is 4fb2a7f02 ("refactor(widgets): a dialog's content
+  padding gets a name of its own")'s coupling one widget down.
+  Two things about measuring it generalise past this row. **A harness that
+  redirects `XDG_CONFIG_HOME` redirects the developer's own
+  `~/.config/fontconfig` with it**, and that file is what puts an Arabic face
+  in front of the fallback here - measured, without a replacement the same
+  string sorts to DejaVu Sans and sets at the Latin height, so both cards come
+  out equal, every check passes, and the harness reports a defect it never
+  measured. `tests/test_phone_tab_layout_runtime.py` writes a `fonts.conf` of
+  its own and skips with a reason when the face is absent, rather than
+  reddening over a machine's font list. And the check a per-row assertion
+  cannot make is that the two cards **differ**: two rows that both fit because
+  both were made generously tall are still a constant, and the constant is the
+  defect. The sibling pages own the same idiom -
+  `PhoneMicPage`/`PhoneWebcamPage` state `huge * 2 + space150` on a header of
+  their own - so the shape is worth looking for rather than assuming it was
+  one row's.
+  2b921d8da ("refactor(phone): a contact card's padding gets a name of its own"),
+  d9a9162ec ("test(phone): drive a contact card's box against what it holds, in two scripts"),
+  07b819f07 ("fix(phone): a contact card is sized by what it holds, not by a constant").
 - **A keyboard is a LATTICE, not a stack of rows, and a `GridLayout` does not
   hand out equal columns on its own.** The numpad's `+` and its Enter are one
   key two rows tall, which a `RowLayout` cannot say — so each of them shipped

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,14 @@ own repo; the installer pins which revision it builds.
   sit dead centre instead of a pixel and a half to the left.
 
 ### Fixed
+- **Contacts with an Arabic name fit inside their row.** In the Phone tab's
+  Contacts list, a contact whose name is written in Arabic had its number and
+  its avatar drawn below the bottom of its own card - a row taller than the
+  card holding it - and with Latin names the avatar sat against the card's
+  bottom edge with almost no room around it. The row was a fixed height, and
+  Arabic sets taller than Latin at the same text size. Every row now takes the
+  height its own contents need, in any script, with the same breathing room
+  above and below.
 - **The Phone tab's Contacts and Android Apps pages draw their contents
   again.** Contacts showed its count — "147 of 150 contacts" — and then an
   empty page, and Android Apps drew its big empty-state icon on top of its

--- a/dots/.config/quickshell/imi/PhoneTabLayoutRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/PhoneTabLayoutRuntimeTest.qml
@@ -41,6 +41,18 @@ ShellRoot {
     readonly property string phoneId: Quickshell.env("PHONE_ID") ?? ""
     // The file the fake daemon reports as the first notification's iconPath.
     readonly property string iconPath: Quickshell.env("PHONE_ICON_PATH") ?? ""
+    // The two names in the vCard fixture, handed in rather than spelled a
+    // second time here: a row is found by the name the fixture wrote, so the
+    // harness and the fixture cannot disagree about which row is which.
+    readonly property string latinName: Quickshell.env("PHONE_CONTACT_LATIN") ?? ""
+    readonly property string arabicName: Quickshell.env("PHONE_CONTACT_ARABIC") ?? ""
+    // What "a real gap" means for the avatar: the shell's base unit. Below
+    // this the glyph reads as sitting on the card's edge - measured at 4px
+    // with the old fixed row height, and photographed by the maintainer.
+    readonly property real minAvatarGap: Appearance.spacing.space100
+
+    property string arabicId: ""
+    property real arabicCollapsedHeight: 0
     // How tall the tab's host is. The window cannot be resized under headless
     // weston - measured: assigning `implicitHeight` left the page at 880 and
     // the "cramped" step scored the tall page a second time - so the host's
@@ -76,6 +88,62 @@ ShellRoot {
 
     function first(type) {
         return harness.all(type)[0] ?? null;
+    }
+
+    function findNamed(item, objName, out) {
+        if (!item)
+            return out;
+        for (const child of item.children) {
+            if (child.objectName === objName)
+                out.push(child);
+            harness.findNamed(child, objName, out);
+        }
+        return out;
+    }
+
+    function firstNamed(item, objName) {
+        return harness.findNamed(item, objName, [])[0] ?? null;
+    }
+
+    // By the name the fixture wrote, never by index: the service sorts with
+    // localeCompare, so which row an Arabic name lands on is the collation's
+    // business and not something this harness may assume.
+    function contactRowFor(list, displayName) {
+        if (!list)
+            return null;
+        for (let i = 0; i < list.count; i++) {
+            const row = list.itemAtIndex(i);
+            if (row && String(row.modelData?.displayName ?? "") === displayName)
+                return row;
+        }
+        return null;
+    }
+
+    // Everything about the row defect is a comparison between the card's own
+    // box and the boxes of the three things it is supposed to contain.
+    function scoreRow(tag, row) {
+        const pad = row.rowPadding;
+        const headerBox = harness.boxIn(harness.firstNamed(row, "contactHeader"), row);
+        const avatarBox = harness.boxIn(harness.firstNamed(row, "contactAvatar"), row);
+        const identityBox = harness.boxIn(harness.firstNamed(row, "contactIdentity"), row);
+        console.log(`[PhoneTabLayout] ${tag} card h=${row.height} pad=${pad}`
+                    + ` header ${headerBox.top}-${headerBox.bottom}`
+                    + ` avatar ${avatarBox.top}-${avatarBox.bottom}`
+                    + ` identity ${identityBox.top}-${identityBox.bottom}`);
+        harness.check(`${tag}: the name and the number stay inside the card, got`
+                      + ` ${identityBox.top}-${identityBox.bottom} of 0-${row.height}`,
+                      identityBox.top >= -0.5 && identityBox.bottom <= row.height + 0.5);
+        harness.check(`${tag}: the avatar's bottom edge clears the card's by a real gap,`
+                      + ` got ${row.height - avatarBox.bottom} against`
+                      + ` ${harness.minAvatarGap}`,
+                      row.height - avatarBox.bottom >= harness.minAvatarGap);
+        harness.check(`${tag}: ...and its top edge does too, got ${avatarBox.top}`
+                      + ` against ${harness.minAvatarGap}`,
+                      avatarBox.top >= harness.minAvatarGap);
+        harness.check(`${tag}: the card is its content plus its own padding and nothing`
+                      + ` else, got ${row.height} against ${headerBox.bottom + pad}`,
+                      Math.abs(row.height - (headerBox.bottom + pad)) <= 1
+                      && Math.abs(headerBox.top - pad) <= 1);
     }
 
     // Where an item is DRAWN, in another item's coordinates. Everything about
@@ -241,6 +309,76 @@ ShellRoot {
                           + ` of ${page.height}`,
                           Math.abs(listBox.bottom - page.height) <= 1);
         },
+
+        // ---- a contact row fits its content, in either script ------------
+        // The reported defect: an Arabic name is taller than a Latin one at
+        // the same pixelSize, and a card sized from a constant fits one and
+        // not the other. Both scripts are on screen at once, because "the
+        // card is tall enough" is satisfied by a card that is tall enough for
+        // everything.
+        () => {
+            const page = harness.first("PhoneContactsPage");
+            const list = harness.findAll(page, "StyledListView", [])[0] ?? null;
+            const latin = harness.contactRowFor(list, harness.latinName);
+            const arabic = harness.contactRowFor(list, harness.arabicName);
+            harness.check(`both scripts have a row to measure, latin=${latin !== null}`
+                          + ` arabic=${arabic !== null} of ${list?.count} rows`,
+                          latin !== null && arabic !== null);
+            if (latin === null || arabic === null)
+                return;
+            harness.scoreRow("latin", latin);
+            harness.scoreRow("arabic", arabic);
+            // The half a per-row check cannot see: two cards that both fit
+            // because both were made generously tall are still a constant.
+            harness.check(`the card's height follows the script rather than a constant,`
+                          + ` latin ${latin.height} against arabic ${arabic.height}`,
+                          arabic.height > latin.height);
+            harness.arabicCollapsedHeight = arabic.height;
+            harness.arabicId = String(arabic.modelData.id);
+        },
+
+        // ---- ...and so does the stack it grows when it is expanded --------
+        () => {
+            harness.first("PhoneContactsPage").expandedId = harness.arabicId;
+        },
+        () => {},
+        () => {
+            const page = harness.first("PhoneContactsPage");
+            const list = harness.findAll(page, "StyledListView", [])[0] ?? null;
+            const arabic = harness.contactRowFor(list, harness.arabicName);
+            const details = harness.firstNamed(arabic, "contactDetails");
+            const detailsBox = harness.boxIn(details, arabic);
+            console.log(`[PhoneTabLayout] arabic expanded card h=${arabic?.height}`
+                        + ` details ${detailsBox.top}-${detailsBox.bottom}`
+                        + ` rows=${details?.children.length}`);
+            harness.check(`expanding the Arabic contact grows its card, got`
+                          + ` ${arabic?.height} against ${harness.arabicCollapsedHeight}`,
+                          arabic !== null && arabic.height > harness.arabicCollapsedHeight);
+            harness.check(`the number and address rows stay inside the card, got`
+                          + ` ${detailsBox.top}-${detailsBox.bottom} of 0-${arabic?.height}`,
+                          details !== null && detailsBox.top >= -0.5
+                          && detailsBox.bottom <= arabic.height + 0.5);
+            // Per row as well as per column: a child overflowing its own
+            // column still reports a column that fits.
+            let escaped = 0;
+            let drawn = 0;
+            for (const child of (details?.children ?? [])) {
+                if (!child.visible || child.height <= 0)
+                    continue;
+                drawn++;
+                const box = harness.boxIn(child, arabic);
+                if (box.top < -0.5 || box.bottom > arabic.height + 0.5)
+                    escaped++;
+            }
+            harness.check(`...and so does every one of the ${drawn} rows in it,`
+                          + ` ${escaped} escaped`,
+                          drawn > 0 && escaped === 0);
+        },
+        () => {
+            harness.first("PhoneContactsPage").expandedId = "";
+        },
+        () => {},
+
         () => loader.item.popSubPage(),
         () => {},
 

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneContactsPage.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneContactsPage.qml
@@ -188,7 +188,22 @@ PhoneSubPage {
                             // thing being measured.
                             objectName: "contactHeader"
                             Layout.fillWidth: true
-                            Layout.preferredHeight: Appearance.font.pixelSize.huge * 2
+                            // No stated height, and the padding said out
+                            // loud. A Control sizes itself from its content
+                            // item, and what this row holds is a different
+                            // height in every script: measured in a real
+                            // window, the name-and-number column is 34px tall
+                            // for a Latin name and 47 for an Arabic one at
+                            // the same pixelSize, because the shell's font
+                            // carries no Arabic and the fallback sets taller.
+                            // `Layout.preferredHeight: huge * 2` therefore
+                            // fitted one script - the avatar ended 6px above
+                            // the card's own edge in Latin and 1px in Arabic,
+                            // and the NUMBER 3px below it, outside the card.
+                            // An aligned layout child answers a cell that is
+                            // too small by overflowing it, not by shrinking,
+                            // so nothing errors and nothing is logged.
+                            verticalPadding: Appearance.spacing.space75
                             buttonRadius: Appearance.rounding.small
                             colBackground: "transparent"
                             colBackgroundHover: Appearance.colors.colLayer3Hover

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneContactsPage.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneContactsPage.qml
@@ -149,8 +149,17 @@ PhoneSubPage {
                     readonly property bool favourite: PhoneContacts.isFavorite(contactRow.modelData.id, PhoneContacts.favorites)
                     readonly property var phones: contactRow.modelData.phones ?? []
 
+                    // The card's padding, spelled ONCE. It used to be two
+                    // numbers - `space50` on the column's anchors and
+                    // `space100` added to the height - which agree only while
+                    // one happens to be exactly twice the other, so changing
+                    // either leaves the card a different height from what is
+                    // in it. Same coupling `WindowDialog.contentPadding`
+                    // removed, one widget down.
+                    readonly property real rowPadding: Appearance.spacing.space50
+
                     width: contactList.width
-                    implicitHeight: rowColumn.implicitHeight + Appearance.spacing.space100
+                    implicitHeight: rowColumn.implicitHeight + contactRow.rowPadding * 2
                     height: implicitHeight
                     radius: Appearance.rounding.normal
                     color: contactRow.expanded ? Appearance.colors.colLayer3 : Appearance.colors.colLayer2
@@ -168,11 +177,16 @@ PhoneSubPage {
                             left: parent.left
                             right: parent.right
                             top: parent.top
-                            margins: Appearance.spacing.space50
+                            margins: contactRow.rowPadding
                         }
                         spacing: Appearance.spacing.space50
 
                         RippleButton {
+                            // Named so a runtime harness can find the three
+                            // boxes this card is supposed to contain by name,
+                            // rather than by walking a tree whose shape is the
+                            // thing being measured.
+                            objectName: "contactHeader"
                             Layout.fillWidth: true
                             Layout.preferredHeight: Appearance.font.pixelSize.huge * 2
                             buttonRadius: Appearance.rounding.small
@@ -186,6 +200,7 @@ PhoneSubPage {
 
                                 Rectangle {
                                     id: avatar
+                                    objectName: "contactAvatar"
                                     Layout.alignment: Qt.AlignVCenter
                                     Layout.preferredWidth: Appearance.font.pixelSize.huge + Appearance.spacing.space200
                                     Layout.preferredHeight: avatar.Layout.preferredWidth
@@ -227,6 +242,7 @@ PhoneSubPage {
                                 }
 
                                 ColumnLayout {
+                                    objectName: "contactIdentity"
                                     Layout.fillWidth: true
                                     Layout.alignment: Qt.AlignVCenter
                                     spacing: 0
@@ -300,6 +316,7 @@ PhoneSubPage {
                         }
 
                         ColumnLayout {
+                            objectName: "contactDetails"
                             Layout.fillWidth: true
                             Layout.leftMargin: Appearance.spacing.space100
                             Layout.rightMargin: Appearance.spacing.space100

--- a/dots/.config/quickshell/imi/tests/test_phone_tab_layout_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_tab_layout_runtime.py
@@ -18,6 +18,13 @@ every other check in this suite:
   happens to be empty rather than full.
 - an app icon that is never drawn, and one whose file failed to load, are the
   same source. Only `Image.status` tells them apart.
+- a contact card sized from a constant fits one script. Arabic sets taller
+  than Latin at the same `pixelSize`, so `Layout.preferredHeight: huge * 2` on
+  the row's header drew the avatar flush on the card's bottom edge for a Latin
+  name and pushed an Arabic contact's avatar and number out through the bottom
+  of the card. An aligned layout child keeps its preferred size when the cell
+  is too small - it overflows rather than shrinking - so nothing errors and
+  nothing is logged. The fixture therefore carries both scripts.
 
 The fake `busctl` serves one paired, reachable phone and two mirrored
 notifications: leaf 70 carries an `iconPath` (a PNG this test writes, the way
@@ -53,7 +60,37 @@ PHONE_ADDRESS = "192.168.100.179"
 # A literal, never read back out of the harness's own output: a step list
 # that shrinks must redden here instead of reporting `failures: 0` for a
 # shorter run.
-EXPECTED_CHECKS = 21
+EXPECTED_CHECKS = 34
+
+# The two names the row-geometry steps measure, handed to the harness in the
+# environment so the fixture is the only place either is spelled. The Arabic
+# one is the maintainer's own screenshot, with the number it carried.
+LATIN_NAME = "Alice Rivers"
+ARABIC_NAME = "\u0627\u0628\u0648 \u0631\u0648\u0641\u0627\u0646 \u0627\u0644\u0645\u062d\u0644\u0645\u064a"
+
+# The Arabic face is the whole measurement, and this test redirects
+# XDG_CONFIG_HOME - which takes the developer's own ~/.config/fontconfig with
+# it. Measured: with the redirect and no replacement, an Arabic string in
+# "Google Sans Flex" falls back to DejaVu Sans and sets 19px, the same as the
+# Latin one, so the row that fits one script fits both and the harness reports
+# a defect it cannot see. This is the shape of the shell's own fontconfig, so
+# the harness measures the stack the user is looking at rather than whatever
+# the machine happens to sort to.
+FONTS_CONF = """<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "urn:fontconfig:fonts.dtd">
+<fontconfig>
+  <match target="pattern">
+    <test compare="eq" name="family">
+      <string>sans-serif</string>
+    </test>
+    <edit name="family" mode="prepend" binding="strong">
+      <string>Noto Sans</string>
+      <string>Noto Sans Arabic</string>
+    </edit>
+  </match>
+</fontconfig>
+"""
+ARABIC_FACE = "Noto Sans Arabic"
 
 RECORD = """#!/usr/bin/env bash
 printf '%s %s\\n' "$(date +%s.%N)" "$*" >> "$PHONE_EXEC_LOG"
@@ -97,15 +134,17 @@ esac
 exit 0
 """
 
-# Three cards shaped after what Android's exporter writes: two named contacts
-# and one that is nothing but a number, so `hideUnnamed` has something to
-# hide and the list still has rows.
+# Four cards shaped after what Android's exporter writes: three named
+# contacts and one that is nothing but a number, so `hideUnnamed` has
+# something to hide and the list still has rows. One of the three is Arabic,
+# because the row's height is a function of the script and a fixture in one
+# script cannot say so.
 VCARDS = {
     "alice.vcf": (
         "BEGIN:VCARD\n"
         "VERSION:3.0\n"
         "UID:alice-uid-1\n"
-        "FN:Alice Rivers\n"
+        f"FN:{LATIN_NAME}\n"
         "N:Rivers;Alice;;;\n"
         "TEL;TYPE=CELL,PREF:+1 (555) 010-0001\n"
         "EMAIL;TYPE=HOME:alice@example.com\n"
@@ -118,6 +157,16 @@ VCARDS = {
         "FN:Bob Stone\n"
         "N:Stone;Bob;;;\n"
         "TEL;TYPE=HOME:555 010 0002\n"
+        "END:VCARD\n"
+    ),
+    "rufan.vcf": (
+        "BEGIN:VCARD\n"
+        "VERSION:3.0\n"
+        "UID:rufan-uid-1\n"
+        f"FN:{ARABIC_NAME}\n"
+        f"N:;{ARABIC_NAME};;;\n"
+        "TEL;TYPE=CELL,PREF:+201016000286\n"
+        "EMAIL;TYPE=WORK:rufan@example.com\n"
         "END:VCARD\n"
     ),
     "nameless.vcf": (
@@ -159,9 +208,26 @@ def _runtime_available():
     return all(shutil.which(name) for name in ("qs", "weston", "dbus-run-session"))
 
 
+def _arabic_face_available():
+    """Whether the face the row-geometry steps measure against is installed.
+
+    Without it the Arabic name sets at the Latin face's height and the two
+    cards come out the same, which reads as "the row is fine" rather than as
+    "the measurement never happened" - so it is a skip with a reason, not a
+    red check.
+    """
+    if not shutil.which("fc-list"):
+        return False
+    probe = subprocess.run(["fc-list", "--format=%{family}\n"],
+                           capture_output=True, text=True)
+    return ARABIC_FACE in probe.stdout
+
+
 @unittest.skipUnless(_runtime_available(), "needs qs, weston and dbus-run-session on PATH")
 class PhoneTabLayoutRuntimeTest(unittest.TestCase):
     def setUp(self):
+        if not _arabic_face_available():
+            self.skipTest(f"needs {ARABIC_FACE} to measure an Arabic row")
         self.home = Path(tempfile.mkdtemp(prefix="imi-phone-layout-"))
         self.addCleanup(shutil.rmtree, self.home, ignore_errors=True)
         self.exec_log = self.home / "exec.log"
@@ -186,7 +252,11 @@ class PhoneTabLayoutRuntimeTest(unittest.TestCase):
         cards = self.home / "data" / "kpeoplevcard" / f"kdeconnect-{PHONE_ID}"
         cards.mkdir(parents=True)
         for name, body in VCARDS.items():
-            (cards / name).write_text(body)
+            (cards / name).write_text(body, encoding="utf-8")
+
+        fontconfig = self.home / "config" / "fontconfig"
+        fontconfig.mkdir(parents=True)
+        (fontconfig / "fonts.conf").write_text(FONTS_CONF)
 
         shell_config = self.home / "config" / "immaterial-impulse"
         shell_config.mkdir(parents=True)
@@ -230,6 +300,8 @@ class PhoneTabLayoutRuntimeTest(unittest.TestCase):
         env["PHONE_EXEC_LOG"] = str(self.exec_log)
         env["PHONE_ID"] = PHONE_ID
         env["PHONE_ICON_PATH"] = str(self.icon_path)
+        env["PHONE_CONTACT_LATIN"] = LATIN_NAME
+        env["PHONE_CONTACT_ARABIC"] = ARABIC_NAME
 
         # dbus-run-session, not the inherited bus: the fake busctl is the only
         # daemon this harness may see.


### PR DESCRIPTION
The Phone tab's Contacts list drew a contact whose name is Arabic with its number and its avatar outside the card, and drew every Latin row's avatar against the card's bottom edge.

## What it was

The row's header stated `Layout.preferredHeight: Appearance.font.pixelSize.huge * 2` (44), and a `Control` sizes its content item to the **padded** rect, so the row's contents were handed 36px. What the row holds is not a constant: measured in a real window with both scripts on screen at once, the name-and-number column is 34px tall for a Latin name and 47 for an Arabic one at the same `pixelSize`, because Google Sans Flex carries no Arabic and the fallback face sets 32px against the Latin face's 19.

An aligned layout child answers a cell that is too small by **overflowing** it, not by shrinking, so nothing errors and nothing is logged.

Measured before, in card coordinates: the Latin card is 52 tall with its 38px avatar at 8-46, six pixels short of the card's own edge and under the shell's 8px base unit — that is the "flush against the bottom border" in the report. The Arabic card is the same 52, with the avatar at 13-51 and the **number** at 8-55, three pixels below the card that is supposed to contain it.

After: 58 and 67, each avatar 10 and 14 pixels clear of the card's bottom, every child inside the card's box.

## What changed

- The header states no height at all — a `Control` derives one from its content — and says its vertical padding out loud in `Appearance.spacing.*` rather than inheriting whatever the Basic style's `padding` happens to be.
- The card's own padding is one `rowPadding` instead of `space50` on the content column's anchors plus `space100` added to the height: two spellings that agree only while one is twice the other, which is `WindowDialog.contentPadding`'s coupling one widget down. No behaviour change on its own.
- `PhoneTabLayoutRuntimeTest` gains an Arabic contact beside the Latin one and measures, per card: the identity column against the card's box, the avatar's bottom gap, and that the card is its content plus its own padding and nothing else — plus the check a per-row assertion cannot make, that the two cards **differ**, since two rows that both fit because both were made tall are still a constant. The expanded number/address rows are checked too; they were already content-sized and measure clean in both scripts.

The harness had to pin its own font, and that is worth knowing: redirecting `XDG_CONFIG_HOME` takes the developer's `~/.config/fontconfig` with it, and without a replacement the Arabic string sorts to DejaVu Sans, sets at the Latin height, and the harness reports the defect cured because the measurement never happened. It writes a `fonts.conf` of its own and skips with a reason when Noto Sans Arabic is absent.

4 of 34 checks fail before the fix; 34/34 after.

## Not in this PR

The same `huge * 2` header idiom is in `PhoneMicPage.qml` and `PhoneWebcamPage.qml`, which this branch does not own.

And RTL is a layout question beyond height. Measured: an Arabic name's `effectiveHorizontalAlignment` is `AlignRight` (Qt follows the string's direction) while the number under it is `AlignLeft`, so one contact's two lines sit on opposite edges of the same column; `elide: Text.ElideRight` on an RTL string truncates the **beginning** of the name; and the avatar stays on the left of a right-to-left name. Mirroring, per-contact direction and an elide side chosen from the string belong in their own change.

Docs: updated AGENT.md §Dynamic/data-driven QML gotchas
Changelog: updated
