### PR TITLE
fix(phone): the Stop button centres, the clear glyph stops latching, the roster unrolls

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -3003,6 +3003,25 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   glyph's centre through `mapToItem`. It was the only `mainText: ""` call site in the tree, so
   this is a note rather than a check.
   bd35286c3 ("fix(phone): the footer's two actions become soft rectangles, glyphs centred").
+- **...and the same slot from the other end: a labelled icon button that FILLS its row cannot be
+  `RippleButtonWithIcon` either, because that fillWidth label slot left-packs a real label
+  exactly as it did an empty one.** A `RowLayout` written as a content item is stretched to the
+  padded rect the same way a `MaterialSymbol` is, so a glyph-plus-label pair declared there lays
+  out from the button's LEFT edge — and a two-child row with room to spare opens the gap between
+  the two rather than keeping them together. The Phone tab's running-card Stop button is the
+  case: measured at card widths of 200 and 460, the pair sat **35.48px and 117.98px left of the
+  button's own centre** and grew from 97.03px to 192.03px wide as it went. An anchor on the
+  content item cannot repair it (the entry two up), so what centres a PAIR is a plain `Item`
+  stretched to that rect with the row centred INSIDE it — an ordinary parent-child anchor the
+  Control never touches; re-measured, 57.03px wide and 0.48px off centre at both widths, the
+  residual being the glyph's box against its painted extent. `RippleButtonWithIcon` was measured
+  rather than reasoned about before it was declined: one at 460px carrying the same glyph and the
+  same word reads **191.46px left of centre**, so it is the component for a button sized by what
+  it holds and not for one that fills a row. Measure the DRAWN extent when checking this, never
+  the boxes — a `Text` a layout has stretched still paints at its content width from its left
+  edge, so the box of a left-packed pair reaches the right border and reports itself centred.
+  df9794dbd ("fix(phone): the running card's Stop button centres its glyph and its label"),
+  238757407 ("test(phone): measure the Stop button's pair at two widths, against a control").
 - **A `Text` positioned with `anchors.centerIn` has no box, so `elide` cannot fire and the
   label paints over its neighbours instead.** Eliding needs a width, and `centerIn` gives a Text
   its implicit one — which is however wide the string happens to be, drawn straight out past its
@@ -4855,6 +4874,67 @@ the icon it went in with, having swapped nothing. Before reaching for
 `animateChange`, ask whether the thing behind the glyph fades with it and how
 often the value can change.
 3c82747df ("fix(phone): the feature card's glyph stops blanking its own badge").
+
+**...and on a `Control`'s content item that same swap also LATCHES the glyph off
+its own centre, permanently, because the coordinates it animates back to were
+read before the Control had placed it.** `StyledText` records
+`originalX`/`originalY` in its own `Component.onCompleted`, and a content item
+completes BEFORE the Control that owns it — so those are (0, 0), the swap ends
+by writing them onto the glyph's `x`/`y`, and the glyph sits on the top-left
+corner of the padded rect for the rest of the session rather than in the middle
+of it. The Phone tab's footer is the case: the clear action's glyph is a ternary
+on the notification count, so it is the one glyph on that bar whose text ever
+changes, and after a single swap it settled **4.00px left and 4.00px above** the
+button's own centre — exactly the Control's padding — having travelled 10.00px
+off it on the way, at a measured minimum opacity of **0.00** inside a button
+background that does not fade with it. The sync action beside it, whose text
+never changes, read (0.00, 0.00) throughout, which is what makes the two look
+like one broken button rather than one broken idiom. Note that none of it is
+reachable from a settled reading taken before the value first moves: a harness
+has to DRIVE the change and watch it, in both axes and signed — the first
+version of this check returned `|dx|` and could not have seen either half.
+`modules/common/widgets/IconToolbarButton.qml` carries the same
+`animateChange` on a content-item glyph and is the open neighbour: several of
+its call sites give it a `text` that really does change (`DockerPopup`'s
+expand chevron, `RecordingRegionPanel`'s play/pause, the wallpaper
+selector's dark/light mark, `FpsLimiterContent`'s state switch), so the same
+latch is available to every toolbar button in the shell. Unmeasured here on
+purpose — it is a shared widget with call sites in a dozen files and the
+repair is somebody's whole change, not a line in a phone fix.
+be89b6614 ("fix(phone): the footer's clear action stops latching its glyph off centre"),
+d9cc8acc9 ("test(phone): drive the count and watch the footer's one glyph swap").
+
+**A roster is a list, and this shell has one component for a multi-item
+selectable list — reaching for a `Repeater` writes a third variant of it.** The
+Phone tab's device roster was a `Repeater` of `PhoneDeviceItem`s in a
+`ColumnLayout`, while the Wi-Fi and Bluetooth device lists in
+`modules/imi/sidebarRight/` draw exactly this shape as a `StyledListView` whose
+delegate is a `DialogListItem` — which `PhoneDeviceItem` already was. Only the
+container differed, and what the view adds past one shape for three lists is its
+own add/remove transitions on the shared tier, so a device joining or leaving
+the network is a row that arrives or leaves instead of a column that jumps.
+Three things about wiring one into a `ColumnLayout` are worth not re-deriving.
+**A `ListView` told it is zero pixels tall builds no delegates**, so it reports a
+`contentHeight` of zero and can never grow out of one: a height that reveals the
+list has to be a box AROUND it, with the list at its own `contentHeight` inside
+(the `implicitHeight: contentHeight` idiom `NotificationGroup.qml` and
+`StyledComboBox.qml` already use). **The reveal rides ONE scalar with ONE
+`Behavior`** — `rosterProgress` beside the tab's own `subPageProgress` — on
+`Appearance.animation.elementMove` taken whole, so the motion-speed slider and
+the reduce-motion floor reach it; `elementMoveEnter`/`Exit` are the wrong tiers
+for a toggle the user reverses, because their curves are directional. And **a
+`QQuickLayout` stops writing the height of a child it has excluded**, so a folded
+box keeps whatever its last laid-out frame left on it (measured: 1.38px) — a test
+reading that number back sees a mid-flight height for the rest of the run and its
+"did this animate" check passes on a snap. Sample only while the box is drawn,
+and read the settled state off the scalar. Measured across the chip's click: the
+box travels 0 → 116 over 7 sampled frames, peaking at 117.61 because
+`expressiveDefaultSpatial` leaves the unit box, and back down over 8; with the
+`Behavior` planted out, both mid-flight counts go to 0 while both settled checks
+stay green, which is why the settled ones alone were never enough.
+ddb0546f8 ("refactor(phone): the device roster is drawn by the shell's own list view"),
+248474b8e ("feat(phone): the roster unrolls and folds instead of appearing whole"),
+3577cf4d8 ("test(phone): watch the roster's reveal in both directions").
 
 **And where the missing link is the whole page rather than one card's subtitle,
 it is drawn as a panel that says what to do.** The Phone tab's Android Apps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,14 @@ own repo; the installer pins which revision it builds.
   that asked.
 
 ### Changed
