### PR TITLE
fix(phone): the webcam and microphone pages take the panel's width

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -674,7 +674,9 @@ services/                  Singletons wrapping external state/processes - one pe
                               tests/test_phone_tab_runtime.py, and what its sub-pages
                               DRAW - the lists' and the empty states' geometry, and a
                               notification card's app icon - by
-                              tests/test_phone_tab_layout_runtime.py
+                              tests/test_phone_tab_layout_runtime.py, and how wide the
+                              webcam and microphone pages ASK to be by
+                              tests/test_phone_subpage_width_runtime.py
   PhoneNotifications.qml       The paired phone's notifications, mirrored off KDE Connect on
                               the same busctl transport through a serialized queue of its
                               own. No monitor of its own: the four notification signals sit
@@ -1978,6 +1980,35 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   2b921d8da ("refactor(phone): a contact card's padding gets a name of its own"),
   d9a9162ec ("test(phone): drive a contact card's box against what it holds, in two scripts"),
   07b819f07 ("fix(phone): a contact card is sized by what it holds, not by a constant").
+- **The third one in that family is a WIDTH, and it comes from `ContentPage.baseWidth` being 600
+  because the settings window is.** `ContentPage` sizes its content column
+  `Math.max(baseWidth, implicitWidth)` and anchors it to the flickable's horizontal CENTRE, which is
+  right in that window - the leftover is symmetric margin - and is an overflow on any surface
+  narrower than 600. The Phone tab's Webcam and Microphone pages are the only `ContentPage`s outside
+  the settings window, and the panel hands a sub-page 440: measured in a real window, a column of
+  600 drawn from **-80 to 520**, so the whole page hung off both edges and every row was clipped at
+  the panel's left edge - the error banner read "m did not start - is the DroidCam app open on the
+  phone?", the section headers "ra" and "ra settings" - while the page rendered perfectly, logged
+  nothing and left the suite green. A `ContentPage` on a panel states `forceWidth: true` and a
+  `baseWidth` bound to the width it is really given.
+  **The other half of that `Math.max` is the banner beside it**: a `NoticeBox` sizes itself from a
+  `StyledText` that wraps, and a wrapping `Text` still reports its string's UNWRAPPED width as its
+  implicit width - so the banner carrying `PhoneCamera.lastError` asked for **495** in a 440px page,
+  and a page-widening error string was one sentence away. The cap is a `Layout.maximumWidth` at the
+  call site, which is what a `QQuickLayout` clamps a child's preferred width to; it does not belong
+  in `NoticeBox`, which is shared with the settings pages, where a banner asking for its own
+  string's width is the right answer.
+  Nothing static can see any of this, and `qmltestrunner` builds neither a laid-out box nor a
+  `ContentPage`, so `PhoneSubPageWidthRuntimeTest.qml` reads the two numbers off the real pages
+  opened by the real sub-page loader - where each row is DRAWN, and what each row ASKS for
+  (`Math.min(implicitWidth, Layout.maximumWidth)`) - at two panel widths, because a column pinned to
+  a literal 440 passes every check at one. Its stubs are the other half of what it is for: `PhoneMic`
+  runs `pactl get-default-sink` from its own `Component.onCompleted` and can go on to
+  `set-default-sink`, which is why `PhoneTabLayoutRuntimeTest.qml` does not drive these two pages -
+  every tool `PhoneDeps` probes is a stub first on PATH there, `pactl` included.
+  94c92757a ("test(phone): drive how wide the webcam and microphone pages ask to be"),
+  01b9871b0 ("fix(phone): the webcam and microphone pages take the panel's width"),
+  1edb61495 ("fix(phone): a long service error wraps in its banner instead of widening the page").
 - **A keyboard is a LATTICE, not a stack of rows, and a `GridLayout` does not
   hand out equal columns on its own.** The numpad's `+` and its Enter are one
   key two rows tall, which a `RowLayout` cannot say — so each of them shipped

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,14 @@ own repo; the installer pins which revision it builds.
   Arabic sets taller than Latin at the same text size. Every row now takes the
   height its own contents need, in any script, with the same breathing room
   above and below.
