### PR TITLE
fix(settings): the surface selector is Edit Mode's tab, never a control on the widget

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -4424,35 +4424,32 @@ mode is built out of are worth not re-deriving:
   feat(plugins): a widget's presence is asked per surface, not once;
   feat(editMode): the Lock section picks which widgets the lock screen shows.)
 - **A widget's own SETTINGS fork per surface too — per key, under `lockOptions`, and the
-  accessors take the surface.** Position, span and presence each had a lock store; the widget's
-  options stayed in the flat `pluginOptions[id][key]`, and since the lock screen has no widget
-  host of its own (the desktop's widget is cross-faded by `AbstractBackgroundWidget`), the desktop
-  and lock "copies" of the resource monitor were one object reading one key — rotated for the
-  lock, rotated on the desktop (the maintainer's report, 2026-09-03). `lockOptions[id][key]` sits
-  beside `pluginOptions` and inherits PER KEY: present is the lock's own, absent reads through,
-  `null` re-inherits. Not the layout's whole-screen snapshot, on purpose — a user who rotates the
-  monitor for the lock still wants its blur to follow the desktop, and "which keys I changed" is
-  what the Settings card shows and its Reset undoes. Three keys never fork
+  accessors take the surface; the surface SELECTOR is Edit Mode's tab, never a control on the
+  widget.** Position, span and presence each had a lock store; the widget's options stayed in the
+  flat `pluginOptions[id][key]`, and since the lock screen has no widget host of its own (the
+  desktop's widget is cross-faded by `AbstractBackgroundWidget`), the desktop and lock "copies" of
+  the resource monitor were one object reading one key — rotated on the Lockscreen tab, rotated
+  on the desktop (the maintainer's report, 2026-09-03). `lockOptions[id][key]` sits beside
+  `pluginOptions` and inherits PER KEY: present is the lock's own, absent reads through, `null`
+  re-inherits. Not the layout's whole-screen snapshot, on purpose — a user who rotates the monitor
+  for the lock still wants its blur to follow the desktop. Three keys never fork
   (`SHARED_OPTION_KEYS`: `positionLocked`, `clickThrough`, `__gridSize`): Edit Mode policy with one
   writer and one meaning, and the span has its own surface path. `PluginState.option()` and
   `setOption()` take a trailing `surface` with the position API's `currentSurface` default, so
   every widget binding and in-widget knob that predates the fork follows the face the desktop
-  is showing — the monitor's rotate button on the Lockscreen tab writes the lock's `vertical`
-  and the desktop's binding re-evaluates when the look flips. Settings (`PluginOptions`) names
-  its surface on EVERY call — the Desktop / Lock screen switch the user pressed, not the look —
-  and hides the shared toggles and the size row on the lock. Presets carry `lockOptions` under
-  the `has()` rule `lockPositions` follows. No migration for the map (absence is the upgrade
-  state), but one for the clock: its hand-rolled `styleLocked` row folds into the overlay's
-  `style`, preserving what the lock showed — a MISSING second style was the row's "cookie"
-  default, which differs from any desktop that is not cookie and becomes an overlay of cookie;
-  the pass is data-driven as well as marked because the legacy Config drain can deliver a
-  `styleLocked` after the load-time pass. The rule for plugin authors is in PLUGINS.md: a setting
-  that must differ between the surfaces is ONE option read through `PluginState.option`, never
-  a second `*Locked` key.
+  is showing — that IS the whole user-facing change: the monitor's rotate button on the Lockscreen
+  tab writes the lock's `vertical`, and the desktop's binding re-evaluates when the look flips.
+  Settings > Widgets rows are desktop-only by construction (the size row's rule) and name
+  `PluginState.desktopSurface` on every call; a Desktop / Lock screen switch on each card was
+  built and REJECTED by the maintainer — Edit Mode's Desktop / Lockscreen tab is the one surface
+  selector, and a second per widget duplicates it. A setting that must be reachable on the lock
+  side without an in-widget knob keeps an explicit manifest row (the clock's "Clock style
+  (locked)"); if per-surface editing of plain options is ever wanted, it goes into Edit Mode's
+  widget menu, not the card. Presets carry `lockOptions` under the `has()` rule `lockPositions`
+  follows. No migration: absence is the upgrade state.
   (feat(plugins): widget options fork per surface in the pure store rules;
   feat(plugins): PluginState.option and setOption take a surface;
-  feat(settings): a Desktop / Lock screen switch on every widget's options;
-  refactor(clock): the lock's style is the style option on the lock surface.)
+  feat(presets): a preset carries the lock screen's widget options.)
 - **A dragged widget holds a neighbour's edge through a Schmitt trigger, and
   both thresholds read the SHADOW — stage 10, spec §6.**
   `modules/common/functions/edge_snap.js` owns the arithmetic: four relations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,19 +12,13 @@ own repo; the installer pins which revision it builds.
 
 ## [Unreleased]
 
-### Added
+### Fixed
 - **Desktop widgets keep separate settings for the desktop and the lock
-  screen.** Every widget card in Settings > Plugins has a Desktop / Lock
-  screen switch; a setting changed on the lock side applies to the lock
-  screen only and the rest keep following the desktop, with a "Reset to
-  desktop" to re-link. The widgets' own knobs (the system monitor's rotate
-  button, for one) write whichever surface they are used on. Presets carry
-  the lock side too.
-
-### Changed
-- **The clock's "Clock style (locked)" row is gone.** Its value moved to the
-  lock side of the ordinary "Clock style" row; what the lock screen showed
-  is what it still shows.
+  screen.** Rotating the System Monitor or GPU Monitor on Edit Mode's
+  Lockscreen tab rotated it on the desktop too; every widget setting now
+  follows the surface it is changed on, and the desktop's stays where it
+  was. Settings > Widgets keeps editing the desktop. Presets carry the lock
+  side too.
 
 ## [1.0.0-rc-11] — 2026-09-03
 

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -204,13 +204,9 @@ cannot read (no `key`) shows the row: a wrongly hidden row is a setting the user
 nothing logs. The older `"enabledWhen": "<booleanKey>"` is the same thing for one boolean and, despite
 its name, hides rather than greys — both fields go through `option_visibility.js`, and when both are
 present both must pass. The clock is the worked example: every `digital*` / `cookie*` / `pixel*` row
-is gated on `style` alone. The desktop and the lock screen can still differ - a widget's options
-fork per surface (`lockOptions` in `plugin-state.json`, reached through the Desktop / Lock screen
-switch on the plugin's card), and the rule is evaluated against whichever surface that switch
-names (`tests/test_clock_options_contract.py` holds that; `tests/tst_option_visibility.qml` holds
-the evaluator). A widget that needs a setting to differ between the two surfaces therefore declares
-ONE option and reads it with `PluginState.option(id, key, default)`, which follows the face the
-desktop is showing; it never declares a second `*Locked` key.
+is gated on its style being chosen for the desktop **or** the lock screen, since the two can differ
+(`tests/test_clock_options_contract.py` holds that; `tests/tst_option_visibility.qml` holds the
+evaluator).
 
 `color` renders a row of palette swatches (`ColorSelectionArray`) instead of chips. Its `choices` are
 `Appearance.colors` role names without the `col` prefix (`primary`, `secondaryContainer`, `layer0`, …).

--- a/docs/superpowers/plans/2026-09-03-per-surface-widget-options.md
+++ b/docs/superpowers/plans/2026-09-03-per-surface-widget-options.md
@@ -2,6 +2,8 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
+> **Revised after review:** Tasks 3 and 4 were withdrawn (no per-card switch; the clock keeps `styleLocked`). Settings rows pass `PluginState.desktopSurface` explicitly. See the spec's Revision note.
+
 **Goal:** A widget's settings fork per surface (desktop / lock screen) the way its position, span and presence already do, with a Settings switch to reach the lock's values and the clock's hand-rolled `styleLocked` folded in.
 
 **Architecture:** `lockOptions[pluginId][key]` beside `pluginOptions` in `plugin-state.json`; absence of a key is per-key inheritance from the desktop. The pure rules live in `layout_surfaces.js`; `PluginState.option/setOption` gain a trailing `surface` defaulting to `currentSurface`, so every existing caller follows the look. `PluginOptions` owns a Desktop / Lock screen switch and passes the surface explicitly. A one-shot migration moves the clock's `styleLocked` into the overlay.

--- a/docs/superpowers/specs/2026-09-03-per-surface-widget-options-design.md
+++ b/docs/superpowers/specs/2026-09-03-per-surface-widget-options-design.md
@@ -17,6 +17,17 @@ one key. The two monitors declare no `grid`, so `vertical` is their whole
 shape and it is shared. The only per-surface setting today is the clock's
 hand-rolled `style` / `styleLocked` pair.
 
+## Revision (2026-09-03, after review)
+
+The maintainer rejected the per-card Desktop / Lock screen switch: Edit Mode's
+Desktop / Lockscreen tab is the surface selector, and a second one inside each
+widget's card duplicates it. Settings > Widgets rows are desktop-only by
+construction (the size row's existing rule); a lock-side value is written by
+the widget's own controls while the Lockscreen tab or the real lock is showing,
+through the accessors' `currentSurface` default. The clock keeps its "Clock
+style (locked)" row (no fold-in, no migration), since it has no in-widget style
+knob. The Settings UI and Clock sections below are superseded by this note.
+
 ## Decisions (user)
 
 1. Surface-scoped option store, not per-manifest opt-in, not a second copy

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginOptions.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginOptions.qml
@@ -7,7 +7,6 @@ import qs.modules.common
 import qs.modules.common.widgets
 import "gridSizes.js" as GridSizes
 import "option_visibility.js" as OptionVisibility
-import "layout_surfaces.js" as Surfaces
 
 ColumnLayout {
     id: root
@@ -15,17 +14,14 @@ ColumnLayout {
     required property var manifest
     spacing: Appearance.spacing.space25
 
-    // Which face of the desktop these rows read and write. A widget's own
-    // settings fork per surface (layout_surfaces.js: lockOptions, inheriting
-    // per key), and this card is where the lock's values are reached - so the
-    // surface is named on EVERY read and write below rather than left to
-    // PluginState's default, which follows the look the desktop is showing
-    // and not the switch the user just pressed.
-    property string surface: PluginState.desktopSurface
-    readonly property bool onLock: root.surface === PluginState.lockSurface
-    // Only a desktop widget has a lock face; a bar- or overlay-only plugin
-    // gets no switch and its rows stay the desktop's.
-    readonly property bool hasLockFace: manifest.desktopWidget !== undefined
+    // These rows edit the DESKTOP, by construction - the same rule the size
+    // row has always had. The surface is a mode the user is already in (Edit
+    // Mode's Lockscreen tab, or the real lock), not a per-widget property:
+    // a widget's own knobs write the surface on screen through PluginState's
+    // default, and a second selector on every card would duplicate the tab.
+    // Named on every read and write below all the same, so a card open while
+    // the lock look is showing still edits the desktop.
+    readonly property string surface: PluginState.desktopSurface
 
     // The widget's own options come first, because they are what the user
     // opened this page for. The host's rows used to be concatenated in FRONT of
@@ -164,10 +160,7 @@ ColumnLayout {
     // Not every widget is resizable, and offering a size where the widget has
     // no layout for it is worse than offering nothing - so this is omitted
     // rather than disabled unless the manifest names more than one span.
-    // The desktop's span only: the lock's forks in its layout record and is
-    // set on the Lockscreen tab (PluginState.gridSize), so the lock card
-    // offers no size row.
-    readonly property var offeredSizes: root.onLock ? [] : GridSizes.offeredSizes(manifest.grid)
+    readonly property var offeredSizes: GridSizes.offeredSizes(manifest.grid)
     readonly property var sizeRows: root.offeredSizes.length > 1 ? [{
         key: "__gridSize",
         type: "choice",
@@ -179,55 +172,6 @@ ColumnLayout {
             value: GridSizes.formatSize(size)
         }))
     }] : []
-
-    // Desktop / Lock screen: which face the rows below edit. The lock's
-    // settings follow the desktop's per key until one is changed here; the
-    // caption says so, and turns into the re-link once any has.
-    ConfigSelectionArray {
-        id: surfaceSwitch
-        visible: root.hasLockFace
-        Layout.fillWidth: true
-        text: Translation.tr("Applies to")
-        icon: "desktop_windows"
-        currentValue: root.surface
-        onSelected: value => root.surface = value
-        options: [
-            { displayName: Translation.tr("Desktop"), icon: "desktop_windows", value: PluginState.desktopSurface },
-            { displayName: Translation.tr("Lock screen"), icon: "lock", value: PluginState.lockSurface }
-        ]
-    }
-    RowLayout {
-        visible: root.hasLockFace && root.onLock
-        Layout.fillWidth: true
-        spacing: Appearance.spacing.space100
-        StyledText {
-            Layout.fillWidth: true
-            font.pixelSize: Appearance.font.pixelSize.smaller
-            color: Appearance.colors.colSubtext
-            wrapMode: Text.WordWrap
-            text: PluginState.lockOptionsForked(root.manifest.id)
-                ? Translation.tr("The lock screen has settings of its own here; the rest follow the desktop.")
-                : Translation.tr("Follows the desktop until you change a setting here.")
-        }
-        RippleButton {
-            visible: PluginState.lockOptionsForked(root.manifest.id)
-            implicitHeight: 32
-            buttonRadius: Appearance.rounding.full
-            colBackground: Appearance.colors.colSecondaryContainer
-            colBackgroundHover: Appearance.colors.colSecondaryContainerHover
-            colRipple: Appearance.colors.colSecondaryContainerActive
-            onClicked: PluginState.resetLockOptions(root.manifest.id)
-            contentItem: StyledText {
-                horizontalAlignment: Text.AlignHCenter
-                verticalAlignment: Text.AlignVCenter
-                leftPadding: Appearance.spacing.space150
-                rightPadding: Appearance.spacing.space150
-                font.pixelSize: Appearance.font.pixelSize.small
-                color: Appearance.colors.colOnSecondaryContainer
-                text: Translation.tr("Reset to desktop")
-            }
-        }
-    }
 
     Repeater {
         model: root.optionRuns
@@ -336,8 +280,6 @@ ColumnLayout {
                 on.push(behaviourSection.presetPersistLabel);
             for (let index = 0; index < root.behaviourRows.length; ++index) {
                 const behaviourRow = root.behaviourRows[index];
-                if (root.onLock && Surfaces.isSharedOptionKey(behaviourRow.key))
-                    continue;
                 if (PluginState.option(root.manifest.id, behaviourRow.key, behaviourRow.default, root.surface))
                     on.push(behaviourRow.label);
             }
@@ -355,9 +297,6 @@ ColumnLayout {
             // the rest of it survives a preset.
             BehaviourToggle {
                 id: presetPersistToggle
-                // Not a per-surface thing: the flag shields the plugin's
-                // settings on BOTH surfaces through a preset.
-                visible: !root.onLock
                 label: behaviourSection.presetPersistLabel
                 buttonIcon: "push_pin"
                 toggled: PluginState.presetPersisted(root.manifest.id)
@@ -369,12 +308,6 @@ ColumnLayout {
                 model: root.behaviourRows
                 delegate: BehaviourToggle {
                     required property var modelData
-                    // On the lock surface only the LOOK toggles: pin and
-                    // click-through are Edit Mode policy with one writer and
-                    // one meaning (SHARED_OPTION_KEYS), and a toggle that
-                    // wrote the desktop's value from the lock's card would
-                    // be a lie.
-                    visible: !root.onLock || !Surfaces.isSharedOptionKey(modelData.key)
                     label: modelData.label
                     buttonIcon: modelData.icon
                     toggled: PluginState.option(root.manifest.id, modelData.key, modelData.default, root.surface)

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginState.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginState.qml
@@ -428,13 +428,8 @@ Singleton {
         return next;
     }
 
-    // Data-driven as well as marked (the sizeMode lesson): a `styleLocked`
-    // that arrives AFTER the marker - the legacy Config drain below still
-    // carries one for a first-run upgrade - is folded whenever it is seen,
-    // and the marker alone covers the absent-key case once.
     function migrateClockStyle() {
-        const stored = root.state?.pluginOptions?.clock?.styleLocked;
-        if (stored === undefined && root.migrationRan(root.clockStyleMarker)) return;
+        if (root.migrationRan(root.clockStyleMarker)) return;
         root.state = root.stateWithClockStyleMigrated(root.state);
         writeTimer.restart();
     }
@@ -516,8 +511,6 @@ Singleton {
         nextState.pluginOptions = nextOptions;
         nextState.desktopPositions = nextScreens;
         root.state = nextState;
-        // The drain may have just delivered the clock's legacy styleLocked.
-        root.migrateClockStyle();
         writeTimer.restart();
 
         Config.pendingPluginOptions = ({});

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginState.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginState.qml
@@ -400,40 +400,6 @@ Singleton {
         writeTimer.restart();
     }
 
-    // The clock carried the shell's only per-surface setting by hand: a
-    // second manifest row, `styleLocked`, selected inside the widget. It
-    // folds into the lock overlay's `style` here, and what the user SEES on
-    // the lock does not change: a stored second style that differs from the
-    // desktop's becomes the overlay; one that matches becomes nothing; an
-    // absent one was the row's default, "cookie", which differs from any
-    // desktop that is not cookie and so becomes an overlay of "cookie" too.
-    // Pure, so the three cases are drivable from a TestCase; run once on
-    // load, recorded in `migrations` like the sizeMode pass.
-    readonly property string clockStyleMarker: "clockStyleLocked"
-
-    function stateWithClockStyleMigrated(state) {
-        const clock = state?.pluginOptions?.clock;
-        const stored = clock && typeof clock === "object" ? clock : {};
-        const desktop = stored.style === undefined ? "cookie" : stored.style;
-        const locked = stored.styleLocked === undefined ? "cookie" : stored.styleLocked;
-        let next = Object.assign({}, state);
-        if (locked !== desktop)
-            next = Surfaces.withOption(next, Surfaces.LOCK, "clock", "style", locked);
-        if (stored.styleLocked !== undefined)
-            next = Surfaces.withOption(next, Surfaces.DESKTOP, "clock", "styleLocked", null);
-        const nextMigrations = Object.assign({}, state?.migrations || {});
-        nextMigrations[root.clockStyleMarker] = true;
-        next.migrations = nextMigrations;
-        next.version = root.schemaVersion;
-        return next;
-    }
-
-    function migrateClockStyle() {
-        if (root.migrationRan(root.clockStyleMarker)) return;
-        root.state = root.stateWithClockStyleMigrated(root.state);
-        writeTimer.restart();
-    }
-
     // A ported built-in's own settings have to end up in this file, but Config
     // cannot write it (and cannot import this module - it is imported *by* it).
     // Config computes the batch instead and parks it on
@@ -588,9 +554,6 @@ Singleton {
                     ? parsed.migrations
                     : {}
             };
-            // Inside the try: a file that did not parse is left on disk as
-            // it was, not replaced by an empty state carrying a marker.
-            root.migrateClockStyle();
         } catch (error) {
             console.warn("[PluginState] Ignoring invalid state file: " + error);
             root.state = root.emptyState();

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/clock/Widget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/clock/Widget.qml
@@ -59,12 +59,8 @@ Item {
     readonly property var hostScreen: Quickshell.screens.find(screen => screen.name === root.screenName) ?? null
     readonly property real hostScreenWidth: root.hostScreen?.width ?? 0
 
-    // The style follows the face the desktop is showing: PluginState.option
-    // reads the lock's own `style` (lockOptions) under the lock look and the
-    // desktop's otherwise - the second manifest row this widget used to
-    // carry, `styleLocked`, folded into that store (PluginState's
-    // clockStyleLocked migration).
     readonly property string style: PluginState.option("clock", "style", "cookie")
+    readonly property string styleLocked: PluginState.option("clock", "styleLocked", "cookie")
     readonly property bool showOnlyWhenLocked: PluginState.option("clock", "showOnlyWhenLocked", false)
 
     readonly property bool digitalVertical: PluginState.option("clock", "digitalVertical", false)
@@ -83,7 +79,7 @@ Item {
     readonly property string quoteText: PluginState.option("clock", "quoteText", "")
     readonly property bool quoteFollowClock: PluginState.option("clock", "quoteFollowClock", false)
 
-    readonly property string clockStyle: root.style
+    readonly property string clockStyle: root.lockLook ? root.styleLocked : root.style
     readonly property bool shouldShow: !root.showOnlyWhenLocked || root.lockLook
 
     readonly property string customClockColorKey: PluginState.option("clock", "color", "")

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/clock/manifest.json
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/clock/manifest.json
@@ -42,6 +42,30 @@
       ]
     },
     {
+      "key": "styleLocked",
+      "type": "choice",
+      "label": "Clock style (locked)",
+      "icon": "shield_watch",
+      "default": "cookie",
+      "choices": [
+        {
+          "displayName": "Digital",
+          "icon": "timer_10",
+          "value": "digital"
+        },
+        {
+          "displayName": "Cookie",
+          "icon": "cookie",
+          "value": "cookie"
+        },
+        {
+          "displayName": "Pixel",
+          "icon": "grid_view",
+          "value": "pixel"
+        }
+      ]
+    },
+    {
       "key": "showOnlyWhenLocked",
       "type": "boolean",
       "label": "Show only when locked",
@@ -55,9 +79,19 @@
       "icon": "vertical_distribute",
       "default": false,
       "visibleWhen": {
-        "key": "style",
-        "in": [
-          "digital"
+        "anyOf": [
+          {
+            "key": "style",
+            "in": [
+              "digital"
+            ]
+          },
+          {
+            "key": "styleLocked",
+            "in": [
+              "digital"
+            ]
+          }
         ]
       },
       "group": "Digital clock",
@@ -70,9 +104,19 @@
       "icon": "date_range",
       "default": true,
       "visibleWhen": {
-        "key": "style",
-        "in": [
-          "digital"
+        "anyOf": [
+          {
+            "key": "style",
+            "in": [
+              "digital"
+            ]
+          },
+          {
+            "key": "styleLocked",
+            "in": [
+              "digital"
+            ]
+          }
         ]
       },
       "group": "Digital clock",
@@ -85,9 +129,19 @@
       "icon": "animation",
       "default": true,
       "visibleWhen": {
-        "key": "style",
-        "in": [
-          "digital"
+        "anyOf": [
+          {
+            "key": "style",
+            "in": [
+              "digital"
+            ]
+          },
+          {
+            "key": "styleLocked",
+            "in": [
+              "digital"
+            ]
+          }
         ]
       },
       "group": "Digital clock",
@@ -100,9 +154,19 @@
       "icon": "activity_zone",
       "default": true,
       "visibleWhen": {
-        "key": "style",
-        "in": [
-          "digital"
+        "anyOf": [
+          {
+            "key": "style",
+            "in": [
+              "digital"
+            ]
+          },
+          {
+            "key": "styleLocked",
+            "in": [
+              "digital"
+            ]
+          }
         ]
       },
       "group": "Digital clock",
@@ -115,9 +179,19 @@
       "icon": "palette",
       "default": "",
       "visibleWhen": {
-        "key": "style",
-        "in": [
-          "digital"
+        "anyOf": [
+          {
+            "key": "style",
+            "in": [
+              "digital"
+            ]
+          },
+          {
+            "key": "styleLocked",
+            "in": [
+              "digital"
+            ]
+          }
         ]
       },
       "choices": [
@@ -143,9 +217,19 @@
       "placeholder": "Google Sans Flex",
       "maxLength": 64,
       "visibleWhen": {
-        "key": "style",
-        "in": [
-          "digital"
+        "anyOf": [
+          {
+            "key": "style",
+            "in": [
+              "digital"
+            ]
+          },
+          {
+            "key": "styleLocked",
+            "in": [
+              "digital"
+            ]
+          }
         ]
       },
       "group": "Digital clock",
@@ -160,9 +244,19 @@
       "from": 1,
       "to": 1000,
       "visibleWhen": {
-        "key": "style",
-        "in": [
-          "digital"
+        "anyOf": [
+          {
+            "key": "style",
+            "in": [
+              "digital"
+            ]
+          },
+          {
+            "key": "styleLocked",
+            "in": [
+              "digital"
+            ]
+          }
         ]
       },
       "group": "Digital clock",
@@ -177,9 +271,19 @@
       "from": 50,
       "to": 700,
       "visibleWhen": {
-        "key": "style",
-        "in": [
-          "digital"
+        "anyOf": [
+          {
+            "key": "style",
+            "in": [
+              "digital"
+            ]
+          },
+          {
+            "key": "styleLocked",
+            "in": [
+              "digital"
+            ]
+          }
         ]
       },
       "group": "Digital clock",
@@ -194,9 +298,19 @@
       "from": 25,
       "to": 125,
       "visibleWhen": {
-        "key": "style",
-        "in": [
-          "digital"
+        "anyOf": [
+          {
+            "key": "style",
+            "in": [
+              "digital"
+            ]
+          },
+          {
+            "key": "styleLocked",
+            "in": [
+              "digital"
+            ]
+          }
         ]
       },
       "group": "Digital clock",
@@ -211,9 +325,19 @@
       "from": 0,
       "to": 100,
       "visibleWhen": {
-        "key": "style",
-        "in": [
-          "digital"
+        "anyOf": [
+          {
+            "key": "style",
+            "in": [
+              "digital"
+            ]
+          },
+          {
+            "key": "styleLocked",
+            "in": [
+              "digital"
+            ]
+          }
         ]
       },
       "group": "Digital clock",
@@ -226,9 +350,19 @@
       "icon": "airwave",
       "default": false,
       "visibleWhen": {
-        "key": "style",
-        "in": [
-          "cookie"
+        "anyOf": [
+          {
+            "key": "style",
+            "in": [
+              "cookie"
+            ]
+          },
+          {
+            "key": "styleLocked",
+            "in": [
+              "cookie"
+            ]
+          }
         ]
       },
       "group": "Cookie clock",
@@ -241,9 +375,19 @@
       "icon": "wand_stars",
       "default": false,
       "visibleWhen": {
-        "key": "style",
-        "in": [
-          "cookie"
+        "anyOf": [
+          {
+            "key": "style",
+            "in": [
+              "cookie"
+            ]
+          },
+          {
+            "key": "styleLocked",
+            "in": [
+              "cookie"
+            ]
+          }
         ]
       },
       "group": "Cookie clock",
@@ -258,9 +402,19 @@
       "from": 0,
       "to": 40,
       "visibleWhen": {
-        "key": "style",
-        "in": [
-          "cookie"
+        "anyOf": [
+          {
+            "key": "style",
+            "in": [
+              "cookie"
+            ]
+          },
+          {
+            "key": "styleLocked",
+            "in": [
+              "cookie"
+            ]
+          }
         ]
       },
       "group": "Cookie clock",
@@ -273,9 +427,19 @@
       "icon": "autoplay",
       "default": false,
       "visibleWhen": {
-        "key": "style",
-        "in": [
-          "cookie"
+        "anyOf": [
+          {
+            "key": "style",
+            "in": [
+              "cookie"
+            ]
+          },
+          {
+            "key": "styleLocked",
+            "in": [
+              "cookie"
+            ]
+          }
         ]
       },
       "group": "Cookie clock",
@@ -288,9 +452,19 @@
       "icon": "brightness_7",
       "default": false,
       "visibleWhen": {
-        "key": "style",
-        "in": [
-          "cookie"
+        "anyOf": [
+          {
+            "key": "style",
+            "in": [
+              "cookie"
+            ]
+          },
+          {
+            "key": "styleLocked",
+            "in": [
+              "cookie"
+            ]
+          }
         ]
       },
       "group": "Cookie clock",
@@ -303,9 +477,19 @@
       "icon": "timer_10",
       "default": true,
       "visibleWhen": {
-        "key": "style",
-        "in": [
-          "cookie"
+        "anyOf": [
+          {
+            "key": "style",
+            "in": [
+              "cookie"
+            ]
+          },
+          {
+            "key": "styleLocked",
+            "in": [
+              "cookie"
+            ]
+          }
         ]
       },
       "group": "Cookie clock",
@@ -318,9 +502,19 @@
       "icon": "graph_6",
       "default": "full",
       "visibleWhen": {
-        "key": "style",
-        "in": [
-          "cookie"
+        "anyOf": [
+          {
+            "key": "style",
+            "in": [
+              "cookie"
+            ]
+          },
+          {
+            "key": "styleLocked",
+            "in": [
+              "cookie"
+            ]
+          }
         ]
       },
       "choices": [
@@ -355,9 +549,19 @@
       "icon": "highlighter_size_2",
       "default": "fill",
       "visibleWhen": {
-        "key": "style",
-        "in": [
-          "cookie"
+        "anyOf": [
+          {
+            "key": "style",
+            "in": [
+              "cookie"
+            ]
+          },
+          {
+            "key": "styleLocked",
+            "in": [
+              "cookie"
+            ]
+          }
         ]
       },
       "choices": [
@@ -392,9 +596,19 @@
       "icon": "eraser_size_1",
       "default": "medium",
       "visibleWhen": {
-        "key": "style",
-        "in": [
-          "cookie"
+        "anyOf": [
+          {
+            "key": "style",
+            "in": [
+              "cookie"
+            ]
+          },
+          {
+            "key": "styleLocked",
+            "in": [
+              "cookie"
+            ]
+          }
         ]
       },
       "choices": [
@@ -434,9 +648,19 @@
       "icon": "pen_size_1",
       "default": "dot",
       "visibleWhen": {
-        "key": "style",
-        "in": [
-          "cookie"
+        "anyOf": [
+          {
+            "key": "style",
+            "in": [
+              "cookie"
+            ]
+          },
+          {
+            "key": "styleLocked",
+            "in": [
+              "cookie"
+            ]
+          }
         ]
       },
       "choices": [
@@ -471,9 +695,19 @@
       "icon": "date_range",
       "default": "bubble",
       "visibleWhen": {
-        "key": "style",
-        "in": [
-          "cookie"
+        "anyOf": [
+          {
+            "key": "style",
+            "in": [
+              "cookie"
+            ]
+          },
+          {
+            "key": "styleLocked",
+            "in": [
+              "cookie"
+            ]
+          }
         ]
       },
       "choices": [
@@ -508,9 +742,19 @@
       "icon": "screen_rotation",
       "default": "vertical",
       "visibleWhen": {
-        "key": "style",
-        "in": [
-          "pixel"
+        "anyOf": [
+          {
+            "key": "style",
+            "in": [
+              "pixel"
+            ]
+          },
+          {
+            "key": "styleLocked",
+            "in": [
+              "pixel"
+            ]
+          }
         ]
       },
       "choices": [

--- a/dots/.config/quickshell/imi/tests/test_clock_options_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_clock_options_contract.py
@@ -28,7 +28,7 @@ ROOT = Path(__file__).resolve().parent.parent
 MANIFEST = ROOT / "modules/common/plugins/bundled/clock/manifest.json"
 STYLES = ("digital", "cookie", "pixel")
 # Rows every style shares. Anything else must name a style.
-SHARED = {"style", "showOnlyWhenLocked", "quoteEnable", "quoteFollowClock", "quoteText"}
+SHARED = {"style", "styleLocked", "showOnlyWhenLocked", "quoteEnable", "quoteFollowClock", "quoteText"}
 # Rows whose key does not carry the style they belong to.
 STYLE_OF = {"color": "digital"}
 
@@ -50,15 +50,12 @@ def expected_style(key: str):
 
 
 def matches(rule, style: str) -> bool:
-    """Whether `rule` is exactly 'style == S'.
-
-    One key, since 2026-09-03: the lock's style is the `style` option on the
-    lock surface (PluginState.option with a surface), and Settings evaluates
-    the rule against the surface its switch names - so the old
-    'style OR styleLocked' pair would show digital rows on a cookie desktop
-    whenever the lock was digital, which is the wrong surface's answer.
-    """
-    return isinstance(rule, dict) and rule.get("key") == "style" and rule.get("in") == [style]
+    """Whether `rule` is exactly 'style == S on either key'."""
+    branches = rule.get("anyOf") if isinstance(rule, dict) else None
+    if not isinstance(branches, list) or len(branches) != 2:
+        return False
+    keys = sorted(b.get("key") for b in branches if isinstance(b, dict))
+    return keys == ["style", "styleLocked"] and all(b.get("in") == [style] for b in branches)
 
 
 def test_every_style_bound_row_is_gated_on_its_style():

--- a/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_edit_mode_contract.py
@@ -1579,20 +1579,9 @@ def test_the_clock_previews_its_locked_look_through_one_derivation():
     assert re.search(r"readonly property bool lockLook:\s*GlobalStates\.screenLocked"
                      r"\s*\n?\s*\|\|\s*GlobalStates\.editLockPreview", clock), \
         "the clock no longer derives its locked look once"
-    # The STYLE is the one of the four that no longer reads `lockLook`: since
-    # widget options fork per surface (2026-09-03) it is the plain `style`
-    # option, and PluginState.option's default surface is currentSurface,
-    # which reads GlobalStates.lockLookActive - the same derivation, one
-    # level down, shared with every position read. A second local selector
-    # here would be the twin the fold-in removed.
-    assert re.search(r'readonly property string style:\s*PluginState\.option\("clock", "style", "cookie"\)', clock), \
-        "the clock's style must be the plain option, read on the current surface"
-    assert re.search(r"clockStyle:\s*root\.style\b", clock), \
-        "the clock's clockStyle is the style option, not a lock-look selector"
-    assert "styleLocked" not in clock.replace("`styleLocked`", ""), \
-        "the clock must not grow its second style key back"
     for name, pattern in (
             ("forceCenter", r"forceCenter:\s*root\.lockLook"),
+            ("clockStyle", r"clockStyle:\s*root\.lockLook"),
             ("shouldShow", r"shouldShow:\s*!root\.showOnlyWhenLocked\s*\|\|\s*root\.lockLook"),
             ("the Locked caption", r"shown:\s*root\.lockLook\s*&&\s*Config\.options\.lock\.showLockedText")):
         assert re.search(pattern, clock), \

--- a/dots/.config/quickshell/imi/tests/test_layout_surfaces_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_layout_surfaces_contract.py
@@ -107,8 +107,9 @@ def test_every_widget_option_read_and_write_names_its_surface():
     # A widget's own settings fork per surface too (2026-09-03: the resource
     # monitor rotated for the lock screen was rotated on the desktop). The
     # store's accessors take a trailing surface with the position API's
-    # default; Settings names its surface on EVERY call, because its switch
-    # and not the look the desktop is showing is what the user pressed.
+    # default, so a widget's own knobs write the surface on screen; Settings
+    # names the desktop on EVERY call - its rows are desktop-only by
+    # construction, and the surface is Edit Mode's tab, not a card switch.
     state = code(STATE)
     for fn in ("option", "setOption"):
         sig = re.search(rf"function {fn}\(([^)]*)\)", state)
@@ -122,17 +123,16 @@ def test_every_widget_option_read_and_write_names_its_surface():
         "loadText must carry lockOptions, or a restart forgets every lock setting"
 
     options = code(ROOT / "modules/common/plugins/PluginOptions.qml")
-    assert 'property string surface: PluginState.desktopSurface' in options, \
-        "PluginOptions must own the surface its rows edit"
+    assert 'readonly property string surface: PluginState.desktopSurface' in options, \
+        ("PluginOptions edits the DESKTOP by construction - the surface is Edit Mode's tab, not "
+         "a per-card selector (the maintainer's rule, 2026-09-03)")
+    assert '"Lock screen"' not in options and "lockOptionsForked" not in options, \
+        "no surface switch and no lock-side affordance on the widget's card"
     calls = re.findall(r"PluginState\.(?:option|setOption)\([^;]*?\)", options, re.S)
     assert len(calls) >= 15, f"expected the card's reads and writes, found {len(calls)}"
     naked = [call for call in calls if "root.surface" not in call]
     assert naked == [], \
         "every PluginOptions read and write must pass root.surface:\n" + "\n".join(naked)
-    assert "Surfaces.isSharedOptionKey(modelData.key)" in options, \
-        "the lock card must hide the shared policy toggles"
-    assert "root.onLock ? [] : GridSizes.offeredSizes(manifest.grid)" in options, \
-        "the lock card offers no size row - the lock's span lives in its layout record"
 
     presets = read(ROOT / "scripts/presets.sh")
     assert presets.count("lockOptions: (.lockOptions // {})") == 3, \

--- a/dots/.config/quickshell/imi/tests/tst_plugin_state.qml
+++ b/dots/.config/quickshell/imi/tests/tst_plugin_state.qml
@@ -446,32 +446,4 @@ TestCase {
         PluginState.loadText(JSON.stringify({ version: 2 }));
         compare(JSON.stringify(PluginState.state.lockOptions), "{}");
     }
-
-    // The clock's hand-rolled `styleLocked` folds into the lock overlay's
-    // `style`, and what every user sees on the lock today is what they see
-    // after: a stored second style that differs becomes the overlay, one
-    // that matches becomes nothing, and an ABSENT second style was the
-    // default "cookie" - which differs from a desktop that is not cookie.
-    function test_theClockStyleMigrationKeepsWhatTheLockShowed() {
-        let next = PluginState.stateWithClockStyleMigrated({
-            pluginOptions: { clock: { style: "digital", styleLocked: "pixel" } } });
-        compare(Surfaces.rawOption(next, Surfaces.LOCK, "clock", "style"), "pixel");
-        compare(next.pluginOptions.clock.styleLocked, undefined);
-        compare(next.pluginOptions.clock.style, "digital");
-        verify(next.migrations[PluginState.clockStyleMarker]);
-
-        next = PluginState.stateWithClockStyleMigrated({
-            pluginOptions: { clock: { style: "pixel", styleLocked: "pixel" } } });
-        compare(next.lockOptions, undefined);
-        compare(next.pluginOptions.clock.styleLocked, undefined);
-
-        next = PluginState.stateWithClockStyleMigrated({
-            pluginOptions: { clock: { style: "pixel" } } });
-        compare(Surfaces.rawOption(next, Surfaces.LOCK, "clock", "style"), "cookie");
-
-        next = PluginState.stateWithClockStyleMigrated({ pluginOptions: {} });
-        compare(next.lockOptions, undefined);
-        compare(next.pluginOptions.clock, undefined);
-        verify(next.migrations[PluginState.clockStyleMarker]);
-    }
 }


### PR DESCRIPTION
Follow-up to #348, which merged at the head pushed before the maintainer's review call landed.

**Withdrawn:** the Desktop / Lock screen switch on every widget's Settings card. Edit Mode's Desktop / Lockscreen tab is the one surface selector; a second one inside each widget duplicates it. Settings > Widgets rows edit the desktop by construction (the size row's existing rule) and name `PluginState.desktopSurface` on every read and write.

**Reverted:** the clock's `styleLocked` fold-in and its migration. With Settings desktop-only and no in-widget style knob, the lock's clock style would have been unreachable; "Clock style (locked)" stays as it was. (A user who ran the merged migration once has a harmless `lockOptions.clock.style` overlay and a marker left in their state; the reverted clock reads `styleLocked` on the lock, so what shows is unchanged.)

**Kept (the fix itself):** `lockOptions` per key, `option()` / `setOption()` defaulting to the surface on screen, presets carrying the overlay. Rotating a monitor on the Lockscreen tab writes the lock's value only.

Contracts follow: the widget card names the desktop and carries no switch; the clock and edit-mode pins are back to their pre-fold-in truth. Suite green on this tree.

Docs: updated AGENT.md §Edit Mode (the per-surface options entry now records the rejected switch and the rule) and docs/superpowers specs/plans revision notes
Changelog: updated
