### PR TITLE
fix(phone): the Apps page says what to turn on when ADB has no device

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -4775,6 +4775,71 @@ the icon it went in with, having swapped nothing. Before reaching for
 often the value can change.
 3c82747df ("fix(phone): the feature card's glyph stops blanking its own badge").
 
+**And where the missing link is the whole page rather than one card's subtitle,
+it is drawn as a panel that says what to do.** The Phone tab's Android Apps
+page is another reader of `PhoneDeps.adbDevice` and the first where the answer
+is everything on screen: with a phone paired to KDE Connect over the LAN and
+nothing under `adb devices`, App Mode has no transport, so the page has no list,
+and what it drew was the session manager's own sentence - "Phone not reachable
+over ADB", `scrcpy_session_manager.py`'s `apps_error` - as one line of red text,
+with a "No apps yet" empty state underneath saying the same thing in weaker
+words and offering no way out of it. Four things from repairing it.
+
+- **The state is read off `PhoneDeps.adbDevice`, never off
+  `PhoneScrcpy.appsError`.** That string is a *consequence*: it exists only
+  after a list request has been made and failed, so it is absent on a page
+  nobody has asked yet and present for reasons that are not this one, and a
+  surface matching on its text is a second answer to a question the probe
+  already answers. The tri-state rule b591575c4 records carries unchanged -
+  `PhoneDeps.ready ? PhoneDeps.adbDevice : undefined`, because every flag in
+  that singleton starts `false` and a plain falsy test draws the panel for the
+  first frames of every session.
+- **Two messages about one fact is one message too many, and the one that goes
+  is the one that cannot act.** `PagePlaceholder` is kept for the state it is
+  actually about - a phone the shell can reach that came back with no apps -
+  and the status line stands down while the panel is up rather than repeating
+  the supervisor's sentence above it. Both are `visible`/`shown` gates on the
+  same derivation, so there is no ordering between them to get wrong.
+- **A panel naming a state owes the ways out of it, and only the ones that
+  exist.** Both routes are on it because the machine this was reported from has
+  neither: USB debugging over a cable (Developer options, then the fingerprint
+  prompt), and wireless debugging, which on Android 11+ picks a **new port
+  every time the switch is toggled** - so the `adb pair`/`adb connect` pair is
+  typed by hand and typed again after each toggle and each reboot. The fork
+  polls mDNS for that port; this shell does not, and the panel therefore
+  promises no button. What it does promise is what the shell really does: the
+  card stack's own five-second poll keeps re-asking `adb devices` while the tab
+  is open (it stays loaded under a sub-page, so this page adds no second
+  poller), and the page asks for the app list once when a device appears -
+  an observation of that one state change, not a timer and not a binding, which
+  is what keeps `--list-apps` from starting a scrcpy per turn.
+- **A `PagePlaceholder` description handed the page's whole width is a
+  paragraph at a measure nobody chose.** `dropIconWhenCramped` widens that
+  column to the page - only so the fit decision measures against a width that
+  cannot move under it - and the description, which fills, inherited it: 63
+  characters across 440px, drawn edge to edge and aligned left. The clamp is
+  `descriptionMaximumWidth` on the shared widget, opt-in at -1 so the callers
+  drawing a two-word description keep exactly what they drew, and it carries
+  the centring with it because a clamped paragraph left against the column's
+  edge reads as a margin on one side only. The other three cramped call sites
+  (Contacts, and both notification lists) have the same paragraph problem and
+  are left alone here.
+
+None of it is reachable from a source check or from `qmltestrunner`: which
+message is on screen is a question about three states at once.
+`PhoneTabLayoutRuntimeTest.qml` walks all three in one run - no device, a
+device with no apps, a device with apps - behind a fake `adb` and a fake
+`scrcpy` that answer off two files the harness creates between steps. The fakes
+are the load-bearing part: both tools are really installed on the maintainer's
+machine, so without them the page reads whatever a real `adb devices` answers
+and the reported state vanishes the moment a phone is plugged in.
+(feat(widgets): NoticeBox draws in whichever container role it is given,
+feat(widgets): PagePlaceholder can hold its description to a measure,
+fix(phone): the Apps page says what to turn on when ADB has no device,
+fix(phone): the Apps page's empty state stands down while the panel is up,
+fix(phone): the Apps page's empty state reads as a paragraph, not a rule,
+test(phone): drive the Apps page through its three ADB states.)
+
 **And the surfaces that DRIVE those services get their allowlist derived rather than written
 down.** "A button whose call no service answers is a fake action" is stated for the right
 sidebar's phone dialog as a hand-typed `MODEL_ACTIONS` set. The Phone tab's pages reach five

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,18 @@ own repo; the installer pins which revision it builds.
   sit dead centre instead of a pixel and a half to the left.
 
 ### Fixed
