### PR TITLE
fix(phone): the webcam preview is a player the shell owns, not a detached spawn

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -745,7 +745,12 @@ services/                  Singletons wrapping external state/processes - one pe
                               launched DETACHED by scripts/phone/droidcam_session.sh (the
                               pidfile is the binary's own) so it outlives a shell restart
                               and is re-adopted at boot from the session's state file.
-                              USB first: adb get-state, then KDE Connect's address
+                              USB first: adb get-state, then KDE Connect's address.
+                              The preview PLAYER is the opposite arrangement and the
+                              only process this file owns: a Process, closed by one
+                              observer of `active`, because the user can close it and a
+                              recorded pid would go stale - see the execDetached entry
+                              below, and tests/test_phone_preview_lifetime_runtime.py
   PhoneMic.qml                 The phone as a microphone: the stream lands on a null sink
                               (DroidCam-Mic) whose .monitor is what applications record.
                               scrcpy's SDL audio ignores PULSE_SINK on PipeWire, so the
@@ -4692,6 +4697,66 @@ singletons (`PhoneConnect.activeDevice`, `PhoneScrcpy.targetArgs`) - the doubles
 them too. The one-shot serialized queue (`run`/`pump`/one `Process` with `exec`) is
 `PhoneConnect`'s busctl queue, reused rather than one Process per command.
 ("test(phone): pin the four session services' process I/O to their doubles").
+
+**`Quickshell.execDetached` returns no handle, so a process spawned with it can
+only ever be stopped by the user - and "detach it and record the pid" is the
+wrong repair for anything the user can close.** The webcam PREVIEW was the
+case. `PhoneCamera.openPreview()` detached its player, so `stop()` - which
+clears `device` and runs `droidcam_session.sh stop video` - had nothing to stop
+it with: ending the session left the player holding a window on a
+`/dev/videoN` that had stopped producing frames, frozen on its last frame,
+until the user closed it by hand. Nothing errors, nothing logs, and the QML
+reads correctly.
+
+The player is a `Process` the service owns now, and which of the two shapes a
+process here takes is decided by **who can end it**, not by how long it should
+live. The stream is detached and tracked by pidfile
+(`scripts/phone/droidcam_session.sh`) because only this shell ever stops it, so
+a recorded pid is good until it is used, and because a webcam other
+applications are using has to survive a shell restart. A player is closed by
+the USER at any moment, so a pid recorded when it started is a number the
+kernel is free to reissue, and a later stop would spend it on a stranger - the
+sibling of the `pgrep -f` trap under
+[Where to look when something goes wrong](#where-to-look-when-something-goes-wrong),
+arriving through a pid rather than through a pattern. A `Process` cannot
+address anything it did not start, which removes that failure by construction.
+What it costs is that the player does not outlive a shell restart the way the
+stream deliberately does; a preview is one click to reopen, and an unstoppable
+one is the worse bug.
+
+Three more things from it.
+
+- **Which ending closes it is ONE observer.** `onActiveChanged` in the synced
+  region, not a `closePreview()` spelled into `stop()`, into `checkSession()`'s
+  death branch and into `fail()` - `active` IS the session and every ending
+  writes it, including the device disappearing, which arrives through
+  `onActiveDeviceIdChanged`'s own `stop()`. Three call sites is three places
+  for a fourth ending to be forgotten in, which is
+  [State propagation is reactive](#state-propagation-is-reactive-or-it-is-a-bug-waiting)
+  applied to a teardown.
+- **`Component.onDestruction: root.closePreview()` is belt and braces, and the
+  measurement says so.** Planted out and re-run, the player is still reaped at
+  shutdown, because Quickshell kills a Process it owns. The line stays as a
+  statement of intent and is pinned by the source contract rather than by the
+  harness, since removing it reddens nothing at runtime - do not read it as the
+  mechanism.
+- **A state flag is not evidence a process died, and here it is exactly what
+  the bug already reported.** Every ending set the service's flags correctly
+  while the window stayed on screen, so
+  `tests/test_phone_preview_lifetime_runtime.py` scores `kill -0` against the
+  pid the player itself wrote, five ways: the stop button, the stream killed
+  under the shell and found by the watchdog, the player's window closed by the
+  user (after which a later stop must reap nothing - a control process is
+  asked), the phone leaving the daemon, and the shell exiting, which is the
+  driver's half with a control of its own. `droidcam-cli` cannot run on this
+  machine at all - built against ffmpeg 8 where the system has 9, so it dies on
+  `libswscale.so.9` - so the stream is a stub of that name, launched by the
+  REAL session script; it deliberately does not `exec`, because
+  `droidcam_session.sh` refuses to kill a pid whose cmdline has stopped looking
+  like droidcam's.
+45d0afbdd ("fix(phone): the webcam preview is a player the shell owns, not a detached spawn"),
+661189c35 ("test(phone): score the preview player's death against its pid, five ways"),
+96574ee7f ("test(phone): say which half of the shutdown reap is measured, and stop leaking a sleep").
 
 **A feature card reported its TOOLING and nothing else, so "the phone is reachable" was
 answering the wrong question.** The Phone tab's three cards gate on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ own repo; the installer pins which revision it builds.
 
 ## [Unreleased]
 
+### Fixed
+- **The phone webcam's preview window closes with the session instead of
+  freezing on screen.** Open the webcam, open the preview, then stop the
+  camera: the preview used to stay up, frozen on its last frame, and nothing in
+  the shell could close it - the player had been launched with no handle to
+  hold. It now closes whichever way the session ends: you press stop, the
+  stream drops on its own, the phone goes away, or the shell restarts. The
+  Preview button is a toggle too, so you can close the window from the page you
+  opened it from.
+
 ### Added
 - **The Phone tab pairs your phone over Wi-Fi instead of telling you to open a
   terminal.** The Android Apps page used to print the two commands Android 11

--- a/dots/.config/quickshell/imi/PhonePreviewLifetimeRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/PhonePreviewLifetimeRuntimeTest.qml
@@ -1,0 +1,379 @@
+import QtQuick
+import QtTest
+import Quickshell
+import Quickshell.Io
+import qs
+import qs.services
+import qs.modules.common
+
+/**
+ * The webcam preview player's LIFETIME, scored as a process that is either
+ * still there or reaped.
+ *
+ * The defect: `openPreview()` spawned the player with
+ * `Quickshell.execDetached`, which returns no handle - so ending the session
+ * stopped the stream and left the player's window on screen, frozen on the
+ * last frame the loopback device produced, with nothing in the shell able to
+ * close it. Every check below is `kill -0 <pid>` against the pid the player
+ * itself wrote, because "the flag went false" is exactly what the broken
+ * version would also have reported.
+ *
+ * Five ways a session can end are driven, each one to the pid:
+ *
+ *   1. the user presses stop;
+ *   2. the stream dies on its own and the service's own 5s watchdog finds
+ *      the pidfile's process gone;
+ *   3. the user closes the player's window, after which a later stop must
+ *      reap nothing - a control process the harness started is asked;
+ *   4. the phone disappears from the daemon;
+ *   5. the shell goes away, which is the driver's half: the harness exits
+ *      with a preview deliberately still up and
+ *      tests/test_phone_preview_lifetime_runtime.py asks the kernel
+ *      afterwards.
+ *
+ * The fakes are the load-bearing part. `droidcam-cli` on the maintainer's
+ * machine cannot run at all (built against ffmpeg 8 on a system with 9), so
+ * the stream is a stub of that name which prints the `Video: /dev/videoN`
+ * line the session script greps for and then sits still until it is signalled
+ * - and the REAL scripts/phone/droidcam_session.sh launches it, so the
+ * pidfile, the status verb and the stop verb are the shell's own. The player
+ * is a stub `mpv` which records its pid and then sits still likewise. Neither
+ * can reach anything of the maintainer's: every XDG directory, the compositor
+ * and the session bus belong to the driver.
+ *
+ * Driven by tests/test_phone_preview_lifetime_runtime.py.
+ *
+ *   PATH=<dir with the stubs>:$PATH qs -p PhonePreviewLifetimeRuntimeTest.qml
+ */
+ShellRoot {
+    id: harness
+
+    property int failures: 0
+    property int checksRun: 0
+    property int elapsed: 0
+
+    // Where the stub player writes its own pid, and the marker the fake
+    // daemon reads to decide whether the phone is still on the network.
+    readonly property string previewPidFile: Quickshell.env("PREVIEW_PIDFILE") ?? ""
+    readonly property string absentMarker: Quickshell.env("PHONE_ABSENT_MARKER") ?? ""
+
+    function check(label, ok) {
+        harness.checksRun++;
+        console.log(`[PhonePreviewLifetime] ${label}: ${ok ? "ok" : "FAIL"}`);
+        if (!ok)
+            harness.failures++;
+    }
+
+    function finish() {
+        console.log(`[PhonePreviewLifetime] checks: ${harness.checksRun} failures: ${harness.failures}`);
+        Qt.exit(harness.failures === 0 ? 0 : 1);
+    }
+
+    // ---- asking the kernel about a pid ------------------------------------
+    //
+    // A property flipping is not evidence a process died: the whole defect
+    // was a player nothing held, so the only honest instrument is `kill -0`
+    // against a real pid. It is argv, never a shell string, for the same
+    // reason the services are.
+
+    property int watchedPid: 0
+    property string watchedState: "unknown" // unknown | alive | gone
+
+    function watchPid(pid) {
+        harness.watchedState = "unknown";
+        harness.watchedPid = pid;
+    }
+
+    Process {
+        id: aliveProc
+        onExited: (exitCode, exitStatus) => {
+            harness.watchedState = exitCode === 0 ? "alive" : "gone";
+        }
+    }
+
+    Timer {
+        interval: 200
+        repeat: true
+        running: harness.watchedPid > 0
+        onTriggered: if (!aliveProc.running) aliveProc.exec(["kill", "-0", String(harness.watchedPid)])
+    }
+
+    // The pid the stub player wrote for itself. Read back rather than taken
+    // off the Process handle, so nothing about this measurement depends on a
+    // property the service would have to grow for a test.
+    property int playerPid: 0
+
+    Process {
+        id: readPid
+        stdout: StdioCollector { id: readPidOut }
+        onExited: (exitCode, exitStatus) => {
+            harness.playerPid = exitCode === 0 ? (parseInt(readPidOut.text.trim()) || 0) : 0;
+        }
+    }
+
+    function refreshPlayerPid() {
+        if (!readPid.running)
+            readPid.exec(["cat", harness.previewPidFile]);
+    }
+
+    // One-shot commands the harness itself issues (killing the stub stream,
+    // planting the daemon's marker). Serialized behind one Process, because a
+    // second exec on a running one terminates the first (AGENT.md).
+    property var pending: []
+
+    Process {
+        id: cmdProc
+        onExited: (exitCode, exitStatus) => harness.pump()
+    }
+
+    function runCmd(argv) {
+        harness.pending = harness.pending.concat([argv]);
+        harness.pump();
+    }
+
+    function pump() {
+        if (cmdProc.running || harness.pending.length === 0)
+            return;
+        const next = harness.pending[0];
+        harness.pending = harness.pending.slice(1);
+        cmdProc.exec(next);
+    }
+
+    // The control for "a stop reaps only what it started": an unrelated
+    // process, alive throughout, asked after the stop that follows a player
+    // the user closed by hand. Without it, "nothing else died" is a claim
+    // about a machine nobody looked at.
+    Process { id: sentinel }
+
+    // ---- the step runner ---------------------------------------------------
+
+    property var waitPredicate: null
+    property string waitLabel: ""
+    property int waitElapsed: 0
+    readonly property int waitTimeoutMs: 30000
+
+    function waitUntil(label, predicate) {
+        harness.waitLabel = label;
+        harness.waitPredicate = predicate;
+        harness.waitElapsed = 0;
+    }
+
+    function waitForPlayerGone() {
+        harness.watchPid(harness.playerPid);
+        harness.waitUntil("the player is reaped", () => harness.watchedState === "gone");
+    }
+
+    function waitForPlayerUp() {
+        harness.waitUntil("the player starts and writes its pid", () => {
+            if (!PhoneCamera.previewRunning)
+                return false;
+            harness.refreshPlayerPid();
+            return harness.playerPid > 0;
+        });
+    }
+
+    // The pidfile is emptied before every open, and the wait is on it being
+    // gone: a round that read the file too early would find the PREVIOUS
+    // round's pid sitting in it, which is dead, and would then score a
+    // perfectly good player as never having started.
+    function waitPidfileCleared() {
+        harness.runCmd(["rm", "-f", harness.previewPidFile]);
+        harness.waitUntil("the player's pidfile is cleared", () => {
+            harness.refreshPlayerPid();
+            return harness.playerPid === 0;
+        });
+    }
+
+    Component.onCompleted: {
+        // A singleton is constructed on first use; this read starts the
+        // presence probes and the daemon sweep.
+        console.log(`[PhonePreviewLifetime] services constructed, installed=${PhoneConnect.installed}`);
+    }
+
+    Timer {
+        id: waitForReady
+        interval: 250
+        repeat: true
+        running: true
+        onTriggered: {
+            harness.elapsed += waitForReady.interval;
+            const ready = Config.ready && PhoneConnect.installed
+                && PhoneConnect.devices.length === 1 && PhoneDeps.ready
+                && PhoneCamera.available;
+            if (!ready) {
+                if (harness.elapsed >= 40000) {
+                    harness.check(`the fake daemon answered and the probes settled`
+                                  + ` (devices ${PhoneConnect.devices.length},`
+                                  + ` deps ready ${PhoneDeps.ready},`
+                                  + ` camera available ${PhoneCamera.available})`, false);
+                    harness.finish();
+                }
+                return;
+            }
+            waitForReady.running = false;
+            steps.running = true;
+        }
+    }
+
+    property var stepList: [
+        () => sentinel.exec(["sleep", "600"]),
+
+        // ---- 1. the user presses stop --------------------------------------
+        () => PhoneCamera.start(),
+        () => harness.waitUntil("the stream comes up",
+                                () => PhoneCamera.active && PhoneCamera.device.length > 0),
+        () => harness.check(`the stub stream is live on ${PhoneCamera.device}`
+                            + ` at pid ${PhoneCamera.sessionPid}`,
+                            PhoneCamera.active && PhoneCamera.sessionPid > 0),
+        () => harness.waitPidfileCleared(),
+        () => PhoneCamera.openPreview(),
+        () => harness.waitForPlayerUp(),
+        () => harness.watchPid(harness.playerPid),
+        () => harness.waitUntil("the player is alive", () => harness.watchedState === "alive"),
+        () => harness.check(`the player is running at pid ${harness.playerPid}`,
+                            PhoneCamera.previewRunning && harness.watchedState === "alive"),
+        () => PhoneCamera.stop(),
+        () => harness.waitForPlayerGone(),
+        () => harness.check(`the stop button reaps the player, pid ${harness.playerPid}`
+                            + ` is ${harness.watchedState}`,
+                            harness.watchedState === "gone" && !PhoneCamera.previewRunning),
+
+        // ---- 2. the stream dies on its own, the watchdog finds it ----------
+        () => PhoneCamera.start(),
+        () => harness.waitUntil("the stream comes up again",
+                                () => PhoneCamera.active && PhoneCamera.device.length > 0),
+        () => harness.check(`the stub stream is live again at pid ${PhoneCamera.sessionPid}`,
+                            PhoneCamera.active && PhoneCamera.sessionPid > 0),
+        () => harness.waitPidfileCleared(),
+        () => PhoneCamera.openPreview(),
+        () => harness.waitForPlayerUp(),
+        () => harness.watchPid(harness.playerPid),
+        () => harness.waitUntil("the player is alive", () => harness.watchedState === "alive"),
+        () => harness.check(`the player is running at pid ${harness.playerPid}`,
+                            PhoneCamera.previewRunning && harness.watchedState === "alive"),
+        // Nothing in the shell asks for this: the stream is killed under it,
+        // the way droidcam-cli exits when the phone leaves the network.
+        () => harness.runCmd(["kill", String(PhoneCamera.sessionPid)]),
+        () => harness.waitUntil("the watchdog notices the stream has gone",
+                                () => !PhoneCamera.active),
+        () => harness.check(`the watchdog ended the session by itself,`
+                            + ` lastError "${PhoneCamera.lastError}"`,
+                            !PhoneCamera.active && PhoneCamera.lastError.length > 0),
+        () => harness.waitForPlayerGone(),
+        () => harness.check(`...and the player went with it, pid ${harness.playerPid}`
+                            + ` is ${harness.watchedState}`,
+                            harness.watchedState === "gone" && !PhoneCamera.previewRunning),
+
+        // ---- 3. the user closes the player's window ------------------------
+        () => PhoneCamera.start(),
+        () => harness.waitUntil("the stream comes up a third time",
+                                () => PhoneCamera.active && PhoneCamera.device.length > 0),
+        () => harness.check(`the stub stream is live a third time at pid ${PhoneCamera.sessionPid}`,
+                            PhoneCamera.active && PhoneCamera.sessionPid > 0),
+        () => harness.waitPidfileCleared(),
+        () => PhoneCamera.openPreview(),
+        () => harness.waitForPlayerUp(),
+        () => harness.watchPid(harness.playerPid),
+        () => harness.waitUntil("the player is alive", () => harness.watchedState === "alive"),
+        () => harness.check(`the player is running at pid ${harness.playerPid}`,
+                            PhoneCamera.previewRunning && harness.watchedState === "alive"),
+        () => harness.runCmd(["kill", String(harness.playerPid)]),
+        () => harness.waitUntil("the service hears the player exit",
+                                () => !PhoneCamera.previewRunning),
+        () => harness.check(`closing the window clears the handle, previewRunning`
+                            + ` ${PhoneCamera.previewRunning}`,
+                            !PhoneCamera.previewRunning),
+        // The pid the player held is now free for the kernel to reissue. A
+        // service tracking that number would spend the stop below on
+        // whatever holds it; a Process handle has nothing left to address.
+        () => PhoneCamera.stop(),
+        () => harness.waitUntil("the session ends", () => !PhoneCamera.active),
+        () => harness.watchPid(parseInt(String(sentinel.processId)) || 0),
+        () => harness.waitUntil("the control process answers",
+                                () => harness.watchedState !== "unknown"),
+        () => harness.check(`a stop after the player has gone reaps nothing else,`
+                            + ` the control at pid ${harness.watchedPid} is ${harness.watchedState}`,
+                            harness.watchedPid > 0 && harness.watchedState === "alive"),
+
+        // ---- 4. the phone disappears from the daemon ----------------------
+        () => PhoneCamera.start(),
+        () => harness.waitUntil("the stream comes up a fourth time",
+                                () => PhoneCamera.active && PhoneCamera.device.length > 0),
+        () => harness.check(`the stub stream is live a fourth time at pid ${PhoneCamera.sessionPid}`,
+                            PhoneCamera.active && PhoneCamera.sessionPid > 0),
+        () => harness.waitPidfileCleared(),
+        () => PhoneCamera.openPreview(),
+        () => harness.waitForPlayerUp(),
+        () => harness.watchPid(harness.playerPid),
+        () => harness.waitUntil("the player is alive", () => harness.watchedState === "alive"),
+        () => harness.check(`the player is running at pid ${harness.playerPid}`,
+                            PhoneCamera.previewRunning && harness.watchedState === "alive"),
+        // The daemon stops listing the phone, and the shell's own sweep is
+        // what notices - never a write to the model from here.
+        () => harness.runCmd(["touch", harness.absentMarker]),
+        () => PhoneConnect.refresh(),
+        () => harness.waitUntil("the daemon stops reporting the phone",
+                                () => PhoneConnect.devices.length === 0),
+        () => harness.check(`the phone is gone from the daemon's list,`
+                            + ` activeDevice ${PhoneConnect.activeDevice === null}`,
+                            PhoneConnect.devices.length === 0 && !PhoneCamera.deviceReachable),
+        () => harness.waitUntil("the session ends with the device", () => !PhoneCamera.active),
+        () => harness.check(`the session ended with the device`, !PhoneCamera.active),
+        () => harness.waitForPlayerGone(),
+        () => harness.check(`...and the player went with it, pid ${harness.playerPid}`
+                            + ` is ${harness.watchedState}`,
+                            harness.watchedState === "gone" && !PhoneCamera.previewRunning),
+
+        // ---- 5. the shell goes away, with a preview deliberately up --------
+        () => harness.runCmd(["rm", "-f", harness.absentMarker]),
+        () => PhoneConnect.refresh(),
+        () => harness.waitUntil("the phone comes back", () => PhoneConnect.devices.length === 1),
+        () => harness.check(`the phone is back on the daemon's list`,
+                            PhoneConnect.devices.length === 1 && PhoneCamera.deviceReachable),
+        () => PhoneCamera.start(),
+        () => harness.waitUntil("the stream comes up a fifth time",
+                                () => PhoneCamera.active && PhoneCamera.device.length > 0),
+        () => harness.waitPidfileCleared(),
+        () => PhoneCamera.openPreview(),
+        () => harness.waitForPlayerUp(),
+        () => harness.watchPid(harness.playerPid),
+        () => harness.waitUntil("the player is alive", () => harness.watchedState === "alive"),
+        () => {
+            // The before half of the driver's after: it reads this pid back
+            // out of the same file once this process is gone, and a check
+            // that only ran afterwards would pass on a player that never
+            // started.
+            console.log(`[PhonePreviewLifetime] player pid at exit: ${harness.playerPid}`);
+            harness.check(`the player is up as the shell exits, pid ${harness.playerPid}`
+                          + ` is ${harness.watchedState}`,
+                          PhoneCamera.previewRunning && harness.watchedState === "alive");
+        },
+
+        () => harness.finish()
+    ]
+
+    property int stepIndex: 0
+    Timer {
+        id: steps
+        interval: 250
+        repeat: true
+        onTriggered: {
+            if (harness.waitPredicate !== null) {
+                if (harness.waitPredicate()) {
+                    harness.waitPredicate = null;
+                    return;
+                }
+                harness.waitElapsed += steps.interval;
+                if (harness.waitElapsed < harness.waitTimeoutMs)
+                    return;
+                harness.check(`${harness.waitLabel} (gave up after ${harness.waitElapsed}ms)`, false);
+                harness.waitPredicate = null;
+                harness.finish();
+                return;
+            }
+            if (harness.stepIndex >= harness.stepList.length)
+                return;
+            harness.stepList[harness.stepIndex++]();
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneWebcamPage.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneWebcamPage.qml
@@ -192,27 +192,40 @@ PhoneSubPage {
                 }
 
                 RippleButton {
+                    id: previewButton
                     Layout.fillWidth: true
                     Layout.preferredHeight: Appearance.font.pixelSize.huge + Appearance.spacing.space250
-                    enabled: PhoneCamera.active && PhoneCamera.device.length > 0
+                    // A preview that is up stays closable whatever the stream
+                    // is doing. The service already closes it with the session,
+                    // so this row only has to cover the one ending the shell
+                    // cannot see coming - the user changing their mind.
+                    enabled: PhoneCamera.previewRunning
+                        || (PhoneCamera.active && PhoneCamera.device.length > 0)
                     buttonRadius: Appearance.rounding.normal
                     colBackground: Appearance.colors.colLayer2
                     colBackgroundHover: Appearance.colors.colLayer2Hover
                     colRipple: Appearance.colors.colLayer2Active
-                    onClicked: PhoneCamera.openPreview()
+                    onClicked: {
+                        if (PhoneCamera.previewRunning)
+                            PhoneCamera.closePreview();
+                        else
+                            PhoneCamera.openPreview();
+                    }
 
                     contentItem: RowLayout {
                         spacing: Appearance.spacing.space75
 
                         MaterialSymbol {
                             Layout.alignment: Qt.AlignVCenter
-                            text: "preview"
+                            text: PhoneCamera.previewRunning ? "visibility_off" : "preview"
                             iconSize: Appearance.font.pixelSize.larger
                             color: Appearance.colors.colOnLayer2
                         }
                         StyledText {
                             Layout.alignment: Qt.AlignVCenter
-                            text: Translation.tr("Preview")
+                            text: PhoneCamera.previewRunning
+                                ? Translation.tr("Close preview")
+                                : Translation.tr("Preview")
                             font.pixelSize: Appearance.font.pixelSize.smaller
                             font.weight: Font.DemiBold
                             color: Appearance.colors.colOnLayer2

--- a/dots/.config/quickshell/imi/services/PhoneCamera.qml
+++ b/dots/.config/quickshell/imi/services/PhoneCamera.qml
@@ -22,6 +22,12 @@ import qs.modules.common
  * Wi-Fi address is taken as written; otherwise `adb get-state` answering
  * `device` wins, then the first address KDE Connect reports for the phone.
  *
+ * The preview PLAYER is the one process this file owns outright, and it is
+ * deliberately the opposite arrangement to the stream's: the stream outlives
+ * the shell because a webcam other applications are using has to, while a
+ * preview is a view of that stream and its lifetime is the session's. See
+ * the `previewProc` block for what "owned" buys and what it costs.
+ *
  * Everything between the sync markers is kept byte-for-byte in sync with
  * the logic-only double (tests/imports/testservices/PhoneCamera.qml);
  * tests/test_phone_sessions_contract.py enforces it.
@@ -47,6 +53,7 @@ Singleton {
     property int startedAt: 0 // unix seconds
     property string lastError: ""
     property bool userStopped: false
+    readonly property bool previewRunning: previewProc.running
 
     readonly property string sessionScript: `${Directories.scriptPath}/phone/droidcam_session.sh`
     readonly property int connectTimeoutMs: 9000
@@ -272,16 +279,66 @@ Singleton {
             root.run(["v4l2-ctl", "-d", root.device, "--set-ctrl=horizontal_flip=" + (on ? "1" : "0")], null);
     }
 
+    // The preview belongs to the SESSION, not to the desktop: a player left
+    // on a /dev/videoN that has stopped producing frames holds its last frame
+    // on screen for ever, which is what it looks like when nothing owns it.
+    // So the player is started through startPreview() - a handle, never a
+    // detached spawn - and a second click while one is up is not a second
+    // window.
     function openPreview(): void {
+        if (root.previewRunning) return;
         const argv = root.previewCommand(root.device, PhoneDeps);
         if (argv.length === 0) {
             root.lastError = "No preview player found - install mpv";
             root.errorOccurred(root.lastError);
             return;
         }
-        Quickshell.execDetached(argv);
+        root.startPreview(argv);
     }
+
+    function closePreview(): void {
+        if (!root.previewRunning) return;
+        root.stopPreview();
+    }
+
+    // One observer rather than a closePreview() in stop(), in checkSession()'s
+    // death branch and in fail(): `active` IS the session, so every way the
+    // session can end arrives here - the stop button, the watchdog finding the
+    // pidfile dead, a connect that timed out, and the device disappearing,
+    // which reaches it through onActiveDeviceIdChanged's own stop().
+    onActiveChanged: if (!root.active) root.closePreview();
     // END phone-camera logic
+
+    // ---- the preview player ----
+    //
+    // Owned rather than detached, and that IS the fix. `Quickshell.
+    // execDetached` returns no handle, so nothing in the shell could stop the
+    // player: ending the session left its window on screen, frozen on the last
+    // frame the loopback device produced.
+    //
+    // The alternative - detach it and record the pid, the way the stream's own
+    // session script does - buys a stop and costs a stale one. A stream is
+    // stopped only by this shell, so its pid is good until it is used; a
+    // player is closed by the USER at any moment, so a pid recorded when it
+    // started is a number the kernel is free to hand to something else, and a
+    // later stop would kill a stranger. A Process cannot address anything it
+    // did not start, which is why that is the shape here and a pidfile is the
+    // shape beside droidcam_session.sh.
+    //
+    // What it costs: the player does not outlive a shell restart the way the
+    // stream deliberately does. A preview is one click to reopen; an
+    // unstoppable one is the bug being fixed.
+    function startPreview(argv: var): void { previewProc.exec(argv); }
+    function stopPreview(): void { previewProc.running = false; }
+
+    Process {
+        id: previewProc
+        // process-lifecycle: restart-safe -- no `running:` binding and no
+        // respawn of any kind. The player starts only from a click through
+        // openPreview() and stops only through closePreview(), so a player
+        // that exits instantly (a node it refuses, a missing codec) cannot
+        // become a respawn loop.
+    }
 
     // ---- timers ----
 
@@ -360,6 +417,12 @@ Singleton {
 
     // A webcam left running by the previous shell is adopted, not doubled.
     Component.onCompleted: root.checkSession()
+
+    // The player is this process's child, so a clean exit takes it with it.
+    // Saying so out loud makes a reload a decision rather than a property of
+    // Quickshell's teardown order - and the stream, which is not a child, is
+    // still there to be re-adopted when the shell comes back.
+    Component.onDestruction: root.closePreview()
 
     onActiveDeviceIdChanged: if (root.active || root.connecting) root.stop()
 }

--- a/dots/.config/quickshell/imi/services/PhoneCamera.qml
+++ b/dots/.config/quickshell/imi/services/PhoneCamera.qml
@@ -418,10 +418,13 @@ Singleton {
     // A webcam left running by the previous shell is adopted, not doubled.
     Component.onCompleted: root.checkSession()
 
-    // The player is this process's child, so a clean exit takes it with it.
-    // Saying so out loud makes a reload a decision rather than a property of
-    // Quickshell's teardown order - and the stream, which is not a child, is
-    // still there to be re-adopted when the shell comes back.
+    // Belt and braces, and measured as such: planted out and re-run, the
+    // player is STILL reaped when the shell exits, because Quickshell kills a
+    // Process it owns rather than leaving it behind. So this line states that
+    // the preview's death at shutdown is intended - it is not the mechanism
+    // that produces it, and it must not be read as one. The stream is not a
+    // child of this process and is untouched either way, which is what lets
+    // it be re-adopted when the shell comes back.
     Component.onDestruction: root.closePreview()
 
     onActiveDeviceIdChanged: if (root.active || root.connecting) root.stop()

--- a/dots/.config/quickshell/imi/tests/imports/testservices/PhoneCamera.qml
+++ b/dots/.config/quickshell/imi/tests/imports/testservices/PhoneCamera.qml
@@ -254,16 +254,55 @@ Singleton {
             root.run(["v4l2-ctl", "-d", root.device, "--set-ctrl=horizontal_flip=" + (on ? "1" : "0")], null);
     }
 
+    // The preview belongs to the SESSION, not to the desktop: a player left
+    // on a /dev/videoN that has stopped producing frames holds its last frame
+    // on screen for ever, which is what it looks like when nothing owns it.
+    // So the player is started through startPreview() - a handle, never a
+    // detached spawn - and a second click while one is up is not a second
+    // window.
     function openPreview(): void {
+        if (root.previewRunning) return;
         const argv = root.previewCommand(root.device, PhoneDeps);
         if (argv.length === 0) {
             root.lastError = "No preview player found - install mpv";
             root.errorOccurred(root.lastError);
             return;
         }
-        Quickshell.execDetached(argv);
+        root.startPreview(argv);
     }
+
+    function closePreview(): void {
+        if (!root.previewRunning) return;
+        root.stopPreview();
+    }
+
+    // One observer rather than a closePreview() in stop(), in checkSession()'s
+    // death branch and in fail(): `active` IS the session, so every way the
+    // session can end arrives here - the stop button, the watchdog finding the
+    // pidfile dead, a connect that timed out, and the device disappearing,
+    // which reaches it through onActiveDeviceIdChanged's own stop().
+    onActiveChanged: if (!root.active) root.closePreview();
     // END phone-camera logic
+
+    // The player, as a record of what the service asked for: `run()`'s shape
+    // one process down. The real service hands these to a Process it owns
+    // (services/PhoneCamera.qml, the previewProc block); what a double can
+    // answer for is the DECISIONS - which argv, whether a second click opens
+    // a second window, and which endings close it.
+    property bool previewRunning: false
+    property var previewCommands: []
+    property int previewStops: 0
+
+    function startPreview(argv: var): void {
+        root.previewCommands = root.previewCommands.concat([argv]);
+        root.previewRunning = true;
+    }
+
+    function stopPreview(): void {
+        root.previewStops++;
+        root.previewRunning = false;
+    }
+
     property real connectStartedAt: 0
     property bool deadlinePassed: false
     function connectDeadlinePassed(): bool { return root.deadlinePassed; }
@@ -299,5 +338,11 @@ Singleton {
         root.watchdogArmed = 0;
         root.responder = null;
         root.ranCommands = [];
+        // After `active`, never before: clearing it above runs the same
+        // onActiveChanged the service does, which would spend a stop on the
+        // counter this line is resetting.
+        root.previewRunning = false;
+        root.previewCommands = [];
+        root.previewStops = 0;
     }
 }

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -1860,6 +1860,18 @@ if ! python3 "$SCRIPT_DIR/test_phone_subpage_width_runtime.py"; then
     exit 1
 fi
 
+# The webcam preview player's lifetime, scored as a process rather than as a
+# flag: a stub stream is ended five ways - the stop button, the watchdog
+# finding it dead, the user closing the player's window, the phone leaving the
+# daemon, and the shell itself exiting - and each one asks `kill -0` about the
+# pid the player wrote. It used to be spawned with execDetached, which returns
+# no handle, so every one of those left a window frozen on a dead /dev/videoN.
+echo "Running Phone preview lifetime runtime tests..."
+if ! python3 "$SCRIPT_DIR/test_phone_preview_lifetime_runtime.py"; then
+    echo "Phone preview lifetime runtime tests failed."
+    exit 1
+fi
+
 # The phone's notification mirror: the parser region synced with its double,
 # argv only, dismiss on the LEAF, the declared reply refetch delay, one
 # stream, the desktop dedupe gate at ingestion, and the cache key declared.

--- a/dots/.config/quickshell/imi/tests/test_phone_preview_lifetime_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_preview_lifetime_runtime.py
@@ -87,7 +87,11 @@ case "$*" in
     printf '{"type":"a{sv}","data":[{"name":{"type":"s","data":"%(name)s"},"type":{"type":"s","data":"phone"},"isPaired":{"type":"b","data":true},"isReachable":{"type":"b","data":true},"isPairRequestedByPeer":{"type":"b","data":false},"pairState":{"type":"i","data":3},"reachableAddresses":{"type":"as","data":["%(address)s"]}}]}\\n'
     ;;
   *monitor*)
-    sleep 3600
+    # `exec`, so the pid the shell holds IS the sleep: a bash that merely
+    # waits on one leaves the sleep behind as an orphan every time the
+    # harness exits, which is how the machine collects an hour's worth of
+    # them over a few runs.
+    exec sleep 3600
     ;;
 esac
 exit 0

--- a/dots/.config/quickshell/imi/tests/test_phone_preview_lifetime_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_preview_lifetime_runtime.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""The webcam preview player is gone after every way the session can end.
+
+`PhonePreviewLifetimeRuntimeTest.qml` opens the preview over a stub DroidCam
+session and then ends that session five different ways, asking `kill -0` about
+the player's own pid each time. It exists because the player used to be
+spawned with `Quickshell.execDetached`, which returns no handle: `stop()`
+killed the stream and nothing could kill the player, so its window stayed on
+screen frozen on the last frame a dead /dev/videoN produced. A check on the
+service's own state would have passed on that bug in every one of these cases -
+the flag it reads is not what was left running.
+
+Four of the five endings are the harness's; the fifth is this file's. The
+harness deliberately exits with a preview still up, and the assertions below
+ask the kernel afterwards, with a control process this driver started so that
+"gone" cannot be what a broken liveness check says about everything.
+
+The fakes are the load-bearing part, and one of them is not a convenience:
+`droidcam-cli` cannot run on this machine at all - it is built against ffmpeg 8
+where the system has 9, so it dies on `libswscale.so.9` before doing anything -
+so there is no version of this test that drives the real tool. The stub of that
+name prints the `Video: /dev/videoN` line the session script greps for and then
+sits still until it is signalled, and the REAL scripts/phone/droidcam_session.sh
+launches it, so the pidfile, the `status` verb and the `stop` verb under test
+are the shell's own. Every other tool `PhoneDeps` probes is stubbed too - the
+reason the sibling width harness gives, plus one of this test's own: `pactl` is
+here so nothing it starts can reach the session's audio, and `mpv` is here so
+nothing it starts can open a window on the maintainer's screen.
+
+Brings its own headless weston, its own XDG directories and its own session bus
+(`dbus-run-session`). Skips when weston, qs or dbus-run-session are missing, as
+in CI.
+"""
+
+import json
+import os
+import shutil
+import signal
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HARNESS = ROOT / "PhonePreviewLifetimeRuntimeTest.qml"
+SESSION_SCRIPT = ROOT / "scripts" / "phone" / "droidcam_session.sh"
+SOCKET = "wayland-imi-preview-life"
+
+PHONE_ID = "6131a746_571a_4176_a007_95625ff8e08e"
+PHONE_NAME = "Galaxy S23 Ultra"
+PHONE_ADDRESS = "192.168.100.179"
+
+# A literal, never read back out of the harness's own output: a step list that
+# loses a round must redden here instead of reporting `failures: 0` for a
+# shorter run.
+EXPECTED_CHECKS = 18
+
+# The daemon, with one switch: while PHONE_ABSENT_MARKER exists it reports no
+# devices at all, which is how the harness makes the phone leave without
+# writing to the shell's own model.
+BUSCTL = """\
+#!/usr/bin/env bash
+absent=0
+if [ -n "${PHONE_ABSENT_MARKER:-}" ] && [ -f "$PHONE_ABSENT_MARKER" ]; then absent=1; fi
+case "$*" in
+  *"org.freedesktop.DBus ListNames")
+    printf '{"type":"as","data":[[":1.5","org.freedesktop.DBus","org.kde.kdeconnect.daemon"]]}\\n'
+    ;;
+  *"org.kde.kdeconnect.daemon devices bb false false")
+    if [ "$absent" = "1" ]; then
+      printf '{"type":"as","data":[[]]}\\n'
+    else
+      printf '{"type":"as","data":[["%(phone)s"]]}\\n'
+    fi
+    ;;
+  *"/notifications org.kde.kdeconnect.device.notifications activeNotifications")
+    printf '{"type":"as","data":[[]]}\\n'
+    ;;
+  *"devices/%(phone)s/battery org.freedesktop.DBus.Properties GetAll s org.kde.kdeconnect.device.battery")
+    printf '{"type":"a{sv}","data":[{"charge":{"type":"i","data":85},"hasBattery":{"type":"b","data":true},"isCharging":{"type":"b","data":false}}]}\\n'
+    ;;
+  *"devices/%(phone)s/connectivity_report org.freedesktop.DBus.Properties GetAll s org.kde.kdeconnect.device.connectivity_report")
+    printf '{"type":"a{sv}","data":[{"cellularNetworkStrength":{"type":"i","data":4},"cellularNetworkType":{"type":"s","data":"LTE"},"iconName":{"type":"s","data":"network-mobile-100-lte"}}]}\\n'
+    ;;
+  *"devices/%(phone)s org.freedesktop.DBus.Properties GetAll s org.kde.kdeconnect.device")
+    printf '{"type":"a{sv}","data":[{"name":{"type":"s","data":"%(name)s"},"type":{"type":"s","data":"phone"},"isPaired":{"type":"b","data":true},"isReachable":{"type":"b","data":true},"isPairRequestedByPeer":{"type":"b","data":false},"pairState":{"type":"i","data":3},"reachableAddresses":{"type":"as","data":["%(address)s"]}}]}\\n'
+    ;;
+  *monitor*)
+    sleep 3600
+    ;;
+esac
+exit 0
+"""
+
+# The stream: it announces its node the way droidcam-cli does (the session
+# script greps that line out of the log to answer `device`), then stays alive
+# until something signals it. It must NOT `exec` anything: droidcam_session.sh
+# refuses to kill a pid whose cmdline has stopped looking like droidcam's, and
+# an exec would rewrite exactly that.
+DROIDCAM = """\
+echo "Video: /dev/video42"
+trap 'exit 0' TERM INT
+left=900
+while [ "$left" -gt 0 ]; do
+  sleep 1 &
+  wait $! 2>/dev/null || true
+  left=$((left - 1))
+done
+exit 0
+"""
+
+# The player: it records its own pid and then behaves like mpv on a live
+# capture device - alive until killed. `exec` is right here (nothing greps this
+# cmdline) and keeps the pid it just wrote.
+MPV = """\
+echo $$ > "$PREVIEW_PIDFILE"
+exec sleep 900
+"""
+
+ADB = """\
+case "${1:-}" in
+  get-state) echo "device" ;;
+  devices)
+    echo "List of devices attached"
+    printf 'R5CT30FAKE\\tdevice\\n'
+    ;;
+esac
+exit 0
+"""
+
+# Every tool PhoneDeps probes, so the webcam reports itself available and no
+# probe reaches a real one.
+STUBS = {
+    "droidcam-cli": DROIDCAM,
+    "mpv": MPV,
+    "adb": ADB,
+    "pactl": 'case "$*" in\n'
+             '  "get-default-sink") echo "alsa_output.fake.stub" ;;\n'
+             '  "get-default-source") echo "alsa_input.fake.stub" ;;\n'
+             'esac\nexit 0\n',
+    "scrcpy": 'echo "scrcpy 4.1 <https://github.com/Genymobile/scrcpy>"\nexit 0\n',
+    "v4l2-ctl": "exit 0\n",
+    "ffplay": "exit 0\n",
+    "vlc": "exit 0\n",
+    "kdialog": "exit 0\n",
+    "wl-paste": "exit 0\n",
+    # Reported loaded, so the webcam is available whatever this machine has.
+    "lsmod": 'echo "Module Size Used by"\necho "v4l2loopback 40960 0"\nexit 0\n',
+    "modinfo": "exit 0\n",
+}
+
+
+def _stop(proc):
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+
+
+def _alive(pid):
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except (ProcessLookupError, PermissionError):
+        return False
+    return True
+
+
+def _runtime_available():
+    return all(shutil.which(name) for name in ("qs", "weston", "dbus-run-session"))
+
+
+@unittest.skipUnless(_runtime_available(), "needs qs, weston and dbus-run-session on PATH")
+class PhonePreviewLifetimeRuntimeTest(unittest.TestCase):
+    def setUp(self):
+        self.home = Path(tempfile.mkdtemp(prefix="imi-preview-life-"))
+        self.addCleanup(shutil.rmtree, self.home, ignore_errors=True)
+
+        self.bin = self.home / "bin"
+        self.bin.mkdir(parents=True)
+        busctl = self.bin / "busctl"
+        busctl.write_text(BUSCTL % {
+            "phone": PHONE_ID, "name": PHONE_NAME, "address": PHONE_ADDRESS,
+        })
+        busctl.chmod(0o755)
+        for name, body in STUBS.items():
+            stub = self.bin / name
+            stub.write_text("#!/usr/bin/env bash\n" + body)
+            stub.chmod(0o755)
+
+        self.pidfile = self.home / "preview.pid"
+        self.absent_marker = self.home / "phone-absent"
+
+        shell_config = self.home / "config" / "immaterial-impulse"
+        shell_config.mkdir(parents=True)
+        # The poll is ten minutes out: the startup sweep populates the model,
+        # and the only other sweep in the run is the refresh() the harness asks
+        # for when it makes the phone leave and come back. A live poll would
+        # answer that question on its own schedule instead.
+        (shell_config / "config.json").write_text(json.dumps({
+            "networking": {"phoneConnect": {"enable": True, "pollInterval": 600000}},
+            "phone": {"contacts": {"enabled": False}},
+        }, indent=2))
+
+    def _env(self):
+        env = dict(os.environ)
+        runtime = self.home / "runtime"
+        runtime.mkdir(mode=0o700, exist_ok=True)
+        env["XDG_RUNTIME_DIR"] = str(runtime)
+        env["WAYLAND_DISPLAY"] = SOCKET
+        env.pop("DISPLAY", None)
+        env.pop("HYPRLAND_INSTANCE_SIGNATURE", None)
+        env["LIBGL_ALWAYS_SOFTWARE"] = "1"
+        env["QT_QUICK_BACKEND"] = "software"
+        env["XDG_CONFIG_HOME"] = str(self.home / "config")
+        env["XDG_STATE_HOME"] = str(self.home / "state")
+        env["XDG_CACHE_HOME"] = str(self.home / "cache")
+        env["XDG_DATA_HOME"] = str(self.home / "data")
+        env["PATH"] = f"{self.bin}{os.pathsep}{env['PATH']}"
+        env["PREVIEW_PIDFILE"] = str(self.pidfile)
+        env["PHONE_ABSENT_MARKER"] = str(self.absent_marker)
+        return env
+
+    def _stop_stub_session(self, env):
+        """The stream is detached on purpose and outlives the shell, which is
+        the one process this test must clean up after itself."""
+        subprocess.run(["bash", str(SESSION_SCRIPT), "stop", "video"],
+                       env=env, capture_output=True, text=True, timeout=60)
+
+    def test_the_preview_player_is_gone_after_every_way_the_session_ends(self):
+        env = self._env()
+        self.addCleanup(self._stop_stub_session, env)
+
+        weston = subprocess.Popen(
+            ["weston", "--backend=headless", "--renderer=pixman",
+             f"--socket={SOCKET}", "--width=900", "--height=1000"],
+            env=env, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        self.addCleanup(_stop, weston)
+
+        socket_path = Path(env["XDG_RUNTIME_DIR"]) / SOCKET
+        deadline = time.monotonic() + 15
+        while not socket_path.exists() and time.monotonic() < deadline:
+            time.sleep(0.2)
+        self.assertTrue(socket_path.exists(), "headless weston never came up")
+
+        # The control for the after-the-shell check below: a process this
+        # driver started, still running when the shell's player must not be.
+        # Without it, "the player is gone" is equally what a liveness test that
+        # answers `False` for everything reports.
+        control = subprocess.Popen(["sleep", "600"])
+        self.addCleanup(_stop, control)
+
+        # dbus-run-session, not the inherited bus: the fake busctl is the only
+        # daemon this harness may see.
+        proc = subprocess.run(
+            ["dbus-run-session", "--", "qs", "-p", str(HARNESS)],
+            cwd=str(ROOT), env=env, capture_output=True, text=True, timeout=600)
+        output = proc.stdout + proc.stderr
+        failed = [line for line in output.splitlines() if "FAIL" in line]
+        self.assertEqual(failed, [], f"harness reported failures:\n{output}")
+        self.assertIn(f"[PhonePreviewLifetime] checks: {EXPECTED_CHECKS} failures: 0", output,
+                      f"harness did not finish cleanly:\n{output}")
+
+        # ---- the fifth ending: the shell itself went away -------------------
+        #
+        # The harness exited with a preview deliberately still up and said so
+        # in the line above, so this is a before-and-after rather than a
+        # question about a player that may never have started.
+        self.assertTrue(self.pidfile.exists(), f"the stub player wrote no pid:\n{output}")
+        pid = int(self.pidfile.read_text().strip())
+        self.assertGreater(pid, 0, "the stub player wrote no pid")
+
+        deadline = time.monotonic() + 10
+        while _alive(pid) and time.monotonic() < deadline:
+            time.sleep(0.2)
+        still_there = _alive(pid)
+        if still_there:
+            # Never leave a 900-second sleep behind on the maintainer's
+            # machine, whatever the verdict is.
+            try:
+                os.kill(pid, signal.SIGKILL)
+            except OSError:
+                pass
+        self.assertTrue(_alive(control.pid),
+                        "the control process died too, so this measurement says "
+                        "nothing about the player")
+        self.assertFalse(still_there,
+                         f"the preview player at pid {pid} outlived the shell that "
+                         f"started it, with nothing left able to stop it:\n{output}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dots/.config/quickshell/imi/tests/test_phone_sessions_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_sessions_contract.py
@@ -20,7 +20,13 @@ CONTRIBUTING.md names outright:
   managerWanted() before stopping anything;
 - the DroidCam sessions are launched detached through droidcam_session.sh
   rather than held by a Process, and the microphone's default-sink swap is
-  both persisted and undone on every exit path.
+  both persisted and undone on every exit path;
+- the webcam PREVIEW is the opposite arrangement, deliberately: it is a
+  Process the service owns, because `Quickshell.execDetached` returns no
+  handle and a player nothing can stop sits frozen on a /dev/videoN that has
+  stopped producing frames. Which endings actually reap it is
+  tests/test_phone_preview_lifetime_runtime.py's question; this half pins that
+  there is one player, one observer of the session, and no detached spawn.
 """
 
 import re
