### PR TITLE
fix(cheatsheet): the window fits the screen, per tab - and the typing test fills it

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1222,10 +1222,13 @@ whose `minimumSize` equals its `maximumSize` is floated, sized and centred by Hy
 purely from the fixed size hints. Prefer that over a runtime rule. It also keeps the window title
 free to stay translated, since nothing is matching on it.
 
-**...and a window sized that way is exactly as tall as its tallest page, on every screen, so the
-pages have to fit the screen themselves.** The cheatsheet's `SwipeView` reports the largest of its
-pages' implicit sizes, and the Elements page was nine rows of fixed 70px tiles - ~800px with the
-window's chrome - which fits a 1080p panel at scale 1 (970px usable) and on the same panel at 1.25x
+**...and a window sized that way is exactly as big as the page it is showing, on every screen, so
+the pages have to fit the screen themselves.** The cheatsheet's `SwipeView` reports the CURRENT
+page's implicit size (indexed out of `contentChildren` by `currentIndex`, not `currentItem`, whose
+size is unsettled on the first frame; it used to report the largest of every page's, which opened
+the typing test as tall as the keybind table - "fix(cheatsheet): size the window to the tab it is
+showing, not the tallest"), and the Elements page was nine rows of fixed 70px tiles - ~800px with
+the window's chrome - which fits a 1080p panel at scale 1 (970px usable) and on the same panel at 1.25x
 (864 logical) put the window 17px under the bar and 17px under the dock, at 1.5x (720) 44px off the
 top of the screen. The keybinds page had a budget of `screen.height - 220`, a literal standing in
 for "the bar, the dock and the chrome" on one desktop, and the Elements page had none. "The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ own repo; the installer pins which revision it builds.
 
 ## [Unreleased]
 
+### Changed
+- **The typing test scales with the screen.** Its stage was a fixed
+  1100x640 on every monitor; it now takes a share of the room the bar and
+  the dock leave, held to a 16:9 stage, so it grows on a larger screen
+  without becoming it.
+
+### Fixed
+- **The cheatsheet fits the screen again.** The window was sized to its
+  tallest page, so the typing test and the periodic table opened as tall as
+  the keybind table - past both screen edges on a 1080p display. The window
+  follows the tab it is showing now, and the keybind table itself shrinks
+  uniformly (the way the Elements page always has) when a full keybind set
+  is larger than the screen, instead of running off it.
+
 ## [1.0.0-rc-9] — 2026-09-03
 
 ### Changed

--- a/dots/.config/quickshell/imi/modules/common/functions/cheatsheetFit.js
+++ b/dots/.config/quickshell/imi/modules/common/functions/cheatsheetFit.js
@@ -5,8 +5,8 @@
 //
 // The window is a fixed-size toplevel (equal minimum and maximum hints are what
 // make Hyprland float and centre it, see Cheatsheet.qml), so it never resizes
-// itself: it is exactly as tall as its tallest page. Its pages therefore have
-// to fit the screen on their own, and "the screen" is the part of it the
+// itself: it is exactly as big as the page it is showing. Its pages therefore
+// have to fit the screen on their own, and "the screen" is the part of it the
 // compositor leaves - `hyprctl monitors` reports the reserved area the bar and
 // the dock hold as [left, top, right, bottom], and a floating window is centred
 // in what is left. The Elements page was a fixed 9 rows of 70px tiles, which is

--- a/dots/.config/quickshell/imi/modules/common/functions/cheatsheetFit.js
+++ b/dots/.config/quickshell/imi/modules/common/functions/cheatsheetFit.js
@@ -53,3 +53,26 @@ function fitScale(naturalWidth, naturalHeight, budgetWidth, budgetHeight) {
         scale = Math.min(scale, budgetHeight / naturalHeight);
     return scale;
 }
+
+// The box a stretchy page takes: a share of the budget, held to an aspect
+// ratio. The typing test is the one page with no natural size - every block
+// in it fills its width - so "fit the budget" is not a fit at all but a
+// choice, and taking the whole budget shaped the stage like whatever the
+// screen minus the panels happened to be. A fraction keeps it a window
+// rather than a takeover, and the fixed aspect keeps the stage the same
+// shape on every monitor. Width-first: take the share of the width, derive
+// the height from the aspect, and if that runs past the height's share,
+// bind on the height instead. Either budget missing (0 or less) means the
+// window has not learned its screen; the caller keeps its fallback.
+function aspectBox(budgetWidth, budgetHeight, fraction, aspect) {
+    if (!(budgetWidth > 0) || !(budgetHeight > 0) || !(fraction > 0) || !(aspect > 0))
+        return { width: 0, height: 0 };
+    let width = budgetWidth * fraction;
+    let height = width / aspect;
+    const heightShare = budgetHeight * fraction;
+    if (height > heightShare) {
+        height = heightShare;
+        width = height * aspect;
+    }
+    return { width: width, height: height };
+}

