### PR TITLE
feat(bar): a Bluetooth battery widget, one ring per device

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -6903,6 +6903,9 @@ while open - the `sidebarLeftTab` shape), not a signal, because the sidebar's co
 that exists only while the panel is shown and a signal fired before it is built reaches nothing.
 `Icons.getBluetoothDeviceMaterialSymbol` maps BlueZ's `input-gaming` to `stadia_controller` ahead of
 the generic fallback, so the same controller is named in the dialog, on the bar and in At-a-glance.
+Nothing on a test machine puts a ring on this widget, so `tests/run_bluetooth_battery_probe.sh`
+fakes the connected list in a COPY of the tree under a nested Hyprland and reads the rings, the
+hover and the click back over IPC; its header carries the numbers it measured.
 ("feat(bar): a Bluetooth battery widget, one ring per device")
 
 **An icon in a circle on the bar is an OUTLINED ring under every bar style but M3.** The

--- a/AGENT.md
+++ b/AGENT.md
@@ -610,7 +610,11 @@ modules/imi/                 The "imi" (Immaterial Impulse) panel family - one d
                               is the one static layer surface per screen that hosts every bar
                               popup's content on a single morphing card - it serves the vertical
                               bar too, which loads the same widget files
-                              (d29cd6e45 ("feat(bar): add the static overlay surface the popup card will live on"))
+                              (d29cd6e45 ("feat(bar): add the static overlay surface the popup card will live on")).
+                              BluetoothBattery.qml (+Popup) is the Bluetooth device battery widget:
+                              one ring per connected device with a known level, hover popup, click
+                              deep-links to the Bluetooth dialog - see "A Bluetooth device's battery
+                              has one lookup and three readers"
   sidebarLeft/, sidebarRight/ Slide-out panels (AI chat, translator, media, the Phone tab;
                               quick settings, notifications, volume mixer). sidebarLeft/phone/ is
                               the Phone tab - the paired phone's chip, six actions, two navigation
@@ -6879,6 +6883,27 @@ mid-fade and jump the layout. Measured in a nested Hyprland with a 15s test: the
 the score at 0.01 - a lifetime past the flag, which is the whole of the rule. The typing contract
 refuses a bare `visible:` on state in the surface and the toolbar.
 ("fix(typing): nothing in the test snaps in or out on state").
+
+**A Bluetooth device's battery has one lookup and three readers.** A device's level comes from
+BlueZ's `Battery1` interface (`BluetoothDevice.batteryAvailable` gating `battery`, 0..1) or, when
+BlueZ has nothing - HID controllers like the DualSense, bluetoothd without `Experimental=true` -
+from the UPower power_supply whose `nativePath` carries the device's MAC. `services/BluetoothStatus.qml`
+knew both but handed the answer out only as the quick toggle's ` • NN%` suffix, so At-a-glance grew
+its own filter on `batteryAvailable` and lost every controller. `BluetoothStatus.batteryLevelOf(device)`
+is now the one lookup (0..1, `-1` when neither source knows), `formatBatterySuffix` formats it,
+`batteryDevices` is the connected devices with a level and `lowestBatteryDevice` the one to worry
+about; the suffix, At-a-glance and the bar's `BluetoothBattery.qml` all read those and nothing else
+(`tests/test_bluetooth_battery_widget.py` forbids `UPower` and `batteryAvailable` in the readers).
+The widget draws a ring only for devices with a level - a device with no report has nothing to
+draw - but its popup lists every CONNECTED device, "No battery report" and all, because the popup
+answers "what is connected", not "what is charged". Its click deep-links to the Bluetooth dialog
+through `GlobalStates.sidebarRightDialog = "bluetooth"` before `sidebarRightOpen = true`: a
+property consumed and cleared by `SidebarRightContent` (on completion, on the open edge, on a write
+while open - the `sidebarLeftTab` shape), not a signal, because the sidebar's content is a `Loader`
+that exists only while the panel is shown and a signal fired before it is built reaches nothing.
+`Icons.getBluetoothDeviceMaterialSymbol` maps BlueZ's `input-gaming` to `stadia_controller` ahead of
+the generic fallback, so the same controller is named in the dialog, on the bar and in At-a-glance.
+("feat(bar): a Bluetooth battery widget, one ring per device")
 
 **An icon in a circle on the bar is an OUTLINED ring under every bar style but M3.** The
 maintainer's rule (2026-09-02), with the resource monitor's four rings as the reference: a bar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ own repo; the installer pins which revision it builds.
 
 ## [Unreleased]
 
+### Added
+- **A Bluetooth battery bar widget.** "Bluetooth battery" in Settings > Bar
+  draws one ring per connected Bluetooth device that reports a level - the
+  device's glyph in the resource monitor's ring, red at the battery low
+  threshold - and collapses when nothing reports. Hover lists every
+  connected device with its level; a click opens the Bluetooth dialog.
+  Controllers whose battery only UPower knows about count too, and they
+  get their own glyph in the device dialog now.
+
+### Fixed
+- **At-a-glance shows a controller's battery.** The desktop widget only
+  counted devices BlueZ reported a battery for; it reads the same lookup as
+  the quick toggle now, UPower fallback included.
+
 ## [1.0.0-rc-10] — 2026-09-03
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ own repo; the installer pins which revision it builds.
   get their own glyph in the device dialog now.
 
 ### Fixed