@@ -98,6 +104,12 @@ def _process_block(source: str, process_id: str) -> str:
         if re.search(rf"\bid:\s*{process_id}\b", block):
             return block
     raise AssertionError(f"Process block for id {process_id} not found")
+
+
+def _without_comments(source: str) -> str:
+    """Line comments removed, newlines kept. A check that reads a file whose
+    comments explain the interface reads the prose (c8810d5ef)."""
+    return re.sub(r"//[^\n]*", "", source)
 
 
 def _shell_strings(source: str):
@@ -241,6 +253,55 @@ def test_droidcam_sessions_are_launched_detached_through_the_session_script():
             )
         assert 'root.checkSession()' in source or 'root.reconcile()' in source
         assert "Component.onCompleted" in source, f"{name}.qml never re-adopts a session at boot"
+
+
+def test_the_webcam_preview_is_a_process_the_service_owns():
+    """The player is a handle, never a detached spawn.
+
+    `Quickshell.execDetached` returns nothing to hold, so ending the session
+    left the preview window on screen frozen on the last frame a dead
+    /dev/videoN produced. Recording a detached pid instead would buy the stop
+    and cost a stale one - the user closes that window whenever they like, and
+    the pid is then free for the kernel to reissue - so the shape is a Process,
+    which cannot address anything it did not start.
+    """
+    source = _source("PhoneCamera")
+    # Comment-stripped, because the block explaining why the player is not
+    # detached has to be able to name the call it is not making.
+    assert "execDetached" not in _without_comments(source), (
+        "PhoneCamera.qml detaches a process again; a detached player has no handle to stop"
+    )
+    block = _process_block(source, "previewProc")
+    assert "process-lifecycle: restart-safe" in block, "the preview player lacks the marker"
+    assert source.count("previewProc.exec(") == 1, "more than one thing starts the player"
+    assert source.count("previewProc.running = false") == 1, "more than one thing stops the player"
+    assert "readonly property bool previewRunning: previewProc.running" in source, (
+        "previewRunning is not the handle's own state, so it can disagree with the player"
+    )
+
+
+def test_the_preview_watches_the_session_rather_than_each_way_it_can_end():
+    """One observer, in the synced region, so the double drives it too.
+
+    A closePreview() spelled into stop(), into checkSession()'s death branch
+    and into fail() is three places for a fourth ending to be forgotten in.
+    `active` is the session, and every ending writes it.
+    """
+    source = _source("PhoneCamera")
+    region = _synced_region(SERVICES / "PhoneCamera.qml", SYNCED["PhoneCamera"])
+    assert "onActiveChanged: if (!root.active) root.closePreview();" in region, (
+        "the preview is not closed by observing the session"
+    )
+    assert source.count("root.closePreview()") == 2, (
+        "closePreview() is called somewhere other than the session observer and the "
+        "destruction hook; every ending already writes `active`"
+    )
+    assert "Component.onDestruction: root.closePreview()" in source, (
+        "a shell restart would leave the player behind"
+    )
+    assert "if (root.previewRunning) return;" in region, (
+        "a second click opens a second player on the same node"
+    )
 
 
 # ---- process lifetimes -------------------------------------------------------