--- a/dots/.config/quickshell/imi/modules/imi/cheatsheet/Cheatsheet.qml
+++ b/dots/.config/quickshell/imi/modules/imi/cheatsheet/Cheatsheet.qml
@@ -262,8 +262,17 @@ Scope { // Scope
                             Persistent.states.cheatsheet.tabIndex = currentIndex;
                         }
 
-                        implicitWidth: Math.max.apply(null, contentChildren.map(child => child.implicitWidth || 0))
-                        implicitHeight: Math.max.apply(null, contentChildren.map(child => child.implicitHeight || 0))
+                        // The window is fixed to this size, so it must be the
+                        // CURRENT page's size, not the tallest page's. Sizing to
+                        // the max over every page (the keybind table is by far
+                        // the tallest) forced the typing test and the periodic
+                        // table to open as tall as the keybinds - the whole
+                        // window ran past the screen. Index the current page's
+                        // Loader, which the Repeater always builds, rather than
+                        // `currentItem`, whose implicit size is not settled yet
+                        // on the first frame and collapses the window.
+                        implicitWidth: (swipeView.contentChildren[swipeView.currentIndex]?.implicitWidth) ?? 0
+                        implicitHeight: (swipeView.contentChildren[swipeView.currentIndex]?.implicitHeight) ?? 0
 
                         clip: true
                         layer.enabled: true

--- a/dots/.config/quickshell/imi/modules/imi/cheatsheet/CheatsheetKeybinds.qml
+++ b/dots/.config/quickshell/imi/modules/imi/cheatsheet/CheatsheetKeybinds.qml
@@ -6,6 +6,7 @@ import qs.modules.common.widgets
 import QtQuick
 import QtQuick.Layouts
 import "../../common/functions/cheatsheetLayout.js" as CheatsheetLayout
