### PR TITLE
fix(phone): fourteen defects in scripts nothing had ever run

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -809,7 +809,11 @@ scripts/                   Standalone helper scripts (Python/bash) invoked via P
   phone/                      The Phone tab's process owners. scrcpy_session_manager.py is
                               the NDJSON supervisor PhoneScrcpy speaks to (protocol in its
                               docstring; tests/test_phone_scrcpy_manager.py drives it with
-                              fake scrcpy/adb/hyprctl on PATH). droidcam_session.sh
+                              fake scrcpy/adb/hyprctl on PATH, including a fake that fills
+                              the stderr pipe and a SIGTERM, which are two of the ways it
+                              really ends). The four SHELL scripts are driven by
+                              tests/test_phone_shell_scripts.py - see the entry on what
+                              nothing ever running them cost. droidcam_session.sh
                               launches droidcam-cli / the scrcpy mic stream detached under
                               ${XDG_STATE_HOME:-~/.local/state}/quickshell/imi/phone/ and
                               answers status/stop by pidfile; droidcam_status.sh is the
@@ -4953,6 +4957,155 @@ disabled `RippleButton` dims to 0.4 through the interaction model and still occu
 width it asked for.
 (feat(phone): the Apps page pairs over Wi-Fi instead of printing a recipe,
 test(phone): pin the pairing argv, the two parsed results and the mDNS records.)
+**The Phone tab's four SHELL scripts had never been RUN by anything, and what
+that cost is the reason this section exists.** `test_phone_sessions_contract.py`
+reads them as source text - the state directory, the `pgrep -x` rule - and
+`tst_phone_scrcpy.qml` drives the QML that parses their output against strings a
+human typed into the test. So the producer and the consumer were each checked
+against a description of the other, and a producer that stopped emitting those
+strings stayed green on both sides.
+`tests/test_phone_shell_scripts.py` runs all four for real with stubbed
+`pgrep`, `pactl`, `v4l2-ctl`, `droidcam-cli`, `scrcpy` and `sudo` on PATH; the
+stubs are the process TABLE and the sound server, while the processes are real
+(launched through `droidcam_session.sh launch`, with real pids and real
+`/proc/<pid>/cmdline`), so the signature matching, the port disambiguation and
+the kill guard all run against what they run against in production. Eight
+defects were sitting in them, and six of the traps generalise past this feature:
+
+- **`exit` inside a shell function ends the SCRIPT, and neither a redirection
+  nor a `|| true` on the call makes a subshell of it.** `cmd_stop`'s two
+  non-kill paths ended with `exit 0`, so `cmd_killall`'s loop over
+  video/audio/scrcpy-mic stopped at the first session with no state file, never
+  stopped the other two, and exited 0 - which the caller reads as success. A
+  command function returns; the dispatch at the bottom of the file is what sets
+  the status. a0b5d84c4 ("fix(phone): killall stops every session instead of
+  exiting on the first").
+- **A substring cannot express a negative, and the two things being told apart
+  here are one binary with and without a flag.** `video`'s signature was
+  `droidcam-cli` and `audio`'s was `droidcam-cli -a`, so the microphone's
+  cmdline matched the WEBCAM's signature; the port could not break the tie
+  because `find_running` is called with an empty port whenever there is no state
+  file. Reachable with no pid reuse at all: a shell restart with only the mic up
+  and `video.json` absent made `status video` answer with the mic's pid, so the
+  tab drew a stream that did not exist and turning it off sent SIGTERM to the
+  microphone. It is a predicate now, and the kill guard asks the same one - it
+  was `*droidcam-cli*|*scrcpy*`, the same over-broad test one function along and
+  the half that pulls the trigger. 44e496940 ("fix(phone): a session signature
+  tells the webcam from the microphone").
+- **`IFS=$'\n\t'` drops space, so an unquoted expansion does not split a
+  cmdline at all.** `cmdline_of` turns NULs into spaces and the rediscovery
+  paths passed `$cl` unquoted to `extract_port`/`extract_ip`, which therefore
+  saw ONE non-numeric argument: every session rediscovered after a restart
+  reported an empty port and an empty address. Split under a local `IFS` and
+  keep the callers on argv arrays rather than putting space back into the global
+  one. d98959eb7 ("fix(phone): a rediscovered session reports the port and
+  address it was given").
+- **`cmd | grep -oE ... | tail -n1 || echo 0` never falls back**, because the
+  pipeline's status is `tail`'s and `tail` succeeds on empty input. This is the
+  sibling of the `cmd | grep -q` trap under
+  [External binaries the shell drives](#external-binaries-the-shell-drives),
+  arriving from the other side. Watch what the empty value then does: the port
+  is printed with an unquoted `%s` because it is a JSON *number*, so the line
+  came out as `"video_port":,`, the QML `JSON.parse` threw, and EVERY field in
+  the payload was lost rather than one. A producer emitting JSON by `printf`
+  needs each unquoted field to be a value it can always emit.
+  c3837b1aa ("fix(phone): the status probe always emits a port, so its payload
+  parses").
+- **`pgrep` answers with the process table as it was when it sampled it**, so
+  `/proc/<pid>/cmdline` needs the `[ -r ]` guard `find_running` already carried.
+  Without it the read fails, the cmdline is empty, and an empty string matches
+  the `*)` default - which was the video arm, so a dead pid was reported as a
+  running webcam. The `2>/dev/null` on that line covers `tr` and not the
+  redirection that opens the file, so the shell's own error reached stderr too.
+  7ad0dc204 ("fix(phone): a process that exited between pgrep and the read is
+  not a webcam").
+- **Two lookups for one fact drift, and here the drift LOADS something.**
+  `setup_droidcam_input.sh`'s idempotence check asked for `DroidCam-Mic.monitor`
+  while the lookup twenty lines below it, for the same fact, tried
+  `alsa_output.DroidCam-Mic.monitor` first - so on a server using the prefixed
+  form that does not also propagate `device.description`, every call missed the
+  sink it had loaded itself and loaded another under the same name, while
+  teardown's awk `exit`ed after the first match and removed one per call. Three
+  setups, three null sinks. It is one `find_monitor` now, and the module index
+  `pactl load-module` prints - the handle teardown otherwise reconstructs by
+  grepping - is captured rather than discarded, so the failure path can take
+  back what it loaded. 5cebeccaa ("fix(phone): the null sink is resolved once,
+  however the server names its monitor"), 9631f2e4e ("fix(phone): setup unloads
+  the null sink it loaded when the monitor never appears"), ec0f42792
+  ("fix(phone): teardown unloads every DroidCam-Mic sink, not just the first").
+
+`install_droidcam.sh` is the fourth, and its defects are the same shape one
+level up: an unchecked `$AUR_HELPER -S` under a `✓ DroidCam installed` and a
+footer telling the user the cards should read "Ready", and an unchecked `unzip`
+followed by an unchecked `cd`, so a failed extract ran `sudo ./install-client`
+in the CALLER's working directory. Its Arch branch also installed neither
+`v4l-utils` nor `android-tools` - both of which the Fedora and Debian branches
+install, both of which `PhoneDeps.missingFor("webcam")` names, and without the
+first of which `droidcam_status.sh` cannot resolve the webcam's `/dev/videoN` at
+all - so on Arch the installer could complete and the webcam still not be found.
+Its dispatch is a `main()` behind the usual `BASH_SOURCE` guard now, because a
+branch nobody can select is a branch nobody can test: the maintainer is on Arch,
+CI is on Ubuntu, and `detect_distro` reads `/etc`.
+bf49d3f72 ("refactor(phone): the installer's dispatch becomes main(), so it can
+be driven"), ce86796d6 ("fix(phone): a failed extract no longer runs
+install-client as root elsewhere"), 0c1b9d31a ("fix(phone): the Arch branch
+stops reporting a failed install as a success"), 6712ce64b ("fix(phone): the
+Arch branch installs the tools the webcam actually needs").
+
+**And the supervisor beside them had three of the same family, all of them
+about a process's OTHER ends.** `scripts/phone/scrcpy_session_manager.py` is one
+long-lived process speaking NDJSON, so every one of these is silent:
+
+- **`stderr=subprocess.PIPE` must be drained WHILE the child runs.** It was read
+  after `proc.wait()`, and a pipe holds about 64 KiB - past that scrcpy blocks
+  in `write()` with nobody reading, so it never exits, `wait()` never returns,
+  no `exited` event is ever emitted, and the card sits on "running" over a
+  mirror that has frozen or died. Measured with a fake writing ~300 KiB: no
+  `exited` in twelve seconds against ~0.1s when the same fake is quiet. A drain
+  thread with a bounded tail, so `wait()` still decides when the event fires and
+  a grandchild holding stderr open delays nothing.
+  b64dd2147 ("fix(phone): drain scrcpy's stderr while it runs, not after it
+  exits").
+- **`print(x, flush=True)` is two writes, and every reaper thread emits.** Under
+  the GIL two small writes are effectively atomic, which is why this hid: the
+  corruption needs an event large enough to flush part way, and an `apps_list`
+  for a real phone is tens of kilobytes. Observed at roughly one in three runs
+  of a stress harness - `{...apps_list...}{"event": "exited", ...}` on one line -
+  which is too rare to be a check, so the check swaps in a stdout whose `write`
+  is deliberately not atomic and requires every line to parse. Note what
+  interleaving costs: the QML parser returns null and BOTH events are dropped,
+  and a lost `exited` leaves a session row live with no window behind it.
+  9121bb5f6 ("fix(phone): one lock around one write, so an event is never half a
+  line").
+- **A blocking command handler blocks the whole protocol.** `list_apps` ran on
+  the command loop and is worth ~26s of subprocesses (`adb connect` 4s +
+  `adb devices` 4s + `scrcpy --list-apps` 10s + `pm list` 8s), during which
+  `stop`, `stop_all` and `focus` were not read off stdin - measured, a focus
+  sent 0.3s into a 4s scan was acted on at 4.01s. A queue with ONE worker, not a
+  thread per request: two scans would run `adb` at each other, and a request
+  dropped as a duplicate is an `apps_list` the page waits for and never gets.
+  The emit lock is a prerequisite for making anything here concurrent.
+  c1caf34ad ("fix(phone): the app scan runs off the command loop").
+- **The docstring's promise held only on the clean-EOF path.** There was no
+  signal handler, and `PhoneScrcpy.stopManager()` sets the Process's
+  `running = false`, which Quickshell sends as SIGTERM - so Python's default
+  handler exited without `stop_all()` and every window the supervisor owned was
+  orphaned. When a script promises something about how it is shut down, ask how
+  its caller shuts it down. 76d9f863d ("fix(phone): a SIGTERMed supervisor stops
+  its scrcpy children").
+
+The one finding there that did NOT stand is worth recording, because it is
+AGENT.md's own rule about a removal being a decision, applied to a preference.
+`resolve_adb_target` returning a USB serial in preference to a wireless one the
+caller named reads as "the tab's device selection is silently ignored", and it
+is not: `PhoneScrcpy.targetArgs()` only ever produces a wireless `-s ip:port`,
+and only when the "use wireless" setting is on - it never names a USB serial, so
+the tab's active device does not reach that function as a serial at all. The
+preference is stated in two docstrings and pinned by a test, and it stays. What
+was fixed is the half with no argument behind it: `usb_devices[0]` is whichever
+`adb devices` printed first, so a named serial adb really lists is honoured now
+and the unsteered pick is sorted. e7c042c19 ("fix(phone): a named USB serial
+wins, and the unsteered pick is deterministic").
 
 **And the surfaces that DRIVE those services get their allowlist derived rather than written
 down.** "A button whose call no service answers is a fake action" is stated for the right

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,48 @@ own repo; the installer pins which revision it builds.
   The Android Apps page tells the same three states apart too — adb missing,
   adb unable to start, and adb working with no phone on it — where it used to
   assume the first two away.
+- **Turning the phone webcam off no longer kills the phone microphone.** The
+  webcam and the microphone are both `droidcam-cli`, and the shell told them
+  apart by looking for `droidcam-cli` in the running process's command line -
+  which the microphone's contains too. After a shell restart with only the
+  microphone running, the Webcam card came up claiming a stream that did not
+  exist, and switching it off sent the stop signal to the microphone instead.
+  The two are told apart properly now, and the same mistake could no longer
+  have let the webcam's stop reach a scrcpy microphone either.
+- **The Phone tab's webcam and microphone state stops disappearing
+  altogether.** The probe the two cards read builds one line of JSON, and
+  when it could not work out the connection's port it left that field empty -
+  which is not a missing port but a broken line, so the shell threw the
+  *whole* answer away: the webcam device, the audio source and both running
+  flags with it. A configured port shorter than three digits was enough on
+  its own. The probe also reported a webcam as running when the process it
+  had just seen exited underneath it, and lost the port and the address of
+  any session it re-adopted after a restart.
+- **A frozen phone mirror stops reading as a running one.** scrcpy is
+  talkative, and the supervisor that owns it only read what it printed after
+  it had finished - so once scrcpy had said about 64 KiB it stopped dead
+  waiting for someone to listen, and since it never exited, the mirror card
+  stayed on "running" over a window that had frozen or died, with no way back
+  but a restart. The Phone tab also stopped answering clicks for up to half a
+  minute while it fetched the phone's app list, and an event lost to two
+  writes colliding could leave a session on screen with no window behind it.
+  Stopping the shell now really does stop every mirror it started, rather
+  than only when it shuts down cleanly.
+- **Installing DroidCam on Arch no longer claims success when it failed, and
+  installs what the webcam needs.** The Arch branch of the installer printed
+  "✓ DroidCam installed" whatever the AUR helper did, and the closing note
+  then told you the Phone tab's cards should read "Ready". It also never
+  installed `v4l-utils` or `android-tools`, both of which the other
+  distributions' branches install and without which the webcam cannot be
+  found at all - so a completed install could leave the feature dead. On
+  every distribution, a failed download or extract no longer runs the
+  DroidCam installer as root from whatever directory you happened to be in.
+- **The DroidCam microphone stops collecting duplicate audio devices.** On a
+  sound server that names the null sink's monitor with a prefix, the setup
+  script could not see the sink it had loaded a moment earlier and loaded
+  another under the same name on every launch, while the teardown removed
+  exactly one per call. A setup that fails now takes its own sink back with
+  it.
 - **The Phone tab's Android Apps page says what to turn on when it cannot
   reach the phone.** App Mode drives the phone over ADB, which is a
   different link from the one KDE Connect pairs: with a phone reachable on

--- a/docs/tests-README.md
+++ b/docs/tests-README.md
@@ -145,6 +145,25 @@ if __name__ == "__main__":
 merely defines its functions and exits zero, and the whole file silently passes
 without executing a single assertion. Three modules shipped in that state.
 
+Two modules are the exception to "static assertions over source text", and both
+are named here so the paragraph above is not read as covering everything.
+`test_phone_scrcpy_manager.py` drives `scripts/phone/scrcpy_session_manager.py`
+over its real stdin/stdout with fake `scrcpy`/`adb`/`hyprctl` on PATH, and
+`test_phone_shell_scripts.py` runs the Phone tab's four shell scripts with
+stubbed `pgrep`, `pactl`, `v4l2-ctl`, `droidcam-cli`, `scrcpy` and `sudo`. In
+the second the stubs are the process TABLE and the sound server only: the
+processes are launched through `droidcam_session.sh launch` and are real, with
+real pids and real `/proc/<pid>/cmdline`, so the signature matching, the port
+disambiguation and the kill guard run against what they run against in
+production. `droidcam-cli` cannot run on this machine at all (built against
+ffmpeg 8, the system has 9), which is the other half of why the fakes are fakes.
+
+Every defect check in those two has a green CONTROL beside it - the microphone
+is still found by its own name, a four-digit port still reads, a teardown leaves
+an unrelated sink alone - because a check that only ever sees the working case
+passes on the defect, and one that only ever sees the broken case cannot tell a
+fix from a feature that stopped working.
+
 `test_discord_voice_plugin.py` verifies private token-cache permissions and RPC
 state minimization, requires one bounded bridge with capped restart backoff, and
 keeps the clickable Discord bar widget on its native single-owner geometry path.

--- a/dots/.config/quickshell/imi/scripts/phone/droidcam_session.sh
+++ b/dots/.config/quickshell/imi/scripts/phone/droidcam_session.sh
@@ -49,26 +49,57 @@ read_json_field() {
     sed -n "s/.*\"$2\"[[:space:]]*:[[:space:]]*\"\{0,1\}\([^\",}]*\)\"\{0,1\}.*/\1/p" "$1" 2>/dev/null | head -n1
 }
 
-# session_signature <session> → substring the process cmdline must contain
-session_signature() {
+# session_binary <session> → the binary `pgrep -x` must match
+session_binary() {
     case "$1" in
-        video)      echo "droidcam-cli" ;;
-        audio)      echo "droidcam-cli -a" ;;
-        scrcpy-mic) echo "--audio-source=mic" ;;
+        scrcpy-mic) echo "scrcpy" ;;
+        video|audio) echo "droidcam-cli" ;;
         *)          echo "" ;;
     esac
+}
+
+# session_matches <session> <cmdline> → 0 when the cmdline belongs to that
+# session kind.
+#
+# This was a plain substring per session, and a substring cannot express what
+# separates the webcam from the microphone: the audio process IS
+# `droidcam-cli -a ...`, so its cmdline contains the video signature
+# `droidcam-cli` and matched it. With `video.json` absent - a shell restart
+# with only the mic up - `status video` therefore answered with the MIC's
+# pid, the tab drew a webcam stream that did not exist, and the user turning
+# it off ran `stop video`, which sent SIGTERM to the microphone. The port
+# could not break the tie either: `find_running` is called with an empty port
+# whenever there is no state file.
+#
+# The `-a` test is on a whole token (the cmdline is padded, and cmdline_of
+# has already turned its NULs into spaces), so `-nocontrols` and a `-size=`
+# value cannot be mistaken for it.
+session_matches() {
+    local session="$1" cl=" $2 "
+    case "$session" in
+        video)
+            case "$cl" in
+                *droidcam-cli*) case "$cl" in *" -a "*) return 1 ;; esac; return 0 ;;
+            esac
+            return 1 ;;
+        audio)
+            case "$cl" in
+                *droidcam-cli*) case "$cl" in *" -a "*) return 0 ;; esac ;;
+            esac
+            return 1 ;;
+        scrcpy-mic)
+            case "$cl" in *"--audio-source=mic"*) return 0 ;; esac
+            return 1 ;;
+    esac
+    return 1
 }
 
 # find_running <session> [port] → pid (empty if none). Matches live processes
 # of the session kind whose cmdline contains the port (when given).
 find_running() {
-    local session="$1" port="${2:-}" sig pid cl comm argv0 want
-    sig="$(session_signature "$session")"
-    [ -n "$sig" ] || return 1
-    case "$session" in
-        scrcpy-mic) want="scrcpy" ;;
-        *)          want="droidcam-cli" ;;
-    esac
+    local session="$1" port="${2:-}" pid cl want
+    want="$(session_binary "$session")"
+    [ -n "$want" ] || return 1
     # `pgrep -x` on the binary's own name, never a full-cmdline match on
     # the signature: that matches every process carrying these args,
     # including the shell that was invoked to launch one, so a session would