--- a/dots/.config/quickshell/imi/tests/test_phone_sessions_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_sessions_contract.py
@@ -296,8 +296,12 @@ def test_the_preview_watches_the_session_rather_than_each_way_it_can_end():
         "closePreview() is called somewhere other than the session observer and the "
         "destruction hook; every ending already writes `active`"
     )
+    # An intent pin rather than the mechanism: measured by planting the line
+    # out, Quickshell reaps a Process it owns at shutdown anyway. Removing it
+    # therefore reddens nothing at runtime, which is exactly why it is held
+    # here instead.
     assert "Component.onDestruction: root.closePreview()" in source, (
-        "a shell restart would leave the player behind"
+        "the preview's death at shutdown stops being stated anywhere"
     )
     assert "if (root.previewRunning) return;" in region, (
         "a second click opens a second player on the same node"

--- a/dots/.config/quickshell/imi/tests/tst_phone_scrcpy.qml
+++ b/dots/.config/quickshell/imi/tests/tst_phone_scrcpy.qml
@@ -747,6 +747,80 @@ TestCase {
         compare(PhoneCamera.previewCommand("", { mpv: true }), [])
     }
 
+    function test_camera_open_preview_starts_one_player_and_a_click_on_top_of_it_starts_none() {
+        PhoneDeps.mpv = true
+        PhoneCamera.active = true
+        PhoneCamera.device = "/dev/video0"
+        PhoneCamera.openPreview()
+        compare(argvJoined(PhoneCamera.previewCommands),
+                ["mpv --profile=low-latency --no-fullscreen --no-osc --title=imi webcam preview av://v4l2:/dev/video0"])
+        verify(PhoneCamera.previewRunning)
+        // The page's button and the feature card's inline action both call
+        // this; a second window on the same node is two players fighting over
+        // one stream rather than a second preview.
+        PhoneCamera.openPreview()
+        compare(PhoneCamera.previewCommands.length, 1)
+    }
+
+    function test_camera_open_preview_without_a_player_reports_instead_of_starting_one() {
+        PhoneCamera.active = true
+        PhoneCamera.device = "/dev/video0"
+        PhoneCamera.openPreview()
+        compare(PhoneCamera.previewCommands, [])
+        verify(!PhoneCamera.previewRunning)
+        verify(PhoneCamera.lastError.indexOf("mpv") >= 0)
+    }
+
+    function test_camera_the_stop_button_takes_the_preview_with_it() {
+        PhoneDeps.mpv = true
+        PhoneCamera.active = true
+        PhoneCamera.device = "/dev/video0"
+        PhoneCamera.openPreview()
+        PhoneCamera.stop()
+        verify(!PhoneCamera.previewRunning)
+        compare(PhoneCamera.previewStops, 1)
+    }
+
+    function test_camera_a_session_that_dies_on_its_own_takes_the_preview_with_it() {
+        PhoneDeps.mpv = true
+        PhoneCamera.active = true
+        PhoneCamera.device = "/dev/video0"
+        PhoneCamera.openPreview()
+        // The watchdog's own reply: the pidfile names a process that is gone.
+        PhoneCamera.responder = argv => ({ text: '{"session":"video","pid":"","alive":false}', code: 0 })
+        PhoneCamera.checkSession()
+        verify(!PhoneCamera.active)
+        verify(!PhoneCamera.previewRunning)
+        compare(PhoneCamera.previewStops, 1)
+    }
+
+    function test_camera_a_connect_that_never_arrives_leaves_no_player_behind() {
+        PhoneDeps.mpv = true
+        PhoneCamera.active = true
+        PhoneCamera.device = "/dev/video0"
+        PhoneCamera.openPreview()
+        // fail() drops `active`, which is the only thing the preview watches,
+        // so the timeout path needs no closePreview() of its own.
+        PhoneCamera.fail("Could not connect")
+        verify(!PhoneCamera.previewRunning)
+        compare(PhoneCamera.previewStops, 1)
+    }
+
+    function test_camera_a_player_closed_by_hand_leaves_nothing_for_a_later_stop_to_kill() {
+        PhoneDeps.mpv = true
+        PhoneCamera.active = true
+        PhoneCamera.device = "/dev/video0"
+        PhoneCamera.openPreview()
+        // What the service sees when the user closes the window: the handle
+        // reports the player gone. A pid recorded at launch would still be a
+        // number here, and the stop below would spend it on a stranger.
+        PhoneCamera.previewRunning = false
+        PhoneCamera.stop()
+        compare(PhoneCamera.previewStops, 0)
+        PhoneCamera.closePreview()
+        compare(PhoneCamera.previewStops, 0)
+    }
+
     function test_camera_start_probes_usb_then_launches_detached() {
         PhoneCamera.responder = argv => {
             if (argv[0] === "adb") return { text: "device\n", code: 0 }


### PR DESCRIPTION
Open the phone webcam, open the preview, then end the DroidCam session: the preview froze on its last frame and stayed on screen. `openPreview()` handed the player to `Quickshell.execDetached`, which returns no handle, so `stop()` — which clears `device` and runs `droidcam_session.sh stop video` — had nothing to stop it with. What was left was a player holding a window on a `/dev/videoN` that had stopped producing frames.

The player is a `Process` the service owns now. **Which of the two shapes a process here takes is decided by who can END it**, not by how long it should live. The stream is detached and tracked by pidfile because only this shell stops it, so a recorded pid is good until it is used — and because a webcam other applications are using has to survive a shell restart. A player is closed by the *user* at any moment, so a pid recorded at launch is a number the kernel is free to reissue, and a later stop would spend it on a stranger. A `Process` cannot address anything it did not start, which removes that by construction. The cost is that the player no longer outlives a shell restart; a preview is one click to reopen, and an unstoppable one is the worse bug.

Which ending closes it is **one observer** — `onActiveChanged`, in the synced region so the double carries it — rather than a `closePreview()` spelled into `stop()`, into `checkSession()`'s death branch and into `fail()`. `active` *is* the session and every ending writes it, the device disappearing included. `openPreview()` also refuses to open a second player on top of a running one, and the page's Preview button is a toggle so the window can be closed from where it was opened.

Verified as a process, not as a flag: every flag was already correct while the window sat frozen. `tests/test_phone_preview_lifetime_runtime.py` opens the preview over a stub session launched by the **real** `droidcam_session.sh` and ends it five ways — the stop button, the stream killed under the shell and found by the watchdog, the player's window closed by the user (after which a later stop must reap nothing; a control process is asked), the phone leaving the daemon, and the shell exiting — asking `kill -0` about the pid the player wrote each time.

Planted mutations: `stopPreview()` made a no-op reddens at round 1; `onActiveDeviceIdChanged`'s `stop()` removed reddens at round 4 with rounds 1-3 green; **`Component.onDestruction` removed stays green**, because Quickshell reaps an owned `Process` anyway — so that line is held by the source contract as a statement of intent, and both it and its comment say so.

Not driven end to end: `droidcam-cli` could not run on this machine while this was written (built against ffmpeg 8 on a system with 9), so the real handshake, a real `/dev/videoN` and a real mpv window are untested.

Suite green twice, default locale and `LC_ALL=C`: 1423 passed, 0 failed.

Docs: updated AGENT.md §Directory map, §External binaries the shell drives
Changelog: updated