+- **The Phone tab's device roster unrolls instead of appearing all at once.**
+  Clicking the device chip used to put the list of every device the daemon
+  knows on screen in one frame and take it away in one. It now unrolls from
+  under the chip and folds back the same way, and it is drawn by the same list
+  the Wi-Fi and Bluetooth device pickers use, so a device joining or leaving
+  the network arrives and leaves as a row rather than making the list jump. The
+  reveal follows the animation-speed slider and the reduce-motion switch like
+  the rest of the shell.
 - **The right sidebar's quick sliders arrive one card at a time.** Each slider
   card now fades in, zooms up from slightly smaller and rises into place —
   the bottom row first, brightness last — while its fill still sweeps up from
@@ -208,6 +216,14 @@ own repo; the installer pins which revision it builds.
   another under the same name on every launch, while the teardown removed
   exactly one per call. A setup that fails now takes its own sink back with
   it.
+- **The Stop button on a running Phone tab card draws its icon and its label in
+  the middle.** They were pressed against the button's left edge with the rest
+  of it empty, and the gap between the icon and the word grew as the button did.
+- **The Phone tab's clear-notifications button stops drifting out of its
+  circle.** The moment the notification count first changed, that button's icon
+  slid up and to the left and stayed there for the rest of the session - and
+  blinked out entirely while it moved, leaving an empty pill behind. Its
+  neighbour was unaffected, which is what made it read as one broken button.
 - **The Phone tab's Android Apps page says what to turn on when it cannot
   reach the phone.** App Mode drives the phone over ADB, which is a
   different link from the one KDE Connect pairs: with a phone reachable on

--- a/dots/.config/quickshell/imi/PhoneTabRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/PhoneTabRuntimeTest.qml
@@ -37,7 +37,7 @@ import qs.modules.imi.sidebarLeft.phone
  * decisions themselves live in phone_cards.js and are driven by
  * tests/tst_phone_cards.qml.
  *
- * Three things here are WATCHED rather than read once, because each of them
+ * Four things here are WATCHED rather than read once, because each of them
  * is a defect that only exists between two settled states:
  *
  *  - the mirror launch. `Directories.scriptPath` resolves to this checkout,
@@ -52,6 +52,12 @@ import qs.modules.imi.sidebarLeft.phone
  *    opacity and scale, and the check that matters is that a MID-flight
  *    reading exists: every "was it ever out of range" assertion passes
  *    identically on a transition that never ran;
+ *  - the footer's clear action, across the one glyph swap this bar has. A
+ *    deferred text swap on a Control's content item lands the glyph on the
+ *    padded rect's corner rather than on its centre and leaves it there, so
+ *    the reading taken before the count first moves is identical whether or
+ *    not the rest of the session is drawn off centre. `swapWatch` samples
+ *    both axes and the glyph's opacity across it;
  *  - the toast's width, against a control. A short message must produce a
  *    toast narrower than the cap before a long one is allowed to prove the
  *    cap holds.