@@ -77,13 +108,10 @@ find_running() {
     for pid in $(pgrep -x "$want" 2>/dev/null); do
         [ -r "/proc/$pid/cmdline" ] || continue
         cl="$(cmdline_of "$pid")"
+        session_matches "$session" "$cl" || continue
+        if [ -z "$port" ]; then printf '%s' "$pid"; return 0; fi
         case "$cl" in
-            *"$sig"*)
-                if [ -z "$port" ]; then printf '%s' "$pid"; return 0; fi
-                case "$cl" in
-                    *"$port"*) printf '%s' "$pid"; return 0 ;;
-                esac
-                ;;
+            *"$port"*) printf '%s' "$pid"; return 0 ;;
         esac
     done
     return 1
@@ -281,24 +309,25 @@ cmd_stop() {
         return 0
     fi
 
-    # Safety: only kill if the cmdline still looks like our kind of process.
+    # Safety: only kill if the cmdline still belongs to THIS session kind.
+    # `droidcam-cli or scrcpy` was the same over-broad test the signature
+    # was, one function along, and it is the half that actually pulls the
+    # trigger: it would have let `stop video` kill a scrcpy mic just as
+    # happily as a droidcam one.
     local cl
     cl="$(cmdline_of "$pid")"
-    case "$cl" in
-        *"droidcam-cli"*|*"scrcpy"*)
-            kill -TERM "$pid" 2>/dev/null
-            for _ in 1 2 3 4 5 6 7 8; do
-                is_alive "$pid" || break
-                sleep 0.25
-            done
-            if is_alive "$pid"; then
-                kill -KILL "$pid" 2>/dev/null || true
-            fi
-            ;;
-        *)
-            echo "droidcam_session: pid $pid no longer matches droidcam/scrcpy — not killing" >&2
-            ;;
-    esac
+    if session_matches "$session" "$cl"; then
+        kill -TERM "$pid" 2>/dev/null
+        for _ in 1 2 3 4 5 6 7 8; do
+            is_alive "$pid" || break
+            sleep 0.25
+        done
+        if is_alive "$pid"; then
+            kill -KILL "$pid" 2>/dev/null || true
+        fi
+    else
+        echo "droidcam_session: pid $pid is not a '$session' session — not killing" >&2
+    fi
     rm -f "$statefile"
 }
 

--- a/dots/.config/quickshell/imi/scripts/phone/droidcam_session.sh
+++ b/dots/.config/quickshell/imi/scripts/phone/droidcam_session.sh
@@ -117,6 +117,23 @@ find_running() {
     return 1
 }
 
+# split_cmdline <cmdline> → fills the global array CMDLINE_WORDS.
+#
+# `IFS` drops space at the top of this file, so an unquoted `$cl` does not
+# split a cmdline into words at all - it is one argument, and `cmdline_of`
+# has already turned the NULs into spaces. The rediscovery paths in
+# cmd_status passed `$cl` to extract_port/extract_ip that way, so both saw a
+# single non-numeric argument and answered empty: a session rediscovered
+# after a shell restart reported no port and no address, for ever. Splitting
+# here, under a local IFS, keeps both callers on argv arrays rather than
+# putting space back into the global IFS for every other expansion in the
+# file.
+split_cmdline() {
+    CMDLINE_WORDS=()
+    local IFS=' '
+    read -r -a CMDLINE_WORDS <<< "$1"
+}
+
 # extract_port <args...> → last standalone numeric token
 extract_port() {
     local a last=""
@@ -250,15 +267,16 @@ cmd_status() {
             alive="true"
             local cl
             cl="$(cmdline_of "$pid")"
+            split_cmdline "$cl"
             if [ -z "$port" ]; then
-                port="$(extract_port $cl)"
+                port="$(extract_port "${CMDLINE_WORDS[@]}")"
             fi
-            case "$cl" in
+            case " $cl " in
                 *" adb "*) mode="usb" ;;
                 *) mode="wifi" ;;
             esac
             if [ "$mode" = "wifi" ] && [ -z "$ip" ]; then
-                ip="$(extract_ip "$mode" $cl)"
+                ip="$(extract_ip "$mode" "${CMDLINE_WORDS[@]}")"
             fi
             [ -z "$started" ] && started="$(stat -c %Y "/proc/$pid" 2>/dev/null || echo 0)"
         fi