+import "../../common/functions/cheatsheetFit.js" as CheatsheetFit
 
 Item {
     id: root
@@ -42,35 +43,27 @@ Item {
     readonly property real rowHeight: 30
     readonly property int availableRows: Math.max(
         8, Math.floor((root.maxContentHeight > 0 ? root.maxContentHeight : 900) * 0.66 / root.rowHeight))
-    // Ceiling on the column count, lowered until the laid-out row fits the
-    // width budget. Measured rather than predicted: a column is as wide as its
-    // widest section, which is not known until the text has been shaped.
+    // Ceiling on the column count. The height budget picks the count below it
+    // (columnCount), so this only bounds a long list; a short one never fans
+    // into slivers.
     readonly property int maxColumns: 4
-    property int columnCap: root.maxColumns
     readonly property var columns: CheatsheetLayout.balance(
-        root.sections, CheatsheetLayout.columnCount(root.sections, root.availableRows, root.columnCap))
+        root.sections, CheatsheetLayout.columnCount(root.sections, root.availableRows, root.maxColumns))
 
-    function fitToWidth() {
-        if (root.maxContentWidth <= 0 || root.columnCap <= 1)
-            return;
-        if (root.implicitWidth > root.maxContentWidth)
-            root.columnCap -= 1;
-    }
-
-    // Only ever shrinks, so this settles: each drop narrows the row, and the
-    // guard stops at a single column. Anything that changes what is being laid
-    // out starts the search again from the top.
-    onImplicitWidthChanged: Qt.callLater(root.fitToWidth)
-    onMaxContentWidthChanged: {
-        root.columnCap = root.maxColumns;
-        Qt.callLater(root.fitToWidth);
-    }
-    onSectionsChanged: {
-        root.columnCap = root.maxColumns;
-        Qt.callLater(root.fitToWidth);
-    }
-    implicitWidth: row.implicitWidth + padding * 2
-    implicitHeight: row.implicitHeight + padding * 2
+    // The columns are chosen to fit the HEIGHT budget, but a full keybind set
+    // in four columns can still be wider than the screen (and, on a laptop,
+    // marginally taller than the height budget once the section chips are drawn)
+    // - and trading more columns for less height just makes it wider still.
+    // So the page fits the same way the Elements page does: keep the columns and
+    // the author order, and shrink the whole thing uniformly when it exceeds
+    // either budget. fit is 1 whenever it already fits, so a roomy screen draws
+    // full size.
+    readonly property real contentWidth: row.implicitWidth + padding * 2
+    readonly property real contentHeight: row.implicitHeight + padding * 2
+    readonly property real fit: CheatsheetFit.fitScale(
+        root.contentWidth, root.contentHeight, root.maxContentWidth, root.maxContentHeight)
+    implicitWidth: root.contentWidth * root.fit
+    implicitHeight: root.contentHeight * root.fit
     // Excellent symbol explaination and source :
     // http://xahlee.info/comp/unicode_computing_symbols.html
     // https://www.nerdfonts.com/cheat-sheet
@@ -173,7 +166,12 @@ Item {
     Row { // Keybind columns
         id: row
         spacing: root.spacing
-        
+        // Scaled about its own centre, which centerIn holds at the page's, so
+        // the shrunk columns land exactly inside the box the page asks for -
+        // the same arrangement CheatsheetPeriodicTable uses.
+        anchors.centerIn: parent
+        scale: root.fit
+
         Repeater {
             model: root.columns
 

--- a/dots/.config/quickshell/imi/modules/imi/cheatsheet/CheatsheetTypingTest.qml
+++ b/dots/.config/quickshell/imi/modules/imi/cheatsheet/CheatsheetTypingTest.qml
@@ -6,6 +6,7 @@ import qs.modules.common
 import qs.modules.common.widgets
 import qs.modules.imi.cheatsheet.typing
 import qs.services
+import "../../common/functions/cheatsheetFit.js" as CheatsheetFit
 
 /**
  * The typing test as a cheatsheet page.
@@ -21,8 +22,12 @@ Item {
 
     // The room the page may take - Cheatsheet.qml derives both from the
     // screen the window is on. The surface lays itself out in whatever it is
-    // given, so the page asks for a comfortable stage and never more than
-    // the budget; 0 means the window has not said, which is the stage alone.
+    // given - the test is the one page whose content stretches rather than
+    // having a natural size - so its size is a choice, not a fit: a share of
+    // the budget, held to a 16:9 stage, so the window scales with the screen
+    // without becoming the screen and the stage keeps one shape on every
+    // monitor. 0 means the window has not said, which falls back to a fixed
+    // stage of the same aspect.
     property real maxContentWidth: 0
     property real maxContentHeight: 0
     // Whether this page is the one on screen. The host says so, because a
@@ -31,12 +36,14 @@ Item {
     // nowhere.
     property bool tabActive: false
 
-    readonly property real preferredWidth: 1100
-    readonly property real preferredHeight: 640
-    implicitWidth: root.maxContentWidth > 0
-        ? Math.min(root.preferredWidth, root.maxContentWidth) : root.preferredWidth
-    implicitHeight: root.maxContentHeight > 0
-        ? Math.min(root.preferredHeight, root.maxContentHeight) : root.preferredHeight
+    readonly property real budgetShare: 0.85
+    readonly property real stageAspect: 16 / 9
+    readonly property real fallbackHeight: 640
+    readonly property var stageBox: CheatsheetFit.aspectBox(
+        root.maxContentWidth, root.maxContentHeight, root.budgetShare, root.stageAspect)
+    implicitWidth: root.stageBox.width > 0 ? root.stageBox.width
+        : root.fallbackHeight * root.stageAspect
+    implicitHeight: root.stageBox.height > 0 ? root.stageBox.height : root.fallbackHeight
 
     onTabActiveChanged: {
         if (root.tabActive)

--- a/dots/.config/quickshell/imi/tests/test_cheatsheet_width_budget.py
+++ b/dots/.config/quickshell/imi/tests/test_cheatsheet_width_budget.py
@@ -1,16 +1,20 @@
 #!/usr/bin/env python3
-"""The cheatsheet's column count has to answer to the screen's width, not only
-its height.
+"""The cheatsheet's pages have to answer to the screen's width as well as its
+height, and the window has to answer to the page on screen.
 
 `columnCount` picks columns from a *row* budget - how many keybind rows fit
 vertically before the card grows past the screen. Columns trade height for
-width, so on a display with height to spare but not width it asked for four
-columns and the outer two ran off both edges, cut off rather than wrapped.
+width, so a full keybind set can exceed BOTH budgets at once on a laptop:
+four columns were ~40px too tall for a 1080p screen and five were ~280px too
+wide (measured live), so no column count fits and lowering a cap just picks
+which axis overflows. The keybinds page therefore fits the way the Elements
+page always has - keep the columns, shrink the whole thing uniformly through
+the shared fitScale, full size again on any screen with room.
 
-Width cannot be predicted the way rows can: a column is as wide as its widest
-section, which is not known until the text has been shaped. So the cap is
-measured and lowered. That makes the loop the thing worth pinning - it must only
-ever shrink, and it must stop.
+The window half: it is fixed-size (equal min/max hints float and centre it),
+and it used to be sized to the *tallest* page - so the typing test opened as
+tall as the keybind table and the whole window ran past the screen. It sizes
+to the current page now.
 """
 
 from pathlib import Path
@@ -34,37 +38,31 @@ class CheatsheetWidthBudgetTests(unittest.TestCase):
         self.assertIn("screen?.width", self.cheatsheet,
                       "the budget has to come from the screen the cheatsheet is on")
 
-    def test_the_column_cap_is_measured_against_that_budget(self):
+    def test_the_keybinds_page_scales_itself_into_both_budgets(self):
         self.assertIn("property real maxContentWidth", self.keybinds)
-        self.assertIn("property int columnCap", self.keybinds)
-        self.assertRegex(
-            self.keybinds,
-            r"columnCount\(root\.sections, root\.availableRows, root\.columnCap\)",
-            "the cap has to reach columnCount, or lowering it changes nothing")
+        self.assertIn("property real maxContentHeight", self.keybinds)
+        self.assertRegex(self.keybinds, r"CheatsheetFit\.fitScale\(",
+                         "the shrink has to be the shared arithmetic, or it drifts from the budget")
+        # The scale has to reach what is drawn AND what is reported: a scaled
+        # row whose page still reports the natural size sizes the window to
+        # the natural size, which is the overflow this exists to remove.
+        self.assertIn("scale: root.fit", self.keybinds)
+        self.assertRegex(self.keybinds, r"implicitWidth:\s*root\.contentWidth \* root\.fit")
+        self.assertRegex(self.keybinds, r"implicitHeight:\s*root\.contentHeight \* root\.fit")
 
-    def test_the_fit_loop_only_shrinks_and_terminates(self):
-        body = re.search(r"function fitToWidth\(\)\s*\{(.*?)\n    \}", self.keybinds, re.S)
-        self.assertIsNotNone(body, "fitToWidth must exist")
-        body = body.group(1)
-
-        # Only ever downward. An increment inside the loop, with implicitWidth
-        # feeding back into it, is how this oscillates forever instead of
-        # settling.
-        self.assertIn("columnCap -= 1", body)
-        self.assertNotIn("columnCap += 1", body)
-        # And a floor, or a card wider than any single column recurses to zero
-        # columns and lays out nothing at all.
-        self.assertIn("columnCap <= 1", body)
-
-    def test_a_changed_layout_starts_the_search_again(self):
-        # Shrink-only means the cap can never recover on its own: rotate to a
-        # wider screen, or change the keybind list, and it would stay at
-        # whatever the narrowest case needed.
-        for trigger in ("onMaxContentWidthChanged", "onSectionsChanged"):
-            self.assertIn(trigger, self.keybinds, f"{trigger} must reset the cap")
-        resets = re.findall(r"columnCap = root\.maxColumns", self.keybinds)
-        self.assertGreaterEqual(len(resets), 2,
-                                "both triggers must reset the cap to the maximum")
+    def test_the_window_is_sized_to_the_current_page_not_the_tallest(self):
+        # Math.max over every page is how the typing test opened at the keybind
+        # table's height - the fixed-size window must follow the tab.
+        swipe = re.search(r"SwipeView \{(.*?)\n                    \}", self.cheatsheet, re.S)
+        self.assertIsNotNone(swipe, "the SwipeView must exist")
+        body = swipe.group(1)
+        self.assertNotIn("Math.max.apply", body,
+                         "the window must not be sized to the tallest page")
+        for axis in ("implicitWidth", "implicitHeight"):
+            self.assertRegex(
+                body,
+                axis + r":\s*\(swipeView\.contentChildren\[swipeView\.currentIndex\]\?\." + axis + r"\)",
+                f"the SwipeView's {axis} must read the current page's")
 
 
 PERIODIC = ROOT / "modules/imi/cheatsheet/CheatsheetPeriodicTable.qml"

--- a/dots/.config/quickshell/imi/tests/tst_cheatsheet_fit.qml
+++ b/dots/.config/quickshell/imi/tests/tst_cheatsheet_fit.qml
@@ -75,4 +75,33 @@ TestCase {
     function test_the_scale_never_grows_a_page_that_already_fits() {
         compare(Fit.fitScale(100, 100, 5000, 5000), 1);
     }
+
+    function test_the_aspect_box_takes_a_share_and_holds_the_ratio() {
+        // A wide budget binds on the height: 85% of 800 is 680, and the width
+        // follows the 16:9 from there.
+        const wide = Fit.aspectBox(1830, 800, 0.85, 16 / 9);
+        fuzzyCompare(wide.height, 800 * 0.85, 0.001);
+        fuzzyCompare(wide.width, wide.height * 16 / 9, 0.001);
+        verify(wide.width <= 1830 * 0.85 + 0.001);
+
+        // A tall budget binds on the width instead.
+        const tall = Fit.aspectBox(1000, 2000, 0.85, 16 / 9);
+        fuzzyCompare(tall.width, 1000 * 0.85, 0.001);
+        fuzzyCompare(tall.height, tall.width * 9 / 16, 0.001);
+    }
+
+    function test_the_aspect_box_answers_zero_until_both_budgets_are_known() {
+        // The caller keeps its fallback stage while the window has not
+        // learned its screen; a NaN or a zero must not leak into geometry.
+        for (const box of [
+            Fit.aspectBox(0, 800, 0.85, 16 / 9),
+            Fit.aspectBox(1830, 0, 0.85, 16 / 9),
+            Fit.aspectBox(NaN, 800, 0.85, 16 / 9),
+            Fit.aspectBox(1830, 800, 0, 16 / 9),
+            Fit.aspectBox(1830, 800, 0.85, 0),
+        ]) {
+            compare(box.width, 0);
+            compare(box.height, 0);
+        }
+    }
 }


### PR DESCRIPTION
The cheatsheet window ran past the screen: its fixed-size `FloatingWindow` was sized to the **tallest** page (`Math.max` over every `SwipeView` page), and the keybind table is by far the tallest — so the typing test and the periodic table opened at the keybind table's height. Measured live on a 1920x1080 laptop: 1662x1122, placed at y=-31, under the bar and past the bottom edge, on every tab.

Two fixes, both verified against the live shell:

**The window follows the tab it is showing.** The `SwipeView` reads the current page's Loader out of `contentChildren` by `currentIndex` — not `currentItem`, whose implicit size is unsettled on the first frame and collapsed the window to 416x110 when tried. The comment beside the size hints already said the size "follows the tab"; the `Math.max` was the half that never did.

**The keybind table scales into the screen's budgets.** A full keybind set can exceed both budgets at once — four columns measured 1662x1122 (fits width, past the height budget) and five measured 2198x1006 (fits height, 280px off both screen edges) — so the old width-trim loop (`columnCap`/`fitToWidth`) could only pick which axis overflows. The page now fits the way the Elements page always has: `columnCount` still picks columns from the height budget, and the laid-out row shrinks uniformly through the shared `CheatsheetFit.fitScale` when it exceeds either budget. `fit` stays 1 whenever the content fits, so a roomy screen draws full size.

**And the typing test scales with the screen.** Its stage was a fixed 1100x640 on every monitor — small in the middle of a large screen, on the one page whose content stretches rather than having a natural size. `CheatsheetFit.aspectBox` gives it an 85% share of the page budget held to a 16:9 stage, bound on whichever axis the share runs out of first, so it grows on a larger screen without becoming it; the fixed stage stays as the fallback for a window that has not learned its screen yet.

Measured after, same laptop: Keybinds 1870x871, Elements 1402x788, Typing test 1325x833 (page 1284x722, exactly 16:9) — all inside the band the bar and the dock leave.

`test_cheatsheet_width_budget.py` pins the replacement from both sides (the shared fitScale reaching both what is drawn and what is reported, and the SwipeView sizing to the current page); both new checks were proven to fail on planted regressions. `tst_cheatsheet_fit.qml` drives `aspectBox`'s share, the ratio on both binding axes, and the zero answer that keeps an unknown budget on the fallback.

Docs: updated AGENT.md §Hyprland integration — the fixed-size-window note recorded the window as tall as its tallest page; it now records the per-tab sizing, the keybind scale and the typing test's 16:9 share (cheatsheetFit.js's header updated with it)
Changelog: updated