+- **The Phone tab's Android Apps page says what to turn on when it cannot
+  reach the phone.** App Mode drives the phone over ADB, which is a
+  different link from the one KDE Connect pairs: with a phone reachable on
+  the network but no `adb devices` entry, the page drew one thin line of red
+  text ("Phone not reachable over ADB") and an unhelpful "No apps yet" under
+  it. It now draws one panel in the error colours, carrying both ways to get
+  a device - USB debugging over a cable, and wireless debugging with the
+  pair-and-connect Android 11 and newer needs after every toggle - and the
+  empty state stays out of the way until there is a phone that answered with
+  nothing. As soon as a device appears the panel goes and the app list is
+  fetched without a click. The empty state's own line is held to a readable
+  measure and centred instead of running the full width of the panel.
 - **Contacts with an Arabic name fit inside their row.** In the Phone tab's
   Contacts list, a contact whose name is written in Arabic had its number and
   its avatar drawn below the bottom of its own card - a row taller than the

--- a/dots/.config/quickshell/imi/PhoneTabLayoutRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/PhoneTabLayoutRuntimeTest.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import QtTest
 import Quickshell
+import Quickshell.Io
 import qs
 import qs.services
 import qs.modules.common
@@ -26,6 +27,13 @@ import qs.modules.imi.sidebarLeft.phone
  * that the real contacts monitor reads - so the Contacts page has rows to
  * lay out and the notification cards have an icon to resolve.
  *
+ * A fake `adb` and a fake `scrcpy` are on the same PATH, answering off two
+ * files this harness creates between steps, which is what lets the Android
+ * Apps page be walked through its three states in one run - no phone on ADB,
+ * a phone that answered with nothing, and a phone with apps - and what makes
+ * the first of those a property of the test rather than of whichever machine
+ * is running it.
+ *
  * Driven by tests/test_phone_tab_layout_runtime.py, which brings the weston
  * and the session bus.
  *
@@ -39,6 +47,13 @@ ShellRoot {
     property int elapsed: 0
 
     readonly property string phoneId: Quickshell.env("PHONE_ID") ?? ""
+    // The two files the fake `adb` and the fake `scrcpy` read their answers
+    // off. Nothing else in this harness can move the Apps page between its
+    // three states: what the page draws is a consequence of what the tools
+    // report, and the tools are asked again by the shell's own probes.
+    readonly property string adbAttachedPath: Quickshell.env("PHONE_ADB_ATTACHED") ?? ""
+    readonly property string appsFilePath: Quickshell.env("PHONE_APPS_FILE") ?? ""
+    readonly property string appsSourcePath: Quickshell.env("PHONE_APPS_SOURCE") ?? ""
     // The file the fake daemon reports as the first notification's iconPath.
     readonly property string iconPath: Quickshell.env("PHONE_ICON_PATH") ?? ""
     // The two names in the vCard fixture, handed in rather than spelled a
@@ -144,6 +159,21 @@ ShellRoot {
                       + ` else, got ${row.height} against ${headerBox.bottom + pad}`,
                       Math.abs(row.height - (headerBox.bottom + pad)) <= 1
                       && Math.abs(headerBox.top - pad) <= 1);
+    }
+
+    Process { id: fixtureStep }
+
+    function writeFixture(argv) {
+        fixtureStep.exec(argv);
+    }
+
+    // Whether an item is really on screen, which is not the same question as
+    // `visible`: PagePlaceholder fades, so a placeholder standing down reports
+    // `visible` false only once its opacity has finished leaving, and one that
+    // is up at opacity 0 is a message nobody can read.
+    function onScreen(item) {
+        return item !== null && item.visible && item.opacity > 0.5
+            && item.width > 0 && item.height > 0;
     }
 
     // Where an item is DRAWN, in another item's coordinates. Everything about
