### PR TITLE
feat(plugins): desktop widgets keep separate settings for the desktop and the lock screen

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -4423,6 +4423,36 @@ mode is built out of are worth not re-deriving:
   (feat(plugins): layout_surfaces.js - the lock's widget choice forks too;
   feat(plugins): a widget's presence is asked per surface, not once;
   feat(editMode): the Lock section picks which widgets the lock screen shows.)
+- **A widget's own SETTINGS fork per surface too — per key, under `lockOptions`, and the
+  accessors take the surface.** Position, span and presence each had a lock store; the widget's
+  options stayed in the flat `pluginOptions[id][key]`, and since the lock screen has no widget
+  host of its own (the desktop's widget is cross-faded by `AbstractBackgroundWidget`), the desktop
+  and lock "copies" of the resource monitor were one object reading one key — rotated for the
+  lock, rotated on the desktop (the maintainer's report, 2026-09-03). `lockOptions[id][key]` sits
+  beside `pluginOptions` and inherits PER KEY: present is the lock's own, absent reads through,
+  `null` re-inherits. Not the layout's whole-screen snapshot, on purpose — a user who rotates the
+  monitor for the lock still wants its blur to follow the desktop, and "which keys I changed" is
+  what the Settings card shows and its Reset undoes. Three keys never fork
+  (`SHARED_OPTION_KEYS`: `positionLocked`, `clickThrough`, `__gridSize`): Edit Mode policy with one
+  writer and one meaning, and the span has its own surface path. `PluginState.option()` and
+  `setOption()` take a trailing `surface` with the position API's `currentSurface` default, so
+  every widget binding and in-widget knob that predates the fork follows the face the desktop
+  is showing — the monitor's rotate button on the Lockscreen tab writes the lock's `vertical`
+  and the desktop's binding re-evaluates when the look flips. Settings (`PluginOptions`) names
+  its surface on EVERY call — the Desktop / Lock screen switch the user pressed, not the look —
+  and hides the shared toggles and the size row on the lock. Presets carry `lockOptions` under
+  the `has()` rule `lockPositions` follows. No migration for the map (absence is the upgrade
+  state), but one for the clock: its hand-rolled `styleLocked` row folds into the overlay's
+  `style`, preserving what the lock showed — a MISSING second style was the row's "cookie"
+  default, which differs from any desktop that is not cookie and becomes an overlay of cookie;
+  the pass is data-driven as well as marked because the legacy Config drain can deliver a
+  `styleLocked` after the load-time pass. The rule for plugin authors is in PLUGINS.md: a setting
+  that must differ between the surfaces is ONE option read through `PluginState.option`, never
+  a second `*Locked` key.
+  (feat(plugins): widget options fork per surface in the pure store rules;
+  feat(plugins): PluginState.option and setOption take a surface;
+  feat(settings): a Desktop / Lock screen switch on every widget's options;
+  refactor(clock): the lock's style is the style option on the lock surface.)
 - **A dragged widget holds a neighbour's edge through a Schmitt trigger, and
   both thresholds read the SHADOW — stage 10, spec §6.**
   `modules/common/functions/edge_snap.js` owns the arithmetic: four relations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ own repo; the installer pins which revision it builds.
 
 ## [Unreleased]
 
+### Added
+- **Desktop widgets keep separate settings for the desktop and the lock
+  screen.** Every widget card in Settings > Plugins has a Desktop / Lock
+  screen switch; a setting changed on the lock side applies to the lock
+  screen only and the rest keep following the desktop, with a "Reset to
+  desktop" to re-link. The widgets' own knobs (the system monitor's rotate
+  button, for one) write whichever surface they are used on. Presets carry
+  the lock side too.
+
+### Changed
+- **The clock's "Clock style (locked)" row is gone.** Its value moved to the
+  lock side of the ordinary "Clock style" row; what the lock screen showed
+  is what it still shows.
+
 ## [1.0.0-rc-11] — 2026-09-03
 
 ### Added

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -204,9 +204,13 @@ cannot read (no `key`) shows the row: a wrongly hidden row is a setting the user
 nothing logs. The older `"enabledWhen": "<booleanKey>"` is the same thing for one boolean and, despite
 its name, hides rather than greys — both fields go through `option_visibility.js`, and when both are
 present both must pass. The clock is the worked example: every `digital*` / `cookie*` / `pixel*` row
-is gated on its style being chosen for the desktop **or** the lock screen, since the two can differ
-(`tests/test_clock_options_contract.py` holds that; `tests/tst_option_visibility.qml` holds the
-evaluator).
+is gated on `style` alone. The desktop and the lock screen can still differ - a widget's options
+fork per surface (`lockOptions` in `plugin-state.json`, reached through the Desktop / Lock screen
+switch on the plugin's card), and the rule is evaluated against whichever surface that switch
+names (`tests/test_clock_options_contract.py` holds that; `tests/tst_option_visibility.qml` holds
+the evaluator). A widget that needs a setting to differ between the two surfaces therefore declares
+ONE option and reads it with `PluginState.option(id, key, default)`, which follows the face the
+desktop is showing; it never declares a second `*Locked` key.
 
 `color` renders a row of palette swatches (`ColorSelectionArray`) instead of chips. Its `choices` are
 `Appearance.colors` role names without the `col` prefix (`primary`, `secondaryContainer`, `layer0`, …).

--- a/docs/superpowers/plans/2026-09-03-per-surface-widget-options.md
+++ b/docs/superpowers/plans/2026-09-03-per-surface-widget-options.md
@@ -1,0 +1,66 @@
+# Per-surface widget options — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A widget's settings fork per surface (desktop / lock screen) the way its position, span and presence already do, with a Settings switch to reach the lock's values and the clock's hand-rolled `styleLocked` folded in.
+
+**Architecture:** `lockOptions[pluginId][key]` beside `pluginOptions` in `plugin-state.json`; absence of a key is per-key inheritance from the desktop. The pure rules live in `layout_surfaces.js`; `PluginState.option/setOption` gain a trailing `surface` defaulting to `currentSurface`, so every existing caller follows the look. `PluginOptions` owns a Desktop / Lock screen switch and passes the surface explicitly. A one-shot migration moves the clock's `styleLocked` into the overlay.
+
+**Tech Stack:** Quickshell QML, `.pragma library` JS, qmltestrunner, Python unittest contracts, jq in `scripts/presets.sh`.
+
+Spec: `docs/superpowers/specs/2026-09-03-per-surface-widget-options-design.md`. Paths under `dots/.config/quickshell/imi/` unless noted.
+
+---
+
+### Task 1: The pure rules (TDD in `tst_layout_surfaces.qml`)
+
+**Files:** `modules/common/plugins/layout_surfaces.js`, `tests/tst_layout_surfaces.qml`
+
+- [ ] Tests: `rawOption` reads the lock key when stored, reads through when absent, answers the desktop for `DESKTOP`; a shared key (`positionLocked`) reads the desktop even on `LOCK`; `withOption(LOCK)` writes `lockOptions` only and leaves `pluginOptions` untouched; `withOption(LOCK, shared key)` writes `pluginOptions`; `withOption(LOCK, null)` deletes the lock key so it re-inherits; `withOption(DESKTOP, null)` deletes the desktop key (today's semantics); `isOptionsForked`; `withoutLockOptions` drops one plugin's map and returns the same object when nothing to drop.
+- [ ] Run red → implement (code in the spec's Store section; `SHARED_OPTION_KEYS`, `isSharedOptionKey`, `rawOption`, `withOption`, `isOptionsForked`, `withoutLockOptions`) → run green.
+- [ ] Commit: `feat(plugins): widget options fork per surface in the pure store rules`
+
+### Task 2: PluginState carries and serves it (TDD in `tst_plugin_state.qml`)
+
+**Files:** `modules/common/plugins/PluginState.qml`, `tests/tst_plugin_state.qml`, `tests/imports/qs/GlobalStates.qml` (add `property bool lockLookActive: false`, `property bool editLockPreview: false`)
+
+- [ ] Tests: `option(id, key, fb, LOCK)` inherits then overrides after `setOption(..., LOCK)`; desktop unchanged; default surface follows `GlobalStates.lockLookActive`; `lockOptionsForked` / `resetLockOptions`; `loadText` keeps a `lockOptions` map and drops a list; the `clockStyleLocked` migration (differs / equal / absent) through a pure `stateWithClockStyleMigrated(state)`.
+- [ ] Implement: `emptyState.lockOptions`, `loadText`, `option(pluginId, key, fallback, surface)`, `setOption(pluginId, key, value, surface)` via `Surfaces.withOption`, `lockOptionsForked`, `resetLockOptions`, `stateWithClockStyleMigrated` + `runClockStyleMigration()` called from `loadText` after `ready` (guarded by `migrationRan("clockStyleLocked")`).
+- [ ] Commit: `feat(plugins): PluginState.option and setOption take a surface`
+
+### Task 3: Settings switch
+
+**Files:** `modules/common/plugins/PluginOptions.qml`
+
+- [ ] `property string surface: PluginState.desktopSurface`; `ConfigSelectionArray` "Applies to" (Desktop `desktop_windows` / Lock screen `lock`) shown when `manifest.desktopWidget !== undefined`; caption / "Reset to desktop" button; every `option`/`setOption` passes `root.surface`; shared behaviour toggles, preset-persist toggle and size rows hidden on the lock surface.
+- [ ] Lints: `lint_spacing`, `lint_material_icons`, `lint_qml_imports`, `lint_icon_glyph_alignment`.
+- [ ] Commit: `feat(settings): a Desktop / Lock screen switch on every widget's options`
+
+### Task 4: Clock folds `styleLocked` in
+
+**Files:** `modules/common/plugins/bundled/clock/manifest.json`, `.../clock/Widget.qml`, `docs/PLUGINS.md`, `tests/test_clock_options_contract.py`
+
+- [ ] Remove the `styleLocked` row; rewrite every `visibleWhen: {anyOf:[{key:style,in:[S]},{key:styleLocked,in:[S]}]}` to `{key: "style", in: [S]}`; `clockStyle: PluginState.option("clock", "style", "cookie")`, drop `styleLocked`; contract `SHARED` and `matches()` updated; PLUGINS.md sentence updated.
+- [ ] Commit: `refactor(clock): the lock's style is the style option on the lock surface`
+
+### Task 5: Presets carry `lockOptions`
+
+**Files:** `scripts/presets.sh`, `tests/test_presets.py`
+
+- [ ] `lockOptions: (.lockOptions // {})` in both save shapes, the apply `has()` rule, the empty fallbacks, and the persist carve-out (`.lockOptions[$id]` kept / deleted like `.pluginOptions[$id]`). Test: round trip + old preset keeps the overlay + persist shields it.
+- [ ] Commit: `feat(presets): a preset carries the lock screen's widget options`
+
+### Task 6: Contracts
+
+**Files:** `tests/test_layout_surfaces_contract.py`
+
+- [ ] `option`/`setOption` signatures carry `surface`; `PluginOptions` passes `root.surface` on every `PluginState.option(`/`setOption(`; `presets.sh` names `lockOptions` in save and apply; `loadText` parses it; `PluginWidget` still reads `positionLocked`/`clickThrough` with no surface (shared).
+- [ ] Commit: `test(plugins): pin the surface on every widget option read and write`
+
+### Task 7: Docs, suite, deploy, PR
+
+**Files:** `AGENT.md`, `CHANGELOG.md`
+
+- [ ] AGENT.md entry after the PRESENCE entry + directory-map line; CHANGELOG Added + Changed. Commit `docs: widget options fork per surface`.
+- [ ] Suite via `setsid -f`; deploy; drive live: Settings > Plugins > System Monitor → Lock screen → toggle Vertical; lock preview shows the change, desktop does not; Reset to desktop re-inherits.
+- [ ] Push, PR with `Docs: updated ...` and `Changelog: updated`.

--- a/docs/superpowers/specs/2026-09-03-per-surface-widget-options-design.md
+++ b/docs/superpowers/specs/2026-09-03-per-surface-widget-options-design.md
@@ -1,0 +1,153 @@
+# Per-surface widget options — design
+
+Approved 2026-09-03. Report: "the resource monitor / GPU monitor desktop
+widgets do not maintain separate configurations between desktop and
+lockscreen."
+
+## Root cause
+
+`plugin-state.json` forked position (`lockPositions`), span (`gridSize` in
+the lock record) and presence (`lockPresence`) per surface, but a widget's
+own settings stayed in the flat `pluginOptions[pluginId][key]` map, and
+`PluginState.option()` / `setOption()` are the only accessors in that file
+that take no `surface`. The lock screen has no widget host of its own: the
+desktop builds one widget per plugin per screen and cross-fades it when the
+lock look is active, so the desktop and lock "copies" are one object reading
+one key. The two monitors declare no `grid`, so `vertical` is their whole
+shape and it is shared. The only per-surface setting today is the clock's
+hand-rolled `style` / `styleLocked` pair.
+
+## Decisions (user)
+
+1. Surface-scoped option store, not per-manifest opt-in, not a second copy
+   of the clock's hack.
+2. Host keys: look keys fork (`blurEnabled`, `keepTranslucent`,
+   `followParallax`); policy keys stay shared (`positionLocked`,
+   `clickThrough`, and `__gridSize`, which has its own surface path).
+3. Settings > Plugins: a Desktop / Lock screen segmented switch per plugin
+   card; the rows below read and write that surface.
+4. The clock's `styleLocked` is retired onto the new store by a one-shot
+   migration that preserves what every user sees today.
+
+## Store: `lockOptions`
+
+A sibling map `lockOptions[pluginId][key]` beside `pluginOptions`, shaped
+like it. Absence is inheritance, per KEY: a key present in
+`lockOptions[id]` is the lock's own value; a key absent there reads through
+to `pluginOptions[id][key]`. This differs from the layout fork, which
+snapshots a whole screen on first edit, on purpose: a user who rotates the
+monitor on the lock screen still wants its blur to follow the desktop, and
+"which keys I changed for the lock" is the model the Settings switch shows.
+Removing a lock key (writing `null`) re-inherits it.
+
+No migration for the map itself: its absence is the correct upgrade state
+(the argument `lockPositions` and `lockPresence` recorded).
+
+`layout_surfaces.js` (pure, tested bare) gains:
+
+- `SHARED_OPTION_KEYS = ["positionLocked", "clickThrough", "__gridSize"]`
+  and `isSharedOptionKey(key)` — keys that always live in `pluginOptions`
+  whatever surface is asked.
+- `rawOption(state, surface, pluginId, key)` → the stored value or
+  `undefined` (the read-through rule above).
+- `withOption(state, surface, pluginId, key, value)` → next state; on the
+  desktop, or for a shared key, it is today's `setOption` body; on the lock
+  it writes `lockOptions`, `null`/`undefined` deleting the key.
+- `isOptionsForked(state, pluginId)` — any lock key stored for the plugin.
+- `withoutLockOptions(state, pluginId)` — drop the plugin's lock map
+  (identity-returning no-op when absent, like `withoutLockLayout`).
+
+`PluginState.qml`:
+
+- `emptyState()` and `loadText()` carry `lockOptions` (map or `{}`).
+- `option(pluginId, key, fallback, surface)` and
+  `setOption(pluginId, key, value, surface)` take a trailing `surface` with
+  the same `surface ?? root.currentSurface` default as `position()`. Every
+  existing caller keeps its call shape and follows the look: the monitor's
+  rotate button on the Lockscreen tab or on a real lock writes the lock's
+  `vertical`; `PluginWidget`'s `blurEnabled` / `keepTranslucent` /
+  `followParallax` bindings re-evaluate when `currentSurface` flips, exactly
+  as `position()` already does; `positionLocked` and `clickThrough` are
+  shared keys and land in `pluginOptions` from either surface.
+- `lockOptionsForked(pluginId)` and `resetLockOptions(pluginId)`.
+- `effectiveBackgroundOpacity` reads `keepTranslucent` through `option()`
+  and therefore follows the look; unchanged.
+- The Config→PluginState drain and the sizeMode migration keep writing
+  `pluginOptions` directly: both are desktop data.
+
+Presets (`scripts/presets.sh`): `lockOptions` is captured and applied under
+the same `has()` rule as `lockPositions`, and the `presetPersist` carve-out
+keeps the current plugin's `lockOptions[id]` alongside its `pluginOptions[id]`.
+
+`scripts/colors/switchwall.sh` keeps reading the clock's desktop
+`cookieAiStyling`; documented, not changed.
+
+## Clock: retire `styleLocked`
+
+One-shot migration `clockStyleLocked` in `PluginState` (run on load, guarded
+by `migrations`): let `desktop = pluginOptions.clock.style ?? "cookie"` and
+`locked = pluginOptions.clock.styleLocked ?? "cookie"`; if `locked !==
+desktop`, write `lockOptions.clock.style = locked`; delete
+`pluginOptions.clock.styleLocked`; mark. A user with desktop `pixel` and no
+stored `styleLocked` saw `cookie` on the lock, and still does.
+
+Clock manifest: the `styleLocked` row goes; every `visibleWhen` that read
+`anyOf [style, styleLocked]` reads `style` alone, since the Settings switch
+now evaluates the rule against the selected surface. Clock widget:
+`clockStyle` is `PluginState.option("clock", "style", "cookie")` and follows
+the look through `currentSurface`; the widget's own `lockLook` stays for
+centring, presence and the caption. `docs/PLUGINS.md` and
+`test_clock_options_contract.py` follow (`SHARED` loses `styleLocked`,
+`matches()` expects a single-key rule).
+
+## Settings UI: `PluginOptions.qml`
+
+- `property string surface: PluginState.desktopSurface`, owned by the card.
+- A `ConfigSelectionArray` "Applies to" with Desktop / Lock screen, shown
+  only when the manifest has a `desktopWidget` (bar-only plugins have no
+  lock face). Beneath it on the lock surface, a caption: "Follows the
+  desktop until you change a setting here", replaced by a "Reset to desktop"
+  `RippleButton` when `PluginState.lockOptionsForked(id)`.
+- Every `PluginState.option(...)` / `setOption(...)` in the file passes
+  `root.surface` explicitly (`readOption` included, so visibility rules
+  follow the selected surface).
+- On the lock surface the behaviour bar hides the shared toggles
+  (`positionLocked`, `clickThrough`, and "Keep settings across presets",
+  which is not an option at all) and the desktop-only size row; the look
+  toggles stay.
+
+## Tests
+
+- `tst_layout_surfaces.qml`: read-through, per-key independence, shared keys
+  never fork, `null` re-inherits, reset drops the plugin's map only,
+  identity no-op.
+- `tst_plugin_state.qml`: `option`/`setOption` with an explicit surface;
+  the default surface follows `GlobalStates.lockLookActive` (the mock gains
+  the property); `loadText` accepts and rejects `lockOptions` shapes; the
+  clock migration's three cases (differs → overlay written and key deleted;
+  equal → key deleted only; absent → nothing, marker set).
+- `test_layout_surfaces_contract.py`: `option`/`setOption` signatures carry
+  `surface` and fall back to `currentSurface`; `PluginOptions` passes
+  `root.surface` on every read and write; `presets.sh` names `lockOptions`
+  beside `lockPositions` in save and apply; `loadText` parses it.
+- `test_clock_options_contract.py` updated; `test_presets.py` gains a case
+  for `lockOptions` surviving apply and the persist carve-out (following
+  its existing `lockPositions` cases).
+- Existing pins unchanged: `test_expressive_design_system.py`'s
+  `onVerticalRequested` string (the wrapper's call shape does not change).
+
+## Docs
+
+AGENT.md: the "PRESENCE forks" entry gains a sibling: options fork per key
+under `lockOptions`, which keys are shared and why, the Settings switch, the
+clock migration, and the rule "a widget setting that must differ between
+the desktop and the lock is a `lockOptions` key, never a second manifest
+key". Directory-map line for `layout_surfaces.js` updated. CHANGELOG:
+Added (per-surface widget settings) and Changed (clock's second style row
+folded in).
+
+## Out of scope
+
+Per-screen options (options are per plugin, like presence); a whole-plugin
+"fork everything" action; Edit Mode UI beyond the in-widget knobs that
+already write the current surface.

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginOptions.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginOptions.qml
@@ -167,8 +167,8 @@ ColumnLayout {
     // The desktop's span only: the lock's forks in its layout record and is
     // set on the Lockscreen tab (PluginState.gridSize), so the lock card
     // offers no size row.
-    readonly property var offeredSizes: GridSizes.offeredSizes(manifest.grid)
-    readonly property var sizeRows: (!root.onLock && root.offeredSizes.length > 1) ? [{
+    readonly property var offeredSizes: root.onLock ? [] : GridSizes.offeredSizes(manifest.grid)
+    readonly property var sizeRows: root.offeredSizes.length > 1 ? [{
         key: "__gridSize",
         type: "choice",
         label: "Size",

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginOptions.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginOptions.qml
@@ -7,12 +7,25 @@ import qs.modules.common
 import qs.modules.common.widgets
 import "gridSizes.js" as GridSizes
 import "option_visibility.js" as OptionVisibility
+import "layout_surfaces.js" as Surfaces
 
 ColumnLayout {
     id: root
 
     required property var manifest
     spacing: Appearance.spacing.space25
+
+    // Which face of the desktop these rows read and write. A widget's own
+    // settings fork per surface (layout_surfaces.js: lockOptions, inheriting
+    // per key), and this card is where the lock's values are reached - so the
+    // surface is named on EVERY read and write below rather than left to
+    // PluginState's default, which follows the look the desktop is showing
+    // and not the switch the user just pressed.
+    property string surface: PluginState.desktopSurface
+    readonly property bool onLock: root.surface === PluginState.lockSurface
+    // Only a desktop widget has a lock face; a bar- or overlay-only plugin
+    // gets no switch and its rows stay the desktop's.
+    readonly property bool hasLockFace: manifest.desktopWidget !== undefined
 
     // The widget's own options come first, because they are what the user
     // opened this page for. The host's rows used to be concatenated in FRONT of
@@ -32,7 +45,7 @@ ColumnLayout {
         return defaults;
     }
     function readOption(key) {
-        return PluginState.option(root.manifest.id, key, root.optionDefaults[key]);
+        return PluginState.option(root.manifest.id, key, root.optionDefaults[key], root.surface, root.surface);
     }
 
     // Options declared with the same `group`, consecutively, render under one
@@ -151,8 +164,11 @@ ColumnLayout {
     // Not every widget is resizable, and offering a size where the widget has
     // no layout for it is worse than offering nothing - so this is omitted
     // rather than disabled unless the manifest names more than one span.
+    // The desktop's span only: the lock's forks in its layout record and is
+    // set on the Lockscreen tab (PluginState.gridSize), so the lock card
+    // offers no size row.
     readonly property var offeredSizes: GridSizes.offeredSizes(manifest.grid)
-    readonly property var sizeRows: root.offeredSizes.length > 1 ? [{
+    readonly property var sizeRows: (!root.onLock && root.offeredSizes.length > 1) ? [{
         key: "__gridSize",
         type: "choice",
         label: "Size",
@@ -163,6 +179,55 @@ ColumnLayout {
             value: GridSizes.formatSize(size)
         }))
     }] : []
+
+    // Desktop / Lock screen: which face the rows below edit. The lock's
+    // settings follow the desktop's per key until one is changed here; the
+    // caption says so, and turns into the re-link once any has.
+    ConfigSelectionArray {
+        id: surfaceSwitch
+        visible: root.hasLockFace
+        Layout.fillWidth: true
+        text: Translation.tr("Applies to")
+        icon: "desktop_windows"
+        currentValue: root.surface
+        onSelected: value => root.surface = value
+        options: [
+            { displayName: Translation.tr("Desktop"), icon: "desktop_windows", value: PluginState.desktopSurface },
+            { displayName: Translation.tr("Lock screen"), icon: "lock", value: PluginState.lockSurface }
+        ]
+    }
+    RowLayout {
+        visible: root.hasLockFace && root.onLock
+        Layout.fillWidth: true
+        spacing: Appearance.spacing.space100
+        StyledText {
+            Layout.fillWidth: true
+            font.pixelSize: Appearance.font.pixelSize.smaller
+            color: Appearance.colors.colSubtext
+            wrapMode: Text.WordWrap
+            text: PluginState.lockOptionsForked(root.manifest.id)
+                ? Translation.tr("The lock screen has settings of its own here; the rest follow the desktop.")
+                : Translation.tr("Follows the desktop until you change a setting here.")
+        }
+        RippleButton {
+            visible: PluginState.lockOptionsForked(root.manifest.id)
+            implicitHeight: 32
+            buttonRadius: Appearance.rounding.full
+            colBackground: Appearance.colors.colSecondaryContainer
+            colBackgroundHover: Appearance.colors.colSecondaryContainerHover
+            colRipple: Appearance.colors.colSecondaryContainerActive
+            onClicked: PluginState.resetLockOptions(root.manifest.id)
+            contentItem: StyledText {
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
+                leftPadding: Appearance.spacing.space150
+                rightPadding: Appearance.spacing.space150
+                font.pixelSize: Appearance.font.pixelSize.small
+                color: Appearance.colors.colOnSecondaryContainer
+                text: Translation.tr("Reset to desktop")
+            }
+        }
+    }
 
     Repeater {
         model: root.optionRuns
@@ -271,7 +336,9 @@ ColumnLayout {
                 on.push(behaviourSection.presetPersistLabel);
             for (let index = 0; index < root.behaviourRows.length; ++index) {
                 const behaviourRow = root.behaviourRows[index];
-                if (PluginState.option(root.manifest.id, behaviourRow.key, behaviourRow.default))
+                if (root.onLock && Surfaces.isSharedOptionKey(behaviourRow.key))
+                    continue;
+                if (PluginState.option(root.manifest.id, behaviourRow.key, behaviourRow.default, root.surface))
                     on.push(behaviourRow.label);
             }
             return on.join("  ·  ");
@@ -288,6 +355,9 @@ ColumnLayout {
             // the rest of it survives a preset.
             BehaviourToggle {
                 id: presetPersistToggle
+                // Not a per-surface thing: the flag shields the plugin's
+                // settings on BOTH surfaces through a preset.
+                visible: !root.onLock
                 label: behaviourSection.presetPersistLabel
                 buttonIcon: "push_pin"
                 toggled: PluginState.presetPersisted(root.manifest.id)
@@ -299,11 +369,17 @@ ColumnLayout {
                 model: root.behaviourRows
                 delegate: BehaviourToggle {
                     required property var modelData
+                    // On the lock surface only the LOOK toggles: pin and
+                    // click-through are Edit Mode policy with one writer and
+                    // one meaning (SHARED_OPTION_KEYS), and a toggle that
+                    // wrote the desktop's value from the lock's card would
+                    // be a lie.
+                    visible: !root.onLock || !Surfaces.isSharedOptionKey(modelData.key)
                     label: modelData.label
                     buttonIcon: modelData.icon
-                    toggled: PluginState.option(root.manifest.id, modelData.key, modelData.default)
+                    toggled: PluginState.option(root.manifest.id, modelData.key, modelData.default, root.surface)
                     onClicked: PluginState.setOption(root.manifest.id, modelData.key,
-                        !PluginState.option(root.manifest.id, modelData.key, modelData.default))
+                        !PluginState.option(root.manifest.id, modelData.key, modelData.default, root.surface), root.surface)
                 }
             }
         }
@@ -405,9 +481,9 @@ ColumnLayout {
                 rightPadding: 0
                 buttonIcon: optionLoader.optionData.icon || "tune"
                 text: optionLoader.optionData.label
-                checked: PluginState.option(root.manifest.id, optionLoader.optionData.key, optionLoader.optionData.default)
+                checked: PluginState.option(root.manifest.id, optionLoader.optionData.key, optionLoader.optionData.default, root.surface)
                 onToggleRequested: PluginState.setOption(root.manifest.id, optionLoader.optionData.key,
-                    !PluginState.option(root.manifest.id, optionLoader.optionData.key, optionLoader.optionData.default))
+                    !PluginState.option(root.manifest.id, optionLoader.optionData.key, optionLoader.optionData.default, root.surface), root.surface)
             }
         }
 
@@ -422,8 +498,8 @@ ColumnLayout {
                 text: optionLoader.optionData.label
                 icon: optionLoader.optionData.icon || "tune"
                 options: optionLoader.optionData.choices || []
-                currentValue: PluginState.option(root.manifest.id, optionLoader.optionData.key, optionLoader.optionData.default)
-                onSelected: value => PluginState.setOption(root.manifest.id, optionLoader.optionData.key, value)
+                currentValue: PluginState.option(root.manifest.id, optionLoader.optionData.key, optionLoader.optionData.default, root.surface)
+                onSelected: value => PluginState.setOption(root.manifest.id, optionLoader.optionData.key, value, root.surface)
             }
         }
 
@@ -441,8 +517,8 @@ ColumnLayout {
                     .filter(choice => choice && choice.enabledWhen !== undefined
                         && !OptionVisibility.rule(choice.enabledWhen, key => root.readOption(key)))
                     .map(choice => choice.value)
-                currentValue: PluginState.option(root.manifest.id, optionLoader.optionData.key, optionLoader.optionData.default)
-                onSelected: value => PluginState.setOption(root.manifest.id, optionLoader.optionData.key, value)
+                currentValue: PluginState.option(root.manifest.id, optionLoader.optionData.key, optionLoader.optionData.default, root.surface)
+                onSelected: value => PluginState.setOption(root.manifest.id, optionLoader.optionData.key, value, root.surface)
             }
         }
 
@@ -458,8 +534,8 @@ ColumnLayout {
                 text: optionLoader.optionData.label
                 options: (optionLoader.optionData.choices || [])
                     .map(choice => choice.value ?? choice)
-                currentValue: PluginState.option(root.manifest.id, optionLoader.optionData.key, optionLoader.optionData.default)
-                onSelected: value => PluginState.setOption(root.manifest.id, optionLoader.optionData.key, value)
+                currentValue: PluginState.option(root.manifest.id, optionLoader.optionData.key, optionLoader.optionData.default, root.surface)
+                onSelected: value => PluginState.setOption(root.manifest.id, optionLoader.optionData.key, value, root.surface)
             }
         }
 
@@ -476,12 +552,12 @@ ColumnLayout {
                     || (optionLoader.optionData.to ?? 100) <= 1
                 from: optionLoader.optionData.from ?? 0
                 to: optionLoader.optionData.to ?? 100
-                value: PluginState.option(root.manifest.id, optionLoader.optionData.key, optionLoader.optionData.default)
+                value: PluginState.option(root.manifest.id, optionLoader.optionData.key, optionLoader.optionData.default, root.surface)
                 onValueModified: {
                     const step = optionLoader.optionData.step ?? 1;
                     const rounded = Math.round(newValue / step) * step;
-                    if (rounded !== PluginState.option(root.manifest.id, optionLoader.optionData.key, optionLoader.optionData.default))
-                        PluginState.setOption(root.manifest.id, optionLoader.optionData.key, rounded);
+                    if (rounded !== PluginState.option(root.manifest.id, optionLoader.optionData.key, optionLoader.optionData.default, root.surface))
+                        PluginState.setOption(root.manifest.id, optionLoader.optionData.key, rounded, root.surface);
                 }
             }
         }
@@ -494,17 +570,15 @@ ColumnLayout {
                 text: optionLoader.optionData.label
                 placeholderText: optionLoader.optionData.placeholder || ""
                 fieldWidth: 160
-                value: String(PluginState.option(root.manifest.id,
-                    optionLoader.optionData.key, optionLoader.optionData.default))
+                value: String(PluginState.option(root.manifest.id, optionLoader.optionData.key, optionLoader.optionData.default, root.surface))
                 onValueChanged: {
                     const trimmed = value.trim();
                     if (trimmed.length === 0) return;
                     const transformed = optionLoader.optionData.uppercase === true
                         ? trimmed.toUpperCase() : trimmed;
                     const normalized = transformed.slice(0, optionLoader.optionData.maxLength ?? 64);
-                    if (normalized !== PluginState.option(root.manifest.id,
-                            optionLoader.optionData.key, optionLoader.optionData.default))
-                        PluginState.setOption(root.manifest.id, optionLoader.optionData.key, normalized);
+                    if (normalized !== PluginState.option(root.manifest.id, optionLoader.optionData.key, optionLoader.optionData.default, root.surface))
+                        PluginState.setOption(root.manifest.id, optionLoader.optionData.key, normalized, root.surface);
                 }
             }
         }

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginState.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginState.qml
@@ -37,6 +37,11 @@ Singleton {
             // shows exactly the set `lock.showWidgets` shows it today.
             lockPresence: null,
             pluginOptions: {},
+            // A widget's own settings on the lock screen, per key: a key
+            // stored here is the lock's own, one absent reads through to
+            // pluginOptions (layout_surfaces.js). Same no-migration argument
+            // as the two above - absence is the correct upgrade state.
+            lockOptions: {},
             // Plugin ids whose options/positions/enabled state survive preset
             // application (never captured INTO presets - see presets.sh).
             presetPersist: {},
@@ -216,9 +221,31 @@ Singleton {
         writeTimer.restart();
     }
 
-    function option(pluginId, key, fallback) {
-        const value = root.state?.pluginOptions?.[pluginId]?.[key];
+    // A widget's option on a surface. Same default-surface rule as
+    // position(): a caller that names none - every widget binding, the
+    // in-widget knobs - reads the face the desktop is showing, so the
+    // resource monitor's rotate button on the Lockscreen tab writes the
+    // lock's `vertical`, and the desktop's binding re-evaluates when the
+    // look flips because it read currentSurface. Settings names its surface
+    // (PluginOptions), and Edit Mode's policy keys are shared whatever is
+    // passed (layout_surfaces.js SHARED_OPTION_KEYS).
+    function option(pluginId, key, fallback, surface) {
+        const value = Surfaces.rawOption(root.state, surface ?? root.currentSurface, pluginId, key);
         return value === undefined ? fallback : value;
+    }
+
+    // Has this widget any lock-screen setting of its own?
+    function lockOptionsForked(pluginId) {
+        return Surfaces.isOptionsForked(root.state, pluginId);
+    }
+
+    // Re-link one widget's lock settings to the desktop's.
+    function resetLockOptions(pluginId) {
+        const nextState = Surfaces.withoutLockOptions(root.state, pluginId);
+        if (nextState === root.state) return;
+        nextState.version = root.schemaVersion;
+        root.state = nextState;
+        writeTimer.restart();
     }
 
     // Desktop-widget panel opacity, resolved against the global transparency
@@ -357,25 +384,53 @@ Singleton {
         writeTimer.restart();
     }
 
-    function setOption(pluginId, key, value) {
+    // null means REMOVE, not store: `option()` falls back only on undefined,
+    // so a persisted null would answer every later read in place of the
+    // caller's fallback - a key that never existed, materialised on disk.
+    // Edit Mode's undo is what reaches this branch: reversing a first-ever
+    // commit restores "no stored choice", which has to leave the store the
+    // way it found it. On the lock surface the same null is the re-inherit:
+    // the lock key goes and the desktop's value reads through again.
+    function setOption(pluginId, key, value, surface) {
         if (!pluginId || !key) return;
-
-        const nextState = Object.assign({}, root.state);
-        const nextOptions = Object.assign({}, nextState.pluginOptions || {});
-        const nextPlugin = Object.assign({}, nextOptions[pluginId] || {});
-        // null means REMOVE, not store: `option()` falls back only on
-        // undefined, so a persisted null would answer every later read in
-        // place of the caller's fallback - a key that never existed,
-        // materialised on disk. Edit Mode's undo is what reaches this branch:
-        // reversing a first-ever commit restores "no stored choice", which
-        // has to leave the store the way it found it. No live caller stored
-        // null before this meaning was assigned (checked, not assumed).
-        if (value === null || value === undefined) delete nextPlugin[key];
-        else nextPlugin[key] = value;
-        nextOptions[pluginId] = nextPlugin;
+        const nextState = Surfaces.withOption(root.state, surface ?? root.currentSurface,
+            pluginId, key, value);
         nextState.version = root.schemaVersion;
-        nextState.pluginOptions = nextOptions;
         root.state = nextState;
+        writeTimer.restart();
+    }
+
+    // The clock carried the shell's only per-surface setting by hand: a
+    // second manifest row, `styleLocked`, selected inside the widget. It
+    // folds into the lock overlay's `style` here, and what the user SEES on
+    // the lock does not change: a stored second style that differs from the
+    // desktop's becomes the overlay; one that matches becomes nothing; an
+    // absent one was the row's default, "cookie", which differs from any
+    // desktop that is not cookie and so becomes an overlay of "cookie" too.
+    // Pure, so the three cases are drivable from a TestCase; run once on
+    // load, recorded in `migrations` like the sizeMode pass.
+    readonly property string clockStyleMarker: "clockStyleLocked"
+
+    function stateWithClockStyleMigrated(state) {
+        const clock = state?.pluginOptions?.clock;
+        const stored = clock && typeof clock === "object" ? clock : {};
+        const desktop = stored.style === undefined ? "cookie" : stored.style;
+        const locked = stored.styleLocked === undefined ? "cookie" : stored.styleLocked;
+        let next = Object.assign({}, state);
+        if (locked !== desktop)
+            next = Surfaces.withOption(next, Surfaces.LOCK, "clock", "style", locked);
+        if (stored.styleLocked !== undefined)
+            next = Surfaces.withOption(next, Surfaces.DESKTOP, "clock", "styleLocked", null);
+        const nextMigrations = Object.assign({}, state?.migrations || {});
+        nextMigrations[root.clockStyleMarker] = true;
+        next.migrations = nextMigrations;
+        next.version = root.schemaVersion;
+        return next;
+    }
+
+    function migrateClockStyle() {
+        if (root.migrationRan(root.clockStyleMarker)) return;
+        root.state = root.stateWithClockStyleMigrated(root.state);
         writeTimer.restart();
     }
 
@@ -517,6 +572,11 @@ Singleton {
                     && !Array.isArray(parsed.pluginOptions)
                     ? parsed.pluginOptions
                     : {},
+                lockOptions: parsed.lockOptions
+                    && typeof parsed.lockOptions === "object"
+                    && !Array.isArray(parsed.lockOptions)
+                    ? parsed.lockOptions
+                    : {},
                 presetPersist: parsed.presetPersist
                     && typeof parsed.presetPersist === "object"
                     && !Array.isArray(parsed.presetPersist)
@@ -528,6 +588,9 @@ Singleton {
                     ? parsed.migrations
                     : {}
             };
+            // Inside the try: a file that did not parse is left on disk as
+            // it was, not replaced by an empty state carrying a marker.
+            root.migrateClockStyle();
         } catch (error) {
             console.warn("[PluginState] Ignoring invalid state file: " + error);
             root.state = root.emptyState();

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginState.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginState.qml
@@ -428,8 +428,13 @@ Singleton {
         return next;
     }
 
+    // Data-driven as well as marked (the sizeMode lesson): a `styleLocked`
+    // that arrives AFTER the marker - the legacy Config drain below still
+    // carries one for a first-run upgrade - is folded whenever it is seen,
+    // and the marker alone covers the absent-key case once.
     function migrateClockStyle() {
-        if (root.migrationRan(root.clockStyleMarker)) return;
+        const stored = root.state?.pluginOptions?.clock?.styleLocked;
+        if (stored === undefined && root.migrationRan(root.clockStyleMarker)) return;
         root.state = root.stateWithClockStyleMigrated(root.state);
         writeTimer.restart();
     }
@@ -511,6 +516,8 @@ Singleton {
         nextState.pluginOptions = nextOptions;
         nextState.desktopPositions = nextScreens;
         root.state = nextState;
+        // The drain may have just delivered the clock's legacy styleLocked.
+        root.migrateClockStyle();
         writeTimer.restart();
 
         Config.pendingPluginOptions = ({});

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/clock/Widget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/clock/Widget.qml
@@ -59,8 +59,12 @@ Item {
     readonly property var hostScreen: Quickshell.screens.find(screen => screen.name === root.screenName) ?? null
     readonly property real hostScreenWidth: root.hostScreen?.width ?? 0
 
+    // The style follows the face the desktop is showing: PluginState.option
+    // reads the lock's own `style` (lockOptions) under the lock look and the
+    // desktop's otherwise - the second manifest row this widget used to
+    // carry, `styleLocked`, folded into that store (PluginState's
+    // clockStyleLocked migration).
     readonly property string style: PluginState.option("clock", "style", "cookie")
-    readonly property string styleLocked: PluginState.option("clock", "styleLocked", "cookie")
     readonly property bool showOnlyWhenLocked: PluginState.option("clock", "showOnlyWhenLocked", false)
 
     readonly property bool digitalVertical: PluginState.option("clock", "digitalVertical", false)
@@ -79,7 +83,7 @@ Item {
     readonly property string quoteText: PluginState.option("clock", "quoteText", "")
     readonly property bool quoteFollowClock: PluginState.option("clock", "quoteFollowClock", false)
 
-    readonly property string clockStyle: root.lockLook ? root.styleLocked : root.style
+    readonly property string clockStyle: root.style
     readonly property bool shouldShow: !root.showOnlyWhenLocked || root.lockLook
 
     readonly property string customClockColorKey: PluginState.option("clock", "color", "")

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/clock/manifest.json
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/clock/manifest.json
@@ -42,30 +42,6 @@
       ]
     },
     {
-      "key": "styleLocked",
-      "type": "choice",
-      "label": "Clock style (locked)",
-      "icon": "shield_watch",
-      "default": "cookie",
-      "choices": [
-        {
-          "displayName": "Digital",
-          "icon": "timer_10",
-          "value": "digital"
-        },
-        {
-          "displayName": "Cookie",
-          "icon": "cookie",
-          "value": "cookie"
-        },
-        {
-          "displayName": "Pixel",
-          "icon": "grid_view",
-          "value": "pixel"
-        }
-      ]
-    },
-    {
       "key": "showOnlyWhenLocked",
       "type": "boolean",
       "label": "Show only when locked",
@@ -79,19 +55,9 @@
       "icon": "vertical_distribute",
       "default": false,
       "visibleWhen": {
-        "anyOf": [
-          {
-            "key": "style",
-            "in": [
-              "digital"
-            ]
-          },
-          {
-            "key": "styleLocked",
-            "in": [
-              "digital"
-            ]
-          }
+        "key": "style",
+        "in": [
+          "digital"
         ]
       },
       "group": "Digital clock",
@@ -104,19 +70,9 @@
       "icon": "date_range",
       "default": true,
       "visibleWhen": {
-        "anyOf": [
-          {
-            "key": "style",
-            "in": [
-              "digital"
-            ]
-          },
-          {
-            "key": "styleLocked",
-            "in": [
-              "digital"
-            ]
-          }
+        "key": "style",
+        "in": [
+          "digital"
         ]
       },
       "group": "Digital clock",
@@ -129,19 +85,9 @@
       "icon": "animation",
       "default": true,
       "visibleWhen": {
-        "anyOf": [
-          {
-            "key": "style",
-            "in": [
-              "digital"
-            ]
-          },
-          {
-            "key": "styleLocked",
-            "in": [
-              "digital"
-            ]
-          }
+        "key": "style",
+        "in": [
+          "digital"
         ]
       },
       "group": "Digital clock",
@@ -154,19 +100,9 @@
       "icon": "activity_zone",
       "default": true,
       "visibleWhen": {
-        "anyOf": [
-          {
-            "key": "style",
-            "in": [
-              "digital"
-            ]
-          },
-          {
-            "key": "styleLocked",
-            "in": [
-              "digital"
-            ]
-          }
+        "key": "style",
+        "in": [
+          "digital"
         ]
       },
       "group": "Digital clock",
@@ -179,19 +115,9 @@
       "icon": "palette",
       "default": "",
       "visibleWhen": {
-        "anyOf": [
-          {
-            "key": "style",
-            "in": [
-              "digital"
-            ]
-          },
-          {
-            "key": "styleLocked",
-            "in": [
-              "digital"
-            ]
-          }
+        "key": "style",
+        "in": [
+          "digital"
         ]
       },
       "choices": [
@@ -217,19 +143,9 @@
       "placeholder": "Google Sans Flex",
       "maxLength": 64,
       "visibleWhen": {
-        "anyOf": [
-          {
-            "key": "style",
-            "in": [
-              "digital"
-            ]
-          },
-          {
-            "key": "styleLocked",
-            "in": [
-              "digital"
-            ]
-          }
+        "key": "style",
+        "in": [
+          "digital"
         ]
       },
       "group": "Digital clock",
@@ -244,19 +160,9 @@
       "from": 1,
       "to": 1000,
       "visibleWhen": {
-        "anyOf": [
-          {
-            "key": "style",
-            "in": [
-              "digital"
-            ]
-          },
-          {
-            "key": "styleLocked",
-            "in": [
-              "digital"
-            ]
-          }
+        "key": "style",
+        "in": [
+          "digital"
         ]
       },
       "group": "Digital clock",
@@ -271,19 +177,9 @@
       "from": 50,
       "to": 700,
       "visibleWhen": {
-        "anyOf": [
-          {
-            "key": "style",
-            "in": [
-              "digital"
-            ]
-          },
-          {
-            "key": "styleLocked",
-            "in": [
-              "digital"
-            ]
-          }
+        "key": "style",
+        "in": [
+          "digital"
         ]
       },
       "group": "Digital clock",
@@ -298,19 +194,9 @@
       "from": 25,
       "to": 125,
       "visibleWhen": {
-        "anyOf": [
-          {
-            "key": "style",
-            "in": [
-              "digital"
-            ]
-          },
-          {
-            "key": "styleLocked",
-            "in": [
-              "digital"
-            ]
-          }
+        "key": "style",
+        "in": [
+          "digital"
         ]
       },
       "group": "Digital clock",
@@ -325,19 +211,9 @@
       "from": 0,
       "to": 100,
       "visibleWhen": {
-        "anyOf": [
-          {
-            "key": "style",
-            "in": [
-              "digital"
-            ]
-          },
-          {
-            "key": "styleLocked",
-            "in": [
-              "digital"
-            ]
-          }
+        "key": "style",
+        "in": [
+          "digital"
         ]
       },
       "group": "Digital clock",
@@ -350,19 +226,9 @@
       "icon": "airwave",
       "default": false,
       "visibleWhen": {
-        "anyOf": [
-          {
-            "key": "style",
-            "in": [
-              "cookie"
-            ]
-          },
-          {
-            "key": "styleLocked",
-            "in": [
-              "cookie"
-            ]
-          }
+        "key": "style",
+        "in": [
+          "cookie"
         ]
       },
       "group": "Cookie clock",
@@ -375,19 +241,9 @@
       "icon": "wand_stars",
       "default": false,
       "visibleWhen": {
-        "anyOf": [
-          {
-            "key": "style",
-            "in": [
-              "cookie"
-            ]
-          },
-          {
-            "key": "styleLocked",
-            "in": [
-              "cookie"
-            ]
-          }
+        "key": "style",
+        "in": [
+          "cookie"
         ]
       },
       "group": "Cookie clock",
@@ -402,19 +258,9 @@
       "from": 0,
       "to": 40,
       "visibleWhen": {
-        "anyOf": [
-          {
-            "key": "style",
-            "in": [
-              "cookie"
-            ]
-          },
-          {
-            "key": "styleLocked",
-            "in": [
-              "cookie"
-            ]
-          }
+        "key": "style",
+        "in": [
+          "cookie"
         ]
       },
       "group": "Cookie clock",
@@ -427,19 +273,9 @@
       "icon": "autoplay",
       "default": false,
       "visibleWhen": {
-        "anyOf": [
-          {
-            "key": "style",
-            "in": [
-              "cookie"
-            ]
-          },
-          {
-            "key": "styleLocked",
-            "in": [
-              "cookie"
-            ]
-          }
+        "key": "style",
+        "in": [
+          "cookie"
         ]
       },
       "group": "Cookie clock",
@@ -452,19 +288,9 @@
       "icon": "brightness_7",
       "default": false,
       "visibleWhen": {
-        "anyOf": [
-          {
-            "key": "style",
-            "in": [
-              "cookie"
-            ]
-          },
-          {
-            "key": "styleLocked",
-            "in": [
-              "cookie"
-            ]
-          }
+        "key": "style",
+        "in": [
+          "cookie"
         ]
       },
       "group": "Cookie clock",
@@ -477,19 +303,9 @@
       "icon": "timer_10",
       "default": true,
       "visibleWhen": {
-        "anyOf": [
-          {
-            "key": "style",
-            "in": [
-              "cookie"
-            ]
-          },
-          {
-            "key": "styleLocked",
-            "in": [
-              "cookie"
-            ]
-          }
+        "key": "style",
+        "in": [
+          "cookie"
         ]
       },
       "group": "Cookie clock",
@@ -502,19 +318,9 @@
       "icon": "graph_6",
       "default": "full",
       "visibleWhen": {
-        "anyOf": [
-          {
-            "key": "style",
-            "in": [
-              "cookie"
-            ]
-          },
-          {
-            "key": "styleLocked",
-            "in": [
-              "cookie"
-            ]
-          }
+        "key": "style",
+        "in": [
+          "cookie"
         ]
       },
       "choices": [
@@ -549,19 +355,9 @@
       "icon": "highlighter_size_2",
       "default": "fill",
       "visibleWhen": {
-        "anyOf": [
-          {
-            "key": "style",
-            "in": [
-              "cookie"
-            ]
-          },
-          {
-            "key": "styleLocked",
-            "in": [
-              "cookie"
-            ]
-          }
+        "key": "style",
+        "in": [
+          "cookie"
         ]
       },
       "choices": [
@@ -596,19 +392,9 @@
       "icon": "eraser_size_1",
       "default": "medium",
       "visibleWhen": {
-        "anyOf": [
-          {
-            "key": "style",
-            "in": [
-              "cookie"
-            ]
-          },
-          {
-            "key": "styleLocked",
-            "in": [
-              "cookie"
-            ]
-          }
+        "key": "style",
+        "in": [
+          "cookie"
         ]
       },
       "choices": [
@@ -648,19 +434,9 @@
       "icon": "pen_size_1",
       "default": "dot",
       "visibleWhen": {
-        "anyOf": [
-          {
-            "key": "style",
-            "in": [
-              "cookie"
-            ]
-          },
-          {
-            "key": "styleLocked",
-            "in": [
-              "cookie"
-            ]
-          }
+        "key": "style",
+        "in": [
+          "cookie"
         ]
       },
       "choices": [
@@ -695,19 +471,9 @@
       "icon": "date_range",
       "default": "bubble",
       "visibleWhen": {
-        "anyOf": [
-          {
-            "key": "style",
-            "in": [
-              "cookie"
-            ]
-          },
-          {
-            "key": "styleLocked",
-            "in": [
-              "cookie"
-            ]
-          }
+        "key": "style",
+        "in": [
+          "cookie"
         ]
       },
       "choices": [
@@ -742,19 +508,9 @@
       "icon": "screen_rotation",
       "default": "vertical",
       "visibleWhen": {
-        "anyOf": [
-          {
-            "key": "style",
-            "in": [
-              "pixel"
-            ]
-          },
-          {
-            "key": "styleLocked",
-            "in": [
-              "pixel"
-            ]
-          }
+        "key": "style",
+        "in": [
+          "pixel"
         ]
       },
       "choices": [

--- a/dots/.config/quickshell/imi/modules/common/plugins/layout_surfaces.js
+++ b/dots/.config/quickshell/imi/modules/common/plugins/layout_surfaces.js
@@ -280,3 +280,80 @@ function withoutLockLayout(state, screenName) {
     next.lockPositions = lock;
     return next;
 }
+
+// ---- options, forked per KEY -----------------------------------------------
+//
+// A widget's own settings were the one thing that did not fork: position,
+// span and presence each had a lock store, but `pluginOptions[id][key]` was
+// read by the same object on both surfaces (the lock has no widget host of
+// its own - the desktop's widget is cross-faded), so a resource monitor
+// rotated for the lock screen was rotated on the desktop too (the
+// maintainer's report, 2026-09-03).
+//
+// `lockOptions[id][key]` sits beside `pluginOptions` in the same shape, and
+// inherits PER KEY: a key present there is the lock's own value, a key absent
+// reads through to the desktop's. Not the layout's whole-screen snapshot, on
+// purpose - a user who rotates the monitor for the lock still wants its blur
+// to follow the desktop, and "which keys I changed for the lock" is the model
+// the Settings switch shows and its Reset undoes. Writing null removes the
+// lock key, which is the re-inherit.
+//
+// A few keys are policy rather than look and never fork: Edit Mode's pin and
+// click-through have one writer and one meaning, and the span has its own
+// surface path (rawGridSize). Asked on the lock they answer the desktop.
+
+var SHARED_OPTION_KEYS = ["positionLocked", "clickThrough", "__gridSize"];
+
+function isSharedOptionKey(key) {
+    return SHARED_OPTION_KEYS.indexOf(key) !== -1;
+}
+
+// The stored value for a widget's option on a surface, or undefined - the
+// caller supplies the manifest default, as PluginState.option always has.
+function rawOption(state, surface, pluginId, key) {
+    if (!state || !pluginId || !key)
+        return undefined;
+    if (surface === LOCK && !isSharedOptionKey(key)) {
+        var lockPlugin = isMap(state.lockOptions) ? state.lockOptions[pluginId] : undefined;
+        if (isMap(lockPlugin) && lockPlugin[key] !== undefined)
+            return lockPlugin[key];
+    }
+    var plugin = isMap(state.pluginOptions) ? state.pluginOptions[pluginId] : undefined;
+    return isMap(plugin) ? plugin[key] : undefined;
+}
+
+// The next state after writing one option on one surface. A lock write of a
+// forkable key lands in the overlay; everything else is the desktop write
+// PluginState.setOption always did, null removing the key. Never mutates the
+// state passed in.
+function withOption(state, surface, pluginId, key, value) {
+    var next = Object.assign({}, state || {});
+    var storeName = (surface === LOCK && !isSharedOptionKey(key)) ? "lockOptions" : "pluginOptions";
+    var store = Object.assign({}, next[storeName] || {});
+    var plugin = Object.assign({}, store[pluginId] || {});
+    if (value === null || value === undefined) delete plugin[key];
+    else plugin[key] = value;
+    store[pluginId] = plugin;
+    next[storeName] = store;
+    return next;
+}
+
+// Has this widget any setting of its own on the lock? An empty map is not a
+// fork - every key still reads through.
+function isOptionsForked(state, pluginId) {
+    var lockPlugin = state && isMap(state.lockOptions) ? state.lockOptions[pluginId] : undefined;
+    return isMap(lockPlugin) && Object.keys(lockPlugin).length > 0;
+}
+
+// The next state after re-linking one widget's lock settings to the desktop's:
+// its lock map goes. Unchanged (same object) when there was nothing to drop.
+function withoutLockOptions(state, pluginId) {
+    var lock = state && state.lockOptions;
+    if (!isMap(lock) || !(pluginId in lock))
+        return state;
+    var next = Object.assign({}, state);
+    var nextLock = Object.assign({}, lock);
+    delete nextLock[pluginId];
+    next.lockOptions = nextLock;
+    return next;
+}

--- a/dots/.config/quickshell/imi/scripts/presets.sh
+++ b/dots/.config/quickshell/imi/scripts/presets.sh
@@ -50,6 +50,7 @@ case "$action" in
                 desktopPositions: (.desktopPositions // {}),
                 lockPositions: (.lockPositions // {}),
                 lockPresence: (.lockPresence // null),
+                lockOptions: (.lockOptions // {}),
                 pluginOptions: (.pluginOptions // {})
             }' 2>/dev/null)" || plugin_state=""
         else
@@ -61,9 +62,10 @@ case "$action" in
             desktopPositions: (.desktopPositions // {}),
             lockPositions: (.lockPositions // {}),
             lockPresence: (.lockPresence // null),
+            lockOptions: (.lockOptions // {}),
             pluginOptions: (.pluginOptions // {})
         }' "$PLUGIN_STATE_FILE" 2>/dev/null \
-            || printf '{"version":2,"desktopPositions":{},"lockPositions":{},"lockPresence":null,"pluginOptions":{}}')"
+            || printf '{"version":2,"desktopPositions":{},"lockPositions":{},"lockPresence":null,"lockOptions":{},"pluginOptions":{}}')"
         fi
         # A preset is a document people SHARE, and `config.json` holds the
         # user's own OpenWeatherMap key. Saving one used to copy it verbatim,
@@ -139,10 +141,11 @@ case "$action" in
                 desktopPositions: (.desktopPositions // {}),
                 lockPositions: (.lockPositions // {}),
                 lockPresence: (.lockPresence // null),
+                lockOptions: (.lockOptions // {}),
                 pluginOptions: (.pluginOptions // {}),
                 presetPersist: (.presetPersist // {})
             }' "$PLUGIN_STATE_FILE" 2>/dev/null \
-                || printf '{"version":2,"desktopPositions":{},"lockPositions":{},"lockPresence":null,"pluginOptions":{},"presetPersist":{}}')"
+                || printf '{"version":2,"desktopPositions":{},"lockPositions":{},"lockPresence":null,"lockOptions":{},"pluginOptions":{},"presetPersist":{}}')"
             # Top-level merging keeps fields omitted by older position-only
             # presets, while a new preset's complete maps replace current state.
             jq -n --argjson current "$current_plugin_state" --argjson preset "$preset_plugin_state" \
@@ -161,11 +164,17 @@ case "$action" in
                     | .pluginOptions = (if ($preset | has("pluginOptions"))
                         then ($preset.pluginOptions // {})
                         else ($current.pluginOptions // {}) end)
+                    | .lockOptions = (if ($preset | has("lockOptions"))
+                        then ($preset.lockOptions // {})
+                        else ($current.lockOptions // {}) end)
                     | .presetPersist = ($current.presetPersist // {})
                     | reduce $persistIds[] as $id (.;
                         (if ($current.pluginOptions // {}) | has($id)
                          then .pluginOptions[$id] = $current.pluginOptions[$id]
                          else .pluginOptions |= del(.[$id]) end)
+                        | (if ($current.lockOptions // {}) | has($id)
+                         then .lockOptions[$id] = $current.lockOptions[$id]
+                         else .lockOptions |= del(.[$id]) end)
                         | ($current.desktopPositions // {}) as $cpos
                         | .desktopPositions = (reduce (((.desktopPositions // {}) + $cpos) | keys_unsorted[]) as $screen (.desktopPositions // {};
                             if ($cpos[$screen] // {}) | has($id)

--- a/dots/.config/quickshell/imi/tests/imports/qs/GlobalStates.qml
+++ b/dots/.config/quickshell/imi/tests/imports/qs/GlobalStates.qml
@@ -5,5 +5,9 @@ import Quickshell
 
 Singleton {
     property bool screenLocked: false
+    // The lock look, as PluginState.currentSurface reads it: a test flips
+    // this to move the default surface to the lock.
+    property bool editLockPreview: false
+    property bool lockLookActive: screenLocked || editLockPreview
     property bool editMode: false
 }

--- a/dots/.config/quickshell/imi/tests/test_clock_options_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_clock_options_contract.py
@@ -28,7 +28,7 @@ ROOT = Path(__file__).resolve().parent.parent
 MANIFEST = ROOT / "modules/common/plugins/bundled/clock/manifest.json"
 STYLES = ("digital", "cookie", "pixel")
 # Rows every style shares. Anything else must name a style.
-SHARED = {"style", "styleLocked", "showOnlyWhenLocked", "quoteEnable", "quoteFollowClock", "quoteText"}
+SHARED = {"style", "showOnlyWhenLocked", "quoteEnable", "quoteFollowClock", "quoteText"}
 # Rows whose key does not carry the style they belong to.
 STYLE_OF = {"color": "digital"}
 
@@ -50,12 +50,15 @@ def expected_style(key: str):
 
 
 def matches(rule, style: str) -> bool:
-    """Whether `rule` is exactly 'style == S on either key'."""
-    branches = rule.get("anyOf") if isinstance(rule, dict) else None
-    if not isinstance(branches, list) or len(branches) != 2:
-        return False
-    keys = sorted(b.get("key") for b in branches if isinstance(b, dict))
-    return keys == ["style", "styleLocked"] and all(b.get("in") == [style] for b in branches)
+    """Whether `rule` is exactly 'style == S'.
+
+    One key, since 2026-09-03: the lock's style is the `style` option on the
+    lock surface (PluginState.option with a surface), and Settings evaluates
+    the rule against the surface its switch names - so the old
+    'style OR styleLocked' pair would show digital rows on a cookie desktop
+    whenever the lock was digital, which is the wrong surface's answer.
+    """
+    return isinstance(rule, dict) and rule.get("key") == "style" and rule.get("in") == [style]
 
 
 def test_every_style_bound_row_is_gated_on_its_style():

--- a/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
@@ -1579,9 +1579,20 @@ def test_the_clock_previews_its_locked_look_through_one_derivation():
     assert re.search(r"readonly property bool lockLook:\s*GlobalStates\.screenLocked"
                      r"\s*\n?\s*\|\|\s*GlobalStates\.editLockPreview", clock), \
         "the clock no longer derives its locked look once"
+    # The STYLE is the one of the four that no longer reads `lockLook`: since
+    # widget options fork per surface (2026-09-03) it is the plain `style`
+    # option, and PluginState.option's default surface is currentSurface,
+    # which reads GlobalStates.lockLookActive - the same derivation, one
+    # level down, shared with every position read. A second local selector
+    # here would be the twin the fold-in removed.
+    assert re.search(r'readonly property string style:\s*PluginState\.option\("clock", "style", "cookie"\)', clock), \
+        "the clock's style must be the plain option, read on the current surface"
+    assert re.search(r"clockStyle:\s*root\.style\b", clock), \
+        "the clock's clockStyle is the style option, not a lock-look selector"
+    assert "styleLocked" not in clock.replace("`styleLocked`", ""), \
+        "the clock must not grow its second style key back"
     for name, pattern in (
             ("forceCenter", r"forceCenter:\s*root\.lockLook"),
-            ("clockStyle", r"clockStyle:\s*root\.lockLook"),
             ("shouldShow", r"shouldShow:\s*!root\.showOnlyWhenLocked\s*\|\|\s*root\.lockLook"),
             ("the Locked caption", r"shown:\s*root\.lockLook\s*&&\s*Config\.options\.lock\.showLockedText")):
         assert re.search(pattern, clock), \

--- a/dots/.config/quickshell/imi/tests/test_layout_surfaces_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_layout_surfaces_contract.py
@@ -103,6 +103,51 @@ def test_every_undoable_position_write_captures_its_surface_at_push_time():
         "the re-link must be undoable"
 
 
+def test_every_widget_option_read_and_write_names_its_surface():
+    # A widget's own settings fork per surface too (2026-09-03: the resource
+    # monitor rotated for the lock screen was rotated on the desktop). The
+    # store's accessors take a trailing surface with the position API's
+    # default; Settings names its surface on EVERY call, because its switch
+    # and not the look the desktop is showing is what the user pressed.
+    state = code(STATE)
+    for fn in ("option", "setOption"):
+        sig = re.search(rf"function {fn}\(([^)]*)\)", state)
+        assert sig and "surface" in sig.group(1), \
+            f"PluginState.{fn} must take an explicit surface parameter"
+    assert "Surfaces.rawOption(root.state, surface ?? root.currentSurface" in state, \
+        "option() must read through layout_surfaces.rawOption on the default surface"
+    assert "Surfaces.withOption(root.state, surface ?? root.currentSurface" in state, \
+        "setOption() must write through layout_surfaces.withOption on the default surface"
+    assert re.search(r"lockOptions: parsed\.lockOptions", state), \
+        "loadText must carry lockOptions, or a restart forgets every lock setting"
+
+    options = code(ROOT / "modules/common/plugins/PluginOptions.qml")
+    assert 'property string surface: PluginState.desktopSurface' in options, \
+        "PluginOptions must own the surface its rows edit"
+    calls = re.findall(r"PluginState\.(?:option|setOption)\([^;]*?\)", options, re.S)
+    assert len(calls) >= 15, f"expected the card's reads and writes, found {len(calls)}"
+    naked = [call for call in calls if "root.surface" not in call]
+    assert naked == [], \
+        "every PluginOptions read and write must pass root.surface:\n" + "\n".join(naked)
+    assert "Surfaces.isSharedOptionKey(modelData.key)" in options, \
+        "the lock card must hide the shared policy toggles"
+    assert "(!root.onLock && root.offeredSizes.length > 1)" in options, \
+        "the lock card offers no size row - the lock's span lives in its layout record"
+
+    presets = read(ROOT / "scripts/presets.sh")
+    assert presets.count("lockOptions: (.lockOptions // {})") == 3, \
+        "presets.sh must capture lockOptions in every state shape it builds"
+    assert 'if ($preset | has("lockOptions"))' in presets, \
+        "presets.sh must apply lockOptions under the has() rule lockPositions follows"
+    assert ".lockOptions[$id] = $current.lockOptions[$id]" in presets, \
+        "the presetPersist carve-out must shield a plugin's lock settings too"
+
+    widget = code(WIDGET)
+    for key in ("positionLocked", "clickThrough"):
+        assert re.search(rf'PluginState\.option\(manifest\.id, "{key}", [^)]*\)\n', widget), \
+            f"PluginWidget reads {key} with no surface - it is a shared key and must stay so"
+
+
 def test_every_span_read_and_write_goes_through_the_surface_api():
     # The span forks with the position: a widget at 3x2 on the desktop and
     # 1x2 on the lock (the report) needs the lock's span in the lock record.

--- a/dots/.config/quickshell/imi/tests/test_layout_surfaces_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_layout_surfaces_contract.py
@@ -131,7 +131,7 @@ def test_every_widget_option_read_and_write_names_its_surface():
         "every PluginOptions read and write must pass root.surface:\n" + "\n".join(naked)
     assert "Surfaces.isSharedOptionKey(modelData.key)" in options, \
         "the lock card must hide the shared policy toggles"
-    assert "(!root.onLock && root.offeredSizes.length > 1)" in options, \
+    assert "root.onLock ? [] : GridSizes.offeredSizes(manifest.grid)" in options, \
         "the lock card offers no size row - the lock's span lives in its layout record"
 
     presets = read(ROOT / "scripts/presets.sh")

--- a/dots/.config/quickshell/imi/tests/test_plugin_options_sections.py
+++ b/dots/.config/quickshell/imi/tests/test_plugin_options_sections.py
@@ -190,8 +190,10 @@ class TheHostBooleansAreAToggleBar(unittest.TestCase):
         self.assertIsNone(
             re.search(r"\btoggled\s*=(?![=~])", self.source),
             "a toggle assigns to `toggled` - that is the binding destroyed by hand")
+        # The surface is named on the read and the write alike: the card's
+        # Desktop / Lock screen switch, not the look the desktop is showing.
         self.assertIn("toggled: PluginState.option(root.manifest.id, modelData.key, "
-                      "modelData.default)", self.section)
+                      "modelData.default, root.surface)", self.section)
         self.assertIn("PluginState.setOption(root.manifest.id, modelData.key,", self.section)
         self.assertIn("toggled: PluginState.presetPersisted(root.manifest.id)", self.section)
         self.assertIn("PluginState.setPresetPersist(root.manifest.id,", self.section)

--- a/dots/.config/quickshell/imi/tests/test_presets.py
+++ b/dots/.config/quickshell/imi/tests/test_presets.py
@@ -311,6 +311,56 @@ class PresetTests(unittest.TestCase):
             self.assertEqual(after_old["lockPositions"]["DP-1"]["clock"]["x"], 900,
                              "a preset without lockPositions must not wipe the user's fork")
 
+    def test_the_lock_widget_options_round_trip_and_an_old_preset_keeps_the_overlay(self):
+        """A widget's settings fork per surface (2026-09-03): `lockOptions`
+        rides beside `pluginOptions` under the same `has()` rule as
+        `lockPositions`, and the presetPersist carve-out shields a plugin's
+        lock settings the way it shields its desktop ones."""
+        forked = {
+            "version": 2,
+            "desktopPositions": {},
+            "lockPositions": {},
+            "pluginOptions": {"monitor": {"vertical": False}, "clock": {"style": "pixel"}},
+            "lockOptions": {"monitor": {"vertical": True}},
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            config_dir, state_file, presets, env = self._sandbox(Path(directory), forked)
+
+            subprocess.run(["bash", str(presets), "--save", "forked"], env=env, check=True)
+            preset = json.loads((config_dir / "presets/forked.json").read_text())
+            self.assertTrue(preset["_pluginState"]["lockOptions"]["monitor"]["vertical"],
+                            "a saved preset must carry the lock screen's widget options")
+
+            state_file.write_text(json.dumps({
+                "version": 2, "desktopPositions": {}, "lockPositions": {},
+                "pluginOptions": {"monitor": {"vertical": True}},
+                "lockOptions": {"monitor": {"vertical": False}, "clock": {"style": "digital"}},
+            }))
+            subprocess.run(["bash", str(presets), "--apply", "forked"], env=env, check=True)
+            restored = json.loads(state_file.read_text())
+            self.assertFalse(restored["pluginOptions"]["monitor"]["vertical"])
+            self.assertTrue(restored["lockOptions"]["monitor"]["vertical"])
+            self.assertNotIn("clock", restored["lockOptions"], "a preset's complete map replaces the current one")
+
+            old = json.loads((config_dir / "presets/forked.json").read_text())
+            del old["_pluginState"]["lockOptions"]
+            (config_dir / "presets/older.json").write_text(json.dumps(old))
+            state_file.write_text(json.dumps(forked))
+            subprocess.run(["bash", str(presets), "--apply", "older"], env=env, check=True)
+            after_old = json.loads(state_file.read_text())
+            self.assertTrue(after_old["lockOptions"]["monitor"]["vertical"],
+                            "a preset without lockOptions must not wipe the user's lock settings")
+
+            # presetPersist shields the plugin's LOCK settings too.
+            shielded = dict(forked, presetPersist={"monitor": True},
+                            lockOptions={"monitor": {"vertical": False}, "other": {"a": 1}})
+            state_file.write_text(json.dumps(shielded))
+            subprocess.run(["bash", str(presets), "--apply", "forked"], env=env, check=True)
+            after = json.loads(state_file.read_text())
+            self.assertFalse(after["lockOptions"]["monitor"]["vertical"],
+                             "a persisted plugin keeps its current lock settings through apply")
+            self.assertNotIn("other", after["lockOptions"])
+
     def test_the_lock_widget_choice_round_trips_and_an_old_preset_keeps_the_fork(self):
         """The other half of the same fork: WHICH widgets the lock shows.
 

--- a/dots/.config/quickshell/imi/tests/tst_layout_surfaces.qml
+++ b/dots/.config/quickshell/imi/tests/tst_layout_surfaces.qml
@@ -270,4 +270,75 @@ TestCase {
         verify(!Surfaces.isForked(undefined, "DP-1"));
         verify(!Surfaces.isForked({ lockPositions: [] }, "DP-1"));
     }
+
+    // ---- options, forked per KEY -------------------------------------------
+
+    readonly property var optionsState: ({
+        pluginOptions: { monitor: { vertical: false, blurEnabled: true, positionLocked: true } },
+        lockOptions: { monitor: { vertical: true } }
+    })
+
+    function test_a_lock_option_reads_its_own_key_and_inherits_the_rest() {
+        compare(Surfaces.rawOption(optionsState, Surfaces.LOCK, "monitor", "vertical"), true);
+        compare(Surfaces.rawOption(optionsState, Surfaces.LOCK, "monitor", "blurEnabled"), true);
+        compare(Surfaces.rawOption(optionsState, Surfaces.DESKTOP, "monitor", "vertical"), false);
+        compare(Surfaces.rawOption(optionsState, Surfaces.LOCK, "monitor", "missing"), undefined);
+        compare(Surfaces.rawOption(optionsState, Surfaces.LOCK, "other", "vertical"), undefined);
+        compare(Surfaces.rawOption({}, Surfaces.LOCK, "monitor", "vertical"), undefined);
+        compare(Surfaces.rawOption(optionsState, Surfaces.LOCK, "", "vertical"), undefined);
+    }
+
+    function test_a_shared_key_never_forks() {
+        verify(Surfaces.isSharedOptionKey("positionLocked"));
+        verify(Surfaces.isSharedOptionKey("clickThrough"));
+        verify(Surfaces.isSharedOptionKey("__gridSize"));
+        verify(!Surfaces.isSharedOptionKey("vertical"));
+        verify(!Surfaces.isSharedOptionKey("blurEnabled"));
+        const pinned = Surfaces.withOption(optionsState, Surfaces.LOCK, "monitor", "positionLocked", false);
+        compare(pinned.pluginOptions.monitor.positionLocked, false);
+        compare(pinned.lockOptions.monitor.positionLocked, undefined);
+        // A lock map that somehow carries one (an older file, a hand edit)
+        // is ignored: the desktop's answer is the only answer.
+        const stray = { pluginOptions: { m: { positionLocked: true } }, lockOptions: { m: { positionLocked: false } } };
+        compare(Surfaces.rawOption(stray, Surfaces.LOCK, "m", "positionLocked"), true);
+    }
+
+    function test_a_lock_write_lands_in_the_overlay_and_leaves_the_desktop_alone() {
+        const next = Surfaces.withOption(optionsState, Surfaces.LOCK, "monitor", "blurEnabled", false);
+        compare(next.lockOptions.monitor.blurEnabled, false);
+        compare(next.pluginOptions.monitor.blurEnabled, true);
+        compare(next.lockOptions.monitor.vertical, true);
+        verify(next !== optionsState);
+        compare(optionsState.lockOptions.monitor.blurEnabled, undefined);
+        const desktop = Surfaces.withOption(optionsState, Surfaces.DESKTOP, "monitor", "blurEnabled", false);
+        compare(desktop.pluginOptions.monitor.blurEnabled, false);
+        compare(desktop.lockOptions.monitor.blurEnabled, undefined);
+        const fresh = Surfaces.withOption({}, Surfaces.LOCK, "clock", "style", "pixel");
+        compare(fresh.lockOptions.clock.style, "pixel");
+        compare(fresh.pluginOptions, undefined);
+    }
+
+    function test_null_re_inherits_on_the_lock_and_removes_on_the_desktop() {
+        const re = Surfaces.withOption(optionsState, Surfaces.LOCK, "monitor", "vertical", null);
+        compare(Surfaces.rawOption(re, Surfaces.LOCK, "monitor", "vertical"), false);
+        verify(!Surfaces.isOptionsForked(re, "monitor"));
+        const gone = Surfaces.withOption(optionsState, Surfaces.DESKTOP, "monitor", "vertical", null);
+        compare(gone.pluginOptions.monitor.vertical, undefined);
+        compare(Surfaces.rawOption(gone, Surfaces.LOCK, "monitor", "vertical"), true);
+    }
+
+    function test_forked_options_are_answered_and_reset_per_plugin() {
+        verify(Surfaces.isOptionsForked(optionsState, "monitor"));
+        verify(!Surfaces.isOptionsForked(optionsState, "other"));
+        verify(!Surfaces.isOptionsForked({ lockOptions: { m: {} } }, "m"));
+        verify(!Surfaces.isOptionsForked({ lockOptions: ["m"] }, "m"));
+        verify(!Surfaces.isOptionsForked(undefined, "m"));
+        const reset = Surfaces.withoutLockOptions(optionsState, "monitor");
+        compare(Surfaces.rawOption(reset, Surfaces.LOCK, "monitor", "vertical"), false);
+        compare(reset.pluginOptions.monitor.vertical, false);
+        compare(optionsState.lockOptions.monitor.vertical, true);
+        verify(Surfaces.withoutLockOptions(optionsState, "other") === optionsState);
+        const empty = {};
+        verify(Surfaces.withoutLockOptions(empty, "monitor") === empty);
+    }
 }

--- a/dots/.config/quickshell/imi/tests/tst_plugin_state.qml
+++ b/dots/.config/quickshell/imi/tests/tst_plugin_state.qml
@@ -1,7 +1,9 @@
 import QtQuick
 import QtTest
+import qs
 import qs.modules.common
 import qs.modules.common.plugins
+import "../modules/common/plugins/layout_surfaces.js" as Surfaces
 
 TestCase {
     name: "PluginStateTest"
@@ -20,6 +22,11 @@ TestCase {
         // leaves every later test reading a fork it did not make.
         Config.options.plugins.enabled = savedEnabled;
         PluginState.resetLockPresence();
+        // Options fork per plugin, not per test: drop the lock maps a test
+        // made, and put the default surface back on the desktop.
+        for (const id of ["surf_monitor", "surf_follow", "surf_shared"])
+            PluginState.resetLockOptions(id);
+        GlobalStates.editLockPreview = false;
     }
 
     function test_positionDefaultsWhenUnset() {
@@ -390,5 +397,81 @@ TestCase {
         const next = PluginState.stateWithSizeModesMigrated(state, [weatherManifest()]);
         compare(next.desktopPositions["DP-1"].nandoroid_weather.x, 12);
         compare(next.presetPersist.nandoroid_weather, true);
+    }
+
+    // ---- options, forked per surface ----------------------------------------
+
+    function test_aLockOptionInheritsTheDesktopUntilWritten() {
+        PluginState.setOption("surf_monitor", "vertical", false, PluginState.desktopSurface);
+        compare(PluginState.option("surf_monitor", "vertical", true, PluginState.lockSurface), false);
+        verify(!PluginState.lockOptionsForked("surf_monitor"));
+
+        PluginState.setOption("surf_monitor", "vertical", true, PluginState.lockSurface);
+        compare(PluginState.option("surf_monitor", "vertical", false, PluginState.lockSurface), true);
+        compare(PluginState.option("surf_monitor", "vertical", true, PluginState.desktopSurface), false);
+        verify(PluginState.lockOptionsForked("surf_monitor"));
+
+        PluginState.resetLockOptions("surf_monitor");
+        compare(PluginState.option("surf_monitor", "vertical", true, PluginState.lockSurface), false);
+        verify(!PluginState.lockOptionsForked("surf_monitor"));
+    }
+
+    function test_theDefaultSurfaceFollowsTheLockLook() {
+        // A caller that names no surface - every widget binding that predates
+        // the fork - reads and writes whichever face the desktop is showing.
+        compare(PluginState.currentSurface, PluginState.desktopSurface);
+        PluginState.setOption("surf_follow", "vertical", false);
+        GlobalStates.editLockPreview = true;
+        compare(PluginState.currentSurface, PluginState.lockSurface);
+        compare(PluginState.option("surf_follow", "vertical", true), false);
+        PluginState.setOption("surf_follow", "vertical", true);
+        compare(PluginState.option("surf_follow", "vertical", false), true);
+        GlobalStates.editLockPreview = false;
+        compare(PluginState.option("surf_follow", "vertical", true), false);
+        compare(PluginState.option("surf_follow", "vertical", false, PluginState.lockSurface), true);
+    }
+
+    function test_aSharedKeyLandsOnTheDesktopFromEitherSurface() {
+        PluginState.setOption("surf_shared", "positionLocked", true, PluginState.lockSurface);
+        compare(PluginState.option("surf_shared", "positionLocked", false, PluginState.desktopSurface), true);
+        verify(!PluginState.lockOptionsForked("surf_shared"));
+    }
+
+    function test_loadTextKeepsALockOptionsMapAndDropsAList() {
+        PluginState.loadText(JSON.stringify({ version: 2, pluginOptions: { m: { vertical: false } },
+            lockOptions: { m: { vertical: true } } }));
+        compare(PluginState.option("m", "vertical", false, PluginState.lockSurface), true);
+        PluginState.loadText(JSON.stringify({ version: 2, lockOptions: ["m"] }));
+        compare(JSON.stringify(PluginState.state.lockOptions), "{}");
+        PluginState.loadText(JSON.stringify({ version: 2 }));
+        compare(JSON.stringify(PluginState.state.lockOptions), "{}");
+    }
+
+    // The clock's hand-rolled `styleLocked` folds into the lock overlay's
+    // `style`, and what every user sees on the lock today is what they see
+    // after: a stored second style that differs becomes the overlay, one
+    // that matches becomes nothing, and an ABSENT second style was the
+    // default "cookie" - which differs from a desktop that is not cookie.
+    function test_theClockStyleMigrationKeepsWhatTheLockShowed() {
+        let next = PluginState.stateWithClockStyleMigrated({
+            pluginOptions: { clock: { style: "digital", styleLocked: "pixel" } } });
+        compare(Surfaces.rawOption(next, Surfaces.LOCK, "clock", "style"), "pixel");
+        compare(next.pluginOptions.clock.styleLocked, undefined);
+        compare(next.pluginOptions.clock.style, "digital");
+        verify(next.migrations[PluginState.clockStyleMarker]);
+
+        next = PluginState.stateWithClockStyleMigrated({
+            pluginOptions: { clock: { style: "pixel", styleLocked: "pixel" } } });
+        compare(next.lockOptions, undefined);
+        compare(next.pluginOptions.clock.styleLocked, undefined);
+
+        next = PluginState.stateWithClockStyleMigrated({
+            pluginOptions: { clock: { style: "pixel" } } });
+        compare(Surfaces.rawOption(next, Surfaces.LOCK, "clock", "style"), "cookie");
+
+        next = PluginState.stateWithClockStyleMigrated({ pluginOptions: {} });
+        compare(next.lockOptions, undefined);
+        compare(next.pluginOptions.clock, undefined);
+        verify(next.migrations[PluginState.clockStyleMarker]);
     }
 }


### PR DESCRIPTION
Desktop widgets keep separate settings for the desktop and the lock screen.

**Root cause.** `plugin-state.json` had forked position (`lockPositions`), span and presence (`lockPresence`) per surface, but a widget's own settings stayed in the flat `pluginOptions[id][key]`, and `PluginState.option()` / `setOption()` were the only accessors that took no surface. The lock screen has no widget host of its own — `Background.qml` builds one widget per plugin per screen and cross-fades it under the lock look — so the desktop and lock "copies" of the resource monitor were one object reading one key: rotated for the lock, rotated on the desktop. The two monitors have no `grid`, so `vertical` was their whole shape. The only per-surface setting in the tree was the clock's hand-rolled `style` / `styleLocked` pair.

**The fourth fork.** `lockOptions[id][key]` sits beside `pluginOptions` and inherits **per key**: a key present there is the lock's own, one absent reads through, `null` re-inherits. Not the layout's whole-screen snapshot, on purpose — rotating the monitor for the lock should not stop its blur from following the desktop, and "which keys I changed" is what the Settings card shows and its Reset undoes. Policy keys never fork (`SHARED_OPTION_KEYS`: `positionLocked`, `clickThrough`, `__gridSize`). `option()` / `setOption()` take a trailing `surface` with the position API's `currentSurface` default, so every existing widget binding and in-widget knob follows the face the desktop is showing: the monitor's rotate button on the Lockscreen tab writes the lock's `vertical`, the desktop's binding re-evaluates when the look flips. Pure rules in `layout_surfaces.js`, driven bare by `tst_layout_surfaces.qml`.

**Settings.** Every widget card gets a Desktop / Lock screen switch; the rows name that surface on every read and write (the switch the user pressed, not the look). On the lock side the shared policy toggles, the preset-persist flag and the desktop's size row step aside; a caption says the lock follows the desktop until a setting is changed, and turns into "Reset to desktop" once one has.

**Clock.** `styleLocked` is retired: a one-shot migration folds it into the overlay's `style`, preserving what the lock showed (an absent second style was the row's `cookie` default, so a non-cookie desktop gets an overlay of `cookie` — verified on the maintainer's own file: desktop `pixel`, lock `cookie`, key gone). Data-driven as well as marked, because the legacy Config drain can deliver a `styleLocked` after the load-time pass. Every `digital*`/`cookie*`/`pixel*` row is gated on `style` alone, evaluated against the surface the switch names. PLUGINS.md tells authors to declare one option, never a `*Locked` twin.

**Presets** carry `lockOptions` under the `has()` rule `lockPositions` follows, with the persist carve-out shielding a plugin's lock settings too. No migration for the map: absence is the correct upgrade state.

**Tests.** 5 new pure-rule cases, 5 store cases (surface default via the mock's new `lockLookActive`, `loadText` shapes, the three migration cases), a preset round trip, the surface contract (accessor signatures, every `PluginOptions` call naming `root.surface`, presets, `loadText`, `PluginWidget`'s policy reads staying surface-less), and the clock/edit-mode/size-row/options-sections pins updated to the new truth. Suite green.

Docs: updated AGENT.md §Edit Mode (new entry after "PRESENCE forks under that same rule") and docs/PLUGINS.md (visibility rules paragraph)
Changelog: updated
