### PR TITLE
fix(phone): the contact chevron, the group button's ripple and the roster's menu surface

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -2661,6 +2661,23 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   allowed to, the way `tst_grouped_list` already did: a Qt too old for the per-corner radii. When a
   widget moves onto a new base, its base's dependencies have to reach `tests/imports` too.
   80d970c89 ("test: resolve InteractionMotion, and fail rather than skip on a load error").
+- **...and the container a caller reaches for is `GroupedList`, which the guidelines already said.**
+  The first fix for the roster below wrapped the rows in a `StyledRectangle` of its own.
+  `docs/M3_GUIDELINES.md` names `GroupedList` for exactly that presentation, the component is used
+  in ten places including the phone's own webcam page, and the wrapper was written anyway. It drew
+  as a perfect rectangle, which is the second lesson: **`clip` on a `Rectangle` clips to the
+  bounding box, not to the radius**, so the opaque rows painted over all four corners while the
+  wrapper reported `radius: 17`. The runtime check written beside it asked for that property, was
+  told 17, and passed against a screen showing square corners - a property is not a pixel, and a
+  shape check reads the drawn rows. `GroupedList` takes a `model` and a `rowDelegate` now, because
+  the roster's rows are the daemon's and the component only took declared ones, and it hands a row
+  the plate's corners for the overpaint reason above.
+  `tests/lint_hand_rolled_row_group.py` fails on the shape now - and its own first version passed
+  over a file containing nothing but the offender, because it read the type from the text before
+  the colon and `delegate: PhoneDeviceItem {` is not that. Prove a lint in both directions.
+  d2c1f434a ("feat(widgets): let a GroupedList draw a model"), 777f32d30 ("fix(phone): the roster
+  is a GroupedList, not a rectangle of its own"), af8f55dcd ("test(lint): fail on a group of rows
+  wrapped in a rectangle of its own").
 - **`DialogListItem` is drawn for a container, and a caller that gives it none gets a bare list.**
   It carries `buttonRadius: 0` on the layer-3 tone because the Wi-Fi and Bluetooth pickers put it
   inside a dialog. The phone roster used it with nothing around it, so its rows sat straight on the

--- a/AGENT.md
+++ b/AGENT.md
@@ -2640,6 +2640,24 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   `RippleButton`, because it is the touch spelling of a right click and every ripple button should
   answer both the same way. 9d073fc3d ("refactor(widgets): build GroupButton on RippleButton so a
   group button ripples").
+- **Re-rooting a widget hands every subclass the base's properties, and a subclass that already
+  declared one now has TWO.** `AndroidQuickToggleButton` declared `property real appear: 1` back
+  when `GroupButton` was rooted on `Button`. The move onto `RippleButton` gave it a second, and QML
+  carries both: the panel's wave writes the derived property, while `RippleButton`'s
+  `opacity: dimOpacity * appear` binding is compiled in the base's scope and reads its own, which
+  stays at 1. Nothing errors. `StaggerEntrance` compounded it from the other side - it leaves
+  opacity and scale to any control exposing `interactionMotion`, which those tiles started doing
+  the same day, so it stopped dressing them while the binding meant to take over was reading the
+  wrong property. Between the two the quick toggles arrived at full strength with no entrance at
+  all, and it was the user who saw it, not the suite. Two things generalise. A duck-typed protocol
+  (here: "a member is a child that declares `appear`") silently widens when a shared base gains the
+  property it keys on - re-rooting is a protocol change, not just an inheritance change. And when a
+  lint walks this repo's type graph it must key a name to EVERY file that has it: the first version
+  of `tests/lint_shadowed_stagger_appear.py` kept one path per stem, `rglob` handed it the vendored
+  designsystem's second `RippleButton.qml` (which declares no `appear`), the chain dead-ended one
+  link early, and it passed over the very regression it was written for. d10c5137c
+  ("fix(quickToggles): one `appear` per tile, so the toggles fade in again"), e45f8f8ca
+  ("test(lint): fail on a wave member's `appear` shadowing an inherited one").
 - **A layout owns `x`, so an animation that writes it has to remember a position - and it
   remembered the wrong one.** `StyledText.animateChange` slid the text out and back by animating
   `root.x`/`root.y` toward an `originalX` captured in `Component.onCompleted`. For anything inside

--- a/AGENT.md
+++ b/AGENT.md
@@ -124,6 +124,23 @@ or use a worktree, validate headlessly, then perform one controlled live load.
   reactive, it just had nothing to observe yet. (feat(search): launch Minecraft modpacks from the
   search bar.)
 
+**The live shell is a copy of this checkout, not the checkout itself.** `qs -c imi` loads
+`~/.config/quickshell/imi`, and nothing under that directory is version controlled — it is filled by
+an `rsync --delete` from `dots/.config/quickshell/imi/`. Two things follow. Editing a file in the
+checkout changes nothing that is running until a deploy; and a deploy from the wrong branch removes
+whatever the live shell had that the branch does not. Deploy with `./deploy-shell` at the repo root
+rather than by hand: it names every open PR branch the deploy would roll back and stops, and it
+writes `.deployed-from` (sha, ref, timestamp) into the target so "what is actually running?" is
+answered by reading one file instead of by inferring from whichever branch you are standing on.
+`tests/test_deploy_guard.py` drives it. 12cf54d00 ("tools: deploy the shell through a guard, not an
+ad-hoc rsync").
+
+**A clean log is not evidence that the code you think is running is running.** The deploy above was
+written after a branch cut off main reverted three fixes that were live on the maintainer's machine,
+and the check that "confirmed" the deploy was a grep of the live log for errors — which was clean,
+because main is clean. A log tells you the shell loaded *something* without complaining. To find out
+*what*, read `.deployed-from`, or grep the live tree for a line only the code you expect contains.
+
 ### Where to look when something goes wrong
 
 The running `qs` process writes two logs per instance, found under

--- a/AGENT.md
+++ b/AGENT.md
@@ -2618,10 +2618,59 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   declaration, because both `RippleButton`s spell `buttonEffectiveRadius` across two lines with
   `pressProgress` on the continuation, and a line-scoped version finds no radius control at all and
   reports a clean tree. And the rule reaches only controls that apply the model:
-  `common/widgets/GroupButton.qml` drives its own `down`-keyed radius and bounce and has never
-  adopted it, so it is a non-adoption rather than a doubling and the lint leaves it alone.
+  `common/widgets/GroupButton.qml` drove its own `down`-keyed radius and bounce and had never
+  adopted it, so it was a non-adoption rather than a doubling and the lint left it alone. It is
+  a `RippleButton` now (see the button-vocabulary point below), so the model reaches it through
+  the base and its ends read `buttonEffectiveRadius` rather than keying `down` themselves.
   fix(sessionScreen): let RippleButton own the session button's press,
   test(lint): fail on a hover/press radius inside a control that already tightens.
+- **Two buttons, and which one a call site picked decided whether it rippled.** `GroupButton` and
+  `RippleButton` were both rooted on `Button`, and each spelled its own background, its own
+  `MouseArea` and its own press morph - twelve property names in common. The notification footer
+  lost its ripple the day it moved onto the group vocabulary: the morph came with `GroupButton`,
+  the ripple never did, and nothing said so. `GroupButton` extends `RippleButton` now and keeps
+  only what a button GROUP adds - the bounce, the segmented `leftRadius`/`rightRadius` ends mapped
+  onto the base's per-corner overrides, and the index bookkeeping. Three things are worth not
+  re-deriving. The call-site surface survived because `colBackgroundActive` and
+  `colBackgroundToggledActive` kept their names and now FEED `colRipple`: M3 draws a press as the
+  state layer and the ripple both, so the old pressed background is not redundant with the new
+  ripple. The one property that did not survive was the `mouseArea` alias, which
+  `AndroidQuickToggleButton` read `containsMouse` through - a `Control` has said `hovered` all
+  along. And the long-press-to-`altAction` that `GroupButton`'s own `MouseArea` carried moved INTO
+  `RippleButton`, because it is the touch spelling of a right click and every ripple button should
+  answer both the same way. 9d073fc3d ("refactor(widgets): build GroupButton on RippleButton so a
+  group button ripples").
+- **A layout owns `x`, so an animation that writes it has to remember a position - and it
+  remembered the wrong one.** `StyledText.animateChange` slid the text out and back by animating
+  `root.x`/`root.y` toward an `originalX` captured in `Component.onCompleted`. For anything inside
+  a layout that capture is taken before the layout has run, so every later glyph swap "returned"
+  the item to a stale place and left it there. A `ListView` builds its first delegate before the
+  view has width, which is what selected the victim: in the contacts list, expanding the FIRST row
+  swapped `expand_more` for `expand_less` and parked that row's chevron **311px** left of the
+  card's trailing edge - in the middle of the contact's name - while every row built after the view
+  had width was correct. It animates a `Translate` now, which no layout writes, so the rest
+  position is zero and there is nothing to remember. This is the same rule `BarGroup` is built on
+  two points up, arrived at from the other end. 1a3f683be ("fix(widgets): move a text change with a
+  transform, not the item's own x"), 764e81d06 ("test(phone): measure the contact chevron, at rest
+  and after the glyph swap").
+- **A skip for a reason it did not name is a check that cannot fail.** Moving `GroupButton` onto
+  `RippleButton` pulled `InteractionMotion` into the chain, and the QML unit tests' import tree - a
+  mirror of symlinks under `tests/imports` with its own `qmldir` - had no entry for it, so the row
+  under test stopped building. `tst_config_selection_array` skipped on ANY load error, so the suite
+  reported two more skips, zero failures and exit 0. The guard now excuses the one thing it is
+  allowed to, the way `tst_grouped_list` already did: a Qt too old for the per-corner radii. When a
+  widget moves onto a new base, its base's dependencies have to reach `tests/imports` too.
+  80d970c89 ("test: resolve InteractionMotion, and fail rather than skip on a load error").
+- **`DialogListItem` is drawn for a container, and a caller that gives it none gets a bare list.**
+  It carries `buttonRadius: 0` on the layer-3 tone because the Wi-Fi and Bluetooth pickers put it
+  inside a dialog. The phone roster used it with nothing around it, so its rows sat straight on the
+  panel and the menu read as a list. It unrolls inside a `StyledRectangle` at the group tier now,
+  with the menu's radius, its vertical padding and a clip so square rows keep rounded ends, and the
+  chosen device carries what M3 gives a selected menu item - the secondary container tone, its
+  matching ink, a trailing check - where `active` had done nothing but cancel the hover colour.
+  Watch the harness when a surface appears: `rosterBox()` was spelled "the list's parent", which
+  the new wrapper would silently have become. 102e91e64 ("fix(phone): give the roster the menu
+  surface its rows are drawn for").
 - **A one-tree widget's geometry reads the SETTLED span's box, never the animating one.** Three
   trees were written with `spanW: root.implicitWidth`, and `implicitWidth` carries a Behavior: every
   rect became a per-frame target, so the Behaviors that carry the travel never converged, and any

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,12 @@ own repo; the installer pins which revision it builds.
   shows the request as a card with Accept and Decline, so pairing no longer
   needs KDE Connect's own window — and it is answered only for the device
   that asked.
+- **`deploy-shell`, for maintainers**: copies this checkout's shell to
+  `~/.config/quickshell/imi` and refuses when the copy would take another open
+  PR's work off the running shell, naming the branches it would roll back. It
+  also records the SHA and branch it deployed in `.deployed-from`, so what is
+  live can be read rather than inferred from whichever branch you happen to be
+  on. Replaces an `rsync --delete` one-liner that had done exactly that revert.
 
 ### Changed
 - **The Phone tab's device roster unrolls instead of appearing all at once.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,11 @@ own repo; the installer pins which revision it builds.
   other button that belongs to a group - the quick toggles, the settings
   chips, the AI chat controls. Their corners also settle into the
   pressed shape instead of snapping to it.
-- **The phone's device list looks like a menu.** Its rows sat straight on
-  the panel with square corners; they sit on a proper menu surface now,
-  and the device you picked is marked with a tick and its own colour
-  instead of looking exactly like the ones you did not.
+- **The phone's device list is drawn the way the rest of the shell's
+  grouped rows are** - each device on its own plate, the group's outer
+  corners rounded - instead of as a plain rectangle, and the device you
+  picked is marked with a tick and its own colour instead of looking
+  exactly like the ones you did not.
 - **The phone panel's buttons behave like the rest of the shell's.** Its
   notification bar is the same one the right sidebar draws, so its two
   actions square off and swell under a press instead of sitting still;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ own repo; the installer pins which revision it builds.
 ## [Unreleased]
 
 ### Fixed
+- **A contact's expand arrow stays where it belongs.** Opening the first
+  contact in the list used to fling its arrow into the middle of the
+  person's name and leave it there. Anything in the shell whose text
+  animates as it changes could drift the same way; none of them can now.
+- **The phone's notification buttons ripple again**, along with every
+  other button that belongs to a group - the quick toggles, the settings
+  chips, the AI chat controls. Their corners also settle into the
+  pressed shape instead of snapping to it.
+- **The phone's device list looks like a menu.** Its rows sat straight on
+  the panel with square corners; they sit on a proper menu surface now,
+  and the device you picked is marked with a tick and its own colour
+  instead of looking exactly like the ones you did not.
 - **The phone panel's buttons behave like the rest of the shell's.** Its
   notification bar is the same one the right sidebar draws, so its two
   actions square off and swell under a press instead of sitting still;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,12 @@ error" is not evidence a change works.
 
 The reliable loop used throughout this project's history:
 
-1. Make the edit.
+1. Make the edit, then **deploy it** — `./deploy-shell` at the repo root. The running shell reads
+   `~/.config/quickshell/imi`, which is a copy of `dots/.config/quickshell/imi/` and not a checkout,
+   so an edit here changes nothing that is running until it is copied over. Deploy through the
+   script rather than by hand: the copy is an `rsync --delete`, so deploying from a branch that
+   lacks another open PR's work silently takes that work off the live shell, and the script refuses
+   and names the branches instead. It also records what it deployed in `.deployed-from`.
 2. Wait ~2-3s for the hot-reload, then check the log for new errors:
    ```bash
    LOG=/run/user/$(id -u)/quickshell/by-id/$(ls /run/user/$(id -u)/quickshell/by-id/ | head -1)/log.log
@@ -107,6 +112,14 @@ Two real examples from this project's history that justify the paranoia:
   **Reproducing an effect by hand is not verifying that the code produces it.** Clear the state the
   code is supposed to create, restart the thing that should create it, and read it back. Here that
   also revealed the registration was unnecessary: fixed size hints already floated the window.
+- A deploy run from a branch cut off `main` reverted three fixes the maintainer was reviewing on
+  their own machine — the copy is `rsync --delete`, and the branch simply did not have them. It was
+  "verified" by grepping the live log for errors, which came back clean, because `main` is clean.
+  **A clean log says the shell loaded something without complaining; it does not say what.** The
+  branch you are standing on is not evidence either: read `.deployed-from` in the live tree, or grep
+  the live tree for a line only the code you expect contains. `./deploy-shell` now refuses this
+  deploy outright and names the branches it would roll back. 12cf54d00 ("tools: deploy the shell
+  through a guard, not an ad-hoc rsync").
 - A commit claiming to have "migrated existing plugins to the new format" only moved the files into
   new subdirectories - it never actually renamed the JSON schema key their content used, so both
   bundled example plugins silently stopped rendering. **A commit message describing what a change
@@ -395,10 +408,10 @@ pushing anything.
 
 ## Multi-agent / parallel workflows (git worktrees)
 
-This repo lives at `~/.config/quickshell/imi` and is loaded by exactly one running process,
-`qs -c imi`, pointed at that exact directory. That has real consequences once more than one
-agent (main session + subagents, or several parallel Claude Code sessions) is touching the repo at
-once:
+This repo deploys to `~/.config/quickshell/imi`, which is loaded by exactly one running process,
+`qs -c imi`, pointed at that exact directory. The deployed tree is a copy, so only a `./deploy-shell`
+run puts a change in front of that process. That has real consequences once more than one agent
+(main session + subagents, or several parallel Claude Code sessions) is touching the repo at once:
 
 - **Stop the primary shell before a multi-file edit burst.** Every QML source write hot-reloads the
   configuration and rebuilds Quickshell's desktop-entry registry. On systems with large Wine/Steam

--- a/deploy-shell
+++ b/deploy-shell
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+#
+# Deploy this checkout's shell to ~/.config/quickshell/imi, and refuse to do it
+# behind an open PR's back.
+#
+# ~/.config/quickshell/imi is a *copy*, not a checkout: `qs -c imi` loads it,
+# and nothing under it is version controlled. So "what is running?" has always
+# been answered by inference - by whichever branch the person deploying happened
+# to be standing on - and deploying itself was an ad-hoc
+# `rsync -a --delete dots/.config/quickshell/imi/ ~/.config/quickshell/imi/`
+# copied out of a plan document.
+#
+# That one-liner is correct exactly once. While several PRs are open, running it
+# from a branch cut off main overwrites the live shell with main's content and
+# silently takes away every unmerged fix. It happened: a branch for one issue
+# reverted three fixes the maintainer was reviewing on their own machine, and
+# the live log stayed clean throughout - because main is clean. A clean log is
+# not evidence that the code you think is running is running.
+#
+# So this does three things the one-liner cannot:
+#   - names every open PR branch this deploy would roll back, and stops;
+#   - records what it deployed, so "what is live?" is answerable by reading;
+#   - prints the SHA it deployed rather than leaving you to infer it.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SOURCE="$REPO_ROOT/dots/.config/quickshell/imi/"
+TARGET="${IMI_DEPLOY_TARGET:-$HOME/.config/quickshell/imi}"
+FORCE=0
+
+for arg in "$@"; do
+    case "$arg" in
+        --anyway) FORCE=1 ;;
+        -h|--help)
+            echo "usage: ${0##*/} [--anyway]"
+            echo "  --anyway   deploy even though open PR branches would be reverted"
+            exit 0
+            ;;
+        *) echo "unknown argument: $arg" >&2; exit 2 ;;
+    esac
+done
+
+cd "$REPO_ROOT"
+HEAD_SHA="$(git rev-parse HEAD)"
+HEAD_REF="$(git rev-parse --abbrev-ref HEAD)"
+
+# Which open PRs would this deploy roll back?
+#
+# Two refinements, both found by running this against the tree it was written
+# for. A branch counts as PRESENT if its commits are patch-equivalent to
+# something in HEAD - cherry-picked work has different SHAs, and a plain
+# ancestor test calls it missing. And a commit only MATTERS if it touches the
+# deployed subtree: a docs-only proposal branch cannot change the running shell,
+# and a guard that names it anyway teaches you to pass --anyway out of habit,
+# which is the same as having no guard at all.
+DEPLOYED_SUBTREE="dots/.config/quickshell/imi"
+LOST=()
+if command -v gh >/dev/null 2>&1; then
+    while read -r branch; do
+        [ -z "$branch" ] && continue
+        ref="refs/remotes/gh/$branch"
+        git show-ref --verify --quiet "$ref" || ref="refs/heads/$branch"
+        git show-ref --verify --quiet "$ref" || continue
+
+        missing=0
+        while read -r mark sha; do
+            [ "$mark" = "+" ] || continue
+            if git show --name-only --format= "$sha" -- "$DEPLOYED_SUBTREE" | grep -q .; then
+                missing=1
+                break
+            fi
+        done < <(git cherry HEAD "$ref" 2>/dev/null || true)
+
+        [ "$missing" -eq 1 ] && LOST+=("$branch")
+    done < <(gh pr list --state open --json headRefName --jq '.[].headRefName' 2>/dev/null || true)
+else
+    echo "note: gh is not on PATH, so open PRs could not be checked" >&2
+fi
+
+if [ ${#LOST[@]} -gt 0 ]; then
+    echo "Deploying $HEAD_REF ($(git rev-parse --short HEAD)) would revert these open PR branches"
+    echo "on the live shell, because their commits are not in HEAD:"
+    for branch in "${LOST[@]}"; do
+        echo "  - $branch"
+    done
+    if [ "$FORCE" -ne 1 ]; then
+        echo
+        echo "Deploy an integration of them instead, or pass --anyway if reverting is what you want."
+        exit 1
+    fi
+    echo "--anyway given; deploying regardless."
+fi
+
+mkdir -p "$TARGET"
+rsync -a --delete --exclude="__pycache__" "$SOURCE" "$TARGET/"
+
+# What is live, recorded where the live shell is - so the question is answered
+# by reading rather than by inferring from the branch someone happens to be on.
+{
+    echo "sha: $HEAD_SHA"
+    echo "ref: $HEAD_REF"
+    echo "deployed: $(date -Iseconds)"
+} > "$TARGET/.deployed-from"
+
+echo "deployed $HEAD_REF ($(git rev-parse --short HEAD)) -> $TARGET"

--- a/docs/M3_GUIDELINES.md
+++ b/docs/M3_GUIDELINES.md
@@ -40,6 +40,13 @@ Visible borders are not required for every surface. Many components rely entirel
 ### Grouped Settings
 
 - Use the standard `GroupedList` presentation when rows are related but remain visually distinct.
+  This is enforced: `tests/lint_hand_rolled_row_group.py` fails on rows of a `DialogListItem`-rooted
+  type wrapped in a list inside a rectangle. It exists because the phone roster was built that way
+  anyway, with this line already on the page. A group whose rows come from a model uses
+  `GroupedList`'s `model` and `rowDelegate` rather than a list view of its own; a row that paints
+  its own background is handed the plate's corners, because a plate cannot show through an opaque
+  row - and `clip` will not save it, since `clip` on a `Rectangle` clips to the bounding box and
+  not to the radius.
 - Use `GroupedList { cohesive: true }` when every row belongs to one continuous form or semantic
   unit. Cohesive groups have no gaps or rounded internal seams; only the outside corners are rounded.
 - Let `GroupedList` provide the common content inset. Child controls must not add another horizontal

--- a/dots/.config/quickshell/imi/PhoneTabLayoutRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/PhoneTabLayoutRuntimeTest.qml
@@ -75,6 +75,10 @@ ShellRoot {
     // this the glyph reads as sitting on the card's edge - measured at 4px
     // with the old fixed row height, and photographed by the maintainer.
     readonly property real minAvatarGap: Appearance.spacing.space100
+    // The chevron's own padding plus the header's right margin. Anything
+    // past this is the chevron floating in the middle of the card.
+    readonly property real maxChevronInset: 24
+    property string firstRowId: ""
     // What each script's card measured for the chrome around its header.
     property var cardPadding: ({})
 
@@ -415,6 +419,30 @@ ShellRoot {
                 return;
             harness.scoreRow("latin", latin);
             harness.scoreRow("arabic", arabic);
+            // The chevron is the LAST child of the header row, so it belongs
+            // against the card's trailing edge on every row. It was reported
+            // sitting mid-name on the first row only, which is a header that
+            // shrink-wrapped instead of filling - a defect no per-name lookup
+            // finds, because it is the row's INDEX that selects it. Scored
+            // over every row at once so the count does not follow collation.
+            let worstRow = -1;
+            let worstInset = -1;
+            for (let i = 0; i < list.count; i++) {
+                const row = list.itemAtIndex(i);
+                const chevron = harness.firstNamed(row, "contactChevron");
+                if (!row || !chevron)
+                    continue;
+                const inset = row.width - harness.boxIn(chevron, row).right;
+                console.log(`[PhoneTabLayout] row ${i} "${row.modelData?.displayName}"`
+                            + ` w=${row.width} chevron inset=${inset}`);
+                if (inset > worstInset) {
+                    worstInset = inset;
+                    worstRow = i;
+                }
+            }
+            harness.check(`every row's chevron sits at the card's trailing edge, worst is`
+                          + ` row ${worstRow} at ${worstInset} of ${harness.maxChevronInset}`,
+                          worstInset >= 0 && worstInset <= harness.maxChevronInset);
             // The half a per-row check cannot see: two cards that both fit
             // because both were made generously tall are still a constant.
             harness.check(`the card's height follows the script rather than a constant,`
@@ -464,6 +492,41 @@ ShellRoot {
             harness.check(`...and so does every one of the ${drawn} rows in it,`
                           + ` ${escaped} escaped`,
                           drawn > 0 && escaped === 0);
+        },
+        () => {
+            harness.first("PhoneContactsPage").expandedId = "";
+        },
+        () => {},
+
+        // ---- the glyph swap does not move the row it happens in ---------
+        // Expanding a row swaps its chevron for `expand_less`, and the text
+        // change is animated. The animation used to move the item's own x,
+        // which a layout also owns, and it returned the item to a position it
+        // captured at Component.onCompleted - before any layout had run. The
+        // FIRST delegate is the one built before its view had width, so its
+        // chevron was the one that came to rest mid-name.
+        () => {
+            const page = harness.first("PhoneContactsPage");
+            const list = harness.findAll(page, "StyledListView", [])[0] ?? null;
+            const row = list?.itemAtIndex(0) ?? null;
+            harness.firstRowId = String(row?.modelData?.id ?? "");
+            page.expandedId = harness.firstRowId;
+        },
+        () => {},
+        () => {
+            const page = harness.first("PhoneContactsPage");
+            const list = harness.findAll(page, "StyledListView", [])[0] ?? null;
+            const row = list?.itemAtIndex(0) ?? null;
+            const chevron = harness.firstNamed(row, "contactChevron");
+            const inset = row && chevron
+                ? row.width - harness.boxIn(chevron, row).right
+                : NaN;
+            console.log(`[PhoneTabLayout] first row expanded=${row?.expanded}`
+                        + ` glyph="${chevron?.text}" chevron inset=${inset}`);
+            harness.check(`the first row's chevron is still at the trailing edge once`
+                          + ` the expand glyph has swapped, got ${inset} of`
+                          + ` ${harness.maxChevronInset}`,
+                          inset >= 0 && inset <= harness.maxChevronInset);
         },
         () => {
             harness.first("PhoneContactsPage").expandedId = "";

--- a/dots/.config/quickshell/imi/PhoneTabRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/PhoneTabRuntimeTest.qml
@@ -213,9 +213,18 @@ ShellRoot {
         return row ? (row.parent?.parent ?? null) : null;
     }
 
+    // The box that folds, found by walking OUT of the list until the item
+    // that owns the reveal turns up. The list's parent is the menu's surface
+    // now, and a locator spelled as "the list's parent" silently measured
+    // that surface instead the day the surface appeared.
     function rosterBox() {
-        const list = harness.rosterList();
-        return list ? list.parent : null;
+        let item = harness.rosterList();
+        while (item) {
+            if (item.objectName === "rosterReveal")
+                return item;
+            item = item.parent;
+        }
+        return null;
     }
 
     // The Stop button of a card that is on its `active` rung, found by what it
@@ -458,6 +467,16 @@ ShellRoot {
                           + ` got ${harness.typeName(list)} of ${list?.count}`,
                           list !== null && harness.typeName(list) === "StyledListView"
                           && list.count === PhoneConnect.devices.length);
+            // ...and the container that makes those rows a MENU rather than a
+            // bare list. `DialogListItem` draws square corners on the layer-3
+            // tone because it expects one; without it the roster's rows sat
+            // straight on the panel.
+            const surface = list?.parent ?? null;
+            harness.check(`the roster's rows sit on a menu surface, got`
+                          + ` ${harness.typeName(surface)} radius=${surface?.radius}`,
+                          surface !== null
+                          && harness.typeName(surface) === "StyledRectangle"
+                          && surface.radius > 0);
             harness.rosterSaw = { samples: 0, mid: 0, maxHeight: 0 };
             harness.click(harness.first("PhoneDeviceChip"));
             rosterWatch.running = true;
@@ -480,9 +499,15 @@ ShellRoot {
                           saw.samples > 10);
             harness.check(`the roster unrolls rather than appearing whole,`
                           + ` ${saw.mid} frames strictly between`, saw.mid > 0);
-            harness.check(`...and settles at the list's own content height, got ${box?.height}`,
+            // The list's content plus the menu surface's own vertical padding,
+            // which is the height a menu HAS - read off the surface rather
+            // than restated as a number here, so the two cannot drift apart.
+            const surfacePad = (list?.parent ? list.y : 0) * 2;
+            harness.check(`...and settles at the list's content height plus the menu's`
+                          + ` padding, got ${box?.height} against`
+                          + ` ${list?.contentHeight} + ${surfacePad}`,
                           box !== null && list !== null && list.contentHeight > 0
-                          && Math.abs(box.height - list.contentHeight) < 1);
+                          && Math.abs(box.height - (list.contentHeight + surfacePad)) < 1);
 
             const rows = harness.all("PhoneDeviceItem").filter(i => i.visible);
             harness.check(`opening the chip lists both devices, got ${rows.length}`, rows.length === 2);

--- a/dots/.config/quickshell/imi/PhoneTabRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/PhoneTabRuntimeTest.qml
@@ -121,6 +121,27 @@ ShellRoot {
         driver.mouseClick(loader.item, centre.x, centre.y, Qt.LeftButton);
     }
 
+    // The plate a group drew for this row, or null. Walked rather than counted:
+    // a row sits under a Loader under the plate's content column, and reading
+    // `parent.parent` off that structure was one level short - which threw on
+    // an Item with no `color` and took the REST of the step with it, including
+    // the click that followed. A lookup in a harness fails by returning null.
+    function plateOf(row) {
+        let item = row?.parent ?? null;
+        while (item) {
+            if (item.color !== undefined && item.topLeftRadius !== undefined)
+                return item;
+            item = item.parent;
+        }
+        return null;
+    }
+
+    // Hover, for the states a click cannot leave an element in.
+    function hover(item) {
+        const centre = item.mapToItem(loader.item, item.width / 2, item.height / 2);
+        driver.mouseMove(loader.item, centre.x, centre.y);
+    }
+
     // The tab's content column: the one ColumnLayout whose children include
     // the notification list.
     function contentColumn() {
@@ -526,19 +547,16 @@ ShellRoot {
                           && first.cornerBottomLeft < Appearance.rounding.normal);
             harness.check(`opening the chip lists both devices, got ${rows.length}`, rows.length === 2);
 
-            // ...and NOTHING is drawn behind them. A row that takes the
-            // group's corners paints its own background, so a plate under it
-            // shows only as an inset ring - which is what shipped, and what a
-            // group of one is entirely made of.
-            const listWidth = harness.rosterList()?.width ?? 0;
-            const insets = rows.map(r => {
-                const left = r.mapToItem(harness.rosterList(), 0, 0).x;
-                return Math.max(left, listWidth - (left + r.width));
-            });
-            console.log(`[PhoneTab] roster row insets ${insets} of width ${listWidth}`);
-            harness.check(`each row is the group's full width - no plate ring around it,`
-                          + ` widest inset ${Math.max(...insets)}`,
-                          listWidth > 0 && insets.every(i => i < 0.5));
+            // ...and NOTHING is PAINTED behind them. A row that takes the
+            // group's corners paints its own background, so the plate under it
+            // is covered except for the inset, where it shows as a ring of
+            // `bgcolor` around every row - which is what shipped. The inset
+            // itself stays: it is the room the hover lift grows into.
+            const plates = rows.map(r => harness.plateOf(r));
+            console.log(`[PhoneTab] roster plates ${plates.map(p => p === null ? "none" : p.color.a)}`);
+            harness.check(`the plate behind a self-painting row paints nothing,`
+                          + ` got ${plates.map(p => p === null ? "no plate" : p.color.a)}`,
+                          plates.length > 0 && plates.every(p => p !== null && p.color.a === 0));
             const laptop = rows.find(r => r.device?.id === harness.laptopId) ?? null;
             harness.rosterSaw = { samples: 0, mid: 0, maxHeight: 0 };
             if (laptop) harness.click(laptop);
@@ -1061,9 +1079,32 @@ ShellRoot {
                           && only.cornerTopRight === Appearance.rounding.normal
                           && only.cornerBottomLeft === Appearance.rounding.normal
                           && only.cornerBottomRight === Appearance.rounding.normal);
-            harness.check(`...and is the group, rather than sitting in a frame, inset ${inset}`,
-                          only !== null && listWidth > 0 && inset < 0.5
-                          && Math.abs(only.width - listWidth) < 0.5);
+            const lonePlate = harness.plateOf(only);
+            harness.check(`...and no plate is painted behind it, got`
+                          + ` ${lonePlate === null ? "no plate" : lonePlate.color.a}`,
+                          lonePlate !== null && lonePlate.color.a === 0);
+            harness.loneRow = only;
+            harness.loneInset = inset;
+            if (only) harness.hover(only);
+        },
+        () => {},
+        () => {
+            // The lift, MEASURED - `interactionMotion.scale` is the number the
+            // transform is actually reading, not the token it was asked for.
+            // A row grows about its own centre, so the width it gains is split
+            // between its two sides and the inset has to cover half of it. The
+            // roster had no inset for one build and the hovered row grew
+            // straight past the panel's edge.
+            const row = harness.loneRow;
+            const scale = row?.interactionMotion?.scale ?? 1;
+            const overhang = row !== null ? row.width * (scale - 1) / 2 : 0;
+            console.log(`[PhoneTab] hovered scale ${scale} over width ${row?.width}`
+                        + ` -> overhang ${overhang.toFixed(2)} against inset ${harness.loneInset}`);
+            harness.check(`hovering a row lifts it, got scale ${scale}`,
+                          scale > 1.001);
+            harness.check(`...and the lift stays inside the group: overhang`
+                          + ` ${overhang.toFixed(2)} within inset ${harness.loneInset}`,
+                          overhang <= harness.loneInset + 0.01);
         },
 
         () => harness.finish()
@@ -1072,6 +1113,9 @@ ShellRoot {
     property var footerButtons: []
     property var footerPill: null
     property var footerLabel: null
+
+    property var loneRow: null
+    property real loneInset: 0
 
     property real listWithCard: 0
     property real cardHeight: 0

--- a/dots/.config/quickshell/imi/PhoneTabRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/PhoneTabRuntimeTest.qml
@@ -525,6 +525,20 @@ ShellRoot {
                           first !== null
                           && first.cornerBottomLeft < Appearance.rounding.normal);
             harness.check(`opening the chip lists both devices, got ${rows.length}`, rows.length === 2);
+
+            // ...and NOTHING is drawn behind them. A row that takes the
+            // group's corners paints its own background, so a plate under it
+            // shows only as an inset ring - which is what shipped, and what a
+            // group of one is entirely made of.
+            const listWidth = harness.rosterList()?.width ?? 0;
+            const insets = rows.map(r => {
+                const left = r.mapToItem(harness.rosterList(), 0, 0).x;
+                return Math.max(left, listWidth - (left + r.width));
+            });
+            console.log(`[PhoneTab] roster row insets ${insets} of width ${listWidth}`);
+            harness.check(`each row is the group's full width - no plate ring around it,`
+                          + ` widest inset ${Math.max(...insets)}`,
+                          listWidth > 0 && insets.every(i => i < 0.5));
             const laptop = rows.find(r => r.device?.id === harness.laptopId) ?? null;
             harness.rosterSaw = { samples: 0, mid: 0, maxHeight: 0 };
             if (laptop) harness.click(laptop);
@@ -1016,6 +1030,40 @@ ShellRoot {
             harness.check(`popping the page brings the tab back, got ${column?.opacity} / ${column?.scale}`,
                           column !== null && Math.abs(column.opacity - 1) < 0.001
                           && Math.abs(column.scale - 1) < 0.001);
+        },
+
+        // ---- a roster of ONE ---------------------------------------------
+        //
+        // The reported shape: with a single device the group was a ring of
+        // `bgcolor` drawn around one row, because every row sat inset inside a
+        // plate it painted over. With several rows that ring passes for seam
+        // material, so two devices could not have caught it - a group of one is
+        // the case where the plate has nothing to be except a frame.
+        () => {
+            PhoneConnect.applyDevices([PhoneConnect.devices[0]]);
+            harness.click(harness.first("PhoneDeviceChip"));
+        },
+        () => {},
+        () => {
+            const rows = harness.rosterRows();
+            const only = rows[0] ?? null;
+            const listWidth = harness.rosterList()?.width ?? 0;
+            const inset = only !== null
+                ? only.mapToItem(harness.rosterList(), 0, 0).x : -1;
+            console.log(`[PhoneTab] lone row corners ${only?.cornerTopLeft}/${only?.cornerTopRight}`
+                        + `/${only?.cornerBottomLeft}/${only?.cornerBottomRight}`
+                        + ` inset ${inset} of ${listWidth}`);
+            harness.check(`one device draws one row, got ${rows.length}`, rows.length === 1);
+            harness.check(`the lone row carries the group's rounding on all four corners, got`
+                          + ` ${only?.cornerTopLeft}/${only?.cornerBottomRight}`,
+                          only !== null
+                          && only.cornerTopLeft === Appearance.rounding.normal
+                          && only.cornerTopRight === Appearance.rounding.normal
+                          && only.cornerBottomLeft === Appearance.rounding.normal
+                          && only.cornerBottomRight === Appearance.rounding.normal);
+            harness.check(`...and is the group, rather than sitting in a frame, inset ${inset}`,
+                          only !== null && listWidth > 0 && inset < 0.5
+                          && Math.abs(only.width - listWidth) < 0.5);
         },
 
         () => harness.finish()

--- a/dots/.config/quickshell/imi/PhoneTabRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/PhoneTabRuntimeTest.qml
@@ -209,8 +209,13 @@ ShellRoot {
     // content item, and the tab draws a second StyledListView - the
     // notification list - that a search by type would reach first.
     function rosterList() {
-        const row = harness.all("PhoneDeviceItem")[0] ?? null;
-        return row ? (row.parent?.parent ?? null) : null;
+        return harness.first("GroupedList");
+    }
+
+    // The roster's rows in the order they are drawn, which is the order their
+    // plates are in - the corners belong to the first and the last of them.
+    function rosterRows() {
+        return harness.all("PhoneDeviceItem").filter(r => r.visible);
     }
 
     // The box that folds, found by walking OUT of the list until the item
@@ -461,22 +466,14 @@ ShellRoot {
             const list = harness.rosterList();
             harness.check("the roster is folded until the chip is opened",
                           harness.all("PhoneDeviceItem").filter(i => i.visible).length === 0);
-            // The component, not a shape of its own: the same StyledListView
-            // the Wi-Fi and Bluetooth device lists are, over the same model.
-            harness.check(`the roster is the shell's own list view over the daemon's devices,`
-                          + ` got ${harness.typeName(list)} of ${list?.count}`,
-                          list !== null && harness.typeName(list) === "StyledListView"
-                          && list.count === PhoneConnect.devices.length);
-            // ...and the container that makes those rows a MENU rather than a
-            // bare list. `DialogListItem` draws square corners on the layer-3
-            // tone because it expects one; without it the roster's rows sat
-            // straight on the panel.
-            const surface = list?.parent ?? null;
-            harness.check(`the roster's rows sit on a menu surface, got`
-                          + ` ${harness.typeName(surface)} radius=${surface?.radius}`,
-                          surface !== null
-                          && harness.typeName(surface) === "StyledRectangle"
-                          && surface.radius > 0);
+            // The component the guidelines name for rows that are related but
+            // stay visually distinct, over the daemon's devices. Not a shape of
+            // its own: a rectangle wrapped around a list view was exactly the
+            // hand-rolled surface that rule exists to prevent.
+            harness.check(`the roster is the shell's grouped list over the daemon's devices,`
+                          + ` got ${harness.typeName(list)} of ${list?.model?.length}`,
+                          list !== null && harness.typeName(list) === "GroupedList"
+                          && (list.model?.length ?? -1) === PhoneConnect.devices.length);
             harness.rosterSaw = { samples: 0, mid: 0, maxHeight: 0 };
             harness.click(harness.first("PhoneDeviceChip"));
             rosterWatch.running = true;
@@ -488,7 +485,7 @@ ShellRoot {
             const list = harness.rosterList();
             const saw = harness.rosterSaw;
             console.log(`[PhoneTab] roster open: samples=${saw.samples} mid=${saw.mid}`
-                + ` peak=${saw.maxHeight.toFixed(2)} settled=${box?.height} of list ${list?.contentHeight}`);
+                + ` peak=${saw.maxHeight.toFixed(2)} settled=${box?.height} of list ${list?.implicitHeight}`);
 
             // The sample count first: a watch that never ran reports the same
             // "nothing was ever part way" a correct reveal does. Then the
@@ -499,17 +496,34 @@ ShellRoot {
                           saw.samples > 10);
             harness.check(`the roster unrolls rather than appearing whole,`
                           + ` ${saw.mid} frames strictly between`, saw.mid > 0);
-            // The list's content plus the menu surface's own vertical padding,
-            // which is the height a menu HAS - read off the surface rather
-            // than restated as a number here, so the two cannot drift apart.
-            const surfacePad = (list?.parent ? list.y : 0) * 2;
-            harness.check(`...and settles at the list's content height plus the menu's`
-                          + ` padding, got ${box?.height} against`
-                          + ` ${list?.contentHeight} + ${surfacePad}`,
-                          box !== null && list !== null && list.contentHeight > 0
-                          && Math.abs(box.height - (list.contentHeight + surfacePad)) < 1);
+            harness.check(`...and settles at the group's own height, got ${box?.height}`
+                          + ` against ${list?.implicitHeight}`,
+                          box !== null && list !== null && list.implicitHeight > 0
+                          && Math.abs(box.height - list.implicitHeight) < 1);
 
-            const rows = harness.all("PhoneDeviceItem").filter(i => i.visible);
+            const rows = harness.rosterRows();
+            // The group's SHAPE, read off the rows as they are drawn rather
+            // than off a property of a container. The check this replaces
+            // asked a wrapper for its `radius` and was told 17 while the
+            // screen showed four square corners: the rows were painting over
+            // them, because `clip` on a Rectangle clips to the box and not to
+            // the radius. A property is not a pixel.
+            const first = rows[0] ?? null;
+            const last = rows[rows.length - 1] ?? null;
+            const inner = rows.length > 2 ? rows[1] : null;
+            console.log(`[PhoneTab] roster corners first=${first?.cornerTopLeft}`
+                        + `/${first?.cornerBottomLeft} last=${last?.cornerTopLeft}`
+                        + `/${last?.cornerBottomLeft} inner=${inner?.cornerTopLeft}`);
+            harness.check(`the group's outer corners are rounded, got`
+                          + ` ${first?.cornerTopLeft} at the top and`
+                          + ` ${last?.cornerBottomLeft} at the bottom of ${rows.length} rows`,
+                          first !== null && last !== null
+                          && first.cornerTopLeft === Appearance.rounding.normal
+                          && last.cornerBottomLeft === Appearance.rounding.normal);
+            harness.check(`...and the seams between them are not, got`
+                          + ` ${first?.cornerBottomLeft} under the first row`,
+                          first !== null
+                          && first.cornerBottomLeft < Appearance.rounding.normal);
             harness.check(`opening the chip lists both devices, got ${rows.length}`, rows.length === 2);
             const laptop = rows.find(r => r.device?.id === harness.laptopId) ?? null;
             harness.rosterSaw = { samples: 0, mid: 0, maxHeight: 0 };
@@ -1065,7 +1079,12 @@ ShellRoot {
             // rest of the run and the fold's own check passes on a snap.
             if (box.visible) {
                 saw.maxHeight = Math.max(saw.maxHeight, box.height);
-                if (box.height > 1 && box.height < list.contentHeight - 1) saw.mid++;
+                // The settled height is the group's own. It was the list
+                // view's `contentHeight` while the roster was one; a
+                // GroupedList has no such property, and `undefined` in this
+                // comparison is a silent false - the mid-flight band empties
+                // and the reveal reads as a snap it is not.
+                if (box.height > 1 && box.height < list.implicitHeight - 1) saw.mid++;
             }
             harness.rosterSaw = saw;
         }

--- a/dots/.config/quickshell/imi/modules/common/widgets/GroupButton.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/GroupButton.qml
@@ -1,24 +1,22 @@
 import qs.modules.common
 import qs.modules.common.widgets
-import qs.modules.common.functions
 import QtQuick
-import QtQuick.Controls
 import QtQuick.Layouts
 
 /**
- * Material 3 button with expressive bounciness. 
+ * Material 3 button with expressive bounciness.
  * See https://m3.material.io/components/button-groups/overview
+ *
+ * Built ON RippleButton rather than beside it. Both were rooted on `Button`
+ * and both spelled their own background, their own mouse handling and their
+ * own press morph, which is why a button gained or lost its ripple according
+ * to which of the two a call site happened to pick - the notification footer
+ * lost its ripple the day it moved onto the group vocabulary. What is left
+ * here is only what a button GROUP adds: the bounce, the segmented end radii
+ * and the index bookkeeping that tells a button where in its group it sits.
  */
-Button {
+RippleButton {
     id: root
-    property bool toggled
-    property string buttonText
-    property real buttonRadius: Appearance?.rounding?.small ?? 8
-    property real buttonRadiusPressed: Appearance?.rounding?.small ?? 6
-    property var downAction // When left clicking (down)
-    property var releaseAction // When left clicking (release)
-    property var altAction // When right clicking
-    property var middleClickAction // When middle clicking
     property bool bounce: true
     property real baseWidth: contentItem.implicitWidth + horizontalPadding * 2
     property real baseHeight: contentItem.implicitHeight + verticalPadding * 2
@@ -36,23 +34,40 @@ Button {
     implicitWidth: (root.down && bounce) ? clickedWidth : baseWidth
     implicitHeight: (root.down && bounce) ? clickedHeight : baseHeight
 
-    property color colBackground: ColorUtils.transparentize(colBackgroundHover, 1) || "transparent"
-    property color colBackgroundHover: Appearance?.colors.colLayer1Hover ?? "#E5DFED"
+    // The pressed state layer. M3 draws a press as the layer AND the ripple,
+    // so these keep their own names and feed the ripple colours a call site
+    // would otherwise have to set twice.
     property color colBackgroundActive: Appearance?.colors.colLayer1Active ?? "#D6CEE2"
-    property color colBackgroundToggled: Appearance?.colors.colPrimary ?? "#65558F"
-    property color colBackgroundToggledHover: Appearance?.colors.colPrimaryHover ?? "#77699C"
     property color colBackgroundToggledActive: Appearance?.colors.colPrimaryActive ?? "#D6CEE2"
+    colRipple: root.colBackgroundActive
+    colRippleToggled: root.colBackgroundToggledActive
 
-    property real radius: root.down ? root.buttonRadiusPressed : root.buttonRadius
-    property real leftRadius: root.down ? root.buttonRadiusPressed : root.buttonRadius
-    property real rightRadius: root.down ? root.buttonRadiusPressed : root.buttonRadius
-    property color color: root.enabled ? (root.toggled ? 
-        (root.down ? colBackgroundToggledActive : 
-            root.hovered ? colBackgroundToggledHover : 
+    // A group's ends are rounded and its joins are not, so the two sides are
+    // named separately. They follow the shared press progress rather than
+    // `down` directly: the corners ARRIVE at the pressed radius instead of
+    // snapping there in one frame.
+    property real radius: root.buttonEffectiveRadius
+    property real leftRadius: root.buttonEffectiveRadius
+    property real rightRadius: root.buttonEffectiveRadius
+    cornerTopLeft: root.leftRadius
+    cornerBottomLeft: root.leftRadius
+    cornerTopRight: root.rightRadius
+    cornerBottomRight: root.rightRadius
+
+    property color color: root.enabled ? (root.toggled ?
+        (root.down ? colBackgroundToggledActive :
+            root.hovered ? colBackgroundToggledHover :
             colBackgroundToggled) :
-        (root.down ? colBackgroundActive : 
-            root.hovered ? colBackgroundHover : 
+        (root.down ? colBackgroundActive :
+            root.hovered ? colBackgroundHover :
             colBackground)) : colBackground
+    buttonColor: root.color
+
+    // Keyboard focus is the one state with no pointer to show it.
+    property bool tabbedTo: root.focus && (focusReason === Qt.TabFocusReason || focusReason === Qt.BacktabFocusReason)
+    border: root.tabbedTo
+    borderWidth: 2
+    colBorder: Appearance.colors.colSecondary
 
     onDownChanged: {
         if (root.down) {
@@ -77,65 +92,5 @@ Button {
     }
     Behavior on rightRadius {
         animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
-    }
-
-    property alias mouseArea: buttonMouseArea
-    MouseArea {
-        id: buttonMouseArea
-        anchors.fill: parent
-        cursorShape: Qt.PointingHandCursor
-        acceptedButtons: Qt.LeftButton | Qt.RightButton | Qt.MiddleButton
-        onPressed: (event) => { 
-            if(event.button === Qt.RightButton) {
-                if (root.altAction) root.altAction();
-                return;
-            }
-            if(event.button === Qt.MiddleButton) {
-                if (root.middleClickAction) root.middleClickAction();
-                return;
-            }
-            root.down = true
-            if (root.downAction) root.downAction();
-        }
-        onReleased: (event) => {
-            root.down = false
-            if (event.button != Qt.LeftButton) return;
-            if (root.releaseAction) root.releaseAction();
-        }
-        onClicked: (event) => {
-            if (event.button != Qt.LeftButton) return;
-            root.click()
-        }
-        onCanceled: (event) => {
-            root.down = false
-        }
-
-        onPressAndHold: () => {
-            altAction(); 
-            root.down = false; 
-            root.clicked = false;
-        };
-    }
-
-    property bool tabbedTo: root.focus && (focusReason === Qt.TabFocusReason || focusReason === Qt.BacktabFocusReason)
-    background: Rectangle {
-        id: buttonBackground
-        topLeftRadius: root.leftRadius
-        topRightRadius: root.rightRadius
-        bottomLeftRadius: root.leftRadius
-        bottomRightRadius: root.rightRadius
-        implicitHeight: 50
-
-        color: root.color
-        Behavior on color {
-            animation: Appearance.animation.elementMoveFast.colorAnimation.createObject(this)
-        }
-
-        border.width: root.tabbedTo ? 2 : 0
-        border.color: Appearance.colors.colSecondary
-    }
-
-    contentItem: StyledText {
-        text: root.buttonText
     }
 }

--- a/dots/.config/quickshell/imi/modules/common/widgets/GroupedList.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/GroupedList.qml
@@ -127,12 +127,14 @@ Item {
 
                 ColumnLayout {
                     id: contentArea
-                    anchors {
-                        fill: parent
-                        // The inset is the plate showing around its content. A
-                        // row that is its own plate has nothing to show.
-                        margins: plate.ownsItsSurface ? 0 : Appearance.spacing.space100
-                    }
+                    // The inset stays whatever the group's rows have always
+                    // had, INCLUDING for a row that paints itself. What made
+                    // the roster look framed was the plate's colour showing
+                    // through it, not the inset - and the inset is also the
+                    // only room a row has to grow into when the interaction
+                    // model lifts it by `hoverScale` on hover. Take it away and
+                    // a hovered row grows straight past the group's edge.
+                    anchors { fill: parent; margins: Appearance.spacing.space100 }
                     spacing: 0
 
                     Loader {

--- a/dots/.config/quickshell/imi/modules/common/widgets/GroupedList.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/GroupedList.qml
@@ -30,6 +30,22 @@ import QtQuick.Layouts
 Item {
     id: root
     default property list<Item> items
+    // ---- a group whose rows are not known when the file is written --------
+    //
+    // The declared spelling above cannot say "one row per device the daemon
+    // knows". A call site that needed that used to wrap a list view in a
+    // rectangle of its own, which is the presentation M3_GUIDELINES.md names
+    // this component for - and it came out square, because `clip` on a
+    // Rectangle clips to the box and not to the radius, so opaque rows paint
+    // straight over the rounded corners.
+    //
+    // A row built from a model gets its data and its plate's corners handed to
+    // it BY NAME after it loads: a Component declared at the call site resolves
+    // its names in the call site's scope, not in the Loader's, so a plate that
+    // merely exposed `modelData` would hand it nothing.
+    property var model: null
+    property Component rowDelegate: null
+    readonly property bool modelDriven: root.rowDelegate !== null
     property real bigRadius: Appearance.rounding.normal
     property real smallRadius: Appearance.rounding.unsharpenmore
     property bool cohesive: false
@@ -45,6 +61,14 @@ Item {
     // rounding while the row above it is drawn square.
     readonly property var drawnIndices: {
         const drawn = [];
+        // A model's rows are all drawn: `rowVisible` is a declared row's way of
+        // leaving the group, and a model leaves by not carrying the entry.
+        if (root.modelDriven) {
+            const count = root.model?.length ?? 0;
+            for (let i = 0; i < count; i++)
+                drawn.push(i);
+            return drawn;
+        }
         for (let i = 0; i < root.items.length; i++) {
             const item = root.items[i];
             if (item && (item.rowVisible ?? true))
@@ -59,9 +83,11 @@ Item {
         spacing: root.cohesive ? 0 : Appearance.spacing.space25
 
         Repeater {
-            model: root.items.length
+            model: root.modelDriven ? root.model : root.items.length
             delegate: Rectangle {
+                id: plate
                 required property int index
+                required property var modelData
                 readonly property bool isFirst: index === root.drawnIndices[0]
                 readonly property bool isLast: index === root.drawnIndices[root.drawnIndices.length - 1]
                 // A `ColumnLayout` leaves an invisible child out of the layout
@@ -70,7 +96,9 @@ Item {
                 // and leaving the other.
                 visible: root.drawnIndices.indexOf(index) !== -1
                 Layout.fillWidth: true
-                implicitHeight: (root.items[index]?.implicitHeight ?? 0) + root.itemVerticalPadding
+                implicitHeight: (root.modelDriven
+                    ? (rowLoader.item?.implicitHeight ?? 0)
+                    : (root.items[index]?.implicitHeight ?? 0)) + root.itemVerticalPadding
                 color: root.bgcolor
                 topLeftRadius:     isFirst ? root.bigRadius : (root.cohesive ? 0 : root.smallRadius)
                 topRightRadius:    isFirst ? root.bigRadius : (root.cohesive ? 0 : root.smallRadius)
@@ -78,6 +106,8 @@ Item {
                 bottomRightRadius: isLast  ? root.bigRadius : (root.cohesive ? 0 : root.smallRadius)
 
                 Component.onCompleted: {
+                    if (root.modelDriven)
+                        return;
                     const child = root.items[index]
                     if (child) {
                         child.parent = contentArea
@@ -89,6 +119,49 @@ Item {
                     id: contentArea
                     anchors { fill: parent; margins: Appearance.spacing.space100 }
                     spacing: 0
+
+                    Loader {
+                        id: rowLoader
+                        active: root.modelDriven
+                        Layout.fillWidth: true
+                        sourceComponent: root.rowDelegate
+                    }
+                }
+
+                // The row's data, and - for a row that paints its own
+                // background, which a plate cannot show through - the plate's
+                // own corners. Bindings rather than an `onLoaded` assignment so
+                // that a row keeps following its entry when the model is
+                // re-filtered under it instead of holding the first one it saw.
+                Binding {
+                    target: rowLoader.item
+                    property: "modelData"
+                    value: plate.modelData
+                    when: rowLoader.item !== null
+                }
+                Binding {
+                    target: rowLoader.item
+                    property: "cornerTopLeft"
+                    value: plate.topLeftRadius
+                    when: rowLoader.item?.cornerTopLeft !== undefined
+                }
+                Binding {
+                    target: rowLoader.item
+                    property: "cornerTopRight"
+                    value: plate.topRightRadius
+                    when: rowLoader.item?.cornerTopRight !== undefined
+                }
+                Binding {
+                    target: rowLoader.item
+                    property: "cornerBottomLeft"
+                    value: plate.bottomLeftRadius
+                    when: rowLoader.item?.cornerBottomLeft !== undefined
+                }
+                Binding {
+                    target: rowLoader.item
+                    property: "cornerBottomRight"
+                    value: plate.bottomRightRadius
+                    when: rowLoader.item?.cornerBottomRight !== undefined
                 }
             }
         }

--- a/dots/.config/quickshell/imi/modules/common/widgets/GroupedList.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/GroupedList.qml
@@ -99,7 +99,17 @@ Item {
                 implicitHeight: (root.modelDriven
                     ? (rowLoader.item?.implicitHeight ?? 0)
                     : (root.items[index]?.implicitHeight ?? 0)) + root.itemVerticalPadding
-                color: root.bgcolor
+                // A row that takes the plate's corners is a row that paints its
+                // own background - that is what the corner protocol below is
+                // FOR, since a plate cannot show through an opaque row. Such a
+                // row IS the plate: painting a second surface behind it leaves
+                // only the inset showing, as a ring of `bgcolor` around every
+                // row. With several rows that ring passes for the group's seam
+                // material; with one row the ring is the entire group, and the
+                // device roster shipped looking like a frame drawn around a
+                // single item for no reason.
+                readonly property bool ownsItsSurface: rowLoader.item?.cornerTopLeft !== undefined
+                color: ownsItsSurface ? "transparent" : root.bgcolor
                 topLeftRadius:     isFirst ? root.bigRadius : (root.cohesive ? 0 : root.smallRadius)
                 topRightRadius:    isFirst ? root.bigRadius : (root.cohesive ? 0 : root.smallRadius)
                 bottomLeftRadius:  isLast  ? root.bigRadius : (root.cohesive ? 0 : root.smallRadius)
@@ -117,7 +127,12 @@ Item {
 
                 ColumnLayout {
                     id: contentArea
-                    anchors { fill: parent; margins: Appearance.spacing.space100 }
+                    anchors {
+                        fill: parent
+                        // The inset is the plate showing around its content. A
+                        // row that is its own plate has nothing to show.
+                        margins: plate.ownsItsSurface ? 0 : Appearance.spacing.space100
+                    }
                     spacing: 0
 
                     Loader {

--- a/dots/.config/quickshell/imi/modules/common/widgets/RippleButton.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/RippleButton.qml
@@ -157,6 +157,15 @@ Button {
             if (!root.rippleEnabled) return;
             rippleFadeAnim.restart();
         }
+        // The touch spelling of the right-click action. A pointer has a
+        // second button; a finger has a long press, and every button built
+        // on this one should answer both the same way.
+        onPressAndHold: () => {
+            if (!root.altAction) return;
+            root.altAction();
+            root.down = false;
+            if (root.rippleEnabled) rippleFadeAnim.restart();
+        }
     }
 
     RippleAnim {

--- a/dots/.config/quickshell/imi/modules/common/widgets/StyledText.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/StyledText.qml
@@ -33,28 +33,35 @@ Text {
         easing.bezierCurve: Appearance.animation.elementMoveFaster.bezierCurve
     }
 
-    Component.onCompleted: {
-        textAnimationBehavior.originalX = root.x;
-        textAnimationBehavior.originalY = root.y;
+    // The change animation moves THIS, never `root.x`/`root.y`. A layout owns
+    // the position of the items it holds, so a text that animated its own x
+    // had to remember where it started, and it remembered at
+    // Component.onCompleted - before the layout had placed it. Every later
+    // glyph swap then "returned" the item to that stale position: a ListView's
+    // first delegate, built before the view had width, parked its chevron
+    // mid-row the first time it was expanded. A transform is the item's own
+    // and no layout writes it, so the rest position is simply zero.
+    transform: Translate {
+        id: textShift
     }
 
     Behavior on text {
         id: textAnimationBehavior
-        property real originalX: root.x
-        property real originalY: root.y
         enabled: root.animateChange
 
         SequentialAnimation {
             alwaysRunToEnd: true
             ParallelAnimation {
                 Anim {
+                    target: textShift
                     property: "x"
-                    to: textAnimationBehavior.originalX - root.animationDistanceX
+                    to: -root.animationDistanceX
                     easing.type: Easing.InSine
                 }
                 Anim {
+                    target: textShift
                     property: "y"
-                    to: textAnimationBehavior.originalY - root.animationDistanceY
+                    to: -root.animationDistanceY
                     easing.type: Easing.InSine
                 }
                 Anim {
@@ -65,24 +72,26 @@ Text {
             }
             PropertyAction {} // Tie the text update to this point (we don't want it to happen during the first slide+fade)
             PropertyAction {
-                target: root
+                target: textShift
                 property: "x"
-                value: textAnimationBehavior.originalX + root.animationDistanceX
+                value: root.animationDistanceX
             }
             PropertyAction {
-                target: root
+                target: textShift
                 property: "y"
-                value: textAnimationBehavior.originalY + root.animationDistanceY
+                value: root.animationDistanceY
             }
             ParallelAnimation {
                 Anim {
+                    target: textShift
                     property: "x"
-                    to: textAnimationBehavior.originalX
+                    to: 0
                     easing.type: Easing.OutSine
                 }
                 Anim {
+                    target: textShift
                     property: "y"
-                    to: textAnimationBehavior.originalY
+                    to: 0
                     easing.type: Easing.OutSine
                 }
                 Anim {

--- a/dots/.config/quickshell/imi/modules/imi/phone/PhoneDeviceItem.qml
+++ b/dots/.config/quickshell/imi/modules/imi/phone/PhoneDeviceItem.qml
@@ -13,9 +13,11 @@ import QtQuick.Layouts
  */
 DialogListItem {
     id: root
-    // Device entry from PhoneConnect.devices.
-    required property var device
-    readonly property bool online: root.device.paired && root.device.reachable
+    // Device entry from PhoneConnect.devices. Optional rather than required:
+    // a row built from a GroupedList's model is handed its entry by the plate
+    // one frame after it loads, so every read below has to survive a null.
+    property var device: null
+    readonly property bool online: (root.device?.paired ?? false) && (root.device?.reachable ?? false)
 
     // M3 marks the chosen item of a menu with the selected container tone AND
     // a trailing check. `active` used only to cancel the hover colour, which
@@ -40,7 +42,7 @@ DialogListItem {
         MaterialSymbol {
             iconSize: Appearance.font.pixelSize.larger
             text: {
-                switch (root.device.type) {
+                switch (root.device?.type ?? "") {
                 case "phone": return "smartphone";
                 case "tablet": return "tablet";
                 case "laptop": return "laptop";
@@ -63,7 +65,7 @@ DialogListItem {
                 color: root.active ? Appearance.colors.colOnSecondaryContainer
                     : Appearance.colors.colOnSurfaceVariant
                 elide: Text.ElideRight
-                text: root.device.name || root.device.id
+                text: root.device?.name || root.device?.id || ""
                 textFormat: Text.PlainText
             }
             StyledText {
@@ -73,6 +75,7 @@ DialogListItem {
                 elide: Text.ElideRight
                 textFormat: Text.PlainText
                 text: {
+                    if (!root.device) return "";
                     if (root.device.hasPairingRequest) return Translation.tr("Wants to pair");
                     if (!root.device.paired) return Translation.tr("Not paired");
                     if (!root.device.reachable) return Translation.tr("Paired • Offline");

--- a/dots/.config/quickshell/imi/modules/imi/phone/PhoneDeviceItem.qml
+++ b/dots/.config/quickshell/imi/modules/imi/phone/PhoneDeviceItem.qml
@@ -1,5 +1,6 @@
 import qs.services
 import qs.modules.common
+import qs.modules.common.functions
 import qs.modules.common.widgets
 import QtQuick
 import QtQuick.Layouts
@@ -15,6 +16,16 @@ DialogListItem {
     // Device entry from PhoneConnect.devices.
     required property var device
     readonly property bool online: root.device.paired && root.device.reachable
+
+    // M3 marks the chosen item of a menu with the selected container tone AND
+    // a trailing check. `active` used only to cancel the hover colour, which
+    // told the user which device was picked by drawing nothing at all.
+    colBackground: root.active
+        ? Appearance.colors.colSecondaryContainer
+        : ColorUtils.transparentize(Appearance.colors.colLayer3)
+    colBackgroundHover: root.active
+        ? Appearance.colors.colSecondaryContainer
+        : Appearance.colors.colLayer3Hover
 
     contentItem: RowLayout {
         anchors {
@@ -38,7 +49,9 @@ DialogListItem {
                 default: return "devices";
                 }
             }
-            color: root.online ? Appearance.colors.colPrimary : Appearance.colors.colOnSurfaceVariant
+            color: root.active ? Appearance.colors.colOnSecondaryContainer
+                : root.online ? Appearance.colors.colPrimary
+                : Appearance.colors.colOnSurfaceVariant
         }
 
         ColumnLayout {
@@ -47,7 +60,8 @@ DialogListItem {
 
             StyledText {
                 Layout.fillWidth: true
-                color: Appearance.colors.colOnSurfaceVariant
+                color: root.active ? Appearance.colors.colOnSecondaryContainer
+                    : Appearance.colors.colOnSurfaceVariant
                 elide: Text.ElideRight
                 text: root.device.name || root.device.id
                 textFormat: Text.PlainText
@@ -69,6 +83,14 @@ DialogListItem {
                     return Translation.tr("Connected");
                 }
             }
+        }
+
+        MaterialSymbol {
+            objectName: "rosterSelectedCheck"
+            visible: root.active
+            text: "check"
+            iconSize: Appearance.font.pixelSize.larger
+            color: Appearance.colors.colOnSecondaryContainer
         }
     }
 }

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/Phone.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/Phone.qml
@@ -191,43 +191,62 @@ Item {
         // off screen when the wave runs takes no slot anyway.
         Item {
             id: rosterReveal
+            objectName: "rosterReveal"
             Layout.fillWidth: true
             // Unrolled from nothing to the list's own height, and faded with
             // it, both off the one scalar declared at the top of this file.
             // The clip is what makes the height a reveal rather than a squash:
             // the rows keep their own size and the box uncovers them.
-            Layout.preferredHeight: rosterList.height * root.rosterProgress
+            Layout.preferredHeight: (rosterList.height + Appearance.spacing.space100 * 2)
+                * root.rosterProgress
             visible: root.rosterProgress > 0
             opacity: root.rosterProgress
             clip: true
 
-            // The list stands at its OWN content height whatever this wrapper
-            // is doing. A `ListView` told it is zero pixels tall builds no
-            // delegates, so it reports a content height of zero and can never
-            // grow out of it - the height that folds has to be a box around
-            // the list rather than the list's own.
-            StyledListView {
-                id: rosterList
-                width: rosterReveal.width
-                height: rosterList.contentHeight
-                interactive: false
-                spacing: 0
+            // The menu's container. `DialogListItem` is drawn with square
+            // corners on the layer-3 tone because it expects to sit INSIDE
+            // something - the Wi-Fi and Bluetooth pickers give it a dialog.
+            // This one gave it nothing, so the rows sat straight on the panel
+            // and the roster read as a bare list rather than as the menu it
+            // is. The surface is what makes it one, and the clip is what lets
+            // square rows keep rounded ends.
+            StyledRectangle {
+                id: rosterSurface
+                objectName: "rosterSurface"
+                anchors.fill: parent
+                contentLayer: StyledRectangle.ContentLayer.Group
+                radius: Appearance.rounding.normal
+                clip: true
 
-                model: ScriptModel {
-                    values: PhoneConnect.devices
-                }
-                delegate: PhoneDeviceItem {
-                    required property var modelData
-                    device: modelData
-                    anchors {
-                        left: parent?.left
-                        right: parent?.right
+                // The list stands at its OWN content height whatever this
+                // wrapper is doing. A `ListView` told it is zero pixels tall
+                // builds no delegates, so it reports a content height of zero
+                // and can never grow out of it - the height that folds has to
+                // be a box around the list rather than the list's own.
+                StyledListView {
+                    id: rosterList
+                    y: Appearance.spacing.space100
+                    width: rosterReveal.width
+                    height: rosterList.contentHeight
+                    interactive: false
+                    spacing: 0
+
+                    model: ScriptModel {
+                        values: PhoneConnect.devices
                     }
-                    active: root.device !== null && root.device.id === modelData.id
-                    onClicked: {
-                        root.pickedDeviceId = modelData.id;
-                        PhoneConnect.selectDevice(modelData.id);
-                        root.rosterOpen = false;
+                    delegate: PhoneDeviceItem {
+                        required property var modelData
+                        device: modelData
+                        anchors {
+                            left: parent?.left
+                            right: parent?.right
+                        }
+                        active: root.device !== null && root.device.id === modelData.id
+                        onClicked: {
+                            root.pickedDeviceId = modelData.id;
+                            PhoneConnect.selectDevice(modelData.id);
+                            root.rosterOpen = false;
+                        }
                     }
                 }
             }

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/Phone.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/Phone.qml
@@ -213,7 +213,8 @@ Item {
                 id: rosterGroup
                 objectName: "rosterGroup"
                 anchors { left: parent.left; right: parent.right; top: parent.top }
-                bgcolor: Appearance.colors.colLayer2
+                // No `bgcolor`: a PhoneDeviceItem paints its own surface, so
+                // the group draws no plate behind it - see GroupedList.
                 itemVerticalPadding: 0
                 model: PhoneConnect.devices
                 rowDelegate: Component {

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/Phone.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/Phone.qml
@@ -197,51 +197,32 @@ Item {
             // it, both off the one scalar declared at the top of this file.
             // The clip is what makes the height a reveal rather than a squash:
             // the rows keep their own size and the box uncovers them.
-            Layout.preferredHeight: (rosterList.height + Appearance.spacing.space100 * 2)
-                * root.rosterProgress
+            Layout.preferredHeight: rosterGroup.implicitHeight * root.rosterProgress
             visible: root.rosterProgress > 0
             opacity: root.rosterProgress
             clip: true
 
-            // The menu's container. `DialogListItem` is drawn with square
-            // corners on the layer-3 tone because it expects to sit INSIDE
-            // something - the Wi-Fi and Bluetooth pickers give it a dialog.
-            // This one gave it nothing, so the rows sat straight on the panel
-            // and the roster read as a bare list rather than as the menu it
-            // is. The surface is what makes it one, and the clip is what lets
-            // square rows keep rounded ends.
-            StyledRectangle {
-                id: rosterSurface
-                objectName: "rosterSurface"
-                anchors.fill: parent
-                contentLayer: StyledRectangle.ContentLayer.Group
-                radius: Appearance.rounding.normal
-                clip: true
-
-                // The list stands at its OWN content height whatever this
-                // wrapper is doing. A `ListView` told it is zero pixels tall
-                // builds no delegates, so it reports a content height of zero
-                // and can never grow out of it - the height that folds has to
-                // be a box around the list rather than the list's own.
-                StyledListView {
-                    id: rosterList
-                    y: Appearance.spacing.space100
-                    width: rosterReveal.width
-                    height: rosterList.contentHeight
-                    interactive: false
-                    spacing: 0
-
-                    model: ScriptModel {
-                        values: PhoneConnect.devices
-                    }
-                    delegate: PhoneDeviceItem {
-                        required property var modelData
+            // The presentation M3_GUIDELINES.md names for rows that are
+            // related but stay visually distinct - each row on its own plate,
+            // the group's outer corners rounded and the inner ones not. This
+            // used to be a StyledRectangle wrapped around a list view, which
+            // is the thing that rule exists to prevent, and it drew square
+            // besides: `clip` on a Rectangle clips to the box, not the radius,
+            // so the rows painted over the corners it was supposed to have.
+            GroupedList {
+                id: rosterGroup
+                objectName: "rosterGroup"
+                anchors { left: parent.left; right: parent.right; top: parent.top }
+                bgcolor: Appearance.colors.colLayer2
+                itemVerticalPadding: 0
+                model: PhoneConnect.devices
+                rowDelegate: Component {
+                    PhoneDeviceItem {
+                        // Handed to the row by the plate; see GroupedList.
+                        property var modelData: null
                         device: modelData
-                        anchors {
-                            left: parent?.left
-                            right: parent?.right
-                        }
-                        active: root.device !== null && root.device.id === modelData.id
+                        active: root.device !== null && modelData !== null
+                            && root.device.id === modelData.id
                         onClicked: {
                             root.pickedDeviceId = modelData.id;
                             PhoneConnect.selectDevice(modelData.id);

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/Phone.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/Phone.qml
@@ -213,9 +213,11 @@ Item {
                 id: rosterGroup
                 objectName: "rosterGroup"
                 anchors { left: parent.left; right: parent.right; top: parent.top }
-                // No `bgcolor`: a PhoneDeviceItem paints its own surface, so
-                // the group draws no plate behind it - see GroupedList.
-                itemVerticalPadding: 0
+                // No `bgcolor` and no padding override: a PhoneDeviceItem
+                // paints its own surface, so the group draws no plate behind
+                // it, and the row is then inset exactly like every other
+                // group's rows - which is also the room its hover lift grows
+                // into. See GroupedList.
                 model: PhoneConnect.devices
                 rowDelegate: Component {
                     PhoneDeviceItem {

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneContactsPage.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/phone/PhoneContactsPage.qml
@@ -279,6 +279,7 @@ PhoneSubPage {
                             }
 
                             MaterialSymbol {
+                                objectName: "contactChevron"
                                 Layout.alignment: Qt.AlignVCenter
                                 text: contactRow.expanded ? "expand_less" : "expand_more"
                                 iconSize: Appearance.font.pixelSize.larger

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/quickToggles/androidStyle/AndroidQuickToggleButton.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/quickToggles/androidStyle/AndroidQuickToggleButton.qml
@@ -38,8 +38,8 @@ GroupButton {
 
     baseWidth: root.baseCellWidth * cellSize + cellSpacing * (cellSize - 1)
     baseHeight: root.baseCellHeight
-    enableImplicitWidthAnimation: !editMode && root.mouseArea.containsMouse
-    enableImplicitHeightAnimation: !editMode && root.mouseArea.containsMouse
+    enableImplicitWidthAnimation: !editMode && root.hovered
+    enableImplicitHeightAnimation: !editMode && root.hovered
     Behavior on baseWidth {
         animation: Appearance.animation.elementMove.numberAnimation.createObject(this)
     }

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/quickToggles/androidStyle/AndroidQuickToggleButton.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/quickToggles/androidStyle/AndroidQuickToggleButton.qml
@@ -46,10 +46,18 @@ GroupButton {
     Behavior on baseHeight {
         animation: Appearance.animation.elementMove.numberAnimation.createObject(this)
     }
-    // The tile's arrival is the panel's convergent wave now (the panel's
-    // StaggerEntrance owns opacity/scale/translate through this): a tile
-    // added mid-session simply appears in place, which is what the old
-    // opacity: 0 + onCompleted self-fade approximated one tile at a time.
+    // The tile's arrival is the panel's convergent wave. `appear` is
+    // INHERITED - RippleButton declares it and folds it into the opacity
+    // binding that also carries the disabled dim - and this file must not
+    // declare it again. It did, back when GroupButton was rooted on Button
+    // and had no `appear` of its own, and it inherited a second one the day
+    // GroupButton moved onto RippleButton. QML then carried TWO properties
+    // of that name: the wave wrote this one while the base's opacity
+    // binding, compiled in the base's scope, read the other. Nothing
+    // errored; the tiles simply stopped fading in. StaggerEntrance had also
+    // stopped dressing them, because it leaves opacity and scale to any
+    // control exposing `interactionMotion` - which a RippleButton does - so
+    // between the two nothing drove the entrance at all.
     // No Behavior on opacity: the wave animates `appear` and opacity is a
     // binding on it, so a Behavior here is a second animation on the same
     // channel. The one left behind by the self-fade's retirement turned
@@ -59,7 +67,6 @@ GroupButton {
     // animated - b710ef731's frozen-Behavior shape - so the tile landed
     // ~200ms after its own wave slot). That was the "toggles visible, then
     // the animation begins" pause.
-    property real appear: 1
 
     // A tile born mid-session - edit mode adding it, a config change - used
     // to pop in at full strength in one frame: the dresser dresses arrivals,

--- a/dots/.config/quickshell/imi/tests/imports/qs/modules/common/widgets/InteractionMotion.qml
+++ b/dots/.config/quickshell/imi/tests/imports/qs/modules/common/widgets/InteractionMotion.qml
@@ -1,0 +1,1 @@
+../../../../../../modules/common/widgets/InteractionMotion.qml

--- a/dots/.config/quickshell/imi/tests/imports/qs/modules/common/widgets/qmldir
+++ b/dots/.config/quickshell/imi/tests/imports/qs/modules/common/widgets/qmldir
@@ -18,3 +18,4 @@ ButtonMouseArea 1.0 ButtonMouseArea.qml
 StyledRectangularShadow 1.0 StyledRectangularShadow.qml
 MaterialShape 1.0 MaterialShape.qml
 CircleUtilButton 1.0 CircleUtilButton.qml
+InteractionMotion 1.0 InteractionMotion.qml

--- a/dots/.config/quickshell/imi/tests/lint_hand_rolled_row_group.py
+++ b/dots/.config/quickshell/imi/tests/lint_hand_rolled_row_group.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""A group of related rows is a `GroupedList`, never a rectangle of one's own.
+
+docs/M3_GUIDELINES.md, "Grouped Settings": *use the standard `GroupedList`
+presentation when rows are related but remain visually distinct.* The phone
+roster broke that rule the day it was written - a `StyledRectangle` wrapped
+around a `StyledListView` of `DialogListItem` rows - and the reason it was
+caught is that it LOOKED wrong: `clip` on a Rectangle clips to the bounding
+box and not to the radius, so the opaque rows painted straight over the four
+rounded corners the wrapper thought it had. The runtime check written
+alongside it asked that wrapper for its `radius`, was told 17, and passed
+while the screen showed a perfect rectangle.
+
+Two rules were already written down and still broken, so this is the third
+spelling and the one that fails: the prose in M3_GUIDELINES.md, the component
+itself, and now a check.
+
+Scope, deliberately narrow enough to have no false positives to argue with: a
+rectangle that CONTAINS a list of rows, where a row is a component this repo
+roots on `DialogListItem`. That is the shape of the mistake. A rectangle
+holding one row, a list of something that is not a row, or `GroupedList`'s own
+plates (a Rectangle around a Loader) are all left alone.
+"""
+
+import pathlib
+import re
+import sys
+
+SHELL = pathlib.Path(__file__).resolve().parent.parent
+RECTANGLES = ("Rectangle", "StyledRectangle")
+LISTS = ("ListView", "StyledListView", "Repeater")
+# GroupedList builds the plates this lint would otherwise report; it is the
+# component the rule points AT.
+EXEMPT = {"GroupedList.qml"}
+
+# The type a `{` opens is the last identifier before it, which is what makes
+# `delegate: PhoneDeviceItem {` read as a PhoneDeviceItem rather than as a
+# property assignment. The first spelling of this lint matched on the text
+# BEFORE the colon and reported a clean tree over the very file it was written
+# for, so the name is taken from the brace backwards now.
+TYPE_BEFORE_BRACE = re.compile(r"([A-Za-z_][\w.]*)\s*$")
+
+
+def row_types() -> set:
+    """Every component in this shell whose root type is `DialogListItem`."""
+    found = {"DialogListItem"}
+    # A row type may itself be subclassed, so settle it rather than
+    # single-pass: PhoneDeviceItem is a DialogListItem, and anything rooted on
+    # PhoneDeviceItem is a row too.
+    changed = True
+    while changed:
+        changed = False
+        for path in SHELL.rglob("*.qml"):
+            if path.stem in found:
+                continue
+            for line in path.read_text(errors="replace").splitlines():
+                stripped = line.strip()
+                if not stripped or stripped.startswith(("//", "*", "/*", "import", "pragma")):
+                    continue
+                root = stripped.split("{")[0].strip()
+                if root in found:
+                    found.add(path.stem)
+                    changed = True
+                break
+    return found
+
+
+def offenders(path: pathlib.Path, rows: set) -> list:
+    """Rows opened while both a list and a rectangle are on the stack."""
+    stack = []
+    hits = []
+    for number, line in enumerate(path.read_text(errors="replace").splitlines(), start=1):
+        stripped = line.strip()
+        if stripped.startswith("//"):
+            continue
+        for position, char in enumerate(stripped):
+            if char == "{":
+                match = TYPE_BEFORE_BRACE.search(stripped[:position])
+                name = match.group(1) if match else ""
+                if name in rows and any(n in LISTS for n in stack) \
+                        and any(n in RECTANGLES for n in stack):
+                    hits.append((number, name))
+                stack.append(name)
+            elif char == "}" and stack:
+                stack.pop()
+    return hits
+
+
+def main() -> int:
+    rows = row_types()
+    failures = []
+    for path in sorted(SHELL.rglob("*.qml")):
+        if path.name in EXEMPT or "/tests/" in str(path):
+            continue
+        for number, row in offenders(path, rows):
+            failures.append(f"{path.relative_to(SHELL)}:{number}: "
+                            f"`{row}` rows wrapped in a rectangle of their own")
+    if failures:
+        print("A group of related rows is a GroupedList, not a hand-rolled surface")
+        print("(docs/M3_GUIDELINES.md, \"Grouped Settings\"). Offenders:")
+        for failure in failures:
+            print(f"  {failure}")
+        return 1
+    print(f"  hand-rolled row groups: none ({len(rows)} row types known)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dots/.config/quickshell/imi/tests/lint_shadowed_stagger_appear.py
+++ b/dots/.config/quickshell/imi/tests/lint_shadowed_stagger_appear.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""A wave member declares `appear` once, and never over one it inherits.
+
+Membership of a StaggerEntrance/StaggerWave is duck-typed: a child is a
+member because it declares `property real appear: 1` and folds it into its
+opacity. That works right up until a type declares `appear` over a base that
+already has one. QML then puts TWO properties of that name on the object: the
+wave writes the derived one (JS resolves most-derived) while the base's
+opacity binding, compiled in the base's scope, keeps reading its own. Nothing
+errors. The member simply stops fading, and the entrance it belongs to looks
+like it was retuned by somebody.
+
+That is exactly what happened to the right sidebar's android quick toggles
+when GroupButton moved onto RippleButton: the tile had declared its own
+`appear` back when its base had none, and inherited a second one that day.
+
+Scope: a QML file whose root type is a shell type that (transitively) declares
+`property real appear`, and which declares `property real appear` itself.
+"""
+
+import pathlib
+import re
+import sys
+
+SHELL = pathlib.Path(__file__).resolve().parent.parent
+DECLARES = re.compile(r"^\s*property\s+real\s+appear\b", re.M)
+ROOT = re.compile(r"^\s*([A-Z][\w.]*)\s*\{", re.M)
+
+
+def root_type(text: str) -> str:
+    body = "\n".join(
+        line for line in text.splitlines()
+        if not line.strip().startswith(("import ", "pragma ", "//", "*", "/*"))
+    )
+    match = ROOT.search(body)
+    return match.group(1) if match else ""
+
+
+def main() -> int:
+    # Keyed by stem to a LIST, never to one path. This shell vendors a
+    # designsystem mirror that carries a second RippleButton.qml, and the
+    # first version of this lint kept whichever copy `rglob` yielded last -
+    # the mirror's, which declares no `appear`. The root chain died there and
+    # the lint reported a clean tree over the very regression it was written
+    # for. A name in this repo can mean more than one file; ask them all.
+    files = {}
+    for path in SHELL.rglob("*.qml"):
+        if "/tests/" in str(path):
+            continue
+        files.setdefault(path.stem, []).append(path)
+    texts = {stem: [p.read_text(errors="replace") for p in paths]
+             for stem, paths in files.items()}
+    declares = {stem for stem, bodies in texts.items()
+                if any(DECLARES.search(body) for body in bodies)}
+
+    failures = []
+    for stem, bodies in sorted(texts.items()):
+        for body, path in zip(bodies, files[stem]):
+            if not DECLARES.search(body):
+                continue
+            seen = set()
+            base = root_type(body)
+            while base in files and base not in seen:
+                seen.add(base)
+                if base in declares:
+                    failures.append(
+                        f"{path.relative_to(SHELL)}: declares `appear` over "
+                        f"`{base}`, which already has one")
+                    break
+                base = next((root_type(b) for b in texts[base] if root_type(b)), "")
+
+    if failures:
+        print("A wave member's `appear` must not shadow an inherited one:")
+        for failure in failures:
+            print(f"  {failure}")
+        print("Delete the local declaration - the base's opacity binding "
+              "already carries it.")
+        return 1
+    print(f"  shadowed stagger `appear`: none ({len(declares)} declaring types)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -294,6 +294,17 @@ if ! python3 "$SCRIPT_DIR/lint_grouped_list_row_visible.py"; then
     exit 1
 fi
 
+# Static lint: the other half of the same component's rule. A group of related
+# rows is a GroupedList and never a rectangle wrapped around a list view -
+# M3_GUIDELINES.md says so in prose, and the phone roster was written the
+# forbidden way anyway. It drew square, because `clip` on a Rectangle clips to
+# the box and not to the radius.
+echo "Running hand-rolled row group lint..."
+if ! python3 "$SCRIPT_DIR/lint_hand_rolled_row_group.py"; then
+    echo "Hand-rolled row group lint failed."
+    exit 1
+fi
+
 # Static lint: the same rule for the interaction model's transform. A scale
 # composites exactly the way an opacity does, and the lint above recognises a
 # doubled dim by its opacity EXPRESSION - so the doubled scale discordVoice

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -305,6 +305,17 @@ if ! python3 "$SCRIPT_DIR/lint_hand_rolled_row_group.py"; then
     exit 1
 fi
 
+# Static lint: a wave member declares `appear` once. Declaring it over a base
+# that already has one puts two properties of that name on the object - the
+# wave writes the derived one, the base's opacity binding reads its own, and
+# the member silently stops fading. The android quick toggles did exactly that
+# the day GroupButton moved onto RippleButton.
+echo "Running shadowed stagger appear lint..."
+if ! python3 "$SCRIPT_DIR/lint_shadowed_stagger_appear.py"; then
+    echo "Shadowed stagger appear lint failed."
+    exit 1
+fi
+
 # Static lint: the same rule for the interaction model's transform. A scale
 # composites exactly the way an opacity does, and the lint above recognises a
 # doubled dim by its opacity EXPRESSION - so the doubled scale discordVoice

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -536,6 +536,19 @@ if ! python3 "$SCRIPT_DIR/test_changelog_receipt.py"; then
     exit 1
 fi
 
+# The deploy guard. ~/.config/quickshell/imi is a copy and the deploy that
+# fills it is `rsync --delete`, so deploying from a branch cut off main takes
+# every other open PR's work off the maintainer's running shell - which is what
+# happened, invisibly, because a clean live log proves nothing when main is
+# clean. This drives `deploy-shell` over a throwaway repo with a stub `gh`,
+# holding both exemptions the first draft got wrong: cherry-picked work counts
+# as present, and a branch outside the deployed subtree is not a loss.
+echo "Running deploy guard tests..."
+if ! python3 "$SCRIPT_DIR/test_deploy_guard.py"; then
+    echo "Deploy guard tests failed."
+    exit 1
+fi
+
 # Static lint: a manifest's option keys and the host's own per-plugin state
 # share one PluginState namespace, so the `__` prefix is the host's alone.
 echo "Running plugin option key lint..."

--- a/dots/.config/quickshell/imi/tests/test_deploy_guard.py
+++ b/dots/.config/quickshell/imi/tests/test_deploy_guard.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""`deploy-shell` refuses to deploy over an open PR's unmerged work.
+
+~/.config/quickshell/imi is a copy, not a checkout, and the deploy that fills it
+is `rsync --delete`. Run from a branch cut off main while other PRs are open, it
+takes every unmerged fix off the maintainer's running shell - and the live log
+stays clean while it does, because main is clean.
+
+The guard's whole value is in which branches it names, so that is what this
+drives, over a throwaway repository with a stub `gh` on PATH:
+
+  - a branch whose commit touches the deployed subtree BLOCKS;
+  - a branch whose commits are all outside it does NOT (a docs-only proposal
+    cannot change the running shell, and a guard that cries about one teaches
+    you to pass --anyway by reflex, which is the same as no guard);
+  - a branch whose work is already in HEAD by cherry-pick does NOT, even though
+    the SHAs differ - the first draft used a plain ancestor test and called
+    cherry-picked work missing.
+
+Both exemptions are regressions this file exists to hold: the first version of
+the script got each of them wrong against the real tree.
+"""
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO = next(p for p in HERE.parents if (p / "AGENT.md").exists())
+SCRIPT = REPO / "deploy-shell"
+SUBTREE = "dots/.config/quickshell/imi"
+
+
+def git(cwd, *args, check=True):
+    return subprocess.run(["git", "-C", str(cwd), *args],
+                          capture_output=True, text=True, check=check)
+
+
+class DeployGuardTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp(prefix="deploy-guard-"))
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+
+        self.repo = self.tmp / "repo"
+        (self.repo / SUBTREE).mkdir(parents=True)
+        self.target = self.tmp / "live"
+        shutil.copy2(SCRIPT, self.repo / "deploy-shell")
+
+        git(self.repo, "init", "-q", "-b", "main")
+        git(self.repo, "config", "user.email", "test@example.invalid")
+        git(self.repo, "config", "user.name", "test")
+        self.write(f"{SUBTREE}/shell.qml", "// base\n")
+        self.commit("base")
+
+        self.bin = self.tmp / "bin"
+        self.bin.mkdir()
+        self.stub_gh([])
+
+    def write(self, relpath, text):
+        path = self.repo / relpath
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text)
+
+    def commit(self, subject):
+        git(self.repo, "add", "-A")
+        git(self.repo, "commit", "-q", "-m", subject)
+        return git(self.repo, "rev-parse", "HEAD").stdout.strip()
+
+    def branch(self, name, relpath, text, subject):
+        """A branch off main holding one commit that writes `relpath`."""
+        git(self.repo, "checkout", "-q", "-b", name)
+        self.write(relpath, text)
+        sha = self.commit(subject)
+        git(self.repo, "checkout", "-q", "main")
+        return sha
+
+    def stub_gh(self, branches):
+        """A `gh` that answers `pr list` with exactly these branch names."""
+        stub = self.bin / "gh"
+        listing = "\n".join(branches)
+        stub.write_text(f'#!/usr/bin/env bash\ncat <<"EOF"\n{listing}\nEOF\n')
+        stub.chmod(0o755)
+
+    def deploy(self, *args):
+        env = dict(os.environ)
+        env["PATH"] = f"{self.bin}{os.pathsep}{env['PATH']}"
+        env["IMI_DEPLOY_TARGET"] = str(self.target)
+        return subprocess.run([str(self.repo / "deploy-shell"), *args],
+                              capture_output=True, text=True, env=env)
+
+    def test_branch_touching_the_deployed_subtree_blocks(self):
+        self.branch("feat/live", f"{SUBTREE}/Widget.qml", "// new\n", "feat: widget")
+        self.stub_gh(["feat/live"])
+
+        run = self.deploy()
+
+        self.assertEqual(run.returncode, 1, run.stdout + run.stderr)
+        self.assertIn("feat/live", run.stdout)
+        self.assertFalse(self.target.exists(),
+                         "a refused deploy must not have written anything")
+
+    def test_branch_outside_the_deployed_subtree_does_not_block(self):
+        self.branch("proposal/docs", "docs/idea.md", "# idea\n", "docs: an idea")
+        self.stub_gh(["proposal/docs"])
+
+        run = self.deploy()
+
+        self.assertEqual(run.returncode, 0, run.stdout + run.stderr)
+        self.assertNotIn("proposal/docs", run.stdout)
+
+    def test_cherry_picked_work_counts_as_present(self):
+        sha = self.branch("fix/elsewhere", f"{SUBTREE}/Fix.qml", "// fix\n", "fix: a fix")
+        git(self.repo, "cherry-pick", sha)
+        self.stub_gh(["fix/elsewhere"])
+
+        run = self.deploy()
+
+        self.assertEqual(run.returncode, 0, run.stdout + run.stderr)
+        self.assertNotIn("fix/elsewhere", run.stdout)
+
+    def test_anyway_deploys_past_the_refusal(self):
+        self.branch("feat/live", f"{SUBTREE}/Widget.qml", "// new\n", "feat: widget")
+        self.stub_gh(["feat/live"])
+
+        run = self.deploy("--anyway")
+
+        self.assertEqual(run.returncode, 0, run.stdout + run.stderr)
+        self.assertIn("feat/live", run.stdout)
+        self.assertTrue((self.target / "shell.qml").exists())
+
+    def test_it_records_what_it_deployed(self):
+        run = self.deploy()
+        self.assertEqual(run.returncode, 0, run.stdout + run.stderr)
+
+        head = git(self.repo, "rev-parse", "HEAD").stdout.strip()
+        recorded = (self.target / ".deployed-from").read_text()
+        self.assertIn(f"sha: {head}", recorded)
+        self.assertIn("ref: main", recorded)
+
+    def test_a_deploy_deletes_what_the_source_does_not_have(self):
+        """Why the guard has to exist at all, rather than being advisory."""
+        self.deploy()
+        stray = self.target / "FromAnotherBranch.qml"
+        stray.write_text("// an unmerged fix, live\n")
+
+        self.deploy()
+
+        self.assertFalse(stray.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dots/.config/quickshell/imi/tests/test_phone_tab_layout_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_tab_layout_runtime.py
@@ -90,13 +90,18 @@ PHONE_ADDRESS = "192.168.100.179"
 # 21 shared, 13 for the contact rows' geometry, 44 for the Apps page - the
 # three states adb itself can be in, the three states the page can be in, and
 # the pairing panel driven through discovery, pair and connect at two widths.
-EXPECTED_CHECKS = 79
+EXPECTED_CHECKS = 81
 
 # The two names the row-geometry steps measure, handed to the harness in the
 # environment so the fixture is the only place either is spelled. The Arabic
 # one is the maintainer's own screenshot, with the number it carried.
 LATIN_NAME = "Alice Rivers"
 ARABIC_NAME = "\u0627\u0628\u0648 \u0631\u0648\u0641\u0627\u0646 \u0627\u0644\u0645\u062d\u0644\u0645\u064a"
+LONG_NAME = ("Abdelrahman Mohamed Al-Sayed Ibrahim El-Masry "
+             "of the Engineering Department")
+# 1x1 PNG. The pipeline under test is "the card has a photo at all",
+# not what it depicts.
+PHOTO_B64 = ("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGP8z8DwHwAFAQIA3f7C2wAAAABJRU5ErkJggg==")
 
 # The Arabic face is the whole measurement, and this test redirects
 # XDG_CONFIG_HOME - which takes the developer's own ~/.config/fontconfig with
@@ -288,6 +293,21 @@ VCARDS = {
         f"N:;{ARABIC_NAME};;;\n"
         "TEL;TYPE=CELL,PREF:+201016000286\n"
         "EMAIL;TYPE=WORK:rufan@example.com\n"
+        "END:VCARD\n"
+    ),
+    # A name no card can fit and an inline photo, which is what the phone
+    # actually exports and what the fixture's three short unadorned names
+    # never exercised: the trailing chevron was reported drawn mid-name on
+    # one row, and a row is only special here through its DATA.
+    "long.vcf": (
+        "BEGIN:VCARD\n"
+        "VERSION:3.0\n"
+        "UID:long-uid-1\n"
+        f"FN:{LONG_NAME}\n"
+        f"N:;{LONG_NAME};;;\n"
+        "TEL;TYPE=CELL,PREF:+20 100 000 0000 (work mobile, do not share)\n"
+        "EMAIL;TYPE=WORK:a.very.long.address.for.one.contact@example.com\n"
+        f"PHOTO;ENCODING=b;TYPE=PNG:{PHOTO_B64}\n"
         "END:VCARD\n"
     ),
     "nameless.vcf": (

--- a/dots/.config/quickshell/imi/tests/test_phone_tab_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_tab_runtime.py
@@ -70,7 +70,7 @@ LAPTOP_ADDRESS = "192.168.100.99"
 # A literal, never read back out of the harness's own output: a step list
 # that shrinks must redden here instead of reporting `failures: 0` for a
 # shorter run.
-EXPECTED_CHECKS = 93
+EXPECTED_CHECKS = 95
 
 RECORD = """#!/usr/bin/env bash
 printf '%s %s\\n' "$(date +%s.%N)" "$*" >> "$PHONE_EXEC_LOG"

--- a/dots/.config/quickshell/imi/tests/test_phone_tab_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_tab_runtime.py
@@ -70,7 +70,7 @@ LAPTOP_ADDRESS = "192.168.100.99"
 # A literal, never read back out of the harness's own output: a step list
 # that shrinks must redden here instead of reporting `failures: 0` for a
 # shorter run.
-EXPECTED_CHECKS = 88
+EXPECTED_CHECKS = 89
 
 RECORD = """#!/usr/bin/env bash
 printf '%s %s\\n' "$(date +%s.%N)" "$*" >> "$PHONE_EXEC_LOG"

--- a/dots/.config/quickshell/imi/tests/test_phone_tab_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_tab_runtime.py
@@ -70,7 +70,7 @@ LAPTOP_ADDRESS = "192.168.100.99"
 # A literal, never read back out of the harness's own output: a step list
 # that shrinks must redden here instead of reporting `failures: 0` for a
 # shorter run.
-EXPECTED_CHECKS = 87
+EXPECTED_CHECKS = 88
 
 RECORD = """#!/usr/bin/env bash
 printf '%s %s\\n' "$(date +%s.%N)" "$*" >> "$PHONE_EXEC_LOG"

--- a/dots/.config/quickshell/imi/tests/test_phone_tab_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_phone_tab_runtime.py
@@ -70,7 +70,7 @@ LAPTOP_ADDRESS = "192.168.100.99"
 # A literal, never read back out of the harness's own output: a step list
 # that shrinks must redden here instead of reporting `failures: 0` for a
 # shorter run.
-EXPECTED_CHECKS = 89
+EXPECTED_CHECKS = 93
 
 RECORD = """#!/usr/bin/env bash
 printf '%s %s\\n' "$(date +%s.%N)" "$*" >> "$PHONE_EXEC_LOG"

--- a/dots/.config/quickshell/imi/tests/tst_config_selection_array.qml
+++ b/dots/.config/quickshell/imi/tests/tst_config_selection_array.qml
@@ -42,14 +42,19 @@ TestCase {
         // per-corner radii, exactly as `tst_grouped_list` says it.
         if (rowComponent.status === Component.Error) {
             const reason = rowComponent.errorString();
-            verify(/(top|bottom)(Left|Right)Radius/.test(reason),
+            // The row reaches `StyledText`, which sets `font.variableAxes` -
+            // Qt 6.7 and up. That, and not the per-corner radii this file
+            // first guessed at, is why the row cannot build on the CI Qt: the
+            // guess was never checked because a skip on ANY error printed the
+            // same green either way.
+            verify(/variableAxes|(top|bottom)(Left|Right)Radius/.test(reason),
                 "the row failed to build for a reason that is not Qt's version: " + reason);
         }
     }
 
     function ensureComponent() {
         if (rowComponent.status === Component.Error)
-            skip("Qt is older than 6.7, so the per-corner radii this row draws with do not exist here");
+            skip("Qt is older than 6.7, so the variable font axes this row's text sets do not exist here");
         compare(rowComponent.status, Component.Ready, rowComponent.errorString());
     }
 

--- a/dots/.config/quickshell/imi/tests/tst_config_selection_array.qml
+++ b/dots/.config/quickshell/imi/tests/tst_config_selection_array.qml
@@ -34,11 +34,22 @@ TestCase {
 
     function initTestCase() {
         rowComponent = Qt.createComponent("fixtures/ConfigSelectionArrayRow.qml");
+        // A skip on ANY load error is a check that cannot fail. This one hid a
+        // real one: `GroupButton` moved onto `RippleButton`, the test import
+        // tree had no `InteractionMotion` to resolve, and the row stopped
+        // building - the suite reported two more skips, zero failures and
+        // exit 0. The only reason this file may skip is a Qt too old for the
+        // per-corner radii, exactly as `tst_grouped_list` says it.
+        if (rowComponent.status === Component.Error) {
+            const reason = rowComponent.errorString();
+            verify(/(top|bottom)(Left|Right)Radius/.test(reason),
+                "the row failed to build for a reason that is not Qt's version: " + reason);
+        }
     }
 
     function ensureComponent() {
         if (rowComponent.status === Component.Error)
-            skip("this Qt cannot build the row: " + rowComponent.errorString());
+            skip("Qt is older than 6.7, so the per-corner radii this row draws with do not exist here");
         compare(rowComponent.status, Component.Ready, rowComponent.errorString());
     }
 


### PR DESCRIPTION
Three reported defects in the phone panel, two of which turned out to live in
shared widgets rather than in the phone tab.

**The contact chevron drawn in the middle of the name, on the first row only.**
`StyledText.animateChange` slid the text out and back by animating `root.x` and
`root.y`, returning the item to an `originalX` captured in
`Component.onCompleted`. A layout owns the position of the items it holds, so
for anything inside one that capture is taken before the layout has run, and
every later glyph swap returned the item to a stale place and left it there. A
`ListView` builds its first delegate before the view has width, which is what
selected the victim: expanding the first contact swapped `expand_more` for
`expand_less` and parked its chevron 311px left of the card's trailing edge,
while every row built after the view had width was correct. It animates a
`Translate` now - no layout writes one - so the rest position is zero and there
is nothing to remember. This reaches every `animateChange` call site in the
shell, not just the contacts list.

**The ripple missing from the notification buttons.** `GroupButton` and
`RippleButton` were both rooted on `Button` and each spelled its own
background, its own `MouseArea` and its own press morph, twelve property names
in common. Whether a button rippled came down to which of the two its call site
picked - the notification footer lost its ripple the day it moved onto the
group vocabulary. `GroupButton` extends `RippleButton` now (141 -> 96 lines)
and keeps only what a button group adds: the bounce, the segmented end radii
mapped onto the base's per-corner overrides, the index bookkeeping.
`colBackgroundActive` and `colBackgroundToggledActive` keep their names and now
feed `colRipple`, so the call-site surface is unchanged and the pressed state
layer still draws alongside the ripple, which is what M3 asks for. The corner
morph also follows the shared animated press progress instead of snapping on
`down`. All 19 call sites gain the ripple; `RippleButton` gains the
long-press-to-`altAction` that `GroupButton`'s own `MouseArea` carried.

**The device roster not using a proper component.** The first attempt here was
wrong twice over and is worth stating plainly, because the second version is
what shipped. It wrapped the rows in a `StyledRectangle` of its own -
`docs/M3_GUIDELINES.md` names `GroupedList` for exactly that presentation, the
component is used in ten places including the phone's own webcam page, and the
rule was on the page the whole time. It also drew as a perfect rectangle, which
is how it was caught: `clip` on a `Rectangle` clips to the bounding box and not
to the radius, so the opaque rows painted over all four corners while the
wrapper reported `radius: 17` - and the runtime check written beside it asked
for that property, was told 17, and passed against a screen showing square
corners.

The roster is a `GroupedList` now. The component gained `model` and
`rowDelegate`, because it only took declared rows and the roster's rows are the
daemon's - that gap is why a wrapper got invented at all. A row that paints its
own background is handed its plate's corners, since a plate cannot show through
an opaque row. Measured on the drawn rows: first `17/6`, last `6/17` - outer
corners rounded, seams tight. The picked device carries the selected container
tone, its matching ink and a trailing check, where `active` had only cancelled
the hover colour.

`tests/lint_hand_rolled_row_group.py` fails on the shape from now on: rows of a
`DialogListItem`-rooted type, inside a list, inside a rectangle. Its own first
version reported a clean tree over a file containing nothing but the offender -
it read the type from the text before the colon, and `delegate: PhoneDeviceItem
{` is not that - so the parser was rewritten and both directions are proven.

**One regression this PR caused and caught.** Moving `GroupButton` onto
`RippleButton` pulled `InteractionMotion` into the chain, and the QML unit
tests' import tree had no entry for it, so the row under test stopped building.
Because `tst_config_selection_array` skipped on any load error, the suite
reported two extra skips, zero failures and exit 0 - it was visible only as
1434 passed where 1436 had been. The symlink is registered, and that guard now
excuses the one thing it is allowed to, the way `tst_grouped_list` already did:
a Qt too old for the per-corner radii.

**A deploy guard, because this PR's own verification reverted the maintainer's
shell.** `~/.config/quickshell/imi` is a copy, not a checkout, and the deploy
that fills it is an `rsync --delete` one-liner people retype from a plan
document. Run from a branch cut off `main` while other PRs are open, it takes
every unmerged fix off the running shell - which is what happened here: a deploy
from #341's branch removed this PR's fixes and #340's from the maintainer's live
session. The check that "confirmed" that deploy was a grep of the live log for
errors, which was clean, because `main` is clean.

`deploy-shell` at the repo root replaces the one-liner. It names every open PR
branch the deploy would roll back and stops, records the SHA and ref it deployed
in `.deployed-from` so what is live is read rather than inferred, and prints the
SHA. Two details are load-bearing and both were wrong in its first draft,
against this very tree: a branch counts as present when its commits are
patch-equivalent to something in HEAD (`git cherry`), because cherry-picked work
has different SHAs; and a commit counts only when it touches
`dots/.config/quickshell/imi`, because a docs-only proposal branch cannot change
the running shell and a guard that names it anyway teaches you to pass
`--anyway` by reflex. `tests/test_deploy_guard.py` holds both, driving the
script over a throwaway repo with a stub `gh`; reverting either behaviour fails
exactly one test, checked by mutation.

CONTRIBUTING.md said "this repo lives at `~/.config/quickshell/imi`" and its
verification loop went straight from "make the edit" to reading the log. Both
are corrected, and the revert is on its list of examples that justify the
paranoia.

**The roster's plate, reported twice after review.** The GroupedList change
above shipped a group of one that drew as a frame around a single item, and
then, once that was fixed, a hovered row that grew past the panel's edge. One
cause behind both: a row that paints its own background sat inset inside a
plate it painted over, so all that showed of the plate was the inset - a ring
of `bgcolor` around every row. With several rows that ring passes for the
group's seam material, which is why review missed it; with one row the ring is
the entire group.

The plate paints nothing behind a row that takes the group's corners - that is
what the corner protocol is FOR, since a plate cannot show through an opaque
row. The inset stays, and the second report is why: the interaction model lifts
a control by `hoverScale` on hover, and the inset is the only room a row has to
grow into. Measured on the reported row - scale 1.02 over 424px is 4.24px of
overhang per side against the 8px the inset gives back. The old plate had been
absorbing that by accident for as long as the component has existed.

## Testing

- Full suite: 1436 passed, 0 failed, 0 skipped.
- `PhoneTabRuntimeTest` 89 -> 95 checks, including a roster of ONE - the case
  two devices structurally cannot show - and a real hover through the test
  driver, reading `interactionMotion.scale` off the row rather than asserting
  the token.
- Both roster checks verified red against the unfixed widget: `roster row
  insets 8,8 of width 440`, lone row `inset 8 of 440`.
- `tests/test_deploy_guard.py` drives `deploy-shell` over a throwaway repo with
  a stub `gh`; both of its exemptions verified by mutation.
- Deployed and read back from the live tree, not from the branch.
- `PhoneTabLayoutRuntimeTest` gained a trailing-edge check on every contact row
  and an expand-then-remeasure check on the first row (79 -> 81 checks). Both
  verified red against the unfixed widget: `worst is row 0 at 311 of 24`.
- The layout fixture gained a long-name, photo-bearing contact - the shape the
  live list has and three short names did not.
- `PhoneTabRuntimeTest` reads the group's shape off the drawn rows - outer
  corners rounded, seams not - rather than off a container's property (87 ->
  89), and its reveal watcher settles against the group's own height: it read
  the list view's `contentHeight`, which a GroupedList has not got, and
  `undefined` in that comparison is a silent false that turns an unroll into a
  snap.
- Deployed to the live shell and read back: reload clean, no type errors.

Docs: updated AGENT.md, CONTRIBUTING.md
Changelog: updated
