### PR TITLE
feat(phone): pair over Wi-Fi from the tab, and tell a tool that cannot run from one that is absent

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -701,20 +701,32 @@ services/                  Singletons wrapping external state/processes - one pe
                               dialer and SMS actions are `adb shell am start` intents,
                               refused with `lastError` when adb cannot reach the phone
   PhoneDeps.qml                What the Phone tab's OPTIONAL tooling looks like on this
-                              machine: scrcpy, adb, droidcam-cli, v4l2-ctl, pactl, the
-                              preview players, the v4l2loopback module (loaded/installed),
-                              scrcpy's major version and the distro - every one a constant
-                              `command -v`/argv probe started at construction, never from a
-                              feature's own activation (lint_capability_probe_gating.py).
+                              machine: scrcpy, adb, droidcam-cli, v4l2-ctl, pactl,
+                              avahi-browse, the preview players, the v4l2loopback module
+                              (loaded/installed), scrcpy's major version and the distro -
+                              every one a constant `command -v`/argv probe started at
+                              construction, never from a feature's own activation
+                              (lint_capability_probe_gating.py).
                               missingFor(feature) is the install guide's rows with the
                               sibling fork's per-distro commands verbatim; nothing here is
                               an installer dependency (sdata/deps-info.md "Phone (optional)").
+                              A tool has THREE states, not two: the three binaries the tab
+                              SPAWNS (scrcpy, adb, droidcam-cli) are started as well as
+                              located, so `scrcpy`/`adb`/`droidcamCli` mean "installed and
+                              able to start" while `*Present` is the raw `command -v`
+                              answer and `*RunError` the soname the loader could not find
+                              - see the entry below
                               `adbDevice` is the one LIVE fact in the file - whether
                               `adb devices` lists a phone in the `device` state, started by
-                              the adb presence probe's own exit and re-asked through
+                              the adb run probe's own exit and re-asked through
                               refreshAdbDevices(), so a card can say "no device over ADB"
                               before it is clicked
                               b591575c4 ("fix(phone): a card that cannot start over ADB says so before the click")
+                              ...and it owns the two commands that CHANGE that fact -
+                              `adb pair` and `adb connect`, constant argv - plus the
+                              avahi lookup that finds the ports Android re-rolls, because
+                              every other adb fact the tab has is already answered here
+                              (feat(phone): PhoneDeps runs adb pair and adb connect, as constant argv)
   PhoneScrcpy.qml              The screen mirror and app mode. QML holds no scrcpy handle:
                               scripts/phone/scrcpy_session_manager.py is ONE supervisor
                               speaking NDJSON on stdin/stdout that owns every scrcpy child
@@ -4839,6 +4851,108 @@ fix(phone): the Apps page says what to turn on when ADB has no device,
 fix(phone): the Apps page's empty state stands down while the panel is up,
 fix(phone): the Apps page's empty state reads as a paragraph, not a rule,
 test(phone): drive the Apps page through its three ADB states.)