@@ -135,11 +141,30 @@ ShellRoot {
 
     // A glyph a Control positions itself: its centre must land on the
     // button's, which an anchor cannot do and both alignments can.
-    function glyphOffCentre(button) {
-        const glyph = harness.findAll(button, "MaterialSymbol", [])[0] ?? null;
-        if (!glyph) return Number.NaN;
+    //
+    // BOTH axes, signed. The first version returned |dx| alone and could not
+    // have seen the defect it was written for: a `Behavior on text` animates
+    // the Text's OWN x and y, so a one-axis reading reports half of what is
+    // on screen and an absolute one cannot say which way it went.
+    function glyphOffset(button) {
+        const glyph = harness.footerGlyph(button);
+        if (!glyph) return { dx: Number.NaN, dy: Number.NaN };
         const centre = glyph.mapToItem(button, glyph.width / 2, glyph.height / 2);
-        return Math.abs(centre.x - button.width / 2);
+        return { dx: centre.x - button.width / 2, dy: centre.y - button.height / 2 };
+    }
+
+    function glyphOffCentre(button) {
+        const off = harness.glyphOffset(button);
+        return Math.max(Math.abs(off.dx), Math.abs(off.dy));
+    }
+
+    function glyphOffsetText(button) {
+        const off = harness.glyphOffset(button);
+        return `(${off.dx.toFixed(2)},${off.dy.toFixed(2)})`;
+    }
+
+    function footerGlyph(button) {
+        return harness.findAll(button, "MaterialSymbol", [])[0] ?? null;
     }
 
     function cardTitled(fragment) {
@@ -403,13 +428,13 @@ ShellRoot {
                           buttons.length === 2 && buttons[0].width === buttons[1].width
                           && buttons[0].width === Appearance.sizes.phoneFooterButtonWidth
                           && buttons[0].height === Appearance.sizes.phoneFooterButtonHeight);
-            const offsets = buttons.map(b => harness.glyphOffCentre(b));
+            const offsets = buttons.map(b => harness.glyphOffsetText(b));
             console.log(`[PhoneTab] glyph off centre by ${offsets}`);
             // A RippleButtonWithIcon's glyph was drawn 1.5px left of centre
             // here, because the empty label's Layout.fillWidth slot took the
             // rest of the row's width from inside the button.
             harness.check(`each glyph is centred in its action, off by ${offsets}`,
-                          offsets.every(offset => offset < 1));
+                          buttons.every(b => harness.glyphOffCentre(b) < 1));
         },
         () => {
             // The pill is the row's only fillWidth item, so the label must
@@ -427,6 +452,76 @@ ShellRoot {
                           && right <= buttons[1].x);
             harness.check("neither action was squeezed to make room for it",
                           buttons.every(b => b.width === Appearance.sizes.phoneFooterButtonWidth));
+        },
+
+        // ---- ...and they stay centred once the count moves ---------------
+        //
+        // The clear action is the one whose glyph is a ternary on the count,
+        // so it is the only one of the two whose text ever changes - and a
+        // reading taken before the first change is identical whether or not
+        // the change displaces the glyph for the rest of the session. The
+        // count is driven through the model, since the fake daemon serves no
+        // notifications.
+        () => {
+            const clear = harness.footerButtons[1];
+            harness.swapSaw = { samples: 0, maxOff: 0, minOpacity: 1 };
+            harness.glyphBefore = harness.footerGlyph(clear)?.text ?? "";
+            PhoneNotifications.notifications = [{
+                publicId: "70",
+                deviceId: harness.phoneId,
+                internalId: "0|org.thunderdog.challegram|1|null|10248",
+                package: "org.thunderdog.challegram",
+                appName: "Telegram",
+                title: "Alice",
+                text: "on my way",
+                ticker: "",
+                iconPath: "",
+                dismissable: true,
+                replyId: "",
+                actions: [],
+                receivedAt: Date.now()
+            }];
+            swapWatch.running = true;
+        },
+        () => {},
+        () => {
+            swapWatch.running = false;
+            const buttons = harness.footerButtons;
+            const clear = buttons[1];
+            const after = harness.footerGlyph(clear)?.text ?? "";
+            const saw = harness.swapSaw;
+            const offsets = buttons.map(b => harness.glyphOffsetText(b));
+            console.log(`[PhoneTab] count 0 -> ${PhoneNotifications.count}:`
+                + ` clear glyph "${harness.glyphBefore}" -> "${after}"`
+                + ` off centre by ${offsets}; watched ${saw.samples} samples,`
+                + ` worst ${saw.maxOff.toFixed(2)}px, min opacity ${saw.minOpacity.toFixed(2)}`);
+
+            // The control first: everything below is vacuous on a swap that
+            // never happened.
+            harness.check(`the count change swapped the clear action's glyph,`
+                          + ` got "${harness.glyphBefore}" -> "${after}"`,
+                          harness.glyphBefore === "do_not_disturb_on" && after === "delete_sweep");
+            harness.check(`the swap was watched frame by frame, got ${saw.samples} samples`,
+                          saw.samples > 10);
+            harness.check(`both glyphs settle back on their own centres, off by ${offsets}`,
+                          buttons.every(b => harness.glyphOffCentre(b) < 1));
+            // A `Behavior on text` animates the Text's own x and y and lands
+            // it back on whatever those were when the item completed - which
+            // for a Control's content item is BEFORE the Control has placed
+            // it. The container behind the glyph does not fade with it
+            // either, so the swap is an empty pill for its own length: the
+            // same pair 3c82747df removed from the feature card's badge.
+            harness.check(`neither glyph leaves its own centre during the swap,`
+                          + ` worst ${saw.maxOff.toFixed(2)}px`,
+                          saw.maxOff < 1);
+            harness.check(`...nor fades inside a container that does not,`
+                          + ` min opacity ${saw.minOpacity.toFixed(2)}`,
+                          saw.minOpacity > 0.99);
+            PhoneNotifications.notifications = [];
+        },
+        () => {
+            harness.check(`clearing the model puts the count pill back, got "${harness.footerLabel?.text}"`,
+                          harness.footerLabel?.text === "0 notifications");
         },
 
         // ---- the feature cards: what a click reaches ---------------------
@@ -713,6 +808,27 @@ ShellRoot {
                     saw.blankGlyph = `${badge?.text}|${glyph.text}`;
             }
             harness.launchSaw = saw;
+        }
+    }
+
+    property string glyphBefore: ""
+    property var swapSaw: ({ samples: 0, maxOff: 0, minOpacity: 1 })
+
+    Timer {
+        id: swapWatch
+        interval: 25
+        repeat: true
+        onTriggered: {
+            const buttons = harness.footerButtons;
+            if (buttons.length !== 2) return;
+            const saw = harness.swapSaw;
+            saw.samples++;
+            for (const button of buttons) {
+                saw.maxOff = Math.max(saw.maxOff, harness.glyphOffCentre(button));
+                const glyph = harness.footerGlyph(button);
+                if (glyph) saw.minOpacity = Math.min(saw.minOpacity, glyph.opacity);
+            }
+            harness.swapSaw = saw;
         }
     }
 