+- **The Phone tab's Phone Webcam and Phone Microphone pages fit the panel
+  again.** Both pages were drawn wider than the sidebar and shifted left, so
+  every label was cut off at the panel's left edge — the error banner read
+  "m did not start - is the DroidCam app open on the phone?", the section
+  headers read "ra" and "ra settings", and the resolution row ran off the
+  right edge. Both pages now take the width the panel gives them, and a long
+  message from the camera or the microphone wraps inside its banner instead
+  of stretching the page around it.
 - **The Phone tab's Contacts and Android Apps pages draw their contents
   again.** Contacts showed its count — "147 of 150 contacts" — and then an
   empty page, and Android Apps drew its big empty-state icon on top of its

--- a/dots/.config/quickshell/imi/PhoneSubPageWidthRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/PhoneSubPageWidthRuntimeTest.qml
@@ -1,0 +1,298 @@
+import QtQuick
+import QtQuick.Layouts
+import QtTest
+import Quickshell
+import qs
+import qs.services
+import qs.modules.common
+import qs.modules.common.widgets
+import qs.modules.imi.phone
+import qs.modules.imi.sidebarLeft.phone
+
+/**
+ * How wide the Phone tab's Webcam and Microphone sub-pages ASK to be, and
+ * where their rows are actually drawn, measured in a real window.
+ *
+ * The defect this exists for is invisible to every static check and to
+ * `qmltestrunner`: both pages are a `ContentPage`, whose content column is
+ * `Math.max(baseWidth, implicitWidth)` wide and centred in the flickable.
+ * `baseWidth` defaults to 600 - a settings-window number - so inside a 460px
+ * sidebar the column hung ~80px off each side and every row was clipped at
+ * the panel's left edge while the page rendered perfectly and logged nothing.
+ * The second half is the same failure from the other end: a `NoticeBox`
+ * reports its string's UNWRAPPED width as its implicit width, so one long
+ * service error (`PhoneCamera.lastError`) widened the whole page past even
+ * that 600.
+ *
+ * So every check here is one of two numbers read off an item that is on
+ * screen: where a row is drawn against the page's own box, and what a row
+ * ASKS for - its implicit width, clamped by whatever `Layout.maximumWidth`
+ * it declares, because that pair is exactly what a QQuickLayout resolves a
+ * child's preferred width to.
+ *
+ * The pages are built inside the REAL tab, by the real `subPageLoader`, so
+ * the width being measured is the width the panel really hands them.
+ *
+ * Two properties keep this harness off the maintainer's machine. Every tool
+ * `PhoneDeps` probes is a stub first on PATH, so `PhoneMic` - which runs
+ * `pactl get-default-sink` from its own `Component.onCompleted` and can go
+ * on to `set-default-sink` - never reaches the session's audio. And the
+ * daemon is a fake `busctl`, under a bus of the driver's own.
+ *
+ * Driven by tests/test_phone_subpage_width_runtime.py, which brings the
+ * weston, the session bus and those stubs.
+ *
+ *   PATH=<dir with the stubs>:$PATH qs -p PhoneSubPageWidthRuntimeTest.qml
+ */
+ShellRoot {
+    id: harness
+
+    property int failures: 0
+    property int checksRun: 0
+    property int elapsed: 0
+
+    // The maintainer's own screenshot: this is the string that was drawn as
+    // "m did not start - is the DroidCam app open on the phone?", its start
+    // hanging off the left edge of the panel.
+    readonly property string longError: "DroidCam did not start - is the DroidCam app open on the phone?"
+
+    // The panel's real width (Appearance.sizes.sidebarWidth), and the width
+    // it takes when the sidebar is extended. The second one is not decoration:
+    // a page pinned to a literal 440 passes every check at the first width.
+    property real viewportWidth: 460
+    property real narrowWidth: 0
+
+    function check(label, ok) {
+        harness.checksRun++;
+        console.log(`[PhoneSubPageWidth] ${label}: ${ok ? "ok" : "FAIL"}`);
+        if (!ok)
+            harness.failures++;
+    }
+
+    function typeName(obj) {
+        return `${obj}`.split("(")[0].split("_QML")[0].trim();
+    }
+
+    function findAll(item, type, out) {
+        if (!item)
+            return out;
+        for (const child of item.children) {
+            if (harness.typeName(child) === type)
+                out.push(child);
+            harness.findAll(child, type, out);
+        }
+        return out;
+    }
+
+    function first(type) {
+        return harness.findAll(loader.item, type, [])[0] ?? null;
+    }
+
+    function boxIn(item, reference) {
+        const origin = item.mapToItem(reference, 0, 0);
+        return { left: origin.x, right: origin.x + item.width };
+    }
+
+    // What a row asks its column for. `Layout.maximumWidth` defaults to
+    // infinity, so this is the implicit width for a row that declares none -
+    // and the clamped value for one that does, which is what the engine
+    // resolves the preferred width to.
+    function askedWidth(row) {
+        const cap = row.Layout.maximumWidth;
+        return (cap !== undefined && cap > 0) ? Math.min(row.implicitWidth, cap) : row.implicitWidth;
+    }
+
+    // The rows a page draws: the direct children of the ContentPage's own
+    // content column, which is where every NoticeBox and ContentSection of
+    // these two pages lands.
+    function pageRows(page) {
+        const flickable = harness.findAll(page, "ContentPage", [])[0] ?? null;
+        if (flickable === null)
+            return null;
+        const column = flickable.contentItem.children
+            .find(child => harness.typeName(child) === "QQuickColumnLayout") ?? null;
+        if (column === null)
+            return null;
+        return {
+            flickable: flickable,
+            column: column,
+            rows: [...column.children].filter(child => child.visible)
+        };
+    }
+
+    function measure(type, label) {
+        const page = harness.first(type);
+        const found = page === null ? null : harness.pageRows(page);
+        if (found === null) {
+            harness.check(`${label}: the page and its content column are on screen`, false);
+            return null;
+        }
+
+        const widest = found.rows
+            .map(row => ({ name: harness.typeName(row), asked: harness.askedWidth(row),
+                           implicit: row.implicitWidth, drawn: harness.boxIn(row, page) }))
+            .sort((a, b) => b.asked - a.asked);
+        console.log(`[PhoneSubPageWidth] ${label}: page ${page.width} flickable ${found.flickable.width}`
+                    + ` column ${found.column.width} (implicit ${found.column.implicitWidth})`);
+        for (const row of widest)
+            console.log(`[PhoneSubPageWidth]   ${row.name} asked ${row.asked}`
+                        + ` implicit ${row.implicit} drawn ${row.drawn.left}-${row.drawn.right}`);
+
+        // The column is what centres, so it is where the overflow starts.
+        harness.check(`${label}: the content column fits the page, got ${found.column.width}`
+                      + ` in ${found.flickable.width}`,
+                      found.column.width <= found.flickable.width + 1);
+
+        const outside = widest.filter(row => row.drawn.left < -1 || row.drawn.right > page.width + 1);
+        harness.check(`${label}: every row is drawn inside the page, ${outside.length} are not`
+                      + `${outside.length > 0 ? ` (${outside[0].name} at ${outside[0].drawn.left}`
+                        + `-${outside[0].drawn.right} of ${page.width})` : ""}`,
+                      outside.length === 0 && widest.length > 0);
+
+        const overWide = widest.filter(row => row.asked > page.width + 1);
+        harness.check(`${label}: no row asks for more width than the page has,`
+                      + ` widest is ${widest[0]?.name} at ${widest[0]?.asked} of ${page.width}`,
+                      overWide.length === 0);
+        return found;
+    }
+
+    FloatingWindow {
+        id: window
+        visible: true
+        implicitWidth: 760
+        implicitHeight: 900
+        color: "black"
+
+        TestCase {
+            id: driver
+            when: false
+            name: "PhoneSubPageWidthDriver"
+        }
+
+        // The host is sized by the harness rather than by the window, because
+        // a FloatingWindow cannot be resized under headless weston - the same
+        // constraint PhoneTabLayoutRuntimeTest.qml records for its height.
+        Loader {
+            id: loader
+            width: harness.viewportWidth
+            height: parent.height
+            active: false
+            sourceComponent: Phone {}
+        }
+    }
+
+    Component.onCompleted: {
+        // A singleton is constructed on first use; this read starts the
+        // presence probes and the daemon sweep.
+        console.log(`[PhoneSubPageWidth] services constructed, installed=${PhoneConnect.installed}`);
+    }
+
+    Timer {
+        id: waitForReady
+        interval: 250
+        repeat: true
+        running: true
+        onTriggered: {
+            harness.elapsed += waitForReady.interval;
+            const ready = Config.ready && PhoneConnect.installed
+                && PhoneConnect.devices.length === 1 && PhoneDeps.ready;
+            if (!ready) {
+                if (harness.elapsed >= 40000) {
+                    harness.check(`the fake daemon answered and the probes settled`
+                                  + ` (devices ${PhoneConnect.devices.length},`
+                                  + ` deps ready ${PhoneDeps.ready})`, false);
+                    harness.finish();
+                }
+                return;
+            }
+            waitForReady.running = false;
+            steps.running = true;
+        }
+    }
+
+    function finish() {
+        console.log(`[PhoneSubPageWidth] checks: ${harness.checksRun} failures: ${harness.failures}`);
+        Qt.exit(harness.failures === 0 ? 0 : 1);
+    }
+
+    property var stepList: [
+        () => {
+            loader.active = true;
+        },
+        () => {},
+
+        // ---- the webcam page, as it opens ---------------------------------
+        () => loader.item.openSubPage("webcam"),
+        () => {},
+        () => {
+            harness.narrowWidth = harness.measure("PhoneWebcamPage", "webcam")?.flickable.width ?? 0;
+        },
+
+        // ---- ...and with the service reporting a failure -------------------
+        () => {
+            PhoneCamera.lastError = harness.longError;
+        },
+        () => {},
+        () => {
+            const page = harness.first("PhoneWebcamPage");
+            const banner = harness.findAll(page, "NoticeBox", []).find(box => box.visible
+                && String(box.text).indexOf("DroidCam did not start") >= 0) ?? null;
+            // The control: a pass measured with the banner absent measures the
+            // page without the row it exists to measure, and says nothing.
+            harness.check("the error banner is on screen to be measured", banner !== null);
+            harness.measure("PhoneWebcamPage", "webcam with a long service error");
+        },
+
+        // ---- ...at the width an extended sidebar gives it ------------------
+        () => {
+            harness.viewportWidth = 740;
+        },
+        () => {},
+        () => {
+            const found = harness.measure("PhoneWebcamPage", "webcam in a wider panel");
+            harness.check(`the page really did get wider, got ${found?.flickable.width}`
+                          + ` against ${harness.narrowWidth}`,
+                          found !== null && found.flickable.width > harness.narrowWidth + 100);
+            // A column that follows the panel, rather than one that happens to
+            // fit at both widths because it is a constant under both.
+            harness.check(`...and the column followed it, got ${found?.column.width}`,
+                          found !== null && found.column.width > harness.narrowWidth);
+        },
+        () => {
+            harness.viewportWidth = 460;
+            loader.item.popSubPage();
+        },
+        () => {},
+
+        // ---- the microphone page, at rest and reporting a failure ---------
+        () => loader.item.openSubPage("mic"),
+        () => {},
+        () => harness.measure("PhoneMicPage", "microphone"),
+        () => {
+            PhoneMic.lastError = harness.longError;
+        },
+        () => {},
+        () => {
+            const page = harness.first("PhoneMicPage");
+            const banner = harness.findAll(page, "NoticeBox", []).find(box => box.visible
+                && String(box.text).indexOf("DroidCam did not start") >= 0) ?? null;
+            harness.check("the microphone's error banner is on screen to be measured",
+                          banner !== null);
+            harness.measure("PhoneMicPage", "microphone with a long service error");
+        },
+
+        () => harness.finish()
+    ]
+
+    property int stepIndex: 0
+    Timer {
+        id: steps
+        interval: 500
+        repeat: true
+        onTriggered: {
+            if (harness.stepIndex >= harness.stepList.length)
+                return;
+            harness.stepList[harness.stepIndex++]();
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneMicPage.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneMicPage.qml
@@ -54,8 +54,15 @@ PhoneSubPage {
         baseWidth: Math.max(0, page.width - Appearance.spacing.space200)
         bottomContentPadding: Appearance.spacing.space400
 
+        // A NoticeBox reports its string's UNWRAPPED width as its implicit
+        // width, so one long service error asks the column for more room than
+        // the panel has - 495px for a failed launch's own message in a 440px
+        // page, which is what `Math.max(baseWidth, implicitWidth)` above was
+        // widening on. Capped, the banner wraps inside itself instead of
+        // moving the page.
         NoticeBox {
             Layout.fillWidth: true
+            Layout.maximumWidth: page.baseWidth
             visible: !PhoneMic.available
             materialIcon: "download"
             text: Translation.tr("The phone microphone is not set up on this machine. %1 is missing.")
@@ -83,6 +90,7 @@ PhoneSubPage {
 
         NoticeBox {
             Layout.fillWidth: true
+            Layout.maximumWidth: page.baseWidth
             visible: PhoneMic.available && !root.deviceReachable
             materialIcon: "phonelink_off"
             text: Translation.tr("No phone is reachable. Pair one in KDE Connect and bring it onto the network.")
@@ -90,6 +98,7 @@ PhoneSubPage {
 
         NoticeBox {
             Layout.fillWidth: true
+            Layout.maximumWidth: page.baseWidth
             visible: PhoneMic.lastError.length > 0
             materialIcon: "error"
             text: PhoneMic.lastError

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneMicPage.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneMicPage.qml
@@ -38,9 +38,20 @@ PhoneSubPage {
     readonly property bool canStart: PhoneMic.available && root.deviceReachable
 
     ContentPage {
+        id: page
+
         Layout.fillWidth: true
         Layout.fillHeight: true
-        forceWidth: false
+        // ContentPage centres its content column at
+        // `Math.max(baseWidth, implicitWidth)`, and `baseWidth` defaults to
+        // 600 - the settings window's number. The panel hands this page 440,
+        // so the column was drawn from -80 to 520 and every row was clipped
+        // at the panel's left edge while the page rendered perfectly and
+        // logged nothing (measured in PhoneSubPageWidthRuntimeTest.qml). The
+        // column takes the width it is really given, less the lane the scroll
+        // bar overlays.
+        forceWidth: true
+        baseWidth: Math.max(0, page.width - Appearance.spacing.space200)
         bottomContentPadding: Appearance.spacing.space400
 
         NoticeBox {

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneWebcamPage.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneWebcamPage.qml
@@ -33,9 +33,20 @@ PhoneSubPage {
     readonly property bool canStart: PhoneCamera.available && root.deviceReachable
 
     ContentPage {
+        id: page
+
         Layout.fillWidth: true
         Layout.fillHeight: true
-        forceWidth: false
+        // ContentPage centres its content column at
+        // `Math.max(baseWidth, implicitWidth)`, and `baseWidth` defaults to
+        // 600 - the settings window's number. The panel hands this page 440,
+        // so the column was drawn from -80 to 520 and every row was clipped
+        // at the panel's left edge while the page rendered perfectly and
+        // logged nothing (measured in PhoneSubPageWidthRuntimeTest.qml). The
+        // column takes the width it is really given, less the lane the scroll
+        // bar overlays.
+        forceWidth: true
+        baseWidth: Math.max(0, page.width - Appearance.spacing.space200)
         bottomContentPadding: Appearance.spacing.space400
 
         NoticeBox {

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneWebcamPage.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneWebcamPage.qml
@@ -49,8 +49,15 @@ PhoneSubPage {
         baseWidth: Math.max(0, page.width - Appearance.spacing.space200)
         bottomContentPadding: Appearance.spacing.space400
 
+        // A NoticeBox reports its string's UNWRAPPED width as its implicit
+        // width, so one long service error asks the column for more room than
+        // the panel has - 495px for PhoneCamera's own "DroidCam did not start
+        // - is the DroidCam app open on the phone?" in a 440px page, which is
+        // what `Math.max(baseWidth, implicitWidth)` above was widening on.
+        // Capped, the banner wraps inside itself instead of moving the page.
         NoticeBox {
             Layout.fillWidth: true
+            Layout.maximumWidth: page.baseWidth
             visible: !PhoneCamera.available
             materialIcon: "download"
             text: Translation.tr("DroidCam is not set up on this machine. %1 is missing.")
@@ -78,6 +85,7 @@ PhoneSubPage {
 
         NoticeBox {
             Layout.fillWidth: true
+            Layout.maximumWidth: page.baseWidth
             visible: PhoneCamera.available && !root.deviceReachable
             materialIcon: "phonelink_off"
             text: Translation.tr("No phone is reachable. Pair one in KDE Connect and bring it onto the network.")
@@ -85,6 +93,7 @@ PhoneSubPage {
 
         NoticeBox {
             Layout.fillWidth: true
+            Layout.maximumWidth: page.baseWidth
             visible: PhoneCamera.lastError.length > 0
             materialIcon: "error"
             text: PhoneCamera.lastError

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -1848,6 +1848,18 @@ if ! python3 "$SCRIPT_DIR/test_phone_tab_layout_runtime.py"; then
     exit 1
 fi
 
+# How wide the Webcam and Microphone sub-pages ASK to be, and where their
+# rows are drawn, at the panel's own width. Both are a `ContentPage`, whose
+# content column is `Math.max(baseWidth, implicitWidth)` and centred, and
+# that baseWidth default is the settings window's 600 - so in a 440px page
+# the column hung 80px off each side and every label was clipped at the
+# panel's left edge, with nothing in any log and a green suite.
+echo "Running Phone sub-page width runtime tests..."
+if ! python3 "$SCRIPT_DIR/test_phone_subpage_width_runtime.py"; then
+    echo "Phone sub-page width runtime tests failed."
+    exit 1
+fi
+
 # The phone's notification mirror: the parser region synced with its double,
 # argv only, dismiss on the LEAF, the declared reply refetch delay, one
 # stream, the desktop dedupe gate at ingestion, and the cache key declared.

--- a/dots/.config/quickshell/imi/tests/test_phone_subpage_width_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_subpage_width_runtime.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""How wide the Phone tab's Webcam and Microphone sub-pages ask to be.
+
+`PhoneSubPageWidthRuntimeTest.qml` opens both pages inside the real tab, at
+the panel's real width, and reads back where every row is DRAWN and what
+every row ASKS for. It exists because the pages shipped overflowing
+horizontally and nothing could see it: both are a `ContentPage`, whose
+content column is `Math.max(baseWidth, implicitWidth)` wide and centred, and
+`baseWidth` defaults to the settings window's 600 - so in a 460px sidebar
+the column hung off both edges and every label was clipped at the panel's
+left edge. The page rendered, the suite stayed green, and `qmltestrunner`
+can build neither a laid-out box nor a `ContentPage`.
+
+The long service error (`PhoneCamera.lastError`, the maintainer's own
+"DroidCam did not start - is the DroidCam app open on the phone?") is the
+same defect from the other end: a `NoticeBox` reports its string's unwrapped
+width as its implicit width, so one banner could widen the page past even
+that 600.
+
+Two things keep this off the maintainer's machine, and the first one is why
+the existing layout harness deliberately does not drive these two pages:
+`PhoneMic` runs `pactl get-default-sink` from its own `Component.onCompleted`
+and can go on to `pactl set-default-sink`. Every tool `PhoneDeps` probes is
+therefore a stub first on PATH - `pactl` included - so the page comes up
+"available" without a single command reaching the session's audio. The
+daemon is a fake `busctl`, under a session bus of this test's own.
+
+Brings its own headless weston and its own session bus (`dbus-run-session`).
+Skips when weston, qs or dbus-run-session are missing, as in CI.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HARNESS = ROOT / "PhoneSubPageWidthRuntimeTest.qml"
+SOCKET = "wayland-imi-phone-width"
+
+PHONE_ID = "6131a746_571a_4176_a007_95625ff8e08e"
+PHONE_NAME = "Galaxy S23 Ultra"
+PHONE_ADDRESS = "192.168.100.179"
+
+# A literal, never read back out of the harness's own output: a step list
+# that shrinks must redden here instead of reporting `failures: 0` for a
+# shorter run.
+EXPECTED_CHECKS = 19
+
+BUSCTL = """\
+#!/usr/bin/env bash
+case "$*" in
+  *"org.freedesktop.DBus ListNames")
+    printf '{"type":"as","data":[[":1.5","org.freedesktop.DBus","org.kde.kdeconnect.daemon"]]}\\n'
+    ;;
+  *"org.kde.kdeconnect.daemon devices bb false false")
+    printf '{"type":"as","data":[["%(phone)s"]]}\\n'
+    ;;
+  *"/notifications org.kde.kdeconnect.device.notifications activeNotifications")
+    printf '{"type":"as","data":[[]]}\\n'
+    ;;
+  *"devices/%(phone)s/battery org.freedesktop.DBus.Properties GetAll s org.kde.kdeconnect.device.battery")
+    printf '{"type":"a{sv}","data":[{"charge":{"type":"i","data":85},"hasBattery":{"type":"b","data":true},"isCharging":{"type":"b","data":false}}]}\\n'
+    ;;
+  *"devices/%(phone)s/connectivity_report org.freedesktop.DBus.Properties GetAll s org.kde.kdeconnect.device.connectivity_report")
+    printf '{"type":"a{sv}","data":[{"cellularNetworkStrength":{"type":"i","data":4},"cellularNetworkType":{"type":"s","data":"LTE"},"iconName":{"type":"s","data":"network-mobile-100-lte"}}]}\\n'
+    ;;
+  *"devices/%(phone)s org.freedesktop.DBus.Properties GetAll s org.kde.kdeconnect.device")
+    printf '{"type":"a{sv}","data":[{"name":{"type":"s","data":"%(name)s"},"type":{"type":"s","data":"phone"},"isPaired":{"type":"b","data":true},"isReachable":{"type":"b","data":true},"isPairRequestedByPeer":{"type":"b","data":false},"pairState":{"type":"i","data":3},"reachableAddresses":{"type":"as","data":["%(address)s"]}}]}\\n'
+    ;;
+  *monitor*)
+    sleep 3600
+    ;;
+esac
+exit 0
+"""
+
+# The tools PhoneDeps probes. Every one of them is here so both pages report
+# "available" and draw their real rows - and `pactl` is here so that nothing
+# this test starts can reach the session's audio.
+STUBS = {
+    "pactl": 'case "$*" in\n'
+             '  "get-default-sink") echo "alsa_output.fake.stub" ;;\n'
+             '  "get-default-source") echo "alsa_input.fake.stub" ;;\n'
+             '  "list sink-inputs") : ;;\n'
+             'esac\nexit 0\n',
+    "scrcpy": 'echo "scrcpy 4.1 <https://github.com/Genymobile/scrcpy>"\nexit 0\n',
+    "adb": 'if [ "$1" = "devices" ]; then\n'
+           '  printf "List of devices attached\\nR5CT30FAKE\\tdevice\\n"\n'
+           'fi\nexit 0\n',
+    "droidcam-cli": "exit 0\n",
+    "v4l2-ctl": "exit 0\n",
+    "mpv": "exit 0\n",
+    "ffplay": "exit 0\n",
+    "vlc": "exit 0\n",
+    "kdialog": "exit 0\n",
+    "wl-paste": "exit 0\n",
+    # The loopback module, reported as loaded: the webcam page must come up
+    # with no "missing dependencies" banner whatever this machine has.
+    "lsmod": 'printf "Module Size Used by\\nv4l2loopback 40960 0\\n"\nexit 0\n',
+    "modinfo": "exit 0\n",
+}
+
+
+def _stop(proc):
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+
+
+def _runtime_available():
+    return all(shutil.which(name) for name in ("qs", "weston", "dbus-run-session"))
+
+
+@unittest.skipUnless(_runtime_available(), "needs qs, weston and dbus-run-session on PATH")
+class PhoneSubPageWidthRuntimeTest(unittest.TestCase):
+    def setUp(self):
+        self.home = Path(tempfile.mkdtemp(prefix="imi-phone-width-"))
+        self.addCleanup(shutil.rmtree, self.home, ignore_errors=True)
+
+        self.bin = self.home / "bin"
+        self.bin.mkdir(parents=True)
+        busctl = self.bin / "busctl"
+        busctl.write_text(BUSCTL % {
+            "phone": PHONE_ID, "name": PHONE_NAME, "address": PHONE_ADDRESS,
+        })
+        busctl.chmod(0o755)
+        for name, body in STUBS.items():
+            stub = self.bin / name
+            stub.write_text("#!/usr/bin/env bash\n" + body)
+            stub.chmod(0o755)
+
+        shell_config = self.home / "config" / "immaterial-impulse"
+        shell_config.mkdir(parents=True)
+        # The poll is ten minutes out: the startup sweep populates the model
+        # and nothing may re-sweep while the harness is measuring geometry.
+        (shell_config / "config.json").write_text(json.dumps({
+            "networking": {"phoneConnect": {"enable": True, "pollInterval": 600000}},
+            "phone": {"contacts": {"enabled": False}},
+        }, indent=2))
+
+    def test_neither_sub_page_asks_for_more_width_than_the_panel_has(self):
+        env = dict(os.environ)
+        # A runtime dir of the harness's own: everything this test starts talks
+        # to its own weston and can never map a surface on the user's display.
+        runtime = self.home / "runtime"
+        runtime.mkdir(mode=0o700)
+        env["XDG_RUNTIME_DIR"] = str(runtime)
+        env["WAYLAND_DISPLAY"] = SOCKET
+        env.pop("DISPLAY", None)
+        env.pop("HYPRLAND_INSTANCE_SIGNATURE", None)
+
+        weston = subprocess.Popen(
+            ["weston", "--backend=headless", "--renderer=pixman",
+             f"--socket={SOCKET}", "--width=900", "--height=1000"],
+            env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        self.addCleanup(_stop, weston)
+
+        socket_path = runtime / SOCKET
+        deadline = time.monotonic() + 15
+        while not socket_path.exists() and time.monotonic() < deadline:
+            time.sleep(0.2)
+        self.assertTrue(socket_path.exists(), "headless weston never came up")
+
+        env["LIBGL_ALWAYS_SOFTWARE"] = "1"
+        env["QT_QUICK_BACKEND"] = "software"
+        env["XDG_CONFIG_HOME"] = str(self.home / "config")
+        env["XDG_STATE_HOME"] = str(self.home / "state")
+        env["XDG_CACHE_HOME"] = str(self.home / "cache")
+        env["XDG_DATA_HOME"] = str(self.home / "data")
+        env["PATH"] = f"{self.bin}{os.pathsep}{env['PATH']}"
+
+        # dbus-run-session, not the inherited bus: the fake busctl is the only
+        # daemon this harness may see.
+        proc = subprocess.run(
+            ["dbus-run-session", "--", "qs", "-p", str(HARNESS)],
+            cwd=str(ROOT), env=env, capture_output=True, text=True, timeout=300)
+        output = proc.stdout + proc.stderr
+        failed = [line for line in output.splitlines() if "FAIL" in line]
+        self.assertEqual(failed, [], f"harness reported failures:\n{output}")
+        self.assertIn(f"[PhoneSubPageWidth] checks: {EXPECTED_CHECKS} failures: 0", output,
+                      f"harness did not finish cleanly:\n{output}")
+
+        # A layout-managed item carrying anchors is a warning, not an error,
+        # and it means the item is not where the source says it is.
+        self.assertNotIn("Detected anchors on an item that is managed by a layout", output,
+                         f"a sub-page's content fights its own layout:\n{output}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Both pages were drawn wider than the sidebar and shifted left: every row was clipped at the panel's left edge — the error banner read "m did not start - is the DroidCam app open on the phone?", the section headers "ra" and "ra settings" — while the 720p row ran past the right edge.

Measured on the real pages, in a real window, at the 440px the panel hands a sub-page. The widest actual row asks for 189px, so no row was forcing it: both pages are a `ContentPage`, whose content column is `Math.max(baseWidth, implicitWidth)` anchored to the flickable's **centre**, and `baseWidth` defaults to 600 — the settings window's number. 600 centred in 440 is drawn from -80 to 520, which is the 80px missing at each end. These two are the only `ContentPage`s outside the settings window.

The other half of that `Math.max` is the banner: a `NoticeBox` sizes itself from a `StyledText` that wraps, and a wrapping `Text` still reports its string's **unwrapped** width as its implicit width, so the banner carrying `PhoneCamera.lastError` asked for 495 in a 440px page. A page-widening error string was one sentence away.

- The column takes the width the page is really given (`forceWidth` plus a bound `baseWidth`, less the lane the scroll bar overlays): 424 in 440, rows drawn 8..432, and 704 in a 720px page.
- The three banners per page cap their ask at that column's width (`Layout.maximumWidth`, which is what a `QQuickLayout` clamps a preferred width to), so a long service error wraps inside its banner: asked 424, implicit 495. The cap is at the call site rather than in `NoticeBox`, which is shared with the settings pages where its own string's width is the right answer.

`PhoneSubPageWidthRuntimeTest.qml` + `tests/test_phone_subpage_width_runtime.py` read both numbers back off the real pages — where each row is **drawn**, and what each row **asks for** — at two panel widths, because a column pinned to a literal 440 passes every check at one. On main it fails 10 of its 19 checks. It stubs every tool `PhoneDeps` probes, `pactl` included, because `PhoneMic` runs `pactl get-default-sink` from its own `Component.onCompleted` and can go on to `set-default-sink` — which is why the existing layout harness does not drive these two pages.

Suite green in both locales (default and `LC_ALL=C LANG=C`).

Docs: updated AGENT.md §Dynamic/data-driven QML gotchas
Changelog: updated
