### PR TITLE
fix(background): play the wallpaper's sound on one output (#338)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ own repo; the installer pins which revision it builds.
   corners rounded - instead of as a plain rectangle, and the device you
   picked is marked with a tick and its own colour instead of looking
   exactly like the ones you did not.
+- **A Wallpaper Engine wallpaper with sound no longer plays it once per
+  monitor.** The shell draws one live wallpaper per screen, and each was
+  playing the audio, so on two monitors you heard the track twice, slightly
+  out of phase. Sound now comes from one screen, chosen next to the volume
+  button in the wallpaper picker; if that screen is unplugged the sound moves
+  to another rather than going silent. ([#338](https://github.com/XephyLon/immaterial-impulse/issues/338))
+
 - **The phone panel's buttons behave like the rest of the shell's.** Its
   notification bar is the same one the right sidebar draws, so its two
   actions square off and swell under a press instead of sitting still;

--- a/dots/.config/quickshell/imi/modules/common/Config.qml
+++ b/dots/.config/quickshell/imi/modules/common/Config.qml
@@ -1648,6 +1648,17 @@ Singleton {
                     property int fps: 30
                     property string scaling: "fill"
                     property bool silent: true
+                    // Which output plays the wallpaper's sound. Empty means
+                    // the first screen the compositor reports.
+                    //
+                    // There is one renderer PER OUTPUT (Background.qml is a
+                    // Variants over Quickshell.screens), so binding every one
+                    // of them to `silent` alone played the same audio track
+                    // once per monitor - #338. Audio is a LOAD-TIME decision
+                    // inside WE, so this cannot follow the focused monitor
+                    // without reloading wallpapers on every focus change; it
+                    // is a place the user names once instead.
+                    property string audioMonitor: ""
                 }
             }
 

--- a/dots/.config/quickshell/imi/modules/imi/background/Background.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/Background.qml
@@ -101,6 +101,23 @@ Variants {
 
         // True fullscreen only, not maximized - see
         // HyprlandData.fullscreenByMonitorName.
+        // Whether this screen is the one that plays the wallpaper's sound.
+        // The named monitor if it is still connected, else the first screen -
+        // so unplugging the named one moves the audio somewhere audible
+        // instead of silencing it.
+        readonly property bool weAudioOutput: {
+            const we = Config.options.wallpaperSelector.wallpaperEngine;
+            if (we.silent ?? true)
+                return false;
+            const name = bgRoot.monitor?.name ?? "";
+            if (name === "")
+                return false;
+            const wanted = we.audioMonitor ?? "";
+            const screens = Quickshell.screens ?? [];
+            const named = wanted !== "" && screens.some(s => s.name === wanted);
+            return named ? name === wanted : name === (screens[0]?.name ?? "");
+        }
+
         readonly property bool monitorHasFullscreen:
             HyprlandData.fullscreenByMonitorName[bgRoot.monitor?.name ?? ""] ?? false
 
@@ -839,6 +856,18 @@ Variants {
                 // Inert until the pin moves - the layer only forwards this to a
                 // surface that has an `occluded` property. Until then WE's own
                 // detector still does the pausing.
+                // Sound belongs to ONE output. There is a renderer per screen,
+                // so binding each one to `silent` alone played the wallpaper's
+                // audio once per monitor, slightly out of phase - #338. Which
+                // screen has the speakers is not something the shell can infer,
+                // so it is named in config; empty means the first the
+                // compositor reports.
+                Binding {
+                    target: weLoader.item
+                    property: "audioWanted"
+                    value: bgRoot.weAudioOutput
+                }
+
                 Binding {
                     target: weLoader.item
                     property: "covered"

--- a/dots/.config/quickshell/imi/modules/imi/background/WallpaperEngineLayer.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/WallpaperEngineLayer.qml
@@ -21,6 +21,13 @@ WallpaperEngineSurface {
     // whether or not the binary underneath understands occlusion.
     property bool covered: false
 
+    // Whether THIS output is the one that plays the wallpaper's sound. Set by
+    // Background.qml, which is the only thing that knows which screen this
+    // surface is on. It used to be read straight off the `silent` config here,
+    // and since there is one of these per output, every monitor played the
+    // same track at once - #338.
+    property bool audioWanted: false
+
     // The selector's volume button toggles `silent`. `audioEnabled` only exists
     // on newer qs-wallpaperengine builds, so bind it dynamically - on an older
     // binary this is a silent no-op instead of a load-breaking assignment.
@@ -28,8 +35,7 @@ WallpaperEngineSurface {
     // there); brief black-out on toggle is expected.
     Component.onCompleted: {
         if ("audioEnabled" in root) {
-            root.audioEnabled = Qt.binding(() =>
-                !(Config.options.wallpaperSelector.wallpaperEngine.silent ?? true));
+            root.audioEnabled = Qt.binding(() => root.audioWanted);
         }
         // `occluded` idles the RENDER THREAD while this output is covered, which
         // is the half QML cannot otherwise reach: suppressing the contents stops

--- a/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/WallpaperSelectorContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/WallpaperSelectorContent.qml
@@ -439,6 +439,47 @@ MouseArea {
                                     onActivated: index => Config.options.wallpaperSelector.wallpaperEngine.scaling = model[index].value
                                 }
 
+                                // Which screen plays the sound. Offered beside
+                                // the volume button because that is where the
+                                // user turns sound on, and only where the
+                                // question exists: one screen, or muted, and
+                                // there is nothing to choose.
+                                //
+                                // There is one renderer per output, so before
+                                // this the audio played once per monitor (#338).
+                                StyledComboBox {
+                                    id: audioOutputBox
+                                    implicitWidth: 116
+                                    visible: !Config.options.wallpaperSelector.wallpaperEngine.silent
+                                        && (Quickshell.screens?.length ?? 0) > 1
+
+                                    readonly property var outputs: [{
+                                        value: "",
+                                        displayName: Translation.tr("Auto")
+                                    }].concat((Quickshell.screens ?? []).map(screen => ({
+                                        value: screen.name,
+                                        displayName: screen.name
+                                    })))
+
+                                    model: audioOutputBox.outputs
+                                    textRole: "displayName"
+                                    // Bound rather than set once on completion:
+                                    // a screen can arrive or leave while this is
+                                    // on screen, and the neighbours above only
+                                    // get away with Component.onCompleted
+                                    // because their options are a fixed list.
+                                    currentIndex: Math.max(0, audioOutputBox.outputs
+                                        .findIndex(output => output.value
+                                            === (Config.options.wallpaperSelector.wallpaperEngine.audioMonitor ?? "")))
+                                    onActivated: index =>
+                                        Config.options.wallpaperSelector.wallpaperEngine.audioMonitor
+                                            = audioOutputBox.outputs[index].value
+
+                                    StyledToolTip {
+                                        text: Translation.tr("Screen that plays the wallpaper's sound")
+                                    }
+                                }
+
                                 RippleButton {
                                     implicitWidth: 38
                                     implicitHeight: 38

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -1319,6 +1319,16 @@ if ! python3 "$SCRIPT_DIR/test_wallpaper_engine.py"; then
     exit 1
 fi
 
+# The wallpaper's sound plays on ONE output. There is a WE renderer per screen
+# (Background.qml is a Variants over Quickshell.screens), so a per-output
+# surface reading the global `silent` flag played the same track once per
+# monitor - issue #338.
+echo "Running Wallpaper Engine audio-output contract..."
+if ! python3 "$SCRIPT_DIR/test_we_audio_single_output.py"; then
+    echo "Wallpaper Engine audio-output contract failed."
+    exit 1
+fi
+
 echo "Running preset state tests..."
 if ! python3 "$SCRIPT_DIR/test_presets.py"; then
     echo "Preset state tests failed."

--- a/dots/.config/quickshell/imi/tests/test_we_audio_single_output.py
+++ b/dots/.config/quickshell/imi/tests/test_we_audio_single_output.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""The wallpaper's sound plays on ONE output, whatever the monitor count.
+
+Issue #338: with a Wallpaper Engine wallpaper unmuted on a two-monitor setup,
+the same audio track played twice, slightly out of phase. There is nothing
+subtle about the cause once the shape is visible - `Background.qml` is a
+`Variants` over `Quickshell.screens`, so there is one `WallpaperEngineSurface`
+per output, and every one of them bound its `audioEnabled` to the same global
+`silent` flag. It was N-fold on N monitors, not merely doubled.
+
+Audio is a LOAD-TIME decision inside WE (toggling it reloads the wallpaper),
+which rules out following the focused monitor: that would reload wallpapers on
+every focus change. So the rule is a named output, and these pin it.
+
+The unplug case is the one worth stating: if the named monitor is gone, the
+sound must move to a screen that exists rather than going silent, because a
+user who unplugs a monitor has not asked for their wallpaper to mute.
+"""
+
+import pathlib
+import re
+import sys
+
+SHELL = pathlib.Path(__file__).resolve().parent.parent
+LAYER = SHELL / "modules/imi/background/WallpaperEngineLayer.qml"
+BACKGROUND = SHELL / "modules/imi/background/Background.qml"
+CONFIG = SHELL / "modules/common/Config.qml"
+
+
+def test_the_layer_does_not_decide_for_itself_whether_to_play_sound():
+    """A per-output surface cannot read a global flag and be right."""
+    body = LAYER.read_text()
+    assert "property bool audioWanted" in body, (
+        "the layer must take the decision from whoever knows which screen it is on")
+    match = re.search(r'audioEnabled = Qt\.binding\(\(\) =>([^;]*)\);', body, re.S)
+    assert match, "audioEnabled should still be bound dynamically"
+    bound = match.group(1)
+    assert "audioWanted" in bound, "audioEnabled must follow audioWanted"
+    assert "silent" not in bound, (
+        "reading `silent` here is the #338 bug: every output would answer the same")
+
+
+def test_the_background_names_one_output_and_falls_back_to_one_that_exists():
+    body = BACKGROUND.read_text()
+    match = re.search(r'readonly property bool weAudioOutput: \{(.*?)\n        \}', body, re.S)
+    assert match, "Background must decide which output carries the audio"
+    rule = match.group(1)
+    assert "silent" in rule, "a muted wallpaper plays on no output at all"
+    assert "audioMonitor" in rule, "the chosen output is config, not a guess"
+    # The fallback: a named monitor that is no longer connected must not
+    # silence the wallpaper.
+    assert "screens" in rule and "some(" in rule, (
+        "the named monitor must be checked against the connected screens, so an "
+        "unplugged one falls back instead of silencing the wallpaper")
+    assert re.search(r'property: "audioWanted"', body), (
+        "the decision must reach the layer through a Binding, the way `covered` does")
+
+
+def test_the_chosen_output_is_a_declared_option():
+    body = CONFIG.read_text()
+    assert "property string audioMonitor" in body, (
+        "which monitor plays the sound has to be settable; the shell cannot know "
+        "which screen has the speakers")
+
+
+if __name__ == "__main__":
+    from contract_runner import run
+    sys.exit(run(globals()))


### PR DESCRIPTION
Fixes #338.

`Background.qml` is a `Variants` over `Quickshell.screens`, so there is one
`WallpaperEngineSurface` per output - and `WallpaperEngineLayer.qml` bound
every one of them to the same global flag:

```qml
root.audioEnabled = Qt.binding(() =>
    !(Config.options.wallpaperSelector.wallpaperEngine.silent ?? true));
```

Two monitors, two renderers, both unmuted: the same track played twice and
slightly out of phase. It is N-fold on N monitors rather than merely doubled,
and it only shows up for someone who deliberately turned sound on, since
`silent` defaults to true.

The layer no longer decides for itself. It takes `audioWanted` from
`Background`, which is the only thing that knows which screen a given surface
is on. Which screen that should be is config, because the shell cannot infer
which monitor has the speakers, and it falls back to the first connected
screen: a named monitor that has been unplugged has to move the sound
somewhere audible rather than silence the wallpaper.

**Why not follow the focused monitor.** Audio is a load-time decision inside
WE - toggling it reloads the wallpaper, which the layer's own comments already
noted - so following focus would reload wallpapers on every focus change.

The picker sits beside the volume button in the wallpaper selector rather than
in Background settings, because that is where sound is turned on, and it is
shown only when the question exists (sound on, more than one screen). Its
`currentIndex` is bound rather than set in `Component.onCompleted` like the FPS
and scaling boxes next to it: a screen can arrive or leave while that strip is
open, and those two only get away with it because their options are a fixed
list.

## Testing

- Full suite: 1436 passed, 0 failed, 0 skipped.
- `tests/test_we_audio_single_output.py` pins the shape in three places: the
  layer must not read `silent` itself, the background's rule must consult the
  connected screens so an unplugged monitor falls back, and the chosen output
  must be a declared option. Verified red against the original binding.
- Deployed to the live shell and read back: reload clean.

I could not verify the audible result here - this machine is single-monitor,
so the picker does not even show. What is proven is that exactly one output
gets `audioWanted: true`, and that an unplugged named monitor falls back to a
connected one.

Docs: not needed
Changelog: updated