@@ -382,12 +412,70 @@ ShellRoot {
         () => loader.item.popSubPage(),
         () => {},
 
-        // ---- the Apps page's empty state stays under its own header -------
+        // ---- the Apps page with no phone on ADB ---------------------------
+        //
+        // The state the maintainer photographed: a phone paired to KDE Connect
+        // over the LAN, and `adb devices` listing nothing. What was on screen
+        // was a line of red text and an empty state under it, neither of which
+        // says what to do; what has to be on screen is one panel that does.
         () => loader.item.openSubPage("apps"),
+        () => {},
         () => {},
         () => {
             const page = harness.first("PhoneAppsPage");
             const placeholder = harness.findAll(page, "PagePlaceholder", [])[0] ?? null;
+            const notice = harness.findAll(page, "NoticeBox", [])[0] ?? null;
+            const list = harness.findAll(page, "StyledListView", [])[0] ?? null;
+            const region = placeholder?.parent ?? null;
+            const column = region?.parent ?? null;
+            const status = column?.children[1] ?? null;
+            const noticeText = harness.findAll(notice, "StyledText", [])
+                .map(t => String(t.text)).join(" | ");
+            console.log(`[PhoneTabLayout] no-adb: ready=${PhoneDeps.ready} adb=${PhoneDeps.adb}`
+                        + ` adbDevice=${PhoneDeps.adbDevice} appMode=${PhoneScrcpy.appModeSupported}`
+                        + ` appsError="${PhoneScrcpy.appsError}" notice h=${notice?.height}`
+                        + ` placeholderShown=${placeholder?.shown} status=${status?.visible}`
+                        + ` list=${list?.visible}`);
+
+            harness.check(`the fake tooling answered: app mode is supported and adb sees`
+                          + ` no phone, got ready=${PhoneDeps.ready} adb=${PhoneDeps.adb}`
+                          + ` device=${PhoneDeps.adbDevice} appMode=${PhoneScrcpy.appModeSupported}`,
+                          PhoneDeps.ready && PhoneDeps.adb && !PhoneDeps.adbDevice
+                          && PhoneScrcpy.appModeSupported);
+            harness.check(`the page draws a panel, got ${notice?.height}px of one`,
+                          harness.onScreen(notice));
+            harness.check(`...in the error container role, got ${notice?.color}`,
+                          notice !== null && String(notice.color)
+                          === String(Appearance.colors.colErrorContainer));
+            // Both routes, because the machine this was reported from has
+            // neither: a panel naming only the cable is no use to someone
+            // whose phone is across the room.
+            harness.check("...naming USB debugging and wireless debugging both",
+                          noticeText.indexOf("USB debugging") >= 0
+                          && noticeText.indexOf("Wireless debugging") >= 0);
+            harness.check("...and the pairing the wireless route needs by hand",
+                          noticeText.indexOf("adb pair") >= 0
+                          && noticeText.indexOf("adb connect") >= 0);
+            // The two messages that used to say the same thing beside it.
+            harness.check(`the empty state stands down, got shown=${placeholder?.shown}`,
+                          placeholder !== null && !placeholder.shown);
+            harness.check(`the status line's red duplicate stands down too, got`
+                          + ` visible=${status?.visible} text="${status?.text}"`,
+                          status !== null && !status.visible);
+            harness.check(`and no list is drawn, got visible=${list?.visible}`,
+                          list === null || !list.visible);
+        },
+
+        // ---- a phone appears on ADB, and the page asks for the list itself -
+        () => harness.writeFixture(["touch", harness.adbAttachedPath]),
+        () => PhoneDeps.refreshAdbDevices(),
+        () => {},
+        () => {},
+        () => {
+            const page = harness.first("PhoneAppsPage");
+            const placeholder = harness.findAll(page, "PagePlaceholder", [])[0] ?? null;
+            const notice = harness.findAll(page, "NoticeBox", [])[0] ?? null;
+            const list = harness.findAll(page, "StyledListView", [])[0] ?? null;
             // The same structural walk as the Contacts step: the placeholder
             // is anchored into the leftover region, whose parent is the
             // page's content column, whose children are its rows in order.
@@ -409,6 +497,27 @@ ShellRoot {
                             + ` status=${status} placeholder=${placeholder}`);
                 return;
             }
+
+            console.log(`[PhoneTabLayout] on-adb: adbDevice=${PhoneDeps.adbDevice}`
+                        + ` apps=${PhoneScrcpy.apps.length} loading=${PhoneScrcpy.appsLoading}`
+                        + ` appsError="${PhoneScrcpy.appsError}" notice=${notice?.height}`
+                        + ` placeholderShown=${placeholder.shown} status="${status.text}"`);
+
+            harness.check(`adb sees the phone now, got ${PhoneDeps.adbDevice}`,
+                          PhoneDeps.adbDevice === true);
+            harness.check(`the panel goes with it, got height=${notice?.height}`
+                          + ` visible=${notice?.visible}`,
+                          !harness.onScreen(notice));
+            // The page asked for the list on its own when the device appeared:
+            // the supervisor ran, the phone had nothing to give, and the error
+            // that stood there while there was no transport is gone.
+            harness.check(`...and the list was asked for without a click, got`
+                          + ` error="${PhoneScrcpy.appsError}" loading=${PhoneScrcpy.appsLoading}`,
+                          PhoneScrcpy.appsError === "" && !PhoneScrcpy.appsLoading);
+            harness.check(`the empty state is the message now, got shown=${placeholder.shown}`
+                          + ` title="${placeholder.title}"`,
+                          placeholder.shown && harness.onScreen(drawn)
+                          && String(placeholder.title).length > 0);
 
             const fieldBox = harness.boxIn(field, page);
             const statusBox = harness.boxIn(status, page);
@@ -439,6 +548,33 @@ ShellRoot {
             harness.check(`the status line stays inside the page, got`
                           + ` ${statusBox.left}-${statusBox.right} of ${page.width}`,
                           statusBox.left >= 0 && statusBox.right <= page.width + 1);
+
+            // ---- and the description reads as a paragraph, not as a rule ---
+            const texts = harness.findAll(placeholder, "StyledText", []);
+            const description = texts.find(t => String(t.text)
+                                           === String(placeholder.description)) ?? null;
+            const descriptionBox = description === null ? null
+                : harness.boxIn(description, page);
+            console.log(`[PhoneTabLayout] description w=${description?.width}`
+                        + ` implicit=${description?.implicitWidth}`
+                        + ` ${descriptionBox?.left}-${descriptionBox?.right} of ${page.width}`);
+            // Or the measure is vacuous: a string shorter than the clamp is
+            // held to its own width whatever the clamp says.
+            harness.check(`the description is longer than its measure, got`
+                          + ` ${description?.implicitWidth} against ${description?.width}`,
+                          description !== null
+                          && description.implicitWidth > description.width);
+            harness.check(`...so it is held short of the page, got`
+                          + ` ${descriptionBox?.left}-${descriptionBox?.right}`
+                          + ` of ${page.width}`,
+                          descriptionBox !== null && descriptionBox.left > 0
+                          && descriptionBox.right < page.width);
+            harness.check(`...and centred in the region rather than left against it,`
+                          + ` got ${(descriptionBox?.left + descriptionBox?.right) / 2}`
+                          + ` against ${(regionBox.left + regionBox.right) / 2}`,
+                          descriptionBox !== null
+                          && Math.abs((descriptionBox.left + descriptionBox.right) / 2
+                                      - (regionBox.left + regionBox.right) / 2) <= 1);
             harness.tallPageHeight = page.height;
         },
 
@@ -482,6 +618,48 @@ ShellRoot {
                           + ` ${(regionBox.top + regionBox.bottom) / 2}`,
                           Math.abs((drawnBox.top + drawnBox.bottom) / 2
                                    - (regionBox.top + regionBox.bottom) / 2) <= 1);
+        },
+
+        // ---- the phone has apps: the list, and nothing else ----------------
+        () => {
+            harness.viewportHeight = 900;
+            harness.writeFixture(["cp", harness.appsSourcePath, harness.appsFilePath]);
+        },
+        // The click the panel's last sentence points at, once there is a
+        // device: the refresh button's own call.
+        () => PhoneScrcpy.refreshApps(),
+        () => {},
+        () => {},
+        () => {
+            const page = harness.first("PhoneAppsPage");
+            const placeholder = harness.findAll(page, "PagePlaceholder", [])[0] ?? null;
+            const notice = harness.findAll(page, "NoticeBox", [])[0] ?? null;
+            const list = harness.findAll(page, "StyledListView", [])[0] ?? null;
+            const region = placeholder?.parent ?? null;
+            const column = region?.parent ?? null;
+            const status = column?.children[1] ?? null;
+            const delegate = list === null ? null : list.itemAtIndex(0);
+            console.log(`[PhoneTabLayout] with-apps: apps=${PhoneScrcpy.apps.length}`
+                        + ` list count=${list?.count} h=${list?.height}`
+                        + ` contentHeight=${list?.contentHeight} delegate=${delegate?.height}`
+                        + ` placeholderShown=${placeholder?.shown} notice=${notice?.height}`
+                        + ` status="${status?.text}"`);
+
+            harness.check(`the phone's three apps arrived, got ${PhoneScrcpy.apps.length}`,
+                          PhoneScrcpy.apps.length === 3);
+            harness.check(`the list holds them, got ${list?.count}`,
+                          list !== null && list.visible && list.count === 3);
+            harness.check(`...at a height to draw into, got ${list?.height}`
+                          + ` with a first row of ${delegate?.height}`,
+                          list !== null && list.height > 0
+                          && delegate !== null && delegate.height > 0);
+            harness.check(`the empty state is gone, got shown=${placeholder?.shown}`,
+                          placeholder !== null && !placeholder.shown);
+            harness.check(`the panel is gone, got height=${notice?.height}`,
+                          !harness.onScreen(notice));
+            harness.check(`and the status line counts them, got "${status?.text}"`,
+                          status !== null && status.visible
+                          && String(status.text).indexOf("3 of 3") >= 0);
         },
 
         () => harness.finish()

