### PR TITLE
feat(widgets): a switch for desktop widget shadows, on by default

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -2695,7 +2695,10 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   is wrong, and would equally hide a real one.
   4046f1854 ("feat(widgets): the card casts a shadow, and lifts when handled").
 - **The elevation is a component of its own, and it is what a widget that is not a card reaches
-  for.** `WidgetElevation` owns the numbers, the hover/drag lift and the layer; `WidgetCard` hands
+  for.** `WidgetElevation` owns the numbers, the hover/drag lift and the layer (and the user's
+  own switch, `plugins.shadows` - Settings > Plugins > Widget shadows, on by default - is ONE gate
+  in its `shadowVisible`, beside the motion drop, never a flag callers pass down;
+  `tests/test_widget_shadow_toggle.py`); `WidgetCard` hands
   it the states and adds a surface. That split exists because five bundled widgets cannot be cards
   — a cookie dial, a punched glyph grid, a shape-masked image, and a card with an avatar bubble
   off its top edge — and each had carried its own `StyledDropShadow` at its own radius and colour

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,22 @@ own repo; the installer pins which revision it builds.
 
 ### Fixed
 - **Desktop widgets keep separate settings for the desktop and the lock
+### Added
+  screen.** Every widget card in Settings > Plugins has a Desktop / Lock
+  screen switch; a setting changed on the lock side applies to the lock
+  screen only and the rest keep following the desktop, with a "Reset to
+  desktop" to re-link. The widgets' own knobs (the system monitor's rotate
+  button, for one) write whichever surface they are used on. Presets carry
+  the lock side too.
+- **Widget shadows can be turned off.** Settings > Plugins > Widget settings
+  gains a "Widget shadows" switch, on by default; off, no desktop widget
+  casts one.
+
+### Changed
+- **The clock's "Clock style (locked)" row is gone.** Its value moved to the
+  lock side of the ordinary "Clock style" row; what the lock screen showed
+  is what it still shows.
+
   screen.** Rotating the System Monitor or GPU Monitor on Edit Mode's
   Lockscreen tab rotated it on the desktop too; every widget setting now
   follows the surface it is changed on, and the desktop's stays where it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,24 +12,13 @@ own repo; the installer pins which revision it builds.
 
 ## [Unreleased]
 
-### Fixed
-- **Desktop widgets keep separate settings for the desktop and the lock
 ### Added
-  screen.** Every widget card in Settings > Plugins has a Desktop / Lock
-  screen switch; a setting changed on the lock side applies to the lock
-  screen only and the rest keep following the desktop, with a "Reset to
-  desktop" to re-link. The widgets' own knobs (the system monitor's rotate
-  button, for one) write whichever surface they are used on. Presets carry
-  the lock side too.
 - **Widget shadows can be turned off.** Settings > Plugins > Widget settings
   gains a "Widget shadows" switch, on by default; off, no desktop widget
   casts one.
 
-### Changed
-- **The clock's "Clock style (locked)" row is gone.** Its value moved to the
-  lock side of the ordinary "Clock style" row; what the lock screen showed
-  is what it still shows.
-
+### Fixed
+- **Desktop widgets keep separate settings for the desktop and the lock
   screen.** Rotating the System Monitor or GPU Monitor on Edit Mode's
   Lockscreen tab rotated it on the desktop too; every widget setting now
   follows the surface it is changed on, and the desktop's stays where it