+- **The battery popup's Health card no longer alarms at full health.** The
+  card was written for usage, where 100% is the problem; a battery's health
+  (and a Bluetooth device's charge) is a level, where empty is.
 - **At-a-glance shows a controller's battery.** The desktop widget only
   counted devices BlueZ reported a battery for; it reads the same lookup as
   the quick toggle now, UPower fallback included.

--- a/docs/superpowers/plans/2026-09-03-bluetooth-battery-widget.md
+++ b/docs/superpowers/plans/2026-09-03-bluetooth-battery-widget.md
@@ -1,0 +1,240 @@
+# Bluetooth battery bar widget — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A bar widget drawing one level ring per connected Bluetooth device that reports a battery, with a hover popup and a click that opens the Bluetooth dialog.
+
+**Architecture:** One numeric lookup on the existing `BluetoothStatus` singleton (`batteryLevelOf`, `batteryDevices`, `lowestBatteryDevice`) feeds the quick-toggle suffix, At-a-glance and the new widget. The widget follows the resource monitor's ring vocabulary and the Docker widget's M3 branch; the popup follows `BatteryPopup`'s hero + cascade layout; the click deep-links through a new `GlobalStates.sidebarRightDialog` consumed by `SidebarRightContent`.
+
+**Tech Stack:** Quickshell QML (Quickshell.Bluetooth, Quickshell.Services.UPower), qmltestrunner tests, Python unittest contracts wired into `tests/run_tests.sh`.
+
+Spec: `docs/superpowers/specs/2026-09-03-bluetooth-battery-widget-design.md`.
+All paths below are under `dots/.config/quickshell/imi/` unless they start with `AGENT.md`, `CHANGELOG.md` or `docs/`.
+
+---
+
+### Task 1: The numeric battery API on BluetoothStatus (TDD)
+
+**Files:**
+- Modify: `services/BluetoothStatus.qml`
+- Modify: `tests/mocks/Quickshell/Bluetooth/BluetoothDevice.qml` (add `icon`)
+- Test: `tests/tst_bluetooth_status.qml`
+
+- [ ] **Step 1: Write the failing tests** — append to `tests/tst_bluetooth_status.qml` before the final `}`:
+
+```qml
+    function test_battery_level_comes_from_bluez_then_upower_then_nothing() {
+        compare(BluetoothStatus.batteryLevelOf(null), -1)
+        compare(BluetoothStatus.batteryLevelOf(undefined), -1)
+        compare(BluetoothStatus.batteryLevelOf(keyboard), -1)
+        compare(BluetoothStatus.batteryLevelOf({ batteryAvailable: true, battery: 0.85 }), 0.85)
+        compare(BluetoothStatus.batteryLevelOf({ batteryAvailable: false, battery: 0.5 }), -1)
+
+        UPower.devices.values = [
+            { isLaptopBattery: true, nativePath: "BAT0", percentage: 0.99 },
+            { isLaptopBattery: false, nativePath: "ps-controller-battery-14:3a:9a:7c:45:47", percentage: 0.45 }
+        ]
+        compare(BluetoothStatus.batteryLevelOf({ batteryAvailable: false, address: "14:3A:9A:7C:45:47" }), 0.45)
+        compare(BluetoothStatus.batteryLevelOf({ batteryAvailable: true, battery: 0.6, address: "14:3A:9A:7C:45:47" }), 0.6)
+        compare(BluetoothStatus.batteryLevelOf({ batteryAvailable: false, address: "AA:BB:CC:DD:EE:FF" }), -1)
+        // The suffix is the level, formatted - never a second lookup.
+        compare(BluetoothStatus.formatBatterySuffix({ batteryAvailable: false, address: "14:3A:9A:7C:45:47" }), " • 45%")
+        UPower.devices.values = []
+    }
+
+    function test_battery_devices_are_the_connected_ones_with_a_level_in_sort_order() {
+        UPower.devices.values = [
+            { isLaptopBattery: false, nativePath: "hid-14:3a:9a:7c:45:47-battery", percentage: 0.3 }
+        ]
+        Bluetooth.devices.values = [
+            { name: "Zeta Buds", connected: true, paired: true, batteryAvailable: true, battery: 0.9 },
+            { name: "Pad", connected: true, paired: true, batteryAvailable: false, address: "14:3A:9A:7C:45:47" },
+            { name: "Mute Mouse", connected: true, paired: true, batteryAvailable: false, address: "AA:BB:CC:DD:EE:FF" },
+            { name: "Away Keys", connected: false, paired: true, batteryAvailable: true, battery: 0.1 }
+        ]
+        compare(BluetoothStatus.batteryDevices.map(d => d.name), ["Pad", "Zeta Buds"])
+        compare(BluetoothStatus.lowestBatteryDevice.name, "Pad")
+
+        Bluetooth.devices.values = []
+        compare(BluetoothStatus.batteryDevices.length, 0)
+        verify(BluetoothStatus.lowestBatteryDevice === null)
+        UPower.devices.values = []
+    }
+```
+
+- [ ] **Step 2: Run to verify they fail** — `cd dots/.config/quickshell/imi && tests/run_tests.sh` is too slow for one case; run the QML runner directly:
+  `qmltestrunner -import tests/mocks -import tests/imports -input tests/tst_bluetooth_status.qml` (the runner path is resolved in `run_tests.sh:195`). Expected: FAIL, `batteryLevelOf is not a function`.
+
+- [ ] **Step 3: Implement** — in `services/BluetoothStatus.qml`, replace the `formatBatterySuffix` block (lines 19–37) with:
+
+```qml
+    // The one battery lookup every consumer shares - the quick toggle and
+    // the device dialog through formatBatterySuffix, At-a-glance, the bar's
+    // BluetoothBattery widget: 0..1 when known, -1 when neither source does.
+    // Primary source is Quickshell.Bluetooth's BluetoothDevice (BlueZ Battery1
+    // interface): `batteryAvailable` gates it, `battery` is a 0..1 fraction.
+    // Many devices never get Battery1 (HID controllers like the DualSense, or
+    // bluetoothd without Experimental=true), but the kernel exposes them as a
+    // power_supply that UPower picks up with the MAC in its nativePath - fall
+    // back to that, matched by address.
+    function batteryLevelOf(device) {
+        if (device?.batteryAvailable)
+            return device.battery;
+        const addr = device?.address?.toLowerCase() ?? "";
+        if (addr) {
+            const fallback = (UPower.devices?.values ?? []).find(d =>
+                d && !d.isLaptopBattery && (d.nativePath ?? "").toLowerCase().includes(addr));
+            if (fallback)
+                return fallback.percentage;
+        }
+        return -1;
+    }
+
+    // " • NN%" for a device whose battery level is known, "" otherwise.
+    function formatBatterySuffix(device) {
+        const level = batteryLevelOf(device);
+        return level < 0 ? "" : ` • ${Math.round(level * 100)}%`;
+    }
+```
+
+  and after `connectedDevices` add:
+
+```qml
+    // Connected devices with a known level, in the same order - what the bar
+    // widget draws a ring for. A binding: batteryLevelOf reads each device's
+    // batteryAvailable/battery and UPower.devices inside it, so a level that
+    // arrives after the connection re-evaluates the list.
+    readonly property list<var> batteryDevices: connectedDevices.filter(d => batteryLevelOf(d) >= 0)
+    readonly property var lowestBatteryDevice: batteryDevices.reduce((low, d) =>
+        low === null || batteryLevelOf(d) < batteryLevelOf(low) ? d : low, null)
+```
+
+  In the mock `BluetoothDevice.qml` add `property string icon: ""`.
+
+- [ ] **Step 4: Run the QML test file again** — expected: all BluetoothStatusTest cases PASS.
+- [ ] **Step 5: Commit** — `git commit --only -- services/BluetoothStatus.qml tests/tst_bluetooth_status.qml tests/mocks/Quickshell/Bluetooth/BluetoothDevice.qml -m "feat(bluetooth): one numeric battery lookup for every consumer"`
+
+### Task 2: Gamepad glyph and At-a-glance consolidation
+
+**Files:**
+- Modify: `modules/common/Icons.qml:20-32`
+- Modify: `modules/common/plugins/designsystem/widgets/AtAGlance.qml:58,72-81`
+- Test: `tests/test_bluetooth_battery_widget.py` (created in Task 5; the assertions for these two files are listed there)
+
+- [ ] **Step 1: Icons** — before `return "bluetooth";` insert:
+
+```qml
+        // BlueZ names a controller input-gaming; the fallback glyph hid it
+        // behind the generic mark on the bar and in the dialog.
+        if (systemIconName.includes("gaming") || systemIconName.includes("gamepad") || systemIconName.includes("joystick"))
+            return "stadia_controller";
+```
+
+- [ ] **Step 2: AtAGlance** — `property var btDevices: BluetoothStatus.batteryDevices` and:
+
+```qml
+    function updateBluetoothInfo() {
+        // One lookup for "has a battery" and "how much": BluetoothStatus's,
+        // so a controller only UPower knows about counts here too.
+        const devices = BluetoothStatus.batteryDevices;
+        const percent = d => Math.round(BluetoothStatus.batteryLevelOf(d) * 100) + "%";
+        let text = "";
+        if (devices.length === 1) {
+            text = devices[0].name + " · " + percent(devices[0]);
+        } else if (devices.length > 1) {
+            text = devices.length + " devices · " + devices.map(percent).join(", ");
+        }
+```
+
+- [ ] **Step 3: Commit** — `git commit --only -- modules/common/Icons.qml modules/common/plugins/designsystem/widgets/AtAGlance.qml -m "fix(bluetooth): a controller gets its glyph, and At-a-glance reads the shared battery lookup"`
+
+### Task 3: The right-sidebar dialog deep link
+
+**Files:**
+- Modify: `GlobalStates.qml` (after `sidebarRightOpen`)
+- Modify: `modules/imi/sidebarRight/SidebarRightContent.qml` (function + Connections + Component.onCompleted)
+
+- [ ] **Step 1: GlobalStates**
+
+```qml
+    // A dialog the right sidebar opens next time it shows ("bluetooth"),
+    // consumed and cleared by SidebarRightContent the way sidebarLeftTab is.
+    // A property, not a signal: the sidebar's content is a Loader that only
+    // exists while the panel is shown, so a signal fired from the bar before
+    // the panel has been built reaches nothing.
+    property string sidebarRightDialog: ""
+```
+
+- [ ] **Step 2: SidebarRightContent** — add
+
+```qml
+    function consumeDialogRequest() {
+        if (GlobalStates.sidebarRightDialog === "") return;
+        if (GlobalStates.sidebarRightDialog === "bluetooth")
+            root.showBluetoothDialog = true;
+        GlobalStates.sidebarRightDialog = "";
+    }
+```
+
+  call it from `Component.onCompleted` (the content is built on the open edge, after `onSidebarRightOpenChanged` has already fired), inside `onSidebarRightOpenChanged` when opening, and from a new `function onSidebarRightDialogChanged() { if (GlobalStates.sidebarRightOpen) root.consumeDialogRequest(); }` in the same `Connections`.
+
+- [ ] **Step 3: Commit** — `git commit --only -- GlobalStates.qml modules/imi/sidebarRight/SidebarRightContent.qml -m "feat(sidebar): a deep link that opens a right-sidebar dialog"`
+
+### Task 4: The widget, its popup and the catalogue row
+
+**Files:**
+- Create: `modules/imi/bar/BluetoothBattery.qml`
+- Create: `modules/imi/bar/BluetoothBatteryPopup.qml`
+- Modify: `modules/common/plugins/BarWidgets.qml:46` (row after `batteryIndicator`)
+
+- [ ] **Step 1: Catalogue row**
+
+```qml
+        { id: "bluetoothBattery",  name: Translation.tr("Bluetooth battery"),    icon: "bluetooth_connected" },
+```
+
+- [ ] **Step 2: Widget** — `BluetoothBattery.qml` as in the spec: `MouseArea` root, `vertical`, `isMaterial`, `devices: BluetoothStatus.batteryDevices`, collapse to 0 when empty, `RowLayout`/`ColumnLayout` loaders of a `Repeater` whose delegate is a `Loader` picking `root.isMaterial ? filledRing : outlineRing` (one per orientation, so the Docker spelling appears twice) and handing the device over in `onLoaded`; rings sized like `Resource.qml`; error colour at or below `Config.options.battery.low / 100`; `cursorShape: Qt.PointingHandCursor`; `onClicked` sets `GlobalStates.sidebarRightDialog = "bluetooth"` then `GlobalStates.sidebarRightOpen = true`; `BluetoothBatteryPopup { hoverTarget: root }`. Full source is the file itself (written in this task).
+
+- [ ] **Step 3: Popup** — `BluetoothBatteryPopup.qml`: `StyledPopup`, `ColumnLayout` with hero `bluetoothHeaderRow` (ClamShell glyph of the lowest device, its name, `n device(s)` subtitle, its percentage) and cascade `deviceCards` (`GridLayout columns: 2`, `property real appear: 1`, opacity/scale/translate through `bar_popup_unroll.js`, a `Repeater` of `ResourceCard` over `BluetoothStatus.connectedDevices`, sublabel `NN%` or `Translation.tr("No battery report")`).
+
+- [ ] **Step 4: Lints** — `python3 tests/lint_material_icons.py`, `python3 tests/lint_spacing.py`, `python3 tests/lint_clickable_cursor.py`, `tests/lint_qml_imports.sh` all clean.
+- [ ] **Step 5: Deploy and look** — `./deploy-shell`, add `bluetoothBattery` to a bar layout, confirm rings, popup, click.
+- [ ] **Step 6: Commit** — `git commit --only -- modules/imi/bar/BluetoothBattery.qml modules/imi/bar/BluetoothBatteryPopup.qml modules/common/plugins/BarWidgets.qml -m "feat(bar): a Bluetooth battery widget, one ring per device"`
+
+### Task 5: Contracts and ratchets
+
+**Files:**
+- Create: `tests/test_bluetooth_battery_widget.py`
+- Modify: `tests/test_bar_icon_ring_contract.py:53` (add the widget to the exact list)
+- Modify: `tests/test_bar_popup_section_entrance.py` (SECTION_WAVES entry)
+- Modify: `tests/run_tests.sh` (register the new test)
+
+- [ ] **Step 1: New contract test** pins: the widget declares `property bool vertical`, reads `BluetoothStatus.batteryDevices` and `BluetoothStatus.batteryLevelOf`, never imports `Quickshell.Services.UPower` nor reads `batteryAvailable`; `sourceComponent: root.isMaterial ? filledRing : outlineRing` appears twice; `cursorShape: Qt.PointingHandCursor`; the click writes `GlobalStates.sidebarRightDialog = "bluetooth"` and `SidebarRightContent` consumes it; the popup is mounted with `hoverTarget: root`; the catalogue row with its `Translation.tr` literal; `Icons` maps `gaming` to `stadia_controller`; `AtAGlance` reads `batteryDevices` and not `batteryAvailable`; `BluetoothStatus.formatBatterySuffix` calls `batteryLevelOf`.
+- [ ] **Step 2: Prove it fails** — run it against a clean `git archive HEAD~N` copy without the widget: expected FAIL.
+- [ ] **Step 3: Ratchets** — ring contract list gains `"modules/imi/bar/BluetoothBattery.qml"` (sorted position: after `BatteryIndicator` would be, i.e. first); SECTION_WAVES gains `f"{BAR}/BluetoothBatteryPopup.qml": {"hero_band": ["bluetoothHeaderRow"], "cascades": ["deviceCards"]}`.
+- [ ] **Step 4: Register** in `run_tests.sh` next to the applycolor block:
+
+```bash
+# The Bluetooth battery widget: one numeric lookup on BluetoothStatus feeds
+# the bar rings, At-a-glance and the dialog suffix; the widget follows the
+# ring rule and deep-links to the dialog.
+echo "Running Bluetooth battery widget contract tests..."
+if ! python3 "$SCRIPT_DIR/test_bluetooth_battery_widget.py"; then
+    echo "Bluetooth battery widget contract tests failed."
+    exit 1
+fi
+```
+
+- [ ] **Step 5: Commit** — `git commit --only -- tests/test_bluetooth_battery_widget.py tests/test_bar_icon_ring_contract.py tests/test_bar_popup_section_entrance.py tests/run_tests.sh -m "test(bar): pin the Bluetooth battery widget's contracts"`
+
+### Task 6: Docs, changelog, suite
+
+**Files:**
+- Modify: `AGENT.md` (bar/ directory-map row; one entry near the icon-ring/PopupAnchorIndicator entries)
+- Modify: `CHANGELOG.md` (`[Unreleased]` → `### Added`)
+
+- [ ] **Step 1: AGENT.md** — directory map: name `BluetoothBattery.qml` under `bar/`. Entry: "**A Bluetooth device's battery has one lookup and three readers.**" — `batteryLevelOf` (Battery1 then UPower by MAC, -1 unknown), `batteryDevices`; the readers; the widget draws rings only for levelled devices but lists every connected device in its popup; the click deep-links through `GlobalStates.sidebarRightDialog` (property, not signal — the content Loader). Cite the Task 4 commit subject.
+- [ ] **Step 2: CHANGELOG** — `### Added` entry under `[Unreleased]`.
+- [ ] **Step 3: Commit** — `git commit --only -- AGENT.md CHANGELOG.md -m "docs: the Bluetooth battery widget and its one battery lookup"`
+- [ ] **Step 4: Suite** — `setsid -f bash -c 'cd dots/.config/quickshell/imi && ./tests/run_tests.sh > LOG 2>&1'`; expected `All tests passed successfully!`.
+- [ ] **Step 5: Deploy, push branch, open PR** with `Docs: updated AGENT.md §...` and `Changelog: updated` receipts.

--- a/docs/superpowers/specs/2026-09-03-bluetooth-battery-widget-design.md
+++ b/docs/superpowers/specs/2026-09-03-bluetooth-battery-widget-design.md
@@ -1,0 +1,161 @@
+# Bluetooth battery bar widget — design
+
+Approved 2026-09-03 (three questions answered: one ring per device; hover popup
+plus click opens the Bluetooth dialog; numeric API on BluetoothStatus with the
+drifted copy consolidated).
+
+## Goal
+
+A bar widget that shows the battery of every connected Bluetooth device that
+reports one — headphones, mouse, keyboard, controller — as a circled device
+glyph with a level ring, in the resource monitor's vocabulary, with a hover
+popup listing the devices and a click that opens the existing Bluetooth
+device dialog.
+
+## Why now
+
+The battery number is already computed for the quick toggle and the device
+dialog (`BluetoothStatus.formatBatterySuffix`), but only as a string, and the
+At-a-glance desktop widget re-derived "which devices have a battery" with
+`batteryAvailable` alone — so it never sees a controller whose level only
+UPower knows. A bar widget is the third consumer; adding it without one
+numeric source of truth would be the fourth copy.
+
+## Data: `services/BluetoothStatus.qml`
+
+Additions, all pure over what the singleton already reads:
+
+- `function batteryLevelOf(device) -> real`: `0..1`, or `-1` when neither
+  source knows. BlueZ `Battery1` first (`device.batteryAvailable` gates
+  `device.battery`), then the UPower device whose `nativePath` contains the
+  device's MAC (lower-cased, `!isLaptopBattery`), reading `percentage`.
+  `null`/`undefined` device → `-1`.
+- `readonly property list<var> batteryDevices`: `connectedDevices` filtered to
+  `batteryLevelOf(d) >= 0`, in the existing sort order. A binding, so a
+  `battery` change on a device or a UPower device appearing re-evaluates it.
+- `readonly property var lowestBatteryDevice`: the `batteryDevices` entry
+  with the smallest level, `null` when empty.
+- `formatBatterySuffix(device)` becomes ``level < 0 ? "" : ` • ${Math.round(level * 100)}%` ``
+  over `batteryLevelOf` — same output as today (the existing tests pin it).
+
+`AtAGlance.qml`'s `updateBluetoothInfo()` reads `BluetoothStatus.batteryDevices`
+and `batteryLevelOf` instead of filtering on `batteryAvailable` and reading
+`battery` directly. Its `btDevices` trigger property follows `batteryDevices`.
+
+`Icons.getBluetoothDeviceMaterialSymbol` gains a gamepad branch before the
+fallback: an icon name containing `gaming` or `gamepad` or `joystick` →
+`stadia_controller`. The dialog row, the widget and the popup all use the
+mapper, so all three learn it.
+
+## Bar widget: `modules/imi/bar/BluetoothBattery.qml`
+
+Catalogue row in `BarWidgets.qml`:
+`{ id: "bluetoothBattery", name: Translation.tr("Bluetooth battery"), icon: "bluetooth_connected" }`.
+The resolver turns the id into `BluetoothBattery.qml` by capitalisation, so
+the file name is fixed by the id.
+
+Shape, copied from the resource monitor:
+
+- Root is a `MouseArea` (`cursorShape: Qt.PointingHandCursor`, a click
+  handler, `hoverEnabled: !Config.options.bar.tooltips.clickToShow`), with the
+  duck-typed `property bool vertical: false` both bars write, and
+  `readonly property bool isMaterial: Config.options.bar.cornerStyle === 3`.
+- One `Repeater` over `BluetoothStatus.batteryDevices` (a `ScriptModel`), in
+  a `RowLayout` when horizontal and a `ColumnLayout` when vertical, each
+  delegate a ring around the device's glyph
+  (`Icons.getBluetoothDeviceMaterialSymbol(device.icon)`), `value` the level.
+- The ring is `ClippedOutlineCircularProgress` under every style, and
+  `ClippedFilledCircularProgress` only under M3 — chosen by
+  `root.isMaterial`, the Docker widget's spelling, once per orientation.
+  Ring geometry matches `Resource.qml`: `implicitSize: 20`,
+  `lineWidth: Appearance.rounding.unsharpen`, glyph at
+  `Appearance.font.pixelSize.normal`, `enableAnimation: false`.
+- Colour: `colOnSecondaryContainer` normally (M3: `m3onSecondaryContainer`
+  for the glyph); the ring and glyph turn `Appearance.colors.colError` when
+  the level is at or below `Config.options.battery.low / 100`, the laptop
+  battery's own threshold. No new Config option and no settings row.
+- Size contract: horizontal `implicitWidth` is the row's implicit width plus
+  `Appearance.spacing.space150` on each side when not M3 (the switcher
+  area's `horizontalExtraPadding`), `implicitHeight: Appearance.sizes.barHeight`;
+  vertical `implicitWidth: Appearance.sizes.verticalBarWidth`, height the
+  column's. With no battery devices both implicit sizes are `0` and the
+  widget is `visible: false`, so the group around it collapses.
+- Click: `GlobalStates.sidebarRightDialog = "bluetooth"` then
+  `GlobalStates.sidebarRightOpen = true`. `GlobalStates` gains
+  `property string sidebarRightDialog: ""`, a deep link consumed and cleared
+  by `SidebarRightContent` the way `sidebarLeftTab` is (on its own
+  completion and on change): `"bluetooth"` sets `showBluetoothDialog`.
+  The right sidebar's content is a `Loader` active only while the panel is
+  shown, so a property that waits to be consumed is the shape that survives
+  the sidebar not existing yet; a signal would be lost.
+- M3 pill: the id takes the default tonal role (`colPrimaryContainer`) and
+  is not blacklisted.
+
+## Popup: `modules/imi/bar/BluetoothBatteryPopup.qml`
+
+A `StyledPopup { hoverTarget: root }` mounted by the widget, in
+`BatteryPopup.qml`'s layout:
+
+- Hero (`id: bluetoothHeaderRow`, never declares `appear`): a
+  `MaterialShapeWrappedMaterialSymbol` (ClamShell) with the lowest device's
+  glyph, the lowest device's name in the title slot, the subtitle
+  `Translation.tr("%1 devices").arg(n)` (or `Translation.tr("1 device")`),
+  and the lowest device's percentage large in `colPrimary`.
+- Cascade (`id: deviceCards`, `property real appear: 1`, the three entrance
+  channels through `bar_popup_unroll.js`): a `Flow`/`RowLayout` of one
+  `ResourceCard` per connected device — `label` the device name, `iconText`
+  the mapped glyph, `iconShape` Clover4Leaf, `value` the level clamped to
+  `0` when unknown, `sublabel` `NN%` or `Translation.tr("No battery report")`
+  in `colOnSurfaceVariant`, `cardWidth: 160`. Connected devices with no
+  battery are listed here (so a controller BlueZ does not report still
+  appears) but do not draw a ring on the bar.
+
+The popup is registered in `test_bar_popup_section_entrance.py`'s
+`SECTION_WAVES` with hero `bluetoothHeaderRow` and cascade `deviceCards`.
+
+## Failure modes
+
+- Adapter off or no adapter: `batteryDevices` is empty, widget collapsed,
+  nothing else drawn. The popup cannot be reached with nothing to hover.
+- A UPower fallback device vanishing mid-session: its level goes to `-1`, the
+  ring leaves the bar, the popup row shows "No battery report".
+- A device whose `icon` is empty maps to `bluetooth`.
+- Mock `BluetoothDevice` gains `property string icon: ""` so tests can name
+  a device type.
+
+## Tests
+
+- `tests/tst_bluetooth_status.qml`: `batteryLevelOf` from Battery1, from the
+  UPower fallback, `-1` for neither and for `null`; Battery1 wins over the
+  fallback; `batteryDevices` keeps only levelled connected devices in sort
+  order; `lowestBatteryDevice`; `formatBatterySuffix` parity with
+  `batteryLevelOf` (existing cases stay).
+- `tests/test_bluetooth_battery_widget.py` (new, wired into `run_tests.sh`):
+  the widget and AtAGlance read `BluetoothStatus.batteryDevices` /
+  `batteryLevelOf` and neither imports `Quickshell.Services.UPower` or reads
+  `batteryAvailable`; the widget declares `property bool vertical`; the
+  catalogue row exists with the literal `Translation.tr`; the widget mounts
+  its popup with `hoverTarget: root`; the click deep-links through
+  `GlobalStates.sidebarRightDialog` and `SidebarRightContent` consumes it;
+  `Icons` has the gamepad branch.
+- Ratchets updated: `test_bar_icon_ring_contract.py`'s exact user list of
+  `ClippedFilledCircularProgress` gains `modules/imi/bar/BluetoothBattery.qml`
+  (and the file follows the Docker spelling, asserted in the new test);
+  `test_bar_popup_section_entrance.py` gains the popup entry. Catalogue
+  count floors (`>= 21`) still hold.
+- Existing lints cover the rest: material icon names, spacing tokens,
+  pointer cursor, dumb widgets, qmldir/registration, suite registration.
+
+## Docs
+
+- `AGENT.md`: directory-map line under `bar/` naming the widget, and one
+  entry: the battery level has one source (`batteryLevelOf`) with three
+  consumers (quick toggle + dialog suffix, At-a-glance, bar widget), the
+  deep link `GlobalStates.sidebarRightDialog`, and why the widget lists
+  battery-less devices in the popup but not on the bar.
+- `CHANGELOG.md` `[Unreleased]` → `### Added`.
+
+## Out of scope
+
+Per-device widgets, per-device thresholds, a low-battery notification,
+connection-event popups, a settings section of its own.

--- a/dots/.config/quickshell/imi/GlobalStates.qml
+++ b/dots/.config/quickshell/imi/GlobalStates.qml
@@ -30,6 +30,12 @@ Singleton {
     // SidebarLeftContent so the bar button's glyph can follow the page.
     property string sidebarLeftTabIcon: ""
     property bool sidebarRightOpen: false
+    // A dialog the right sidebar opens next time it shows ("bluetooth"),
+    // consumed and cleared by SidebarRightContent the way sidebarLeftTab is.
+    // A property, not a signal: the sidebar's content is a Loader that only
+    // exists while the panel is shown, so a signal fired from the bar before
+    // the panel has been built reaches nothing.
+    property string sidebarRightDialog: ""
     property bool mediaControlsOpen: false
     property bool sysTrayOverflowOpen: false
     // The idle path: hypridle's listener blanks every screen, and the ladder

--- a/dots/.config/quickshell/imi/modules/common/Icons.qml
+++ b/dots/.config/quickshell/imi/modules/common/Icons.qml
@@ -28,6 +28,10 @@ Singleton {
             return "mouse";
         if (systemIconName.includes("keyboard"))
             return "keyboard";
+        // BlueZ names a controller input-gaming; the generic fallback hid
+        // it behind the plain Bluetooth mark in the dialog and on the bar.
+        if (systemIconName.includes("gaming") || systemIconName.includes("gamepad") || systemIconName.includes("joystick"))
+            return "stadia_controller";
         return "bluetooth";
     }
 

--- a/dots/.config/quickshell/imi/modules/common/plugins/BarWidgets.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/BarWidgets.qml
@@ -44,6 +44,7 @@ Singleton {
         { id: "utilButtons",       name: Translation.tr("Util Buttons"),         icon: "toggle_on" },
         { id: "sysTray",           name: Translation.tr("Tray"),                 icon: "inbox" },
         { id: "batteryIndicator",  name: Translation.tr("Battery"),              icon: "battery_android_frame_full" },
+        { id: "bluetoothBattery",  name: Translation.tr("Bluetooth battery"),    icon: "bluetooth_connected" },
         { id: "activeWindow",      name: Translation.tr("Active Window"),        icon: "subtitles" },
         { id: "powerButton",       name: Translation.tr("Power Button"),         icon: "power_settings_new" },
         { id: "updatesCount",      name: Translation.tr("Updates"),              icon: "deployed_code_update" },

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/AtAGlance.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/AtAGlance.qml
@@ -55,7 +55,7 @@ Item {
     property real _scheduleContentOpacity: 1
 
     // ── Bluetooth Integration ──
-    property var btDevices: BluetoothStatus.connectedDevices
+    property var btDevices: BluetoothStatus.batteryDevices
     property string _displayedBluetoothText: ""
     property string _pendingBluetoothText: ""
     property real _bluetoothContentOpacity: 1
@@ -69,15 +69,15 @@ Item {
     Timer { id: bluetoothFadeTimer; interval: 200; onTriggered: { _displayedBluetoothText = _pendingBluetoothText; _bluetoothContentOpacity = 1; } }
 
     function updateBluetoothInfo() {
-        const devices = BluetoothStatus.connectedDevices.filter(d => d.batteryAvailable);
+        // One lookup for "has a battery" and "how much" - BluetoothStatus's,
+        // so a controller only UPower knows about counts here too.
+        const devices = BluetoothStatus.batteryDevices;
+        const percent = d => Math.round(BluetoothStatus.batteryLevelOf(d) * 100) + "%";
         let text = "";
         if (devices.length === 1) {
-            text = devices[0].name + " \u00b7 " + Math.round(devices[0].battery * 100) + "%";
+            text = devices[0].name + " \u00b7 " + percent(devices[0]);
         } else if (devices.length > 1) {
-            let parts = [];
-            for (let i = 0; i < devices.length; i++)
-                parts.push(Math.round(devices[i].battery * 100) + "%");
-            text = devices.length + " devices \u00b7 " + parts.join(", ");
+            text = devices.length + " devices \u00b7 " + devices.map(percent).join(", ");
         }
 
         const wasVisible = _displayedBluetoothText !== "";

--- a/dots/.config/quickshell/imi/modules/common/widgets/ResourceCard.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/ResourceCard.qml
@@ -13,6 +13,18 @@ Rectangle {
     required property string sublabel
     property color sublabelColor: Appearance.colors.colOnSurfaceVariant
     property int cardWidth: 150 
+    // Which end of the bar is the trouble end. A usage card runs hot at the
+    // top (a full disk is the problem); a LEVEL card - a battery, a health -
+    // runs out at the bottom, and painting its full state in the error
+    // colour alarms at exactly the state that is fine. `strain` is the
+    // distance from the good end either way; the ramp and the warning
+    // border read it, never `value`.
+    property bool lowIsWarning: false
+    // Where the warning starts, on strain - 0.9 is "over 90% used"; a
+    // battery card passes 1 minus its low threshold.
+    property real warnAt: 0.9
+    readonly property real strain: root.lowIsWarning ? 1 - root.value : root.value
+    readonly property bool warning: root.strain >= root.warnAt
 
     width: cardWidth
     height: 96 
@@ -21,8 +33,9 @@ Rectangle {
     color: Appearance.colors.colSurfaceContainerLow
 
     function usageColor(v) {
-        if (v > 0.9) return Appearance.colors.colError
-        if (v > 0.6) return Appearance.colors.colTertiary || Appearance.m3colors.m3tertiary
+        const s = root.lowIsWarning ? 1 - v : v
+        if (s >= root.warnAt) return Appearance.colors.colError
+        if (s > 0.6) return Appearance.colors.colTertiary || Appearance.m3colors.m3tertiary
         return Appearance.colors.colPrimary
     }
 
@@ -90,6 +103,6 @@ Rectangle {
         }
     }
 
-    border.width: root.value > 0.9 ? Appearance.borderWidth.emphasis : 0
-    border.color: root.value > 0.9 ? Appearance.colors.colError : "transparent"
+    border.width: root.warning ? Appearance.borderWidth.emphasis : 0
+    border.color: root.warning ? Appearance.colors.colError : "transparent"
 }

--- a/dots/.config/quickshell/imi/modules/imi/bar/BatteryPopup.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/BatteryPopup.qml
@@ -93,6 +93,9 @@ StyledPopup {
                 iconText: "heart_check"
                 iconShape: MaterialShape.Shape.Clover4Leaf
                 value: Battery.health / 100
+                // Health is a level: a full one is the good news, not a
+                // 90%-used alarm.
+                lowIsWarning: true
                 sublabel: Battery.chargeCycles > 0
                     ? `${Battery.chargeCycles} ${Translation.tr("cycles")}`
                     : Translation.tr("N/A")

--- a/dots/.config/quickshell/imi/modules/imi/bar/BluetoothBattery.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/BluetoothBattery.qml
@@ -1,0 +1,149 @@
+pragma ComponentBehavior: Bound
+
+import qs
+import qs.modules.common
+import qs.modules.common.widgets
+import qs.services
+import Quickshell
+import QtQuick
+import QtQuick.Layouts
+
+// The battery of every connected Bluetooth device that reports one, as a
+// circled device glyph with a level ring - the resource monitor's
+// vocabulary: an outlined ring under every bar style but M3, where the
+// tonal pill is the container and the ring is filled. The level itself is
+// BluetoothStatus.batteryLevelOf, the one lookup the quick toggle, the
+// device dialog and At-a-glance share, so a controller only UPower knows
+// about is on the bar too. Hover lists the devices; a click deep-links to
+// the Bluetooth dialog in the right sidebar.
+MouseArea {
+    id: root
+    property bool vertical: false
+    readonly property bool isMaterial: Config.options.bar.cornerStyle === 3
+    readonly property var devices: BluetoothStatus.batteryDevices
+    readonly property bool populated: root.devices.length > 0
+    // The laptop battery's own low threshold: one number for "low" on the bar.
+    readonly property real lowLevel: Config.options.battery.low / 100
+
+    // Nothing to draw collapses the whole slot: a zero-size widget lets the
+    // group around it close, where a hidden one would leave the padding.
+    visible: root.populated
+    implicitWidth: !root.populated ? 0 : root.vertical
+        ? Appearance.sizes.verticalBarWidth
+        : (rowLoader.item?.implicitWidth ?? 0) + (root.isMaterial ? 0 : Appearance.spacing.space150 * 2)
+    implicitHeight: !root.populated ? 0 : root.vertical
+        ? (colLoader.item?.implicitHeight ?? 0)
+        : Appearance.sizes.barHeight
+
+    hoverEnabled: !Config.options.bar.tooltips.clickToShow
+    cursorShape: Qt.PointingHandCursor
+    onClicked: {
+        GlobalStates.sidebarRightDialog = "bluetooth";
+        GlobalStates.sidebarRightOpen = true;
+    }
+
+    function glyphFor(device) {
+        return Icons.getBluetoothDeviceMaterialSymbol(device?.icon || "");
+    }
+
+    Component {
+        id: outlineRing
+        ClippedOutlineCircularProgress {
+            id: ring
+            property var device: null
+            readonly property real level: BluetoothStatus.batteryLevelOf(ring.device)
+            readonly property bool low: ring.level <= root.lowLevel
+            implicitSize: 20
+            lineWidth: Appearance.rounding.unsharpen
+            value: Math.max(0, ring.level)
+            colPrimary: ring.low ? Appearance.colors.colError : Appearance.colors.colOnSecondaryContainer
+            enableAnimation: false
+            Item {
+                anchors.centerIn: parent
+                width: 20
+                height: 20
+                MaterialSymbol {
+                    anchors.centerIn: parent
+                    font.weight: Font.DemiBold
+                    fill: 1
+                    text: root.glyphFor(ring.device)
+                    iconSize: Appearance.font.pixelSize.normal
+                    color: ring.low ? Appearance.colors.colError : Appearance.colors.colOnSecondaryContainer
+                }
+            }
+        }
+    }
+
+    Component {
+        id: filledRing
+        ClippedFilledCircularProgress {
+            id: ring
+            property var device: null
+            readonly property real level: BluetoothStatus.batteryLevelOf(ring.device)
+            readonly property bool low: ring.level <= root.lowLevel
+            implicitSize: 20
+            lineWidth: Appearance.rounding.unsharpen
+            value: Math.max(0, ring.level)
+            colPrimary: ring.low ? Appearance.colors.colError : Appearance.colors.colOnSecondaryContainer
+            accountForLightBleeding: !ring.low
+            enableAnimation: false
+            Item {
+                anchors.centerIn: parent
+                width: 20
+                height: 20
+                MaterialSymbol {
+                    anchors.centerIn: parent
+                    font.weight: Font.DemiBold
+                    fill: 1
+                    text: root.glyphFor(ring.device)
+                    iconSize: Appearance.font.pixelSize.normal
+                    color: ring.low ? Appearance.colors.colError : Appearance.m3colors.m3onSecondaryContainer
+                }
+            }
+        }
+    }
+
+    // Horizontal: a row of rings.
+    Loader {
+        id: rowLoader
+        active: !root.vertical
+        visible: active
+        anchors.centerIn: parent
+        sourceComponent: RowLayout {
+            spacing: Appearance.spacing.space75
+            Repeater {
+                model: ScriptModel { values: root.devices }
+                delegate: Loader {
+                    required property var modelData
+                    Layout.alignment: Qt.AlignVCenter
+                    sourceComponent: root.isMaterial ? filledRing : outlineRing
+                    onLoaded: item.device = modelData
+                }
+            }
+        }
+    }
+
+    // Vertical: the same rings stacked.
+    Loader {
+        id: colLoader
+        active: root.vertical
+        visible: active
+        anchors.centerIn: parent
+        sourceComponent: ColumnLayout {
+            spacing: Appearance.spacing.space75
+            Repeater {
+                model: ScriptModel { values: root.devices }
+                delegate: Loader {
+                    required property var modelData
+                    Layout.alignment: Qt.AlignHCenter
+                    sourceComponent: root.isMaterial ? filledRing : outlineRing
+                    onLoaded: item.device = modelData
+                }
+            }
+        }
+    }
+
+    BluetoothBatteryPopup {
+        hoverTarget: root
+    }
+}

--- a/dots/.config/quickshell/imi/modules/imi/bar/BluetoothBatteryPopup.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/BluetoothBatteryPopup.qml
@@ -102,6 +102,11 @@ StyledPopup {
                     value: Math.max(0, level)
                     sublabel: level >= 0 ? root.percentOf(modelData) : Translation.tr("No battery report")
                     sublabelColor: Appearance.colors.colOnSurfaceVariant
+                    // A level, not a usage: empty is the alarm, and it sounds
+                    // at the same threshold as the ring on the bar. A device
+                    // with no report has no level to alarm about.
+                    lowIsWarning: level >= 0
+                    warnAt: 1 - Config.options.battery.low / 100
                     cardWidth: 160
                 }
             }

--- a/dots/.config/quickshell/imi/modules/imi/bar/BluetoothBatteryPopup.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/BluetoothBatteryPopup.qml
@@ -1,0 +1,110 @@
+pragma ComponentBehavior: Bound
+
+import qs.modules.common
+import qs.modules.common.widgets
+import qs.services
+import Quickshell
+import QtQuick
+import QtQuick.Layouts
+import "bar_popup_unroll.js" as BarPopupUnroll
+
+// The Bluetooth battery widget's popup: the device to worry about as the
+// hero, every connected device as a card below - including the ones with no
+// battery report, which the bar draws no ring for but which are still the
+// devices that are connected.
+StyledPopup {
+    id: root
+
+    readonly property var lowest: BluetoothStatus.lowestBatteryDevice
+    readonly property var devices: BluetoothStatus.connectedDevices
+
+    function glyphFor(device) {
+        return Icons.getBluetoothDeviceMaterialSymbol(device?.icon || "");
+    }
+
+    function percentOf(device) {
+        return `${Math.round(BluetoothStatus.batteryLevelOf(device) * 100)}%`;
+    }
+
+    ColumnLayout {
+        spacing: Appearance.spacing.space150
+
+        // The header row is this popup's HERO - the first drawn section,
+        // whose height the card opens at - so it never declares `appear`.
+        RowLayout {
+            id: bluetoothHeaderRow
+            Layout.fillWidth: true
+            Layout.leftMargin: Appearance.spacing.space50
+            spacing: Appearance.spacing.space100
+
+            MaterialShapeWrappedMaterialSymbol {
+                shape: MaterialShape.Shape.ClamShell
+                text: root.glyphFor(root.lowest)
+                iconSize: Appearance.font.pixelSize.large
+                implicitSize: 36
+                color: Appearance.colors.colPrimaryContainer
+                colSymbol: Appearance.colors.colPrimary
+            }
+
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: -Appearance.spacing.space50
+
+                StyledText {
+                    text: root.lowest?.name ?? Translation.tr("Bluetooth")
+                    font {
+                        weight: Font.Medium
+                        pixelSize: Appearance.font.pixelSize.normal
+                    }
+                    color: Appearance.colors.colOnSurfaceVariant
+                }
+
+                StyledText {
+                    font.pixelSize: Appearance.font.pixelSize.smaller
+                    color: Appearance.colors.colOnSurfaceVariant
+                    opacity: 0.6
+                    text: root.devices.length === 1
+                        ? Translation.tr("1 device connected")
+                        : Translation.tr("%1 devices connected").arg(root.devices.length)
+                }
+            }
+
+            Item { Layout.fillWidth: true }
+
+            StyledText {
+                Layout.rightMargin: Appearance.spacing.space100
+                font.pixelSize: Appearance.font.pixelSize.huge
+                font.weight: Font.Bold
+                color: Appearance.colors.colPrimary
+                text: root.lowest ? `${Math.round(BluetoothStatus.batteryLevelOf(root.lowest) * 100)}` : ""
+            }
+        }
+
+        GridLayout {
+            id: deviceCards
+            property real appear: 1
+            opacity: deviceCards.appear
+            scale: BarPopupUnroll.entranceScale(deviceCards.appear, root.entranceRise, deviceCards.width)
+            transform: Translate { y: BarPopupUnroll.entranceOffset(deviceCards.appear, root.entranceRise) }
+            Layout.fillWidth: true
+            columns: 2
+            rowSpacing: Appearance.spacing.space100
+            columnSpacing: Appearance.spacing.space100
+
+            Repeater {
+                model: ScriptModel { values: root.devices }
+                delegate: ResourceCard {
+                    required property var modelData
+                    readonly property real level: BluetoothStatus.batteryLevelOf(modelData)
+                    label: modelData.name
+                    iconText: root.glyphFor(modelData)
+                    iconShape: MaterialShape.Shape.Clover4Leaf
+                    value: Math.max(0, level)
+                    sublabel: level >= 0 ? root.percentOf(modelData) : Translation.tr("No battery report")
+                    sublabelColor: Appearance.colors.colOnSurfaceVariant
+                    cardWidth: 160
+                }
+            }
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/SidebarRightContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/SidebarRightContent.qml
@@ -81,6 +81,19 @@ Item {
                 if (GlobalStates.sidebarRightOpen)
                     root.runEntrance();
             });
+        // The content is built on the open edge, after onSidebarRightOpenChanged
+        // has already fired without it - so a deep link written before the
+        // panel existed is honoured here.
+        root.consumeDialogRequest();
+    }
+
+    // GlobalStates.sidebarRightDialog names a dialog to open ("bluetooth");
+    // consume it and clear it, the way SidebarLeftContent consumes its tab.
+    function consumeDialogRequest() {
+        if (GlobalStates.sidebarRightDialog === "") return;
+        if (GlobalStates.sidebarRightDialog === "bluetooth")
+            root.showBluetoothDialog = true;
+        GlobalStates.sidebarRightDialog = "";
     }
 
     function runEntrance() {
@@ -94,6 +107,7 @@ Item {
         function onSidebarRightOpenChanged() {
             if (GlobalStates.sidebarRightOpen) {
                 root.runEntrance();
+                root.consumeDialogRequest();
                 return;
             }
             if (!GlobalStates.sidebarRightOpen) {
@@ -103,6 +117,12 @@ Item {
                 root.showAudioOutputDialog = false;
                 root.showAudioInputDialog = false;
             }
+        }
+        // A request written while the panel is already open has no open
+        // edge behind it, so it is honoured on the write as well.
+        function onSidebarRightDialogChanged() {
+            if (GlobalStates.sidebarRightOpen)
+                root.consumeDialogRequest();
         }
     }
 

--- a/dots/.config/quickshell/imi/services/BluetoothStatus.qml
+++ b/dots/.config/quickshell/imi/services/BluetoothStatus.qml
@@ -16,24 +16,32 @@ Singleton {
     readonly property int activeDeviceCount: Bluetooth.defaultAdapter?.devices.values.filter(device => device.connected).length ?? 0
     readonly property bool connected: Bluetooth.devices.values.some(d => d.connected)
 
-    // " • NN%" for a device whose battery level is reported, "" otherwise.
+    // The one battery lookup every consumer shares - the quick toggle and
+    // the device dialog through formatBatterySuffix, At-a-glance, the bar's
+    // BluetoothBattery widget: 0..1 when known, -1 when neither source does.
     // Primary source is Quickshell.Bluetooth's BluetoothDevice (BlueZ Battery1
     // interface): `batteryAvailable` gates it, `battery` is a 0..1 fraction.
     // Many devices never get Battery1 (HID controllers like the DualSense, or
     // bluetoothd without Experimental=true), but the kernel exposes them as a
     // power_supply that UPower picks up with the MAC in its nativePath - fall
     // back to that, matched by address.
-    function formatBatterySuffix(device) {
+    function batteryLevelOf(device) {
         if (device?.batteryAvailable)
-            return ` • ${Math.round(device.battery * 100)}%`;
+            return device.battery;
         const addr = device?.address?.toLowerCase() ?? "";
         if (addr) {
             const fallback = (UPower.devices?.values ?? []).find(d =>
                 d && !d.isLaptopBattery && (d.nativePath ?? "").toLowerCase().includes(addr));
             if (fallback)
-                return ` • ${Math.round(fallback.percentage * 100)}%`;
+                return fallback.percentage;
         }
-        return "";
+        return -1;
+    }
+
+    // " • NN%" for a device whose battery level is known, "" otherwise.
+    function formatBatterySuffix(device) {
+        const level = batteryLevelOf(device);
+        return level < 0 ? "" : ` • ${Math.round(level * 100)}%`;
     }
 
     function sortFunction(a, b) {
@@ -48,6 +56,13 @@ Singleton {
         return a.name.localeCompare(b.name);
     }
     property list<var> connectedDevices: Bluetooth.devices.values.filter(d => d.connected).sort(sortFunction)
+    // Connected devices with a known level, in the same order - what the bar
+    // widget draws a ring for. A binding: batteryLevelOf reads each device's
+    // batteryAvailable/battery and UPower.devices inside it, so a level that
+    // arrives after the connection re-evaluates the list.
+    readonly property list<var> batteryDevices: connectedDevices.filter(d => batteryLevelOf(d) >= 0)
+    readonly property var lowestBatteryDevice: batteryDevices.reduce((low, d) =>
+        low === null || batteryLevelOf(d) < batteryLevelOf(low) ? d : low, null)
     property list<var> pairedButNotConnectedDevices: Bluetooth.devices.values.filter(d => d.paired && !d.connected).sort(sortFunction)
     property list<var> unpairedDevices: Bluetooth.devices.values.filter(d => !d.paired && !d.connected).sort(sortFunction)
     property list<var> friendlyDeviceList: [

--- a/dots/.config/quickshell/imi/tests/mocks/Quickshell/Bluetooth/BluetoothDevice.qml
+++ b/dots/.config/quickshell/imi/tests/mocks/Quickshell/Bluetooth/BluetoothDevice.qml
@@ -5,6 +5,7 @@ import QtQuick
 QtObject {
     property string name: ""
     property string address: ""
+    property string icon: ""
     property bool connected: false
     property bool paired: false
     property bool batteryAvailable: false

--- a/dots/.config/quickshell/imi/tests/run_bluetooth_battery_probe.sh
+++ b/dots/.config/quickshell/imi/tests/run_bluetooth_battery_probe.sh
@@ -16,7 +16,9 @@
 # the 12% mouse in the error colour, the controller at UPower's 100%; M3 swaps
 # them for FILLED rings; vertical draws a 56x72 column; hover opens the popup
 # with five children under deviceCards (the Repeater and four cards); the
-# click opens the dialog. No WARN names the widget's files.
+# click opens the dialog; the popup's cards read back with the 12% mouse
+# warning, the 100% controller and the no-report keyboard not. No WARN names
+# the widget's files.
 #
 # Same shape as run_bar_exclusive_zone_probe.sh: own D-Bus session, own XDG
 # dirs, SHORT runtime dir (a long one makes Hyprland's socket path too long
@@ -78,6 +80,16 @@ w = w.replace("import QtQuick.Layouts\n", "import QtQuick.Layouts\nimport Quicks
 p = (c/"modules/imi/bar/BluetoothBatteryPopup.qml").read_text()
 p = p.replace("    readonly property var lowest: BluetoothStatus.lowestBatteryDevice\n",
               "    readonly property var lowest: BluetoothStatus.lowestBatteryDevice\n    onPopupVisibleChanged: console.log(\"BTPROBE popup visible=\" + popupVisible + \" lowest=\" + (lowest ? lowest.name : \"none\") + \" cards=\" + deviceCards.children.length)\n", 1)
+p = p.replace("import QtQuick.Layouts\n", "import QtQuick.Layouts\nimport Quickshell.Io\n", 1)
+p = p.replace("    ColumnLayout {\n        spacing: Appearance.spacing.space150\n", "    ColumnLayout {\n        spacing: Appearance.spacing.space150\n" + '''
+    IpcHandler {
+        target: "btpopup"
+        function cards(): string {
+            return JSON.stringify(Array.from(deviceCards.children).filter(c => c && c.label !== undefined).map(c =>
+                `${c.label} value=${c.value.toFixed(2)} strain=${c.strain.toFixed(2)} warnAt=${c.warnAt.toFixed(2)} warning=${c.warning} border=${c.border.color} icon=${c.usageColor(c.value)}`));
+        }
+    }
+''', 1)
 (c/"modules/imi/bar/BluetoothBatteryPopup.qml").write_text(p)
 sb = (c/"modules/imi/sidebarRight/SidebarRightContent.qml").read_text()
 sb = sb.replace("    function consumeDialogRequest() {\n", "    onShowBluetoothDialogChanged: console.log(\"BTPROBE sidebar showBluetoothDialog=\" + showBluetoothDialog)\n    function consumeDialogRequest() {\n", 1)
@@ -139,6 +151,7 @@ hyprctl dispatch movecursor $((BARX+X)) $((BARY+Y)) >/dev/null; sleep 2.5
 grep "BTPROBE popup" "$TMP/shell.log" | tail -2
 hyprctl dispatch movecursor 640 600 >/dev/null; sleep 2
 grep "BTPROBE popup" "$TMP/shell.log" | tail -1
+echo "--- cards ---"; qs ipc -p "$COPY/shell.qml" call btpopup cards
 echo "--- M3 style ---"; qs ipc -p "$COPY/shell.qml" call btprobe style 3 >/dev/null; sleep 1.5; qs ipc -p "$COPY/shell.qml" call btprobe geom
 echo "--- click ---"; qs ipc -p "$COPY/shell.qml" call btprobe click; sleep 2.5
 grep "BTPROBE sidebar" "$TMP/shell.log" | tail -2

--- a/dots/.config/quickshell/imi/tests/run_bluetooth_battery_probe.sh
+++ b/dots/.config/quickshell/imi/tests/run_bluetooth_battery_probe.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+# Drives the Bluetooth battery bar widget in a nested Hyprland with the
+# connected-device list FAKED, because nothing else can put a ring on it: the
+# widget draws only for a Bluetooth-connected device with a battery level, and
+# a test machine has none. A COPY of this tree gets BluetoothStatus's
+# connectedDevices replaced by four plain objects - buds and a low mouse
+# through the Battery1 path, a controller through the UPower fallback (a
+# DualSense on USB shows up in UPower with its MAC, so on a machine that has
+# one the fallback is the REAL one), a keyboard with no report - plus a probe
+# IpcHandler patched into the widget. Then, on the nested compositor's own
+# signature: the widget's geometry and ring types under Float and M3, a hover
+# (movecursor onto the widget, the popup's popupVisible flips), and the click
+# (the sidebar's showBluetoothDialog flips).
+#
+# Measured when it landed (1280x720, Float): 96x50 with three OUTLINE rings,
+# the 12% mouse in the error colour, the controller at UPower's 100%; M3 swaps
+# them for FILLED rings; vertical draws a 56x72 column; hover opens the popup
+# with five children under deviceCards (the Repeater and four cards); the
+# click opens the dialog. No WARN names the widget's files.
+#
+# Same shape as run_bar_exclusive_zone_probe.sh: own D-Bus session, own XDG
+# dirs, SHORT runtime dir (a long one makes Hyprland's socket path too long
+# and "IPC will not work"), nested signature exported before any hyprctl.
+#
+# Usage: tests/run_bluetooth_battery_probe.sh [cornerStyle] [vertical]
+#        tests/run_bluetooth_battery_probe.sh 1 false
+set -u
+SRC="$(cd "$(dirname "$0")/.." && pwd)"
+for binary in Hyprland qs dbus-run-session python3 rsync; do
+    command -v "$binary" >/dev/null 2>&1 || { echo "SKIPPED: $binary not on PATH"; exit 0; }
+done
+if [ -z "${WAYLAND_DISPLAY:-}" ]; then
+    echo "SKIPPED: no WAYLAND_DISPLAY - the nested compositor needs a parent"
+    exit 0
+fi
+STYLE="${1:-1}"; VERT="${2:-false}"
+PARENT_SOCKET="$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY"
+TMP=$(mktemp -d /tmp/btp.XXXX)
+trap 'rm -rf "$TMP" 2>/dev/null' EXIT
+echo "TMP=$TMP"
+mkdir -p "$TMP/imi"; rsync -a --exclude tests "$SRC/" "$TMP/imi/"
+COPY="$TMP/imi"
+python3 - "$COPY" <<'PY'
+import sys, re
+from pathlib import Path
+c = Path(sys.argv[1])
+s = (c/"services/BluetoothStatus.qml").read_text()
+old = "    property list<var> connectedDevices: Bluetooth.devices.values.filter(d => d.connected).sort(sortFunction)\n"
+new = '''    property list<var> connectedDevices: [
+        { name: "Pixel Buds", icon: "audio-headset", address: "", batteryAvailable: true, battery: 0.72 },
+        { name: "MX Anywhere", icon: "input-mouse", address: "", batteryAvailable: true, battery: 0.12 },
+        { name: "DualSense Edge", icon: "input-gaming", address: "14:3A:9A:7C:45:47", batteryAvailable: false },
+        { name: "Keychron", icon: "input-keyboard", address: "AA:BB:CC:DD:EE:FF", batteryAvailable: false }
+    ]
+'''
+assert old in s; (c/"services/BluetoothStatus.qml").write_text(s.replace(old, new, 1))
+w = (c/"modules/imi/bar/BluetoothBattery.qml").read_text()
+probe = '''
+    IpcHandler {
+        target: "btprobe"
+        function geom(): string {
+            const p = root.mapToItem(null, 0, 0);
+            const loader = root.vertical ? colLoader : rowLoader;
+            const rings = loader.item ? Array.from(loader.item.children).filter(c => c && c.item).map(c =>
+                `${c.item.toString().split("(")[0]} level=${c.item.level.toFixed(2)} low=${c.item.low} col=${c.item.colPrimary} size=${c.item.width}x${c.item.height}`) : [];
+            return JSON.stringify({ x: p.x, y: p.y, w: root.width, h: root.height, implicitWidth: root.implicitWidth,
+                implicitHeight: root.implicitHeight, populated: root.populated, visible: root.visible,
+                devices: root.devices.map(d => d.name), rings: rings, style: Config.options.bar.cornerStyle });
+        }
+        function click(): string { root.clicked(null); return "clicked"; }
+        function style(n: int): string { Config.options.bar.cornerStyle = n; return "style " + n; }
+    }
+    Component.onCompleted: console.log("BTPROBE widget completed populated=" + root.populated)
+'''
+w = w.rstrip()[:-1] + probe + "}\n"
+w = w.replace("import QtQuick.Layouts\n", "import QtQuick.Layouts\nimport Quickshell.Io\n", 1)
+(c/"modules/imi/bar/BluetoothBattery.qml").write_text(w)
+p = (c/"modules/imi/bar/BluetoothBatteryPopup.qml").read_text()
+p = p.replace("    readonly property var lowest: BluetoothStatus.lowestBatteryDevice\n",
+              "    readonly property var lowest: BluetoothStatus.lowestBatteryDevice\n    onPopupVisibleChanged: console.log(\"BTPROBE popup visible=\" + popupVisible + \" lowest=\" + (lowest ? lowest.name : \"none\") + \" cards=\" + deviceCards.children.length)\n", 1)
+(c/"modules/imi/bar/BluetoothBatteryPopup.qml").write_text(p)
+sb = (c/"modules/imi/sidebarRight/SidebarRightContent.qml").read_text()
+sb = sb.replace("    function consumeDialogRequest() {\n", "    onShowBluetoothDialogChanged: console.log(\"BTPROBE sidebar showBluetoothDialog=\" + showBluetoothDialog)\n    function consumeDialogRequest() {\n", 1)
+(c/"modules/imi/sidebarRight/SidebarRightContent.qml").write_text(sb)
+print("patched")
+PY
+export XDG_CONFIG_HOME="$TMP/config" XDG_CACHE_HOME="$TMP/cache" XDG_STATE_HOME="$TMP/state" XDG_DATA_HOME="$TMP/data"
+mkdir -p "$XDG_CONFIG_HOME/immaterial-impulse" "$XDG_CACHE_HOME" "$XDG_STATE_HOME" "$XDG_DATA_HOME" "$TMP/run"
+cat > "$XDG_CONFIG_HOME/immaterial-impulse/config.json" <<JSON
+{"bar":{"cornerStyle":$STYLE,"vertical":$VERT,"layouts":{"leftLayout":["bluetoothBattery","activeWindow"],"middleLayout":["workspaces","clockWidget"],"rightLayout":["systemIcons"]}},"policies":{"ai":0,"weeb":0}}
+JSON
+cat > "$TMP/hypr.lua" <<'LUA'
+hl.monitor({ output = "", mode = "1280x720@60", position = "auto", scale = 1 })
+hl.config({ misc = { disable_hyprland_logo = true, disable_splash_rendering = true, force_default_wallpaper = 0, disable_autoreload = true }, animations = { enabled = false } })
+LUA
+export XDG_RUNTIME_DIR="$TMP/run"; export WAYLAND_DISPLAY="$PARENT_SOCKET"
+dbus-run-session -- bash -s "$TMP" "$COPY" <<'NESTED'
+set -u
+TMP="$1"; COPY="$2"
+Hyprland -c "$TMP/hypr.lua" > "$TMP/hypr.log" 2>&1 &
+HPID=$!
+SIG=""
+for _ in $(seq 1 60); do sleep 0.5; SIG=$(ls "$XDG_RUNTIME_DIR/hypr" 2>/dev/null | head -1); [ -n "$SIG" ] && [ -S "$XDG_RUNTIME_DIR/hypr/$SIG/.socket.sock" ] && break; SIG=""; done
+[ -z "$SIG" ] && { echo "FAILED: nested compositor"; tail -5 "$TMP/hypr.log"; kill $HPID; exit 1; }
+export HYPRLAND_INSTANCE_SIGNATURE="$SIG"
+export WAYLAND_DISPLAY=$(ls "$XDG_RUNTIME_DIR" | grep -E '^wayland-[0-9]+$' | head -1)
+echo "nested: sig=$SIG display=$WAYLAND_DISPLAY"
+cd "$COPY"
+qs -p "$COPY/shell.qml" > "$TMP/shell.log" 2>&1 &
+QPID=$!
+for _ in $(seq 1 40); do sleep 0.5; grep -q "BTPROBE widget completed" "$TMP/shell.log" && break; done
+sleep 3
+echo "--- bar layer ---"; hyprctl layers -j | python3 -c "
+import json,sys
+for m,v in json.load(sys.stdin).items():
+    for lvl,ls in v['levels'].items():
+        for l in ls:
+            if 'bar' in l['namespace']: print(' ', l['namespace'], l['x'], l['y'], l['w'], l['h'])"
+echo "--- geom ---"; G=$(qs ipc -p "$COPY/shell.qml" call btprobe geom 2>&1); echo "$G"
+X=$(python3 -c "import json,sys; g=json.loads(sys.argv[1]); print(int(g['x']+g['w']/2))" "$G" 2>/dev/null)
+Y=$(python3 -c "import json,sys; g=json.loads(sys.argv[1]); print(int(g['y']+g['h']/2))" "$G" 2>/dev/null)
+BARY=$(hyprctl layers -j | python3 -c "
+import json,sys
+for m,v in json.load(sys.stdin).items():
+    for lvl,ls in v['levels'].items():
+        for l in ls:
+            if l['namespace']=='quickshell:bar': print(l['y']); raise SystemExit
+print(0)")
+BARX=$(hyprctl layers -j | python3 -c "
+import json,sys
+for m,v in json.load(sys.stdin).items():
+    for lvl,ls in v['levels'].items():
+        for l in ls:
+            if l['namespace']=='quickshell:bar': print(l['x']); raise SystemExit
+print(0)")
+echo "--- hover at $((BARX+X)),$((BARY+Y)) ---"
+hyprctl dispatch movecursor 640 600 >/dev/null; sleep 0.5
+hyprctl dispatch movecursor $((BARX+X)) $((BARY+Y)) >/dev/null; sleep 2.5
+grep "BTPROBE popup" "$TMP/shell.log" | tail -2
+hyprctl dispatch movecursor 640 600 >/dev/null; sleep 2
+grep "BTPROBE popup" "$TMP/shell.log" | tail -1
+echo "--- M3 style ---"; qs ipc -p "$COPY/shell.qml" call btprobe style 3 >/dev/null; sleep 1.5; qs ipc -p "$COPY/shell.qml" call btprobe geom
+echo "--- click ---"; qs ipc -p "$COPY/shell.qml" call btprobe click; sleep 2.5
+grep "BTPROBE sidebar" "$TMP/shell.log" | tail -2
+hyprctl layers -j | python3 -c "
+import json,sys
+for m,v in json.load(sys.stdin).items():
+    for lvl,ls in v['levels'].items():
+        for l in ls:
+            if 'sidebar' in l['namespace']: print('  layer', l['namespace'], l['w'], l['h'])"
+echo "--- vertical ---"; qs ipc -p "$COPY/shell.qml" call btprobe style 1 >/dev/null
+kill $QPID 2>/dev/null; sleep 1; kill $HPID 2>/dev/null; sleep 1; kill -9 $HPID 2>/dev/null
+echo "--- shell log: errors/warnings naming our files ---"
+grep -E "ERROR|WARN" "$TMP/shell.log" | grep -i -E "Bluetooth|BarWidgets|GlobalStates|SidebarRight|btprobe" | head -20
+echo "--- all BTPROBE lines ---"; grep BTPROBE "$TMP/shell.log" | head -20
+NESTED

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -1547,6 +1547,15 @@ if ! python3 "$SCRIPT_DIR/test_applycolor_tmux_panes.py"; then
     exit 1
 fi
 
+# The Bluetooth battery widget: one numeric lookup on BluetoothStatus feeds
+# the bar rings, At-a-glance and the dialog suffix; the widget follows the
+# ring rule and deep-links its click to the dialog.
+echo "Running Bluetooth battery widget contract tests..."
+if ! python3 "$SCRIPT_DIR/test_bluetooth_battery_widget.py"; then
+    echo "Bluetooth battery widget contract tests failed."
+    exit 1
+fi
+
 # WHEN the settings host builds its fifteen pages. It used to build all of them
 # synchronously in one turn at Config.ready - 622ms of frozen GUI thread paid by
 # the whole shell at startup, measured on the harness's own heartbeat, and

--- a/dots/.config/quickshell/imi/tests/test_bar_icon_ring_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_bar_icon_ring_contract.py
@@ -45,13 +45,15 @@ class BarIconRingContractTests(unittest.TestCase):
         self.assertEqual(media.count("ClippedOutlineCircularProgress {"), 2, "horizontal and vertical")
 
     def test_the_filled_progress_ring_stays_the_m3_or_opted_in_shape(self):
-        # Resource: the user's own Filled/Outline knob. Docker: the M3 branch.
+        # Resource: the user's own Filled/Outline knob. Docker and the Bluetooth
+        # battery widget: the M3 branch (test_bluetooth_battery_widget.py pins
+        # the spelling).
         # LockSurface predates the rule and is not a bar widget.
         users = sorted(str(p.relative_to(ROOT)) for p in (ROOT / "modules").rglob("*.qml")
                        if "ClippedFilledCircularProgress {" in p.read_text(encoding="utf-8")
                        and p.name != "ClippedFilledCircularProgress.qml")
-        self.assertEqual(users, ["modules/imi/bar/DockerPlugin.qml", "modules/imi/bar/Resource.qml",
-                                 "modules/imi/lock/LockSurface.qml"], users)
+        self.assertEqual(users, ["modules/imi/bar/BluetoothBattery.qml", "modules/imi/bar/DockerPlugin.qml",
+                                 "modules/imi/bar/Resource.qml", "modules/imi/lock/LockSurface.qml"], users)
         docker = source("modules/imi/bar/DockerPlugin.qml")
         self.assertIn("root.isMaterial ? filledRing : outlineRing", docker)
 

--- a/dots/.config/quickshell/imi/tests/test_bar_popup_section_entrance.py
+++ b/dots/.config/quickshell/imi/tests/test_bar_popup_section_entrance.py
@@ -63,6 +63,10 @@ SECTION_WAVES = {
         "hero_band": ["batteryHeaderRow"],
         "cascades": ["batteryCards"],
     },
+    f"{BAR}/BluetoothBatteryPopup.qml": {
+        "hero_band": ["bluetoothHeaderRow"],
+        "cascades": ["deviceCards"],
+    },
     f"{BAR}/ResourcesPopup.qml": {
         "hero_band": ["ramCpuColumn"],
         "cascades": ["swapDiskColumn", "gpuColumn"],

--- a/dots/.config/quickshell/imi/tests/test_bluetooth_battery_widget.py
+++ b/dots/.config/quickshell/imi/tests/test_bluetooth_battery_widget.py
@@ -136,6 +136,24 @@ class PopupContractTests(unittest.TestCase):
         self.assertIn("id: bluetoothHeaderRow", popup)
         self.assertIn("id: deviceCards", popup)
 
+    def test_a_battery_card_alarms_at_empty_not_at_full(self):
+        # ResourceCard was written for usage, where 100% is the problem; a
+        # full battery drawn in the error colour alarms at the state that is
+        # fine (the maintainer's 100%-charge-is-not-danger-red, 2026-09-03).
+        card = source(ROOT / "modules/common/widgets/ResourceCard.qml")
+        self.assertIn("property bool lowIsWarning: false", card)
+        self.assertIn("readonly property real strain: root.lowIsWarning ? 1 - root.value : root.value", card)
+        self.assertNotRegex(card, r"border\.(width|color): root\.value >",
+                            "the warning border reads strain, never value")
+        popup = source(POPUP)
+        cards = popup.split("id: deviceCards", 1)[1]
+        self.assertIn("lowIsWarning: level >= 0", cards,
+                      "empty is the alarm - unless there is no level to alarm about")
+        self.assertIn("warnAt: 1 - Config.options.battery.low / 100", cards,
+                      "the card alarms at the same threshold as the ring on the bar")
+        health = source(ROOT / "modules/imi/bar/BatteryPopup.qml").split('Translation.tr("Health")', 1)[1].split("}", 1)[0]
+        self.assertIn("lowIsWarning: true", health, "battery health is a level too")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/dots/.config/quickshell/imi/tests/test_bluetooth_battery_widget.py
+++ b/dots/.config/quickshell/imi/tests/test_bluetooth_battery_widget.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""The Bluetooth battery widget reads one battery lookup, and follows the bar's rules.
+
+A Bluetooth device's battery comes from two places - BlueZ's Battery1
+interface, or the UPower power_supply that carries the device's MAC when
+BlueZ has nothing (HID controllers). `BluetoothStatus.batteryLevelOf` is the
+one place that knows both; the quick-toggle suffix, At-a-glance and the bar
+widget all read it. At-a-glance used to filter on `batteryAvailable` alone,
+which is how a controller vanished from it - the drift this file exists to
+keep from growing back in the third consumer.
+
+The widget itself follows the resource monitor's ring vocabulary (outlined
+ring, filled under M3 - the Docker spelling, checked by the ring contract),
+collapses to nothing when no device reports a level, and deep-links its
+click to the Bluetooth dialog through GlobalStates.sidebarRightDialog.
+"""
+
+from pathlib import Path
+import re
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WIDGET = ROOT / "modules/imi/bar/BluetoothBattery.qml"
+POPUP = ROOT / "modules/imi/bar/BluetoothBatteryPopup.qml"
+SERVICE = ROOT / "services/BluetoothStatus.qml"
+AT_A_GLANCE = ROOT / "modules/common/plugins/designsystem/widgets/AtAGlance.qml"
+ICONS = ROOT / "modules/common/Icons.qml"
+CATALOGUE = ROOT / "modules/common/plugins/BarWidgets.qml"
+GLOBAL_STATES = ROOT / "GlobalStates.qml"
+SIDEBAR = ROOT / "modules/imi/sidebarRight/SidebarRightContent.qml"
+
+
+def source(path):
+    return re.sub(r"//.*", "", path.read_text(encoding="utf-8"))
+
+
+class OneBatteryLookupTests(unittest.TestCase):
+    def test_the_service_owns_the_lookup_and_the_suffix_formats_it(self):
+        service = source(SERVICE)
+        self.assertIn("function batteryLevelOf(device)", service)
+        suffix = service.split("function formatBatterySuffix(device)", 1)[1].split("\n    }", 1)[0]
+        self.assertIn("batteryLevelOf(device)", suffix,
+                      "the suffix must format the shared level, not look the battery up again")
+        self.assertNotIn("UPower", suffix)
+        self.assertIn("property list<var> batteryDevices: connectedDevices.filter(d => batteryLevelOf(d) >= 0)",
+                      service)
+        self.assertIn("property var lowestBatteryDevice:", service)
+
+    def test_every_other_reader_takes_the_level_from_the_service(self):
+        for path in (WIDGET, POPUP, AT_A_GLANCE):
+            text = source(path)
+            with self.subTest(file=path.name):
+                self.assertIn("BluetoothStatus.batteryLevelOf(", text)
+                self.assertNotIn("Quickshell.Services.UPower", text,
+                                 "the UPower fallback lives in the service, nowhere else")
+                self.assertNotIn("batteryAvailable", text,
+                                 "gating on batteryAvailable is the copy that lost the controllers")
+        self.assertIn("BluetoothStatus.batteryDevices", source(WIDGET))
+        self.assertIn("BluetoothStatus.batteryDevices", source(AT_A_GLANCE))
+
+    def test_a_controller_maps_to_its_own_glyph(self):
+        icons = source(ICONS)
+        body = icons.split("function getBluetoothDeviceMaterialSymbol", 1)[1].split("\n    }", 1)[0]
+        self.assertIn('includes("gaming")', body)
+        self.assertIn('return "stadia_controller"', body)
+        self.assertLess(body.index('"stadia_controller"'), body.index('return "bluetooth"'),
+                        "the gamepad branch has to come before the fallback")
+
+
+class WidgetContractTests(unittest.TestCase):
+    def setUp(self):
+        self.widget = source(WIDGET)
+
+    def test_the_catalogue_offers_it_with_a_translation_literal(self):
+        self.assertRegex(source(CATALOGUE),
+                         r'\{\s*id:\s*"bluetoothBattery",\s*name:\s*Translation\.tr\("Bluetooth battery"\)')
+        self.assertTrue(WIDGET.is_file(), "the id resolves to BluetoothBattery.qml by capitalisation")
+
+    def test_both_bars_can_orient_it(self):
+        self.assertIn("property bool vertical: false", self.widget)
+
+    def test_the_ring_follows_the_style_rule_once_per_orientation(self):
+        self.assertIn("readonly property bool isMaterial: Config.options.bar.cornerStyle === 3", self.widget)
+        self.assertEqual(self.widget.count("sourceComponent: root.isMaterial ? filledRing : outlineRing"), 2)
+        outline = self.widget.split("id: outlineRing", 1)[1].split("Component {", 1)[0]
+        self.assertIn("ClippedOutlineCircularProgress {", outline)
+        filled = self.widget.split("id: filledRing", 1)[1].split("Loader {", 1)[0]
+        self.assertIn("ClippedFilledCircularProgress {", filled)
+
+    def test_nothing_to_draw_collapses_the_slot(self):
+        self.assertIn("visible: root.populated", self.widget)
+        self.assertRegex(self.widget, r"implicitWidth: !root\.populated \? 0 :")
+        self.assertRegex(self.widget, r"implicitHeight: !root\.populated \? 0 :")
+
+    def test_low_is_the_laptop_batterys_own_threshold(self):
+        self.assertIn("Config.options.battery.low / 100", self.widget)
+        self.assertNotIn("Config.options.bar.bluetoothBattery", self.widget,
+                         "no options of its own - the design has none")
+
+    def test_hover_is_the_popup_and_click_is_the_dialog(self):
+        self.assertIn("cursorShape: Qt.PointingHandCursor", self.widget)
+        self.assertIn("hoverEnabled: !Config.options.bar.tooltips.clickToShow", self.widget)
+        self.assertRegex(self.widget, r"BluetoothBatteryPopup \{\s*hoverTarget: root")
+        self.assertNotIn("property bool popupOpen", self.widget,
+                         "hover-driven: no click-held state, so no anchor indicator")
+        click = self.widget.split("onClicked: {", 1)[1].split("}", 1)[0]
+        self.assertIn('GlobalStates.sidebarRightDialog = "bluetooth"', click)
+        self.assertIn("GlobalStates.sidebarRightOpen = true", click)
+        self.assertLess(click.index("sidebarRightDialog"), click.index("sidebarRightOpen"),
+                        "the request is written before the open edge that consumes it")
+
+
+class DeepLinkTests(unittest.TestCase):
+    def test_the_sidebar_consumes_the_request_on_every_road_in(self):
+        self.assertIn('property string sidebarRightDialog: ""', source(GLOBAL_STATES))
+        sidebar = source(SIDEBAR)
+        self.assertIn("function consumeDialogRequest()", sidebar)
+        body = sidebar.split("function consumeDialogRequest()", 1)[1].split("\n    }", 1)[0]
+        self.assertIn('GlobalStates.sidebarRightDialog === "bluetooth"', body)
+        self.assertIn("root.showBluetoothDialog = true", body)
+        self.assertIn('GlobalStates.sidebarRightDialog = ""', body, "consumed means cleared")
+        # Completion (the content is a Loader built on the open edge), the
+        # open edge itself, and a write while already open.
+        self.assertGreaterEqual(sidebar.count("root.consumeDialogRequest()"), 3)
+        self.assertIn("function onSidebarRightDialogChanged()", sidebar)
+
+
+class PopupContractTests(unittest.TestCase):
+    def test_the_popup_lists_every_connected_device_and_names_the_worst(self):
+        popup = source(POPUP)
+        self.assertIn("BluetoothStatus.lowestBatteryDevice", popup)
+        self.assertIn("BluetoothStatus.connectedDevices", popup,
+                      "a connected device with no battery report is still listed")
+        self.assertIn('Translation.tr("No battery report")', popup)
+        self.assertIn("id: bluetoothHeaderRow", popup)
+        self.assertIn("id: deviceCards", popup)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dots/.config/quickshell/imi/tests/tst_bluetooth_status.qml
+++ b/dots/.config/quickshell/imi/tests/tst_bluetooth_status.qml
@@ -137,4 +137,42 @@ TestCase {
         compare(BluetoothStatus.activeDeviceCount, 1)
         verify(BluetoothStatus.firstActiveDevice === earbuds)
     }
+
+    function test_battery_level_comes_from_bluez_then_upower_then_nothing() {
+        compare(BluetoothStatus.batteryLevelOf(null), -1)
+        compare(BluetoothStatus.batteryLevelOf(undefined), -1)
+        compare(BluetoothStatus.batteryLevelOf(keyboard), -1)
+        compare(BluetoothStatus.batteryLevelOf({ batteryAvailable: true, battery: 0.85 }), 0.85)
+        compare(BluetoothStatus.batteryLevelOf({ batteryAvailable: false, battery: 0.5 }), -1)
+
+        UPower.devices.values = [
+            { isLaptopBattery: true, nativePath: "BAT0", percentage: 0.99 },
+            { isLaptopBattery: false, nativePath: "ps-controller-battery-14:3a:9a:7c:45:47", percentage: 0.45 }
+        ]
+        compare(BluetoothStatus.batteryLevelOf({ batteryAvailable: false, address: "14:3A:9A:7C:45:47" }), 0.45)
+        compare(BluetoothStatus.batteryLevelOf({ batteryAvailable: true, battery: 0.6, address: "14:3A:9A:7C:45:47" }), 0.6)
+        compare(BluetoothStatus.batteryLevelOf({ batteryAvailable: false, address: "AA:BB:CC:DD:EE:FF" }), -1)
+        // The suffix is the level, formatted - never a second lookup.
+        compare(BluetoothStatus.formatBatterySuffix({ batteryAvailable: false, address: "14:3A:9A:7C:45:47" }), " • 45%")
+        UPower.devices.values = []
+    }
+
+    function test_battery_devices_are_the_connected_ones_with_a_level_in_sort_order() {
+        UPower.devices.values = [
+            { isLaptopBattery: false, nativePath: "hid-14:3a:9a:7c:45:47-battery", percentage: 0.3 }
+        ]
+        Bluetooth.devices.values = [
+            { name: "Zeta Buds", connected: true, paired: true, batteryAvailable: true, battery: 0.9 },
+            { name: "Pad", connected: true, paired: true, batteryAvailable: false, address: "14:3A:9A:7C:45:47" },
+            { name: "Mute Mouse", connected: true, paired: true, batteryAvailable: false, address: "AA:BB:CC:DD:EE:FF" },
+            { name: "Away Keys", connected: false, paired: true, batteryAvailable: true, battery: 0.1 }
+        ]
+        compare(BluetoothStatus.batteryDevices.map(d => d.name), ["Pad", "Zeta Buds"])
+        compare(BluetoothStatus.lowestBatteryDevice.name, "Pad")
+
+        Bluetooth.devices.values = []
+        compare(BluetoothStatus.batteryDevices.length, 0)
+        verify(BluetoothStatus.lowestBatteryDevice === null)
+        UPower.devices.values = []
+    }
 }


### PR DESCRIPTION
A bar widget for the battery of connected Bluetooth devices, and the one battery lookup it made necessary.

**One lookup, three readers.** A device's level comes from BlueZ's `Battery1` interface or, when BlueZ has nothing (HID controllers like the DualSense), from the UPower power_supply that carries the device's MAC. `BluetoothStatus` knew both but only handed the answer out as the quick toggle's ` • NN%` suffix, so At-a-glance grew its own `batteryAvailable` filter and lost every controller. `BluetoothStatus.batteryLevelOf(device)` is now the one lookup (0..1, -1 unknown), `formatBatterySuffix` formats it, `batteryDevices` / `lowestBatteryDevice` derive from it, and the suffix, At-a-glance and the new widget read those and nothing else — `test_bluetooth_battery_widget.py` forbids `UPower` and `batteryAvailable` in the readers.

**The widget** (`bluetoothBattery`, "Bluetooth battery" in Settings > Bar): one circled device glyph per connected device with a known level, the level as a ring in the resource monitor's vocabulary — outlined under every style, filled under M3, the Docker spelling — red at the laptop battery's own low threshold, collapsing to nothing when no device reports. Hover opens a popup: the device to worry about as the hero, one card per connected device below, including the ones with no report. Click deep-links to the Bluetooth dialog through a new `GlobalStates.sidebarRightDialog`, a property consumed and cleared by `SidebarRightContent` (the `sidebarLeftTab` shape) rather than a signal, because the sidebar's content is a Loader that only exists while the panel is shown. BlueZ's `input-gaming` now maps to `stadia_controller` in the shared icon mapper, so the same controller is named in the dialog, on the bar and in At-a-glance.

**Cards learned which end is the trouble end.** `ResourceCard` was written for usage, where 100% is the problem; a device at 100% charge came up in the error colour with the emphasis border (caught live during the nested probe). `lowIsWarning` / `strain` / `warnAt` give it a level semantics; the Bluetooth cards alarm at the bar ring's threshold, a device with no report does not alarm, and the battery popup's Health card — same bug, same fix — no longer alarms at full health.

**Verified** in a nested Hyprland with the connected list faked in a copy of the tree (`tests/run_bluetooth_battery_probe.sh`, its header carries the numbers): Float draws 96x50 with three outline rings (72%, 12% in the error colour, the real USB DualSense at UPower's 100%), M3 swaps them for filled rings, vertical draws a 56x72 column, hover flips the popup on and off, the click flips `showBluetoothDialog`, the cards read back 12% warning / 100% clear / no-report clear, and no WARN names the new files. QML tests for the lookup (`tst_bluetooth_status.qml`, 12 cases) and the widget contract (12 checks, proven to fail on `main`) are wired into the suite; the ring-contract user list and the popup entrance register gain their entries.

Docs: updated AGENT.md §Directory map (bar/) and the new entry "A Bluetooth device's battery has one lookup and three readers"
Changelog: updated