--- a/dots/.config/quickshell/imi/scripts/phone/droidcam_session.sh
+++ b/dots/.config/quickshell/imi/scripts/phone/droidcam_session.sh
@@ -121,7 +121,7 @@ extract_ip() {
 # cmd_launch <session> <bin> <args...>
 cmd_launch() {
     local session="$1" bin="$2"; shift 2
-    [ $# -ge 1 ] || { echo "droidcam_session: launch needs args" >&2; exit 1; }
+    [ $# -ge 1 ] || { echo "droidcam_session: launch needs args" >&2; return 1; }
 
     local statefile logfile
     statefile="$(statefile_for "$session")"
@@ -145,7 +145,7 @@ cmd_launch() {
         atomically_write "$statefile" \
             "{\"pid\":\"$existing\",\"started\":$(date +%s),\"port\":\"$port\",\"mode\":\"$mode\",\"ip\":\"$ip\",\"cmdline\":\"$cl\"}"
         echo "$existing"
-        exit 0
+        return 0
     fi
 
     # An idle wireless ADB transport drops the first command thrown at it.
@@ -182,7 +182,7 @@ cmd_launch() {
     fi
     if [ -z "$pid" ]; then
         echo "droidcam_session: failed to start session '$session'" >&2
-        exit 1
+        return 1
     fi
 
     local cl
@@ -270,7 +270,7 @@ cmd_stop() {
             is_alive "$stray" && kill -KILL "$stray" 2>/dev/null || true
         fi
         echo "droidcam_session: no state for '$session'" >&2
-        exit 0
+        return 0
     fi
 
     local pid
@@ -278,7 +278,7 @@ cmd_stop() {
     if [ -z "$pid" ] || ! is_alive "$pid"; then
         rm -f "$statefile"
         echo "droidcam_session: '$session' not running" >&2
-        exit 0
+        return 0
     fi
 
     # Safety: only kill if the cmdline still looks like our kind of process.
@@ -303,10 +303,19 @@ cmd_stop() {
 }
 
 # cmd_killall — stop every tracked session.
+#
+# `exit` inside a function ends the SCRIPT, not the function: neither the
+# redirection nor a `|| true` makes a subshell of it. cmd_stop's two non-kill
+# paths used to end with `exit 0`, so the first session with no state file
+# ended this loop, the other two were never stopped, and the caller saw a 0.
+# Every cmd_* returns now, and `tests/test_phone_shell_scripts.py` counts the
+# process-table lookups to prove the loop got all the way round.
 cmd_killall() {
+    local session status=0
     for session in video audio scrcpy-mic; do
-        cmd_stop "$session" >/dev/null 2>&1 || true
+        cmd_stop "$session" >/dev/null 2>&1 || status=$?
     done
+    return "$status"
 }
 
 # ─── Dispatch ────────────────────────────────────────────────────────────

--- a/dots/.config/quickshell/imi/scripts/phone/droidcam_status.sh
+++ b/dots/.config/quickshell/imi/scripts/phone/droidcam_status.sh
@@ -149,7 +149,13 @@ fi
 if command -v pactl >/dev/null 2>&1; then
     sources_output="$(pactl list sources short 2>/dev/null || true)"
     if [ -n "$sources_output" ]; then
-        match="$(echo "$sources_output" | awk '$0 ~ /DroidCam-Mic/ || $0 ~ /droidcam/ {print $1; exit}')"
+        # `pactl list sources short` is `<index>\t<name>\t...`, so the
+        # source's NAME is field 2. This printed field 1 - the index - while
+        # this file's own header documents a name
+        # (`alsa_output.droidcam_input.monitor`) and
+        # `tst_phone_scrcpy.qml` feeds `PhoneMic.parseStatus` a name. Both
+        # sides agreed with each other and neither agreed with the producer.
+        match="$(echo "$sources_output" | awk '$0 ~ /DroidCam-Mic/ || $0 ~ /droidcam/ {print $2; exit}')"
         if [ -n "$match" ]; then
             audio_source="$match"
         fi

--- a/dots/.config/quickshell/imi/scripts/phone/droidcam_status.sh
+++ b/dots/.config/quickshell/imi/scripts/phone/droidcam_status.sh
@@ -88,9 +88,18 @@ if command -v v4l2-ctl >/dev/null 2>&1; then
 fi
 
 # ─── Processes: droidcam-cli (video or audio) and scrcpy (mic) ──────────
+# `pgrep` answers with the process table as it was when it sampled it, so a
+# process that exits before the read below leaves nothing to read. The guard
+# is the one droidcam_session.sh's `find_running` already carries: without
+# it, `/proc/<pid>/cmdline` fails, `cl` is empty, and an empty string matches
+# the `*)` default - the VIDEO arm - so a dead pid was reported as a running
+# webcam, with the shell's own "No such file or directory" going to stderr
+# because `2>/dev/null` covers `tr`, not the redirection that opens the file.
 if command -v pgrep >/dev/null 2>&1; then
     for pid in $(pgrep -x droidcam-cli 2>/dev/null); do
+        [ -r "/proc/$pid/cmdline" ] || continue
         cl="$(tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null | sed 's/[[:space:]]*$//')"
+        [ -n "$cl" ] || continue
         case "$cl" in
             *' -a '*|*'-a '*)   # audio mode: droidcam-cli ... -a ...
                 audio_running=true
@@ -125,7 +134,9 @@ if command -v pgrep >/dev/null 2>&1; then
     done
     # scrcpy with --audio-source=mic is an audio session too.
     for pid in $(pgrep -x scrcpy 2>/dev/null); do
+        [ -r "/proc/$pid/cmdline" ] || continue
         cl="$(tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null | sed 's/[[:space:]]*$//')"
+        [ -n "$cl" ] || continue
         case "$cl" in
             *'--audio-source=mic'*) audio_running=true ;;
         esac

--- a/dots/.config/quickshell/imi/scripts/phone/droidcam_status.sh
+++ b/dots/.config/quickshell/imi/scripts/phone/droidcam_status.sh
@@ -102,8 +102,22 @@ if command -v pgrep >/dev/null 2>&1; then
                     case "$cl" in
                         *' adb '*) video_mode="usb" ;;
                     esac
-                    # Port = last numeric token.
-                    video_port="$(echo "$cl" | grep -oE '[0-9]{3,5}$' | tail -n1 || echo 0)"
+                    # Port = the last token, when it is a number.
+                    # `grep ... | tail -n1 || echo 0` never fell back: grep
+                    # exits 1 with no match but `tail` exits 0, so the
+                    # pipeline succeeded with an empty answer and the
+                    # unquoted `%s` below emitted `"video_port":,`. That is
+                    # invalid JSON, so the QML JSON.parse threw and EVERY
+                    # field in the payload was lost, not just the port - and
+                    # the pattern only ever admitted 3-to-5-digit ports, so
+                    # a configured port of 80 was enough to trigger it.
+                    # droidcam-cli's argv ends `<ip|adb> <port>`, so the last
+                    # word is the answer and there is nothing to search for.
+                    last_token="${cl##* }"
+                    case "$last_token" in
+                        ''|*[!0-9]*) video_port=0 ;;
+                        *)           video_port="$last_token" ;;
+                    esac
                 fi
                 video_running=true
                 ;;

--- a/dots/.config/quickshell/imi/scripts/phone/install_droidcam.sh
+++ b/dots/.config/quickshell/imi/scripts/phone/install_droidcam.sh
@@ -169,15 +169,28 @@ case "$DISTRO" in
         echo "▸ Using AUR helper: $AUR_HELPER"
         echo ""
         # The 'droidcam' AUR package bundles the client AND the v4l2loopback-dc
-        # kernel module, so this single command covers everything.
-        $AUR_HELPER -S --needed droidcam
+        # kernel module, so this single command covers the client itself.
+        # It was UNCHECKED, and the "✓ DroidCam installed" below printed
+        # regardless — after which the footer told the user the Phone tab's
+        # cards should now read "Ready".
+        if ! "$AUR_HELPER" -S --needed droidcam; then
+            echo ""
+            echo "✗ $AUR_HELPER could not install droidcam."
+            press_enter_to_close
+            return 1
+        fi
 
         # Also install pactl (in pulseaudio-utils) for microphone routing.
         if ! command -v pactl >/dev/null 2>&1; then
             echo ""
             echo "▸ Installing pactl (for microphone routing)..."
-            sudo pacman -S --needed --noconfirm pulseaudio-utils || \
-                sudo pacman -S --needed --noconfirm pipewire-pulse
+            if ! sudo pacman -S --needed --noconfirm pulseaudio-utils \
+                && ! sudo pacman -S --needed --noconfirm pipewire-pulse; then
+                echo ""
+                echo "✗ Could not install a PulseAudio client (pactl)."
+                press_enter_to_close
+                return 1
+            fi
         fi
 
         echo ""

--- a/dots/.config/quickshell/imi/scripts/phone/install_droidcam.sh
+++ b/dots/.config/quickshell/imi/scripts/phone/install_droidcam.sh
@@ -90,26 +90,41 @@ install_from_official_zip() {
     download_droidcam "$zpath" || { rm -rf "$tmpdir"; return 1; }
     verify_droidcam "$zpath" || { rm -rf "$tmpdir"; return 1; }
 
+    # The extract was unchecked and so was the `cd` after it, so a corrupt or
+    # truncated download left `sudo ./install-client` running in whatever
+    # directory the caller happened to be in — as root.
     echo "▸ Extracting..."
-    unzip -q -o "$zpath" -d "$tmpdir/droidcam"
+    local clientdir="$tmpdir/droidcam"
+    if ! unzip -q -o "$zpath" -d "$clientdir"; then
+        echo "✗ Could not extract the DroidCam archive."
+        rm -rf "$tmpdir"
+        return 1
+    fi
+    if [ ! -f "$clientdir/install-client" ]; then
+        echo "✗ The archive did not contain install-client."
+        rm -rf "$tmpdir"
+        return 1
+    fi
 
+    # Each step runs in a subshell, so the directory is this function's
+    # business and never the caller's, and a failed `cd` cannot leak into the
+    # next command.
     echo "▸ Running install-client (sudo required)..."
-    cd "$tmpdir/droidcam"
-    sudo ./install-client || {
+    if ! ( cd "$clientdir" && sudo ./install-client ); then
         echo "✗ install-client failed."
         rm -rf "$tmpdir"
         return 1
-    }
+    fi
 
     echo ""
     echo "▸ Compiling video module (v4l2loopback-dc) ..."
-    sudo ./install-video || {
+    ( cd "$clientdir" && sudo ./install-video ) || {
         echo "  ! install-video failed (this may be expected if you already have v4l2loopback from your distro)."
     }
 
     echo ""
     echo "▸ Loading audio loopback module ..."
-    sudo ./install-sound || {
+    ( cd "$clientdir" && sudo ./install-sound ) || {
         echo "  ! install-sound failed (optional — you may already have pipe wire/PulseAudio working)."
     }
 

--- a/dots/.config/quickshell/imi/scripts/phone/install_droidcam.sh
+++ b/dots/.config/quickshell/imi/scripts/phone/install_droidcam.sh
@@ -12,11 +12,6 @@
 set -u
 IFS=$'\n\t'
 
-echo "╔═══════════════════════════════════════════════╗"
-echo "║     DroidCam Installer for the ImI Phone tab     ║"
-echo "╚═══════════════════════════════════════════════╝"
-echo ""
-
 # ─── Distro detection ─────────────────────────────────
 detect_distro() {
     if [ -f /etc/arch-release ]; then
@@ -30,13 +25,14 @@ detect_distro() {
     fi
 }
 
-DISTRO=$(detect_distro)
-
 # Common pause helper
 press_enter_to_close() {
     echo ""
     echo "Press Enter to close..."
-    read -r
+    # `read` answers 1 at EOF, and this is the last command on the success
+    # path, so without the guard a completed install exits non-zero whenever
+    # stdin is not a terminal.
+    read -r || true
 }
 
 # URL of the official DroidCam Linux client zip.
@@ -123,6 +119,14 @@ install_from_official_zip() {
     return 0
 }
 
+main() {
+    local DISTRO="${1:-$(detect_distro)}"
+
+    echo "╔═══════════════════════════════════════════════╗"
+    echo "║     DroidCam Installer for the ImI Phone tab     ║"
+    echo "╚═══════════════════════════════════════════════╝"
+    echo ""
+
 case "$DISTRO" in
     arch)
         echo "▸ Detected: Arch Linux"
@@ -144,7 +148,7 @@ case "$DISTRO" in
             echo "    git clone https://aur.archlinux.org/yay.git /tmp/yay"
             echo "    cd /tmp/yay && makepkg -si"
             press_enter_to_close
-            exit 1
+            return 1
         fi
 
         echo "▸ Using AUR helper: $AUR_HELPER"
@@ -221,7 +225,7 @@ case "$DISTRO" in
             echo ""
             echo "✗ Installation failed."
             press_enter_to_close
-            exit 1
+            return 1
         }
         ;;
 
@@ -254,7 +258,7 @@ case "$DISTRO" in
             echo ""
             echo "✗ Installation failed."
             press_enter_to_close
-            exit 1
+            return 1
         }
         ;;
 
@@ -269,7 +273,7 @@ case "$DISTRO" in
         echo "  Debian:  sudo apt install v4l2loopback-dkms v4l-utils pulseaudio-utils"
         echo "           Download from https://www.dev47apps.com/droidcam/linux/"
         press_enter_to_close
-        exit 1
+        return 1
         ;;
 esac
 
@@ -281,4 +285,14 @@ echo "   2. Open DroidCam on phone, enter IP, connect"
 echo "   3. Re-open the Phone tab in ImI — cards should"
 echo "      now show 'Ready' instead of 'Install'"
 echo "═══════════════════════════════════════════════"
-press_enter_to_close
+    press_enter_to_close
+}
+
+# The dispatch lives in a function so that the file can be SOURCED without
+# installing anything: nothing had ever run these scripts, and a test that
+# has to pick the branch (the maintainer is on Arch, CI is on Ubuntu, and the
+# Arch branch is the one with the defects) cannot do it through
+# `detect_distro`, which reads /etc.
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+    main "$@"
+fi

--- a/dots/.config/quickshell/imi/scripts/phone/install_droidcam.sh
+++ b/dots/.config/quickshell/imi/scripts/phone/install_droidcam.sh
@@ -180,6 +180,21 @@ case "$DISTRO" in
             return 1
         fi
 
+        # v4l-utils and android-tools are what the OTHER branches install and
+        # what PhoneDeps treats as dependencies: droidcam_status.sh reports
+        # the webcam device through `v4l2-ctl --list-devices` and cannot find
+        # it at all without them, and adb is the mirror's whole transport. The
+        # Arch branch installed neither, so it could complete successfully and
+        # leave the webcam unfindable.
+        echo ""
+        echo "▸ Installing v4l-utils and android-tools..."
+        if ! sudo pacman -S --needed --noconfirm v4l-utils android-tools; then
+            echo ""
+            echo "✗ Could not install v4l-utils / android-tools."
+            press_enter_to_close
+            return 1
+        fi
+
         # Also install pactl (in pulseaudio-utils) for microphone routing.
         if ! command -v pactl >/dev/null 2>&1; then
             echo ""

--- a/dots/.config/quickshell/imi/scripts/phone/scrcpy_session_manager.py
+++ b/dots/.config/quickshell/imi/scripts/phone/scrcpy_session_manager.py
@@ -36,6 +36,7 @@ import argparse
 import collections
 import json
 import os
+import queue
 import re
 import subprocess
 import sys
@@ -111,6 +112,9 @@ class ScrcpySessionManager:
         self.emit_lock = threading.Lock()
         self.processes = {}     # session_id -> subprocess.Popen
         self.session_info = {}  # session_id -> {id, type, title, pid, startedAt}
+        # The app scan runs on a worker of its own (see request_apps).
+        self.apps_queue = queue.Queue()
+        self.apps_worker = None
 
     def emit(self, event):
         """One lock around one write.
@@ -200,6 +204,37 @@ class ScrcpySessionManager:
             os.replace(tmp, path)
         except Exception as error:
             sys.stderr.write(f"cache write failed: {error}\n")
+
+    def request_apps(self, target_args=None, device_id="default"):
+        """Queue an app scan for the worker, and return to reading stdin.
+
+        `list_apps` was called straight from the command loop, and it is
+        worth up to ~26 seconds of blocking subprocesses: `adb connect` (4s)
+        + `adb devices` (4s) + `scrcpy --list-apps` (10s) + `pm list` (8s).
+        For all of that time `stop`, `stop_all` and `focus` were not even
+        read off stdin, so a click on a live mirror did nothing until the
+        scan the user had not asked about finished. Measured with a fake
+        that sleeps 4s in `--list-apps`: a focus sent 0.3s in was acted on at
+        4.01s.
+
+        A queue with one worker rather than a thread per request, so two
+        scans cannot run `adb` at each other, and so every request is
+        answered in the order it arrived - a scan dropped as a duplicate is
+        an `apps_list` the page waits for and never gets.
+        """
+        if self.apps_worker is None or not self.apps_worker.is_alive():
+            self.apps_worker = threading.Thread(target=self._apps_loop, daemon=True)
+            self.apps_worker.start()
+        self.apps_queue.put((target_args, device_id))
+
+    def _apps_loop(self):
+        while True:
+            target_args, device_id = self.apps_queue.get()
+            try:
+                self.list_apps(target_args, device_id)
+            except Exception as error:
+                self.emit({"event": "apps_error",
+                           "message": f"Failed to list apps: {error}"})
 
     def list_apps(self, target_args=None, device_id="default"):
         device_id = device_id or "default"
@@ -358,8 +393,8 @@ class ScrcpySessionManager:
             return
         cmd = msg.get("cmd")
         if cmd == "list_apps":
-            self.list_apps(target_args=msg.get("target_args"),
-                           device_id=msg.get("deviceId", "default"))
+            self.request_apps(target_args=msg.get("target_args"),
+                              device_id=msg.get("deviceId", "default"))
         elif cmd == "launch":
             self.launch_session(msg.get("id"), msg.get("type", "app"),
                                 msg.get("target_args"), msg.get("extra_args"))

--- a/dots/.config/quickshell/imi/scripts/phone/scrcpy_session_manager.py
+++ b/dots/.config/quickshell/imi/scripts/phone/scrcpy_session_manager.py
@@ -33,6 +33,7 @@ stdin closing means the shell went away; every session is stopped then, so a
 shell restart never leaves headless scrcpy windows behind.
 """
 import argparse
+import collections
 import json
 import os
 import re
@@ -41,6 +42,13 @@ import sys
 import threading
 import time
 from pathlib import Path
+
+# scrcpy's last stderr line is what an `exited` event carries, so the drain
+# below only has to keep the tail. Bounded because the drain runs for the
+# life of the child and a chatty one is exactly the case it exists for.
+STDERR_TAIL_LINES = 40
+# How long to wait past the child's exit for the drain thread to see EOF.
+STDERR_DRAIN_TIMEOUT = 2.0
 
 CACHE_DIR = (Path(os.environ.get("XDG_CACHE_HOME") or Path.home() / ".cache")
              / "immaterial-impulse" / "phone" / "apps")
@@ -243,16 +251,43 @@ class ScrcpySessionManager:
         threading.Thread(target=self._wait_process, args=(session_id, proc),
                          daemon=True).start()
 
-    def _wait_process(self, session_id, proc):
-        code = proc.wait()
-        err_msg = ""
+    @staticmethod
+    def _drain_stderr(proc, tail):
+        """Read the child's stderr for as long as it writes, keeping the tail.
+
+        This used to be a single `proc.stderr.read()` AFTER `proc.wait()`.
+        A pipe holds ~64 KiB: past that, scrcpy blocks in `write()` with
+        nobody reading, so it never exits, `wait()` never returns, no
+        `exited` event is ever emitted, and the card sits on "running" over a
+        frozen mirror with nothing in any log. Draining while it runs is what
+        `communicate()` does; a thread is used so the wait below still
+        returns the moment the child is gone rather than when its stderr
+        reaches EOF (a grandchild can hold that open).
+        """
+        stream = proc.stderr
+        if stream is None:
+            return
         try:
-            stderr_output = proc.stderr.read() if proc.stderr else ""
-            lines = [line for line in (stderr_output or "").splitlines() if line.strip()]
-            if lines:
-                err_msg = lines[-1].strip()
+            for line in stream:
+                stripped = line.strip()
+                if stripped:
+                    tail.append(stripped)
         except Exception:
             pass
+        finally:
+            try:
+                stream.close()
+            except Exception:
+                pass
+
+    def _wait_process(self, session_id, proc):
+        tail = collections.deque(maxlen=STDERR_TAIL_LINES)
+        drain = threading.Thread(target=self._drain_stderr, args=(proc, tail),
+                                 daemon=True)
+        drain.start()
+        code = proc.wait()
+        drain.join(timeout=STDERR_DRAIN_TIMEOUT)
+        err_msg = tail[-1] if tail else ""
         with self.lock:
             if self.processes.get(session_id) is proc:
                 del self.processes[session_id]

--- a/dots/.config/quickshell/imi/scripts/phone/scrcpy_session_manager.py
+++ b/dots/.config/quickshell/imi/scripts/phone/scrcpy_session_manager.py
@@ -23,11 +23,12 @@ Events (one JSON object per line on stdout):
 Every scrcpy child is spawned as
   scrcpy [-s <serial>] --window-title=imi-phone-<type>-<id> <extra_args...>
 so that `focus` can address the window by its title and nothing else. The
-`-s` target is resolved from `adb devices` on every launch: a USB serial (no
-":" in it) wins over any ip:port, and only when adb lists nothing do the
-caller's target_args stand. A wireless target the caller names is `adb
-connect`ed first, bounded, so a phone on wireless debugging that adb has not
-seen yet still resolves.
+`-s` target is resolved from `adb devices` on every launch: a USB serial the
+caller names and adb lists wins outright, then any USB serial (no ":" in it)
+over any ip:port, and only when adb lists nothing do the caller's target_args
+stand. Among several USB devices the pick is sorted, not adb's print order. A
+wireless target the caller names is `adb connect`ed first, bounded, so a phone
+on wireless debugging that adb has not seen yet still resolves.
 
 stdin closing means the shell went away; every session is stopped then, so a
 shell restart never leaves headless scrcpy windows behind.
@@ -141,12 +142,18 @@ class ScrcpySessionManager:
     # ---- adb -------------------------------------------------------------
 
     @staticmethod
-    def wireless_serial(target_args):
+    def named_serial(target_args):
+        """The serial the caller asked for, `-s <serial>`, or ""."""
         args = list(target_args or [])
         for index, arg in enumerate(args):
-            if arg == "-s" and index + 1 < len(args) and ":" in args[index + 1]:
+            if arg == "-s" and index + 1 < len(args):
                 return args[index + 1]
         return ""
+
+    @classmethod
+    def wireless_serial(cls, target_args):
+        serial = cls.named_serial(target_args)
+        return serial if ":" in serial else ""
 
     def connect_wireless(self, target_args):
         serial = self.wireless_serial(target_args)
@@ -159,7 +166,24 @@ class ScrcpySessionManager:
             pass
 
     def resolve_adb_target(self, target_args=None):
+        """Which phone this launch is aimed at.
+
+        A USB serial still beats a WIRELESS one the caller named, and that is
+        deliberate rather than an oversight: `PhoneScrcpy.targetArgs()` names
+        a wireless address whenever the "use wireless" setting is on and
+        never names a USB serial at all, scrcpy over USB is the better link,
+        and the rule is stated in the docstring at the top of this file and
+        pinned by `test_a_usb_serial_wins_over_a_wireless_one`.
+
+        What was wrong is narrower and had no argument behind it: with two
+        phones attached, `usb_devices[0]` is whichever `adb devices` happened
+        to print first, and nothing - not the caller, not the tab - could
+        steer it. So a USB serial the caller names and adb really lists is
+        honoured, and the unsteered pick is sorted rather than left to adb's
+        output order, which is not a choice anybody made.
+        """
         self.connect_wireless(target_args)
+        requested = self.named_serial(target_args)
         try:
             res = subprocess.run(["adb", "devices"], capture_output=True,
                                  text=True, timeout=4)
@@ -173,10 +197,12 @@ class ScrcpySessionManager:
                 if len(parts) >= 2 and parts[1] == "device":
                     serial = parts[0]
                     (ip_devices if ":" in serial else usb_devices).append(serial)
+            if requested and requested in usb_devices:
+                return ["-s", requested]
             if usb_devices:
-                return ["-s", usb_devices[0]]
+                return ["-s", sorted(usb_devices)[0]]
             if ip_devices:
-                return ["-s", ip_devices[0]]
+                return ["-s", sorted(ip_devices)[0]]
         except Exception:
             pass
         return list(target_args or [])

--- a/dots/.config/quickshell/imi/scripts/phone/scrcpy_session_manager.py
+++ b/dots/.config/quickshell/imi/scripts/phone/scrcpy_session_manager.py
@@ -38,6 +38,7 @@ import json
 import os
 import queue
 import re
+import signal
 import subprocess
 import sys
 import threading
@@ -407,6 +408,35 @@ class ScrcpySessionManager:
         else:
             sys.stderr.write(f"unknown command: {cmd}\n")
 
+    def install_signal_handlers(self):
+        """A signal is the other way this process ends, and it was unhandled.
+
+        The docstring above promises that a shell restart never leaves
+        headless scrcpy windows behind, and only the clean-EOF path kept it:
+        `PhoneScrcpy.stopManager()` sets `running = false`, which Quickshell
+        sends as SIGTERM, and Python's default handler exits the process
+        without running `stop_all()` - so every mirror and every app window
+        the supervisor owned was orphaned. Measured: the child was still
+        alive a second after the supervisor was gone.
+
+        The signal is re-raised through the default handler afterwards, so
+        the exit status still says what killed it. Called from `main`,
+        because `signal.signal` only works on the main thread.
+        """
+        def handler(signum, _frame):
+            self.stop_all()
+            signal.signal(signum, signal.SIG_DFL)
+            os.kill(os.getpid(), signum)
+
+        for name in ("SIGTERM", "SIGINT", "SIGHUP"):
+            number = getattr(signal, name, None)
+            if number is None:
+                continue
+            try:
+                signal.signal(number, handler)
+            except (ValueError, OSError):
+                pass
+
     def run(self):
         for line in sys.stdin:
             self.handle_line(line)
@@ -423,6 +453,7 @@ def main():
     if args.list_apps:
         manager.list_apps(device_id=args.device_id)
         return 0
+    manager.install_signal_handlers()
     manager.run()
     return 0
 

--- a/dots/.config/quickshell/imi/scripts/phone/scrcpy_session_manager.py
+++ b/dots/.config/quickshell/imi/scripts/phone/scrcpy_session_manager.py
@@ -105,12 +105,31 @@ def cache_path(device_id):
 class ScrcpySessionManager:
     def __init__(self):
         self.lock = threading.Lock()
+        # A lock of its own, never `self.lock`: that one is held around the
+        # process maps and an emit inside it would tie the two orders
+        # together.
+        self.emit_lock = threading.Lock()
         self.processes = {}     # session_id -> subprocess.Popen
         self.session_info = {}  # session_id -> {id, type, title, pid, startedAt}
 
     def emit(self, event):
+        """One lock around one write.
+
+        `print(json.dumps(event), flush=True)` is two writes into a shared
+        buffered stream, and every reaper thread emits `exited` concurrently
+        with the main thread and with the app scan. An event large enough to
+        flush part way through - an `apps_list` for a real phone is tens of
+        kilobytes - can therefore be split by another thread's line, and
+        interleaved NDJSON makes the QML parser return null and drop BOTH
+        events. A lost `exited` leaves a session row live with no window
+        behind it. Observed against real stdout at roughly one corruption in
+        three runs of a stress harness.
+        """
+        line = json.dumps(event) + "\n"
         try:
-            print(json.dumps(event), flush=True)
+            with self.emit_lock:
+                sys.stdout.write(line)
+                sys.stdout.flush()
         except Exception as error:  # a closed stdout: nothing left to tell
             sys.stderr.write(f"emit failed: {error}\n")
 

--- a/dots/.config/quickshell/imi/scripts/phone/setup_droidcam_input.sh
+++ b/dots/.config/quickshell/imi/scripts/phone/setup_droidcam_input.sh
@@ -64,11 +64,14 @@ if [ -n "$existing" ]; then
     # load rather than reporting a source nothing can open.
 fi
 
-# Load module-null-sink with the DroidCam name and description.
-pactl load-module module-null-sink \
+# Load module-null-sink with the DroidCam name and description. The index it
+# prints is the handle teardown otherwise reconstructs by grepping, and it was
+# being discarded into /dev/null — so the failure path below had nothing to
+# undo with.
+module_id="$(pactl load-module module-null-sink \
     sink_name="$SINK_NAME" \
     sink_properties="device.description='$SINK_DESC'" \
-    >/dev/null 2>&1 || {
+    2>/dev/null)" || {
         echo "Failed to load module-null-sink" >&2
         exit 1
     }
@@ -76,6 +79,13 @@ pactl load-module module-null-sink \
 found="$(find_monitor || true)"
 
 if [ -z "$found" ]; then
+    # Undo what this run did before giving up. Exiting 1 with the module still
+    # resident left a null sink behind on every failed attempt, and the caller
+    # never learned there was one to unload.
+    case "$module_id" in
+        ''|*[!0-9]*) ;;
+        *) pactl unload-module "$module_id" >/dev/null 2>&1 || true ;;
+    esac
     echo "Could not find monitor source after loading null-sink" >&2
     exit 1
 fi

--- a/dots/.config/quickshell/imi/scripts/phone/setup_droidcam_input.sh
+++ b/dots/.config/quickshell/imi/scripts/phone/setup_droidcam_input.sh
@@ -6,7 +6,8 @@
 # as a *microphone* (source), we create a null-sink named "DroidCam-Mic" whose
 # `.monitor` source becomes an available input device for system apps.
 #
-# Output: prints the monitor source name on stdout (e.g. "alsa_output.DroidCam-Mic.monitor")
+# Output: prints the monitor source name on stdout ("DroidCam-Mic.monitor", or
+#         "alsa_output.DroidCam-Mic.monitor" on a server that prefixes it)
 #         so the QML service can use it with `pactl set-source-*` commands.
 # Exit codes: 0 on success (sink already existed or was created), 1 on failure.
 
@@ -20,25 +21,47 @@ if ! command -v pactl >/dev/null 2>&1; then
     exit 1
 fi
 
-# Check if the null-sink is already loaded (idempotent).
+# find_monitor → the null-sink's monitor source name, empty when it is absent.
+#
+# There is ONE resolution now, and that is the whole fix. The idempotence
+# check used to ask for `DroidCam-Mic.monitor` alone, while the lookup after a
+# fresh load — twenty lines below it, for the same fact — tried
+# `alsa_output.DroidCam-Mic.monitor` FIRST and then two fallbacks. So on a
+# server using the prefixed form that does not also propagate
+# `device.description`, the existing-sink branch missed a sink it had already
+# loaded and loaded a second one under the same name, on every call, while
+# teardown removed one per call. Driven against a fake server: three setups,
+# three null sinks.
+find_monitor() {
+    local name resolved
+    for name in "alsa_output.${SINK_NAME}.monitor" "${SINK_NAME}.monitor"; do
+        resolved="$(pactl list short sources 2>/dev/null \
+            | awk -v m="$name" '$2 == m { print $2; exit }')"
+        if [ -n "$resolved" ]; then
+            echo "$resolved"
+            return 0
+        fi
+    done
+    # Last resort: the server named it something else entirely, so ask by the
+    # description the sink was loaded with.
+    resolved="$(pactl list sources 2>/dev/null | awk -v desc="$SINK_DESC" '
+        /Name:/ { name=$2 }
+        /Description:/ && $0 ~ desc { print name; exit }
+    ')"
+    [ -n "$resolved" ] || return 1
+    echo "$resolved"
+}
+
+# Already loaded? Then the monitor it published is the answer (idempotent).
 existing="$(pactl list short sinks 2>/dev/null | awk -v sink="$SINK_NAME" '$2 == sink {print $1; exit}' || true)"
 if [ -n "$existing" ]; then
-    # Already loaded — emit the monitor source name.
-    monitor_name=""
-    # PulseAudio convention: <driver>.<sink_name>.monitor
-    monitor_name="$(pactl list short sources 2>/dev/null | awk -v sink="$SINK_NAME" -v monitor="$SINK_NAME.monitor" '$2 == monitor {print $2; exit}')"
-    if [ -z "$monitor_name" ]; then
-        # Fallback: search by description match
-        monitor_name="$(pactl list sources 2>/dev/null | awk -v desc="$SINK_DESC" '
-            /Name:/ { name=$2 }
-            /Description:/ && $0 ~ desc { print name; exit }
-        ')"
-    fi
+    monitor_name="$(find_monitor || true)"
     if [ -n "$monitor_name" ]; then
         echo "$monitor_name"
         exit 0
     fi
-    # Fall through to recreate if monitor not found.
+    # A sink whose monitor cannot be named is not usable; fall through to the
+    # load rather than reporting a source nothing can open.
 fi
 
 # Load module-null-sink with the DroidCam name and description.
@@ -50,26 +73,7 @@ pactl load-module module-null-sink \
         exit 1
     }
 
-# The monitor source follows the naming convention:
-#   <server_type>.<sink_name>.monitor
-# PipeWire (most common now): "alsa_output.DroidCam-Mic.monitor"
-# PulseAudio: same convention.
-MONITOR="alsa_output.${SINK_NAME}.monitor"
-found="$(pactl list short sources 2>/dev/null | awk -v m="$MONITOR" '$2 == m {print $2; exit}')"
-
-if [ -z "$found" ]; then
-    # Try alternate naming: just <sink_name>.monitor
-    MONITOR="${SINK_NAME}.monitor"
-    found="$(pactl list short sources 2>/dev/null | awk -v m="$MONITOR" '$2 == m {print $2; exit}')"
-fi
-
-if [ -z "$found" ]; then
-    # Last resort: search by description.
-    found="$(pactl list sources 2>/dev/null | awk -v desc="$SINK_DESC" '
-        /Name:/ { name=$2 }
-        /Description:/ && $0 ~ desc { print name; exit }
-    ')"
-fi
+found="$(find_monitor || true)"
 
 if [ -z "$found" ]; then
     echo "Could not find monitor source after loading null-sink" >&2

--- a/dots/.config/quickshell/imi/scripts/phone/teardown_droidcam_input.sh
+++ b/dots/.config/quickshell/imi/scripts/phone/teardown_droidcam_input.sh
@@ -13,14 +13,21 @@ if ! command -v pactl >/dev/null 2>&1; then
     exit 0
 fi
 
-# Find the module ID of the null-sink with our name and unload it.
+# Find EVERY module ID of a null-sink with our name and unload all of them.
 # `pactl list short modules` is the safest cross-server (PA/PW) way.
-module_id="$(pactl list short modules 2>/dev/null | awk -v sink="$SINK_NAME" '
-    $0 ~ "sink_name="sink { print $1; exit }
+#
+# The awk had an `exit` after the first match, so one call removed exactly one
+# module. Nothing in the shell calls this in a loop, so a server that had
+# accumulated duplicates — which setup_droidcam_input.sh used to produce, one
+# per launch, on a naming its idempotence check could not see — kept all but
+# one of them for the life of the session. Removing the `exit` costs nothing
+# in the ordinary case, where there is exactly one.
+module_ids="$(pactl list short modules 2>/dev/null | awk -v sink="$SINK_NAME" '
+    $0 ~ "sink_name="sink { print $1 }
 ' || true)"
 
-if [ -n "$module_id" ]; then
+for module_id in $module_ids; do
     pactl unload-module "$module_id" >/dev/null 2>&1 || true
-fi
+done
 
 exit 0

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -1898,6 +1898,20 @@ if ! python3 "$SCRIPT_DIR/test_phone_contacts_contract.py"; then
     exit 1
 fi
 
+# The Phone tab's four SHELL scripts, run for real with stubbed pgrep,
+# pactl, v4l2-ctl, droidcam-cli, scrcpy and sudo first on PATH. Nothing had
+# ever run them: the contract check beside this one reads them as source text
+# and tst_phone_scrcpy.qml drives the QML that parses their output against
+# strings a human typed, so a producer that stopped emitting those strings
+# stayed green on both sides. What that cost: a `stop video` that sent
+# SIGTERM to the MICROPHONE, and a status probe whose JSON did not parse, so
+# every field in the payload was lost rather than one.
+echo "Running Phone shell script tests..."
+if ! python3 "$SCRIPT_DIR/test_phone_shell_scripts.py"; then
+    echo "Phone shell script tests failed."
+    exit 1
+fi
+
 # The scrcpy supervisor over its real stdin/stdout, with fake scrcpy/adb/
 # hyprctl first on PATH: the exact argv, the events, focus by window title,
 # the USB-over-wireless rule, the app-list parse and its fallback, the cache

--- a/dots/.config/quickshell/imi/tests/test_phone_scrcpy_manager.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_scrcpy_manager.py
@@ -12,9 +12,11 @@ apps_error that keeps a dropped phone from wiping the list on screen, the
 cache file the next launch reads back, and the stop-everything-on-EOF that
 keeps a shell restart from stranding headless scrcpy windows.
 """
+import importlib.util
 import json
 import os
 import queue
+import signal
 import subprocess
 import sys
 import tempfile
@@ -31,9 +33,19 @@ printf '%s\n' "$*" >> "$FAKE_LOG/scrcpy.argv"
 case " $* " in
   *" --version "*) echo "scrcpy 4.1 <https://github.com/Genymobile/scrcpy>"; exit 0 ;;
   *" --list-apps "*)
+    if [ -n "${FAKE_SCRCPY_LIST_DELAY:-}" ]; then sleep "$FAKE_SCRCPY_LIST_DELAY"; fi
     if [ -n "${FAKE_LIST_APPS:-}" ]; then cat "$FAKE_LIST_APPS"; fi
     exit 0 ;;
 esac
+if [ -n "${FAKE_SCRCPY_CHATTY:-}" ]; then
+  # Real scrcpy is talkative. Past the pipe buffer (~64 KiB on Linux) a child
+  # whose stderr nobody is reading blocks in write() and never exits.
+  i=0
+  while [ "$i" -lt "$FAKE_SCRCPY_CHATTY" ]; do
+    echo "WARN: [server] diagnostic line $i, padded out so the pipe fills quickly xxxxxxxxxxxxxxxxxxxxxxxxxxxx" >&2
+    i=$((i+1))
+  done
+fi
 if [ -n "${FAKE_SCRCPY_FAIL:-}" ]; then
   echo "WARN: something minor" >&2
   echo "ERROR: Could not find ADB device" >&2
@@ -311,6 +323,176 @@ class ScrcpySessionManagerTests(unittest.TestCase):
         sup.send(cmd="nonsense")
         sup.send(cmd="launch", id="mirror", type="mirror")
         sup.expect("started", id="mirror")
+
+    def test_a_chatty_scrcpy_still_reports_its_exit(self):
+        """`stderr=subprocess.PIPE` was drained only AFTER `wait()`. Once
+        scrcpy writes past the pipe buffer it blocks in `write()`, so
+        `wait()` never returns, no `exited` is ever emitted, and the card is
+        stuck on "running" over a frozen mirror. 3000 lines is ~300 KiB,
+        comfortably past Linux's 64 KiB."""
+        sup = self._start(FAKE_SCRCPY_CHATTY="3000", FAKE_SCRCPY_FAIL="1")
+        sup.send(cmd="launch", id="mirror", type="mirror")
+        sup.expect("started", id="mirror")
+        exited = sup.expect("exited", id="mirror", timeout=15)
+        self.assertEqual(exited["code"], 1)
+        self.assertEqual(exited["error"], "ERROR: Could not find ADB device")
+
+    def test_a_slow_app_scan_does_not_block_stop_and_focus(self):
+        """`list_apps` ran on the command loop: adb connect (4s) + adb
+        devices (4s) + `scrcpy --list-apps` (10s) + `pm list` (8s), during
+        which `stop`, `stop_all` and `focus` were not even read off stdin."""
+        sup = self._start(FAKE_SCRCPY_LIST_DELAY="4")
+        sup.send(cmd="launch", id="mirror", type="mirror")
+        sup.expect("started", id="mirror")
+        started = time.monotonic()
+        sup.send(cmd="list_apps", deviceId="dev_1")
+        sup.send(cmd="focus", id="mirror")
+        self.assertEqual(sup.argv("hyprctl", timeout=3.0),
+                         ["dispatch focuswindow title:^imi-phone-mirror-mirror$"],
+                         "a click during the app scan was not acted on")
+        self.assertLess(time.monotonic() - started, 3.0)
+        sup.expect("apps_list", deviceId="dev_1", timeout=20)
+
+    def test_a_sigtermed_supervisor_stops_its_scrcpy_children(self):
+        """The docstring promises that a shell restart never leaves headless
+        scrcpy windows behind, and only the clean-EOF path kept it:
+        `PhoneScrcpy.stopManager()` sets `running = false`, which is a
+        SIGTERM, and Python's default handler exits without running
+        `stop_all()`."""
+        sup = self._start()
+        sup.send(cmd="launch", id="mirror", type="mirror")
+        child = sup.expect("started", id="mirror")["pid"]
+        # `started` is emitted the instant Popen returns, so the fake may not
+        # have reached its `exec sleep` yet - and "comm is not sleep" is what
+        # this check reads as success. Wait for the child to BE the thing
+        # whose survival is the defect, or the whole test is vacuous.
+        self.assertTrue(self._wait_comm(child, "sleep"),
+                        "the fake scrcpy never reached its sleep")
+        sup.proc.send_signal(signal.SIGTERM)
+        try:
+            sup.proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            sup.proc.kill()
+            self.fail("the supervisor did not exit on SIGTERM")
+        if not self._wait_gone(child, "sleep"):
+            os.kill(child, signal.SIGKILL)
+            self.fail("the scrcpy child outlived a SIGTERMed supervisor")
+
+    @staticmethod
+    def _wait_comm(pid, name, timeout=5.0):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            try:
+                if Path(f"/proc/{pid}/comm").read_text().strip() == name:
+                    return True
+            except OSError:
+                pass
+            time.sleep(0.05)
+        return False
+
+    @staticmethod
+    def _wait_gone(pid, name, timeout=5.0):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            try:
+                if Path(f"/proc/{pid}/comm").read_text().strip() != name:
+                    return True
+            except OSError:
+                return True
+            time.sleep(0.05)
+        return False
+
+    def test_a_named_usb_serial_is_honoured_when_adb_lists_it(self):
+        """With two phones attached, `usb_devices[0]` is whichever `adb
+        devices` printed first and nothing could steer it."""
+        sup = self._start(FAKE_ADB_DEVICES="PHONE_A\\tdevice\\nPHONE_B\\tdevice")
+        sup.send(cmd="launch", id="mirror", type="mirror", target_args=["-s", "PHONE_B"])
+        sup.expect("started", id="mirror")
+        self.assertTrue(sup.argv("scrcpy")[0].startswith("-s PHONE_B "),
+                        sup.argv("scrcpy"))
+
+    def test_the_pick_among_several_usb_devices_does_not_follow_adbs_order(self):
+        """Unsteered, the choice is at least the same one twice: adb's print
+        order is not a decision anybody made."""
+        picks = []
+        for listing in ("PHONE_B\\tdevice\\nPHONE_A\\tdevice",
+                        "PHONE_A\\tdevice\\nPHONE_B\\tdevice"):
+            room = tempfile.TemporaryDirectory()
+            self.addCleanup(room.cleanup)
+            sup = Supervisor(room.name, {"FAKE_ADB_DEVICES": listing})
+            self.addCleanup(sup.close)
+            sup.send(cmd="launch", id="mirror", type="mirror")
+            sup.expect("started", id="mirror")
+            picks.append(sup.argv("scrcpy")[0].split()[1])
+        self.assertEqual(picks[0], picks[1], f"adb's print order decided the phone: {picks}")
+
+
+class EmitSerializationTests(unittest.TestCase):
+    """`emit` writes from every reaper thread as well as from the main one.
+
+    `print(json.dumps(event), flush=True)` is two writes into a shared
+    buffered stream, so an event large enough to flush part way - an
+    `apps_list` for a real phone is tens of kilobytes - can be split by
+    another thread's line. Interleaved NDJSON makes the QML parser return
+    null and BOTH events are dropped; a lost `exited` leaves a session row
+    live with no window behind it.
+
+    Observed against real stdout at roughly one corruption in three runs
+    (`{...apps_list...}{"event": "exited", ...}` on one line), which is too
+    rare to be a check. The stream below makes the window explicit instead of
+    waiting for the scheduler to open it: its `write` is deliberately not
+    atomic, which is exactly the property a buffered TextIOWrapper flushing
+    mid-write has. Without one lock around one write this fails every time.
+    """
+
+    class SplittingStream:
+        def __init__(self):
+            self.pieces = []
+
+        def write(self, text):
+            for index in range(0, len(text), 16):
+                self.pieces.append(text[index:index + 16])
+                time.sleep(0)
+            return len(text)
+
+        def flush(self):
+            time.sleep(0)
+
+    def test_every_event_is_one_whole_line(self):
+        spec = importlib.util.spec_from_file_location("scrcpy_session_manager", MANAGER)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        manager = module.ScrcpySessionManager()
+        stream = self.SplittingStream()
+        apps = [{"package": f"com.example.app{i}", "name": f"App {i}", "system": False}
+                for i in range(40)]
+
+        def reaper(index):
+            for step in range(20):
+                manager.emit({"event": "exited", "id": f"s-{index}-{step}",
+                              "code": 0, "error": ""})
+
+        def lister(index):
+            for step in range(20):
+                manager.emit({"event": "apps_list", "deviceId": f"dev-{index}-{step}",
+                              "apps": apps})
+
+        original = sys.stdout
+        sys.stdout = stream
+        try:
+            threads = ([threading.Thread(target=reaper, args=(n,)) for n in range(4)]
+                       + [threading.Thread(target=lister, args=(n,)) for n in range(2)])
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join()
+        finally:
+            sys.stdout = original
+
+        lines = [line for line in "".join(stream.pieces).split("\n") if line]
+        self.assertEqual(len(lines), 120)
+        for line in lines:
+            json.loads(line)
 
 
 if __name__ == "__main__":

--- a/dots/.config/quickshell/imi/tests/test_phone_shell_scripts.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_shell_scripts.py
@@ -1,0 +1,525 @@
+#!/usr/bin/env python3
+"""Drives the Phone tab's four shell scripts for real, with stubbed
+`pgrep`, `pactl`, `v4l2-ctl`, `droidcam-cli`, `scrcpy` and `sudo` first on
+PATH.
+
+Nothing in this tree had ever RUN these scripts. `test_phone_sessions_
+contract.py` reads them as source text - the state directory, the `pgrep -x`
+rule - and `tst_phone_scrcpy.qml` drives the QML that parses their output
+against strings a human typed, so a producer that stopped emitting those
+strings stayed green on both sides. That is how a `stop video` that kills the
+MICROPHONE, and a status probe whose JSON does not parse, both shipped.
+
+What is stubbed and what is not: the stubs are the process TABLE (`pgrep`
+answers with the pids this harness spawned) and the sound server (`pactl`
+keeps a module list in a file). The processes themselves are real - launched
+through `droidcam_session.sh launch`, with real pids and real
+`/proc/<pid>/cmdline` - so the signature matching, the port disambiguation
+and the kill guard all run against the thing they run against in production.
+`droidcam-cli` cannot run on this machine at all (it is built against ffmpeg
+8 and the system has 9), which is the other half of why the fakes are fakes.
+
+The one artefact worth knowing: a fake `droidcam-cli` is a `#!` script, so
+its cmdline carries the interpreter ahead of the path
+(`bash /tmp/.../bin/droidcam-cli -nocontrols 10.0.0.5 4747`). Every rule
+under test is a substring or a token test over that line, so the extra
+leading words make the fixture harder rather than easier.
+"""
+import json
+import os
+import re
+import shutil
+import signal
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts" / "phone"
+SESSION = SCRIPTS / "droidcam_session.sh"
+STATUS = SCRIPTS / "droidcam_status.sh"
+SETUP = SCRIPTS / "setup_droidcam_input.sh"
+TEARDOWN = SCRIPTS / "teardown_droidcam_input.sh"
+INSTALL = SCRIPTS / "install_droidcam.sh"
+
+# `pgrep -x <name>` over the pids this harness spawned. Real pgrep would
+# answer for the fake's INTERPRETER (a `#!` script's comm is `bash`), so the
+# selection is the stub and everything the scripts then do with the pid -
+# reading /proc, matching the signature, killing it - is real.
+#
+# It deliberately does NOT check that a pid is still alive. Real pgrep prints
+# what the process table held when it sampled it, and the window between that
+# sample and the reader's `open("/proc/<pid>/cmdline")` is one of the things
+# under test - a stub that filtered dead pids would close it by hand.
+FAKE_PGREP = r"""#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$FAKE_LOG/pgrep.argv"
+if [ "${1:-}" != "-x" ]; then exit 2; fi
+f="$FAKE_PROCS/${2:-}.pids"
+[ -f "$f" ] || exit 1
+missing=1
+while read -r p; do
+    [ -n "$p" ] || continue
+    echo "$p"
+    missing=0
+done < "$f"
+exit $missing
+"""
+
+# A stateful sound server: FAKE_PA/modules holds one "<index>\t<args>" row
+# per loaded module. FAKE_PA_MONITOR_FORM picks how the server names a null
+# sink's monitor source, and FAKE_PA_DESC whether it propagates the
+# description - the two facts the setup script's lookups disagree about.
+FAKE_PACTL = r"""#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$FAKE_LOG/pactl.argv"
+M="$FAKE_PA/modules"; N="$FAKE_PA/next"
+[ -f "$M" ] || : > "$M"
+[ -f "$N" ] || echo 100 > "$N"
+monitor_name() {
+    case "${FAKE_PA_MONITOR_FORM:-plain}" in
+        alsa_output) echo "alsa_output.DroidCam-Mic.monitor" ;;
+        none)        echo "" ;;
+        *)           echo "DroidCam-Mic.monitor" ;;
+    esac
+}
+case "$*" in
+    "list short sinks"|"list sinks short")
+        while IFS=$'\t' read -r i a; do
+            case "$a" in *sink_name=DroidCam-Mic*)
+                printf '%s\tDroidCam-Mic\tPipeWire\ts16le 2ch 48000Hz\tSUSPENDED\n' "$i" ;;
+            esac
+        done < "$M" ;;
+    "list short sources"|"list sources short")
+        name="$(monitor_name)"
+        printf '%s\n' "1	alsa_input.pci-0000_00_1f.3.analog-stereo	PipeWire	s32le 2ch 48000Hz	SUSPENDED"
+        [ -n "$name" ] || exit 0
+        while IFS=$'\t' read -r i a; do
+            case "$a" in *sink_name=DroidCam-Mic*)
+                printf '%s\t%s\tPipeWire\ts16le 2ch 48000Hz\tRUNNING\n' "$i" "$name" ;;
+            esac
+        done < "$M" ;;
+    "list sources")
+        name="$(monitor_name)"
+        [ -n "$name" ] || exit 0
+        while IFS=$'\t' read -r i a; do
+            case "$a" in *sink_name=DroidCam-Mic*)
+                printf 'Source #%s\n\tName: %s\n' "$i" "$name"
+                if [ "${FAKE_PA_DESC:-1}" = "1" ]; then
+                    printf '\tDescription: Monitor of DroidCam Microphone\n'
+                else
+                    printf '\tDescription: Monitor of DroidCam-Mic\n'
+                fi ;;
+            esac
+        done < "$M" ;;
+    "list short modules")
+        while IFS=$'\t' read -r i a; do
+            printf '%s\tmodule-null-sink\t%s\t\n' "$i" "$a"
+        done < "$M" ;;
+    load-module*)
+        idx="$(cat "$N")"; echo $((idx + 1)) > "$N"
+        shift
+        printf '%s\t%s\n' "$idx" "$*" >> "$M"
+        echo "$idx" ;;
+    unload-module*)
+        target="$2"; tmp="$M.tmp"; : > "$tmp"
+        while IFS=$'\t' read -r i a; do
+            [ "$i" = "$target" ] || printf '%s\t%s\n' "$i" "$a" >> "$tmp"
+        done < "$M"
+        mv "$tmp" "$M" ;;
+esac
+exit 0
+"""
+
+FAKE_V4L2_CTL = r"""#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$FAKE_LOG/v4l2-ctl.argv"
+case "$*" in
+    "--list-devices")
+        printf 'DroidCam (platform:v4l2loopback-000):\n\t/dev/video10\n\n'
+        exit 0 ;;
+esac
+exit 1
+"""
+
+# A fake camera/microphone/mirror that just stays alive. What matters is its
+# cmdline, which the harness controls through the argv it is launched with -
+# so it must NOT `exec` anything, or /proc would report the replacement's
+# argv and every signature test would be measuring `sleep`. The short sleep
+# is what makes the SIGTERM the scripts send land promptly: bash defers a
+# trap until the command in front of it returns.
+FAKE_SLEEPER = """#!/usr/bin/env bash
+trap 'exit 0' TERM INT HUP
+while :; do sleep 0.2; done
+"""
+
+FAKE_RECORDER = r"""#!/usr/bin/env bash
+printf '%s\n' "$0 $*" >> "$FAKE_LOG/%(name)s.argv"
+exit %(code)s
+"""
+
+
+def write_stub(path: Path, body: str) -> None:
+    path.write_text(body)
+    path.chmod(0o755)
+
+
+class PhoneScriptHarness(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="imi-phone-scripts-"))
+        self.addCleanup(self._cleanup)
+        self.spawned = []
+        self.bin = self.tmp / "bin"
+        self.bin.mkdir()
+        self.log = self.tmp / "log"
+        self.log.mkdir()
+        self.procs = self.tmp / "procs"
+        self.procs.mkdir()
+        self.pa = self.tmp / "pa"
+        self.pa.mkdir()
+        write_stub(self.bin / "pgrep", FAKE_PGREP)
+        write_stub(self.bin / "pactl", FAKE_PACTL)
+        write_stub(self.bin / "v4l2-ctl", FAKE_V4L2_CTL)
+        write_stub(self.bin / "droidcam-cli", FAKE_SLEEPER)
+        write_stub(self.bin / "scrcpy", FAKE_SLEEPER)
+        self.env = dict(os.environ)
+        self.env["PATH"] = f"{self.bin}:{self.env.get('PATH', '')}"
+        self.env["FAKE_LOG"] = str(self.log)
+        self.env["FAKE_PROCS"] = str(self.procs)
+        self.env["FAKE_PA"] = str(self.pa)
+        self.env["XDG_STATE_HOME"] = str(self.tmp / "state")
+        self.env["HOME"] = str(self.tmp)
+        self.state_dir = self.tmp / "state" / "quickshell" / "imi" / "phone"
+
+    def _cleanup(self):
+        for pid in self.spawned:
+            try:
+                os.kill(pid, signal.SIGKILL)
+            except OSError:
+                pass
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    # ---- helpers ---------------------------------------------------------
+
+    def run_script(self, script, *args, stdin=subprocess.DEVNULL, env_extra=None):
+        env = dict(self.env)
+        env.update(env_extra or {})
+        return subprocess.run(["bash", str(script), *args], capture_output=True,
+                              text=True, env=env, stdin=stdin, timeout=60)
+
+    def launch(self, session, *argv, env_extra=None):
+        """Start a real detached session through the script under test and
+        register its pid with the fake process table."""
+        res = self.run_script(SESSION, "launch", session, str(self.bin / argv[0]),
+                              *argv[1:], env_extra=env_extra)
+        self.assertEqual(res.returncode, 0, f"launch {session} failed: {res.stderr}")
+        pid = int(res.stdout.strip())
+        self.spawned.append(pid)
+        binary = "scrcpy" if argv[0] == "scrcpy" else "droidcam-cli"
+        with (self.procs / f"{binary}.pids").open("a") as handle:
+            handle.write(f"{pid}\n")
+        return pid
+
+    def pgrep_calls(self):
+        path = self.log / "pgrep.argv"
+        return path.read_text().splitlines() if path.exists() else []
+
+    def alive(self, pid):
+        return Path(f"/proc/{pid}").exists()
+
+    def dead_pid(self):
+        """A pid nothing holds, for the between-pgrep-and-the-read window."""
+        candidate = 4194300
+        while Path(f"/proc/{candidate}").exists():
+            candidate -= 1
+        return candidate
+
+    def modules(self):
+        path = self.pa / "modules"
+        return path.read_text().splitlines() if path.exists() else []
+
+
+class DroidcamSessionTests(PhoneScriptHarness):
+    def test_killall_stops_every_session_even_with_no_state_files(self):
+        """`exit` inside a function ends the SCRIPT. cmd_stop's two non-kill
+        paths ended with one, so the first session without a state file
+        ended the loop and the other two were never stopped - and killall
+        still exited 0, so the caller saw success."""
+        res = self.run_script(SESSION, "killall")
+        self.assertEqual(res.returncode, 0, res.stderr)
+        self.assertEqual(self.pgrep_calls(),
+                         ["-x droidcam-cli", "-x droidcam-cli", "-x scrcpy"],
+                         "killall did not reach all three sessions")
+
+    def test_stopping_the_webcam_does_not_kill_the_microphone(self):
+        """The shell restarts with only the mic running and video.json gone.
+        `status video` used to answer with the MIC's pid - the video
+        signature is a plain `droidcam-cli` substring and the audio process's
+        cmdline contains it - so the tab drew a webcam stream that did not
+        exist, and turning it off sent SIGTERM to the microphone."""
+        mic = self.launch("audio", "droidcam-cli", "-a", "-nocontrols", "10.0.0.5", "4748")
+        (self.state_dir / "video.json").unlink(missing_ok=True)
+
+        status = json.loads(self.run_script(SESSION, "status", "video").stdout)
+        self.assertFalse(status["alive"], f"status video adopted the microphone: {status}")
+        self.assertEqual(status["pid"], "")
+        self.assertFalse(status["video_running"])
+
+        self.run_script(SESSION, "stop", "video")
+        time.sleep(0.6)
+        self.assertTrue(self.alive(mic), "stop video killed the microphone session")
+
+    def test_the_microphone_is_still_found_by_its_own_name(self):
+        """The mirror image: narrowing the video signature must not make the
+        audio session unfindable."""
+        mic = self.launch("audio", "droidcam-cli", "-a", "-nocontrols", "10.0.0.5", "4748")
+        (self.state_dir / "audio.json").unlink()
+        status = json.loads(self.run_script(SESSION, "status", "audio").stdout)
+        self.assertTrue(status["alive"], f"the microphone was not rediscovered: {status}")
+        self.assertEqual(status["pid"], str(mic))
+        self.assertTrue(status["audio_running"])
+
+    def test_a_scrcpy_mic_session_is_neither_the_webcam_nor_droidcam_audio(self):
+        scrcpy = self.launch("scrcpy-mic", "scrcpy", "--no-video", "--no-window",
+                             "--audio-source=mic", "--audio-buffer=50")
+        for name in ("video.json", "scrcpy-mic.json"):
+            (self.state_dir / name).unlink(missing_ok=True)
+        video = json.loads(self.run_script(SESSION, "status", "video").stdout)
+        self.assertFalse(video["alive"], f"status video adopted the scrcpy mic: {video}")
+        mic = json.loads(self.run_script(SESSION, "status", "scrcpy-mic").stdout)
+        self.assertEqual(mic["pid"], str(scrcpy))
+
+    def test_a_rediscovered_session_reports_its_port_and_address(self):
+        """`IFS` drops space, so the two rediscovery paths' unquoted `$cl`
+        was one word: `extract_port` saw a single non-numeric argument and
+        answered empty, and so did `extract_ip`."""
+        self.launch("video", "droidcam-cli", "-nocontrols", "10.0.0.5", "4747")
+        (self.state_dir / "video.json").unlink()
+        status = json.loads(self.run_script(SESSION, "status", "video").stdout)
+        self.assertTrue(status["alive"], status)
+        self.assertEqual(status["port"], "4747")
+        self.assertEqual(status["ip"], "10.0.0.5")
+        self.assertEqual(status["mode"], "wifi")
+
+    def test_a_rediscovered_usb_session_reports_usb_mode(self):
+        self.launch("video", "droidcam-cli", "-nocontrols", "adb", "4747")
+        (self.state_dir / "video.json").unlink()
+        status = json.loads(self.run_script(SESSION, "status", "video").stdout)
+        self.assertEqual(status["mode"], "usb")
+        self.assertEqual(status["port"], "4747")
+
+    def test_every_status_answer_is_json_the_shell_can_parse(self):
+        for session in ("video", "audio", "scrcpy-mic"):
+            res = self.run_script(SESSION, "status", session)
+            json.loads(res.stdout)
+
+
+class DroidcamStatusTests(PhoneScriptHarness):
+    def _status(self, env_extra=None):
+        res = self.run_script(STATUS, env_extra=env_extra)
+        try:
+            return json.loads(res.stdout), res
+        except json.JSONDecodeError as error:
+            self.fail(f"droidcam_status.sh emitted invalid JSON ({error}): {res.stdout!r}")
+
+    def test_a_pid_that_exited_is_not_reported_as_a_running_webcam(self):
+        """`/proc/<pid>/cmdline` was read with no readability guard, so a
+        process that exited between the `pgrep` and the read produced an
+        empty cmdline, fell through to the `*)` default - the video arm -
+        and was reported as a live webcam on a dead pid."""
+        (self.procs / "droidcam-cli.pids").write_text(f"{self.dead_pid()}\n")
+        doc, res = self._status()
+        self.assertFalse(doc["video_running"], doc)
+        self.assertEqual(doc["video_pid"], 0)
+        self.assertNotIn("No such file or directory", res.stderr)
+
+    def test_the_payload_parses_when_the_port_is_not_four_digits(self):
+        """`grep ... | tail -n1 || echo 0` never falls back: grep exits 1 and
+        `tail` exits 0, so the pipeline succeeds with an empty answer and the
+        unquoted `%s` emitted `"video_port":,`. That is invalid JSON, so
+        QML's JSON.parse threw and EVERY field in the payload was lost."""
+        pid = self.launch("video", "droidcam-cli", "-nocontrols", "10.0.0.5", "80")
+        (self.procs / "droidcam-cli.pids").write_text(f"{pid}\n")
+        doc, _ = self._status()
+        self.assertTrue(doc["video_running"], doc)
+        self.assertEqual(doc["video_port"], 80)
+
+    def test_a_four_digit_port_still_reads(self):
+        pid = self.launch("video", "droidcam-cli", "-nocontrols", "10.0.0.5", "4747")
+        (self.procs / "droidcam-cli.pids").write_text(f"{pid}\n")
+        doc, _ = self._status()
+        self.assertEqual(doc["video_port"], 4747)
+        self.assertEqual(doc["video_mode"], "wifi")
+
+    def test_an_audio_session_is_not_counted_as_the_webcam(self):
+        pid = self.launch("audio", "droidcam-cli", "-a", "-nocontrols", "10.0.0.5", "4748")
+        (self.procs / "droidcam-cli.pids").write_text(f"{pid}\n")
+        doc, _ = self._status()
+        self.assertTrue(doc["audio_running"], doc)
+        self.assertFalse(doc["video_running"], doc)
+
+    def test_audio_source_is_the_source_name_this_file_documents(self):
+        """The header documents a NAME (`alsa_output.droidcam_input.monitor`)
+        and `tst_phone_scrcpy.qml` feeds `PhoneMic.parseStatus` a name; the
+        awk printed pactl's INDEX."""
+        self.run_script(SETUP)
+        doc, _ = self._status()
+        self.assertEqual(doc["audio_source"], "DroidCam-Mic.monitor")
+
+    def test_the_payload_parses_with_nothing_running_at_all(self):
+        doc, _ = self._status()
+        self.assertFalse(doc["video_running"])
+        self.assertEqual(doc["video_port"], 0)
+
+
+class DroidcamInputTests(PhoneScriptHarness):
+    def _setup_thrice(self, **env_extra):
+        answers = []
+        for _ in range(3):
+            res = self.run_script(SETUP, env_extra=env_extra)
+            answers.append((res.returncode, res.stdout.strip()))
+        return answers
+
+    def test_repeated_setup_loads_one_sink_however_the_server_names_the_monitor(self):
+        """The existing-sink branch looked for `DroidCam-Mic.monitor` while
+        the fresh-load branch below it tried `alsa_output.DroidCam-Mic.
+        monitor` FIRST - two lookups for one fact. On a server using the
+        `alsa_output.` form that does not also propagate the description,
+        every call missed the sink it had already loaded and loaded another
+        under the same name."""
+        answers = self._setup_thrice(FAKE_PA_MONITOR_FORM="alsa_output", FAKE_PA_DESC="0")
+        for code, name in answers:
+            self.assertEqual(code, 0)
+            self.assertEqual(name, "alsa_output.DroidCam-Mic.monitor")
+        self.assertEqual(len(self.modules()), 1, "setup stacked null sinks")
+
+    def test_repeated_setup_loads_one_sink_on_the_plain_naming(self):
+        answers = self._setup_thrice(FAKE_PA_MONITOR_FORM="plain", FAKE_PA_DESC="1")
+        for code, name in answers:
+            self.assertEqual(code, 0)
+            self.assertEqual(name, "DroidCam-Mic.monitor")
+        self.assertEqual(len(self.modules()), 1)
+
+    def test_a_setup_that_cannot_find_its_monitor_unloads_what_it_loaded(self):
+        res = self.run_script(SETUP, env_extra={"FAKE_PA_MONITOR_FORM": "none"})
+        self.assertEqual(res.returncode, 1, res.stdout)
+        self.assertEqual(self.modules(), [],
+                         "the failure path left the null sink resident")
+
+    def test_teardown_unloads_every_copy_of_the_sink(self):
+        """teardown's awk had an `exit` after the first match, so it removed
+        exactly one module per call and duplicates accumulated."""
+        for _ in range(3):
+            self.run_script(SETUP, env_extra={"FAKE_PA_MONITOR_FORM": "none"})
+        # Three loads that each failed to resolve a monitor; whatever is
+        # resident, one teardown must clear all of it.
+        (self.pa / "modules").write_text(
+            "".join(f"{100 + i}\tmodule-null-sink sink_name=DroidCam-Mic\n" for i in range(3)))
+        res = self.run_script(TEARDOWN)
+        self.assertEqual(res.returncode, 0)
+        self.assertEqual(self.modules(), [], "teardown left duplicate sinks behind")
+
+    def test_teardown_leaves_other_modules_alone(self):
+        (self.pa / "modules").write_text(
+            "100\tmodule-null-sink sink_name=Other-Sink\n"
+            "101\tmodule-null-sink sink_name=DroidCam-Mic\n")
+        self.run_script(TEARDOWN)
+        self.assertEqual(len(self.modules()), 1)
+        self.assertIn("Other-Sink", self.modules()[0])
+
+
+class InstallDroidcamTests(PhoneScriptHarness):
+    """The installer is driven by sourcing it and calling `main <distro>`, so
+    the branch under test does not depend on the machine running the suite:
+    CI is Ubuntu and the maintainer is on Arch, and the Arch branch is the
+    one with the defects."""
+
+    def _install_bin(self, name, code=0, extra=""):
+        write_stub(self.bin / name, FAKE_RECORDER % {"name": name, "code": code} + extra)
+
+    def _main(self, distro, *, aur_code=0):
+        self._install_bin("yay", aur_code)
+        self._install_bin("sudo")
+        self._install_bin("pacman")
+        return subprocess.run(
+            ["bash", "-c", 'source "$1"; main "$2"', "_", str(INSTALL), distro],
+            capture_output=True, text=True, env=self.env,
+            stdin=subprocess.DEVNULL, timeout=60)
+
+    def test_a_failing_aur_helper_is_not_reported_as_a_successful_install(self):
+        """The Arch branch printed "✓ DroidCam installed" after an unchecked
+        `$AUR_HELPER -S`, and the footer then told the user the cards should
+        read "Ready"."""
+        res = self._main("arch", aur_code=1)
+        self.assertNotEqual(res.returncode, 0, res.stdout)
+        self.assertNotIn("✓ DroidCam installed", res.stdout)
+        self.assertNotIn("now show 'Ready'", res.stdout)
+
+    def test_the_arch_branch_installs_the_tools_the_webcam_needs(self):
+        """`PhoneDeps` treats v4l-utils and android-tools as dependencies and
+        `droidcam_status.sh` cannot report the webcam device without
+        `v4l2-ctl`, so the Arch branch could complete with the webcam still
+        unfindable."""
+        res = self._main("arch")
+        self.assertEqual(res.returncode, 0, res.stderr + res.stdout)
+        requested = " ".join(
+            (self.log / name).read_text() if (self.log / name).exists() else ""
+            for name in ("yay.argv", "sudo.argv", "pacman.argv"))
+        self.assertIn("v4l-utils", requested)
+        self.assertIn("android-tools", requested)
+        self.assertIn("✓ DroidCam installed", res.stdout)
+
+    def test_a_failed_extract_does_not_run_install_client_anywhere(self):
+        """`unzip` and `cd` were both unchecked, so a failed extract left
+        `sudo ./install-client` running in the CALLER's working directory."""
+        self._install_bin("sudo")
+        write_stub(self.bin / "curl",
+                   '#!/usr/bin/env bash\nprev=""\nfor a in "$@"; do '
+                   '[ "$prev" = "-o" ] && printf "not a zip" > "$a"; prev="$a"; done\nexit 0\n')
+        write_stub(self.bin / "sha1sum",
+                   '#!/usr/bin/env bash\necho "ce44abefbadec0a2183837605df23643ca13fb02  $1"\n')
+        write_stub(self.bin / "unzip",
+                   '#!/usr/bin/env bash\necho "cannot find zipfile directory" >&2\nexit 9\n')
+        cwd = self.tmp / "cwd"
+        cwd.mkdir()
+        res = subprocess.run(
+            ["bash", "-c", 'source "$1"; install_from_official_zip', "_", str(INSTALL)],
+            capture_output=True, text=True, env=self.env, cwd=str(cwd),
+            stdin=subprocess.DEVNULL, timeout=60)
+        self.assertNotEqual(res.returncode, 0, res.stdout)
+        self.assertNotIn("✓ DroidCam installed", res.stdout)
+        sudo_log = self.log / "sudo.argv"
+        ran = sudo_log.read_text() if sudo_log.exists() else ""
+        self.assertNotIn("install-client", ran,
+                         "install-client ran despite the extract failing")
+
+    def test_sourcing_the_installer_installs_nothing(self):
+        """The `main` split is only safe if sourcing the file is inert."""
+        res = subprocess.run(
+            ["bash", "-c", 'source "$1"; echo SOURCED', "_", str(INSTALL)],
+            capture_output=True, text=True, env=self.env,
+            stdin=subprocess.DEVNULL, timeout=30)
+        self.assertEqual(res.returncode, 0, res.stderr)
+        self.assertEqual(res.stdout.strip(), "SOURCED")
+        self.assertEqual(self.pgrep_calls(), [])
+
+    def test_the_unsupported_branch_still_says_what_to_do_by_hand(self):
+        res = self._main("unknown")
+        self.assertNotEqual(res.returncode, 0)
+        self.assertIn("Unsupported distribution", res.stdout)
+
+
+class ScriptHygieneTests(unittest.TestCase):
+    def test_no_session_command_ends_a_function_with_exit(self):
+        """The defect killall shipped with, as a rule: a command function
+        returns, and the dispatch at the bottom is what sets the status."""
+        text = SESSION.read_text()
+        bodies = re.findall(r"^cmd_\w+\(\) \{\n(.*?)^\}", text, re.S | re.M)
+        self.assertEqual(len(bodies), 4, "the four cmd_* functions were not found")
+        for body in bodies:
+            stripped = re.sub(r"^\s*#.*$", "", body, flags=re.M)
+            self.assertNotRegex(stripped, r"(?<![\w-])exit \d",
+                                "a cmd_* function exits the whole script")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dots/.config/quickshell/imi/tests/test_phone_shell_scripts.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_shell_scripts.py
@@ -153,7 +153,7 @@ while :; do sleep 0.2; done
 """
 
 FAKE_RECORDER = r"""#!/usr/bin/env bash
