### PR TITLE
refactor(phone): four surfaces stop re-implementing the shell's own components

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1769,6 +1769,16 @@ row. ("perf(search): rebuild the launcher results once per turn, not per input c
 
 ## Dynamic/data-driven QML gotchas
 
+- **A clickable card that contains buttons puts its control BEHIND the
+  content, not around it.** Rooting the card on a `RippleButton` nests its
+  own buttons inside a control that dims itself when disabled, and opacity
+  composites - two dims render at x*x, not x, which is what
+  `lint_disabled_opacity.py` fails on. `ExpandablePanel` shows the shape:
+  a non-dimming root, a `RippleButton` filling it for the gesture, and the
+  other controls as that surface's siblings. Reached by measuring in
+  `PhoneFeatureCard.qml`, whose three cards were the only controls in this
+  shell a keyboard could not reach until they became controls at all.
+
 - **A `Flow` with no width of its own and an incubated parent wraps once and
   stays wrapped.** `Flow` takes its `implicitWidth` when a layout does not
   give it a width, and computes that implicit width from the width it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ own repo; the installer pins which revision it builds.
 ## [Unreleased]
 
 ### Fixed
+- **The phone panel's buttons behave like the rest of the shell's.** Its
+  notification bar is the same one the right sidebar draws, so its two
+  actions square off and swell under a press instead of sitting still;
+  the mirror, webcam and microphone cards ripple, dim when they cannot
+  start, and can be reached from the keyboard; a contact card expands
+  the way the Docker panel's cards do; and a notification group of one
+  no longer offers to expand into nothing.
 - **Settings rows show their choices in a row again.** Every segmented
   option row on every settings page had started stacking its buttons one
   per line - Bar position, Bar style, Group style and the rest - since

--- a/dots/.config/quickshell/imi/PhoneTabLayoutRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/PhoneTabLayoutRuntimeTest.qml
@@ -75,6 +75,8 @@ ShellRoot {
     // this the glyph reads as sitting on the card's edge - measured at 4px
     // with the old fixed row height, and photographed by the maintainer.
     readonly property real minAvatarGap: Appearance.spacing.space100
+    // What each script's card measured for the chrome around its header.
+    property var cardPadding: ({})
 
     property string arabicId: ""
     property real arabicCollapsedHeight: 0
@@ -152,10 +154,16 @@ ShellRoot {
     // Everything about the row defect is a comparison between the card's own
     // box and the boxes of the three things it is supposed to contain.
     function scoreRow(tag, row) {
-        const pad = row.rowPadding;
         const headerBox = harness.boxIn(harness.firstNamed(row, "contactHeader"), row);
         const avatarBox = harness.boxIn(harness.firstNamed(row, "contactAvatar"), row);
         const identityBox = harness.boxIn(harness.firstNamed(row, "contactIdentity"), row);
+        // The panel owns the padding now that this card is the shell's own
+        // ExpandablePanel rather than a Rectangle that spelled its own; read
+        // it off the geometry instead of off a property the row no longer
+        // declares. A property that has gone reads as NaN, and every
+        // comparison against NaN is false, which is a check that cannot pass
+        // rather than one that caught something.
+        const pad = headerBox.top;
         console.log(`[PhoneTabLayout] ${tag} card h=${row.height} pad=${pad}`
                     + ` header ${headerBox.top}-${headerBox.bottom}`
                     + ` avatar ${avatarBox.top}-${avatarBox.bottom}`
@@ -172,8 +180,17 @@ ShellRoot {
                       avatarBox.top >= harness.minAvatarGap);
         harness.check(`${tag}: the card is its content plus its own padding and nothing`
                       + ` else, got ${row.height} against ${headerBox.bottom + pad}`,
-                      Math.abs(row.height - (headerBox.bottom + pad)) <= 1
-                      && Math.abs(headerBox.top - pad) <= 1);
+                      Math.abs(row.height - (headerBox.bottom + pad)) <= 1);
+        // ...and that padding is the panel's, so it is the SAME in both scripts:
+        // a card that grew its own chrome to fit a taller name would satisfy the
+        // line above on its own.
+        harness.cardPadding[tag] = pad;
+        const other = tag === "latin" ? "arabic" : "latin";
+        if (harness.cardPadding[other] !== undefined)
+            harness.check(`the chrome around the header is the panel's, so it is the same`
+                          + ` in both scripts, got ${harness.cardPadding.latin} and`
+                          + ` ${harness.cardPadding.arabic}`,
+                          Math.abs(harness.cardPadding[tag] - harness.cardPadding[other]) <= 1);
     }
 
     Process { id: fixtureStep }
@@ -405,6 +422,8 @@ ShellRoot {
                           arabic.height > latin.height);
             harness.arabicCollapsedHeight = arabic.height;
             harness.arabicId = String(arabic.modelData.id);
+            console.log(`[PhoneTabLayout] captured arabicId="${harness.arabicId}"`
+                        + ` from ${arabic.modelData?.id} collapsed=${harness.arabicCollapsedHeight}`);
         },
 
         // ---- ...and so does the stack it grows when it is expanded --------
@@ -420,7 +439,9 @@ ShellRoot {
             const detailsBox = harness.boxIn(details, arabic);
             console.log(`[PhoneTabLayout] arabic expanded card h=${arabic?.height}`
                         + ` details ${detailsBox.top}-${detailsBox.bottom}`
-                        + ` rows=${details?.children.length}`);
+                        + ` rows=${details?.children.length}`
+                        + ` panelExpanded=${arabic?.expanded}`
+                        + ` wantId=${harness.arabicId} rowId=${arabic?.modelData?.id}`);
             harness.check(`expanding the Arabic contact grows its card, got`
                           + ` ${arabic?.height} against ${harness.arabicCollapsedHeight}`,
                           arabic !== null && arabic.height > harness.arabicCollapsedHeight);

--- a/dots/.config/quickshell/imi/PhoneTabRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/PhoneTabRuntimeTest.qml
@@ -175,12 +175,20 @@ ShellRoot {
         return harness.all("PhoneFeatureCard").find(c => `${c.title}`.indexOf(fragment) >= 0) ?? null;
     }
 
-    // The footer's row, read structurally rather than by type: its three
-    // children ARE the two actions and the pill between them, in that order,
-    // and which of them is which is the whole thing being measured.
-    function footerRow() {
+    // The footer's three slots. Read by TYPE now, not by walking children: the
+    // bar is a ButtonGroup, whose `default property alias data` reparents what
+    // it is given into an inner RowLayout, so the bar's own first child is that
+    // layout rather than the first button. Which slot is which is still the
+    // thing being measured - the two actions are the ends, the count is the
+    // middle - so the order matters and the count does.
+    function footerSlots() {
         const footer = harness.first("PhoneFooterBar");
-        return footer ? (footer.children[0] ?? null) : null;
+        return footer ? harness.findAll(footer, "NotificationStatusButton", []) : [];
+    }
+
+    function footerRow() {
+        const slots = harness.footerSlots();
+        return slots.length > 0 ? slots[0].parent : null;
     }
 
     // The badge a feature card leads with: the MaterialShape and the
@@ -544,14 +552,18 @@ ShellRoot {
             // The roster step above left the unpaired laptop showing, which is
             // the pill's other branch: a count of zero must not stand in for
             // "the phone is not here".
-            const label = harness.findAll(harness.first("PhoneFooterBar"), "StyledText", [])[0] ?? null;
+            // The middle slot's own label: every slot is the same component now,
+            // and the two actions carry an empty one, so the first StyledText
+            // under the bar is not the count.
+            const countSlot = harness.footerSlots()[1] ?? null;
+            const label = countSlot ? (harness.findAll(countSlot, "StyledText", [])[0] ?? null) : null;
             harness.check(`an offline device says so instead of counting, got "${label?.text}"`,
                           label !== null && label.text === "Device offline");
             loader.item.pickedDeviceId = harness.phoneId;
         },
         () => {
             const row = harness.footerRow();
-            const slots = row ? row.children : [];
+            const slots = harness.footerSlots();
             harness.footerButtons = slots.length === 3 ? [slots[0], slots[2]] : [];
             harness.footerPill = slots.length === 3 ? slots[1] : null;
             harness.footerLabel = harness.footerPill
@@ -576,10 +588,15 @@ ShellRoot {
             const wider = buttons.every(b => b.width > b.height);
             harness.check(`each action is wider than it is tall, got ${buttons.map(b => `${b.width}x${b.height}`)}`,
                           buttons.length === 2 && wider);
-            harness.check("both actions take the same stated width",
-                          buttons.length === 2 && buttons[0].width === buttons[1].width
-                          && buttons[0].width === Appearance.sizes.phoneFooterButtonWidth
-                          && buttons[0].height === Appearance.sizes.phoneFooterButtonHeight);
+            // Against each other and against the component, not against a
+            // phone-only token: this bar is the right sidebar's status row now,
+            // and NotificationStatusButton states its own baseHeight. The width
+            // follows the glyph, as it does over there.
+            harness.check(`both actions are one shape, got ${buttons.map(b => `${b.width}x${b.height}`)}`,
+                          buttons.length === 2
+                          && buttons[0].width === buttons[1].width
+                          && buttons[0].height === buttons[1].height
+                          && buttons[0].height === buttons[0].baseHeight);
             const offsets = buttons.map(b => harness.glyphOffsetText(b));
             console.log(`[PhoneTab] glyph off centre by ${offsets}`);
             // A RippleButtonWithIcon's glyph was drawn 1.5px left of centre
@@ -603,7 +620,7 @@ ShellRoot {
                           left >= buttons[0].x + buttons[0].width
                           && right <= buttons[1].x);
             harness.check("neither action was squeezed to make room for it",
-                          buttons.every(b => b.width === Appearance.sizes.phoneFooterButtonWidth));
+                          buttons.every(b => b.width === b.baseWidth));
         },
 
         // ---- ...and they stay centred once the count moves ---------------

--- a/dots/.config/quickshell/imi/PhoneTabRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/PhoneTabRuntimeTest.qml
@@ -792,7 +792,10 @@ ShellRoot {
             // The settings chip is a SECOND affordance on the same card, and
             // it must not be what the card's own click reaches.
             const webcam = harness.cardTitled("Webcam");
-            const chip = harness.findAll(webcam, "RippleButton", [])[0] ?? null;
+            // By name, not by position: the card's surface is a RippleButton
+            // as well, so "the first one" is the surface rather than the chip.
+            const chip = harness.findAll(webcam, "RippleButton", [])
+                .find(b => b.objectName === "cardSettingsChip") ?? null;
             harness.check("the webcam card carries its settings chip", chip !== null);
             harness.check("the sub-page is closed before the chip is clicked",
                           loader.item.subPage === "");

--- a/dots/.config/quickshell/imi/modules/common/Appearance.qml
+++ b/dots/.config/quickshell/imi/modules/common/Appearance.qml
@@ -872,8 +872,6 @@ Singleton {
         // out 44x35, near enough square to read as a circle under
         // `rounding.full`. Both dimensions are stated here so the two buttons
         // and the pill between them cannot disagree about the row's height.
-        property real phoneFooterButtonHeight: 35
-        property real phoneFooterButtonWidth: 48
         // Edit Mode's viewport is inset by exactly what the drawer will need,
         // so the drawer opens into space that already exists rather than
         // covering the desktop or resizing it (spec §1.2). This is the one

--- a/dots/.config/quickshell/imi/modules/common/widgets/NotificationStatusButton.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/NotificationStatusButton.qml
@@ -39,6 +39,12 @@ GroupButton {
                 text: buttonText
                 font.pixelSize: Appearance.font.pixelSize.small
                 color: button.colText
+                // The middle slot of a status row states a count that grows
+                // with the list, and the two actions beside it are not for
+                // pushing off the end of the bar.
+                Layout.fillWidth: true
+                horizontalAlignment: Text.AlignHCenter
+                elide: Text.ElideRight
             }
         }
     }

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneContactsPage.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneContactsPage.qml
@@ -141,152 +141,203 @@ PhoneSubPage {
                 animateAppearance: false
                 visible: PhoneContacts.filtered.length > 0
 
-                delegate: Rectangle {
+                delegate: ExpandablePanel {
                     id: contactRow
                     required property var modelData
-
-                    readonly property bool expanded: root.expandedId === contactRow.modelData.id
                     readonly property bool favourite: PhoneContacts.isFavorite(contactRow.modelData.id, PhoneContacts.favorites)
                     readonly property var phones: contactRow.modelData.phones ?? []
 
-                    // The card's padding, spelled ONCE. It used to be two
-                    // numbers - `space50` on the column's anchors and
-                    // `space100` added to the height - which agree only while
-                    // one happens to be exactly twice the other, so changing
-                    // either leaves the card a different height from what is
-                    // in it. Same coupling `WindowDialog.contentPadding`
-                    // removed, one widget down.
-                    readonly property real rowPadding: Appearance.spacing.space50
-
+                    // The card the Docker manager already draws. It owns the
+                    // expand motion, the clipping, the input gating, the surface
+                    // and the ripple across its header - all of which this row
+                    // used to spell out for itself, which is why the two panels
+                    // in this shell behaved differently under the same gesture.
                     width: contactList.width
-                    implicitHeight: rowColumn.implicitHeight + contactRow.rowPadding * 2
-                    height: implicitHeight
-                    radius: Appearance.rounding.normal
-                    color: contactRow.expanded ? Appearance.colors.colLayer3 : Appearance.colors.colLayer2
+                    // A ListView delegate does not adopt its own implicit height,
+                    // and the panel's grows as it expands: without this the card
+                    // stayed at its collapsed height and drew the detail rows
+                    // outside itself.
+                    height: contactRow.implicitHeight
+                    expanded: root.expandedId === contactRow.modelData.id
+                    headerClickable: true
+                    onHeaderClicked: root.expandedId = contactRow.expanded ? "" : contactRow.modelData.id
 
-                    Behavior on height {
-                        animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
-                    }
-                    Behavior on color {
-                        animation: Appearance.animation.elementMoveFast.colorAnimation.createObject(this)
-                    }
-
-                    ColumnLayout {
-                        id: rowColumn
-                        anchors {
-                            left: parent.left
-                            right: parent.right
-                            top: parent.top
-                            margins: contactRow.rowPadding
-                        }
-                        spacing: Appearance.spacing.space50
-
-                        RippleButton {
-                            // Named so a runtime harness can find the three
-                            // boxes this card is supposed to contain by name,
-                            // rather than by walking a tree whose shape is the
-                            // thing being measured.
+                    header: [
+                        RowLayout {
+                            // Named so the runtime harness can find the boxes this
+                            // card contains by name rather than by walking a tree
+                            // whose shape is the thing being measured.
                             objectName: "contactHeader"
                             Layout.fillWidth: true
-                            // No stated height, and the padding said out
-                            // loud. A Control sizes itself from its content
-                            // item, and what this row holds is a different
-                            // height in every script: measured in a real
-                            // window, the name-and-number column is 34px tall
-                            // for a Latin name and 47 for an Arabic one at
-                            // the same pixelSize, because the shell's font
-                            // carries no Arabic and the fallback sets taller.
-                            // `Layout.preferredHeight: huge * 2` therefore
-                            // fitted one script - the avatar ended 6px above
-                            // the card's own edge in Latin and 1px in Arabic,
-                            // and the NUMBER 3px below it, outside the card.
-                            // An aligned layout child answers a cell that is
-                            // too small by overflowing it, not by shrinking,
-                            // so nothing errors and nothing is logged.
-                            verticalPadding: Appearance.spacing.space75
-                            buttonRadius: Appearance.rounding.small
-                            colBackground: "transparent"
-                            colBackgroundHover: Appearance.colors.colLayer3Hover
-                            colRipple: Appearance.colors.colLayer3Active
-                            onClicked: root.expandedId = contactRow.expanded ? "" : contactRow.modelData.id
+                            spacing: Appearance.spacing.space125
 
-                            contentItem: RowLayout {
-                                spacing: Appearance.spacing.space125
+                            Rectangle {
+                                id: avatar
+                                objectName: "contactAvatar"
+                                Layout.alignment: Qt.AlignVCenter
+                                Layout.preferredWidth: Appearance.font.pixelSize.huge + Appearance.spacing.space200
+                                Layout.preferredHeight: avatar.Layout.preferredWidth
+                                radius: Appearance.rounding.full
+                                color: Appearance.colors.colPrimaryContainer
 
-                                Rectangle {
-                                    id: avatar
-                                    objectName: "contactAvatar"
-                                    Layout.alignment: Qt.AlignVCenter
-                                    Layout.preferredWidth: Appearance.font.pixelSize.huge + Appearance.spacing.space200
-                                    Layout.preferredHeight: avatar.Layout.preferredWidth
-                                    radius: Appearance.rounding.full
-                                    color: Appearance.colors.colPrimaryContainer
+                                StyledText {
+                                    anchors.centerIn: parent
+                                    visible: photo.status !== Image.Ready
+                                    text: String(contactRow.modelData.displayName || "?").charAt(0).toUpperCase()
+                                    font.pixelSize: Appearance.font.pixelSize.normal
+                                    font.weight: Font.DemiBold
+                                    color: Appearance.colors.colOnPrimaryContainer
+                                }
 
-                                    StyledText {
-                                        anchors.centerIn: parent
-                                        visible: photo.status !== Image.Ready
-                                        text: String(contactRow.modelData.displayName || "?").charAt(0).toUpperCase()
-                                        font.pixelSize: Appearance.font.pixelSize.normal
-                                        font.weight: Font.DemiBold
-                                        color: Appearance.colors.colOnPrimaryContainer
-                                    }
-
-                                    // The vCard carries the photo inline as a
-                                    // data URI, so this is the whole avatar
-                                    // pipeline - no file, no cache, nothing to
-                                    // invalidate when the phone re-syncs. The
-                                    // mask is what rounds it: `clip` on a
-                                    // rounded Rectangle clips to the box, not
-                                    // to the corner.
-                                    StyledImage {
-                                        id: photo
-                                        anchors.fill: parent
-                                        source: contactRow.modelData.photo ?? ""
-                                        sourceSize.width: avatar.width * 2
-                                        sourceSize.height: avatar.height * 2
-                                        fillMode: Image.PreserveAspectCrop
-                                        layer.enabled: true
-                                        layer.effect: OpacityMask {
-                                            maskSource: Rectangle {
-                                                width: avatar.width
-                                                height: avatar.height
-                                                radius: avatar.width / 2
-                                            }
+                                // The vCard carries the photo inline as a
+                                // data URI, so this is the whole avatar
+                                // pipeline - no file, no cache, nothing to
+                                // invalidate when the phone re-syncs. The
+                                // mask is what rounds it: `clip` on a
+                                // rounded Rectangle clips to the box, not
+                                // to the corner.
+                                StyledImage {
+                                    id: photo
+                                    anchors.fill: parent
+                                    source: contactRow.modelData.photo ?? ""
+                                    sourceSize.width: avatar.width * 2
+                                    sourceSize.height: avatar.height * 2
+                                    fillMode: Image.PreserveAspectCrop
+                                    layer.enabled: true
+                                    layer.effect: OpacityMask {
+                                        maskSource: Rectangle {
+                                            width: avatar.width
+                                            height: avatar.height
+                                            radius: avatar.width / 2
                                         }
                                     }
                                 }
+                            }
+
+                            ColumnLayout {
+                                objectName: "contactIdentity"
+                                Layout.fillWidth: true
+                                Layout.alignment: Qt.AlignVCenter
+                                spacing: 0
+
+                                StyledText {
+                                    Layout.fillWidth: true
+                                    // A contact's name is the phone's own;
+                                    // never markup.
+                                    textFormat: Text.PlainText
+                                    text: contactRow.modelData.displayName || Translation.tr("Unknown")
+                                    font.pixelSize: Appearance.font.pixelSize.small
+                                    font.weight: Font.DemiBold
+                                    color: Appearance.colors.colOnLayer2
+                                    elide: Text.ElideRight
+                                }
+                                StyledText {
+                                    Layout.fillWidth: true
+                                    textFormat: Text.PlainText
+                                    text: {
+                                        if (contactRow.modelData.organization)
+                                            return contactRow.modelData.organization;
+                                        if (contactRow.phones.length > 0)
+                                            return contactRow.phones[0].value;
+                                        const emails = contactRow.modelData.emails ?? [];
+                                        return emails.length > 0 ? emails[0].value : "";
+                                    }
+                                    font.pixelSize: Appearance.font.pixelSize.smaller
+                                    color: Appearance.colors.colSubtext
+                                    elide: Text.ElideRight
+                                }
+                            }
+
+                            RippleButton {
+                                Layout.preferredWidth: Appearance.font.pixelSize.huge + Appearance.spacing.space150
+                                Layout.preferredHeight: Appearance.font.pixelSize.huge + Appearance.spacing.space150
+                                buttonRadius: Appearance.rounding.full
+                                colBackground: "transparent"
+                                colBackgroundHover: Appearance.colors.colLayer3Hover
+                                colRipple: Appearance.colors.colLayer3Active
+                                onClicked: PhoneContacts.toggleFavorite(contactRow.modelData.id)
+
+                                contentItem: MaterialSymbol {
+                                    horizontalAlignment: Text.AlignHCenter
+                                    verticalAlignment: Text.AlignVCenter
+                                    text: contactRow.favourite ? "star" : "star_outline"
+                                    fill: contactRow.favourite ? 1 : 0
+                                    iconSize: Appearance.font.pixelSize.large
+                                    color: contactRow.favourite ? Appearance.colors.colPrimary : Appearance.colors.colSubtext
+                                    animateChange: true
+                                }
+
+                                StyledToolTip {
+                                    // Starring is also what keeps a
+                                    // nameless card (a SIM import, a
+                                    // blocked number) out of the
+                                    // hide-unnamed filter.
+                                    text: contactRow.favourite
+                                        ? Translation.tr("Remove from favourites")
+                                        : Translation.tr("Add to favourites")
+                                }
+                            }
+
+                            MaterialSymbol {
+                                Layout.alignment: Qt.AlignVCenter
+                                text: contactRow.expanded ? "expand_less" : "expand_more"
+                                iconSize: Appearance.font.pixelSize.larger
+                                color: Appearance.colors.colSubtext
+                                animateChange: true
+                            }
+                        }
+                    ]
+
+                    ColumnLayout {
+                        objectName: "contactDetails"
+                        Layout.fillWidth: true
+                        Layout.leftMargin: Appearance.spacing.space100
+                        Layout.rightMargin: Appearance.spacing.space100
+                        Layout.bottomMargin: Appearance.spacing.space50
+                        // Deliberately not `visible: contactRow.expanded`: the
+                        // panel hides its content with zero height and a clip,
+                        // and says in place why - `visible: false` collapses
+                        // the content column's implicit height to 0, which is
+                        // the height the panel animates TO, so the card would
+                        // never grow.
+                        spacing: Appearance.spacing.space75
+
+                        Repeater {
+                            model: contactRow.phones
+
+                            delegate: RowLayout {
+                                id: phoneRow
+                                required property var modelData
+
+                                Layout.fillWidth: true
+                                spacing: Appearance.spacing.space100
+
+                                MaterialSymbol {
+                                    Layout.alignment: Qt.AlignVCenter
+                                    text: phoneRow.modelData.type === "mobile" ? "smartphone" : "call"
+                                    iconSize: Appearance.font.pixelSize.large
+                                    color: Appearance.colors.colPrimary
+                                }
 
                                 ColumnLayout {
-                                    objectName: "contactIdentity"
                                     Layout.fillWidth: true
-                                    Layout.alignment: Qt.AlignVCenter
                                     spacing: 0
 
                                     StyledText {
                                         Layout.fillWidth: true
-                                        // A contact's name is the phone's own;
-                                        // never markup.
                                         textFormat: Text.PlainText
-                                        text: contactRow.modelData.displayName || Translation.tr("Unknown")
+                                        text: phoneRow.modelData.value
                                         font.pixelSize: Appearance.font.pixelSize.small
-                                        font.weight: Font.DemiBold
-                                        color: Appearance.colors.colOnLayer2
+                                        color: Appearance.colors.colOnLayer3
                                         elide: Text.ElideRight
                                     }
                                     StyledText {
                                         Layout.fillWidth: true
+                                        visible: String(phoneRow.modelData.type || "").length > 0
                                         textFormat: Text.PlainText
-                                        text: {
-                                            if (contactRow.modelData.organization)
-                                                return contactRow.modelData.organization;
-                                            if (contactRow.phones.length > 0)
-                                                return contactRow.phones[0].value;
-                                            const emails = contactRow.modelData.emails ?? [];
-                                            return emails.length > 0 ? emails[0].value : "";
-                                        }
-                                        font.pixelSize: Appearance.font.pixelSize.smaller
+                                        text: phoneRow.modelData.type
+                                        font.pixelSize: Appearance.font.pixelSize.smallest
                                         color: Appearance.colors.colSubtext
-                                        elide: Text.ElideRight
                                     }
                                 }
 
@@ -294,202 +345,113 @@ PhoneSubPage {
                                     Layout.preferredWidth: Appearance.font.pixelSize.huge + Appearance.spacing.space150
                                     Layout.preferredHeight: Appearance.font.pixelSize.huge + Appearance.spacing.space150
                                     buttonRadius: Appearance.rounding.full
-                                    colBackground: "transparent"
-                                    colBackgroundHover: Appearance.colors.colLayer3Hover
-                                    colRipple: Appearance.colors.colLayer3Active
-                                    onClicked: PhoneContacts.toggleFavorite(contactRow.modelData.id)
+                                    colBackground: Appearance.colors.colPrimaryContainer
+                                    colBackgroundHover: Appearance.colors.colPrimaryContainerHover
+                                    colRipple: Appearance.colors.colPrimaryContainerActive
+                                    onClicked: PhoneContacts.openDialer(phoneRow.modelData.value)
 
                                     contentItem: MaterialSymbol {
                                         horizontalAlignment: Text.AlignHCenter
                                         verticalAlignment: Text.AlignVCenter
-                                        text: contactRow.favourite ? "star" : "star_outline"
-                                        fill: contactRow.favourite ? 1 : 0
-                                        iconSize: Appearance.font.pixelSize.large
-                                        color: contactRow.favourite ? Appearance.colors.colPrimary : Appearance.colors.colSubtext
-                                        animateChange: true
+                                        text: "call"
+                                        iconSize: Appearance.font.pixelSize.small
+                                        color: Appearance.colors.colOnPrimaryContainer
                                     }
 
                                     StyledToolTip {
-                                        // Starring is also what keeps a
-                                        // nameless card (a SIM import, a
-                                        // blocked number) out of the
-                                        // hide-unnamed filter.
-                                        text: contactRow.favourite
-                                            ? Translation.tr("Remove from favourites")
-                                            : Translation.tr("Add to favourites")
+                                        text: Translation.tr("Open the dialer on the phone")
                                     }
                                 }
 
-                                MaterialSymbol {
-                                    Layout.alignment: Qt.AlignVCenter
-                                    text: contactRow.expanded ? "expand_less" : "expand_more"
-                                    iconSize: Appearance.font.pixelSize.larger
-                                    color: Appearance.colors.colSubtext
-                                    animateChange: true
+                                RippleButton {
+                                    Layout.preferredWidth: Appearance.font.pixelSize.huge + Appearance.spacing.space150
+                                    Layout.preferredHeight: Appearance.font.pixelSize.huge + Appearance.spacing.space150
+                                    buttonRadius: Appearance.rounding.full
+                                    colBackground: Appearance.colors.colSecondaryContainer
+                                    colBackgroundHover: Appearance.colors.colSecondaryContainerHover
+                                    colRipple: Appearance.colors.colSecondaryContainerActive
+                                    onClicked: PhoneContacts.composeSms(phoneRow.modelData.value)
+
+                                    contentItem: MaterialSymbol {
+                                        horizontalAlignment: Text.AlignHCenter
+                                        verticalAlignment: Text.AlignVCenter
+                                        text: "sms"
+                                        iconSize: Appearance.font.pixelSize.small
+                                        color: Appearance.colors.colOnSecondaryContainer
+                                    }
+
+                                    StyledToolTip {
+                                        text: Translation.tr("Write a message on the phone")
+                                    }
+                                }
+
+                                RippleButton {
+                                    Layout.preferredWidth: Appearance.font.pixelSize.huge + Appearance.spacing.space150
+                                    Layout.preferredHeight: Appearance.font.pixelSize.huge + Appearance.spacing.space150
+                                    buttonRadius: Appearance.rounding.full
+                                    colBackground: Appearance.colors.colLayer4
+                                    colBackgroundHover: Appearance.colors.colLayer4Hover
+                                    colRipple: Appearance.colors.colLayer4Active
+                                    onClicked: Quickshell.clipboardText = phoneRow.modelData.value
+
+                                    contentItem: MaterialSymbol {
+                                        horizontalAlignment: Text.AlignHCenter
+                                        verticalAlignment: Text.AlignVCenter
+                                        text: "content_copy"
+                                        iconSize: Appearance.font.pixelSize.small
+                                        color: Appearance.colors.colOnLayer4
+                                    }
+
+                                    StyledToolTip {
+                                        text: Translation.tr("Copy the number")
+                                    }
                                 }
                             }
                         }
 
-                        ColumnLayout {
-                            objectName: "contactDetails"
-                            Layout.fillWidth: true
-                            Layout.leftMargin: Appearance.spacing.space100
-                            Layout.rightMargin: Appearance.spacing.space100
-                            Layout.bottomMargin: Appearance.spacing.space50
-                            visible: contactRow.expanded
-                            spacing: Appearance.spacing.space75
+                        Repeater {
+                            model: contactRow.modelData.emails ?? []
 
-                            Repeater {
-                                model: contactRow.phones
+                            delegate: RowLayout {
+                                id: emailRow
+                                required property var modelData
 
-                                delegate: RowLayout {
-                                    id: phoneRow
-                                    required property var modelData
+                                Layout.fillWidth: true
+                                spacing: Appearance.spacing.space100
 
-                                    Layout.fillWidth: true
-                                    spacing: Appearance.spacing.space100
-
-                                    MaterialSymbol {
-                                        Layout.alignment: Qt.AlignVCenter
-                                        text: phoneRow.modelData.type === "mobile" ? "smartphone" : "call"
-                                        iconSize: Appearance.font.pixelSize.large
-                                        color: Appearance.colors.colPrimary
-                                    }
-
-                                    ColumnLayout {
-                                        Layout.fillWidth: true
-                                        spacing: 0
-
-                                        StyledText {
-                                            Layout.fillWidth: true
-                                            textFormat: Text.PlainText
-                                            text: phoneRow.modelData.value
-                                            font.pixelSize: Appearance.font.pixelSize.small
-                                            color: Appearance.colors.colOnLayer3
-                                            elide: Text.ElideRight
-                                        }
-                                        StyledText {
-                                            Layout.fillWidth: true
-                                            visible: String(phoneRow.modelData.type || "").length > 0
-                                            textFormat: Text.PlainText
-                                            text: phoneRow.modelData.type
-                                            font.pixelSize: Appearance.font.pixelSize.smallest
-                                            color: Appearance.colors.colSubtext
-                                        }
-                                    }
-
-                                    RippleButton {
-                                        Layout.preferredWidth: Appearance.font.pixelSize.huge + Appearance.spacing.space150
-                                        Layout.preferredHeight: Appearance.font.pixelSize.huge + Appearance.spacing.space150
-                                        buttonRadius: Appearance.rounding.full
-                                        colBackground: Appearance.colors.colPrimaryContainer
-                                        colBackgroundHover: Appearance.colors.colPrimaryContainerHover
-                                        colRipple: Appearance.colors.colPrimaryContainerActive
-                                        onClicked: PhoneContacts.openDialer(phoneRow.modelData.value)
-
-                                        contentItem: MaterialSymbol {
-                                            horizontalAlignment: Text.AlignHCenter
-                                            verticalAlignment: Text.AlignVCenter
-                                            text: "call"
-                                            iconSize: Appearance.font.pixelSize.small
-                                            color: Appearance.colors.colOnPrimaryContainer
-                                        }
-
-                                        StyledToolTip {
-                                            text: Translation.tr("Open the dialer on the phone")
-                                        }
-                                    }
-
-                                    RippleButton {
-                                        Layout.preferredWidth: Appearance.font.pixelSize.huge + Appearance.spacing.space150
-                                        Layout.preferredHeight: Appearance.font.pixelSize.huge + Appearance.spacing.space150
-                                        buttonRadius: Appearance.rounding.full
-                                        colBackground: Appearance.colors.colSecondaryContainer
-                                        colBackgroundHover: Appearance.colors.colSecondaryContainerHover
-                                        colRipple: Appearance.colors.colSecondaryContainerActive
-                                        onClicked: PhoneContacts.composeSms(phoneRow.modelData.value)
-
-                                        contentItem: MaterialSymbol {
-                                            horizontalAlignment: Text.AlignHCenter
-                                            verticalAlignment: Text.AlignVCenter
-                                            text: "sms"
-                                            iconSize: Appearance.font.pixelSize.small
-                                            color: Appearance.colors.colOnSecondaryContainer
-                                        }
-
-                                        StyledToolTip {
-                                            text: Translation.tr("Write a message on the phone")
-                                        }
-                                    }
-
-                                    RippleButton {
-                                        Layout.preferredWidth: Appearance.font.pixelSize.huge + Appearance.spacing.space150
-                                        Layout.preferredHeight: Appearance.font.pixelSize.huge + Appearance.spacing.space150
-                                        buttonRadius: Appearance.rounding.full
-                                        colBackground: Appearance.colors.colLayer4
-                                        colBackgroundHover: Appearance.colors.colLayer4Hover
-                                        colRipple: Appearance.colors.colLayer4Active
-                                        onClicked: Quickshell.clipboardText = phoneRow.modelData.value
-
-                                        contentItem: MaterialSymbol {
-                                            horizontalAlignment: Text.AlignHCenter
-                                            verticalAlignment: Text.AlignVCenter
-                                            text: "content_copy"
-                                            iconSize: Appearance.font.pixelSize.small
-                                            color: Appearance.colors.colOnLayer4
-                                        }
-
-                                        StyledToolTip {
-                                            text: Translation.tr("Copy the number")
-                                        }
-                                    }
+                                MaterialSymbol {
+                                    Layout.alignment: Qt.AlignVCenter
+                                    text: "mail"
+                                    iconSize: Appearance.font.pixelSize.large
+                                    color: Appearance.colors.colPrimary
                                 }
-                            }
-
-                            Repeater {
-                                model: contactRow.modelData.emails ?? []
-
-                                delegate: RowLayout {
-                                    id: emailRow
-                                    required property var modelData
-
+                                StyledText {
                                     Layout.fillWidth: true
-                                    spacing: Appearance.spacing.space100
+                                    textFormat: Text.PlainText
+                                    text: emailRow.modelData.value
+                                    font.pixelSize: Appearance.font.pixelSize.small
+                                    color: Appearance.colors.colOnLayer3
+                                    elide: Text.ElideRight
+                                }
+                                RippleButton {
+                                    Layout.preferredWidth: Appearance.font.pixelSize.huge + Appearance.spacing.space150
+                                    Layout.preferredHeight: Appearance.font.pixelSize.huge + Appearance.spacing.space150
+                                    buttonRadius: Appearance.rounding.full
+                                    colBackground: Appearance.colors.colLayer4
+                                    colBackgroundHover: Appearance.colors.colLayer4Hover
+                                    colRipple: Appearance.colors.colLayer4Active
+                                    onClicked: Quickshell.clipboardText = emailRow.modelData.value
 
-                                    MaterialSymbol {
-                                        Layout.alignment: Qt.AlignVCenter
-                                        text: "mail"
-                                        iconSize: Appearance.font.pixelSize.large
-                                        color: Appearance.colors.colPrimary
+                                    contentItem: MaterialSymbol {
+                                        horizontalAlignment: Text.AlignHCenter
+                                        verticalAlignment: Text.AlignVCenter
+                                        text: "content_copy"
+                                        iconSize: Appearance.font.pixelSize.small
+                                        color: Appearance.colors.colOnLayer4
                                     }
-                                    StyledText {
-                                        Layout.fillWidth: true
-                                        textFormat: Text.PlainText
-                                        text: emailRow.modelData.value
-                                        font.pixelSize: Appearance.font.pixelSize.small
-                                        color: Appearance.colors.colOnLayer3
-                                        elide: Text.ElideRight
-                                    }
-                                    RippleButton {
-                                        Layout.preferredWidth: Appearance.font.pixelSize.huge + Appearance.spacing.space150
-                                        Layout.preferredHeight: Appearance.font.pixelSize.huge + Appearance.spacing.space150
-                                        buttonRadius: Appearance.rounding.full
-                                        colBackground: Appearance.colors.colLayer4
-                                        colBackgroundHover: Appearance.colors.colLayer4Hover
-                                        colRipple: Appearance.colors.colLayer4Active
-                                        onClicked: Quickshell.clipboardText = emailRow.modelData.value
 
-                                        contentItem: MaterialSymbol {
-                                            horizontalAlignment: Text.AlignHCenter
-                                            verticalAlignment: Text.AlignVCenter
-                                            text: "content_copy"
-                                            iconSize: Appearance.font.pixelSize.small
-                                            color: Appearance.colors.colOnLayer4
-                                        }
-
-                                        StyledToolTip {
-                                            text: Translation.tr("Copy the address")
-                                        }
+                                    StyledToolTip {
+                                        text: Translation.tr("Copy the address")
                                     }
                                 }
                             }

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneFeatureCard.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneFeatureCard.qml
@@ -33,7 +33,7 @@ import qs.modules.common.functions
  * Transitions, and a string property shadowing it means a typo elsewhere in
  * the file silently becomes a state name that matches nothing.
  */
-RippleButton {
+Item {
     id: root
 
     property string cardState: "ready"
@@ -59,7 +59,6 @@ RippleButton {
     // the install guide, and `active`, where it is the feature's own toggle.
     property bool hasSettings: false
 
-    // `clicked` comes from the Button underneath - not redeclared here.
     signal settingsClicked
     signal stopClicked
     signal filesDropped(var urls)
@@ -78,25 +77,46 @@ RippleButton {
         animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
     }
 
-    // The card IS the button. It used to be a Rectangle with a second
-    // Rectangle washing it at two hand-picked opacities and a MouseArea on top,
-    // which re-earned hover and press and got neither the ripple, the press
-    // radius morph, the keyboard, nor the disabled dim - and the tab's three
-    // primary actions were the only controls in this shell a keyboard could not
-    // reach. `RippleButton` drives InteractionMotion once, which is the whole
-    // point of f62673b7f's toolbar note: the states come from the control
-    // rather than being re-earned per widget.
-    buttonRadius: Appearance.rounding.normal
-    colBackground: root.isMuted ? Appearance.colors.colLayer3 : Appearance.colors.colPrimaryContainer
-    colBackgroundHover: root.isMuted ? Appearance.colors.colLayer3Hover : Appearance.colors.colPrimaryContainerHover
-    colRipple: root.isMuted ? Appearance.colors.colLayer3Active : Appearance.colors.colPrimaryContainerActive
+    signal clicked
 
-    Behavior on colBackground {
-        animation: Appearance.animation.elementMoveFast.colorAnimation.createObject(this)
+    // The card's surface IS a control, drawn BEHIND the content rather than
+    // around it - the shape ExpandablePanel uses for its own clickable header,
+    // and for the same reason. Rooting the card ON the button instead nests the
+    // Stop button and the settings chip inside a control that dims itself when
+    // disabled, and opacity composites: two dims render at x*x, not x.
+    // lint_disabled_opacity.py failed on exactly that, and it was right.
+    //
+    // What this replaced: a Rectangle with a second Rectangle washing it at two
+    // hand-picked opacities (0.14 pressed, 0.07 hovered) under a MouseArea.
+    // That re-earns hover and press and still gets none of the ripple, the
+    // press radius morph, the disabled dim, or the keyboard - and these three
+    // cards are the tab's primary actions, the only controls in this shell a
+    // keyboard could not reach.
+    RippleButton {
+        id: cardSurface
+        anchors.fill: parent
+        buttonRadius: Appearance.rounding.normal
+        colBackground: root.isMuted ? Appearance.colors.colLayer3 : Appearance.colors.colPrimaryContainer
+        colBackgroundHover: root.isMuted ? Appearance.colors.colLayer3Hover : Appearance.colors.colPrimaryContainerHover
+        colRipple: root.isMuted ? Appearance.colors.colLayer3Active : Appearance.colors.colPrimaryContainerActive
+        onClicked: root.clicked()
+
+        Behavior on colBackground {
+            animation: Appearance.animation.elementMoveFast.colorAnimation.createObject(this)
+        }
     }
 
-    contentItem: ColumnLayout {
+
+    ColumnLayout {
         id: cardColumn
+        anchors {
+            left: parent.left
+            right: parent.right
+            top: parent.top
+            leftMargin: Appearance.spacing.space150
+            rightMargin: Appearance.spacing.space150
+            topMargin: Appearance.spacing.space100
+        }
         spacing: Appearance.spacing.space75
 
         RowLayout {
@@ -165,6 +185,10 @@ RippleButton {
 
             RippleButton {
                 id: settingsButton
+                // Named because the card's own surface is a RippleButton too
+                // now, and "the first RippleButton in the card" stopped being
+                // this one the moment the surface was drawn behind it.
+                objectName: "cardSettingsChip"
                 Layout.alignment: Qt.AlignVCenter
                 Layout.preferredWidth: Appearance.font.pixelSize.huge + Appearance.spacing.space150
                 Layout.preferredHeight: Appearance.font.pixelSize.huge + Appearance.spacing.space150

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneFeatureCard.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneFeatureCard.qml
@@ -33,7 +33,7 @@ import qs.modules.common.functions
  * Transitions, and a string property shadowing it means a typo elsewhere in
  * the file silently becomes a state name that matches nothing.
  */
-Item {
+RippleButton {
     id: root
 
     property string cardState: "ready"
@@ -59,7 +59,7 @@ Item {
     // the install guide, and `active`, where it is the feature's own toggle.
     property bool hasSettings: false
 
-    signal clicked
+    // `clicked` comes from the Button underneath - not redeclared here.
     signal settingsClicked
     signal stopClicked
     signal filesDropped(var urls)
@@ -78,49 +78,25 @@ Item {
         animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
     }
 
-    Rectangle {
-        id: cardBackground
-        anchors.fill: parent
-        radius: Appearance.rounding.normal
-        color: root.isMuted ? Appearance.colors.colLayer3 : Appearance.colors.colPrimaryContainer
+    // The card IS the button. It used to be a Rectangle with a second
+    // Rectangle washing it at two hand-picked opacities and a MouseArea on top,
+    // which re-earned hover and press and got neither the ripple, the press
+    // radius morph, the keyboard, nor the disabled dim - and the tab's three
+    // primary actions were the only controls in this shell a keyboard could not
+    // reach. `RippleButton` drives InteractionMotion once, which is the whole
+    // point of f62673b7f's toolbar note: the states come from the control
+    // rather than being re-earned per widget.
+    buttonRadius: Appearance.rounding.normal
+    colBackground: root.isMuted ? Appearance.colors.colLayer3 : Appearance.colors.colPrimaryContainer
+    colBackgroundHover: root.isMuted ? Appearance.colors.colLayer3Hover : Appearance.colors.colPrimaryContainerHover
+    colRipple: root.isMuted ? Appearance.colors.colLayer3Active : Appearance.colors.colPrimaryContainerActive
 
-        Behavior on color {
-            animation: Appearance.animation.elementMoveFast.colorAnimation.createObject(this)
-        }
-
-        // The press/hover wash. Drawn as its own rectangle rather than by
-        // mixing the body's colour, so the two Behaviors do not fight over one
-        // property while a state change is also recolouring the card.
-        Rectangle {
-            anchors.fill: parent
-            radius: parent.radius
-            color: root.colForeground
-            opacity: cardArea.containsPress ? 0.14 : (cardArea.containsMouse ? 0.07 : 0)
-
-            Behavior on opacity {
-                animation: Appearance.animation.elementMoveFaster.numberAnimation.createObject(this)
-            }
-        }
+    Behavior on colBackground {
+        animation: Appearance.animation.elementMoveFast.colorAnimation.createObject(this)
     }
 
-    MouseArea {
-        id: cardArea
-        anchors.fill: parent
-        hoverEnabled: true
-        cursorShape: Qt.PointingHandCursor
-        onClicked: root.clicked()
-    }
-
-    ColumnLayout {
+    contentItem: ColumnLayout {
         id: cardColumn
-        anchors {
-            left: parent.left
-            right: parent.right
-            top: parent.top
-            leftMargin: Appearance.spacing.space150
-            rightMargin: Appearance.spacing.space150
-            topMargin: Appearance.spacing.space100
-        }
         spacing: Appearance.spacing.space75
 
         RowLayout {

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneFooterBar.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneFooterBar.qml
@@ -5,51 +5,28 @@ import QtQuick
 import QtQuick.Layouts
 
 /**
- * The toolbar under the notification list: re-read the phone's
- * notifications, how many there are, dismiss them all.
+ * The Phone tab's footer: sync, the count, and clear.
  *
- * The count pill is deliberately not a button - there is nothing to do to a
- * number - and it says why the count is zero when the reason is the link
- * rather than the phone, so "0 notifications" never stands in for "the phone
- * is not here". The word is spelled out rather than abbreviated, in the
- * spelling `sidebarRight/notifications/NotificationList.qml` already uses for
- * the same count, so the two surfaces share one translation key - and the
- * singular is its own key, because `Translation.tr` takes one string and has
- * no plural form to select.
+ * It is the right sidebar's own notification status row, not a second one -
+ * `ButtonGroup` and three `NotificationStatusButton`s, the same three roles in
+ * the same order, so the two notification surfaces in this shell agree about
+ * what that bar is. That component is where the M3 Expressive state morph
+ * lives: `buttonRadius: baseHeight / 2` at rest against
+ * `buttonRadiusPressed: Appearance.rounding.small`, and `clickedWidth` six
+ * pixels wider than `baseWidth`, so a press squares the pill off and swells it
+ * rather than only tinting it. Hand-rolled here, this bar had a fixed
+ * `rounding.full` and no width response at all.
  *
- * The pill is the row's only `Layout.fillWidth` item, so it can never push
- * the two actions off the row - but its label was centred in it with nothing
- * bounding it, and a centred label paints straight over its neighbours rather
- * than eliding. The label is anchored to the pill's own box now.
- *
- * The two actions state BOTH of their dimensions
- * (`Appearance.sizes.phoneFooterButton*`) rather than sizing themselves from
- * their content. `RippleButtonWithIcon` measures a glyph plus a label, and
- * with the label empty its `Layout.fillWidth` slot still took the row's
- * leftover width - so each button came out 44x35, near enough square to read
- * as a circle under `rounding.full`, with the glyph drawn 1.5px left of the
- * button's own centre (its SLOT was 2.5px off; the glyph sits a pixel into
- * that slot, and the drawn number is the one a reader can check against
- * PhoneTabRuntimeTest). An icon-only button is a `RippleButton` whose
- * contentItem is a `MaterialSymbol` declaring both alignments, which is what
- * centres a Control's content item - an anchor on it is decoration, because a
- * Control sizes and positions its content item itself.
- *
- * Neither glyph carries `animateChange`, and on the clear action that is a fix
- * rather than an omission. `StyledText`'s deferred swap animates the Text's OWN
- * `x` and `y` away and back to the `originalX`/`originalY` it recorded in its
- * own `Component.onCompleted` - which for a Control's content item runs BEFORE
- * the Control has placed it, so those two are (0, 0) and the glyph lands on the
- * top-left corner of the padded rect instead of on its centre, for the rest of
- * the session. Measured in PhoneTabRuntimeTest at the sidebar's 460px: after
- * one swap the clear glyph settled 4.00px left and 4.00px above the button's
- * centre - exactly the Control's own padding - having travelled 10.00px off it
- * on the way, while the sync glyph beside it, whose text never changes, read
- * (0.00, 0.00) throughout. The swap also fades the glyph to zero (measured
- * minimum opacity 0.00) inside a button background that does not fade with it,
- * so the action is an empty pill for a tier's length: the same pair 3c82747df
- * removed from the feature card's badge. The count is the one thing on this bar
- * that changes, which is why this was the one glyph it could happen to.
+ * It also ends a defect by deletion rather than by repair. The clear action
+ * used to be a `RippleButton` whose contentItem carried `animateChange`, and
+ * `StyledText`'s deferred swap animates the Text back to the `originalX`/
+ * `originalY` it recorded in its own `Component.onCompleted` - which for a
+ * Control's content item runs BEFORE the Control has placed it, so those are
+ * (0, 0). Measured at 460px: after one count change the clear glyph settled
+ * 4.00px left and 4.00px above centre, exactly the Control's padding, having
+ * travelled 10.00px on the way, and faded to opacity 0.00 inside a pill that
+ * does not fade. The shared button draws its glyph without that swap, so the
+ * latch has nowhere to happen.
  */
 Item {
     id: root
@@ -59,84 +36,44 @@ Item {
 
     property real appear: 1
 
-    implicitHeight: footerRow.implicitHeight
+    implicitHeight: statusRow.implicitHeight
 
-    RowLayout {
-        id: footerRow
+    ButtonGroup {
+        id: statusRow
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.verticalCenter: parent.verticalCenter
-        spacing: Appearance.spacing.space100
 
-        RippleButton {
-            id: syncButton
-            implicitWidth: Appearance.sizes.phoneFooterButtonWidth
-            implicitHeight: Appearance.sizes.phoneFooterButtonHeight
+        NotificationStatusButton {
+            Layout.fillWidth: false
+            buttonIcon: "sync"
             enabled: root.online
-            buttonRadius: Appearance.rounding.full
-            colBackground: Appearance.colors.colSecondaryContainer
-            colBackgroundHover: Appearance.colors.colSecondaryContainerHover
-            colRipple: Appearance.colors.colSecondaryContainerActive
             onClicked: PhoneNotifications.refresh()
-
-            contentItem: MaterialSymbol {
-                horizontalAlignment: Text.AlignHCenter
-                verticalAlignment: Text.AlignVCenter
-                text: "sync"
-                iconSize: Appearance.font.pixelSize.larger
-                color: Appearance.colors.colOnSecondaryContainer
-            }
 
             StyledToolTip {
                 text: Translation.tr("Sync notifications")
             }
         }
 
-        Rectangle {
-            id: countPill
+        // Not a button at all, and says so: the middle slot is the same
+        // component held disabled, the way the right sidebar's row states its
+        // own count. Drawing it as a Rectangle instead is what let this bar
+        // drift a spacing step away from that one.
+        NotificationStatusButton {
+            enabled: false
             Layout.fillWidth: true
-            implicitHeight: Appearance.sizes.phoneFooterButtonHeight
-            radius: Appearance.rounding.full
-            color: Appearance.colors.colLayer2
-
-            StyledText {
-                anchors.fill: parent
-                anchors.leftMargin: Appearance.spacing.space125
-                anchors.rightMargin: Appearance.spacing.space125
-                horizontalAlignment: Text.AlignHCenter
-                verticalAlignment: Text.AlignVCenter
-                elide: Text.ElideRight
-                maximumLineCount: 1
-                font.pixelSize: Appearance.font.pixelSize.small
-                color: Appearance.colors.colOnLayer2
-                text: {
-                    if (!root.online)
-                        return Translation.tr("Device offline");
-                    return root.count === 1
-                        ? Translation.tr("1 notification")
-                        : Translation.tr("%1 notifications").arg(String(root.count));
-                }
-            }
+            buttonText: root.online
+                ? (root.count === 1
+                    ? Translation.tr("1 notification")
+                    : Translation.tr("%1 notifications").arg(root.count))
+                : Translation.tr("Device offline")
         }
 
-        RippleButton {
-            id: clearButton
-            implicitWidth: Appearance.sizes.phoneFooterButtonWidth
-            implicitHeight: Appearance.sizes.phoneFooterButtonHeight
+        NotificationStatusButton {
+            Layout.fillWidth: false
+            buttonIcon: root.count > 0 ? "delete_sweep" : "do_not_disturb_on"
             enabled: root.online && root.count > 0
-            buttonRadius: Appearance.rounding.full
-            colBackground: Appearance.colors.colSecondaryContainer
-            colBackgroundHover: Appearance.colors.colSecondaryContainerHover
-            colRipple: Appearance.colors.colSecondaryContainerActive
             onClicked: PhoneNotifications.dismissAll()
-
-            contentItem: MaterialSymbol {
-                horizontalAlignment: Text.AlignHCenter
-                verticalAlignment: Text.AlignVCenter
-                text: root.count > 0 ? "delete_sweep" : "do_not_disturb_on"
-                iconSize: Appearance.font.pixelSize.larger
-                color: Appearance.colors.colOnSecondaryContainer
-            }
 
             StyledToolTip {
                 text: root.count > 0

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneNotificationList.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneNotificationList.qml
@@ -231,6 +231,12 @@ Item {
                             color: Appearance.colors.colSubtext
                         }
                         NotificationGroupExpandButton {
+                            // Only where there is a second notification to
+                            // reveal. `NotificationGroup` gates its own on
+                            // `multipleNotifications: notificationCount > 1`
+                            // and this copy did not, so a group of one drew an
+                            // affordance that expanded nothing.
+                            visible: card.notificationCount > 1
                             count: card.notificationCount
                             expanded: card.expanded
                             onClicked: card.expanded = !card.expanded

--- a/dots/.config/quickshell/imi/tests/test_phone_tab_layout_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_tab_layout_runtime.py
@@ -90,7 +90,7 @@ PHONE_ADDRESS = "192.168.100.179"
 # 21 shared, 13 for the contact rows' geometry, 44 for the Apps page - the
 # three states adb itself can be in, the three states the page can be in, and
 # the pairing panel driven through discovery, pair and connect at two widths.
-EXPECTED_CHECKS = 78
+EXPECTED_CHECKS = 79
 
 # The two names the row-geometry steps measure, handed to the harness in the
 # environment so the fixture is the only place either is spelled. The Arabic

--- a/dots/.config/quickshell/imi/tests/test_phone_tab_surface_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_tab_surface_contract.py
@@ -317,16 +317,8 @@ class FeatureCardsContractTests(unittest.TestCase):
         for service in SERVICE_NAMES:
             self.assertNotIn(f"{service}.", self.card,
                              f"PhoneFeatureCard reaches {service} directly")
-        # `clicked` is the Button's own now that the card is rooted on
-        # RippleButton - redeclaring it would be a duplicate-signal error - so
-        # what is checked is that the card still RAISES rather than calls, and
-        # that the click has somewhere to go.
-        for name in ("settingsClicked", "stopClicked"):
+        for name in ("clicked", "settingsClicked", "stopClicked"):
             self.assertRegex(self.card, rf"signal {name}\b", f"the card has no {name} signal")
-        self.assertNotRegex(
-            self.card, r"signal clicked\b",
-            "the card redeclares `clicked`, which the control underneath already carries",
-        )
 
     def test_every_state_key_the_arithmetic_can_answer_with_has_an_arm(self):
         """An unmapped key draws an empty line, which reads as a card with
@@ -507,15 +499,24 @@ class ClickableSurfacesAreControls(unittest.TestCase):
         "PhoneAdbPairPanel.qml": "a form of controls",
     }
 
-    def test_a_card_the_user_clicks_is_a_button(self):
+    def test_a_card_the_user_clicks_goes_through_a_control(self):
+        """Not "the root is a Button": the card contains a Stop button and a
+        settings chip, and nesting those inside a control that dims itself
+        composites the two dims at x*x - `lint_disabled_opacity.py` fails on it.
+        The surface is a RippleButton drawn BEHIND the content instead, which is
+        what `ExpandablePanel` does for its own clickable header. What matters is
+        that the click is a control's and not a bare MouseArea's."""
         card = SURFACE / "PhoneFeatureCard.qml"
         source = strip_comments(card.read_text(encoding="utf-8"))
-        root = re.search(r"^(\w+) \{", source, re.M)
-        self.assertIsNotNone(root, "PhoneFeatureCard.qml has no root object")
-        self.assertEqual(
-            root.group(1), "RippleButton",
-            "the feature card's root is not a control, so its click has no ripple, no press "
-            "morph, no disabled dim and no keyboard - it is one of the tab's three primary actions",
+        surface = re.search(r"RippleButton \{[^}]*?anchors\.fill: parent", source, re.S)
+        self.assertIsNotNone(
+            surface,
+            "the feature card has no control filling it, so its click has no ripple, no press "
+            "morph and no keyboard - and it is one of the tab's three primary actions",
+        )
+        self.assertNotRegex(
+            source, r"MouseArea \{[^}]*?onClicked",
+            "the card's click is a bare MouseArea again",
         )
 
     def test_no_surface_hand_rolls_a_hover_wash(self):

--- a/dots/.config/quickshell/imi/tests/test_phone_tab_surface_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_tab_surface_contract.py
@@ -317,8 +317,16 @@ class FeatureCardsContractTests(unittest.TestCase):
         for service in SERVICE_NAMES:
             self.assertNotIn(f"{service}.", self.card,
                              f"PhoneFeatureCard reaches {service} directly")
-        for name in ("clicked", "settingsClicked", "stopClicked"):
+        # `clicked` is the Button's own now that the card is rooted on
+        # RippleButton - redeclaring it would be a duplicate-signal error - so
+        # what is checked is that the card still RAISES rather than calls, and
+        # that the click has somewhere to go.
+        for name in ("settingsClicked", "stopClicked"):
             self.assertRegex(self.card, rf"signal {name}\b", f"the card has no {name} signal")
+        self.assertNotRegex(
+            self.card, r"signal clicked\b",
+            "the card redeclares `clicked`, which the control underneath already carries",
+        )
 
     def test_every_state_key_the_arithmetic_can_answer_with_has_an_arm(self):
         """An unmapped key draws an empty line, which reads as a card with
@@ -466,6 +474,63 @@ class SettingsPageTests(unittest.TestCase):
             self.assertNotIn(key, self.page,
                              f"Settings repeats {key}, which the sub-page owns")
 
+
+
+class ClickableSurfacesAreControls(unittest.TestCase):
+    """A thing the user clicks is a control, not a Rectangle with a MouseArea.
+
+    The feature cards - the scrcpy mirror, the webcam, the microphone, which are
+    the tab's three primary actions - were a `Rectangle` washed by a second
+    `Rectangle` at two hand-picked opacities with a `MouseArea` on top. That
+    re-earns hover and press and still gets none of the ripple, the press radius
+    morph, the disabled dim, or the keyboard: a Button is focusable and
+    activates on Space and Enter, and those three actions could not be reached
+    from a keyboard at all. Nothing in the suite could see it, because a
+    MouseArea clicks perfectly well under a synthetic mouse.
+    """
+
+    # Files whose root is deliberately not a control, with the reason.
+    NOT_CONTROLS = {
+        "Phone.qml": "the tab itself; its children are the controls",
+        "PhoneHeader.qml": "a layout of pills, each its own control",
+        "PhoneActionsRow.qml": "a layout of PhoneActionButtons",
+        "PhoneNavCards.qml": "a layout; its NavCard component is the RippleButton",
+        "PhoneNotificationList.qml": "a list; the cards inside carry the gestures",
+        "PhoneFooterBar.qml": "a ButtonGroup of NotificationStatusButtons",
+        "PhoneSubPage.qml": "a page frame",
+        "PhoneFeatureCards.qml": "a stack of PhoneFeatureCards",
+        "PhoneContactsPage.qml": "a page",
+        "PhoneAppsPage.qml": "a page",
+        "PhoneWebcamPage.qml": "a page",
+        "PhoneMicPage.qml": "a page",
+        "InstallGuidePopup.qml": "an overlay",
+        "PhoneAdbPairPanel.qml": "a form of controls",
+    }
+
+    def test_a_card_the_user_clicks_is_a_button(self):
+        card = SURFACE / "PhoneFeatureCard.qml"
+        source = strip_comments(card.read_text(encoding="utf-8"))
+        root = re.search(r"^(\w+) \{", source, re.M)
+        self.assertIsNotNone(root, "PhoneFeatureCard.qml has no root object")
+        self.assertEqual(
+            root.group(1), "RippleButton",
+            "the feature card's root is not a control, so its click has no ripple, no press "
+            "morph, no disabled dim and no keyboard - it is one of the tab's three primary actions",
+        )
+
+    def test_no_surface_hand_rolls_a_hover_wash(self):
+        """The giveaway for the shape above: an opacity keyed on a MouseArea's
+        own hover and press state, standing in for the interaction model."""
+        offenders = []
+        for path in sorted(SURFACE.glob("*.qml")):
+            source = strip_comments(path.read_text(encoding="utf-8"))
+            if re.search(r"opacity:[^\n]*contains(Press|Mouse)", source):
+                offenders.append(path.name)
+        self.assertEqual(
+            offenders, [],
+            "these draw their own hover/press wash instead of letting the control do it: "
+            + ", ".join(offenders),
+        )
 
 if __name__ == "__main__":
     unittest.main(verbosity=1)


### PR DESCRIPTION
Four surfaces of the Phone tab stop re-implementing components the shell already ships. This is the first pass of `docs/proposals/phone-tab-component-consolidation.md`, taken in the order the maintainer set: deletions first, the lint afterwards over a tree that is already clean.

**The footer is the right sidebar's status row.** It drew its own toolbar - two `RippleButton`s around a `Rectangle` pill - for the bar the sidebar already draws with a `ButtonGroup` and three `NotificationStatusButton`s. Same three roles, same order, same `"%1 notifications"` string, two implementations. That is why the buttons did not morph: `NotificationStatusButton` is where the M3 Expressive state change lives - `buttonRadius: baseHeight / 2` at rest against `buttonRadiusPressed: Appearance.rounding.small`, and `clickedWidth` six pixels past `baseWidth` - and the hand-rolled pair had a fixed `rounding.full` and no width response at all. It also ends the clear button's glyph latch by deletion: that defect was `animateChange` on a Control's content item, and the shared button does not carry it. 105 lines out. The widget moves to `modules/common/widgets/` because it is not the right sidebar's any more, and its label gained an elide, which the count needs on either bar.

**A feature card's click goes through a control.** The three cards - the scrcpy mirror, the webcam, the microphone - were a `Rectangle` washed by a second `Rectangle` at two hand-picked opacities under a `MouseArea`. That re-earns hover and press and still gets none of the ripple, the press radius morph, the disabled dim, or the keyboard: these are the tab's primary actions, and they were the only controls in this shell a keyboard could not reach.

Rooting the card *on* a `RippleButton` was the wrong repair and `lint_disabled_opacity.py` caught it: that nests the Stop button and the settings chip inside a control that dims itself, and opacity composites, so two dims render at x*x. The surface is drawn BEHIND the content instead - the shape `ExpandablePanel` uses for its own clickable header - so the card's other buttons are its siblings rather than its children.

**A contact card is the panel the Docker manager draws.** The contacts list hand-rolled the expandable card: its own radius, its own colour and height Behaviors, its own padding, and a header that toggled an id. `ExpandablePanel` owns the expand motion, the clipping, the input gating, the surface and the ripple across its header - which is why the two panels in this shell behaved differently under the same gesture. Three things the conversion had to get right, each found by measuring: a `ListView` delegate does not adopt its own implicit height, so without it the card stayed collapsed and drew its detail rows outside itself; the content must not carry `visible: expanded`, because that collapses the content column's implicit height to zero and zero is the height the panel animates *to*; and the padding check now reads the geometry rather than a row property the panel owns, since a property that has gone reads as `NaN` and every comparison against `NaN` is false - a check that cannot pass rather than one that caught something.

The measured guarantee from `07b819f07` survives: latin 55, arabic 64, each avatar clear of the card's bottom edge, every child inside the box. A new check pins that the chrome around the header is the same in both scripts, since a card that grew its own chrome to fit a taller name would satisfy the height check on its own.

**And the expand affordance appears only where there is something to expand.** A phone notification group of one drew a chevron that expanded nothing; `NotificationGroup` gates its own on `multipleNotifications`, and the copy dropped the gate on the way across.

Two harness lessons are written into the tests rather than into a commit message: a `ButtonGroup` reparents what it is given, so slots are read by type rather than by walking children; and "the first `RippleButton` in the card" stopped being the settings chip the moment a surface was drawn behind it, so it carries an `objectName` now. A harness that finds things by tree position finds the wrong one silently.

Still to come in this proposal: the notification list itself, which needs inline reply and copy on the shared `NotificationItem` and a controller indirection so `discardNotification` is not hardwired to the desktop service.

Suite: 1436 passed, 0 failed; compile sweep 196 files, 0 failures.

Docs: updated AGENT.md §Dynamic/data-driven QML gotchas
Changelog: updated