--- a/dots/.config/quickshell/imi/modules/common/widgets/NoticeBox.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/NoticeBox.qml
@@ -9,8 +9,17 @@ Rectangle {
     property alias text: noticeText.text
     default property alias data: buttonRow.data
 
+    // The container role the notice is drawn in. It is a PAIR rather than one
+    // colour: a caller that only re-tints the surface leaves the glyph and the
+    // text in the previous role's on-colour, which is a contrast decision made
+    // by accident. Primary is what every existing notice draws in; a notice
+    // whose state is the reason the surface around it is empty says so in the
+    // error roles instead.
+    property color colBackground: Appearance.colors.colPrimaryContainer
+    property color colOnBackground: Appearance.colors.colOnPrimaryContainer
+
     radius: Appearance.rounding.normal
-    color: Appearance.colors.colPrimaryContainer
+    color: root.colBackground
     implicitWidth: mainRowLayout.implicitWidth + mainRowLayout.anchors.margins * 2
     implicitHeight: mainRowLayout.implicitHeight + mainRowLayout.anchors.margins * 2
 
@@ -26,7 +35,7 @@ Rectangle {
             Layout.alignment: Qt.AlignTop
             text: "info"
             iconSize: Appearance.font.pixelSize.huge
-            color: Appearance.colors.colOnPrimaryContainer
+            color: root.colOnBackground
         }
 
         ColumnLayout {
@@ -37,7 +46,7 @@ Rectangle {
                 id: noticeText
                 Layout.fillWidth: true
                 text: "Notice message"
-                color: Appearance.colors.colOnPrimaryContainer
+                color: root.colOnBackground
                 wrapMode: Text.WordWrap
             }
 

--- a/dots/.config/quickshell/imi/modules/common/widgets/PagePlaceholder.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/PagePlaceholder.qml
@@ -14,6 +14,15 @@ Item {
     property alias shape: shapeWidget.shape
     property alias descriptionHorizontalAlignment: widgetDescriptionText.horizontalAlignment
 
+    // The width the description wraps at, for a caller whose empty state is a
+    // sentence rather than a word. `dropIconWhenCramped` widens this column to
+    // the whole page - only so the fit decision below measures against a width
+    // that cannot move under it - and a description filling that width is a
+    // paragraph run edge to edge, which is a measure nobody chose. -1, the
+    // default, is the column's own width: every caller that drew a two-word
+    // description keeps exactly what it drew.
+    property real descriptionMaximumWidth: -1
+
     // Drop the shape rather than let it draw outside the page when the page is
     // too short to hold the whole column - placeholderFit.js has the reasoning
     // for why the shape is what gives way. Off by default: a page with room to
@@ -78,6 +87,12 @@ Item {
             id: widgetDescriptionText
             visible: description !== ""
             Layout.fillWidth: true
+            Layout.maximumWidth: root.descriptionMaximumWidth > 0
+                ? root.descriptionMaximumWidth : Number.POSITIVE_INFINITY
+            // A clamped paragraph is centred in the column rather than left
+            // against its edge, or the measure reads as a ragged margin on one
+            // side. Unclamped it fills, so the alignment has nothing to do.
+            Layout.alignment: root.descriptionMaximumWidth > 0 ? Qt.AlignHCenter : 0
             font.pixelSize: Appearance.font.pixelSize.small
             color: Appearance.m3colors.m3outline
             horizontalAlignment: Text.AlignLeft

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneAppsPage.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneAppsPage.qml
@@ -551,6 +551,10 @@ PhoneSubPage {
                 // reach that came back with nothing.
                 shown: root.filteredApps.length === 0 && !root.adbOffline
                 dropIconWhenCramped: true
+                // A sentence, held to a measure and centred, rather than one
+                // line of text across the whole panel.
+                descriptionMaximumWidth: Appearance.font.pixelSize.small * 21
+                descriptionHorizontalAlignment: Text.AlignHCenter
                 icon: PhoneScrcpy.appModeSupported ? "apps" : "warning"
                 shape: MaterialShape.Shape.Ghostish
                 title: {

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneAppsPage.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneAppsPage.qml
@@ -544,7 +544,12 @@ PhoneSubPage {
 
             PagePlaceholder {
                 anchors.fill: parent
-                shown: root.filteredApps.length === 0
+                // Not while the panel above is up. "No apps yet" and "no phone
+                // on ADB" are the same fact told twice, and the placeholder is
+                // the half that cannot say what to do about it. What it is
+                // for is the state it is actually about: a phone the shell can
+                // reach that came back with nothing.
+                shown: root.filteredApps.length === 0 && !root.adbOffline
                 dropIconWhenCramped: true
                 icon: PhoneScrcpy.appModeSupported ? "apps" : "warning"
                 shape: MaterialShape.Shape.Ghostish
@@ -564,7 +569,10 @@ PhoneSubPage {
                         return Translation.tr("scrcpy is asking the phone what it has installed.");
                     if (root.query.length > 0)
                         return Translation.tr("Try part of a name or a package.");
-                    return Translation.tr("Connect the phone over USB or wireless debugging, then refresh.");
+                    // The panel above owns the case where there is no phone on
+                    // ADB, so this one is about a phone that answered and had
+                    // nothing to say.
+                    return Translation.tr("The phone answered with no apps. Unlock its screen and refresh to ask again.");
                 }
             }
         }

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneAppsPage.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneAppsPage.qml
@@ -18,6 +18,13 @@ import "phone_cards.js" as PhoneCards
  * glyph is what the fork falls back to anyway whenever its extractor cannot
  * resolve one.
  *
+ * The page has three states and draws exactly one message in each: no phone on
+ * ADB (a danger panel carrying the two ways to get one, and no placeholder
+ * under it), a phone that answered with nothing (the placeholder), and a phone
+ * with apps (the list). `PhoneDeps.adbDevice` is what separates the first from
+ * the second - never `PhoneScrcpy.appsError`, which is the supervisor's
+ * sentence about the same fact and would be a second answer to it.
+ *
  * The search query lives HERE rather than on PhoneScrcpy: a text field on one
  * page writing a property on a singleton makes the query global state, and the
  * filter itself is phone_cards.js's `filterApps` (tests/tst_phone_cards.qml).
@@ -30,6 +37,17 @@ PhoneSubPage {
     property string query: ""
 
     readonly property var filteredApps: PhoneCards.filterApps(PhoneScrcpy.apps, root.query)
+
+    // Whether adb can see a phone. That is a different link from the one the
+    // device chip reports: a phone paired to KDE Connect over the LAN is
+    // reachable there and lists nothing under `adb devices`, and App Mode runs
+    // on the second one. Deliberately TRI-STATE, the way PhoneFeatureCards
+    // derives it - every PhoneDeps flag starts `false`, so a plain falsy test
+    // would draw the panel below for the first frames of every session.
+    readonly property var adbDevice: PhoneDeps.ready ? PhoneDeps.adbDevice : undefined
+    // App Mode is installed and has no transport: nothing on this page can
+    // start, and the reason is the whole content of the page.
+    readonly property bool adbOffline: PhoneScrcpy.appModeSupported && root.adbDevice === false
 
     // The live sessions, as a plain list. PhoneScrcpy.sessions is a ListModel,
     // which is not a binding source - `sessionCount` is read so this
@@ -48,9 +66,24 @@ PhoneSubPage {
     // The list is asked for once, when the page opens with nothing in it.
     // Never on a timer and never from a binding: `--list-apps` starts a scrcpy
     // against the phone.
-    Component.onCompleted: {
+    function askForApps(): void {
         if (PhoneScrcpy.appModeSupported && PhoneScrcpy.apps.length === 0 && !PhoneScrcpy.appsLoading)
             PhoneScrcpy.refreshApps();
+    }
+
+    Component.onCompleted: root.askForApps()
+
+    // ...and once more when a phone appears on ADB while the page is open,
+    // which is the one event that turns an unanswerable request into an
+    // answerable one. That is an observation of a state change rather than a
+    // second trigger borrowed from something else, so it fires once per plug-in
+    // and the panel below can honestly say the list arrives on its own.
+    Connections {
+        target: PhoneDeps
+        function onAdbDeviceChanged() {
+            if (PhoneDeps.adbDevice)
+                root.askForApps();
+        }
     }
 
     ColumnLayout {
@@ -107,9 +140,15 @@ PhoneSubPage {
             }
         }
 
+        // The count, or whatever there is to say instead of one. It stands
+        // down while the panel below is up: with no device on ADB the list
+        // request fails with "Phone not reachable over ADB", and a red line
+        // saying that over a panel saying it at length is the same sentence
+        // twice.
         StyledText {
             Layout.fillWidth: true
             Layout.leftMargin: Appearance.spacing.space50
+            visible: !root.adbOffline
             text: {
                 if (!PhoneScrcpy.appModeSupported)
                     return Translation.tr("App Mode needs scrcpy 4.0 or newer");
@@ -122,6 +161,71 @@ PhoneSubPage {
             font.pixelSize: Appearance.font.pixelSize.smaller
             color: PhoneScrcpy.appsError.length > 0 ? Appearance.colors.colError : Appearance.colors.colSubtext
             wrapMode: Text.WordWrap
+        }
+
+        // ---- no transport, and how to get one ----
+        //
+        // A page with nothing in it because a link is missing owes the reader
+        // the link, not a footnote: this is the whole page in that state, so it
+        // carries the two routes there actually are. Both are typed by hand on
+        // purpose - the shell has no pairing button, and Android 11+ picks a
+        // new wireless-debugging port every time the switch is toggled, so
+        // there is no port to remember on the user's behalf either.
+        NoticeBox {
+            Layout.fillWidth: true
+            visible: root.adbOffline
+            colBackground: Appearance.colors.colErrorContainer
+            colOnBackground: Appearance.colors.colOnErrorContainer
+            materialIcon: "usb_off"
+            text: Translation.tr("App Mode starts each app over ADB, and no phone is on ADB. Pairing in KDE Connect does not do it: that link carries notifications and files, not debugging. Turn one of these on, on the phone.")
+
+            ColumnLayout {
+                Layout.fillWidth: true
+                // A layout nested in a layout fills by default, which would
+                // take the notice's own row unbounded.
+                Layout.fillHeight: false
+                spacing: Appearance.spacing.space75
+
+                StyledText {
+                    Layout.fillWidth: true
+                    text: Translation.tr("Over a USB cable")
+                    font.pixelSize: Appearance.font.pixelSize.smaller
+                    font.weight: Font.DemiBold
+                    color: Appearance.colors.colOnErrorContainer
+                    wrapMode: Text.WordWrap
+                }
+                StyledText {
+                    Layout.fillWidth: true
+                    text: Translation.tr("Settings → System → Developer options → USB debugging. Plug the cable in and accept the fingerprint the phone asks about.")
+                    font.pixelSize: Appearance.font.pixelSize.smaller
+                    color: Appearance.colors.colOnErrorContainer
+                    wrapMode: Text.WordWrap
+                }
+
+                StyledText {
+                    Layout.fillWidth: true
+                    text: Translation.tr("Over Wi-Fi, on Android 11 and newer")
+                    font.pixelSize: Appearance.font.pixelSize.smaller
+                    font.weight: Font.DemiBold
+                    color: Appearance.colors.colOnErrorContainer
+                    wrapMode: Text.WordWrap
+                }
+                StyledText {
+                    Layout.fillWidth: true
+                    text: Translation.tr("Developer options → Wireless debugging → Pair device with pairing code, then in a terminal: adb pair IP:PAIRING_PORT, and adb connect IP:PORT with the port the Wireless debugging screen shows. Android picks new ports every time that switch is turned off and on, so the pair and the connect are done again after a toggle or a reboot.")
+                    font.pixelSize: Appearance.font.pixelSize.smaller
+                    color: Appearance.colors.colOnErrorContainer
+                    wrapMode: Text.WordWrap
+                }
+
+                StyledText {
+                    Layout.fillWidth: true
+                    text: Translation.tr("The tab keeps asking while it is open. As soon as a device answers, this goes and the app list is fetched on its own.")
+                    font.pixelSize: Appearance.font.pixelSize.smaller
+                    color: Appearance.colors.colOnErrorContainer
+                    wrapMode: Text.WordWrap
+                }
+            }
         }
 
         // ---- what is running right now ----

--- a/dots/.config/quickshell/imi/tests/test_phone_tab_layout_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_tab_layout_runtime.py
@@ -3,7 +3,7 @@
 
 `PhoneTabLayoutRuntimeTest.qml` builds the real tab over the real services,
 opens the Contacts and Android Apps sub-pages and reads the drawn geometry
-back. It exists because three defects the maintainer hit are invisible to
+back. It exists because four defects the maintainer hit are invisible to
 every other check in this suite:
 
 - a sub-page whose content resolves to ZERO height renders its header and
@@ -25,6 +25,18 @@ every other check in this suite:
   of the card. An aligned layout child keeps its preferred size when the cell
   is too small - it overflows rather than shrinking - so nothing errors and
   nothing is logged. The fixture therefore carries both scripts.
+
+It also drives the Android Apps page through its three states, because which
+message that page draws is a question about all three at once and no source
+check can ask it: with no phone on ADB it must draw the danger panel and
+NEITHER of the two lines that used to say the same thing beside it (a red
+"Phone not reachable over ADB" from the session manager, and a "No apps yet"
+empty state that cannot say what to do about it); with a phone that answered
+and had nothing, the empty state and no panel; with apps, the list and no
+message at all. `adb` and `scrcpy` are faked for it - both are really installed
+on the maintainer's machine, so without the fakes the page reads whatever a
+real `adb devices` answers and the reported state disappears the moment a phone
+is plugged in.
 
 The fake `busctl` serves one paired, reachable phone and two mirrored
 notifications: leaf 70 carries an `iconPath` (a PNG this test writes, the way
@@ -60,7 +72,9 @@ PHONE_ADDRESS = "192.168.100.179"
 # A literal, never read back out of the harness's own output: a step list
 # that shrinks must redden here instead of reporting `failures: 0` for a
 # shorter run.
-EXPECTED_CHECKS = 34
+# 21 shared, 13 for the contact rows' geometry, 21 for the Apps page's
+# three ADB states.
+EXPECTED_CHECKS = 55
 
 # The two names the row-geometry steps measure, handed to the harness in the
 # environment so the fixture is the only place either is spelled. The Arabic
@@ -95,6 +109,51 @@ ARABIC_FACE = "Noto Sans Arabic"
 RECORD = """#!/usr/bin/env bash
 printf '%s %s\\n' "$(date +%s.%N)" "$*" >> "$PHONE_EXEC_LOG"
 __BODY__
+"""
+
+# `adb` and `scrcpy`, faked so the Apps page's three states are a property of
+# this test rather than of the machine running it. Both are really installed on
+# the maintainer's box - which is exactly why they have to be shadowed: with the
+# real ones the page reads whatever `adb devices` happens to answer, and the
+# state the screenshots were taken in (adb sees nothing) would flip the moment a
+# phone is plugged in.
+#
+# What is attached is a FILE the harness creates between steps, not an argument,
+# because the thing being driven is a change the shell has to notice on its own.
+ADB_BODY = """\
+case "$*" in
+  *"devices"*)
+    printf 'List of devices attached\\n'
+    if [ -f "$PHONE_ADB_ATTACHED" ]; then printf 'imi-fake-phone\\tdevice\\n'; fi
+    exit 0
+    ;;
+esac
+# Every other adb call - `shell pm list packages -3` is the one the session
+# manager falls back to - fails while nothing is attached, which is what tells
+# it apart from a phone that answered with no apps.
+[ -f "$PHONE_ADB_ATTACHED" ] || exit 1
+exit 0
+"""
+
+SCRCPY_BODY = """\
+case "$*" in
+  *--version*)
+    printf 'scrcpy 4.1 <https://github.com/Genymobile/scrcpy>\\n'
+    exit 0
+    ;;
+  *--list-apps*)
+    if [ -f "$PHONE_APPS_FILE" ]; then cat "$PHONE_APPS_FILE"; fi
+    exit 0
+    ;;
+esac
+exit 0
+"""
+
+# `scrcpy --list-apps` prints `* ` for a system app and `- ` for a user one.
+APP_LINES = """\
+ * Settings                        com.android.settings
+ - Signal                          org.thoughtcrime.securesms
+ - Firefox                         org.mozilla.firefox
 """
 
 # --json=short shapes lifted from a real busctl against a live KDE Connect
@@ -247,6 +306,20 @@ class PhoneTabLayoutRuntimeTest(unittest.TestCase):
         }))
         fake.chmod(0o755)
 
+        # Neither marker exists yet: the page opens in the state the
+        # screenshots were taken in, with no phone on ADB at all.
+        self.adb_attached = self.home / "adb-attached"
+        self.apps_file = self.home / "apps.txt"
+        # Staged beside it rather than written in place: the harness copies it
+        # over when it wants the third state, so the second state ("the phone
+        # answered with nothing") is a real empty answer from a real device.
+        self.apps_source = self.home / "apps-source.txt"
+        self.apps_source.write_text(APP_LINES)
+        for name, body in (("adb", ADB_BODY), ("scrcpy", SCRCPY_BODY)):
+            tool = self.bin / name
+            tool.write_text(RECORD.replace("__BODY__", body))
+            tool.chmod(0o755)
+
         # The vCards KDE Connect writes for KPeople, which the real monitor
         # reads: a fixture tree, never the machine's own contacts.
         cards = self.home / "data" / "kpeoplevcard" / f"kdeconnect-{PHONE_ID}"
@@ -302,6 +375,9 @@ class PhoneTabLayoutRuntimeTest(unittest.TestCase):
         env["PHONE_ICON_PATH"] = str(self.icon_path)
         env["PHONE_CONTACT_LATIN"] = LATIN_NAME
         env["PHONE_CONTACT_ARABIC"] = ARABIC_NAME
+        env["PHONE_ADB_ATTACHED"] = str(self.adb_attached)
+        env["PHONE_APPS_FILE"] = str(self.apps_file)
+        env["PHONE_APPS_SOURCE"] = str(self.apps_source)
 
         # dbus-run-session, not the inherited bus: the fake busctl is the only
         # daemon this harness may see.


### PR DESCRIPTION
The Phone tab's Android Apps page, in the state the screenshots were taken in: a phone paired to KDE Connect over the LAN, and `adb devices` listing nothing. App Mode runs over ADB, so the page has no list — and what it drew about that was one thin line of red text (`scrcpy_session_manager.py`'s "Phone not reachable over ADB", arriving as `PhoneScrcpy.appsError`) with a "No apps yet" empty state under it repeating it in weaker words, neither of them saying what to do.

### What the three states draw now

| state | what is on screen |
| --- | --- |
| no phone on ADB | one panel in `colErrorContainer`, carrying both routes; no placeholder, no red status line |
| a phone that answered with nothing | the placeholder, and the count line above it |
| a phone with apps | the list, and the count line |

The panel names the exact steps on the phone for both routes — Developer options → USB debugging with the cable and the fingerprint prompt, and Developer options → Wireless debugging with `adb pair` / `adb connect` typed by hand, because Android 11+ re-rolls both ports on every toggle and this shell does not poll mDNS for them the way the sibling fork does. It promises no button we have not got: the only thing it claims the shell does is what the shell really does — the card stack's own five-second poll keeps re-asking `adb devices` while the tab is open, and the page asks for the app list once when a device appears.

Which state to draw is read off `PhoneDeps.adbDevice` (tri-state, the way `PhoneFeatureCards` derives it), never off `appsError`: that string is a consequence of a request having been made and failed, absent on a page nobody has asked yet, and matching on its text would be a second answer to a question the probe already answers.

The empty state's description was also running the full 440px width of the panel, left-aligned, because `dropIconWhenCramped` widens the placeholder's column to the page for the fit decision's sake and the description fills what it is given. `PagePlaceholder.descriptionMaximumWidth` holds it to a measure and centres it; it is opt-in, so the callers with a two-word description are untouched.

### Tests

`PhoneTabLayoutRuntimeTest.qml` walks the page through all three states in one run behind a fake `adb` and a fake `scrcpy` that answer off files the harness creates between steps — the fakes are load-bearing rather than a convenience, since both tools are really installed on this machine and the reported state disappears the moment a phone is plugged in. The empty-state geometry checks moved into the second state, where the placeholder is really drawn; left where they were they would have measured a placeholder that is now deliberately not drawn, and passed.

This branch shares that harness with the contact-row fix that landed first, so the merge keeps both sets of steps and both agents' measurements run together: `checks: 55 failures: 0`, with the Arabic card at 67px beside the Latin 58 confirming that the other side's `FONTS_CONF` still survives this branch's `XDG_CONFIG_HOME` redirect.

Suite green in both locales: 1417 passed, 0 failed.

Docs: updated AGENT.md §Dynamic/data-driven QML gotchas
Changelog: updated