+
+**`command -v` answers presence, and presence is not "this feature can start" - a package
+linked against a library the system has moved past is on PATH and dies before `main`.**
+`droidcam-cli` was exactly that here: on PATH, and `error while loading shared libraries:
+libswscale.so.9: cannot open shared object file`, because the package was built against
+ffmpeg 8 on a system that had moved to ffmpeg 9's `libswscale.so.10`. So the webcam card
+read `ready`, the click did nothing, and the message the user got - "is the DroidCam app
+open on the phone?" - sent them to look at the wrong machine entirely. Note the shape:
+nothing errors, nothing is logged, the QML is correct, and the flag is a perfectly good
+answer to the question it was asked.
+
+`services/PhoneDeps.qml` has three states now. The three binaries the tab SPAWNS - scrcpy,
+adb, droidcam-cli - are started as well as located, each run probe kicked by its own
+presence probe rather than by a feature's activation (which is
+`lint_capability_probe_gating.py`'s rule one hop along, since that check only sees the
+`command -v` half). Five things about it are worth not re-deriving.
+
+- **The classifier needs BOTH halves of the loader's signature.** The loader writes its
+  sentence to stderr and the process comes back **127**; `droidcam-cli` with no arguments
+  prints a page of usage and exits **1**, which is a tool that ran and refused. Matching the
+  phrase alone would classify that as broken, and matching 127 alone names no library, so
+  there is nothing to tell the user. 127 cannot be a shell's "command not found" here
+  because every probe is a constant argv with no shell on the path.
+- **A tool that BLOCKS is neither state, and must not become a probe that never answers.**
+  Each run probe carries a kill guard; a killed process is not a loader failure, so it lands
+  on "it runs". Erring that way is deliberate - calling a slow tool broken is a worse lie
+  than the one this replaced.
+- **The plain names stay the ones consumers read.** `scrcpy`/`adb`/`droidcamCli` mean
+  "installed and able to start", which is the question every one of them was really asking;
+  `*Present` and `*RunError` are the two halves. That is what makes the fix reach
+  `PhoneCamera.available` and the webcam card without either of them learning a new word.
+- **A broken tool is missing, and its install-guide row says what it actually is.**
+  `missingDeps` counts it as missing - the click does nothing either way - and
+  `brokenDependency` swaps the description for the loader's own missing library and a note
+  that the package needs rebuilding, keeping the install commands, because on Arch
+  `yay -S droidcam` IS the rebuild.
+- **Only the tools the tab spawns are asked.** `pactl`, `v4l2-ctl` and the preview players
+  keep a presence probe alone: their failure is a message on a page rather than a feature
+  that silently does nothing, and three extra processes per sweep buys nothing.
+
+`tests/tst_phone_scrcpy.qml` drives the classifier from both sides through the double, and
+`PhoneTabLayoutRuntimeTest.qml` walks the real page through all three states behind a fake
+adb the driver copies in between steps. **That harness strips `adb` out of PATH entirely**,
+which is the only way a test on this machine can say what `command -v adb` answers - the
+maintainer's own lives in `/opt/android-sdk/platform-tools`, and `command -v` searches the
+whole of PATH, so a non-executable placeholder in front is skipped rather than shadowing.
+(feat(phone): PhoneDeps tells a tool that cannot run from one that is absent,
+test(phone): drive the loader failure and the dependency row it produces,
+test(phone): drive adb's three states and the pairing panel end to end.)
+
+**...and where a page's whole content is "a link is missing", the link is a job the shell
+can do rather than a command line to retype.** The Apps page's panel printed `adb pair
+host:port code` and `adb connect host:port` and told the reader to open a terminal. It runs
+them now, as a form: two address fields, a six-digit code field, and a button per step. Five
+things measured rather than assumed, all against the installed platform-tools (1.0.41,
+Version 37.0.1-15733141):
+
+- **`adb pair HOST:PORT CODE` takes the code as an ARGUMENT and does not prompt.** `adb
+  help` documents `pair HOST[:PORT] [PAIRING CODE]`, and `adb pair 127.0.0.1:1` with no code
+  and stdin closed answers `Enter pairing code: adb: No pairing code provided` and exits 1.
+  So the code has to be on the command line, and it is one argv element - the address and
+  the code are the user's own typing and there is no shell anywhere on this path. The
+  sibling fork's every adb helper is a `bash -c` string with values pasted through a
+  hand-rolled quoter, one of them a *translated* string pasted into single quotes; that is
+  the shape this may not take.
+- **`adb connect` exits 0 whatever happens.** `adb connect 127.0.0.1:1` prints `failed to
+  connect to '127.0.0.1:1': Connection refused` and exits **0**; so does a host that does not
+  resolve. The exit code is therefore not evidence and the printed line is - and the line is
+  still only a claim, so what takes the panel down is the phone turning up under `adb
+  devices`, which the connect handler re-asks. `adb pair` reports through both, so both are
+  required: a success sentence with a non-zero exit is not a pairing.
+- **Android re-rolls BOTH ports on every toggle of the switch**, and they are different
+  ports: the pairing screen advertises `_adb-tls-pairing._tcp` only while it is open, and
+  `_adb-tls-connect._tcp` is up for as long as wireless debugging is. `avahi-browse -rpt`
+  finds them; its parsable resolved record puts the address in field 8 and the port in field
+  9 (the layout the fork reads with `awk -F';' $8":"$9`). **That layout could not be
+  confirmed against a live daemon here** - avahi-daemon is not running on this machine - so
+  the parser validates the port rather than trusting the position and skips a record it
+  cannot read, because an address offered confidently and wrongly is worse than none.
+- **What is honestly prefillable is the HOST, and it is offered as a head start rather than
+  as an address.** `PhoneConnect.activeDevice.reachableAddresses` is where KDE Connect
+  reaches the phone, which is the same LAN address wireless debugging listens on; the ports
+  are not derivable from it. So the field is prefilled with the bare host and the Pair button
+  stays refused until a port is there. The six-digit code is never prefillable - it is
+  generated per pairing and advertised nowhere - and with no avahi-browse installed the
+  discovery row is simply not drawn rather than being a button that cannot work.
+- **Every prefill is an ASSIGNMENT guarded on the field still holding the shell's last
+  suggestion.** A binding on a `TextField.text` is destroyed by the first keystroke
+  ([#158](https://github.com/XephyLon/immaterial-impulse/issues/158)'s shape), and the guard
+  is what stops a discovery that lands after the user has typed from taking their typing
+  away.
+
+The panel also answers **which** link is missing, which used to be one message covering three
+facts: adb absent (the old wording assumed it away and sent the reader to their phone), adb
+present and unable to start (the entry above), and adb working with nothing on it. Only the
+third is a pairing job. And the runtime harness measures the form at **two page widths**,
+because a column pinned to one passes every check at that one - `ContentPage.baseWidth` is
+the case that already cost a round - scoring items that are DRAWN rather than lit, since a
+disabled `RippleButton` dims to 0.4 through the interaction model and still occupies the
+width it asked for.
+(feat(phone): the Apps page pairs over Wi-Fi instead of printing a recipe,
+test(phone): pin the pairing argv, the two parsed results and the mDNS records.)
 
 **And the surfaces that DRIVE those services get their allowlist derived rather than written
 down.** "A button whose call no service answers is a fake action" is stated for the right

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ own repo; the installer pins which revision it builds.
 ## [Unreleased]
 
 ### Added
+- **The Phone tab pairs your phone over Wi-Fi instead of telling you to open a
+  terminal.** The Android Apps page used to print the two commands Android 11
+  and newer needs — `adb pair host:port code`, then `adb connect host:port` —
+  and leave you to retype them after every toggle of the Wireless debugging
+  switch. It now offers them as a form: an address and the six-digit code the
+  phone shows, a Pair button, then the connect address and a Connect button,
+  with whatever adb answered printed under each step. Where `avahi-browse` is
+  installed, **Find the ports** asks the network which ports the phone is
+  advertising and fills both addresses in; the address KDE Connect already
+  reaches the phone on is filled in either way. The six-digit code is still
+  read off the phone — it is generated per pairing and published nowhere.
 - **Opening a Phone tab page fades the tab back behind it.** Contacts and
   Android Apps slide in over a tab that now recedes and dims as they arrive,
   rather than sitting there at full strength underneath. It follows the
@@ -133,6 +144,18 @@ own repo; the installer pins which revision it builds.
   sit dead centre instead of a pixel and a half to the left.
 
 ### Fixed
+- **A phone feature no longer says "ready" when the tool it needs cannot
+  start.** The shell checked whether scrcpy, adb and DroidCam CLI were
+  installed and not whether they run. On this machine `droidcam-cli` was
+  installed and died on startup with a missing `libswscale.so.9` — the package
+  was built against an older ffmpeg than the system now ships — so the webcam
+  card read "ready", pressing it did nothing, and the message on screen asked
+  whether the DroidCam app was open on the phone. The three tools are started
+  as well as located now, and a tool that cannot start says so: which library
+  is missing, and that the package needs rebuilding rather than installing.
+  The Android Apps page tells the same three states apart too — adb missing,
+  adb unable to start, and adb working with no phone on it — where it used to
+  assume the first two away.
 - **The Phone tab's Android Apps page says what to turn on when it cannot
   reach the phone.** App Mode drives the phone over ADB, which is a
   different link from the one KDE Connect pairs: with a phone reachable on

--- a/dots/.config/quickshell/imi/PhoneTabLayoutRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/PhoneTabLayoutRuntimeTest.qml
@@ -52,6 +52,16 @@ ShellRoot {
     // three states: what the page draws is a consequence of what the tools
     // report, and the tools are asked again by the shell's own probes.
     readonly property string adbAttachedPath: Quickshell.env("PHONE_ADB_ATTACHED") ?? ""
+    // The two adb stubs and where one has to land to be found. `adb` is
+    // deliberately ABSENT from PATH when this harness starts - the driver
+    // strips every directory holding one - so the Apps page can be walked
+    // through all three states a tool has: not installed, installed and
+    // unable to start, installed and working.
+    readonly property string adbBinPath: Quickshell.env("PHONE_ADB_BIN") ?? ""
+    readonly property string adbOkPath: Quickshell.env("PHONE_ADB_OK") ?? ""
+    readonly property string adbBrokenPath: Quickshell.env("PHONE_ADB_BROKEN") ?? ""
+    readonly property string adbBrokenLibrary: Quickshell.env("PHONE_ADB_BROKEN_LIB") ?? ""
+    readonly property string phoneAddress: Quickshell.env("PHONE_LAN_ADDRESS") ?? ""
     readonly property string appsFilePath: Quickshell.env("PHONE_APPS_FILE") ?? ""
     readonly property string appsSourcePath: Quickshell.env("PHONE_APPS_SOURCE") ?? ""
     // The file the fake daemon reports as the first notification's iconPath.
@@ -73,6 +83,11 @@ ShellRoot {
     // the "cramped" step scored the tall page a second time - so the host's
     // own height is what the short-page step moves.
     property real viewportHeight: 900
+    // ...and how wide. A column pinned to one width passes every check at
+    // that width, which is what let a 600px settings column ship on a 440px
+    // panel (AGENT.md, ContentPage.baseWidth), so the pairing panel is
+    // measured at two.
+    property real viewportWidth: 460
     property real tallPageHeight: 0
 
     function check(label, ok) {
@@ -176,6 +191,31 @@ ShellRoot {
             && item.width > 0 && item.height > 0;
     }
 
+    // Every item of a given type that is really on screen, drawn inside the
+    // reference and reported by how far it escapes it. Used for the pairing
+    // panel, where the class of bug is a control asking for more width than
+    // the panel has and overflowing rather than shrinking.
+    function widestOverflow(page, types) {
+        let worst = 0;
+        let offender = "";
+        for (const type of types) {
+            for (const item of harness.findAll(page, type, [])) {
+                // Drawn, not necessarily lit: a control the interaction model
+                // has dimmed to 0.4 because it is disabled still occupies the
+                // width it asked for, which is the thing being measured.
+                if (!item.visible || item.width <= 0 || item.height <= 0)
+                    continue;
+                const box = harness.boxIn(item, page);
+                const over = Math.max(-box.left, box.right - page.width);
+                if (over > worst) {
+                    worst = over;
+                    offender = type;
+                }
+            }
+        }
+        return { over: worst, offender: offender };
+    }
+
     // Where an item is DRAWN, in another item's coordinates. Everything about
     // both defects is a comparison between two of these.
     function boxIn(item, reference) {
@@ -203,7 +243,7 @@ ShellRoot {
 
         Loader {
             id: loader
-            width: parent.width
+            width: harness.viewportWidth
             height: harness.viewportHeight
             active: false
             sourceComponent: Phone {}
@@ -412,50 +452,155 @@ ShellRoot {
         () => loader.item.popSubPage(),
         () => {},
 
-        // ---- the Apps page with no phone on ADB ---------------------------
+        // ---- the Apps page with no adb at all -----------------------------
         //
-        // The state the maintainer photographed: a phone paired to KDE Connect
-        // over the LAN, and `adb devices` listing nothing. What was on screen
-        // was a line of red text and an empty state under it, neither of which
-        // says what to do; what has to be on screen is one panel that does.
+        // The old panel assumed adb was installed and told the reader to go
+        // and turn something on on their phone. There is nothing to turn on:
+        // the tool is not here.
         () => loader.item.openSubPage("apps"),
         () => {},
         () => {},
         () => {
             const page = harness.first("PhoneAppsPage");
+            const panel = harness.findAll(page, "PhoneAdbPairPanel", [])[0] ?? null;
+            const notice = harness.findAll(page, "NoticeBox", [])[0] ?? null;
+            const fields = harness.findAll(panel, "ToolbarTextField", [])
+                .filter(f => harness.onScreen(f));
+            const noticeText = harness.findAll(notice, "StyledText", [])
+                .filter(item => harness.onScreen(item))
+                .map(item => String(item.text)).join(" | ");
+            console.log(`[PhoneTabLayout] no-adb-at-all: present=${PhoneDeps.adbPresent}`
+                        + ` adb=${PhoneDeps.adb} runError="${PhoneDeps.adbRunError}"`
+                        + ` mode=${panel?.mode} fields=${fields.length}`);
+
+            harness.check(`adb is genuinely absent for this step, got present=`
+                          + `${PhoneDeps.adbPresent} usable=${PhoneDeps.adb}`,
+                          PhoneDeps.ready && !PhoneDeps.adbPresent && !PhoneDeps.adb
+                          && PhoneDeps.adbRunError === "");
+            harness.check(`the panel says so rather than the phone does, got mode=${panel?.mode}`,
+                          panel !== null && panel.mode === "absent" && harness.onScreen(notice));
+            harness.check(`...naming adb and not the phone, got "${noticeText}"`,
+                          noticeText.indexOf("adb is not installed") >= 0
+                          && noticeText.indexOf("Developer options") < 0);
+            harness.check(`...and carrying the install command for this machine,`
+                          + ` got "${noticeText}"`,
+                          noticeText.indexOf("pacman -S android-tools") >= 0);
+            // A pairing form for a machine with no adb would be a form whose
+            // buttons cannot do anything.
+            harness.check(`no pairing form is offered, got ${fields.length} fields`,
+                          fields.length === 0);
+        },
+
+        // ---- adb is installed and cannot start ----------------------------
+        //
+        // The class of failure the whole probe change exists for, driven with
+        // an adb that answers the way the loader does: the sentence on stderr
+        // and exit 127. `command -v` alone reports this as present.
+        () => harness.writeFixture(["install", "-m", "755",
+                                    harness.adbBrokenPath, harness.adbBinPath]),
+        () => PhoneDeps.recheck(),
+        () => {},
+        () => {},
+        () => {
+            const page = harness.first("PhoneAppsPage");
+            const panel = harness.findAll(page, "PhoneAdbPairPanel", [])[0] ?? null;
+            const notice = harness.findAll(page, "NoticeBox", [])[0] ?? null;
+            const noticeText = harness.findAll(notice, "StyledText", [])
+                .filter(item => harness.onScreen(item))
+                .map(item => String(item.text)).join(" | ");
+            const fields = harness.findAll(panel, "ToolbarTextField", [])
+                .filter(f => harness.onScreen(f));
+            console.log(`[PhoneTabLayout] adb-broken: present=${PhoneDeps.adbPresent}`
+                        + ` adb=${PhoneDeps.adb} runError="${PhoneDeps.adbRunError}"`
+                        + ` mode=${panel?.mode}`);
+
+            harness.check(`command -v finds it and it still cannot start, got present=`
+                          + `${PhoneDeps.adbPresent} usable=${PhoneDeps.adb}`
+                          + ` runError="${PhoneDeps.adbRunError}"`,
+                          PhoneDeps.ready && PhoneDeps.adbPresent && !PhoneDeps.adb
+                          && PhoneDeps.adbRunError === harness.adbBrokenLibrary);
+            harness.check(`the panel names the library, got mode=${panel?.mode}`
+                          + ` text="${noticeText}"`,
+                          panel !== null && panel.mode === "broken"
+                          && noticeText.indexOf(harness.adbBrokenLibrary) >= 0);
+            // The message this replaced sent the maintainer to look at their
+            // phone. Nothing about a missing shared object is about a phone.
+            harness.check(`...and says nothing about the phone, got "${noticeText}"`,
+                          noticeText.indexOf("phone") < 0
+                          && noticeText.indexOf("rebuilding") >= 0);
+            harness.check(`no pairing form for a tool that cannot run, got`
+                          + ` ${fields.length} fields`, fields.length === 0);
+        },
+
+        // ---- adb works, and nothing is on it ------------------------------
+        () => harness.writeFixture(["install", "-m", "755",
+                                    harness.adbOkPath, harness.adbBinPath]),
+        () => PhoneDeps.recheck(),
+        () => {},
+        () => {},
+        () => {
+            const page = harness.first("PhoneAppsPage");
+            const panel = harness.findAll(page, "PhoneAdbPairPanel", [])[0] ?? null;
             const placeholder = harness.findAll(page, "PagePlaceholder", [])[0] ?? null;
             const notice = harness.findAll(page, "NoticeBox", [])[0] ?? null;
             const list = harness.findAll(page, "StyledListView", [])[0] ?? null;
             const region = placeholder?.parent ?? null;
             const column = region?.parent ?? null;
             const status = column?.children[1] ?? null;
-            const noticeText = harness.findAll(notice, "StyledText", [])
-                .map(t => String(t.text)).join(" | ");
-            console.log(`[PhoneTabLayout] no-adb: ready=${PhoneDeps.ready} adb=${PhoneDeps.adb}`
-                        + ` adbDevice=${PhoneDeps.adbDevice} appMode=${PhoneScrcpy.appModeSupported}`
-                        + ` appsError="${PhoneScrcpy.appsError}" notice h=${notice?.height}`
-                        + ` placeholderShown=${placeholder?.shown} status=${status?.visible}`
-                        + ` list=${list?.visible}`);
+            const fields = harness.findAll(panel, "ToolbarTextField", [])
+                .filter(f => harness.onScreen(f));
+            const pairAddress = fields[0] ?? null;
+            const pairCode = fields[1] ?? null;
+            const connectAddress = fields[2] ?? null;
+            // Every button, lit or not: a disabled RippleButton dims to 0.4
+            // through the interaction model, and the one being asked about
+            // here is disabled on purpose.
+            const buttons = harness.findAll(panel, "RippleButtonWithIcon", []);
+            console.log(`[PhoneTabLayout] no-device: adb=${PhoneDeps.adb}`
+                        + ` device=${PhoneDeps.adbDevice} mode=${panel?.mode}`
+                        + ` appMode=${PhoneScrcpy.appModeSupported}`
+                        + ` fields=${fields.length} buttons=${buttons.length}`
+                        + ` pairAddress="${pairAddress?.text}"`);
 
             harness.check(`the fake tooling answered: app mode is supported and adb sees`
-                          + ` no phone, got ready=${PhoneDeps.ready} adb=${PhoneDeps.adb}`
+                          + ` no phone, got adb=${PhoneDeps.adb}`
                           + ` device=${PhoneDeps.adbDevice} appMode=${PhoneScrcpy.appModeSupported}`,
                           PhoneDeps.ready && PhoneDeps.adb && !PhoneDeps.adbDevice
                           && PhoneScrcpy.appModeSupported);
             harness.check(`the page draws a panel, got ${notice?.height}px of one`,
-                          harness.onScreen(notice));
+                          harness.onScreen(notice) && panel !== null
+                          && panel.mode === "noDevice");
             harness.check(`...in the error container role, got ${notice?.color}`,
                           notice !== null && String(notice.color)
                           === String(Appearance.colors.colErrorContainer));
             // Both routes, because the machine this was reported from has
             // neither: a panel naming only the cable is no use to someone
             // whose phone is across the room.
+            const panelText = harness.findAll(panel, "StyledText", [])
+                .filter(item => harness.onScreen(item))
+                .map(item => String(item.text)).join(" | ");
             harness.check("...naming USB debugging and wireless debugging both",
-                          noticeText.indexOf("USB debugging") >= 0
-                          && noticeText.indexOf("Wireless debugging") >= 0);
-            harness.check("...and the pairing the wireless route needs by hand",
-                          noticeText.indexOf("adb pair") >= 0
-                          && noticeText.indexOf("adb connect") >= 0);
+                          panelText.indexOf("USB debugging") >= 0
+                          && panelText.indexOf("Wireless debugging") >= 0);
+            // The whole point of the round: the wireless route is a form the
+            // shell drives, not a command line to retype.
+            harness.check(`...and offering the pairing as controls rather than a`
+                          + ` recipe, got ${fields.length} fields and`
+                          + ` ${buttons.length} buttons`,
+                          fields.length === 3 && buttons.length === 3
+                          && panelText.indexOf("adb pair ") < 0
+                          && panelText.indexOf("in a terminal") < 0);
+            // The host is the half the shell honestly knows; the ports are
+            // not, so the button stays refused until one is typed or found.
+            harness.check(`the address KDE Connect reaches the phone on is prefilled,`
+                          + ` got "${pairAddress?.text}" and "${connectAddress?.text}"`,
+                          pairAddress !== null && connectAddress !== null
+                          && String(pairAddress.text) === harness.phoneAddress
+                          && String(connectAddress.text) === harness.phoneAddress);
+            const pairButton = buttons.find(b => String(b.mainText).indexOf("Pair") === 0) ?? null;
+            harness.check(`...and Pair is refused while there is no port and no code,`
+                          + ` got enabled=${pairButton?.enabled}`,
+                          pairButton !== null && !pairButton.enabled);
             // The two messages that used to say the same thing beside it.
             harness.check(`the empty state stands down, got shown=${placeholder?.shown}`,
                           placeholder !== null && !placeholder.shown);
@@ -464,6 +609,141 @@ ShellRoot {
                           status !== null && !status.visible);
             harness.check(`and no list is drawn, got visible=${list?.visible}`,
                           list === null || !list.visible);
+
+            const overflow = harness.widestOverflow(page,
+                ["ToolbarTextField", "RippleButtonWithIcon", "NoticeBox", "StyledText"]);
+            console.log(`[PhoneTabLayout] pairing panel at ${page.width}:`
+                        + ` worst overflow ${overflow.over} (${overflow.offender})`);
+            harness.check(`nothing on the pairing panel hangs off the page at`
+                          + ` ${page.width}, worst ${overflow.over}px`
+                          + ` (${overflow.offender})`,
+                          overflow.over <= 1);
+        },
+
+        // ---- ...and at a panel width nothing was tuned against -------------
+        () => {
+            harness.viewportWidth = 360;
+        },
+        () => {},
+        () => {
+            const page = harness.first("PhoneAppsPage");
+            const overflow = harness.widestOverflow(page,
+                ["ToolbarTextField", "RippleButtonWithIcon", "NoticeBox", "StyledText"]);
+            console.log(`[PhoneTabLayout] pairing panel at ${page.width}:`
+                        + ` worst overflow ${overflow.over} (${overflow.offender})`);
+            // Or the check is vacuous: a column pinned to 460 passes at 460.
+            harness.check(`the page really did get narrower, got ${page.width}`,
+                          page.width < 400);
+            harness.check(`nothing hangs off it there either, worst`
+                          + ` ${overflow.over}px (${overflow.offender})`,
+                          overflow.over <= 1);
+        },
+        () => {
+            harness.viewportWidth = 460;
+        },
+        () => {},
+
+        // ---- the ports come off the network, not off the phone's screen ----
+        () => {
+            const panel = harness.first("PhoneAdbPairPanel");
+            const discover = harness.findAll(panel, "RippleButtonWithIcon", [])
+                .find(b => String(b.mainText).indexOf("Find") === 0) ?? null;
+            harness.check(`avahi-browse is on PATH, so the lookup is offered, got`
+                          + ` ${discover === null ? "no button" : "one"}`,
+                          PhoneDeps.avahiBrowse && discover !== null
+                          && harness.onScreen(discover));
+            if (discover !== null)
+                discover.clicked();
+        },
+        () => {},
+        () => {},
+        () => {
+            const panel = harness.first("PhoneAdbPairPanel");
+            const fields = harness.findAll(panel, "ToolbarTextField", [])
+                .filter(f => harness.onScreen(f));
+            console.log(`[PhoneTabLayout] mdns: state=${PhoneDeps.mdnsState}`
+                        + ` pairing="${PhoneDeps.mdnsPairingAddress}"`
+                        + ` connect="${PhoneDeps.mdnsConnectAddress}"`
+                        + ` fields="${fields.map(f => f.text).join(", ")}"`);
+            harness.check(`both ports came back, got "${PhoneDeps.mdnsPairingAddress}"`
+                          + ` and "${PhoneDeps.mdnsConnectAddress}"`,
+                          PhoneDeps.mdnsState === "done"
+                          && PhoneDeps.mdnsPairingAddress === `${harness.phoneAddress}:37129`
+                          && PhoneDeps.mdnsConnectAddress === `${harness.phoneAddress}:41235`);
+            // The suggestion replaces the shell's own earlier one, which is
+            // the only text either field is holding.
+            harness.check(`...and both fields carry them, got "${fields[0]?.text}"`
+                          + ` and "${fields[2]?.text}"`,
+                          String(fields[0]?.text) === `${harness.phoneAddress}:37129`
+                          && String(fields[2]?.text) === `${harness.phoneAddress}:41235`);
+        },
+
+        // ---- and the two steps are commands the shell runs ------------------
+        () => {
+            const panel = harness.first("PhoneAdbPairPanel");
+            const fields = harness.findAll(panel, "ToolbarTextField", [])
+                .filter(f => harness.onScreen(f));
+            fields[1].text = "123456";
+        },
+        () => {},
+        () => {
+            const panel = harness.first("PhoneAdbPairPanel");
+            const pairButton = harness.findAll(panel, "RippleButtonWithIcon", [])
+                .find(b => String(b.mainText).indexOf("Pair") === 0) ?? null;
+            harness.check(`Pair is offered once the address carries a port and the`
+                          + ` code six digits, got enabled=${pairButton?.enabled}`,
+                          pairButton !== null && pairButton.enabled);
+            if (pairButton !== null)
+                pairButton.clicked();
+        },
+        () => {},
+        () => {},
+        () => {
+            const panel = harness.first("PhoneAdbPairPanel");
+            const lines = harness.findAll(panel, "StyledText", [])
+                .filter(item => harness.onScreen(item))
+                .map(item => String(item.text)).join(" | ");
+            console.log(`[PhoneTabLayout] pair: state=${PhoneDeps.pairState}`
+                        + ` message="${PhoneDeps.pairMessage}"`);
+            harness.check(`the pairing ran and adb answered, got state=`
+                          + `${PhoneDeps.pairState} message="${PhoneDeps.pairMessage}"`,
+                          PhoneDeps.pairState === "ok"
+                          && PhoneDeps.pairMessage.indexOf("Successfully paired") === 0);
+            // adb's OWN sentence reaches the panel - the point of running the
+            // command rather than printing it is that its answer is what the
+            // user is told.
+            harness.check(`...and it is on screen, got "${lines}"`,
+                          lines.indexOf(PhoneDeps.pairMessage) >= 0);
+        },
+        () => {
+            const panel = harness.first("PhoneAdbPairPanel");
+            const connectButton = harness.findAll(panel, "RippleButtonWithIcon", [])
+                .find(b => String(b.mainText).indexOf("Connect") === 0) ?? null;
+            harness.check(`Connect is offered, got enabled=${connectButton?.enabled}`,
+                          connectButton !== null && connectButton.enabled);
+            if (connectButton !== null)
+                connectButton.clicked();
+        },
+        () => {},
+        () => {},
+        () => {},
+        () => {
+            const page = harness.first("PhoneAppsPage");
+            const panel = harness.findAll(page, "PhoneAdbPairPanel", [])[0] ?? null;
+            console.log(`[PhoneTabLayout] connect: state=${PhoneDeps.connectState}`
+                        + ` message="${PhoneDeps.connectMessage}"`
+                        + ` device=${PhoneDeps.adbDevice} mode="${panel?.mode}"`);
+            harness.check(`the connect ran and adb answered, got state=`
+                          + `${PhoneDeps.connectState} message="${PhoneDeps.connectMessage}"`,
+                          PhoneDeps.connectState === "ok"
+                          && PhoneDeps.connectMessage.indexOf("connected to") === 0);
+            // adb exits 0 on a refused connection too, so the line adb printed
+            // is a claim: what takes the panel down is the phone turning up
+            // under `adb devices`, which the connect handler re-asks.
+            harness.check(`...and the device list is what took the panel down, got`
+                          + ` device=${PhoneDeps.adbDevice} mode="${panel?.mode}"`,
+                          PhoneDeps.adbDevice === true && panel !== null
+                          && panel.mode === "" && !panel.shown);
         },
 
         // ---- a phone appears on ADB, and the page asks for the list itself -

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneAdbPairPanel.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneAdbPairPanel.qml
@@ -1,0 +1,436 @@
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import QtQuick.Layouts
+import qs.services
+import qs.modules.common
+import qs.modules.common.widgets
+import "phone_cards.js" as PhoneCards
+
+/**
+ * What the Android Apps page draws when App Mode has no transport, which
+ * on Android 11+ is a job rather than a paragraph.
+ *
+ * The page used to print a recipe - open a terminal, type `adb pair
+ * host:port code`, then `adb connect host:port` - and the maintainer's
+ * objection was the right one: the shell can run those. It does, as
+ * constant argv through `PhoneDeps` (which owns every other adb fact the
+ * tab has), and each step's line here is the one adb actually printed
+ * rather than a sentence written for it.
+ *
+ * Three states, because "no phone on ADB" was three facts wearing one
+ * message:
+ *
+ *   absent    - adb is not installed at all, which the old panel assumed
+ *               away. Nothing on this page can work and no amount of
+ *               fiddling with the phone changes it.
+ *   broken    - adb is installed and cannot start. The dynamic loader's
+ *               own missing library is what is drawn, because "is the app
+ *               open on your phone" is the message that class of failure
+ *               used to get (see PhoneDeps.parseLoaderFailure).
+ *   noDevice  - adb works and lists nothing, which is the state the
+ *               pairing form is for.
+ *
+ * What it still asks the user to read off the phone: the six-digit
+ * pairing code, always - it is generated per pairing and advertised
+ * nowhere - and both ports whenever avahi cannot see them. The host is
+ * prefilled from the address KDE Connect already reaches the phone on;
+ * the ports are prefilled from `_adb-tls-pairing._tcp` /
+ * `_adb-tls-connect._tcp` when the phone is advertising them and avahi is
+ * installed. Nothing here promises more than that: with no avahi the
+ * discovery row is simply not drawn.
+ */
+ColumnLayout {
+    id: root
+
+    // "" while there is nothing to say. Read as a tri-state through
+    // PhoneDeps.ready: every flag in that singleton starts false, so a plain
+    // falsy test would draw this panel for the first frames of every session
+    // (b591575c4's rule, one surface along).
+    readonly property string mode: {
+        if (!PhoneDeps.ready)
+            return "";
+        if (!PhoneDeps.adbPresent)
+            return "absent";
+        if (PhoneDeps.adbRunError.length > 0)
+            return "broken";
+        if (!PhoneDeps.adbDevice)
+            return "noDevice";
+        return "";
+    }
+
+    readonly property bool shown: root.mode.length > 0
+
+    // The install command for this machine, so the absent state carries the
+    // one thing that fixes it. `PhoneDeps.dependency` is the same table the
+    // install guide draws, and `initialDistro` is the same fallback.
+    readonly property var adbDependency: PhoneDeps.dependency("android-tools")
+    readonly property string adbInstallCommand:
+        PhoneCards.firstCommand(PhoneCards.commandFor(root.adbDependency,
+                                                      PhoneCards.initialDistro(PhoneDeps.distro)))
+
+    // The host half of both addresses, which is the part the shell honestly
+    // knows: KDE Connect reports where it reaches the phone, and that is the
+    // same LAN address wireless debugging listens on. The PORTS are not
+    // knowable from it - Android re-rolls both every time the switch is
+    // flipped - so a suggestion with no port is offered as a head start
+    // rather than as an address, and the Pair button stays refused until the
+    // port is there.
+    readonly property string knownHost: PhoneDeps.preferredWirelessHost()
+
+    // What was last put into each field on the shell's behalf. A suggestion
+    // is an ASSIGNMENT and never a binding on `text`: a binding would be
+    // destroyed by the first keystroke (#158's shape), and comparing against
+    // what was last suggested is what stops a discovery landing after the
+    // user has typed from taking their typing away.
+    property string pairSuggested: ""
+    property string connectSuggested: ""
+
+    function offerPairAddress(next: string): void {
+        if (next.length === 0)
+            return;
+        if (pairAddressField.text.length > 0 && pairAddressField.text !== root.pairSuggested)
+            return;
+        pairAddressField.text = next;
+        root.pairSuggested = next;
+    }
+
+    function offerConnectAddress(next: string): void {
+        if (next.length === 0)
+            return;
+        if (connectAddressField.text.length > 0 && connectAddressField.text !== root.connectSuggested)
+            return;
+        connectAddressField.text = next;
+        root.connectSuggested = next;
+    }
+
+    function offerEverythingKnown(): void {
+        root.offerPairAddress(PhoneDeps.mdnsPairingAddress.length > 0
+                              ? PhoneDeps.mdnsPairingAddress : root.knownHost);
+        root.offerConnectAddress(PhoneDeps.mdnsConnectAddress.length > 0
+                                 ? PhoneDeps.mdnsConnectAddress : root.knownHost);
+    }
+
+    Component.onCompleted: root.offerEverythingKnown()
+    onKnownHostChanged: root.offerEverythingKnown()
+
+    // An observation of the two results, rather than a poll or a binding on
+    // `text`: a discovery that answers while the panel is open has to reach
+    // the fields, and a discovery that answers with nothing must leave them
+    // exactly as they were.
+    Connections {
+        target: PhoneDeps
+
+        function onMdnsPairingAddressChanged(): void {
+            root.offerPairAddress(PhoneDeps.mdnsPairingAddress);
+        }
+
+        function onMdnsConnectAddressChanged(): void {
+            root.offerConnectAddress(PhoneDeps.mdnsConnectAddress);
+        }
+    }
+
+    Layout.fillWidth: true
+    // A layout nested in a layout fills by default, which would take the
+    // page's whole leftover and leave the app list nothing.
+    Layout.fillHeight: false
+    spacing: Appearance.spacing.space100
+
+    // ---- what is wrong, and the route that needs no shell at all ----------
+    NoticeBox {
+        id: diagnosis
+
+        Layout.fillWidth: true
+        colBackground: Appearance.colors.colErrorContainer
+        colOnBackground: Appearance.colors.colOnErrorContainer
+        materialIcon: root.mode === "broken" ? "warning" : "usb_off"
+        text: {
+            if (root.mode === "absent")
+                return Translation.tr("App Mode starts each app over ADB, and adb is not installed on this machine.");
+            if (root.mode === "broken")
+                return Translation.tr("adb is installed and cannot start: the dynamic loader cannot find %1. The package was built against an older library than this system ships, so it needs rebuilding or reinstalling.").arg(PhoneDeps.adbRunError);
+            return Translation.tr("App Mode starts each app over ADB, and no phone is on ADB. Pairing in KDE Connect does not do it: that link carries notifications and files, not debugging.");
+        }
+
+        ColumnLayout {
+            Layout.fillWidth: true
+            Layout.fillHeight: false
+            spacing: Appearance.spacing.space75
+
+            StyledText {
+                id: installCommandLabel
+                Layout.fillWidth: true
+                visible: (root.mode === "absent" || root.mode === "broken")
+                    && root.adbInstallCommand.length > 0
+                // A package manager command is not markup, and it is not this
+                // repo's string either - it comes out of the dependency table.
+                textFormat: Text.PlainText
+                text: root.adbInstallCommand
+                font.family: Appearance.font.family.monospace
+                font.pixelSize: Appearance.font.pixelSize.smaller
+                color: Appearance.colors.colOnErrorContainer
+                wrapMode: Text.WrapAnywhere
+            }
+
+            StyledText {
+                id: usbRouteTitle
+                Layout.fillWidth: true
+                visible: root.mode === "noDevice"
+                text: Translation.tr("Over a USB cable")
+                font.pixelSize: Appearance.font.pixelSize.smaller
+                font.weight: Font.DemiBold
+                color: Appearance.colors.colOnErrorContainer
+                wrapMode: Text.WordWrap
+            }
+
+            StyledText {
+                id: usbRouteBody
+                Layout.fillWidth: true
+                visible: root.mode === "noDevice"
+                text: Translation.tr("Settings → System → Developer options → USB debugging. Plug the cable in and accept the fingerprint the phone asks about.")
+                font.pixelSize: Appearance.font.pixelSize.smaller
+                color: Appearance.colors.colOnErrorContainer
+                wrapMode: Text.WordWrap
+            }
+        }
+    }
+
+    // ---- ...and the route that is a job the shell can do ------------------
+    ContentSubsection {
+        id: wirelessSection
+
+        visible: root.mode === "noDevice"
+        title: Translation.tr("Pair over Wi-Fi")
+        icon: "wifi_tethering"
+
+        StyledText {
+            id: wirelessIntro
+            Layout.fillWidth: true
+            text: Translation.tr("On the phone: Developer options → Wireless debugging → Pair device with pairing code. That screen shows an address and a six-digit code; the main Wireless debugging screen shows a different port for the second step. Android picks new ports every time the switch is turned off and on.")
+            font.pixelSize: Appearance.font.pixelSize.smaller
+            color: Appearance.colors.colSubtext
+            wrapMode: Text.WordWrap
+        }
+
+        Rectangle {
+            id: formCard
+
+            Layout.fillWidth: true
+            Layout.topMargin: Appearance.spacing.space50
+            implicitHeight: formColumn.implicitHeight + Appearance.spacing.space150 * 2
+            radius: Appearance.rounding.normal
+            color: Appearance.colors.colLayer2
+
+            ColumnLayout {
+                id: formColumn
+                anchors {
+                    left: parent.left
+                    right: parent.right
+                    top: parent.top
+                    margins: Appearance.spacing.space150
+                }
+                spacing: Appearance.spacing.space75
+
+                // ---- step one: pair ---------------------------------------
+                StyledText {
+                    id: pairStepLabel
+                    Layout.fillWidth: true
+                    text: Translation.tr("1 · Pairing address and code")
+                    font.pixelSize: Appearance.font.pixelSize.smallest
+                    font.weight: Font.DemiBold
+                    color: Appearance.colors.colSubtext
+                    wrapMode: Text.WordWrap
+                }
+
+                RowLayout {
+                    Layout.fillWidth: true
+                    // ToolbarTextField declares Layout.fillHeight of its own,
+                    // which makes a row holding one unbounded and lets it eat
+                    // the column (f29079c51).
+                    Layout.fillHeight: false
+                    spacing: Appearance.spacing.space75
+
+                    ToolbarTextField {
+                        id: pairAddressField
+                        Layout.fillWidth: true
+                        enabled: PhoneDeps.pairState !== "busy"
+                        placeholderText: Translation.tr("192.168.1.42:37129")
+                    }
+
+                    ToolbarTextField {
+                        id: pairCodeField
+                        Layout.fillWidth: false
+                        Layout.preferredWidth: Appearance.font.pixelSize.huge * 5
+                        enabled: PhoneDeps.pairState !== "busy"
+                        maximumLength: 6
+                        inputMethodHints: Qt.ImhDigitsOnly
+                        placeholderText: Translation.tr("123456")
+                    }
+                }
+
+                RowLayout {
+                    Layout.fillWidth: true
+                    Layout.fillHeight: false
+                    spacing: Appearance.spacing.space75
+
+                    RippleButtonWithIcon {
+                        id: pairButton
+                        enabled: PhoneDeps.pairState !== "busy"
+                            && PhoneDeps.pairInputsReady(pairAddressField.text, pairCodeField.text)
+                        materialIcon: "link"
+                        materialIconFill: false
+                        colBackground: Appearance.colors.colLayer3
+                        colBackgroundHover: Appearance.colors.colLayer3Hover
+                        colRipple: Appearance.colors.colLayer3Active
+                        mainText: PhoneDeps.pairState === "busy"
+                            ? Translation.tr("Pairing…") : Translation.tr("Pair")
+                        onClicked: PhoneDeps.pairWireless(pairAddressField.text, pairCodeField.text)
+                    }
+
+                    RippleButtonWithIcon {
+                        id: discoverButton
+                        // An absent avahi-browse is an ordinary absence: the
+                        // row is simply not there, and both addresses are
+                        // typed. Promising a lookup the machine cannot do is
+                        // the thing this panel exists to stop doing.
+                        visible: PhoneDeps.avahiBrowse
+                        enabled: PhoneDeps.mdnsState !== "searching"
+                        materialIcon: "wifi_find"
+                        materialIconFill: false
+                        colBackground: Appearance.colors.colLayer3
+                        colBackgroundHover: Appearance.colors.colLayer3Hover
+                        colRipple: Appearance.colors.colLayer3Active
+                        mainText: PhoneDeps.mdnsState === "searching"
+                            ? Translation.tr("Looking…") : Translation.tr("Find the ports")
+                        onClicked: PhoneDeps.discoverWirelessPorts()
+
+                        StyledToolTip {
+                            text: Translation.tr("Ask the network which ports the phone is advertising")
+                        }
+                    }
+
+                    Item { Layout.fillWidth: true }
+                }
+
+                StatusLine {
+                    id: discoveryStatus
+                    shownWhen: PhoneDeps.avahiBrowse && PhoneDeps.mdnsState !== "idle"
+                    glyph: PhoneDeps.mdnsState === "searching" ? "search"
+                        : (PhoneDeps.mdnsPairingAddress.length > 0
+                           || PhoneDeps.mdnsConnectAddress.length > 0) ? "check_circle" : "info"
+                    message: {
+                        if (PhoneDeps.mdnsState === "searching")
+                            return Translation.tr("Asking the network…");
+                        if (PhoneDeps.mdnsPairingAddress.length === 0
+                            && PhoneDeps.mdnsConnectAddress.length === 0)
+                            return Translation.tr("Nothing is advertising wireless debugging. The pairing screen only advertises while it is open, so leave it on the phone and try again.");
+                        if (PhoneDeps.mdnsPairingAddress.length === 0)
+                            return Translation.tr("Found the connect port. The pairing one is only advertised while the pairing screen is open on the phone.");
+                        return Translation.tr("Found both ports.");
+                    }
+                }
+
+                StatusLine {
+                    id: pairStatus
+                    shownWhen: PhoneDeps.pairState === "ok" || PhoneDeps.pairState === "failed"
+                    glyph: PhoneDeps.pairState === "ok" ? "check_circle" : "error"
+                    // What adb printed, never a sentence written here: the
+                    // whole point of running the command instead of quoting
+                    // it is that its answer is the one the user gets.
+                    message: PhoneDeps.pairMessage
+                }
+
+                // ---- step two: connect ------------------------------------
+                StyledText {
+                    id: connectStepLabel
+                    Layout.fillWidth: true
+                    Layout.topMargin: Appearance.spacing.space50
+                    text: Translation.tr("2 · Connect address, from the Wireless debugging screen")
+                    font.pixelSize: Appearance.font.pixelSize.smallest
+                    font.weight: Font.DemiBold
+                    color: Appearance.colors.colSubtext
+                    wrapMode: Text.WordWrap
+                }
+
+                RowLayout {
+                    Layout.fillWidth: true
+                    Layout.fillHeight: false
+                    spacing: Appearance.spacing.space75
+
+                    ToolbarTextField {
+                        id: connectAddressField
+                        Layout.fillWidth: true
+                        enabled: PhoneDeps.connectState !== "busy"
+                        placeholderText: Translation.tr("192.168.1.42:41235")
+                    }
+
+                    RippleButtonWithIcon {
+                        id: connectButton
+                        enabled: PhoneDeps.connectState !== "busy"
+                            && PhoneDeps.connectInputReady(connectAddressField.text)
+                        materialIcon: "power"
+                        materialIconFill: false
+                        colBackground: Appearance.colors.colLayer3
+                        colBackgroundHover: Appearance.colors.colLayer3Hover
+                        colRipple: Appearance.colors.colLayer3Active
+                        mainText: PhoneDeps.connectState === "busy"
+                            ? Translation.tr("Connecting…") : Translation.tr("Connect")
+                        onClicked: PhoneDeps.connectWireless(connectAddressField.text)
+                    }
+                }
+
+                StatusLine {
+                    id: connectStatus
+                    shownWhen: PhoneDeps.connectState === "ok" || PhoneDeps.connectState === "failed"
+                    glyph: PhoneDeps.connectState === "ok" ? "check_circle" : "error"
+                    message: PhoneDeps.connectMessage
+                }
+
+                StyledText {
+                    id: closingNote
+                    Layout.fillWidth: true
+                    text: Translation.tr("The tab keeps asking while it is open. As soon as a device answers, this goes and the app list is fetched on its own.")
+                    font.pixelSize: Appearance.font.pixelSize.smallest
+                    color: Appearance.colors.colSubtext
+                    wrapMode: Text.WordWrap
+                }
+            }
+        }
+    }
+
+    // One line of feedback: a glyph and whatever the step has to say. A
+    // component rather than four copies, because the four differ only in
+    // which property they read and a fourth hand-written copy is how three
+    // come to disagree about their own spacing.
+    component StatusLine: RowLayout {
+        id: statusLine
+
+        property bool shownWhen: false
+        property string glyph: "info"
+        property string message: ""
+
+        Layout.fillWidth: true
+        Layout.fillHeight: false
+        visible: statusLine.shownWhen && statusLine.message.length > 0
+        spacing: Appearance.spacing.space50
+
+        MaterialSymbol {
+            Layout.alignment: Qt.AlignTop
+            text: statusLine.glyph
+            iconSize: Appearance.font.pixelSize.normal
+            color: statusLine.glyph === "error"
+                ? Appearance.colors.colError : Appearance.colors.colSubtext
+        }
+
+        StyledText {
+            Layout.fillWidth: true
+            // adb writes this, so it is never markup.
+            textFormat: Text.PlainText
+            text: statusLine.message
+            font.pixelSize: Appearance.font.pixelSize.smallest
+            color: statusLine.glyph === "error"
+                ? Appearance.colors.colError : Appearance.colors.colSubtext
+            wrapMode: Text.WordWrap
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneAppsPage.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneAppsPage.qml
@@ -18,12 +18,14 @@ import "phone_cards.js" as PhoneCards
  * glyph is what the fork falls back to anyway whenever its extractor cannot
  * resolve one.
  *
- * The page has three states and draws exactly one message in each: no phone on
- * ADB (a danger panel carrying the two ways to get one, and no placeholder
- * under it), a phone that answered with nothing (the placeholder), and a phone
- * with apps (the list). `PhoneDeps.adbDevice` is what separates the first from
- * the second - never `PhoneScrcpy.appsError`, which is the supervisor's
- * sentence about the same fact and would be a second answer to it.
+ * The page has three states and draws exactly one message in each: App Mode
+ * with no transport (`PhoneAdbPairPanel`, which owns the diagnosis and the
+ * pairing job, and no placeholder under it), a phone that answered with
+ * nothing (the placeholder), and a phone with apps (the list). What
+ * separates the first from the second is the probe - `PhoneDeps.adbDevice`
+ * and the two states around it - never `PhoneScrcpy.appsError`, which is the
+ * supervisor's sentence about the same fact and would be a second answer to
+ * it.
  *
  * The search query lives HERE rather than on PhoneScrcpy: a text field on one
  * page writing a property on a singleton makes the query global state, and the
@@ -46,8 +48,11 @@ PhoneSubPage {
     // would draw the panel below for the first frames of every session.
     readonly property var adbDevice: PhoneDeps.ready ? PhoneDeps.adbDevice : undefined
     // App Mode is installed and has no transport: nothing on this page can
-    // start, and the reason is the whole content of the page.
-    readonly property bool adbOffline: PhoneScrcpy.appModeSupported && root.adbDevice === false
+    // start, and the reason is the whole content of the page. WHICH reason is
+    // the panel's own question now - adb absent, adb unable to start, or adb
+    // working with nothing on it - because the old wording assumed the first
+    // two away and told everybody to go and look at their phone.
+    readonly property bool adbOffline: PhoneScrcpy.appModeSupported && adbPanel.shown
 
     // The live sessions, as a plain list. PhoneScrcpy.sessions is a ListModel,
     // which is not a binding source - `sessionCount` is read so this
@@ -163,69 +168,18 @@ PhoneSubPage {
             wrapMode: Text.WordWrap
         }
 
-        // ---- no transport, and how to get one ----
+        // ---- no transport, and what to do about it ----
         //
         // A page with nothing in it because a link is missing owes the reader
-        // the link, not a footnote: this is the whole page in that state, so it
-        // carries the two routes there actually are. Both are typed by hand on
-        // purpose - the shell has no pairing button, and Android 11+ picks a
-        // new wireless-debugging port every time the switch is toggled, so
-        // there is no port to remember on the user's behalf either.
-        NoticeBox {
+        // the link. It used to owe them a recipe - open a terminal and type
+        // `adb pair host:port code` - and the shell can run that instead, so
+        // the panel is a job now rather than a paragraph. It answers three
+        // states rather than one, because "no phone on ADB" was hiding "adb
+        // is not installed" and "adb cannot start" inside it.
+        PhoneAdbPairPanel {
+            id: adbPanel
             Layout.fillWidth: true
-            visible: root.adbOffline
-            colBackground: Appearance.colors.colErrorContainer
-            colOnBackground: Appearance.colors.colOnErrorContainer
-            materialIcon: "usb_off"
-            text: Translation.tr("App Mode starts each app over ADB, and no phone is on ADB. Pairing in KDE Connect does not do it: that link carries notifications and files, not debugging. Turn one of these on, on the phone.")
-
-            ColumnLayout {
-                Layout.fillWidth: true
-                // A layout nested in a layout fills by default, which would
-                // take the notice's own row unbounded.
-                Layout.fillHeight: false
-                spacing: Appearance.spacing.space75
-
-                StyledText {
-                    Layout.fillWidth: true
-                    text: Translation.tr("Over a USB cable")
-                    font.pixelSize: Appearance.font.pixelSize.smaller
-                    font.weight: Font.DemiBold
-                    color: Appearance.colors.colOnErrorContainer
-                    wrapMode: Text.WordWrap
-                }
-                StyledText {
-                    Layout.fillWidth: true
-                    text: Translation.tr("Settings → System → Developer options → USB debugging. Plug the cable in and accept the fingerprint the phone asks about.")
-                    font.pixelSize: Appearance.font.pixelSize.smaller
-                    color: Appearance.colors.colOnErrorContainer
-                    wrapMode: Text.WordWrap
-                }
-
-                StyledText {
-                    Layout.fillWidth: true
-                    text: Translation.tr("Over Wi-Fi, on Android 11 and newer")
-                    font.pixelSize: Appearance.font.pixelSize.smaller
-                    font.weight: Font.DemiBold
-                    color: Appearance.colors.colOnErrorContainer
-                    wrapMode: Text.WordWrap
-                }
-                StyledText {
-                    Layout.fillWidth: true
-                    text: Translation.tr("Developer options → Wireless debugging → Pair device with pairing code, then in a terminal: adb pair IP:PAIRING_PORT, and adb connect IP:PORT with the port the Wireless debugging screen shows. Android picks new ports every time that switch is turned off and on, so the pair and the connect are done again after a toggle or a reboot.")
-                    font.pixelSize: Appearance.font.pixelSize.smaller
-                    color: Appearance.colors.colOnErrorContainer
-                    wrapMode: Text.WordWrap
-                }
-
-                StyledText {
-                    Layout.fillWidth: true
-                    text: Translation.tr("The tab keeps asking while it is open. As soon as a device answers, this goes and the app list is fetched on its own.")
-                    font.pixelSize: Appearance.font.pixelSize.smaller
-                    color: Appearance.colors.colOnErrorContainer
-                    wrapMode: Text.WordWrap
-                }
-            }
+            visible: PhoneScrcpy.appModeSupported && adbPanel.shown
         }
 
         // ---- what is running right now ----

--- a/dots/.config/quickshell/imi/services/PhoneDeps.qml
+++ b/dots/.config/quickshell/imi/services/PhoneDeps.qml
@@ -10,8 +10,8 @@ import QtQuick
  * (docs/superpowers/specs/2026-08-27-phone-tab-design.md, W3).
  *
  * Nothing here is an installer dependency: scrcpy, adb, DroidCam, the
- * v4l2loopback module, pactl and the preview players are all probed with a
- * constant `command -v` at construction
+ * v4l2loopback module, pactl, avahi-browse and the preview players are all
+ * probed with a constant `command -v` at construction
  * (tests/lint_capability_probe_gating.py is why every probe starts itself),
  * and `missingFor(feature)` turns the flags into the install guide's rows -
  * one per missing dependency, with the sibling fork's per-distro commands
@@ -24,6 +24,11 @@ import QtQuick
  * moved past is on PATH and dies before main, and a flag that says "present"
  * for it is a card that reads `ready` and does nothing when clicked. See
  * `parseLoaderFailure` for the measurement.
+ *
+ * It also owns the two commands that CHANGE what adb can see - `adb pair` and
+ * `adb connect`, both constant argv - and the avahi lookup that finds the
+ * two ports Android re-rolls on every toggle, because every other adb fact
+ * the tab has is already answered here.
  *
  * The dependency table and the feature -> dependency mapping between the
  * sync markers are kept byte-for-byte in sync with the logic-only double
@@ -60,6 +65,10 @@ Singleton {
     property bool vlc: false
     property bool kdialog: false
     property bool wlPaste: false
+    // Not a Phone-tab tool: it is how the wireless-debugging ports are found
+    // without the user reading them off the phone. Absent is ordinary - the
+    // pairing form simply asks for both addresses by hand.
+    property bool avahiBrowse: false
     property bool v4l2loopbackLoaded: false
     property bool v4l2loopbackInstalled: false
     property string scrcpyVersion: ""
@@ -89,6 +98,10 @@ Singleton {
     // How long a run probe may take before it is killed. Generous, because
     // the only thing a short one buys is a wrong answer.
     readonly property int runProbeTimeoutMs: 5000
+    // How long `adb pair` / `adb connect` may take before the panel is told
+    // nothing came back. A pairing is a TLS handshake with a phone on the
+    // LAN, so this is the round trip plus a lot of slack.
+    readonly property int adbActionTimeoutMs: 30000
 
     // BEGIN phone-deps logic (synced with tests/imports/testservices/PhoneDeps.qml)
     // `scrcpy --version` prints "scrcpy 4.1 <url>" on its first line.
@@ -296,6 +309,146 @@ Singleton {
         return missing;
     }
 
+    // ---- wireless debugging, as arithmetic -----------------------------
+    //
+    // Android 11+ re-rolls BOTH ports every time the Wireless debugging
+    // switch is flipped: "Pair device with pairing code" shows one address
+    // and a six-digit code, while the connect step uses a different port
+    // printed on the Wireless debugging screen itself. Neither is guessable,
+    // which is why the two steps are two addresses rather than one.
+
+    // `adb pair HOST:PORT CODE` takes the code as an ARGUMENT and does not
+    // prompt - measured against platform-tools 37.0.1 (Version 37.0.1-...):
+    // `adb help` documents `pair HOST[:PORT] [PAIRING CODE]`, and running
+    // `adb pair 127.0.0.1:1` with no code and stdin closed answers
+    // "Enter pairing code: adb: No pairing code provided" and exits 1, so the
+    // code has to be on the command line. Both the address and the code are
+    // the user's own typing, so they are separate argv elements and there is
+    // no shell anywhere on this path.
+    function adbPairArgv(address: string, code: string): var {
+        return ["adb", "pair", String(address ?? "").trim(), String(code ?? "").trim()];
+    }
+
+    function adbConnectArgv(address: string): var {
+        return ["adb", "connect", String(address ?? "").trim()];
+    }
+
+    // The two service types Android advertises while wireless debugging is
+    // on: the pairing screen publishes `_adb-tls-pairing._tcp` only while it
+    // is open, and `_adb-tls-connect._tcp` is up for as long as the switch
+    // is.
+    function avahiBrowseArgv(serviceType: string): var {
+        return ["avahi-browse", "-rpt", String(serviceType ?? "")];
+    }
+
+    // avahi-browse's parsable RESOLVED record is
+    // `=;iface;proto;name;type;domain;host;address;port;txt`, so the address
+    // is field 8 and the port field 9 - the layout the sibling fork's
+    // `_adb-tls-connect._tcp` snippet reads with `awk -F';' $8":"$9`. It
+    // could not be confirmed against a live daemon here (avahi-daemon is not
+    // running on this machine), so this VALIDATES rather than trusts the
+    // positions: a record whose field 9 is not a port number is skipped
+    // rather than becoming an address the user is asked to believe.
+    function parseAvahiRecords(text: string): var {
+        const out = [];
+        for (const raw of String(text ?? "").split("\n")) {
+            const line = raw.trim();
+            if (line.length === 0 || line.charAt(0) !== "=") continue;
+            const parts = line.split(";");
+            if (parts.length < 9) continue;
+            const host = String(parts[7] ?? "").trim();
+            const port = String(parts[8] ?? "").trim();
+            if (host.length === 0) continue;
+            if (!/^\d{1,5}$/.test(port)) continue;
+            const number = parseInt(port);
+            if (number < 1 || number > 65535) continue;
+            out.push({ host: host, port: port, address: host + ":" + port });
+        }
+        return out;
+    }
+
+    // The phone KDE Connect already reaches wins when several are
+    // advertising; otherwise the first record is offered and the user can
+    // correct it, which is the whole reason the address stays a field.
+    function pickAvahiRecord(records: var, preferredHost: string): var {
+        const list = records ?? [];
+        const want = String(preferredHost ?? "").trim();
+        if (want.length > 0)
+            for (let i = 0; i < list.length; i++)
+                if (String(list[i].host) === want) return list[i];
+        return list.length > 0 ? list[0] : null;
+    }
+
+    function firstMeaningfulLine(text: string): string {
+        for (const raw of String(text ?? "").split("\n")) {
+            const line = raw.trim();
+            if (line.length > 0) return line;
+        }
+        return "";
+    }
+
+    // `adb pair` reports through its exit code AND its own sentence, and both
+    // are required so that an adb which one day exits 0 on a refusal is still
+    // read as one. Measured: an unreachable target answers "error: protocol
+    // fault (couldn't read status message): Success" with exit 1; a
+    // successful pairing prints "Successfully paired to HOST [guid=...]".
+    function parsePairResult(exitCode: int, out: string, err: string): var {
+        const text = (String(out ?? "") + "\n" + String(err ?? "")).trim();
+        return {
+            ok: exitCode === 0 && /successfully paired/i.test(text),
+            message: root.firstMeaningfulLine(text)
+        };
+    }
+
+    // `adb connect` exits **0 whatever happens** - measured against
+    // platform-tools 37.0.1, `adb connect 127.0.0.1:1` prints
+    // "failed to connect to '127.0.0.1:1': Connection refused" and exits 0,
+    // and so does a host that does not resolve. The exit code is therefore
+    // not evidence here and the printed line is the whole of it; the phone
+    // turning up under `adb devices` is the confirmation, which is why the
+    // caller re-asks that rather than believing this.
+    function parseConnectResult(exitCode: int, out: string, err: string): var {
+        const text = (String(out ?? "") + "\n" + String(err ?? "")).trim();
+        return {
+            ok: exitCode === 0 && /^(already )?connected to /im.test(text),
+            message: root.firstMeaningfulLine(text)
+        };
+    }
+
+    // The code the phone shows is six digits; anything else is a typo a pair
+    // would spend a round trip discovering.
+    function normalizePairingCode(text: string): string {
+        return String(text ?? "").replace(/\D/g, "").substring(0, 6);
+    }
+
+    // `host:port`, split at the LAST colon so a bracketed IPv6 literal - the
+    // only form adb accepts - keeps its own. Returns null for something that
+    // is not an address at all; an empty port is a legal answer, because
+    // `adb connect` defaults to 5555 while a pairing address never can.
+    function splitAddress(text: string): var {
+        const raw = String(text ?? "").trim();
+        if (raw.length === 0) return null;
+        const index = raw.lastIndexOf(":");
+        if (index < 0) return { host: raw, port: "" };
+        const host = raw.substring(0, index).trim();
+        const port = raw.substring(index + 1).trim();
+        if (host.length === 0) return null;
+        if (port.length === 0) return { host: host, port: "" };
+        if (!/^\d{1,5}$/.test(port)) return null;
+        const number = parseInt(port);
+        if (number < 1 || number > 65535) return null;
+        return { host: host, port: port };
+    }
+
+    function pairInputsReady(address: string, code: string): bool {
+        const parts = root.splitAddress(address);
+        return parts !== null && parts.port.length > 0
+            && root.normalizePairingCode(code).length === 6;
+    }
+
+    function connectInputReady(address: string): bool {
+        return root.splitAddress(address) !== null;
+    }
     // END phone-deps logic
 
     function flags(): var {
@@ -326,7 +479,7 @@ Singleton {
     function recheck(): void {
         for (const probe of [scrcpyProbe, adbProbe, droidcamProbe, v4l2CtlProbe, pactlProbe,
                              mpvProbe, ffplayProbe, vlcProbe, kdialogProbe, wlPasteProbe,
-                             lsmodProbe, modinfoProbe, distroProbe])
+                             avahiBrowseProbe, lsmodProbe, modinfoProbe, distroProbe])
             root.startProbe(probe);
     }
 
@@ -345,6 +498,190 @@ Singleton {
     }
 
     Component.onCompleted: root.probed = true
+
+    // ---- the two commands that CHANGE what adb can see ------------------
+    //
+    // Everything above answers a question about the machine; these two act on
+    // it. They live here because this singleton already owns every adb fact
+    // the Phone tab has - whether adb is installed, whether it starts, and
+    // whether `adb devices` lists a phone - and pairing is that last fact
+    // being changed. The surface that draws the form therefore reaches no
+    // Process of its own, which is the same rule the feature cards follow.
+
+    // idle | busy | ok | failed, per step. `pairMessage` and
+    // `connectMessage` are adb's OWN sentence rather than one written here:
+    // the whole point of running the command instead of printing a recipe is
+    // that its answer is the one the user gets.
+    property string pairState: "idle"
+    property string pairMessage: ""
+    property string connectState: "idle"
+    property string connectMessage: ""
+
+    function pairWireless(address: string, code: string): void {
+        if (root.pairState === "busy") return;
+        if (!root.adb) {
+            root.pairState = "failed";
+            root.pairMessage = Translation.tr("adb is not available on this machine.");
+            return;
+        }
+        if (!root.pairInputsReady(address, code)) {
+            root.pairState = "failed";
+            root.pairMessage = Translation.tr("A pairing address needs a host and the port the phone shows, and the code is six digits.");
+            return;
+        }
+        root.pairState = "busy";
+        root.pairMessage = "";
+        pairProcess.exec(root.adbPairArgv(address, root.normalizePairingCode(code)));
+    }
+
+    function connectWireless(address: string): void {
+        if (root.connectState === "busy") return;
+        if (!root.adb) {
+            root.connectState = "failed";
+            root.connectMessage = Translation.tr("adb is not available on this machine.");
+            return;
+        }
+        if (!root.connectInputReady(address)) {
+            root.connectState = "failed";
+            root.connectMessage = Translation.tr("A connect address needs a host, and the port the Wireless debugging screen shows.");
+            return;
+        }
+        root.connectState = "busy";
+        root.connectMessage = "";
+        connectProcess.exec(root.adbConnectArgv(address));
+    }
+
+    Process {
+        id: pairProcess
+        stdout: StdioCollector { id: pairOut }
+        stderr: StdioCollector { id: pairErr }
+        onRunningChanged: {
+            if (running) pairGuard.restart();
+            else pairGuard.stop();
+        }
+        onExited: (exitCode, exitStatus) => {
+            const result = root.parsePairResult(exitCode, pairOut.text, pairErr.text);
+            root.pairState = result.ok ? "ok" : "failed";
+            root.pairMessage = result.message;
+        }
+    }
+
+    Process {
+        id: connectProcess
+        stdout: StdioCollector { id: connectOut }
+        stderr: StdioCollector { id: connectErr }
+        onRunningChanged: {
+            if (running) connectGuard.restart();
+            else connectGuard.stop();
+        }
+        onExited: (exitCode, exitStatus) => {
+            const result = root.parseConnectResult(exitCode, connectOut.text, connectErr.text);
+            root.connectState = result.ok ? "ok" : "failed";
+            root.connectMessage = result.message;
+            // The line adb printed is a claim; the phone turning up under
+            // adb devices is the evidence, and it is what takes the panel
+            // down.
+            root.refreshAdbDevices();
+        }
+    }
+
+    Timer {
+        id: pairGuard
+        interval: root.adbActionTimeoutMs
+        onTriggered: if (pairProcess.running) pairProcess.signal(15)
+    }
+
+    Timer {
+        id: connectGuard
+        interval: root.adbActionTimeoutMs
+        onTriggered: if (connectProcess.running) connectProcess.signal(15)
+    }
+
+    // ---- and where the two addresses come from ---------------------------
+    //
+    // Both ports are re-rolled on every toggle of the Wireless debugging
+    // switch, so the honest default is to ask the network rather than to
+    // remember. Absent avahi is an ordinary absence: the state goes
+    // `unavailable`, the fields stay empty, and the form promises nothing.
+
+    // idle | searching | done | unavailable
+    property string mdnsState: "idle"
+    property string mdnsPairingAddress: ""
+    property string mdnsConnectAddress: ""
+    property int mdnsPending: 0
+
+    function discoverWirelessPorts(): void {
+        if (root.mdnsState === "searching") return;
+        if (!root.avahiBrowse) {
+            root.mdnsState = "unavailable";
+            return;
+        }
+        root.mdnsState = "searching";
+        root.mdnsPairingAddress = "";
+        root.mdnsConnectAddress = "";
+        root.mdnsPending = 2;
+        pairingBrowse.exec(root.avahiBrowseArgv("_adb-tls-pairing._tcp"));
+        connectBrowse.exec(root.avahiBrowseArgv("_adb-tls-connect._tcp"));
+    }
+
+    // The phone's LAN address as KDE Connect already knows it, which is the
+    // host half of both addresses and the tie-breaker when more than one
+    // phone is advertising. Read here rather than in the surface so the pure
+    // picker takes it as an argument and stays testable.
+    function preferredWirelessHost(): string {
+        const addresses = PhoneConnect.activeDevice?.reachableAddresses ?? [];
+        for (let i = 0; i < addresses.length; i++) {
+            const address = String(addresses[i] ?? "").trim();
+            if (address.length > 0) return address;
+        }
+        return "";
+    }
+
+    function mdnsAnswered(): void {
+        root.mdnsPending = Math.max(0, root.mdnsPending - 1);
+        if (root.mdnsPending === 0) root.mdnsState = "done";
+    }
+
+    Process {
+        id: pairingBrowse
+        stdout: StdioCollector { id: pairingBrowseOut }
+        stderr: StdioCollector {}
+        onRunningChanged: {
+            if (running) mdnsGuard.restart();
+            else root.mdnsAnswered();
+        }
+        onExited: (exitCode, exitStatus) => {
+            const record = root.pickAvahiRecord(root.parseAvahiRecords(pairingBrowseOut.text),
+                                                root.preferredWirelessHost());
+            root.mdnsPairingAddress = record ? record.address : "";
+        }
+    }
+
+    Process {
+        id: connectBrowse
+        stdout: StdioCollector { id: connectBrowseOut }
+        stderr: StdioCollector {}
+        onRunningChanged: {
+            if (running) mdnsGuard.restart();
+            else root.mdnsAnswered();
+        }
+        onExited: (exitCode, exitStatus) => {
+            const record = root.pickAvahiRecord(root.parseAvahiRecords(connectBrowseOut.text),
+                                                root.preferredWirelessHost());
+            root.mdnsConnectAddress = record ? record.address : "";
+        }
+    }
+
+    // `avahi-browse -t` terminates on its own once the cache is exhausted and
+    // fails immediately with no daemon, but it is a network wait either way.
+    Timer {
+        id: mdnsGuard
+        interval: root.runProbeTimeoutMs
+        onTriggered: {
+            if (pairingBrowse.running) pairingBrowse.signal(15);
+            if (connectBrowse.running) connectBrowse.signal(15);
+        }
+    }
 
     // One constant `command -v` per tool. Each starts itself at construction
     // (the capability-probe lint's rule) and again from recheck(). The flag
@@ -547,6 +884,14 @@ Singleton {
         Component.onCompleted: root.startProbe(this)
         onRunningChanged: if (!running) root.probeAnswered()
         onExited: (exitCode, exitStatus) => { root.wlPaste = exitCode === 0; }
+    }
+
+    Process {
+        id: avahiBrowseProbe
+        command: ["sh", "-c", "command -v avahi-browse"]
+        Component.onCompleted: root.startProbe(this)
+        onRunningChanged: if (!running) root.probeAnswered()
+        onExited: (exitCode, exitStatus) => { root.avahiBrowse = exitCode === 0; }
     }
 
     Process {

--- a/dots/.config/quickshell/imi/services/PhoneDeps.qml
+++ b/dots/.config/quickshell/imi/services/PhoneDeps.qml
@@ -11,12 +11,19 @@ import QtQuick
  *
  * Nothing here is an installer dependency: scrcpy, adb, DroidCam, the
  * v4l2loopback module, pactl and the preview players are all probed with a
- * constant `command -v` at construction (tests/lint_capability_probe_gating.py
- * is why every probe starts itself), and `missingFor(feature)` turns the
- * flags into the install guide's rows - one per missing dependency, with
- * the sibling fork's per-distro commands verbatim. `recheck()` re-runs
- * every probe, which is what the guide's Re-check button and a finished
- * install script call.
+ * constant `command -v` at construction
+ * (tests/lint_capability_probe_gating.py is why every probe starts itself),
+ * and `missingFor(feature)` turns the flags into the install guide's rows -
+ * one per missing dependency, with the sibling fork's per-distro commands
+ * verbatim. `recheck()` re-runs every probe, which is what the guide's
+ * Re-check button and a finished install script call.
+ *
+ * A tool has THREE states here, not two. `command -v` answers presence; the
+ * three binaries the tab spawns - scrcpy, adb and droidcam-cli - are then
+ * actually STARTED, because a package linked against a library the system has
+ * moved past is on PATH and dies before main, and a flag that says "present"
+ * for it is a card that reads `ready` and does nothing when clicked. See
+ * `parseLoaderFailure` for the measurement.
  *
  * The dependency table and the feature -> dependency mapping between the
  * sync markers are kept byte-for-byte in sync with the logic-only double
@@ -26,9 +33,26 @@ import QtQuick
 Singleton {
     id: root
 
-    property bool scrcpy: false
-    property bool adb: false
-    property bool droidcamCli: false
+    // PRESENCE is `command -v`. USABILITY is presence plus the binary
+    // actually starting, and the three tools this tab SPAWNS are asked both
+    // questions - see the run-probe block below for the machine that made
+    // that difference matter. The plain names stay the ones every consumer
+    // reads, because "can I use this tool" is the question they were all
+    // really asking.
+    property bool scrcpyPresent: false
+    property bool adbPresent: false
+    property bool droidcamCliPresent: false
+
+    // The soname the dynamic loader could not find when one of those three is
+    // on PATH and cannot start; "" for a binary that starts.
+    property string scrcpyRunError: ""
+    property string adbRunError: ""
+    property string droidcamCliRunError: ""
+
+    readonly property bool scrcpy: root.scrcpyPresent && root.scrcpyRunError.length === 0
+    readonly property bool adb: root.adbPresent && root.adbRunError.length === 0
+    readonly property bool droidcamCli: root.droidcamCliPresent && root.droidcamCliRunError.length === 0
+
     property bool v4l2Ctl: false
     property bool pactl: false
     property bool mpv: false
@@ -61,6 +85,10 @@ Singleton {
     property int probesPending: 0
     property bool probed: false
     readonly property bool ready: root.probed && root.probesPending === 0
+
+    // How long a run probe may take before it is killed. Generous, because
+    // the only thing a short one buys is a wrong answer.
+    readonly property int runProbeTimeoutMs: 5000
 
     // BEGIN phone-deps logic (synced with tests/imports/testservices/PhoneDeps.qml)
     // `scrcpy --version` prints "scrcpy 4.1 <url>" on its first line.
@@ -109,6 +137,28 @@ Singleton {
             if (parts.length >= 2 && parts[1] === "device") return true;
         }
         return false;
+    }
+
+    // Three states, not two, and the third is what `command -v` cannot see.
+    // Measured on this machine: `droidcam-cli` was on PATH and died before
+    // main with `error while loading shared libraries: libswscale.so.9:
+    // cannot open shared object file` - the package built against ffmpeg 8 on
+    // a system that had moved to ffmpeg 9's libswscale.so.10 - so the webcam
+    // card read `ready`, the click did nothing, and the message the user was
+    // given sent them to look at their phone.
+    //
+    // A dynamic-loader failure is distinctive and is NOT the same as a tool
+    // that runs and exits non-zero: the loader writes that sentence to stderr
+    // and the process comes back **127**, where `droidcam-cli` with no
+    // arguments prints its usage and exits 1. Both halves are required, so a
+    // tool that merely quotes the phrase is not classified by it, and 127
+    // cannot be a shell's "command not found" here because every probe is a
+    // constant argv with no shell on the path. Returns the soname the loader
+    // could not find, or "" for a binary that started.
+    function parseLoaderFailure(exitCode: int, stderrText: string): string {
+        if (exitCode !== 127) return "";
+        const match = /error while loading shared libraries:\s*([^\s:]+)/.exec(String(stderrText ?? ""));
+        return match ? match[1] : "";
     }
 
     // The install guide's rows: the sibling fork's table, verbatim.
@@ -192,33 +242,67 @@ Singleton {
         return { key: key, name: entry.name, description: entry.description, commands: entry.commands };
     }
 
+    // A dependency row for a tool that IS installed and cannot start. The
+    // install commands stay on it - reinstalling is the repair for a package
+    // linked against a library the system has moved past, and on Arch
+    // `yay -S droidcam` rebuilds it - but the description says what the
+    // problem actually is, because "install DroidCam CLI" is a lie told to
+    // somebody who has. An empty library name returns the row untouched, so
+    // an absent tool reads exactly as it did before.
+    function brokenDependency(entry: var, missingLibrary: string): var {
+        const library = String(missingLibrary ?? "");
+        if (!entry || library.length === 0) return entry;
+        return {
+            key: entry.key,
+            name: entry.name,
+            commands: entry.commands,
+            broken: true,
+            missingLibrary: library,
+            description: Translation.tr("Installed, but it cannot start: the dynamic loader cannot find %1. This package was built against an older library than the system now ships, so it needs rebuilding or reinstalling rather than installing.").arg(library)
+        };
+    }
+
     // Which dependencies a feature is missing, given the presence flags.
     // "mirror" is scrcpy + adb; "webcam" is DroidCam + the loopback module
     // (loaded or merely installed), with v4l-utils and mpv recommended;
     // "microphone" is pactl + either audio backend.
+    //
+    // A tool that is present and cannot start counts as missing here - the
+    // click does nothing either way, which is the whole complaint - and its
+    // row carries `broken` and the loader's own missing library.
     function missingDeps(feature: string, flags: var): var {
         const f = flags ?? {};
         const missing = [];
-        const need = (key, present) => { if (!present) missing.push(root.dependency(key)); };
+        const need = (key, present, brokenBy) => {
+            if (present) return;
+            missing.push(root.brokenDependency(root.dependency(key), brokenBy));
+        };
+        const scrcpyBroken = String(f.scrcpyRunError ?? "");
+        const adbBroken = String(f.adbRunError ?? "");
+        const droidcamBroken = String(f.droidcamCliRunError ?? "");
         if (feature === "mirror") {
-            need("scrcpy", f.scrcpy === true);
-            need("android-tools", f.adb === true);
+            need("scrcpy", f.scrcpy === true, scrcpyBroken);
+            need("android-tools", f.adb === true, adbBroken);
         } else if (feature === "webcam") {
-            need("droidcam-cli", f.droidcamCli === true);
-            need("v4l2loopback", f.v4l2loopbackLoaded === true || f.v4l2loopbackInstalled === true);
-            need("v4l-utils", f.v4l2Ctl === true);
-            need("mpv", f.mpv === true);
+            need("droidcam-cli", f.droidcamCli === true, droidcamBroken);
+            need("v4l2loopback", f.v4l2loopbackLoaded === true || f.v4l2loopbackInstalled === true, "");
+            need("v4l-utils", f.v4l2Ctl === true, "");
+            need("mpv", f.mpv === true, "");
         } else if (feature === "microphone") {
-            need("pactl", f.pactl === true);
-            need("audio-backend", f.scrcpy === true || f.droidcamCli === true);
+            need("pactl", f.pactl === true, "");
+            need("audio-backend", f.scrcpy === true || f.droidcamCli === true,
+                 scrcpyBroken.length > 0 ? scrcpyBroken : droidcamBroken);
         }
         return missing;
     }
+
     // END phone-deps logic
 
     function flags(): var {
         return {
             scrcpy: root.scrcpy, adb: root.adb, droidcamCli: root.droidcamCli,
+            scrcpyRunError: root.scrcpyRunError, adbRunError: root.adbRunError,
+            droidcamCliRunError: root.droidcamCliRunError,
             v4l2Ctl: root.v4l2Ctl, pactl: root.pactl, mpv: root.mpv, ffplay: root.ffplay,
             vlc: root.vlc, kdialog: root.kdialog, wlPaste: root.wlPaste,
             v4l2loopbackLoaded: root.v4l2loopbackLoaded,
@@ -247,9 +331,10 @@ Singleton {
     }
 
     // Live state, so it is re-asked rather than answered once. Refused while
-    // adb is not installed: a Process whose binary is not on PATH never emits
+    // adb is not USABLE - a Process whose binary is not on PATH never emits
     // `exited`, so the flag would keep whatever it had while the probe count
-    // still moved.
+    // still moved, and one that cannot start answers 127 to every question
+    // there is.
     function refreshAdbDevices(): void {
         if (!root.adb) return;
         root.startProbe(adbDevicesProbe);
@@ -270,10 +355,11 @@ Singleton {
         Component.onCompleted: root.startProbe(this)
         onRunningChanged: if (!running) root.probeAnswered()
         onExited: (exitCode, exitStatus) => {
-            root.scrcpy = exitCode === 0;
-            if (root.scrcpy) {
+            root.scrcpyPresent = exitCode === 0;
+            if (root.scrcpyPresent) {
                 root.startProbe(versionProbe);
             } else {
+                root.scrcpyRunError = "";
                 root.scrcpyVersion = "";
                 root.scrcpyMajor = 0;
                 root.scrcpyMinor = 0;
@@ -281,12 +367,19 @@ Singleton {
         }
     }
 
+    // scrcpy's run probe and its version probe are the same run: it is the
+    // one of the three that already had to be started to be asked something.
     Process {
         id: versionProbe
         command: ["scrcpy", "--version"]
         stdout: StdioCollector { id: versionOut }
-        onRunningChanged: if (!running) root.probeAnswered()
+        stderr: StdioCollector { id: versionErr }
+        onRunningChanged: {
+            if (running) scrcpyRunGuard.restart();
+            else { scrcpyRunGuard.stop(); root.probeAnswered(); }
+        }
         onExited: (exitCode, exitStatus) => {
+            root.scrcpyRunError = root.parseLoaderFailure(exitCode, versionErr.text);
             const parsed = root.parseScrcpyVersion(versionOut.text.split("\n")[0] ?? "");
             root.scrcpyVersion = parsed?.version ?? "";
             root.scrcpyMajor = parsed?.major ?? 0;
@@ -300,12 +393,34 @@ Singleton {
         Component.onCompleted: root.startProbe(this)
         onRunningChanged: if (!running) root.probeAnswered()
         onExited: (exitCode, exitStatus) => {
-            root.adb = exitCode === 0;
-            if (root.adb) {
-                root.startProbe(adbDevicesProbe);
+            root.adbPresent = exitCode === 0;
+            if (root.adbPresent) {
+                root.startProbe(adbRunProbe);
             } else {
+                root.adbRunError = "";
                 root.adbDevice = false;
             }
+        }
+    }
+
+    // `adb --version` prints the client's banner and starts no server -
+    // measured, it answers instantly on a machine with no adb server running.
+    // Started by the presence probe's own exit rather than from anything a
+    // feature does, which is the capability-probe gating rule
+    // (tests/lint_capability_probe_gating.py) followed one hop along.
+    Process {
+        id: adbRunProbe
+        command: ["adb", "--version"]
+        stdout: StdioCollector {}
+        stderr: StdioCollector { id: adbRunErr }
+        onRunningChanged: {
+            if (running) adbRunGuard.restart();
+            else { adbRunGuard.stop(); root.probeAnswered(); }
+        }
+        onExited: (exitCode, exitStatus) => {
+            root.adbRunError = root.parseLoaderFailure(exitCode, adbRunErr.text);
+            if (root.adb) root.startProbe(adbDevicesProbe);
+            else root.adbDevice = false;
         }
     }
 
@@ -328,7 +443,54 @@ Singleton {
         command: ["sh", "-c", "command -v droidcam-cli"]
         Component.onCompleted: root.startProbe(this)
         onRunningChanged: if (!running) root.probeAnswered()
-        onExited: (exitCode, exitStatus) => { root.droidcamCli = exitCode === 0; }
+        onExited: (exitCode, exitStatus) => {
+            root.droidcamCliPresent = exitCode === 0;
+            if (root.droidcamCliPresent) root.startProbe(droidcamRunProbe);
+            else root.droidcamCliRunError = "";
+        }
+    }
+
+    // Bare, because nothing droidcam-cli accepts exits zero: with no
+    // arguments it prints its usage to stderr and exits 1, which is a tool
+    // that RAN. The loader failure this exists for happens before main, so
+    // the arguments are beside the point - what matters is that the command
+    // returns promptly, which a usage message does.
+    Process {
+        id: droidcamRunProbe
+        command: ["droidcam-cli"]
+        stdout: StdioCollector {}
+        stderr: StdioCollector { id: droidcamRunErr }
+        onRunningChanged: {
+            if (running) droidcamRunGuard.restart();
+            else { droidcamRunGuard.stop(); root.probeAnswered(); }
+        }
+        onExited: (exitCode, exitStatus) => {
+            root.droidcamCliRunError = root.parseLoaderFailure(exitCode, droidcamRunErr.text);
+        }
+    }
+
+    // A tool that BLOCKS is neither of the two states this file can report,
+    // and it must not become a probe that never answers: the guard kills it
+    // and lets its own exit classify it, which lands on "it runs" because a
+    // killed process is not a loader failure. Erring that way is deliberate -
+    // claiming a tool is broken on the strength of it being slow is a worse
+    // lie than the one this whole block replaced.
+    Timer {
+        id: scrcpyRunGuard
+        interval: root.runProbeTimeoutMs
+        onTriggered: if (versionProbe.running) versionProbe.signal(15)
+    }
+
+    Timer {
+        id: adbRunGuard
+        interval: root.runProbeTimeoutMs
+        onTriggered: if (adbRunProbe.running) adbRunProbe.signal(15)
+    }
+
+    Timer {
+        id: droidcamRunGuard
+        interval: root.runProbeTimeoutMs
+        onTriggered: if (droidcamRunProbe.running) droidcamRunProbe.signal(15)
     }
 
     Process {

--- a/dots/.config/quickshell/imi/services/PhoneDeps.qml
+++ b/dots/.config/quickshell/imi/services/PhoneDeps.qml
@@ -531,6 +531,13 @@ Singleton {
         }
         root.pairState = "busy";
         root.pairMessage = "";
+        // Armed HERE rather than from the process going live, because a
+        // Process whose binary is not on PATH never emits `exited` - it drops
+        // `running` and says nothing - and a step armed off `running` would
+        // then sit on "busy" with its button refused for the rest of the
+        // session. The guard resolves that as well as killing a pair that
+        // takes too long.
+        pairGuard.restart();
         pairProcess.exec(root.adbPairArgv(address, root.normalizePairingCode(code)));
     }
 
@@ -548,6 +555,7 @@ Singleton {
         }
         root.connectState = "busy";
         root.connectMessage = "";
+        connectGuard.restart();
         connectProcess.exec(root.adbConnectArgv(address));
     }
 
@@ -555,11 +563,8 @@ Singleton {
         id: pairProcess
         stdout: StdioCollector { id: pairOut }
         stderr: StdioCollector { id: pairErr }
-        onRunningChanged: {
-            if (running) pairGuard.restart();
-            else pairGuard.stop();
-        }
         onExited: (exitCode, exitStatus) => {
+            pairGuard.stop();
             const result = root.parsePairResult(exitCode, pairOut.text, pairErr.text);
             root.pairState = result.ok ? "ok" : "failed";
             root.pairMessage = result.message;
@@ -570,11 +575,8 @@ Singleton {
         id: connectProcess
         stdout: StdioCollector { id: connectOut }
         stderr: StdioCollector { id: connectErr }
-        onRunningChanged: {
-            if (running) connectGuard.restart();
-            else connectGuard.stop();
-        }
         onExited: (exitCode, exitStatus) => {
+            connectGuard.stop();
             const result = root.parseConnectResult(exitCode, connectOut.text, connectErr.text);
             root.connectState = result.ok ? "ok" : "failed";
             root.connectMessage = result.message;
@@ -585,16 +587,37 @@ Singleton {
         }
     }
 
+    // A live command is killed and reports through its own exit; one that
+    // never started has nothing to kill and is reported here, because a step
+    // stuck on "busy" is a button that never comes back.
     Timer {
         id: pairGuard
         interval: root.adbActionTimeoutMs
-        onTriggered: if (pairProcess.running) pairProcess.signal(15)
+        onTriggered: {
+            if (pairProcess.running) {
+                pairProcess.signal(15);
+                return;
+            }
+            if (root.pairState === "busy") {
+                root.pairState = "failed";
+                root.pairMessage = Translation.tr("adb did not answer.");
+            }
+        }
     }
 
     Timer {
         id: connectGuard
         interval: root.adbActionTimeoutMs
-        onTriggered: if (connectProcess.running) connectProcess.signal(15)
+        onTriggered: {
+            if (connectProcess.running) {
+                connectProcess.signal(15);
+                return;
+            }
+            if (root.connectState === "busy") {
+                root.connectState = "failed";
+                root.connectMessage = Translation.tr("adb did not answer.");
+            }
+        }
     }
 
     // ---- and where the two addresses come from ---------------------------
@@ -620,6 +643,7 @@ Singleton {
         root.mdnsPairingAddress = "";
         root.mdnsConnectAddress = "";
         root.mdnsPending = 2;
+        mdnsGuard.restart();
         pairingBrowse.exec(root.avahiBrowseArgv("_adb-tls-pairing._tcp"));
         connectBrowse.exec(root.avahiBrowseArgv("_adb-tls-connect._tcp"));
     }
@@ -646,10 +670,10 @@ Singleton {
         id: pairingBrowse
         stdout: StdioCollector { id: pairingBrowseOut }
         stderr: StdioCollector {}
-        onRunningChanged: {
-            if (running) mdnsGuard.restart();
-            else root.mdnsAnswered();
-        }
+        // The count hangs off `running` rather than `exited` for the reason
+        // the presence probes do: an absent binary drops one and never emits
+        // the other.
+        onRunningChanged: if (!running) root.mdnsAnswered()
         onExited: (exitCode, exitStatus) => {
             const record = root.pickAvahiRecord(root.parseAvahiRecords(pairingBrowseOut.text),
                                                 root.preferredWirelessHost());
@@ -661,10 +685,7 @@ Singleton {
         id: connectBrowse
         stdout: StdioCollector { id: connectBrowseOut }
         stderr: StdioCollector {}
-        onRunningChanged: {
-            if (running) mdnsGuard.restart();
-            else root.mdnsAnswered();
-        }
+        onRunningChanged: if (!running) root.mdnsAnswered()
         onExited: (exitCode, exitStatus) => {
             const record = root.pickAvahiRecord(root.parseAvahiRecords(connectBrowseOut.text),
                                                 root.preferredWirelessHost());
@@ -674,12 +695,17 @@ Singleton {
 
     // `avahi-browse -t` terminates on its own once the cache is exhausted and
     // fails immediately with no daemon, but it is a network wait either way.
+    // Armed by the caller for the reason the two above are.
     Timer {
         id: mdnsGuard
         interval: root.runProbeTimeoutMs
         onTriggered: {
             if (pairingBrowse.running) pairingBrowse.signal(15);
             if (connectBrowse.running) connectBrowse.signal(15);
+            if (root.mdnsState === "searching" && root.mdnsPending > 0) {
+                root.mdnsPending = 0;
+                root.mdnsState = "done";
+            }
         }
     }
 

--- a/dots/.config/quickshell/imi/tests/imports/testservices/PhoneDeps.qml
+++ b/dots/.config/quickshell/imi/tests/imports/testservices/PhoneDeps.qml
@@ -22,6 +22,7 @@ Singleton {
     property bool vlc: false
     property bool kdialog: false
     property bool wlPaste: false
+    property bool avahiBrowse: false
     property bool v4l2loopbackLoaded: false
     property bool v4l2loopbackInstalled: false
     property string scrcpyVersion: ""
@@ -251,6 +252,146 @@ Singleton {
         return missing;
     }
 
+    // ---- wireless debugging, as arithmetic -----------------------------
+    //
+    // Android 11+ re-rolls BOTH ports every time the Wireless debugging
+    // switch is flipped: "Pair device with pairing code" shows one address
+    // and a six-digit code, while the connect step uses a different port
+    // printed on the Wireless debugging screen itself. Neither is guessable,
+    // which is why the two steps are two addresses rather than one.
+
+    // `adb pair HOST:PORT CODE` takes the code as an ARGUMENT and does not
+    // prompt - measured against platform-tools 37.0.1 (Version 37.0.1-...):
+    // `adb help` documents `pair HOST[:PORT] [PAIRING CODE]`, and running
+    // `adb pair 127.0.0.1:1` with no code and stdin closed answers
+    // "Enter pairing code: adb: No pairing code provided" and exits 1, so the
+    // code has to be on the command line. Both the address and the code are
+    // the user's own typing, so they are separate argv elements and there is
+    // no shell anywhere on this path.
+    function adbPairArgv(address: string, code: string): var {
+        return ["adb", "pair", String(address ?? "").trim(), String(code ?? "").trim()];
+    }
+
+    function adbConnectArgv(address: string): var {
+        return ["adb", "connect", String(address ?? "").trim()];
+    }
+
+    // The two service types Android advertises while wireless debugging is
+    // on: the pairing screen publishes `_adb-tls-pairing._tcp` only while it
+    // is open, and `_adb-tls-connect._tcp` is up for as long as the switch
+    // is.
+    function avahiBrowseArgv(serviceType: string): var {
+        return ["avahi-browse", "-rpt", String(serviceType ?? "")];
+    }
+
+    // avahi-browse's parsable RESOLVED record is
+    // `=;iface;proto;name;type;domain;host;address;port;txt`, so the address
+    // is field 8 and the port field 9 - the layout the sibling fork's
+    // `_adb-tls-connect._tcp` snippet reads with `awk -F';' $8":"$9`. It
+    // could not be confirmed against a live daemon here (avahi-daemon is not
+    // running on this machine), so this VALIDATES rather than trusts the
+    // positions: a record whose field 9 is not a port number is skipped
+    // rather than becoming an address the user is asked to believe.
+    function parseAvahiRecords(text: string): var {
+        const out = [];
+        for (const raw of String(text ?? "").split("\n")) {
+            const line = raw.trim();
+            if (line.length === 0 || line.charAt(0) !== "=") continue;
+            const parts = line.split(";");
+            if (parts.length < 9) continue;
+            const host = String(parts[7] ?? "").trim();
+            const port = String(parts[8] ?? "").trim();
+            if (host.length === 0) continue;
+            if (!/^\d{1,5}$/.test(port)) continue;
+            const number = parseInt(port);
+            if (number < 1 || number > 65535) continue;
+            out.push({ host: host, port: port, address: host + ":" + port });
+        }
+        return out;
+    }
+
+    // The phone KDE Connect already reaches wins when several are
+    // advertising; otherwise the first record is offered and the user can
+    // correct it, which is the whole reason the address stays a field.
+    function pickAvahiRecord(records: var, preferredHost: string): var {
+        const list = records ?? [];
+        const want = String(preferredHost ?? "").trim();
+        if (want.length > 0)
+            for (let i = 0; i < list.length; i++)
+                if (String(list[i].host) === want) return list[i];
+        return list.length > 0 ? list[0] : null;
+    }
+
+    function firstMeaningfulLine(text: string): string {
+        for (const raw of String(text ?? "").split("\n")) {
+            const line = raw.trim();
+            if (line.length > 0) return line;
+        }
+        return "";
+    }
+
+    // `adb pair` reports through its exit code AND its own sentence, and both
+    // are required so that an adb which one day exits 0 on a refusal is still
+    // read as one. Measured: an unreachable target answers "error: protocol
+    // fault (couldn't read status message): Success" with exit 1; a
+    // successful pairing prints "Successfully paired to HOST [guid=...]".
+    function parsePairResult(exitCode: int, out: string, err: string): var {
+        const text = (String(out ?? "") + "\n" + String(err ?? "")).trim();
+        return {
+            ok: exitCode === 0 && /successfully paired/i.test(text),
+            message: root.firstMeaningfulLine(text)
+        };
+    }
+
+    // `adb connect` exits **0 whatever happens** - measured against
+    // platform-tools 37.0.1, `adb connect 127.0.0.1:1` prints
+    // "failed to connect to '127.0.0.1:1': Connection refused" and exits 0,
+    // and so does a host that does not resolve. The exit code is therefore
+    // not evidence here and the printed line is the whole of it; the phone
+    // turning up under `adb devices` is the confirmation, which is why the
+    // caller re-asks that rather than believing this.
+    function parseConnectResult(exitCode: int, out: string, err: string): var {
+        const text = (String(out ?? "") + "\n" + String(err ?? "")).trim();
+        return {
+            ok: exitCode === 0 && /^(already )?connected to /im.test(text),
+            message: root.firstMeaningfulLine(text)
+        };
+    }
+
+    // The code the phone shows is six digits; anything else is a typo a pair
+    // would spend a round trip discovering.
+    function normalizePairingCode(text: string): string {
+        return String(text ?? "").replace(/\D/g, "").substring(0, 6);
+    }
+
+    // `host:port`, split at the LAST colon so a bracketed IPv6 literal - the
+    // only form adb accepts - keeps its own. Returns null for something that
+    // is not an address at all; an empty port is a legal answer, because
+    // `adb connect` defaults to 5555 while a pairing address never can.
+    function splitAddress(text: string): var {
+        const raw = String(text ?? "").trim();
+        if (raw.length === 0) return null;
+        const index = raw.lastIndexOf(":");
+        if (index < 0) return { host: raw, port: "" };
+        const host = raw.substring(0, index).trim();
+        const port = raw.substring(index + 1).trim();
+        if (host.length === 0) return null;
+        if (port.length === 0) return { host: host, port: "" };
+        if (!/^\d{1,5}$/.test(port)) return null;
+        const number = parseInt(port);
+        if (number < 1 || number > 65535) return null;
+        return { host: host, port: port };
+    }
+
+    function pairInputsReady(address: string, code: string): bool {
+        const parts = root.splitAddress(address);
+        return parts !== null && parts.port.length > 0
+            && root.normalizePairingCode(code).length === 6;
+    }
+
+    function connectInputReady(address: string): bool {
+        return root.splitAddress(address) !== null;
+    }
     // END phone-deps logic
     function flags(): var {
         return {

--- a/dots/.config/quickshell/imi/tests/imports/testservices/PhoneDeps.qml
+++ b/dots/.config/quickshell/imi/tests/imports/testservices/PhoneDeps.qml
@@ -30,6 +30,14 @@ Singleton {
     property string distro: "unknown"
     property bool adbDevice: false
 
+    // Presence and usability are one writable flag each here: the real
+    // service derives `scrcpy`/`adb`/`droidcamCli` from a `command -v` and a
+    // run probe, and a test states the outcome rather than the two halves.
+    // The run errors are separate because missingDeps() reads them.
+    property string scrcpyRunError: ""
+    property string adbRunError: ""
+    property string droidcamCliRunError: ""
+
     readonly property bool appModeSupported: root.scrcpy && root.scrcpyMajor >= 4
 
     property int probesPending: 0
@@ -84,6 +92,28 @@ Singleton {
             if (parts.length >= 2 && parts[1] === "device") return true;
         }
         return false;
+    }
+
+    // Three states, not two, and the third is what `command -v` cannot see.
+    // Measured on this machine: `droidcam-cli` was on PATH and died before
+    // main with `error while loading shared libraries: libswscale.so.9:
+    // cannot open shared object file` - the package built against ffmpeg 8 on
+    // a system that had moved to ffmpeg 9's libswscale.so.10 - so the webcam
+    // card read `ready`, the click did nothing, and the message the user was
+    // given sent them to look at their phone.
+    //
+    // A dynamic-loader failure is distinctive and is NOT the same as a tool
+    // that runs and exits non-zero: the loader writes that sentence to stderr
+    // and the process comes back **127**, where `droidcam-cli` with no
+    // arguments prints its usage and exits 1. Both halves are required, so a
+    // tool that merely quotes the phrase is not classified by it, and 127
+    // cannot be a shell's "command not found" here because every probe is a
+    // constant argv with no shell on the path. Returns the soname the loader
+    // could not find, or "" for a binary that started.
+    function parseLoaderFailure(exitCode: int, stderrText: string): string {
+        if (exitCode !== 127) return "";
+        const match = /error while loading shared libraries:\s*([^\s:]+)/.exec(String(stderrText ?? ""));
+        return match ? match[1] : "";
     }
 
     // The install guide's rows: the sibling fork's table, verbatim.
@@ -167,32 +197,66 @@ Singleton {
         return { key: key, name: entry.name, description: entry.description, commands: entry.commands };
     }
 
+    // A dependency row for a tool that IS installed and cannot start. The
+    // install commands stay on it - reinstalling is the repair for a package
+    // linked against a library the system has moved past, and on Arch
+    // `yay -S droidcam` rebuilds it - but the description says what the
+    // problem actually is, because "install DroidCam CLI" is a lie told to
+    // somebody who has. An empty library name returns the row untouched, so
+    // an absent tool reads exactly as it did before.
+    function brokenDependency(entry: var, missingLibrary: string): var {
+        const library = String(missingLibrary ?? "");
+        if (!entry || library.length === 0) return entry;
+        return {
+            key: entry.key,
+            name: entry.name,
+            commands: entry.commands,
+            broken: true,
+            missingLibrary: library,
+            description: Translation.tr("Installed, but it cannot start: the dynamic loader cannot find %1. This package was built against an older library than the system now ships, so it needs rebuilding or reinstalling rather than installing.").arg(library)
+        };
+    }
+
     // Which dependencies a feature is missing, given the presence flags.
     // "mirror" is scrcpy + adb; "webcam" is DroidCam + the loopback module
     // (loaded or merely installed), with v4l-utils and mpv recommended;
     // "microphone" is pactl + either audio backend.
+    //
+    // A tool that is present and cannot start counts as missing here - the
+    // click does nothing either way, which is the whole complaint - and its
+    // row carries `broken` and the loader's own missing library.
     function missingDeps(feature: string, flags: var): var {
         const f = flags ?? {};
         const missing = [];
-        const need = (key, present) => { if (!present) missing.push(root.dependency(key)); };
+        const need = (key, present, brokenBy) => {
+            if (present) return;
+            missing.push(root.brokenDependency(root.dependency(key), brokenBy));
+        };
+        const scrcpyBroken = String(f.scrcpyRunError ?? "");
+        const adbBroken = String(f.adbRunError ?? "");
+        const droidcamBroken = String(f.droidcamCliRunError ?? "");
         if (feature === "mirror") {
-            need("scrcpy", f.scrcpy === true);
-            need("android-tools", f.adb === true);
+            need("scrcpy", f.scrcpy === true, scrcpyBroken);
+            need("android-tools", f.adb === true, adbBroken);
         } else if (feature === "webcam") {
-            need("droidcam-cli", f.droidcamCli === true);
-            need("v4l2loopback", f.v4l2loopbackLoaded === true || f.v4l2loopbackInstalled === true);
-            need("v4l-utils", f.v4l2Ctl === true);
-            need("mpv", f.mpv === true);
+            need("droidcam-cli", f.droidcamCli === true, droidcamBroken);
+            need("v4l2loopback", f.v4l2loopbackLoaded === true || f.v4l2loopbackInstalled === true, "");
+            need("v4l-utils", f.v4l2Ctl === true, "");
+            need("mpv", f.mpv === true, "");
         } else if (feature === "microphone") {
-            need("pactl", f.pactl === true);
-            need("audio-backend", f.scrcpy === true || f.droidcamCli === true);
+            need("pactl", f.pactl === true, "");
+            need("audio-backend", f.scrcpy === true || f.droidcamCli === true,
+                 scrcpyBroken.length > 0 ? scrcpyBroken : droidcamBroken);
         }
         return missing;
     }
+
     // END phone-deps logic
     function flags(): var {
         return {
             scrcpy: root.scrcpy, adb: root.adb, droidcamCli: root.droidcamCli,
+            scrcpyRunError: root.scrcpyRunError, adbRunError: root.adbRunError,
+            droidcamCliRunError: root.droidcamCliRunError,
             v4l2Ctl: root.v4l2Ctl, pactl: root.pactl, mpv: root.mpv, ffplay: root.ffplay,
             vlc: root.vlc, kdialog: root.kdialog, wlPaste: root.wlPaste,
             v4l2loopbackLoaded: root.v4l2loopbackLoaded,

--- a/dots/.config/quickshell/imi/tests/test_phone_sessions_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_sessions_contract.py
@@ -164,7 +164,7 @@ def test_the_only_shell_strings_are_phone_deps_constant_probes():
         )
     deps = _shell_strings(_source("PhoneDeps"))
     probes = [s for s in deps if s.startswith('"command -v ')]
-    assert len(probes) == 10, f"expected ten `command -v` probes, found {probes}"
+    assert len(probes) == 11, f"expected eleven `command -v` probes, found {probes}"
     for string in deps:
         assert string.startswith('"') and string.endswith('"'), f"not a plain literal: {string}"
         assert "${" not in string and "+" not in string, f"interpolation into a shell string: {string}"
@@ -291,7 +291,7 @@ def test_the_supervisor_idle_timer_is_ten_seconds_and_asks_before_stopping():
 def test_the_capability_probes_start_themselves_and_again_from_recheck():
     source = _source("PhoneDeps")
     probes = [block for block in _process_blocks(source) if '"command -v ' in block]
-    assert len(probes) == 10, f"expected ten probes, found {len(probes)}"
+    assert len(probes) == 11, f"expected eleven probes, found {len(probes)}"
     for block in probes:
         assert "Component.onCompleted: root.startProbe(this)" in block, f"a probe does not start itself: {block[:80]}"
         assert "onRunningChanged: if (!running) root.probeAnswered()" in block, (
@@ -301,7 +301,7 @@ def test_the_capability_probes_start_themselves_and_again_from_recheck():
     assert recheck, "recheck() missing"
     for probe_id in ("scrcpyProbe", "adbProbe", "droidcamProbe", "v4l2CtlProbe", "pactlProbe",
                      "mpvProbe", "ffplayProbe", "vlcProbe", "kdialogProbe", "wlPasteProbe",
-                     "lsmodProbe", "modinfoProbe", "distroProbe"):
+                     "avahiBrowseProbe", "lsmodProbe", "modinfoProbe", "distroProbe"):
         assert probe_id in recheck.group(1), f"recheck() does not restart {probe_id}"
     assert '["scrcpy", "--version"]' in source, "the version probe is not the argv scrcpy --version"
 
@@ -334,6 +334,34 @@ def test_the_three_spawned_tools_are_asked_whether_they_run_not_only_whether_the
     parse = re.search(r"function parseLoaderFailure\(.*?\n    \}", source, re.S).group(0)
     assert "exitCode !== 127" in parse, "the classifier does not require exit 127"
     assert "error while loading shared libraries" in parse, "the classifier does not read the loader"
+
+
+def test_the_adb_pair_and_connect_commands_are_constant_argv():
+    """The address and the pairing code are the user's own typing. They reach
+    adb as separate argv elements through a Process, with no shell anywhere on
+    the path - the sibling fork's wireless-ADB helpers are `bash -c` strings
+    with values pasted into them, which is the shape this may not take."""
+    source = _source("PhoneDeps")
+    for builder, expected in (("adbPairArgv", '["adb", "pair"'),
+                              ("adbConnectArgv", '["adb", "connect"'),
+                              ("avahiBrowseArgv", '["avahi-browse", "-rpt"')):
+        body = re.search(r"function %s\(.*?\n    \}" % builder, source, re.S)
+        assert body, f"{builder} is missing"
+        assert expected in body.group(0), f"{builder} does not build a constant argv"
+        assert '"-c"' not in body.group(0), f"{builder} reaches a shell"
+    for name in ("pairProcess", "connectProcess", "pairingBrowse", "connectBrowse"):
+        block = _named_block(source, name)
+        assert "command:" not in block, (
+            f"{name} declares a command instead of being handed one by an argv builder"
+        )
+    # `adb connect` exits 0 whatever happens, so the exit code alone may not
+    # decide it - and the phone turning up under `adb devices` is what the
+    # panel really waits for.
+    connect = re.search(r"function parseConnectResult\(.*?\n    \}", source, re.S).group(0)
+    assert "connected to" in connect, "the connect result is not read off what adb printed"
+    assert "root.refreshAdbDevices()" in _named_block(source, "connectProcess"), (
+        "a successful connect never re-asks adb devices, so nothing confirms it"
+    )
 
 
 def test_the_microphone_swap_is_persisted_and_undone_on_every_exit_path():

--- a/dots/.config/quickshell/imi/tests/test_phone_sessions_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_sessions_contract.py
@@ -52,6 +52,25 @@ def _synced_region(path: Path, tag: str) -> str:
     return text[start:text.index(end)]
 
 
+def _named_block(source: str, object_id: str) -> str:
+    """The body of the `Process`/`Timer` block carrying `id: <object_id>`.
+
+    Brace-counted forward from the brace that opened it, which is found by
+    walking back from the id - these blocks are located by what they are
+    called rather than by where they sit in the file.
+    """
+    marker = source.index("id: " + object_id + "\n")
+    start = source.rindex("{", 0, marker)
+    depth, index = 1, start + 1
+    while index < len(source) and depth:
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+        index += 1
+    return source[start:index]
+
+
 def _process_blocks(source: str):
     """Every `Process { ... }` block, brace-counted with string literals
     skipped, so a `}` inside a shell string cannot end a block early."""
@@ -285,6 +304,36 @@ def test_the_capability_probes_start_themselves_and_again_from_recheck():
                      "lsmodProbe", "modinfoProbe", "distroProbe"):
         assert probe_id in recheck.group(1), f"recheck() does not restart {probe_id}"
     assert '["scrcpy", "--version"]' in source, "the version probe is not the argv scrcpy --version"
+
+
+def test_the_three_spawned_tools_are_asked_whether_they_run_not_only_whether_they_exist():
+    """`command -v` answers presence; a package linked against a library the
+    system has moved past is present and dies before main. The three binaries
+    the tab spawns are therefore started as well, each from its own presence
+    probe rather than from a feature's activation, and each under a kill guard
+    so a tool that blocks cannot leave a probe outstanding for the session."""
+    source = _source("PhoneDeps")
+    assert '["adb", "--version"]' in source, "adb is never actually started"
+    assert '["droidcam-cli"]' in source, "droidcam-cli is never actually started"
+    assert '["scrcpy", "--version"]' in source, "scrcpy is never actually started"
+    for probe, presence in (("adbRunProbe", "adbProbe"),
+                            ("droidcamRunProbe", "droidcamProbe"),
+                            ("versionProbe", "scrcpyProbe")):
+        block = _named_block(source, presence)
+        assert "root.startProbe(%s)" % probe in block, (
+            f"{probe} is not started by {presence}, so it answers only once a feature asks"
+        )
+    for guard, probe in (("adbRunGuard", "adbRunProbe"),
+                         ("droidcamRunGuard", "droidcamRunProbe"),
+                         ("scrcpyRunGuard", "versionProbe")):
+        assert f"{guard}.restart()" in source and f"{probe}.signal(15)" in source, (
+            f"{probe} has no kill guard: a tool that blocks would hang its probe"
+        )
+    # Both halves, or a tool that merely quotes the phrase - or any non-zero
+    # exit at all - would be reported as unable to run.
+    parse = re.search(r"function parseLoaderFailure\(.*?\n    \}", source, re.S).group(0)
+    assert "exitCode !== 127" in parse, "the classifier does not require exit 127"
+    assert "error while loading shared libraries" in parse, "the classifier does not read the loader"
 
 
 def test_the_microphone_swap_is_persisted_and_undone_on_every_exit_path():

--- a/dots/.config/quickshell/imi/tests/test_phone_tab_layout_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_tab_layout_runtime.py
@@ -26,17 +26,32 @@ every other check in this suite:
   is too small - it overflows rather than shrinking - so nothing errors and
   nothing is logged. The fixture therefore carries both scripts.
 
-It also drives the Android Apps page through its three states, because which
-message that page draws is a question about all three at once and no source
-check can ask it: with no phone on ADB it must draw the danger panel and
-NEITHER of the two lines that used to say the same thing beside it (a red
-"Phone not reachable over ADB" from the session manager, and a "No apps yet"
-empty state that cannot say what to do about it); with a phone that answered
-and had nothing, the empty state and no panel; with apps, the list and no
-message at all. `adb` and `scrcpy` are faked for it - both are really installed
-on the maintainer's machine, so without the fakes the page reads whatever a
-real `adb devices` answers and the reported state disappears the moment a phone
-is plugged in.
+It also drives the Android Apps page through every state it has, because which
+message that page draws is a question about several facts at once and no source
+check can ask it. Two families:
+
+- what adb IS on this machine, which used to be one state and is three. `adb`
+  is stripped out of the harness's PATH entirely (the maintainer's own lives in
+  /opt/android-sdk/platform-tools), and the two stubs are copied in between
+  steps: absent, then one that answers the way the dynamic loader does - the
+  `error while loading shared libraries` sentence on stderr and exit 127 -
+  then one that works. `command -v` reports the middle one as present, which
+  is the whole defect: the webcam card read `ready`, the click did nothing, and
+  the message pointed at the phone.
+- what is ON adb: with no device the page must draw the pairing panel and
+  NEITHER of the two lines that used to say the same thing beside it (a red
+  "Phone not reachable over ADB" from the session manager, and a "No apps yet"
+  empty state that cannot say what to do about it); with a phone that answered
+  and had nothing, the empty state and no panel; with apps, the list and no
+  message at all.
+
+The pairing panel itself is driven end to end - discovery through a fake
+`avahi-browse`, then `adb pair` and `adb connect` through the fake adb, whose
+`connect` creates the attach marker so the panel is taken down by the phone
+turning up under `adb devices` rather than by adb's own line (which is a claim:
+the real `adb connect` exits 0 on a refused connection). It is measured at two
+page widths, because a column pinned to one width passes every check at that
+width.
 
 The fake `busctl` serves one paired, reachable phone and two mirrored
 notifications: leaf 70 carries an `iconPath` (a PNG this test writes, the way
@@ -72,9 +87,10 @@ PHONE_ADDRESS = "192.168.100.179"
 # A literal, never read back out of the harness's own output: a step list
 # that shrinks must redden here instead of reporting `failures: 0` for a
 # shorter run.
-# 21 shared, 13 for the contact rows' geometry, 21 for the Apps page's
-# three ADB states.
-EXPECTED_CHECKS = 55
+# 21 shared, 13 for the contact rows' geometry, 44 for the Apps page - the
+# three states adb itself can be in, the three states the page can be in, and
+# the pairing panel driven through discovery, pair and connect at two widths.
+EXPECTED_CHECKS = 78
 
 # The two names the row-geometry steps measure, handed to the harness in the
 # environment so the fixture is the only place either is spelled. The Arabic
@@ -120,11 +136,28 @@ __BODY__
 #
 # What is attached is a FILE the harness creates between steps, not an argument,
 # because the thing being driven is a change the shell has to notice on its own.
+# The working adb. `connect` creates the attach marker, so the panel is taken
+# down by the phone appearing under `adb devices` rather than by the sentence
+# adb printed - which is the distinction that matters, since the real
+# `adb connect` exits 0 on a refused connection too.
 ADB_BODY = """\
-case "$*" in
-  *"devices"*)
+case "$1" in
+  --version)
+    printf 'Android Debug Bridge version 1.0.41\\n'
+    exit 0
+    ;;
+  devices)
     printf 'List of devices attached\\n'
     if [ -f "$PHONE_ADB_ATTACHED" ]; then printf 'imi-fake-phone\\tdevice\\n'; fi
+    exit 0
+    ;;
+  pair)
+    printf 'Successfully paired to %s [guid=adb-imi-fake]\\n' "$2"
+    exit 0
+    ;;
+  connect)
+    : > "$PHONE_ADB_ATTACHED"
+    printf 'connected to %s\\n' "$2"
     exit 0
     ;;
 esac
@@ -132,6 +165,35 @@ esac
 # manager falls back to - fails while nothing is attached, which is what tells
 # it apart from a phone that answered with no apps.
 [ -f "$PHONE_ADB_ATTACHED" ] || exit 1
+exit 0
+"""
+
+# An adb that is on PATH and cannot start, spelled exactly the way the dynamic
+# loader spells it: the sentence on stderr, nothing on stdout, and 127. This is
+# what droidcam-cli did on the maintainer's machine while `command -v` reported
+# it present.
+ADB_BROKEN_LIB = "libimi-not-a-real-library.so.7"
+ADB_BROKEN_BODY = """\
+printf '%s: error while loading shared libraries: %s: cannot open shared object file: No such file or directory\\n' \\
+  "$0" "$PHONE_ADB_BROKEN_LIB" >&2
+exit 127
+"""
+
+# The two service types Android advertises while wireless debugging is on, in
+# avahi's parsable resolved form. The unresolved `+` line is there because the
+# parser has to skip one.
+AVAHI_BODY = """\
+case "$*" in
+  *_adb-tls-pairing._tcp*)
+    printf '+;wlan0;IPv4;adb-imi-fake;_adb-tls-pairing._tcp;local\\n'
+    printf '=;wlan0;IPv4;adb-imi-fake;_adb-tls-pairing._tcp;local;phone.local;%s;37129;\\n' \\
+      "$PHONE_LAN_ADDRESS"
+    ;;
+  *_adb-tls-connect._tcp*)
+    printf '=;wlan0;IPv4;adb-imi-fake;_adb-tls-connect._tcp;local;phone.local;%s;41235;\\n' \\
+      "$PHONE_LAN_ADDRESS"
+    ;;
+esac
 exit 0
 """
 
@@ -315,10 +377,22 @@ class PhoneTabLayoutRuntimeTest(unittest.TestCase):
         # answered with nothing") is a real empty answer from a real device.
         self.apps_source = self.home / "apps-source.txt"
         self.apps_source.write_text(APP_LINES)
-        for name, body in (("adb", ADB_BODY), ("scrcpy", SCRCPY_BODY)):
+        # scrcpy and avahi-browse are on PATH from the start; `adb` is NOT.
+        # It is staged beside them and copied in by the harness, which is the
+        # only way a test can say what `command -v adb` answers - the machine
+        # this runs on has one, and the first state the page has to draw is
+        # the one where it does not.
+        for name, body in (("scrcpy", SCRCPY_BODY), ("avahi-browse", AVAHI_BODY)):
             tool = self.bin / name
             tool.write_text(RECORD.replace("__BODY__", body))
             tool.chmod(0o755)
+        self.adb_bin = self.bin / "adb"
+        self.adb_ok = self.home / "adb-ok"
+        self.adb_broken = self.home / "adb-broken"
+        self.adb_ok.write_text(RECORD.replace("__BODY__", ADB_BODY))
+        self.adb_ok.chmod(0o755)
+        self.adb_broken.write_text(RECORD.replace("__BODY__", ADB_BROKEN_BODY))
+        self.adb_broken.chmod(0o755)
 
         # The vCards KDE Connect writes for KPeople, which the real monitor
         # reads: a fixture tree, never the machine's own contacts.
@@ -369,7 +443,16 @@ class PhoneTabLayoutRuntimeTest(unittest.TestCase):
         env["XDG_STATE_HOME"] = str(self.home / "state")
         env["XDG_CACHE_HOME"] = str(self.home / "cache")
         env["XDG_DATA_HOME"] = str(self.home / "data")
-        env["PATH"] = f"{self.bin}{os.pathsep}{env['PATH']}"
+        # Every directory holding an `adb` comes out: this test decides
+        # whether adb exists, and on the maintainer's machine it lives in
+        # /opt/android-sdk/platform-tools rather than anywhere a stub could
+        # shadow it (`command -v` searches the whole of PATH, so a
+        # non-executable placeholder in front would simply be skipped).
+        inherited = [d for d in env["PATH"].split(os.pathsep)
+                     if d and not (Path(d) / "adb").exists()]
+        env["PATH"] = os.pathsep.join([str(self.bin)] + inherited)
+        self.assertIsNone(shutil.which("adb", path=env["PATH"]),
+                          "adb is still reachable, so the absent state is not a state")
         env["PHONE_EXEC_LOG"] = str(self.exec_log)
         env["PHONE_ID"] = PHONE_ID
         env["PHONE_ICON_PATH"] = str(self.icon_path)
@@ -378,6 +461,11 @@ class PhoneTabLayoutRuntimeTest(unittest.TestCase):
         env["PHONE_ADB_ATTACHED"] = str(self.adb_attached)
         env["PHONE_APPS_FILE"] = str(self.apps_file)
         env["PHONE_APPS_SOURCE"] = str(self.apps_source)
+        env["PHONE_ADB_BIN"] = str(self.adb_bin)
+        env["PHONE_ADB_OK"] = str(self.adb_ok)
+        env["PHONE_ADB_BROKEN"] = str(self.adb_broken)
+        env["PHONE_ADB_BROKEN_LIB"] = ADB_BROKEN_LIB
+        env["PHONE_LAN_ADDRESS"] = PHONE_ADDRESS
 
         # dbus-run-session, not the inherited bus: the fake busctl is the only
         # daemon this harness may see.

--- a/dots/.config/quickshell/imi/tests/tst_phone_scrcpy.qml
+++ b/dots/.config/quickshell/imi/tests/tst_phone_scrcpy.qml
@@ -47,6 +47,7 @@ TestCase {
         PhoneDeps.scrcpyMajor = 0
         PhoneDeps.adbDevice = false
         PhoneDeps.adbDeviceRefreshes = 0
+        PhoneDeps.avahiBrowse = false
         PhoneDeps.scrcpyRunError = ""
         PhoneDeps.adbRunError = ""
         PhoneDeps.droidcamCliRunError = ""
@@ -249,6 +250,136 @@ TestCase {
             { pactl: true, scrcpyRunError: "libavutil.so.58" })
         compare(audio.map(d => d.key), ["audio-backend"])
         compare(audio[0].missingLibrary, "libavutil.so.58")
+    }
+
+    // ================================================================
+    // PhoneDeps - wireless debugging
+    // ================================================================
+
+    // Constant argv, always: the address and the code are the user's own
+    // typing and never reach a shell. `adb pair HOST:PORT CODE` takes the
+    // code as an argument - measured against platform-tools 37.0.1, where
+    // omitting it makes adb prompt on stdin instead.
+    function test_deps_the_pair_and_connect_argv_are_constant() {
+        compare(PhoneDeps.adbPairArgv("192.168.1.42:37129", "123456"),
+                ["adb", "pair", "192.168.1.42:37129", "123456"])
+        compare(PhoneDeps.adbPairArgv("  192.168.1.42:37129  ", " 123456 "),
+                ["adb", "pair", "192.168.1.42:37129", "123456"])
+        // Whatever the user types stays ONE element - there is nothing here
+        // for a shell metacharacter to mean.
+        compare(PhoneDeps.adbPairArgv("1.2.3.4:1; rm -rf ~", "1 2"),
+                ["adb", "pair", "1.2.3.4:1; rm -rf ~", "1 2"])
+        compare(PhoneDeps.adbConnectArgv("192.168.1.42:41235"),
+                ["adb", "connect", "192.168.1.42:41235"])
+        compare(PhoneDeps.avahiBrowseArgv("_adb-tls-pairing._tcp"),
+                ["avahi-browse", "-rpt", "_adb-tls-pairing._tcp"])
+    }
+
+    function test_deps_a_pairing_code_is_six_digits_and_an_address_carries_a_port() {
+        compare(PhoneDeps.normalizePairingCode("123 456"), "123456")
+        compare(PhoneDeps.normalizePairingCode("12-34-56"), "123456")
+        compare(PhoneDeps.normalizePairingCode("1234567"), "123456")
+        compare(PhoneDeps.normalizePairingCode(""), "")
+        compare(PhoneDeps.normalizePairingCode(undefined), "")
+
+        compare(PhoneDeps.splitAddress("192.168.1.42:37129"),
+                { host: "192.168.1.42", port: "37129" })
+        compare(PhoneDeps.splitAddress("phone.local"), { host: "phone.local", port: "" })
+        // A bracketed IPv6 literal keeps its own colons.
+        compare(PhoneDeps.splitAddress("[fe80::1]:5555"), { host: "[fe80::1]", port: "5555" })
+        compare(PhoneDeps.splitAddress("192.168.1.42:nope"), null)
+        compare(PhoneDeps.splitAddress("192.168.1.42:70000"), null)
+        compare(PhoneDeps.splitAddress(":5555"), null)
+        compare(PhoneDeps.splitAddress("   "), null)
+
+        // The pairing port is never guessable, so it is required; the connect
+        // one has a default adb supplies.
+        verify(PhoneDeps.pairInputsReady("192.168.1.42:37129", "123456"))
+        verify(!PhoneDeps.pairInputsReady("192.168.1.42", "123456"))
+        verify(!PhoneDeps.pairInputsReady("192.168.1.42:37129", "12345"))
+        verify(PhoneDeps.connectInputReady("192.168.1.42"))
+        verify(!PhoneDeps.connectInputReady(""))
+    }
+
+    // avahi-browse -p prints one semicolon-separated field list per record;
+    // a resolved one starts with `=` and carries the address in field 8 and
+    // the port in field 9.
+    function test_deps_the_mdns_records_are_validated_rather_than_trusted() {
+        const text =
+            "+;wlan0;IPv4;adb-R5CT30ABCDE-abcdef;_adb-tls-pairing._tcp;local\n"
+            + "=;wlan0;IPv4;adb-R5CT30ABCDE-abcdef;_adb-tls-pairing._tcp;local;"
+            + "phone.local;192.168.100.179;37129;\n"
+        const records = PhoneDeps.parseAvahiRecords(text)
+        compare(records.length, 1)
+        compare(records[0].host, "192.168.100.179")
+        compare(records[0].port, "37129")
+        compare(records[0].address, "192.168.100.179:37129")
+
+        // An unresolved record, a truncated one and one whose ninth field is
+        // not a port are all skipped rather than offered as an address.
+        compare(PhoneDeps.parseAvahiRecords("=;wlan0;IPv4;name;_x._tcp;local\n").length, 0)
+        compare(PhoneDeps.parseAvahiRecords(
+            "=;wlan0;IPv4;n;_x._tcp;local;h;192.168.1.5;txt-not-a-port;\n").length, 0)
+        compare(PhoneDeps.parseAvahiRecords(
+            "=;wlan0;IPv4;n;_x._tcp;local;h;;37129;\n").length, 0)
+        compare(PhoneDeps.parseAvahiRecords(""), [])
+        compare(PhoneDeps.parseAvahiRecords(undefined), [])
+    }
+
+    function test_deps_the_phone_kde_connect_reaches_wins_when_several_advertise() {
+        const records = [
+            { host: "192.168.100.5", port: "1", address: "192.168.100.5:1" },
+            { host: "192.168.100.179", port: "2", address: "192.168.100.179:2" }
+        ]
+        compare(PhoneDeps.pickAvahiRecord(records, "192.168.100.179").address, "192.168.100.179:2")
+        // No preference, or a preference nothing advertises: the first record
+        // is offered and the user can correct it, which is why the address is
+        // a field rather than a fact.
+        compare(PhoneDeps.pickAvahiRecord(records, "").address, "192.168.100.5:1")
+        compare(PhoneDeps.pickAvahiRecord(records, "10.0.0.1").address, "192.168.100.5:1")
+        compare(PhoneDeps.pickAvahiRecord([], "192.168.100.179"), null)
+        compare(PhoneDeps.pickAvahiRecord(null, ""), null)
+    }
+
+    // The two commands report differently and neither is read the other way.
+    function test_deps_a_pair_is_believed_only_on_adbs_own_success_sentence() {
+        const ok = PhoneDeps.parsePairResult(0,
+            "Successfully paired to 192.168.100.179:37129 [guid=adb-R5CT30ABCDE-abcdef]\n", "")
+        compare(ok.ok, true)
+        verify(ok.message.indexOf("Successfully paired") === 0)
+
+        // The measured failure: an address nothing answers on.
+        const refused = PhoneDeps.parsePairResult(1, "",
+            "error: protocol fault (couldn't read status message): Success\n")
+        compare(refused.ok, false)
+        verify(refused.message.indexOf("error: protocol fault") === 0)
+
+        // Exit 0 with no success sentence is not a pairing, and a success
+        // sentence with a non-zero exit is not one either.
+        compare(PhoneDeps.parsePairResult(0, "Failed to pair to 192.168.1.42:37129\n", "").ok, false)
+        compare(PhoneDeps.parsePairResult(1, "Successfully paired to x\n", "").ok, false)
+    }
+
+    // `adb connect` exits 0 whatever happens - measured, a refused connection
+    // and a host that does not resolve both come back 0 - so the exit code
+    // alone would report every failure as a success.
+    function test_deps_a_connect_is_read_off_what_adb_printed_not_off_its_exit_code() {
+        compare(PhoneDeps.parseConnectResult(0, "connected to 192.168.100.179:41235\n", "").ok, true)
+        compare(PhoneDeps.parseConnectResult(0, "already connected to 192.168.100.179:41235\n", "").ok, true)
+
+        const refused = PhoneDeps.parseConnectResult(0,
+            "failed to connect to '127.0.0.1:1': Connection refused\n", "")
+        compare(refused.ok, false)
+        verify(refused.message.indexOf("failed to connect") === 0)
+
+        const unresolved = PhoneDeps.parseConnectResult(0,
+            "failed to resolve host: 'no-such-host.invalid': Name or service not known\n", "")
+        compare(unresolved.ok, false)
+        verify(unresolved.message.indexOf("failed to resolve host") === 0)
+
+        // An exit that printed nothing at all still has to say something.
+        compare(PhoneDeps.parseConnectResult(0, "", "").ok, false)
+        compare(PhoneDeps.parseConnectResult(0, "", "").message, "")
     }
 
     // ================================================================

--- a/dots/.config/quickshell/imi/tests/tst_phone_scrcpy.qml
+++ b/dots/.config/quickshell/imi/tests/tst_phone_scrcpy.qml
@@ -47,6 +47,9 @@ TestCase {
         PhoneDeps.scrcpyMajor = 0
         PhoneDeps.adbDevice = false
         PhoneDeps.adbDeviceRefreshes = 0
+        PhoneDeps.scrcpyRunError = ""
+        PhoneDeps.adbRunError = ""
+        PhoneDeps.droidcamCliRunError = ""
         PhoneScrcpy.reset()
         PhoneScrcpy.available = true
         PhoneScrcpy.appModeSupported = true
@@ -179,6 +182,73 @@ TestCase {
         compare(PhoneDeps.missingFor("mirror").map(d => d.key), ["android-tools"])
         PhoneDeps.adb = true
         compare(PhoneDeps.missingFor("mirror"), [])
+    }
+
+    // ================================================================
+    // PhoneDeps - a tool that is there and cannot run
+    // ================================================================
+
+    // The loader writes its sentence to stderr and the process comes back
+    // 127. Both halves are required: `droidcam-cli` with no arguments prints
+    // a page of usage and exits 1, which is a tool that RAN.
+    function test_deps_a_loader_failure_is_exit_127_and_the_loaders_own_sentence() {
+        compare(PhoneDeps.parseLoaderFailure(127,
+            "droidcam-cli: error while loading shared libraries: libswscale.so.9: "
+            + "cannot open shared object file: No such file or directory\n"),
+            "libswscale.so.9")
+        // A tool that ran and failed is not a tool that cannot start.
+        compare(PhoneDeps.parseLoaderFailure(1,
+            "droidcam-cli: error while loading shared libraries: libswscale.so.9: x"), "")
+        compare(PhoneDeps.parseLoaderFailure(1, "Usage:\n droidcam-cli [options] -l <port>\n"), "")
+        // 127 alone is not it either - the phrase is what names the library,
+        // and without one there is nothing to tell the user.
+        compare(PhoneDeps.parseLoaderFailure(127, "something else entirely"), "")
+        compare(PhoneDeps.parseLoaderFailure(0, ""), "")
+        compare(PhoneDeps.parseLoaderFailure(127, undefined), "")
+    }
+
+    // The three states, at the level the cards read: absent, present and
+    // working, present and unable to run. The middle one is the only one that
+    // used to exist.
+    function test_deps_a_broken_tool_is_missing_and_says_what_it_actually_is() {
+        const absent = PhoneDeps.missingDeps("webcam",
+            { v4l2loopbackLoaded: true, v4l2Ctl: true, mpv: true })
+        compare(absent.map(d => d.key), ["droidcam-cli"])
+        compare(absent[0].broken, undefined)
+        verify(absent[0].description.indexOf("Connects to the DroidCam app") === 0)
+
+        const working = PhoneDeps.missingDeps("webcam",
+            { droidcamCli: true, v4l2loopbackLoaded: true, v4l2Ctl: true, mpv: true })
+        compare(working, [])
+
+        // The reported case: on PATH, linked against ffmpeg 8, on a system
+        // that ships libswscale.so.10.
+        const broken = PhoneDeps.missingDeps("webcam",
+            { droidcamCli: false, droidcamCliRunError: "libswscale.so.9",
+              v4l2loopbackLoaded: true, v4l2Ctl: true, mpv: true })
+        compare(broken.map(d => d.key), ["droidcam-cli"])
+        compare(broken[0].broken, true)
+        compare(broken[0].missingLibrary, "libswscale.so.9")
+        verify(broken[0].description.indexOf("libswscale.so.9") > 0)
+        // ...and it must not be the "is the DroidCam app open on your phone"
+        // family of message, nor an instruction to install what is installed.
+        verify(broken[0].description.indexOf("phone") < 0)
+        verify(broken[0].description.indexOf("rebuilding") > 0)
+        // The commands stay, because reinstalling IS the repair.
+        compare(broken[0].commands.arch, "yay -S droidcam")
+    }
+
+    function test_deps_a_broken_adb_reaches_the_mirrors_rows_too() {
+        const rows = PhoneDeps.missingDeps("mirror",
+            { scrcpy: true, adb: false, adbRunError: "libc++.so.1" })
+        compare(rows.map(d => d.key), ["android-tools"])
+        compare(rows[0].broken, true)
+        compare(rows[0].missingLibrary, "libc++.so.1")
+        // And the audio backend row names whichever of the two is broken.
+        const audio = PhoneDeps.missingDeps("microphone",
+            { pactl: true, scrcpyRunError: "libavutil.so.58" })
+        compare(audio.map(d => d.key), ["audio-backend"])
+        compare(audio[0].missingLibrary, "libavutil.so.58")
     }
 
     // ================================================================

--- a/sdata/deps-info.md
+++ b/sdata/deps-info.md
@@ -212,6 +212,11 @@ shows the install command for Arch, Fedora and Debian when one is missing. Insta
 - `mpv` (recommended), else `ffplay` (`ffmpeg`) or `vlc` — the webcam preview window.
 - `kdialog` (already in `immaterial-impulse-quickshell-git`) and `wl-clipboard` (already in
   `immaterial-impulse-hyprland`) — the Send file picker and the clipboard share.
+- `avahi` — `avahi-browse`, optional: the Android Apps page's **Find the ports** button, which
+  asks the network which wireless-debugging ports the phone is advertising instead of making you
+  read them off its screen. Android re-rolls both on every toggle of the switch. Without it the
+  button is not drawn and both addresses are typed. Arch: `avahi` (the daemon has to be running,
+  not just installed).
 
 # Actual packages
 ## immaterial-impulse-quickshell-git


### PR DESCRIPTION
The Phone tab's Android Apps page printed a recipe — open a terminal, type `adb pair host:port code`, then `adb connect host:port` — for a flow whose two ports Android re-rolls on every toggle of the switch. The shell can run those commands, so it does: two address fields, the six-digit code, a button per step, and each step's line read off what adb actually printed. Where `avahi-browse` is installed, one button asks the network which ports the phone is advertising and fills both addresses in; the host comes from the address KDE Connect already reaches the phone on either way. The code is still read off the phone — it is generated per pairing and published nowhere — and with no avahi the discovery button is simply not drawn.

Four things measured against the installed platform-tools (37.0.1) rather than assumed, and they decide the design:

- `adb pair HOST:PORT CODE` takes the code as an argument and does not prompt; without it, adb reads stdin. Both the address and the code are the user's typing, so they are separate argv elements and no shell is on this path.
- **`adb connect` exits 0 whatever happens** — a refused connection and an unresolvable host both do. The printed line is the evidence, and it is still only a claim: what takes the panel down is the phone turning up under `adb devices`.
- Both ports are re-rolled on every toggle, and they are different ports; the pairing one is advertised only while that screen is open.
- avahi's parsable record layout could not be confirmed against a live daemon here, so the parser validates rather than trusts it.

Underneath: `command -v` answers presence, which is only half of "can this feature start". `droidcam-cli` was on PATH here and died before `main` with a missing `libswscale.so.9` — built against ffmpeg 8 on a system shipping ffmpeg 9's `libswscale.so.10` — so the webcam card read `ready`, the click did nothing, and the message sent the user to look at their phone. The three binaries the tab spawns are started as well as located now; a loader failure is exit 127 **and** the loader's own sentence, both halves required, and a broken tool's install-guide row says the package needs rebuilding instead of telling somebody to install what they have. The Apps page tells the same three states apart — adb absent, adb unable to start, adb working with nothing on it — where it used to assume the first two away.

Driven end to end: the runtime harness strips `adb` out of PATH and copies stubs in between steps, then drives discovery, pair and connect through a fake adb whose `connect` creates the attach marker. Measured at two page widths, on items that are drawn rather than lit.

checks: 55 -> 78.

Docs: updated AGENT.md §Directory map (services/PhoneDeps.qml) and the phone service notes; sdata/deps-info.md §Phone (optional)
Changelog: updated