--- a/dots/.config/quickshell/imi/PhoneTabRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/PhoneTabRuntimeTest.qml
@@ -37,7 +37,7 @@ import qs.modules.imi.sidebarLeft.phone
  * decisions themselves live in phone_cards.js and are driven by
  * tests/tst_phone_cards.qml.
  *
- * Four things here are WATCHED rather than read once, because each of them
+ * Five things here are WATCHED rather than read once, because each of them
  * is a defect that only exists between two settled states:
  *
  *  - the mirror launch. `Directories.scriptPath` resolves to this checkout,
@@ -52,6 +52,10 @@ import qs.modules.imi.sidebarLeft.phone
  *    opacity and scale, and the check that matters is that a MID-flight
  *    reading exists: every "was it ever out of range" assertion passes
  *    identically on a transition that never ran;
+ *  - the roster's reveal, in both directions. `rosterWatch` samples the box
+ *    that uncovers the device list, and what is asserted is that a MID-flight
+ *    height exists: a reveal that never ran and one that completed in a frame
+ *    settle on the same number;
  *  - the footer's clear action, across the one glyph swap this bar has. A
  *    deferred text swap on a Control's content item lands the glyph on the
  *    padded rect's corner rather than on its centre and leaves it there, so
@@ -190,6 +194,20 @@ ShellRoot {
     function cardGlyph(card) {
         const badge = harness.cardBadge(card);
         return badge ? (harness.findAll(badge, "MaterialSymbol", [])[0] ?? null) : null;
+    }
+
+    // The roster's list, and the box that reveals it. Reached through a row
+    // rather than by type: a ListView parents its delegates into its own
+    // content item, and the tab draws a second StyledListView - the
+    // notification list - that a search by type would reach first.
+    function rosterList() {
+        const row = harness.all("PhoneDeviceItem")[0] ?? null;
+        return row ? (row.parent?.parent ?? null) : null;
+    }
+
+    function rosterBox() {
+        const list = harness.rosterList();
+        return list ? list.parent : null;
     }
 
     // The Stop button of a card that is on its `active` rung, found by what it
@@ -423,17 +441,68 @@ ShellRoot {
 
         // ---- the roster, behind the chip's arrow --------------------------
         () => {
+            const list = harness.rosterList();
             harness.check("the roster is folded until the chip is opened",
                           harness.all("PhoneDeviceItem").filter(i => i.visible).length === 0);
+            // The component, not a shape of its own: the same StyledListView
+            // the Wi-Fi and Bluetooth device lists are, over the same model.
+            harness.check(`the roster is the shell's own list view over the daemon's devices,`
+                          + ` got ${harness.typeName(list)} of ${list?.count}`,
+                          list !== null && harness.typeName(list) === "StyledListView"
+                          && list.count === PhoneConnect.devices.length);
+            harness.rosterSaw = { samples: 0, mid: 0, maxHeight: 0 };
             harness.click(harness.first("PhoneDeviceChip"));
+            rosterWatch.running = true;
         },
+        () => {},
         () => {
+            rosterWatch.running = false;
+            const box = harness.rosterBox();
+            const list = harness.rosterList();
+            const saw = harness.rosterSaw;
+            console.log(`[PhoneTab] roster open: samples=${saw.samples} mid=${saw.mid}`
+                + ` peak=${saw.maxHeight.toFixed(2)} settled=${box?.height} of list ${list?.contentHeight}`);
+
+            // The sample count first: a watch that never ran reports the same
+            // "nothing was ever part way" a correct reveal does. Then the
+            // mid-flight frames, because an unrolled reading and a snapped one
+            // are the same reading once it settles - the two this repo has
+            // shipped that mistake on are recorded in AGENT.md.
+            harness.check(`the reveal was watched frame by frame, got ${saw.samples} samples`,
+                          saw.samples > 10);
+            harness.check(`the roster unrolls rather than appearing whole,`
+                          + ` ${saw.mid} frames strictly between`, saw.mid > 0);
+            harness.check(`...and settles at the list's own content height, got ${box?.height}`,
+                          box !== null && list !== null && list.contentHeight > 0
+                          && Math.abs(box.height - list.contentHeight) < 1);
+
             const rows = harness.all("PhoneDeviceItem").filter(i => i.visible);
             harness.check(`opening the chip lists both devices, got ${rows.length}`, rows.length === 2);
             const laptop = rows.find(r => r.device?.id === harness.laptopId) ?? null;
+            harness.rosterSaw = { samples: 0, mid: 0, maxHeight: 0 };
             if (laptop) harness.click(laptop);
+            rosterWatch.running = true;
         },
+        () => {},
         () => {
+            rosterWatch.running = false;
+            const box = harness.rosterBox();
+            const saw = harness.rosterSaw;
+            console.log(`[PhoneTab] roster fold: samples=${saw.samples} mid=${saw.mid}`
+                + ` peak=${saw.maxHeight.toFixed(2)} progress=${loader.item.rosterProgress}`
+                + ` visible=${box?.visible}`);
+
+            harness.check(`the fold was watched frame by frame too, got ${saw.samples} samples`,
+                          saw.samples > 10);
+            harness.check(`picking a row folds the roster rather than cutting it,`
+                          + ` ${saw.mid} frames strictly between`, saw.mid > 0);
+            // The scalar, not the box's height: an excluded layout child keeps
+            // the height its last laid-out frame left on it.
+            harness.check(`...and it ends folded and out of the column,`
+                          + ` progress ${loader.item.rosterProgress}`,
+                          box !== null && !box.visible && loader.item.rosterProgress === 0
+                          && harness.all("PhoneDeviceItem").every(i => !i.visible));
+
             const chip = harness.first("PhoneDeviceChip");
             harness.check(`picking a row shows that device on the chip, got ${chip?.device?.name}`,
                           chip?.device?.id === harness.laptopId);
@@ -929,6 +998,31 @@ ShellRoot {
                     saw.blankGlyph = `${badge?.text}|${glyph.text}`;
             }
             harness.launchSaw = saw;
+        }
+    }
+
+    property var rosterSaw: ({ samples: 0, mid: 0, maxHeight: 0 })
+
+    Timer {
+        id: rosterWatch
+        interval: 25
+        repeat: true
+        onTriggered: {
+            const box = harness.rosterBox();
+            const list = harness.rosterList();
+            if (!box || !list) return;
+            const saw = harness.rosterSaw;
+            saw.samples++;
+            // Only while the box is DRAWN. A QQuickLayout excludes an
+            // invisible child and stops writing its height, so a folded box
+            // keeps whatever height its last laid-out frame left on it - read
+            // ungated, that stale number sits in the mid-flight band for the
+            // rest of the run and the fold's own check passes on a snap.
+            if (box.visible) {
+                saw.maxHeight = Math.max(saw.maxHeight, box.height);
+                if (box.height > 1 && box.height < list.contentHeight - 1) saw.mid++;
+            }
+            harness.rosterSaw = saw;
         }
     }
 

--- a/dots/.config/quickshell/imi/PhoneTabRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/PhoneTabRuntimeTest.qml
@@ -192,6 +192,41 @@ ShellRoot {
         return badge ? (harness.findAll(badge, "MaterialSymbol", [])[0] ?? null) : null;
     }
 
+    // The Stop button of a card that is on its `active` rung, found by what it
+    // draws rather than by position: a card carries a settings chip and its
+    // inline actions in the same tree, and which RippleButton comes first is a
+    // property of the file's declaration order.
+    function stopButton(card) {
+        return harness.findAll(card, "RippleButton", [])
+            .find(b => harness.findAll(b, "MaterialSymbol", [])
+                              .some(g => `${g.text}` === "stop_circle")) ?? null;
+    }
+
+    // A glyph-plus-label pair's DRAWN extent inside its button, and where the
+    // middle of it lands against the button's own middle.
+    //
+    // The drawn extent, never the boxes: a Text a layout has stretched still
+    // PAINTS at its content width from its left edge, so a label slot reaching
+    // the right border reports a box that looks centred and a picture that is
+    // not. That difference is the whole question this measures.
+    function labelledPair(button) {
+        if (!button) return null;
+        const glyph = harness.findAll(button, "MaterialSymbol", [])[0] ?? null;
+        const label = harness.findAll(button, "StyledText", [])[0] ?? null;
+        if (!glyph || !label) return null;
+        const g = glyph.mapToItem(button, 0, 0);
+        const l = label.mapToItem(button, 0, 0);
+        const left = Math.min(g.x, l.x);
+        const right = Math.max(g.x + Math.min(glyph.width, glyph.contentWidth),
+                               l.x + Math.min(label.width, label.contentWidth));
+        return { left: left, right: right, width: right - left,
+                 offset: (left + right) / 2 - button.width / 2 };
+    }
+
+    function pairText(pair) {
+        return pair ? `${pair.width.toFixed(2)}w@${pair.offset.toFixed(2)}` : "none";
+    }
+
     FloatingWindow {
         id: window
         visible: true
@@ -210,6 +245,54 @@ ShellRoot {
             anchors.fill: parent
             active: false
             sourceComponent: Phone {}
+        }
+    }
+
+    // ---- the Stop button, at two widths, and the component it declined ----
+    //
+    // A Stop button exists only on a card's `active` rung, and nothing this
+    // harness can drive puts a card there: the fake `adb` lists no device, so
+    // every launch fails before it starts. The cards are built directly
+    // instead - in a window of their own, so a fixture can never take a click
+    // aimed at the tab - and at TWO widths, because a pair that is centred at
+    // one width is also exactly what a pair filling its button looks like.
+    //
+    // The third fixture is the control for the component decision.
+    // `RippleButtonWithIcon` is the shell's glyph-plus-label button and is the
+    // obvious thing to reach for here; what it does on a button wider than its
+    // content is the measured reason the card does not.
+    FloatingWindow {
+        id: stopWindow
+        visible: true
+        implicitWidth: 520
+        implicitHeight: 360
+        color: "black"
+
+        Column {
+            anchors.fill: parent
+            anchors.margins: Appearance.spacing.space100
+            spacing: Appearance.spacing.space100
+
+            PhoneFeatureCard {
+                id: narrowStopCard
+                width: 200
+                cardState: "active"
+                title: "Narrow"
+                subtitle: "stop fixture"
+            }
+            PhoneFeatureCard {
+                id: wideStopCard
+                width: 460
+                cardState: "active"
+                title: "Wide"
+                subtitle: "stop fixture"
+            }
+            RippleButtonWithIcon {
+                id: labelledControl
+                width: 460
+                materialIcon: "stop_circle"
+                mainText: "Stop"
+            }
         }
     }
 
@@ -633,6 +716,44 @@ ShellRoot {
             harness.check(`the chip opens the webcam page, got "${loader.item.subPage}"`,
                           loader.item.subPage === "webcam");
             loader.item.popSubPage();
+        },
+
+        // ---- a running card's Stop button, read off the fixture window ----
+        () => {
+            const narrow = harness.stopButton(narrowStopCard);
+            const wide = harness.stopButton(wideStopCard);
+            const pairs = [harness.labelledPair(narrow), harness.labelledPair(wide)];
+            const control = harness.labelledPair(labelledControl);
+            console.log(`[PhoneTab] stop buttons ${narrow?.width}/${wide?.width}`
+                + ` pairs ${pairs.map(p => harness.pairText(p))};`
+                + ` ${harness.typeName(labelledControl)} ${labelledControl.width}`
+                + ` pair ${harness.pairText(control)}`);
+
+            // Two controls before the claim. The pair has to be found at all,
+            // and each button has to be WIDER than it - a button the pair
+            // fills is centred by construction and says nothing.
+            harness.check(`the fixture drew a Stop button at two widths, got ${narrow?.width} and ${wide?.width}`,
+                          narrow !== null && wide !== null && wide.width > narrow.width);
+            harness.check(`...each with room around its pair, ${pairs.map(p => harness.pairText(p))}`,
+                          pairs.every(p => p !== null && p.width > 0)
+                          && narrow.width - pairs[0].width > 1
+                          && wide.width - pairs[1].width > 1);
+
+            // A Control stretches its content item to the padded rect and
+            // positions it itself, so a RowLayout declared there lays its
+            // children out from the LEFT edge of a button that fills its row.
+            harness.check(`the glyph and its label centre in the button at both widths,`
+                          + ` off by ${pairs.map(p => p.offset.toFixed(2))}`,
+                          pairs.every(p => Math.abs(p.offset) < 1));
+
+            // ...and why the shared component is not what does that. Its label
+            // slot is `Layout.fillWidth: true`, so on a button wider than its
+            // content the label absorbs the leftover from inside and the pair
+            // is left-packed - the same shape bd35286c3 measured from the
+            // other end, where the label was empty.
+            harness.check(`the shared labelled-icon button left-packs the same pair instead,`
+                          + ` off by ${control?.offset?.toFixed(2)}`,
+                          control !== null && control.offset < -1);
         },
 
         // ---- a launch that fails says so, on the card and in the toast ----

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/Phone.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/Phone.qml
@@ -163,23 +163,46 @@ Item {
             onToggleRoster: root.rosterOpen = !root.rosterOpen
         }
 
-        // The roster behind the chip's arrow. Not a wave member: it is
-        // folded at every open, and a member that is off screen when the
-        // wave runs takes no slot anyway.
-        ColumnLayout {
-            id: roster
+        // The roster behind the chip's arrow: every device the daemon knows,
+        // one selectable row each. Drawn by the component the Wi-Fi and the
+        // Bluetooth dialogs already draw their device lists with - a
+        // `StyledListView` of `DialogListItem` rows, which is exactly what
+        // `PhoneDeviceItem` is - rather than by a `Repeater` of its own. What
+        // that buys past one shape for three lists is the view's own
+        // add/remove transitions on the shared tier: a device joining or
+        // leaving the network becomes a row that arrives or leaves instead of
+        // a column that jumps.
+        //
+        // Not a wave member: it is folded at every open, and a member that is
+        // off screen when the wave runs takes no slot anyway.
+        Item {
+            id: rosterReveal
             Layout.fillWidth: true
+            Layout.preferredHeight: rosterList.height
             visible: root.rosterOpen
-            spacing: 0
 
-            Repeater {
+            // The list stands at its OWN content height whatever this wrapper
+            // is doing. A `ListView` told it is zero pixels tall builds no
+            // delegates, so it reports a content height of zero and can never
+            // grow out of it - the height that folds has to be a box around
+            // the list rather than the list's own.
+            StyledListView {
+                id: rosterList
+                width: rosterReveal.width
+                height: rosterList.contentHeight
+                interactive: false
+                spacing: 0
+
                 model: ScriptModel {
                     values: PhoneConnect.devices
                 }
                 delegate: PhoneDeviceItem {
                     required property var modelData
                     device: modelData
-                    Layout.fillWidth: true
+                    anchors {
+                        left: parent?.left
+                        right: parent?.right
+                    }
                     active: root.device !== null && root.device.id === modelData.id
                     onClicked: {
                         root.pickedDeviceId = modelData.id;

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/Phone.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/Phone.qml
@@ -63,6 +63,20 @@ Item {
         && root.device.paired && root.device.reachable
 
     property bool rosterOpen: false
+    // The roster's reveal: ONE scalar with ONE `Behavior`, the shape
+    // `subPageProgress` below already uses and for the same two reasons. A
+    // second Behavior is two numbers that have to agree, agreeing at rest -
+    // the only place anyone looks - and disagreeing on exactly the frames the
+    // transition is made of; and the tier is taken WHOLE off `Appearance`, so
+    // the motion-speed slider and the reduce-motion floor reach the roster the
+    // way they reach everything else. `elementMove` rather than
+    // `elementMoveEnter`/`Exit`: those two carry directional curves, and this
+    // is a toggle the user can reverse in the middle of.
+    property real rosterProgress: root.rosterOpen ? 1 : 0
+
+    Behavior on rosterProgress {
+        animation: Appearance.animation.elementMove.numberAnimation.createObject(this)
+    }
 
     // "" | "contacts" | "apps" | "webcam" | "mic"
     property string subPage: ""
@@ -178,8 +192,14 @@ Item {
         Item {
             id: rosterReveal
             Layout.fillWidth: true
-            Layout.preferredHeight: rosterList.height
-            visible: root.rosterOpen
+            // Unrolled from nothing to the list's own height, and faded with
+            // it, both off the one scalar declared at the top of this file.
+            // The clip is what makes the height a reveal rather than a squash:
+            // the rows keep their own size and the box uncovers them.
+            Layout.preferredHeight: rosterList.height * root.rosterProgress
+            visible: root.rosterProgress > 0
+            opacity: root.rosterProgress
+            clip: true
 
             // The list stands at its OWN content height whatever this wrapper
             // is doing. A `ListView` told it is zero pixels tall builds no

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneFeatureCard.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneFeatureCard.qml
@@ -296,6 +296,7 @@ Item {
                 spacing: Appearance.spacing.space75
 
                 RippleButton {
+                    id: stopButton
                     Layout.fillWidth: true
                     Layout.preferredHeight: Appearance.font.pixelSize.huge + Appearance.spacing.space150
                     buttonRadius: Appearance.rounding.normal
@@ -304,22 +305,54 @@ Item {
                     colRipple: Appearance.colors.colErrorContainerActive
                     onClicked: root.stopClicked()
 
-                    contentItem: RowLayout {
-                        spacing: Appearance.spacing.space75
+                    // A Control stretches its content item to the padded rect
+                    // and places it itself, so a `RowLayout` declared there is
+                    // the width of a button that fills the card's row and lays
+                    // its two children out inside THAT - the glyph against the
+                    // left border and the word adrift somewhere after it.
+                    // Measured before this: at card widths of 200 and 460 the
+                    // pair sat 35.48px and 117.98px left of the button's own
+                    // centre, and grew from 97px to 192px wide as the gap
+                    // between the glyph and the word opened up with the
+                    // button. An anchor on the content item cannot repair
+                    // that - the Control ignores it, the same rule this file's
+                    // settings chip and the footer's two actions record for a
+                    // `MaterialSymbol` content item. What centres a PAIR is a
+                    // plain Item stretched to that rect with the row centred
+                    // INSIDE it, which is an ordinary parent-child anchor the
+                    // Control never touches.
+                    //
+                    // `RippleButtonWithIcon` is the shell's glyph-plus-label
+                    // button and is deliberately not what this is. Its label
+                    // slot is `Layout.fillWidth: true`, so on a button wider
+                    // than its content the label absorbs the leftover from
+                    // inside and the pair is left-packed exactly as this was:
+                    // measured at the same 460, 191.46px left of centre. That
+                    // is bd35286c3's finding from the other end, where the
+                    // label was empty rather than real.
+                    contentItem: Item {
+                        implicitWidth: stopRow.implicitWidth
+                        implicitHeight: stopRow.implicitHeight
 
-                        MaterialSymbol {
-                            Layout.alignment: Qt.AlignVCenter
-                            text: "stop_circle"
-                            fill: 1
-                            iconSize: Appearance.font.pixelSize.larger
-                            color: Appearance.colors.colOnErrorContainer
-                        }
-                        StyledText {
-                            Layout.alignment: Qt.AlignVCenter
-                            text: Translation.tr("Stop")
-                            font.pixelSize: Appearance.font.pixelSize.small
-                            font.weight: Font.DemiBold
-                            color: Appearance.colors.colOnErrorContainer
+                        RowLayout {
+                            id: stopRow
+                            anchors.centerIn: parent
+                            spacing: Appearance.spacing.space75
+
+                            MaterialSymbol {
+                                Layout.alignment: Qt.AlignVCenter
+                                text: "stop_circle"
+                                fill: 1
+                                iconSize: Appearance.font.pixelSize.larger
+                                color: Appearance.colors.colOnErrorContainer
+                            }
+                            StyledText {
+                                Layout.alignment: Qt.AlignVCenter
+                                text: Translation.tr("Stop")
+                                font.pixelSize: Appearance.font.pixelSize.small
+                                font.weight: Font.DemiBold
+                                color: Appearance.colors.colOnErrorContainer
+                            }
                         }
                     }
                 }

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneFooterBar.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneFooterBar.qml
@@ -34,6 +34,22 @@ import QtQuick.Layouts
  * contentItem is a `MaterialSymbol` declaring both alignments, which is what
  * centres a Control's content item - an anchor on it is decoration, because a
  * Control sizes and positions its content item itself.
+ *
+ * Neither glyph carries `animateChange`, and on the clear action that is a fix
+ * rather than an omission. `StyledText`'s deferred swap animates the Text's OWN
+ * `x` and `y` away and back to the `originalX`/`originalY` it recorded in its
+ * own `Component.onCompleted` - which for a Control's content item runs BEFORE
+ * the Control has placed it, so those two are (0, 0) and the glyph lands on the
+ * top-left corner of the padded rect instead of on its centre, for the rest of
+ * the session. Measured in PhoneTabRuntimeTest at the sidebar's 460px: after
+ * one swap the clear glyph settled 4.00px left and 4.00px above the button's
+ * centre - exactly the Control's own padding - having travelled 10.00px off it
+ * on the way, while the sync glyph beside it, whose text never changes, read
+ * (0.00, 0.00) throughout. The swap also fades the glyph to zero (measured
+ * minimum opacity 0.00) inside a button background that does not fade with it,
+ * so the action is an empty pill for a tier's length: the same pair 3c82747df
+ * removed from the feature card's badge. The count is the one thing on this bar
+ * that changes, which is why this was the one glyph it could happen to.
  */
 Item {
     id: root
@@ -120,7 +136,6 @@ Item {
                 text: root.count > 0 ? "delete_sweep" : "do_not_disturb_on"
                 iconSize: Appearance.font.pixelSize.larger
                 color: Appearance.colors.colOnSecondaryContainer
-                animateChange: true
             }
 
             StyledToolTip {

--- a/dots/.config/quickshell/imi/tests/test_phone_tab_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_tab_runtime.py
@@ -70,7 +70,7 @@ LAPTOP_ADDRESS = "192.168.100.99"
 # A literal, never read back out of the harness's own output: a step list
 # that shrinks must redden here instead of reporting `failures: 0` for a
 # shorter run.
-EXPECTED_CHECKS = 80
+EXPECTED_CHECKS = 87
 
 RECORD = """#!/usr/bin/env bash
 printf '%s %s\\n' "$(date +%s.%N)" "$*" >> "$PHONE_EXEC_LOG"

--- a/dots/.config/quickshell/imi/tests/test_phone_tab_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_tab_runtime.py
@@ -38,6 +38,13 @@ not, and a failed launch that snaps back to the line it started on. The
 sub-page cross-fade and the toast's width are watched the same way, each with
 a control, since a settled reading is identical whether or not anything moved.
 
+So is the footer's clear action, which carries the one glyph on that bar whose
+text ever changes: the count is driven through `PhoneNotifications` and the
+swap sampled in both axes and in opacity, because a deferred text swap on a
+Control's content item lands the glyph on the padded rect's corner and leaves
+it there - a reading taken before the first change agrees with itself either
+way.
+
 Brings its own headless weston and its own session bus (`dbus-run-session`).
 Skips when weston, qs or dbus-run-session are missing, as in CI.
 """
@@ -63,7 +70,7 @@ LAPTOP_ADDRESS = "192.168.100.99"
 # A literal, never read back out of the harness's own output: a step list
 # that shrinks must redden here instead of reporting `failures: 0` for a
 # shorter run.
-EXPECTED_CHECKS = 70
+EXPECTED_CHECKS = 76
 
 RECORD = """#!/usr/bin/env bash
 printf '%s %s\\n' "$(date +%s.%N)" "$*" >> "$PHONE_EXEC_LOG"

--- a/dots/.config/quickshell/imi/tests/test_phone_tab_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_tab_runtime.py
@@ -70,7 +70,7 @@ LAPTOP_ADDRESS = "192.168.100.99"
 # A literal, never read back out of the harness's own output: a step list
 # that shrinks must redden here instead of reporting `failures: 0` for a
 # shorter run.
-EXPECTED_CHECKS = 76
+EXPECTED_CHECKS = 80
 
 RECORD = """#!/usr/bin/env bash
 printf '%s %s\\n' "$(date +%s.%N)" "$*" >> "$PHONE_EXEC_LOG"


### PR DESCRIPTION
Three presentation defects on the Phone tab, each measured rather than eyeballed.

**The Stop button's label was not centred.** Its content item was a bare `RowLayout`, stretched to the padded rect of a `Layout.fillWidth` button, so the pair laid out from the left edge *and* the gap between glyph and word opened as the button grew. Measured at card widths 200 and 460: the pair sat **35.48px** and **117.98px** left of the button's centre, and grew **97.03px → 192.03px** wide. It is now a plain `Item` at the padded rect with the row `anchors.centerIn` inside it — an ordinary parent-child anchor the Control never touches. After: **57.03px wide, 0.48px off centre at both widths**, the residual being the glyph's box against its painted extent.

`RippleButtonWithIcon` was measured rather than argued about, and rejected: its label slot is `Layout.fillWidth: true`, so one at 460px with the same glyph and word reads **191.46px left of centre** — bd35286c3's finding arriving from the other end. That measurement stays in the harness as a permanent control.

**The footer's clear button latched its glyph off centre.** The difference from the sync button beside it was `animateChange: true`. `StyledText`'s deferred swap animates the Text's own `x`/`y` back to the `originalX`/`originalY` recorded in its *own* `Component.onCompleted` — which, for a Control's content item, runs before the Control has placed it, so those are (0,0). Measured after one count change: the clear glyph settled at **(-4.00, -4.00)** — exactly the Control's padding — peaked **10.00px** off centre and dropped to **opacity 0.00** inside a pill that does not fade, while the sync glyph held (0.00, 0.00) throughout. The `animateChange` is gone; no nudge. After: **(0.00, 0.00) both, worst 0.00px, min opacity 1.00**.

**The device roster snapped in and out, and was hand-rolled.** It is a `StyledListView` over `PhoneConnect.devices` with `PhoneDeviceItem` delegates now — the shape `sidebarRight/wifiNetworks/WifiDialog.qml` and `bluetoothDevices/BluetoothDialog.qml` already use. Rejected, with reasons: `Revealer` (its tier is `elementMoveEnter`, a directional curve, wrong for a toggle the user reverses), `GroupedList` (settings-row grouping, not a selectable device list), `SelectionDialog` (a modal with a scrim); the designsystem mirror has no list container of its own. The reveal is `rosterProgress` — one scalar, one `Behavior` on `Appearance.animation.elementMove` taken whole, the tab's own `subPageProgress` precedent — watched at **7** mid-flight frames unrolling to a peak of 117.61 (the spatial curve leaving the unit box) and **8** folding back; planting the `Behavior` out takes both counts to 0 while both settled checks stay green.

One reusable trap, recorded in AGENT.md: a `QQuickLayout` stops writing the height of a child it has excluded, so a folded box keeps a stale **1.38px**. Read ungated, that sits in the mid-flight band forever and the fold's own check passes on a snap.

`EXPECTED_CHECKS` 70 -> 87, in three steps matching the commits.

Suite: default locale `All tests passed successfully!` (1417 passed, 0 failed). The `LC_ALL=C` pass is **not** reported here — it waited ~40 minutes on the suite lock, cleared the lints and three compositor harnesses with nothing failing, and was reaped mid-run before reaching this branch's own harness. Nothing here is locale-sensitive, but that is reasoning rather than a measurement.

Docs: updated AGENT.md §Dynamic/data-driven QML gotchas
Changelog: updated