--- a/dots/.config/quickshell/imi/modules/common/Config.qml
+++ b/dots/.config/quickshell/imi/modules/common/Config.qml
@@ -574,6 +574,10 @@ Singleton {
                 //            the widget (samples the live Wallpaper Engine surface
                 //            or the static image)
                 property string frostMode: "blur"
+                // Whether desktop widgets cast their shadow (WidgetElevation,
+                // the one shadow a widget casts). On by default; off is one
+                // gate at that one place, whatever a widget passes down.
+                property bool shadows: true
                 // Set once the built-in desktop widgets have been
                 // translated into `enabled`. Without it the migration
                 // re-adds a widget on every launch and the user can never

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/WidgetElevation.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/WidgetElevation.qml
@@ -38,7 +38,11 @@ Item {
     // does: re-rendering a blurred copy of the body every frame of a morph is
     // the expensive path, and the body is moving too fast to read a shadow.
     property bool motionActive: false
+    // ...and the user's own switch (Settings > Plugins > Widget shadows)
+    // sits above both: one gate here, at the one shadow every widget casts,
+    // rather than a flag every caller has to remember to pass down.
     readonly property bool shadowVisible: root.shadowEnabled && !root.motionActive
+        && Config.options.plugins.shadows
 
     property real bleed: Tension.BOW_PX * 2
 

--- a/dots/.config/quickshell/imi/modules/imi/settings/pages/PluginsPage.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/pages/PluginsPage.qml
@@ -149,6 +149,14 @@ Item {
                         ]
                     }
 
+                    ConfigSwitch {
+                        buttonIcon: "ev_shadow"
+                        text: Translation.tr("Widget shadows")
+                        description: Translation.tr("Desktop widgets cast a shadow on the wallpaper")
+                        checked: Config.options.plugins.shadows
+                        onToggleRequested: Config.options.plugins.shadows = !Config.options.plugins.shadows
+                    }
+
                     // Widgets can take the shell's opacity - Settings > Quick's
                     // "Shell opacity", what the bar, the sidebars and the dock
                     // draw at - instead of their own slider, which then shows

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -1556,6 +1556,14 @@ if ! python3 "$SCRIPT_DIR/test_bluetooth_battery_widget.py"; then
     exit 1
 fi
 
+# Desktop widget shadows have one switch, gating the one shadow every widget
+# casts (WidgetElevation), on by default.
+echo "Running widget shadow toggle tests..."
+if ! python3 "$SCRIPT_DIR/test_widget_shadow_toggle.py"; then
+    echo "Widget shadow toggle tests failed."
+    exit 1
+fi
+
 # WHEN the settings host builds its fifteen pages. It used to build all of them
 # synchronously in one turn at Config.ready - 622ms of frozen GUI thread paid by
 # the whole shell at startup, measured on the harness's own heartbeat, and

--- a/dots/.config/quickshell/imi/tests/test_widget_shadow_toggle.py
+++ b/dots/.config/quickshell/imi/tests/test_widget_shadow_toggle.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Desktop widget shadows have one switch, and it sits at the one shadow.
+
+The maintainer asked (2026-09-03) for a toggle to enable or disable desktop
+widget shadows, on by default. `WidgetElevation` is the one shadow a widget
+casts (AGENT.md), so the switch is one gate there - in `shadowVisible`,
+beside the motion drop - rather than a flag every widget would have to pass
+down and the next widget would forget. The setting is `plugins.shadows`,
+defaulting to true so an upgrade changes nothing, and its row lives with the
+other widget-wide settings on Settings > Plugins.
+"""
+
+from pathlib import Path
+import re
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONFIG = ROOT / "modules/common/Config.qml"
+ELEVATION = ROOT / "modules/common/plugins/designsystem/widgets/WidgetElevation.qml"
+PAGE = ROOT / "modules/imi/settings/pages/PluginsPage.qml"
+
+
+def code(path):
+    return re.sub(r"//.*", "", path.read_text(encoding="utf-8"))
+
+
+class WidgetShadowToggleTests(unittest.TestCase):
+    def test_the_setting_defaults_on(self):
+        plugins = code(CONFIG).split("property JsonObject plugins:", 1)[1].split("\n            }", 1)[0]
+        self.assertIn("property bool shadows: true", plugins,
+                      "plugins.shadows must exist and default on, so an upgrade changes nothing")
+
+    def test_the_gate_is_at_the_one_shadow(self):
+        elevation = code(ELEVATION)
+        gate = re.search(r"readonly property bool shadowVisible:\s*(.*?)\n\n", elevation, re.S)
+        self.assertIsNotNone(gate, "WidgetElevation.shadowVisible must exist")
+        self.assertIn("Config.options.plugins.shadows", gate.group(1),
+                      "the switch gates shadowVisible - the one place every widget's shadow is drawn")
+        self.assertIn("root.shadowEnabled", gate.group(1))
+        self.assertIn("!root.motionActive", gate.group(1))
+        # No second gate anywhere else: a caller-side copy is the one that drifts.
+        others = [p for p in (ROOT / "modules").rglob("*.qml")
+                  if p != ELEVATION and "Config.options.plugins.shadows" in code(p) and p != PAGE]
+        self.assertEqual(others, [], "plugins.shadows is read in one place")
+
+    def test_the_row_is_an_intent_on_the_plugins_page(self):
+        page = code(PAGE)
+        row = re.search(r'ConfigSwitch \{[^}]*Translation\.tr\("Widget shadows"\)[^}]*\}', page, re.S)
+        self.assertIsNotNone(row, "Settings > Plugins needs a Widget shadows switch")
+        self.assertIn("checked: Config.options.plugins.shadows", row.group(0))
+        self.assertIn("onToggleRequested: Config.options.plugins.shadows = !Config.options.plugins.shadows",
+                      row.group(0), "ConfigSwitch writes back through onToggleRequested, never by assigning checked")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A switch for desktop widget shadows, on by default.

`plugins.shadows` gates `WidgetElevation.shadowVisible` — the one shadow every desktop widget casts — beside the motion drop, so every widget follows it without a flag passed down and the next widget cannot forget one. The row lives with the other widget-wide settings on Settings > Plugins > Widget settings. Default `true`, so an upgrade changes nothing.

`test_widget_shadow_toggle.py` pins the default, the single gate (and that nothing else reads the key), and the row writing through `onToggleRequested`; proven to fail on `main`.

Docs: updated AGENT.md §Design system ("The elevation is a component of its own" entry)
Changelog: updated