-printf '%s\n' "$0 $*" >> "$FAKE_LOG/%(name)s.argv"
+printf '%%s\n' "$0 $*" >> "$FAKE_LOG/%(name)s.argv"
 exit %(code)s
 """
 


### PR DESCRIPTION
Fourteen defects in the Phone tab's shell scripts and its scrcpy supervisor, found by a read-only audit and each reproduced before it was fixed.

Nothing in this tree had ever RUN these scripts. `test_phone_sessions_contract.py` reads them as source text and `tst_phone_scrcpy.qml` drives the QML that parses their output against strings a human typed into the test, so the producer and the consumer were each checked against a description of the other. What that cost: a `stop video` that sent SIGTERM to the **microphone**, a status probe whose JSON did not parse (so every field was lost, not one), a mirror card stuck on "running" over a frozen scrcpy, and an Arch installer that reported success after a failed AUR install and never installed the tools the webcam needs.

`tests/test_phone_shell_scripts.py` is new and runs all four shell scripts for real with stubbed `pgrep`/`pactl`/`v4l2-ctl`/`droidcam-cli`/`scrcpy`/`sudo` on PATH; the stubs are the process table and the sound server, the processes are real. `test_phone_scrcpy_manager.py` gains five checks including a fake that fills the stderr pipe and a SIGTERM. Every defect check has a green control beside it.

Two findings needed more than the audit claimed, and the write-ups say so: the unlocked `emit` does **not** corrupt at small payloads (under the GIL two consecutive writes are effectively atomic — 24,000 events across 12 threads produced none), so the committed check swaps in a deliberately non-atomic stdout and fails 100% without the lock; and the double null sink needs both the `alsa_output.` monitor naming **and** a server that does not propagate `device.description`, with the control run recorded beside it.

One reported finding does not stand and is written up rather than acted on: `resolve_adb_target` preferring a USB serial over a caller-named wireless one is a stated decision, not an oversight — `PhoneScrcpy.targetArgs()` never names a USB serial, so the tab's device selection does not reach it as one. The half with no argument behind it (adb's print order deciding between two phones) is fixed.

Docs: updated AGENT.md §"The Phone tab's four SHELL scripts had never been RUN by anything" and §Directory map, and docs/tests-README.md §"What the Python checks are, and are not"
Changelog: updated
