### PR TITLE
fix(phone): a spawned scrcpy is not a running mirror, and the tab recedes behind a sub-page

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -723,7 +723,12 @@ services/                  Singletons wrapping external state/processes - one pe
                               apps_list. Started by the first command, stopped by a 10 s
                               idle timer once nothing is live, restarted on the DiscordVoice
                               ladder only while commands are queued. mirrorArgs()/
-                              appModeArgs() are the pure flag tables (tst_phone_scrcpy.qml)
+                              appModeArgs() are the pure flag tables (tst_phone_scrcpy.qml).
+                              `started` means the supervisor SPAWNED scrcpy, so the mirror
+                              stays `mirrorLaunching` until it survives mirrorSettleMs or
+                              the supervisor reports an exit, and `mirrorError` is the
+                              mirror's OWN last failure beside the service-wide lastError
+                              b53c8c260 ("fix(phone): a spawned scrcpy is still launching, not a running mirror")
   PhoneCamera.qml              The phone as a webcam through droidcam-cli into v4l2loopback,
                               launched DETACHED by scripts/phone/droidcam_session.sh (the
                               pidfile is the binary's own) so it outlives a shell restart
@@ -2985,6 +2990,19 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   string (a translation, a count in the hundreds) would simply have been drawn on top of them.
   `anchors.fill` plus `horizontalAlignment` is the spelling that both centres and bounds.
   8f8f14c8c ("fix(phone): the footer's count pill spells \"notifications\" out").
+- **The same family from the container's side: a box sized by its content, centred on a
+  panel, has no width of its own to elide against — the panel's is the one to derive from.**
+  The Phone tab's toast is `implicitWidth: toastRow.implicitWidth + <padding>` under
+  `anchors.horizontalCenter`, so its width was whatever the message wanted; with the label
+  inside it carrying no width, no wrap and no elide either, a long service error drew a
+  full-width bar clipped at the panel edge with the text running off the end (the real one
+  is "DroidCam did not start - is the DroidCam app open on the phone?"). Cap it from the
+  PANEL's width and the spacing tokens rather than from a guess about the longest string —
+  any service's error can reach a toast — and measure the label's own bound off the panel
+  too, never off the container, because the container's width is derived from the label and
+  reading it back closes that circle. Check it with a control: a cap only proves something
+  against a message it did not cap.
+  e2d1dcb70 ("fix(phone): the toast wraps inside the panel instead of running off it").
 - **The two bars load the same widget files out of `modules/imi/bar/`, and each used to decide
   which file for itself.** `Config.options.bar.layouts.*` is shared and Settings > Bar offers a
   plugin's bar widget whatever the orientation, but only `BarContent.qml` ever learned the
@@ -4694,6 +4712,68 @@ it; what needed the runtime harness is whether the click reaches the service at 
 the card or its settings chip is what a click at the card's centre lands on.
 b591575c4 ("fix(phone): a card that cannot start over ADB says so before the click"),
 cf945864c ("fix(phone): a failed webcam or microphone launch reaches its card's subtitle").
+
+**And the third: the mirror card believed the supervisor's `started`, which
+means "I spawned scrcpy" and not "a mirror is on screen".**
+`scripts/phone/scrcpy_session_manager.py` emits that event the instant
+`subprocess.Popen` returns; it has no way to know a window appeared. On a phone
+`adb devices` does not list, scrcpy prints `Could not find any ADB device` and
+exits about a second later — so for that second the card read **"scrcpy Mirror /
+Mirror is running · click to focus its window"**, with a filled check mark and a
+detail line saying "Active for 0s", on a machine where no mirror could exist,
+and then dropped back to the line it had before the click. A spawn keeps the
+mirror `launching` now and arms a settle (`PhoneScrcpy.mirrorSettleMs`);
+surviving the window in which a launch fails is the only evidence the three
+events there are can offer, and erring long only costs a beat more of
+"Connecting scrcpy…". `alreadyRunning` is exempt — that is the supervisor
+answering about a child it has been watching since an earlier launch — which is
+also why `launchMirror()` refuses while a launch is in flight: a second click
+inside the settle would otherwise get exactly that answer back about the child
+spawned a moment ago, i.e. the same weak evidence wearing the strong event's
+name. Three more things fall out of it:
+
+- **`mirrorError` is a second string on purpose.** `lastError` is written by
+  any session's exit and by the supervisor's own restart ladder, so a failed
+  *app* launch an hour ago was already reaching the mirror's card. Scoped to the
+  mirror and cleared by every `launchMirror()`, a non-empty one means "the click
+  you just made did not take" — which is what lets the subtitle ladder ask the
+  error BEFORE the ADB precondition. That ordering was the other way round, with
+  a test asserting it and a comment explaining it, and both were right while the
+  flag carried `lastError`: the repair is not the ordering but what the flag
+  means. Preferring the precondition made a failed launch byte-identical to no
+  launch at all — the card flashes and comes back to the words it started with.
+- **An exit with no stderr line still reports.** A launch that never settled
+  produced nothing whatever the exit code says, and an empty error string is
+  drawn as silence.
+- **None of it is reachable from a settled reading.** `PhoneTabRuntimeTest.qml`
+  drives the real supervisor (`Directories.scriptPath` resolves to the checkout,
+  so a `qs -p` harness really spawns the fake `scrcpy` on its PATH) and samples
+  the card every 25ms across the launch; the driver asserts the sample count
+  first, because a watch that never ran reports "nothing bad happened" exactly
+  as loudly as a correct one.
+
+b53c8c260 ("fix(phone): a spawned scrcpy is still launching, not a running mirror"),
+940c4c3be ("fix(phone): a failed mirror launch says why, instead of snapping back"),
+597e7a2cd ("test(phone): watch the three transitions a settled reading cannot see").
+
+**A deferred text swap fades the GLYPH and not the shape behind it, so on a
+badge it is an empty badge.** `StyledText`'s `animateChange` — the
+`Behavior on text` ending in a bare `PropertyAction` documented under
+[Design language](#design-language) — fades the Text to zero, applies the
+pending string there, and fades it back. Inside
+`MaterialShapeWrappedMaterialSymbol` the shape does not fade with it, so every
+frame of the swap is a painted blob with nothing in it. Two things made that a
+defect rather than a flourish on the Phone tab's feature cards. The card's other
+three elements (title, subtitle, trailing mark) change in one frame, so the
+glyph was the only part out of step with the state it labels. And a five-rung
+ladder can move twice inside one tier — `offline → connecting → offline` is what
+a launch that cannot start does — which retriggers the fade from wherever the
+first write had got to: measured in the runtime harness, the glyph sat at or
+under 0.02 opacity for over **200ms of a 150ms tier** and came out still drawing
+the icon it went in with, having swapped nothing. Before reaching for
+`animateChange`, ask whether the thing behind the glyph fades with it and how
+often the value can change.
+3c82747df ("fix(phone): the feature card's glyph stops blanking its own badge").
 
 **And the surfaces that DRIVE those services get their allowlist derived rather than written
 down.** "A button whose call no service answers is a fake action" is stated for the right

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ own repo; the installer pins which revision it builds.
 ## [Unreleased]
 
 ### Added
+- **Opening a Phone tab page fades the tab back behind it.** Contacts and
+  Android Apps slide in over a tab that now recedes and dims as they arrive,
+  rather than sitting there at full strength underneath. It follows the
+  animation-speed slider and the reduce-motion switch like the rest of the
+  shell.
 - **The Phone tab.** The paired phone gets a tab of its own in the left
   sidebar, beside Intelligence, Translator and Media. Top to bottom: the
   device on a chip whose arrow opens the list of every device the daemon
@@ -144,6 +149,19 @@ own repo; the installer pins which revision it builds.
   right edge. Both pages now take the width the panel gives them, and a long
   message from the camera or the microphone wraps inside its banner instead
   of stretching the page around it.
+- **The scrcpy Mirror card stops claiming a mirror it never opened.**
+  Clicking it on a phone your machine can reach over KDE Connect but that
+  `adb devices` does not list flipped the card to "scrcpy Mirror / Mirror is
+  running · click to focus its window" with a tick and "Active for 0s" — and
+  a second later dropped it back to exactly the line it had before the
+  click, with the icon missing from its badge. The card now says
+  "Connecting scrcpy…" for the whole time between the click and the answer,
+  and a launch that fails shows why it failed instead of quietly returning
+  to where it started. The badge keeps its icon throughout.
+- **The Phone tab's message bar stays inside the panel.** A long error — for
+  instance "DroidCam did not start - is the DroidCam app open on the phone?"
+  — drew as a red bar clipped at the panel's edge with its text running off
+  the end. It now wraps and stays within the tab, however long the message.
 - **The Phone tab's Contacts and Android Apps pages draw their contents
   again.** Contacts showed its count — "147 of 150 contacts" — and then an
   empty page, and Android Apps drew its big empty-state icon on top of its

--- a/dots/.config/quickshell/imi/PhoneTabRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/PhoneTabRuntimeTest.qml
@@ -37,6 +37,25 @@ import qs.modules.imi.sidebarLeft.phone
  * decisions themselves live in phone_cards.js and are driven by
  * tests/tst_phone_cards.qml.
  *
+ * Three things here are WATCHED rather than read once, because each of them
+ * is a defect that only exists between two settled states:
+ *
+ *  - the mirror launch. `Directories.scriptPath` resolves to this checkout,
+ *    so the click really starts scripts/phone/scrcpy_session_manager.py,
+ *    which really spawns the fake scrcpy, which exits 1 the way the real one
+ *    does with no phone on adb. `launchWatch` samples every 25ms and the step
+ *    after it asserts that the card was NEVER read as running or active -
+ *    the supervisor's `started` means "spawned" - that the badge's glyph
+ *    never blanked, and that what the card settles on is the error rather
+ *    than the line it was already showing before the click;
+ *  - the sub-page cross-fade. `fadeWatch` samples the outgoing column's
+ *    opacity and scale, and the check that matters is that a MID-flight
+ *    reading exists: every "was it ever out of range" assertion passes
+ *    identically on a transition that never ran;
+ *  - the toast's width, against a control. A short message must produce a
+ *    toast narrower than the cap before a long one is allowed to prove the
+ *    cap holds.
+ *
  *   PATH=<dir with fake busctl>:$PATH qs -p PhoneTabRuntimeTest.qml
  */
 ShellRoot {
@@ -133,6 +152,19 @@ ShellRoot {
     function footerRow() {
         const footer = harness.first("PhoneFooterBar");
         return footer ? (footer.children[0] ?? null) : null;
+    }
+
+    // The badge a feature card leads with: the MaterialShape and the
+    // MaterialSymbol inside it are two objects with two `text` values (the
+    // shape aliases the symbol's), and the defect this reads for is the
+    // symbol drawn at zero opacity inside a shape that is not.
+    function cardBadge(card) {
+        return harness.findAll(card, "MaterialShapeWrappedMaterialSymbol", [])[0] ?? null;
+    }
+
+    function cardGlyph(card) {
+        const badge = harness.cardBadge(card);
+        return badge ? (harness.findAll(badge, "MaterialSymbol", [])[0] ?? null) : null;
     }
 
     FloatingWindow {
@@ -431,19 +463,66 @@ ShellRoot {
         () => {
             // Does the primary click fire at all, or is it swallowed by the
             // settings chip or by the status mark beside it? Clicked at the
-            // card's own centre, and scored on the service.
+            // card's own centre, and scored on the service - and then WATCHED
+            // for a second, because what this branch exists to fix is what
+            // the card said in between.
+            //
+            // The supervisor is the real one (Directories.scriptPath resolves
+            // to this checkout's scripts/), so the click really does spawn
+            // the fake scrcpy on PATH, which exits 1 with "Could not find any
+            // ADB device" the way the real one does with no phone attached.
             const mirror = harness.cardTitled("scrcpy Mirror");
+            const glyph = harness.cardGlyph(mirror);
             harness.check("the mirror is not already launching", !PhoneScrcpy.mirrorLaunching);
+            harness.check(`the badge draws its offline glyph before the click, got "${glyph?.text}"`,
+                          glyph !== null && glyph.text === "cast"
+                          && harness.cardBadge(mirror).text === glyph.text);
+            harness.launchSaw = { running: false, active: false, blankGlyph: "",
+                                  minGlyphOpacity: 1, samples: 0 };
             harness.click(mirror);
+            launchWatch.running = true;
         },
+        () => {},
+        () => {},
         () => {
+            launchWatch.running = false;
+            const saw = harness.launchSaw;
+            const mirror = harness.cardTitled("scrcpy Mirror") ?? harness.cardTitled("Connecting");
+            const glyph = harness.cardGlyph(mirror);
+            console.log(`[PhoneTab] launch watch: samples=${saw.samples} sawRunning=${saw.running}`
+                + ` sawActive=${saw.active} minGlyphOpacity=${saw.minGlyphOpacity.toFixed(2)}`
+                + ` blank="${saw.blankGlyph}" state=${mirror?.cardState} "${mirror?.subtitle}"`);
+
+            // A watch that never ran reports "nothing bad happened" just as
+            // loudly as a correct one, so the sample count is asserted first.
+            harness.check(`the launch was watched frame by frame, got ${saw.samples} samples`,
+                          saw.samples > 20);
             harness.check("a click on the card's body reaches launchMirror()",
-                          PhoneScrcpy.mirrorLaunching || PhoneScrcpy.mirrorRunning
-                          || PhoneScrcpy.lastError.length > 0);
-            // Disarmed through the model rather than by stopping the mirror:
-            // this harness has no phone and the supervisor's own exit is not
-            // what is being scored here.
-            PhoneScrcpy.mirrorLaunching = false;
+                          PhoneScrcpy.mirrorError.length > 0);
+
+            // Defect 1: the supervisor answers `started` when it has SPAWNED
+            // scrcpy. Reading that as a live mirror put "scrcpy Mirror /
+            // Mirror is running - click to focus its window", a filled check
+            // and "Active for 0s" on a card whose phone adb has never seen.
+            harness.check("a launch with no ADB device is never read as a running mirror",
+                          !saw.running);
+            harness.check("...so the card never draws its active rung either", !saw.active);
+
+            // Defect 2: the badge's glyph used to cross-fade to zero inside a
+            // shape that does not fade with it, on a ladder that moves twice
+            // inside one tier - so the icon simply went missing.
+            harness.check(`the badge's glyph never blanks, min opacity ${saw.minGlyphOpacity.toFixed(2)}`,
+                          saw.minGlyphOpacity > 0.99);
+            harness.check(`the glyph and its shape never disagree or empty, got "${saw.blankGlyph}"`,
+                          saw.blankGlyph === "");
+
+            // And the failure is REPORTED rather than snapped back to the
+            // line the card was already showing before the click.
+            harness.check(`a failed launch leaves the card on the error, got "${mirror?.subtitle}"`,
+                          mirror !== null && mirror.cardState === "offline"
+                          && mirror.subtitle.indexOf("Could not find any ADB device") >= 0);
+            harness.check(`...and the glyph is back to the offline one, got "${glyph?.text}"`,
+                          glyph !== null && glyph.text === "cast");
         },
         () => {
             // The settings chip is a SECOND affordance on the same card, and
@@ -495,6 +574,106 @@ ShellRoot {
                           toast !== null && toast.message === "scrcpy: no device found" && !toast.ok);
         },
 
+        // ---- the toast stays inside the tab, however long the message ----
+        () => {
+            // The control, taken first: a short message must produce a toast
+            // NARROWER than the cap, or the long-message check below passes
+            // on a toast that was always full width.
+            const toast = harness.toastCard();
+            loader.item.showToast("Ringing", true);
+            harness.shortToastWidth = 0;
+            harness.toastCap = toast.maxWidth;
+        },
+        () => {
+            const toast = harness.toastCard();
+            harness.shortToastWidth = toast.width;
+            console.log(`[PhoneTab] short toast ${toast.width} of cap ${harness.toastCap}`
+                + ` in tab ${loader.item.width}`);
+            harness.check(`a short message does not fill the tab, got ${toast.width} of ${harness.toastCap}`,
+                          toast.width > 0 && toast.width < harness.toastCap);
+            // The real string, from the screenshot the maintainer sent.
+            loader.item.showToast("DroidCam did not start - is the DroidCam app open on the phone?", false);
+        },
+        () => {
+            const toast = harness.toastCard();
+            const label = harness.findAll(toast, "StyledText", [])[0] ?? null;
+            const left = toast.mapToItem(loader.item, 0, 0).x;
+            const right = left + toast.width;
+            console.log(`[PhoneTab] long toast ${toast.width} at ${left}..${right}`
+                + ` in tab ${loader.item.width}; label ${label?.width}`
+                + ` lines=${label?.lineCount} truncated=${label?.truncated}`);
+
+            harness.check(`the long message widened the toast, got ${toast.width}`
+                          + ` against ${harness.shortToastWidth}`,
+                          toast.width > harness.shortToastWidth);
+            harness.check(`the toast stays inside the tab (${left}..${right} of ${loader.item.width})`,
+                          left >= 0 && right <= loader.item.width);
+            harness.check(`...and inside the cap the panel's own margins set, got ${toast.width}`,
+                          toast.width <= harness.toastCap);
+            harness.check(`the label is bounded and wraps rather than running off, got ${label?.width}`,
+                          label !== null && label.width <= toast.width
+                          && label.wrapMode !== Text.NoWrap && label.lineCount > 1);
+            const labelRight = label.mapToItem(toast, label.width, 0).x;
+            harness.check(`the label's own right edge is inside the toast, got ${labelRight}`,
+                          labelRight <= toast.width);
+        },
+
+        // ---- the tab recedes as a sub-page slides in ---------------------
+        () => {
+            const column = harness.contentColumn();
+            harness.check(`the tab rests at full strength, got ${column?.opacity} / ${column?.scale}`,
+                          column !== null && column.opacity === 1 && column.scale === 1);
+            harness.fadeSaw = { samples: 0, minOpacity: 2, maxOpacity: -1,
+                                minScale: 2, maxScale: -1, mid: 0 };
+            loader.item.openSubPage("contacts");
+            fadeWatch.running = true;
+        },
+        () => {},
+        () => {
+            fadeWatch.running = false;
+            const saw = harness.fadeSaw;
+            const column = harness.contentColumn();
+            console.log(`[PhoneTab] fade watch: samples=${saw.samples}`
+                + ` opacity ${saw.minOpacity.toFixed(3)}..${saw.maxOpacity.toFixed(3)}`
+                + ` scale ${saw.minScale.toFixed(4)}..${saw.maxScale.toFixed(4)}`
+                + ` midFrames=${saw.mid} settled=${column?.opacity}/${column?.scale}`);
+
+            harness.check(`the transition was watched frame by frame, got ${saw.samples} samples`,
+                          saw.samples > 10);
+            // A transition that never ran reports the same "nothing was ever
+            // out of range" as one that ran correctly, so what is asserted is
+            // that a MID-flight reading exists - the shape b2b5de2a1 records
+            // for a step that measures the state it was supposed to change.
+            harness.check(`the outgoing tab was caught mid-fade, ${saw.mid} frames strictly between`,
+                          saw.mid > 0);
+            harness.check(`...and it recedes rather than only fading, scale down to ${saw.minScale.toFixed(4)}`,
+                          saw.minScale < 1);
+            // The recede is DERIVED, not picked, and this is the check that
+            // says so: the excursion may not exceed twice the derived one.
+            // It is a band rather than the number itself because
+            // `elementMove`'s expressiveDefaultSpatial curve leaves the unit
+            // box - it peaks at 1.0139 - so the scale legitimately travels a
+            // hair past its destination on the way there.
+            const excursion = column !== null ? 1 - column.recedeTo : 0;
+            harness.check(`the recede stays the derived size, ${saw.minScale.toFixed(4)}`
+                          + ` against ${column?.recedeTo?.toFixed(4)}`,
+                          column !== null && saw.minScale >= column.recedeTo - excursion);
+            harness.check(`the tab ends the transition gone, got ${column?.opacity} / ${column?.scale}`,
+                          column !== null && column.opacity < 0.001
+                          && Math.abs(column.scale - column.recedeTo) < 0.001);
+            loader.item.popSubPage();
+        },
+        () => {},
+        () => {
+            // Both channels come back, which is the half a one-way check
+            // cannot see: a recede that never returned would leave the tab
+            // permanently a hair small and permanently transparent.
+            const column = harness.contentColumn();
+            harness.check(`popping the page brings the tab back, got ${column?.opacity} / ${column?.scale}`,
+                          column !== null && Math.abs(column.opacity - 1) < 0.001
+                          && Math.abs(column.scale - 1) < 0.001);
+        },
+
         () => harness.finish()
     ]
 
@@ -505,6 +684,61 @@ ShellRoot {
     property real listWithCard: 0
     property real cardHeight: 0
     property real columnSpacing: 0
+
+    // What the launch watch saw. Written by the timer below, read by the
+    // step after it - never re-read out of the harness's own log line.
+    property var launchSaw: ({ running: false, active: false, blankGlyph: "",
+                               minGlyphOpacity: 1, samples: 0 })
+
+    Timer {
+        id: launchWatch
+        interval: 25
+        repeat: true
+        onTriggered: {
+            const card = harness.cardTitled("scrcpy Mirror")
+                ?? harness.cardTitled("Connecting") ?? harness.cardTitled("Mirror");
+            if (!card) return;
+            const badge = harness.cardBadge(card);
+            const glyph = harness.cardGlyph(card);
+            const saw = harness.launchSaw;
+            saw.samples++;
+            if (PhoneScrcpy.mirrorRunning) saw.running = true;
+            if (card.cardState === "active") saw.active = true;
+            if (glyph) {
+                if (glyph.opacity < saw.minGlyphOpacity) saw.minGlyphOpacity = glyph.opacity;
+                // Empty on either object, or the two disagreeing, is a badge
+                // with nothing in it - recorded as the offending pair rather
+                // than as a bool, so a failure names what was on screen.
+                if (`${glyph.text}`.length === 0 || `${badge?.text}` !== `${glyph.text}`)
+                    saw.blankGlyph = `${badge?.text}|${glyph.text}`;
+            }
+            harness.launchSaw = saw;
+        }
+    }
+
+    property real shortToastWidth: 0
+    property real toastCap: 0
+
+    property var fadeSaw: ({ samples: 0, minOpacity: 2, maxOpacity: -1,
+                             minScale: 2, maxScale: -1, mid: 0 })
+
+    Timer {
+        id: fadeWatch
+        interval: 25
+        repeat: true
+        onTriggered: {
+            const column = harness.contentColumn();
+            if (!column) return;
+            const saw = harness.fadeSaw;
+            saw.samples++;
+            saw.minOpacity = Math.min(saw.minOpacity, column.opacity);
+            saw.maxOpacity = Math.max(saw.maxOpacity, column.opacity);
+            saw.minScale = Math.min(saw.minScale, column.scale);
+            saw.maxScale = Math.max(saw.maxScale, column.scale);
+            if (column.opacity > 0.001 && column.opacity < 0.999) saw.mid++;
+            harness.fadeSaw = saw;
+        }
+    }
 
     property int stepIndex: 0
     Timer {

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/Phone.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/Phone.qml
@@ -125,7 +125,23 @@ Item {
         anchors.margins: Appearance.spacing.space125
         spacing: Appearance.spacing.space125
 
+        // The outgoing half of the transition. The tab does not sit still
+        // behind the page sliding over it: it fades AND recedes, so what the
+        // eye reads is the tab going back a layer rather than being covered
+        // up. Both channels ride `subPageProgress` - the ONE scalar, with the
+        // one Behavior on it - because a second Behavior is two numbers that
+        // have to agree, agreeing at rest (where nobody looks) and
+        // disagreeing on exactly the frames the transition is made of.
+        //
+        // The scale's destination is derived, never picked:
+        // `entranceScaleFrom` matches the excursion to the shell's entrance
+        // rise at this panel's own width, floored at the survey's measured
+        // 0.85, which is the same derivation every StaggerEntrance member
+        // arrives on. A hand-picked 0.85 on a full-width column is a zoom.
+        readonly property real recedeTo: Appearance.animation.entranceScaleFrom(root.width)
         opacity: 1 - root.subPageProgress
+        scale: 1 - (1 - phoneColumn.recedeTo) * root.subPageProgress
+        transformOrigin: Item.Center
         // A page on top is a picture, not a control: a click landing on the
         // tab mid-slide is aimed at the page the pointer moved toward.
         enabled: root.subPage === ""

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/Phone.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/Phone.qml
@@ -329,7 +329,19 @@ Item {
         property string message: ""
         property bool ok: true
 
-        implicitWidth: toastRow.implicitWidth + Appearance.spacing.space300
+        // What the toast may not cross. Any service's error string can reach
+        // here - "DroidCam did not start - is the DroidCam app open on the
+        // phone?" is a real one - and with the width taken from the row's own
+        // implicit width and nothing above it, a long message drew a
+        // full-width bar clipped at the panel edge with its text running off
+        // the end. The bound comes from the panel and the spacing tokens
+        // rather than from a guess about the longest string: the tab's own
+        // column is inset by space125 on each side, and the toast sits inside
+        // the same margin.
+        readonly property real maxWidth: root.width - Appearance.spacing.space125 * 2
+        readonly property real horizontalPadding: Appearance.spacing.space300
+
+        implicitWidth: Math.min(toastRow.implicitWidth + toast.horizontalPadding, toast.maxWidth)
         implicitHeight: toastRow.implicitHeight + Appearance.spacing.space150
         radius: Appearance.rounding.full
         color: toast.ok ? Appearance.colors.colPrimaryContainer : Appearance.colors.colErrorContainer
@@ -351,12 +363,26 @@ Item {
             spacing: Appearance.spacing.space100
 
             MaterialSymbol {
+                id: toastGlyph
+                Layout.alignment: Qt.AlignVCenter
                 text: toast.ok ? "check_circle" : "error"
                 iconSize: Appearance.font.pixelSize.larger
                 color: toast.ok ? Appearance.colors.colOnPrimaryContainer : Appearance.colors.colOnErrorContainer
             }
             StyledText {
+                id: toastLabel
+                Layout.alignment: Qt.AlignVCenter
+                // Measured off the PANEL, not off the toast: the toast's own
+                // width is derived from this row's implicit width, so binding
+                // the label to it closes that circle. Wrapping first and
+                // eliding after keeps a two-line sentence readable and still
+                // refuses to grow a third line into the tab's content.
+                Layout.maximumWidth: toast.maxWidth - toast.horizontalPadding
+                    - toastGlyph.implicitWidth - toastRow.spacing
                 text: toast.message
+                wrapMode: Text.WordWrap
+                maximumLineCount: 2
+                elide: Text.ElideRight
                 font.pixelSize: Appearance.font.pixelSize.small
                 color: toast.ok ? Appearance.colors.colOnPrimaryContainer : Appearance.colors.colOnErrorContainer
             }

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneFeatureCard.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneFeatureCard.qml
@@ -142,7 +142,24 @@ Item {
                 padding: Appearance.spacing.space125
                 color: ColorUtils.transparentize(root.colForeground, 0.82)
                 colSymbol: root.colForeground
-                animateChange: true
+                // No `animateChange` here, deliberately, and it is a fix
+                // rather than an omission. StyledText's deferred swap fades
+                // the GLYPH to zero, holds it there for the PropertyAction
+                // that applies the pending text, and fades it back - inside a
+                // MaterialShape that does not fade with it, so every frame of
+                // the swap is a badge with a hole in it. Two things make that
+                // worse here than anywhere else the idiom is used. This
+                // card's other three elements - the title, the subtitle and
+                // the trailing mark - change in one frame, so the glyph was
+                // the only part of the card out of step with its own state.
+                // And a rung can move twice inside one tier (offline ->
+                // connecting -> offline is what a launch that cannot start
+                // does), which retriggers the fade from wherever it had got
+                // to: measured in PhoneTabRuntimeTest, the glyph sat at or
+                // under 0.02 opacity for over 200ms of a 150ms tier and came
+                // out the other side still drawing the icon it went in with,
+                // having swapped nothing at all. Read on screen that is "the
+                // card's icon is gone".
             }
 
             ColumnLayout {

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneFeatureCards.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneFeatureCards.qml
@@ -114,7 +114,11 @@ Item {
                 running: PhoneScrcpy.mirrorRunning,
                 launching: PhoneScrcpy.mirrorLaunching,
                 adbDevice: root.adbDevice,
-                error: PhoneScrcpy.lastError
+                // The MIRROR's own failure, not the service-wide lastError:
+                // that one is written by any session's exit and by the
+                // supervisor's ladder, so a failed app launch used to put its
+                // message on this card.
+                error: PhoneScrcpy.mirrorError
             })
 
             iconName: "smart_display"
@@ -141,7 +145,7 @@ Item {
                 case "noDevice":
                     return Translation.tr("No device over ADB · turn on USB or wireless debugging");
                 case "error":
-                    return PhoneCards.errorHeadline(PhoneScrcpy.lastError);
+                    return PhoneCards.errorHeadline(PhoneScrcpy.mirrorError);
                 case "running":
                     return Translation.tr("Mirror is running · click to focus its window");
                 case "launching":

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/phone_cards.js
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/phone_cards.js
@@ -34,6 +34,13 @@ function cardState(available, reachable, connecting, active) {
 // fork's choice): the card is not running, and the subtitle carries the
 // error's first line, so a second state would say the same thing twice.
 //
+// `launching` is the whole window between the click and the supervisor
+// answering, and it is a rung of its own so that it cannot be mistaken for
+// `running`: PhoneScrcpy holds it from launchMirror() until either the
+// session has survived its settle or the supervisor reports an exit. The
+// service used to leave it the moment the supervisor said it had SPAWNED
+// scrcpy, which is not the same event.
+//
 // The same is true of a phone that is reachable over KDE Connect but that
 // `adb devices` does not list: scrcpy has nothing to attach to, so the card
 // cannot start - and that is knowable BEFORE the click, the way missing
@@ -92,16 +99,22 @@ function mirrorSubtitleKey(flags) {
     if (!f.available) return "install";
     if (!f.reachable) return "offline";
     // Running and launching are asked BEFORE the error, and the order is the
-    // load-bearing part: PhoneScrcpy.lastError is written by any session's
-    // failure and cleared only by the next launchMirror(), so an app that
-    // failed an hour ago is still sitting there while the mirror runs. Asking
-    // the error first put a live mirror's card on a stale line.
+    // load-bearing part: a failure the card is still carrying belongs to a
+    // launch that is over, so a live or in-flight session outranks it.
     if (f.running) return "running";
     if (f.launching) return "launching";
-    // Asked before the error, because "the phone is not on ADB" is what to do
-    // about the error scrcpy's exit produced.
-    if (f.adbDevice === false) return "noDevice";
+    // ...and the error outranks the ADB precondition, which is the opposite
+    // of how this shipped. `error` is PhoneScrcpy.mirrorError now - the
+    // MIRROR's own last failure, cleared by the next launchMirror() - so a
+    // non-empty one means the click the user just made did not take. The
+    // "no device over ADB" line is what the card was already saying BEFORE
+    // that click, so preferring it makes a failed launch byte-identical to no
+    // launch at all: the card flashes and comes back to where it started,
+    // which is what "clicking it does nothing" looked like. It was the right
+    // order while `error` was the service-wide lastError, which any session's
+    // failure could have written an hour earlier.
     if (errorHeadline(f.error).length > 0) return "error";
+    if (f.adbDevice === false) return "noDevice";
     return "ready";
 }
 

--- a/dots/.config/quickshell/imi/services/PhoneScrcpy.qml
+++ b/dots/.config/quickshell/imi/services/PhoneScrcpy.qml
@@ -43,6 +43,14 @@ Singleton {
     property bool mirrorRunning: false
     property bool mirrorLaunching: false
     property string lastError: ""
+    // The MIRROR's own last failure, cleared by the next launchMirror().
+    // `lastError` is written by any session's failure and by the supervisor's
+    // own ladder, so a failed app launch an hour ago is still sitting in it
+    // while the mirror card reads it - which is why the card's subtitle used
+    // to have to ask the ADB precondition first to avoid quoting somebody
+    // else's error. Scoped here, a non-empty string means "the launch you
+    // just asked for did not take".
+    property string mirrorError: ""
 
     // [{ name, package, system }]
     property var apps: []
@@ -197,6 +205,17 @@ Singleton {
     }
 
     // One supervisor event onto the model.
+    //
+    // `started` is the supervisor saying it SPAWNED scrcpy, not that a mirror
+    // is on screen - it emits the event the instant Popen returns and has no
+    // way to know a window appeared. On a phone adb cannot see, scrcpy prints
+    // "Could not find any ADB device" and exits about a second later, so
+    // reading the spawn as `mirrorRunning` put the card on "scrcpy Mirror /
+    // Mirror is running - click to focus its window", a filled check mark and
+    // "Active for 0s" where no mirror could possibly exist, and then dropped
+    // it back to the line it had before the click. A spawn therefore keeps
+    // the mirror LAUNCHING and arms the settle; the settle, or the exit, is
+    // what decides which it was.
     function applyEvent(msg: var): void {
         if (!msg) return;
         const id = String(msg.id ?? "");
@@ -216,22 +235,47 @@ Singleton {
                 sessionsModel.append(row);
             }
             if (id === "mirror") {
-                root.mirrorRunning = true;
-                root.mirrorLaunching = false;
+                // `alreadyRunning` is the supervisor answering about a child
+                // it has been watching since some earlier launch, which IS
+                // evidence of a live session - there is nothing to settle.
+                if (msg.alreadyRunning === true) {
+                    root.cancelMirrorSettle();
+                    root.mirrorRunning = true;
+                    root.mirrorLaunching = false;
+                } else {
+                    root.mirrorRunning = false;
+                    root.mirrorLaunching = true;
+                    root.armMirrorSettle();
+                }
             }
         } else if (msg.event === "exited") {
             const index = root.sessionIndex(id);
             if (index >= 0) sessionsModel.remove(index);
+            const failure = Number(msg.code ?? 0) !== 0 ? String(msg.error ?? "") : "";
             if (id === "mirror") {
+                const wasLaunching = root.mirrorLaunching;
+                root.cancelMirrorSettle();
                 root.mirrorRunning = false;
                 root.mirrorLaunching = false;
+                // A mirror that exits before it has settled never opened, so
+                // the click produced nothing at all - and the only other line
+                // the card has is the precondition the user already read
+                // before clicking, which is why a silent snap back to it
+                // reads as the card having ignored them.
+                root.mirrorError = failure.length > 0 ? failure
+                    : (wasLaunching ? "scrcpy exited before the mirror window opened" : "");
             }
-            if (Number(msg.code ?? 0) !== 0 && String(msg.error ?? "").length > 0) {
-                root.lastError = String(msg.error);
+            if (failure.length > 0) {
+                root.lastError = failure;
                 root.feedback(root.lastError, false);
             }
         } else if (msg.event === "error") {
-            if (id === "mirror") root.mirrorLaunching = false;
+            if (id === "mirror") {
+                root.cancelMirrorSettle();
+                root.mirrorLaunching = false;
+                root.mirrorRunning = false;
+                root.mirrorError = String(msg.message ?? "scrcpy error");
+            }
             root.lastError = String(msg.message ?? "scrcpy error");
             root.feedback(root.lastError, false);
         } else if (msg.event === "apps_list") {
@@ -246,6 +290,16 @@ Singleton {
             root.appsLoading = false;
             root.appsError = String(msg.message ?? "Failed to list apps");
         }
+    }
+
+    // The settle's own answer: a spawned scrcpy still in the session list
+    // after the settle has outlived every way a launch fails, so it is a
+    // mirror rather than an attempt. A row that has gone means `exited`
+    // already answered and this must not put the card back on `running`.
+    function mirrorSettled(): void {
+        if (root.sessionIndex("mirror") < 0) return;
+        root.mirrorLaunching = false;
+        root.mirrorRunning = true;
     }
 
     function handleLine(line: string): void {
@@ -269,8 +323,16 @@ Singleton {
             root.focusMirror();
             return;
         }
+        // A launch already in flight answers itself, through the settle or
+        // through the supervisor's exit. Without this, a second click inside
+        // the settle window gets `alreadyRunning` back - which is the
+        // supervisor saying only that the child it spawned a moment ago has
+        // not exited yet, i.e. exactly the weak evidence the settle exists to
+        // stop reading as a mirror.
+        if (root.mirrorLaunching) return;
         root.mirrorLaunching = true;
         root.lastError = "";
+        root.mirrorError = "";
         root.send({
             cmd: "launch", id: "mirror", type: "mirror",
             target_args: root.scrcpyTarget(),
@@ -334,6 +396,34 @@ Singleton {
     }
     // END phone-scrcpy logic
 
+    // ---- the mirror's settle ----
+
+    // How long a spawned scrcpy has to stay alive before the mirror counts as
+    // running, rather than as still launching. The supervisor cannot answer
+    // "is a window up" - see applyEvent - so surviving the window in which a
+    // launch fails is the evidence there is. Measured against scrcpy 3.1 with
+    // no device attached: it prints "Could not find any ADB device" and exits
+    // well inside a second. Erring long is the conservative direction here:
+    // the card says "Connecting scrcpy…" for a beat longer than it strictly
+    // needs to, where erring short is the lie this replaced.
+    readonly property int mirrorSettleMs: 1500
+
+    // Named hooks rather than the timer itself, because applyEvent is inside
+    // the synced region and the logic-only double has no Timer to reach.
+    function armMirrorSettle(): void {
+        mirrorSettleTimer.restart();
+    }
+
+    function cancelMirrorSettle(): void {
+        mirrorSettleTimer.stop();
+    }
+
+    Timer {
+        id: mirrorSettleTimer
+        interval: root.mirrorSettleMs
+        onTriggered: root.mirrorSettled()
+    }
+
     // ---- the supervisor's lifetime ----
 
     function send(message: var): void {
@@ -370,6 +460,7 @@ Singleton {
     }
 
     function clearLive(): void {
+        root.cancelMirrorSettle();
         sessionsModel.clear();
         root.mirrorRunning = false;
         root.mirrorLaunching = false;
@@ -419,6 +510,11 @@ Singleton {
                 root.managerState = "stopped";
                 root.pendingMessages = [];
                 root.lastError = "scrcpy session manager stopped after repeated failures";
+                // The mirror card is where a click that asked for this
+                // supervisor is waiting for an answer; clearLive() has just
+                // taken it off `launching`, so with nothing here it would go
+                // back to its pre-click line and say nothing happened.
+                root.mirrorError = root.lastError;
                 root.feedback(root.lastError, false);
                 return;
             }

--- a/dots/.config/quickshell/imi/tests/imports/testservices/PhoneScrcpy.qml
+++ b/dots/.config/quickshell/imi/tests/imports/testservices/PhoneScrcpy.qml
@@ -21,6 +21,7 @@ Singleton {
     property bool mirrorRunning: false
     property bool mirrorLaunching: false
     property string lastError: ""
+    property string mirrorError: ""
 
     property var apps: []
     property bool appsLoading: false
@@ -172,6 +173,17 @@ Singleton {
     }
 
     // One supervisor event onto the model.
+    //
+    // `started` is the supervisor saying it SPAWNED scrcpy, not that a mirror
+    // is on screen - it emits the event the instant Popen returns and has no
+    // way to know a window appeared. On a phone adb cannot see, scrcpy prints
+    // "Could not find any ADB device" and exits about a second later, so
+    // reading the spawn as `mirrorRunning` put the card on "scrcpy Mirror /
+    // Mirror is running - click to focus its window", a filled check mark and
+    // "Active for 0s" where no mirror could possibly exist, and then dropped
+    // it back to the line it had before the click. A spawn therefore keeps
+    // the mirror LAUNCHING and arms the settle; the settle, or the exit, is
+    // what decides which it was.
     function applyEvent(msg: var): void {
         if (!msg) return;
         const id = String(msg.id ?? "");
@@ -191,22 +203,47 @@ Singleton {
                 sessionsModel.append(row);
             }
             if (id === "mirror") {
-                root.mirrorRunning = true;
-                root.mirrorLaunching = false;
+                // `alreadyRunning` is the supervisor answering about a child
+                // it has been watching since some earlier launch, which IS
+                // evidence of a live session - there is nothing to settle.
+                if (msg.alreadyRunning === true) {
+                    root.cancelMirrorSettle();
+                    root.mirrorRunning = true;
+                    root.mirrorLaunching = false;
+                } else {
+                    root.mirrorRunning = false;
+                    root.mirrorLaunching = true;
+                    root.armMirrorSettle();
+                }
             }
         } else if (msg.event === "exited") {
             const index = root.sessionIndex(id);
             if (index >= 0) sessionsModel.remove(index);
+            const failure = Number(msg.code ?? 0) !== 0 ? String(msg.error ?? "") : "";
             if (id === "mirror") {
+                const wasLaunching = root.mirrorLaunching;
+                root.cancelMirrorSettle();
                 root.mirrorRunning = false;
                 root.mirrorLaunching = false;
+                // A mirror that exits before it has settled never opened, so
+                // the click produced nothing at all - and the only other line
+                // the card has is the precondition the user already read
+                // before clicking, which is why a silent snap back to it
+                // reads as the card having ignored them.
+                root.mirrorError = failure.length > 0 ? failure
+                    : (wasLaunching ? "scrcpy exited before the mirror window opened" : "");
             }
-            if (Number(msg.code ?? 0) !== 0 && String(msg.error ?? "").length > 0) {
-                root.lastError = String(msg.error);
+            if (failure.length > 0) {
+                root.lastError = failure;
                 root.feedback(root.lastError, false);
             }
         } else if (msg.event === "error") {
-            if (id === "mirror") root.mirrorLaunching = false;
+            if (id === "mirror") {
+                root.cancelMirrorSettle();
+                root.mirrorLaunching = false;
+                root.mirrorRunning = false;
+                root.mirrorError = String(msg.message ?? "scrcpy error");
+            }
             root.lastError = String(msg.message ?? "scrcpy error");
             root.feedback(root.lastError, false);
         } else if (msg.event === "apps_list") {
@@ -221,6 +258,16 @@ Singleton {
             root.appsLoading = false;
             root.appsError = String(msg.message ?? "Failed to list apps");
         }
+    }
+
+    // The settle's own answer: a spawned scrcpy still in the session list
+    // after the settle has outlived every way a launch fails, so it is a
+    // mirror rather than an attempt. A row that has gone means `exited`
+    // already answered and this must not put the card back on `running`.
+    function mirrorSettled(): void {
+        if (root.sessionIndex("mirror") < 0) return;
+        root.mirrorLaunching = false;
+        root.mirrorRunning = true;
     }
 
     function handleLine(line: string): void {
@@ -244,8 +291,16 @@ Singleton {
             root.focusMirror();
             return;
         }
+        // A launch already in flight answers itself, through the settle or
+        // through the supervisor's exit. Without this, a second click inside
+        // the settle window gets `alreadyRunning` back - which is the
+        // supervisor saying only that the child it spawned a moment ago has
+        // not exited yet, i.e. exactly the weak evidence the settle exists to
+        // stop reading as a mirror.
+        if (root.mirrorLaunching) return;
         root.mirrorLaunching = true;
         root.lastError = "";
+        root.mirrorError = "";
         root.send({
             cmd: "launch", id: "mirror", type: "mirror",
             target_args: root.scrcpyTarget(),
@@ -308,6 +363,29 @@ Singleton {
             root.toggleInList(Config.options.phone.scrcpy.appMode.favoritePackages, packageName);
     }
     // END phone-scrcpy logic
+
+    // The settle is a Timer in the real service; here it is a flag the test
+    // advances with fireMirrorSettle(), the way every other timer in this
+    // module is a counter - the region above calls the two hooks and cannot
+    // see which of the two it got.
+    property int mirrorSettleArmed: 0
+    property bool mirrorSettlePending: false
+
+    function armMirrorSettle(): void {
+        root.mirrorSettleArmed++;
+        root.mirrorSettlePending = true;
+    }
+
+    function cancelMirrorSettle(): void {
+        root.mirrorSettlePending = false;
+    }
+
+    function fireMirrorSettle(): void {
+        if (!root.mirrorSettlePending) return;
+        root.mirrorSettlePending = false;
+        root.mirrorSettled();
+    }
+
     property var sentMessages: []
     property var feedbackLog: []
     onFeedback: (message, ok) => { root.feedbackLog = root.feedbackLog.concat([{ message: message, ok: ok }]); }
@@ -321,6 +399,9 @@ Singleton {
         root.mirrorRunning = false;
         root.mirrorLaunching = false;
         root.lastError = "";
+        root.mirrorError = "";
+        root.mirrorSettleArmed = 0;
+        root.mirrorSettlePending = false;
         root.apps = [];
         root.appsLoading = false;
         root.appsError = "";

--- a/dots/.config/quickshell/imi/tests/test_phone_tab_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_tab_runtime.py
@@ -28,6 +28,16 @@ Those two clicks are scored HERE, off the fake's recorded invocations:
 laptop's device path, and never on the phone's. A click that reached nothing
 would leave the harness green (a button is a button) and this red.
 
+The mirror card's click is driven all the way through the real supervisor -
+the fake `scrcpy` on PATH exits 1 with "Could not find any ADB device", which
+is what a real one does with no phone attached - and the harness watches the
+card frame by frame across it. That is the only place the three defects this
+harness grew for are visible: a card that reads "running" between the spawn
+and the exit, a badge whose glyph fades to nothing inside a shape that does
+not, and a failed launch that snaps back to the line it started on. The
+sub-page cross-fade and the toast's width are watched the same way, each with
+a control, since a settled reading is identical whether or not anything moved.
+
 Brings its own headless weston and its own session bus (`dbus-run-session`).
 Skips when weston, qs or dbus-run-session are missing, as in CI.
 """
@@ -53,7 +63,7 @@ LAPTOP_ADDRESS = "192.168.100.99"
 # A literal, never read back out of the harness's own output: a step list
 # that shrinks must redden here instead of reporting `failures: 0` for a
 # shorter run.
-EXPECTED_CHECKS = 49
+EXPECTED_CHECKS = 70
 
 RECORD = """#!/usr/bin/env bash
 printf '%s %s\\n' "$(date +%s.%N)" "$*" >> "$PHONE_EXEC_LOG"

--- a/dots/.config/quickshell/imi/tests/tst_phone_cards.qml
+++ b/dots/.config/quickshell/imi/tests/tst_phone_cards.qml
@@ -83,10 +83,44 @@ TestCase {
         };
         compare(PhoneCards.mirrorState(away), "offline");
         compare(PhoneCards.mirrorSubtitleKey(away), "noDevice");
-        // And it says which link is missing rather than which failed: the
-        // error the failed launch left behind is the consequence.
-        compare(PhoneCards.mirrorSubtitleKey(Object.assign({}, away,
-            { error: "ERROR: Could not find any ADB device" })), "noDevice");
+    }
+
+    function test_a_launch_that_failed_outranks_the_precondition_it_failed_on() {
+        // This assertion used to run the other way, on the reasoning that
+        // "the phone is not on ADB" is what to DO about scrcpy's exit. The
+        // reasoning held while `error` was PhoneScrcpy.lastError - any
+        // session's failure, possibly an hour old - and it is wrong now that
+        // the flag carries the mirror's OWN error, cleared by every
+        // launchMirror(): a non-empty one means the click the user just made
+        // failed, and "No device over ADB" is the line the card was already
+        // showing before that click. Preferring it made a failed launch and
+        // no launch at all the same two words, which is the silent snap back
+        // the recording caught.
+        const away = {
+            available: true, reachable: true, running: false, launching: false,
+            adbDevice: false, error: "ERROR: Could not find any ADB device"
+        };
+        compare(PhoneCards.mirrorState(away), "offline");
+        compare(PhoneCards.mirrorSubtitleKey(away), "error");
+        // A launching card still outranks both: the failure being carried
+        // belongs to the launch before this one.
+        compare(PhoneCards.mirrorSubtitleKey(Object.assign({}, away, { launching: true })), "launching");
+        compare(PhoneCards.mirrorState(Object.assign({}, away, { launching: true })), "connecting");
+    }
+
+    function test_the_window_between_the_click_and_the_answer_is_never_running() {
+        // The recorded defect: the supervisor's `started` means it SPAWNED
+        // scrcpy, so the card read "scrcpy Mirror / Mirror is running - click
+        // to focus its window" with a filled check on a machine adb had never
+        // seen a phone on. Whatever else is true, a launching mirror draws as
+        // connecting - no check mark, no detail line, no focus invitation.
+        const launching = {
+            available: true, reachable: true, running: false, launching: true,
+            adbDevice: false, error: ""
+        };
+        compare(PhoneCards.mirrorState(launching), "connecting");
+        compare(PhoneCards.mirrorTitleKey(launching), "connecting");
+        compare(PhoneCards.mirrorSubtitleKey(launching), "launching");
     }
 
     function test_a_probe_that_has_not_answered_yet_is_not_a_refusal() {

--- a/dots/.config/quickshell/imi/tests/tst_phone_scrcpy.qml
+++ b/dots/.config/quickshell/imi/tests/tst_phone_scrcpy.qml
@@ -246,11 +246,17 @@ TestCase {
     // PhoneScrcpy - the event ladder
     // ================================================================
 
-    function test_scrcpy_started_and_exited_move_the_mirror_and_the_session_list() {
+    function test_scrcpy_a_spawned_mirror_is_still_launching_until_it_settles() {
+        // `started` is the supervisor answering that it SPAWNED scrcpy. It
+        // emits that the instant Popen returns and cannot know whether a
+        // window appeared, so the spawn alone must never read as a running
+        // mirror - that is what put "Mirror is running" and a filled check on
+        // a card whose phone adb has never seen.
         PhoneScrcpy.mirrorLaunching = true
         PhoneScrcpy.handleLine('{"event":"started","id":"mirror","pid":4242,"title":"imi-phone-mirror-mirror"}')
-        verify(PhoneScrcpy.mirrorRunning)
-        verify(!PhoneScrcpy.mirrorLaunching)
+        verify(!PhoneScrcpy.mirrorRunning)
+        verify(PhoneScrcpy.mirrorLaunching)
+        compare(PhoneScrcpy.mirrorSettleArmed, 1)
         compare(PhoneScrcpy.sessionCount, 1)
         compare(PhoneScrcpy.sessions.get(0).title, "imi-phone-mirror-mirror")
         compare(PhoneScrcpy.sessions.get(0).pid, 4242)
@@ -259,18 +265,69 @@ TestCase {
         compare(PhoneScrcpy.sessionCount, 2)
         compare(PhoneScrcpy.sessions.get(1).package, "org.mozilla.firefox")
         verify(PhoneScrcpy.isAppRunning("org.mozilla.firefox"))
-        // A repeat `started` (alreadyRunning) updates the row in place.
+        // An app session's spawn is not the mirror's and arms nothing.
+        compare(PhoneScrcpy.mirrorSettleArmed, 1)
+        // Surviving the settle is the evidence there is that it opened.
+        PhoneScrcpy.fireMirrorSettle()
+        verify(PhoneScrcpy.mirrorRunning)
+        verify(!PhoneScrcpy.mirrorLaunching)
+        // A repeat `started` (alreadyRunning) updates the row in place and
+        // needs no settle: the supervisor is answering about a child it has
+        // been watching.
         PhoneScrcpy.handleLine('{"event":"started","id":"mirror","pid":4242,"title":"imi-phone-mirror-mirror","alreadyRunning":true}')
         compare(PhoneScrcpy.sessionCount, 2)
+        verify(PhoneScrcpy.mirrorRunning)
+        compare(PhoneScrcpy.mirrorSettleArmed, 1)
         PhoneScrcpy.handleLine('{"event":"exited","id":"mirror","code":0,"error":""}')
         verify(!PhoneScrcpy.mirrorRunning)
         compare(PhoneScrcpy.sessionCount, 1)
         compare(PhoneScrcpy.lastError, "")
+        // A mirror that was RUNNING and closed cleanly is not a failure.
+        compare(PhoneScrcpy.mirrorError, "")
         PhoneScrcpy.handleLine('{"event":"exited","id":"app:org.mozilla.firefox","code":1,"error":"ERROR: Could not find ADB device"}')
         compare(PhoneScrcpy.sessionCount, 0)
         compare(PhoneScrcpy.lastError, "ERROR: Could not find ADB device")
+        // ...and an APP's failure is not the mirror's, which is the whole
+        // reason mirrorError is a second string.
+        compare(PhoneScrcpy.mirrorError, "")
         compare(PhoneScrcpy.feedbackLog.length, 1)
         compare(PhoneScrcpy.feedbackLog[0].ok, false)
+    }
+
+    function test_scrcpy_a_launch_that_exits_before_it_settles_is_a_failure() {
+        // The recorded defect end to end: the supervisor spawns scrcpy, adb
+        // has no device, scrcpy exits about a second later. The card must
+        // never have read `running`, and what it says afterwards is the
+        // error rather than the line it had before the click.
+        PhoneScrcpy.available = true
+        PhoneScrcpy.launchMirror()
+        verify(PhoneScrcpy.mirrorLaunching)
+        compare(PhoneScrcpy.mirrorError, "")
+        PhoneScrcpy.handleLine('{"event":"started","id":"mirror","pid":4242,"title":"imi-phone-mirror-mirror"}')
+        verify(!PhoneScrcpy.mirrorRunning)
+        verify(PhoneScrcpy.mirrorSettlePending)
+        PhoneScrcpy.handleLine('{"event":"exited","id":"mirror","code":1,"error":"ERROR: Could not find any ADB device"}')
+        verify(!PhoneScrcpy.mirrorRunning)
+        verify(!PhoneScrcpy.mirrorLaunching)
+        verify(!PhoneScrcpy.mirrorSettlePending)
+        compare(PhoneScrcpy.mirrorError, "ERROR: Could not find any ADB device")
+        compare(PhoneScrcpy.sessionCount, 0)
+        // And the settle firing late must not resurrect it: the row is gone,
+        // which is the one thing mirrorSettled() asks about.
+        PhoneScrcpy.mirrorSettled()
+        verify(!PhoneScrcpy.mirrorRunning)
+    }
+
+    function test_scrcpy_an_exit_with_no_stderr_line_still_reports_the_failure() {
+        // scrcpy can die without printing anything the supervisor kept. A
+        // launch that never settled still produced nothing, so the card gets
+        // a sentence rather than an empty string it would draw as silence.
+        PhoneScrcpy.available = true
+        PhoneScrcpy.launchMirror()
+        PhoneScrcpy.handleLine('{"event":"started","id":"mirror","pid":4242,"title":"imi-phone-mirror-mirror"}')
+        PhoneScrcpy.handleLine('{"event":"exited","id":"mirror","code":1,"error":""}')
+        compare(PhoneScrcpy.mirrorError, "scrcpy exited before the mirror window opened")
+        compare(PhoneScrcpy.lastError, "")
     }
 
     function test_scrcpy_an_error_event_ends_the_launch_and_names_the_cause() {
@@ -279,6 +336,15 @@ TestCase {
         verify(!PhoneScrcpy.mirrorLaunching)
         verify(!PhoneScrcpy.mirrorRunning)
         compare(PhoneScrcpy.lastError, "Failed to launch scrcpy: [Errno 2]")
+        compare(PhoneScrcpy.mirrorError, "Failed to launch scrcpy: [Errno 2]")
+    }
+
+    function test_scrcpy_a_new_launch_clears_the_mirrors_own_error() {
+        PhoneScrcpy.available = true
+        PhoneScrcpy.mirrorError = "ERROR: Could not find any ADB device"
+        PhoneScrcpy.launchMirror()
+        compare(PhoneScrcpy.mirrorError, "")
+        verify(PhoneScrcpy.mirrorLaunching)
     }
 
     function test_scrcpy_a_cached_app_list_shows_but_keeps_loading_until_the_live_one() {
@@ -328,7 +394,14 @@ TestCase {
     }
 
     function test_scrcpy_launch_mirror_while_running_focuses_instead() {
+        // Running, not merely spawned: the settle is what turns the one into
+        // the other, and a click before it lands is answered by the launch
+        // that is already in flight rather than by a second one.
         PhoneScrcpy.handleLine('{"event":"started","id":"mirror","pid":1,"title":"t"}')
+        PhoneScrcpy.launchMirror()
+        compare(PhoneScrcpy.sentMessages, [])
+        PhoneScrcpy.fireMirrorSettle()
+        verify(PhoneScrcpy.mirrorRunning)
         PhoneScrcpy.launchMirror()
         compare(PhoneScrcpy.sentMessages, [{ cmd: "focus", id: "mirror" }])
         PhoneScrcpy.stopMirror()


### PR DESCRIPTION
Three defects on the Phone tab, all of them things that only exist between two settled states, plus the sub-page transition's missing outgoing half.

**The scrcpy card lied about a mirror that could not start, then lost its icon.** The supervisor emits `started` the instant `subprocess.Popen` returns — it has no way to know a window appeared — and on a phone `adb devices` does not list, scrcpy prints "Could not find any ADB device" and exits about a second later. For that second the card read "scrcpy Mirror / Mirror is running - click to focus its window", with a filled check mark and "Active for 0s", and then dropped back to the line it had before the click with nothing said. A spawn keeps the mirror `launching` now and arms a settle; the settle, or the supervisor's exit, decides. `alreadyRunning` is exempt, and `launchMirror()` refuses while a launch is in flight so a second click cannot fish that answer out of the supervisor about the child it spawned a moment ago.

The failure is reported rather than swallowed: `mirrorError` is the mirror's **own** last error, cleared by every launch, so the subtitle ladder can ask it before the ADB precondition. That ordering was the other way round, with a test asserting it and a comment explaining it, and both were right while the flag carried the service-wide `lastError` — the repair is what the flag means, not the ordering. Preferring the precondition made a failed launch byte-identical to no launch.

**The empty badge** is `StyledText.animateChange`: it fades the **glyph** to zero inside a `MaterialShape` that does not fade with it, and the card's ladder can move twice inside one tier. Measured, the glyph sat at or under 0.02 opacity for over 200 ms of a 150 ms tier and came out still drawing the icon it went in with.

**The toast overflowed the panel** with a long service error. Its bound now comes from the panel's width and the spacing tokens rather than from a guess about the longest string, and the label wraps.

**The sub-page transition** grew its outgoing half: the tab recedes as well as fading, both channels on the one `subPageProgress` scalar with the one `Behavior` already on it, so `elementMove` is taken whole and the motion slider and reduce-motion reach it. The scale's destination is `Appearance.animation.entranceScaleFrom(root.width)` — the same derivation every `StaggerEntrance` member arrives on — rather than a picked number.

All four are driven in `PhoneTabRuntimeTest.qml`, which now watches rather than reads: the mirror click runs through the real supervisor and the fake scrcpy on the harness's PATH, sampled every 25 ms, and each watch asserts its own sample count first, because a watch that never ran reports "nothing bad happened" exactly as loudly as a correct one.

Docs: updated AGENT.md §External binaries the shell drives (the phone services' entries), §Directory map and §Design language
Changelog: updated
