### PR TITLE
fix(settings): a segmented row's chips lay out on the width the row has

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1769,6 +1769,22 @@ row. ("perf(search): rebuild the launcher results once per turn, not per input c
 
 ## Dynamic/data-driven QML gotchas
 
+- **A `Flow` with no width of its own and an incubated parent wraps once and
+  stays wrapped.** `Flow` takes its `implicitWidth` when a layout does not
+  give it a width, and computes that implicit width from the width it
+  currently has - the two define each other. Built in one pass it settles
+  on one line; built a few frames at a time, which is what
+  `SettingsContent`'s page host does since it stopped blocking on
+  construction, it latches at the narrow intermediate width and never
+  re-flows, because the wrap is what keeps the implicit width narrow.
+  Measured on `ConfigSelectionArray` at 628px: 43px synchronous, 154px
+  incubated, and every segmented row on every settings page looked like
+  the second one. Give such a Flow a `Layout.preferredWidth` summed from
+  its children's own implicit widths - an answer rather than a circle.
+  Note also that `Layout.alignment` hands a child its preferred size and
+  positions it, never resizes it, so an aligned Flow overflows a narrow
+  row instead of wrapping; that is a separate, older question.
+
 - **CI's Qt is older than yours, and its JS parser is too.** The workflow
   installs Ubuntu's `qt6-declarative-dev`; a developer here runs Arch's
   current one. Syntax the newer parser accepts is a COMPILE error on the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ own repo; the installer pins which revision it builds.
 ## [Unreleased]
 
 ### Fixed
+- **Settings rows show their choices in a row again.** Every segmented
+  option row on every settings page had started stacking its buttons one
+  per line - Bar position, Bar style, Group style and the rest - since
+  the settings window stopped building all of its pages at once. A page
+  built a few frames at a time gave the buttons a width they then kept.
 - **The phone webcam's preview window closes with the session instead of
   freezing on screen.** Open the webcam, open the preview, then stop the
   camera: the preview used to stay up, frozen on its last frame, and nothing in

--- a/dots/.config/quickshell/imi/modules/common/widgets/ConfigSelectionArray.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/ConfigSelectionArray.qml
@@ -72,6 +72,42 @@ ColumnLayout {
             Layout.alignment: Qt.AlignRight
             spacing: Appearance.spacing.space25
 
+            // A Flow with no width of its own takes its implicitWidth, and a
+            // Flow computes THAT from the width it currently has - so the two
+            // define each other. Built in one pass it happens to settle on one
+            // line; incubated across frames (which is how a settings page is
+            // built since the page host stopped blocking on construction) it
+            // latches at the narrow intermediate width, wraps every chip onto
+            // its own line, and never re-flows, because the wrap is what keeps
+            // the implicit width narrow. Measured on this row at 628px: 43px
+            // tall built synchronously, 154px incubated.
+            //
+            // `naturalWidth` is summed from the buttons' own implicit widths,
+            // which owe nothing to this Flow, so it is an answer rather than a
+            // circle. Handing it over as the PREFERRED width leaves the layout
+            // free to give less when there is less, and the chips wrap then for
+            // the real reason.
+            readonly property real naturalWidth: {
+                let total = 0;
+                let counted = 0;
+                for (let i = 0; i < children.length; i++) {
+                    const child = children[i];
+                    if (!child.visible || child.implicitWidth <= 0) continue;
+                    total += child.implicitWidth;
+                    counted++;
+                }
+                return counted > 0 ? total + spacing * (counted - 1) : 0;
+            }
+            Layout.preferredWidth: root.text ? buttonsFlow.naturalWidth : -1
+            // Not paired with a `Layout.minimumWidth: 0`: an ALIGNED child is
+            // handed its preferred size and positioned, never resized, so the
+            // minimum is never consulted. A row too narrow for its chips
+            // therefore overflows rather than wrapping - measured, a 228px row
+            // leaves this Flow at its full 333px. That predates this fix and is
+            // its own change: making the chips yield means giving up
+            // `Layout.alignment`, and then the right edge has to be earned some
+            // other way.
+
             Repeater {
                 model: root.options
                 delegate: SelectionGroupButton {

--- a/dots/.config/quickshell/imi/tests/fixtures/ConfigSelectionArrayRow.qml
+++ b/dots/.config/quickshell/imi/tests/fixtures/ConfigSelectionArrayRow.qml
@@ -1,0 +1,32 @@
+import QtQuick
+import QtQuick.Layouts
+import qs.modules.common
+import qs.modules.common.widgets
+
+Item {
+    id: host
+    property alias row: sel
+    property int hostWidth: 660
+    width: hostWidth
+    ColumnLayout {
+        width: parent.width
+        ConfigSelectionArray {
+                id: sel
+                Layout.fillWidth: true
+                // The host's width is only a constraint if the row is
+                // told it cannot exceed it: a QQuickLayout hands a child
+                // its implicit width when nothing caps it, so without
+                // this the "narrow" case is not narrow at all.
+                Layout.maximumWidth: host.hostWidth - Appearance.spacing.space400
+                text: "Bar position"
+                icon: "swap_vert"
+                currentValue: "top"
+                options: [
+                    {"displayName": "Top", "icon": "arrow_upward", "value": "top"},
+                    {"displayName": "Left", "icon": "arrow_back", "value": "left"},
+                    {"displayName": "Bottom", "icon": "arrow_downward", "value": "bottom"},
+                    {"displayName": "Right", "icon": "arrow_forward", "value": "right"}
+                ]
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/tests/imports/qs/modules/common/widgets/ButtonMouseArea.qml
+++ b/dots/.config/quickshell/imi/tests/imports/qs/modules/common/widgets/ButtonMouseArea.qml
@@ -1,0 +1,1 @@
+../../../../../../modules/common/widgets/ButtonMouseArea.qml

--- a/dots/.config/quickshell/imi/tests/imports/qs/modules/common/widgets/CircleUtilButton.qml
+++ b/dots/.config/quickshell/imi/tests/imports/qs/modules/common/widgets/CircleUtilButton.qml
@@ -1,0 +1,1 @@
+../../../../../../modules/common/widgets/CircleUtilButton.qml

--- a/dots/.config/quickshell/imi/tests/imports/qs/modules/common/widgets/ConfigSelectionArray.qml
+++ b/dots/.config/quickshell/imi/tests/imports/qs/modules/common/widgets/ConfigSelectionArray.qml
@@ -1,0 +1,1 @@
+../../../../../../modules/common/widgets/ConfigSelectionArray.qml

--- a/dots/.config/quickshell/imi/tests/imports/qs/modules/common/widgets/GroupButton.qml
+++ b/dots/.config/quickshell/imi/tests/imports/qs/modules/common/widgets/GroupButton.qml
@@ -1,0 +1,1 @@
+../../../../../../modules/common/widgets/GroupButton.qml

--- a/dots/.config/quickshell/imi/tests/imports/qs/modules/common/widgets/InfoTooltipIcon.qml
+++ b/dots/.config/quickshell/imi/tests/imports/qs/modules/common/widgets/InfoTooltipIcon.qml
@@ -1,0 +1,1 @@
+../../../../../../modules/common/widgets/InfoTooltipIcon.qml

--- a/dots/.config/quickshell/imi/tests/imports/qs/modules/common/widgets/MaterialShape.qml
+++ b/dots/.config/quickshell/imi/tests/imports/qs/modules/common/widgets/MaterialShape.qml
@@ -1,0 +1,1 @@
+../../../../../../modules/common/widgets/MaterialShape.qml

--- a/dots/.config/quickshell/imi/tests/imports/qs/modules/common/widgets/MaterialSymbol.qml
+++ b/dots/.config/quickshell/imi/tests/imports/qs/modules/common/widgets/MaterialSymbol.qml
@@ -1,0 +1,1 @@
+../../../../../../modules/common/widgets/MaterialSymbol.qml

--- a/dots/.config/quickshell/imi/tests/imports/qs/modules/common/widgets/OptionalMaterialSymbol.qml
+++ b/dots/.config/quickshell/imi/tests/imports/qs/modules/common/widgets/OptionalMaterialSymbol.qml
@@ -1,0 +1,1 @@
+../../../../../../modules/common/widgets/OptionalMaterialSymbol.qml

--- a/dots/.config/quickshell/imi/tests/imports/qs/modules/common/widgets/RippleButton.qml
+++ b/dots/.config/quickshell/imi/tests/imports/qs/modules/common/widgets/RippleButton.qml
@@ -1,0 +1,1 @@
+../../../../../../modules/common/widgets/RippleButton.qml

--- a/dots/.config/quickshell/imi/tests/imports/qs/modules/common/widgets/SelectionGroupButton.qml
+++ b/dots/.config/quickshell/imi/tests/imports/qs/modules/common/widgets/SelectionGroupButton.qml
@@ -1,0 +1,1 @@
+../../../../../../modules/common/widgets/SelectionGroupButton.qml

--- a/dots/.config/quickshell/imi/tests/imports/qs/modules/common/widgets/StyledRectangularShadow.qml
+++ b/dots/.config/quickshell/imi/tests/imports/qs/modules/common/widgets/StyledRectangularShadow.qml
@@ -1,0 +1,1 @@
+../../../../../../modules/common/widgets/StyledRectangularShadow.qml

--- a/dots/.config/quickshell/imi/tests/imports/qs/modules/common/widgets/StyledText.qml
+++ b/dots/.config/quickshell/imi/tests/imports/qs/modules/common/widgets/StyledText.qml
@@ -1,0 +1,1 @@
+../../../../../../modules/common/widgets/StyledText.qml

--- a/dots/.config/quickshell/imi/tests/imports/qs/modules/common/widgets/StyledToolTip.qml
+++ b/dots/.config/quickshell/imi/tests/imports/qs/modules/common/widgets/StyledToolTip.qml
@@ -1,0 +1,1 @@
+../../../../../../modules/common/widgets/StyledToolTip.qml

--- a/dots/.config/quickshell/imi/tests/imports/qs/modules/common/widgets/StyledToolTipContent.qml
+++ b/dots/.config/quickshell/imi/tests/imports/qs/modules/common/widgets/StyledToolTipContent.qml
@@ -1,0 +1,1 @@
+../../../../../../modules/common/widgets/StyledToolTipContent.qml

--- a/dots/.config/quickshell/imi/tests/imports/qs/modules/common/widgets/qmldir
+++ b/dots/.config/quickshell/imi/tests/imports/qs/modules/common/widgets/qmldir
@@ -4,3 +4,17 @@ LiveDesktopEntry 1.0 LiveDesktopEntry.qml
 WallpaperBlurSurface 1.0 WallpaperBlurSurface.qml
 StaggerEntrance 1.0 StaggerEntrance.qml
 StaggerWave 1.0 StaggerWave.qml
+ConfigSelectionArray 1.0 ConfigSelectionArray.qml
+SelectionGroupButton 1.0 SelectionGroupButton.qml
+OptionalMaterialSymbol 1.0 OptionalMaterialSymbol.qml
+InfoTooltipIcon 1.0 InfoTooltipIcon.qml
+StyledText 1.0 StyledText.qml
+MaterialSymbol 1.0 MaterialSymbol.qml
+RippleButton 1.0 RippleButton.qml
+StyledToolTip 1.0 StyledToolTip.qml
+StyledToolTipContent 1.0 StyledToolTipContent.qml
+GroupButton 1.0 GroupButton.qml
+ButtonMouseArea 1.0 ButtonMouseArea.qml
+StyledRectangularShadow 1.0 StyledRectangularShadow.qml
+MaterialShape 1.0 MaterialShape.qml
+CircleUtilButton 1.0 CircleUtilButton.qml

--- a/dots/.config/quickshell/imi/tests/tst_config_selection_array.qml
+++ b/dots/.config/quickshell/imi/tests/tst_config_selection_array.qml
@@ -1,0 +1,109 @@
+import QtQuick
+import QtQuick.Layouts
+import QtTest
+import qs.modules.common
+import qs.modules.common.widgets
+
+// A segmented row's chips wrap on the width the row really has, not on the
+// width the Flow inferred from itself while it was still being built.
+//
+// The defect this pins: a Flow with no width of its own takes its
+// implicitWidth, and computes that from the width it currently has. Built in
+// one pass it settles on one line; INCUBATED across frames - which is how a
+// settings page has been built since the page host stopped blocking on
+// construction - it latched at the narrow intermediate width and wrapped every
+// chip onto its own line, permanently. Measured at 628px: 43px synchronous,
+// 154px asynchronous. Every segmented row on every settings page looked like
+// that, and no check could see it, because a synchronous build is correct.
+TestCase {
+    id: tc
+    name: "ConfigSelectionArrayTest"
+    visible: true
+    when: windowShown
+    width: 700
+    height: 500
+
+    Component {
+        id: rowComponent
+        Item {
+            id: host
+            property alias row: sel
+            property int hostWidth: 660
+            width: hostWidth
+            ColumnLayout {
+                width: parent.width
+                GroupedList {
+                    Layout.fillWidth: true
+                    ConfigSelectionArray {
+                        id: sel
+                        Layout.fillWidth: true
+                        // The host's width is only a constraint if the row is
+                        // told it cannot exceed it: a QQuickLayout hands a child
+                        // its implicit width when nothing caps it, so without
+                        // this the "narrow" case is not narrow at all.
+                        Layout.maximumWidth: host.hostWidth - Appearance.spacing.space400
+                        text: "Bar position"
+                        icon: "swap_vert"
+                        currentValue: "top"
+                        options: [
+                            {"displayName": "Top", "icon": "arrow_upward", "value": "top"},
+                            {"displayName": "Left", "icon": "arrow_back", "value": "left"},
+                            {"displayName": "Bottom", "icon": "arrow_downward", "value": "bottom"},
+                            {"displayName": "Right", "icon": "arrow_forward", "value": "right"}
+                        ]
+                    }
+                }
+            }
+        }
+    }
+
+    property var incubated: null
+
+    function buildAsync(props) {
+        tc.incubated = null;
+        const incubator = rowComponent.incubateObject(tc, props ?? {}, Qt.Asynchronous);
+        incubator.onStatusChanged = function (status) {
+            if (status === Component.Ready)
+                tc.incubated = incubator.object;
+        };
+        if (incubator.status === Component.Ready)
+            tc.incubated = incubator.object;
+        tryVerify(function () { return tc.incubated !== null; }, 5000, "the row never finished incubating");
+        wait(400);
+        return tc.incubated;
+    }
+
+    // The measurement that matters: the same row, built both ways, is the same
+    // height. Asserting a literal height instead would pin the font metrics of
+    // whichever machine ran it last.
+    function test_an_incubated_row_lays_its_chips_out_like_a_built_one() {
+        const built = rowComponent.createObject(tc);
+        wait(400);
+        const syncHeight = built.row.height;
+        verify(syncHeight > 0, "the synchronous row has no height at all");
+
+        const incubatedRow = buildAsync(null);
+        compare(incubatedRow.row.height, syncHeight,
+                "an incubated row is taller than the same row built in one pass, which is the Flow "
+                + "wrapping on a width it inferred from itself mid-construction");
+
+        built.destroy();
+        incubatedRow.destroy();
+    }
+
+    // The other half: the same agreement at a width where the chips genuinely
+    // do not fit on one line. Comparing only the roomy case would pass just as
+    // well on a row that had stopped wrapping altogether.
+    function test_the_two_builds_agree_when_the_row_is_cramped() {
+        const built = rowComponent.createObject(tc, {hostWidth: 320});
+        wait(400);
+        const syncHeight = built.row.height;
+
+        const incubatedRow = buildAsync({hostWidth: 320});
+        compare(incubatedRow.row.height, syncHeight,
+                "at 320px an incubated row and a built one disagree about how many lines the chips take");
+
+        built.destroy();
+        incubatedRow.destroy();
+    }
+}

--- a/dots/.config/quickshell/imi/tests/tst_config_selection_array.qml
+++ b/dots/.config/quickshell/imi/tests/tst_config_selection_array.qml
@@ -32,9 +32,7 @@ TestCase {
             width: hostWidth
             ColumnLayout {
                 width: parent.width
-                GroupedList {
-                    Layout.fillWidth: true
-                    ConfigSelectionArray {
+                ConfigSelectionArray {
                         id: sel
                         Layout.fillWidth: true
                         // The host's width is only a constraint if the row is
@@ -51,7 +49,6 @@ TestCase {
                             {"displayName": "Bottom", "icon": "arrow_downward", "value": "bottom"},
                             {"displayName": "Right", "icon": "arrow_forward", "value": "right"}
                         ]
-                    }
                 }
             }
         }

--- a/dots/.config/quickshell/imi/tests/tst_config_selection_array.qml
+++ b/dots/.config/quickshell/imi/tests/tst_config_selection_array.qml
@@ -23,38 +23,24 @@ TestCase {
     width: 700
     height: 500
 
-    Component {
-        id: rowComponent
-        Item {
-            id: host
-            property alias row: sel
-            property int hostWidth: 660
-            width: hostWidth
-            ColumnLayout {
-                width: parent.width
-                ConfigSelectionArray {
-                        id: sel
-                        Layout.fillWidth: true
-                        // The host's width is only a constraint if the row is
-                        // told it cannot exceed it: a QQuickLayout hands a child
-                        // its implicit width when nothing caps it, so without
-                        // this the "narrow" case is not narrow at all.
-                        Layout.maximumWidth: host.hostWidth - Appearance.spacing.space400
-                        text: "Bar position"
-                        icon: "swap_vert"
-                        currentValue: "top"
-                        options: [
-                            {"displayName": "Top", "icon": "arrow_upward", "value": "top"},
-                            {"displayName": "Left", "icon": "arrow_back", "value": "left"},
-                            {"displayName": "Bottom", "icon": "arrow_downward", "value": "bottom"},
-                            {"displayName": "Right", "icon": "arrow_forward", "value": "right"}
-                        ]
-                }
-            }
-        }
+
+    // Built from a URL rather than declared inline, the way
+    // tst_bar_group_collapse.qml does it: this row draws through RippleButton
+    // and the per-corner radii Qt below 6.7 does not have, and declared inline
+    // the whole FILE fails to compile there rather than this one check. Through
+    // createComponent the version dependency is a status the test can read.
+    property Component rowComponent: null
+    property var incubated: null
+
+    function initTestCase() {
+        rowComponent = Qt.createComponent("fixtures/ConfigSelectionArrayRow.qml");
     }
 
-    property var incubated: null
+    function ensureComponent() {
+        if (rowComponent.status === Component.Error)
+            skip("this Qt cannot build the row: " + rowComponent.errorString());
+        compare(rowComponent.status, Component.Ready, rowComponent.errorString());
+    }
 
     function buildAsync(props) {
         tc.incubated = null;
@@ -74,6 +60,7 @@ TestCase {
     // height. Asserting a literal height instead would pin the font metrics of
     // whichever machine ran it last.
     function test_an_incubated_row_lays_its_chips_out_like_a_built_one() {
+        ensureComponent();
         const built = rowComponent.createObject(tc);
         wait(400);
         const syncHeight = built.row.height;
@@ -92,6 +79,7 @@ TestCase {
     // do not fit on one line. Comparing only the roomy case would pass just as
     // well on a row that had stopped wrapping altogether.
     function test_the_two_builds_agree_when_the_row_is_cramped() {
+        ensureComponent();
         const built = rowComponent.createObject(tc, {hostWidth: 320});
         wait(400);
         const syncHeight = built.row.height;


### PR DESCRIPTION
Every segmented option row on every settings page — Bar position, Bar style, Group style and the rest — had been stacking its buttons one per line.

The cause is two correct changes meeting. `ConfigSelectionArray`'s chips sit in a `Flow` with `Layout.fillWidth: false`, so its width **is** its `implicitWidth` — and a `Flow` computes that implicit width from the width it currently has. The two define each other. Built in one pass it happens to settle on one line; **incubated across frames**, which is what the settings page host has done since it stopped building all fifteen pages in one turn of the event loop, it latches at the narrow intermediate width and never re-flows, because the wrap is what keeps the implicit width narrow.

Measured on the Bar position row at 628px: **43px built synchronously, 154px incubated.**

The Flow now states a `Layout.preferredWidth` summed from the buttons' own implicit widths, which owe nothing to the Flow — an answer rather than a circle.

Two checks, both of which go **red against the unfixed widget**: the same row built twice, once with `createObject` and once with `incubateObject`, at a roomy width and at a cramped one where the chips genuinely do not fit on a line. Comparing only the roomy case would pass equally well on a row that had stopped wrapping altogether.

One thing recorded rather than fixed: `Layout.alignment` hands a child its preferred size and positions it, never resizes it, so a row too narrow for its chips overflows instead of wrapping — measured, a 228px row leaves the Flow at its full 333px. That predates this fix and wants its own change, since making the chips yield means giving up the alignment and earning the right edge some other way.

The test needed `ConfigSelectionArray` and its transitive widgets in the `tests/imports` shim; those are symlinks to the real files, as the existing shims are.

Suite: 1436 passed, 0 failed.

Docs: updated AGENT.md §Dynamic/data-driven QML gotchas
Changelog: updated
