### PR TITLE
feat(wallpaperSelector): the Wallpaper Engine sidebar — settings, properties, compatibility, crop picker, Quality; plus resource-polling perf

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -908,9 +908,17 @@ services/                  Singletons wrapping external state/processes - one pe
   WallpaperEngineFeatures.qml  Which properties THIS binary's embedded renderer has, probed once
                               by building a bare WallpaperEngineSurface (no project, so no thread
                               or GL) and asking `"x" in surface`. The extended controls (the
-                              qs-wallpaperengine 0.3 flag set, per-project properties) gate on
-                              it; WallpaperEngineLayer binds the same properties dynamically for
-                              the same reason. See "WE_REF pins the renderer" below
+                              qs-wallpaperengine 0.3 flag set, per-project properties, the live
+                              crop focus) gate on it; WallpaperEngineLayer binds the same
+                              properties dynamically for the same reason. See "WE_REF pins the
+                              renderer" below. The Fill crop picker
+                              (modules/imi/wallpaperSelector/crop_picker.js +
+                              WallpaperSelectorSidebar's active card) reads
+                              GlobalStates.weContentAspect - the LIVE scene's real authored
+                              aspect, published by Background from the surface's contentWidth/
+                              Height, because a 32:9 wallpaper's portrait preview would pick the
+                              wrong overflow axis - and drives focusX/focusY, which pan the
+                              wallpaper live (scene only; a video is centre-cropped by WE)
   WallpaperEngineCompat.qml    Per-wallpaper compatibility verdicts, the reference app's bulk
                               scanner: the scan runs in a SPAWNED `qs -p` scanner process
                               (scripts/wallpapers/we_compat_scan.qml) loading each project into a

--- a/AGENT.md
+++ b/AGENT.md
@@ -871,6 +871,21 @@ services/                  Singletons wrapping external state/processes - one pe
                               takes to appear, the original persisted in Persistent so a
                               restart mid-swap still undoes it - see the entry under
                               "External binaries the shell drives"
+  WallpaperEngineOverrides.qml Per-project Wallpaper Engine settings (fps, scaling, audio), keyed
+                              by runtime project ids so it is a raw FileView over
+                              wallpaper-engine-overrides.json on the PluginState pattern - never
+                              a JsonAdapter. services/we_overrides.js is the resolution (per-key
+                              fallback to the globals, clear-on-null, sanitation); `active` is
+                              THE one live derivation, read by WallpaperEngineLayer's
+                              fps/scaleMode, Background's audio routing and the selector
+                              sidebar's controls - tests/test_we_overrides_wiring.py refuses a
+                              raw-config read beside it. The sidebar
+                              (modules/imi/wallpaperSelector/WallpaperSelectorSidebar.qml) is the
+                              editor: a places rail over local files (selector_places.js), the
+                              engine's configuration over Wallpaper Engine, and only the knobs
+                              WallpaperEngineSurface actually answers - a control for a flag the
+                              renderer does not read would be a fake action
+                              ("feat(wallpaperSelector): a sidebar - places over files, engine config over WE")
   SchemePreview.qml            Per-scheme swatches for the scheme pickers: one venv run of
                               scripts/colors/scheme_preview.py quantizes the wallpaper once and
                               builds every Material variant from it. Cached against the wallpaper

--- a/AGENT.md
+++ b/AGENT.md
@@ -6559,8 +6559,15 @@ map-time keyboard grant. A third obligation lives in `services/GlobalFocusGrab.q
 the grab's whitelist must end with the dismissables — Hyprland hands the grab's keyboard focus to
 a surface picked from the END of the list, and with the bar/OSK after the panel, an opening panel
 never activates and every keypress is silently dropped (the persistent-sidebar contract pins the
-order; fix(sidebars): route the focus grab's keyboard to the opening panel). `SessionScreen` still
-maps per open and pays this same 61ms.
+order; fix(sidebars): route the focus grab's keyboard to the opening panel). `SessionScreen` is
+that family too now — per-screen windows, the latch, Exclusive keyboard and the whole-surface
+mask both gated on `isTarget`, an exit that owns `reallyOpen` — with one addition of its own:
+`rules.lua`'s `quickshell:session` rule was `ignore_alpha = 0`, under which a permanently-mapped
+surface's fully transparent idle pixels would ask the compositor to blur the entire screen, so
+the threshold moved to 0.4 (the scrim sits at ~0.88+, so it frosts exactly as before). Its layer
+follows the overview's #339 rule — Overlay only while open over a true fullscreen window, Top
+otherwise — because a permanently-mapped Overlay surface holds the fullscreen fast path shut.
+("perf(sessionScreen): the session menu's surface outlives the gesture").
 
 A fourth cost, found by the first multi-monitor user to update (#297): **a persistent surface has
 to say which screen it lives on.** A `PanelWindow` with no `screen:` asks the compositor to choose

--- a/AGENT.md
+++ b/AGENT.md
@@ -918,7 +918,14 @@ services/                  Singletons wrapping external state/processes - one pe
                               aspect, published by Background from the surface's contentWidth/
                               Height, because a 32:9 wallpaper's portrait preview would pick the
                               wrong overflow axis - and drives focusX/focusY, which pan the
-                              wallpaper live (scene only; a video is centre-cropped by WE)
+                              wallpaper live (scene only; a video is centre-cropped by WE). The
+                              picker draws the actual scene, grabbed by the renderer
+                              (requestSceneGrab -> GlobalStates.weSceneGrabPath, a PNG at the
+                              real 32:9 aspect), NOT the preview image - the preview does not
+                              depict an ultrawide scene. Note: WE renders a scene at its authored
+                              resolution regardless of window, so a render-scale lever does
+                              nothing for scenes (measured) and was not shipped; fps is the
+                              scene's only in-shell cost lever
   WallpaperEngineCompat.qml    Per-wallpaper compatibility verdicts, the reference app's bulk
                               scanner: the scan runs in a SPAWNED `qs -p` scanner process
                               (scripts/wallpapers/we_compat_scan.qml) loading each project into a

--- a/AGENT.md
+++ b/AGENT.md
@@ -367,7 +367,7 @@ at startup). None of the documented env vars stops the probe
 (`QT_FFMPEG_DECODING_HW_DEVICE_TYPES` filters codec selection, not this enumeration). Before
 adding a QtMultimedia object anywhere, know that its first construction costs a near-second stall
 and permanently attaches the process to the dGPU.
-7ef4e762 ("perf(resources): poll through files, and stop waking a sleeping dGPU").
+417e9819 ("docs(agent): the first QtMultimedia object probes every hw context, cuda included").
 
 **A sound event is one `pw-play` on a path the shell resolved, and neither half of that sentence
 was true before.** `Audio.playSystemSound()` built
@@ -904,7 +904,7 @@ services/                  Singletons wrapping external state/processes - one pe
                               Wallpaper Engine, gated on WallpaperEngineFeatures so an older
                               renderer binary shows only what it answers - a control for a flag
                               the renderer does not read would be a fake action
-                              ("feat(wallpaperSelector): a sidebar - places over files, engine config over WE")
+                              c0c05d3f ("feat(wallpaperSelector): a sidebar - places over files, engine config over WE")
   WallpaperEngineFeatures.qml  Which properties THIS binary's embedded renderer has, probed once
                               by building a bare WallpaperEngineSurface (no project, so no thread
                               or GL) and asking `"x" in surface`. The extended controls (the
@@ -922,10 +922,14 @@ services/                  Singletons wrapping external state/processes - one pe
                               picker draws the actual scene, grabbed by the renderer
                               (requestSceneGrab -> GlobalStates.weSceneGrabPath, a PNG at the
                               real 32:9 aspect), NOT the preview image - the preview does not
-                              depict an ultrawide scene. Note: WE renders a scene at its authored
-                              resolution regardless of window, so a render-scale lever does
-                              nothing for scenes (measured) and was not shipped; fps is the
-                              scene's only in-shell cost lever
+                              depict an ultrawide scene. The render-scale Quality dial
+                              (WallpaperSelectorSidebar, surface renderScale 0.25..1) IS shipped
+                              and gated the same way, but honest about its reach: WE renders a
+                              scene into its own authored-resolution FBO regardless of window, so
+                              the dial only trims a scene's final composite (fps is the lever for
+                              a heavy scene); it is the video path, composited at window size,
+                              where a lower quality cuts real work
+                              bc571a8d ("feat(wallpaperSelector): a render-scale Quality dial, gated and honest")
   WallpaperEngineCompat.qml    Per-wallpaper compatibility verdicts, the reference app's bulk
                               scanner: the scan runs in a SPAWNED `qs -p` scanner process
                               (scripts/wallpapers/we_compat_scan.qml) loading each project into a
@@ -941,7 +945,7 @@ services/                  Singletons wrapping external state/processes - one pe
                               Decisions in services/we_compat.js; the grid badges broken tiles
                               and the sidebar's Hide broken filters them, both through
                               statusFor - tests/test_we_compat_wiring.py pins the one reader
-                              ("feat(wallpaperSelector): a compatibility scan that marks the wallpapers the renderer cannot start")
+                              dd97c0a1 ("feat(wallpaperSelector): the engine's full settings, per-wallpaper properties, and a compatibility scan")
   SchemePreview.qml            Per-scheme swatches for the scheme pickers: one venv run of
                               scripts/colors/scheme_preview.py quantizes the wallpaper once and
                               builds every Material variant from it. Cached against the wallpaper
@@ -3288,7 +3292,7 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   which is what keeps the depth registration's `coverRect` — an aspect-only computation — correct.
   33139b688 ("fix(widgets): give every desktop widget's frost one shared wallpaper decode"),
   e15b9f166 ("test(widgets): pin the desktop frost to one shared wallpaper request"),
-  ("perf(background): bound the wallpaper decode to what a screen can draw").
+  61aec909 ("perf(background): bound the wallpaper decode to what a screen can draw").
 - Desktop plugin delegates are retained for every available manifest and gated through an animated
   `FadeLoader`, rather than repeating only the enabled ids. Removing a model delegate destroys it
   immediately and makes an M3 exit transition impossible; keep disabled loaders dormant until their
@@ -6638,7 +6642,7 @@ surface's fully transparent idle pixels would ask the compositor to blur the ent
 the threshold moved to 0.4 (the scrim sits at ~0.88+, so it frosts exactly as before). Its layer
 follows the overview's #339 rule — Overlay only while open over a true fullscreen window, Top
 otherwise — because a permanently-mapped Overlay surface holds the fullscreen fast path shut.
-("perf(sessionScreen): the session menu's surface outlives the gesture").
+c27bebd0 ("perf(sessionScreen): the session menu's surface outlives the gesture").
 
 A fourth cost, found by the first multi-monitor user to update (#297): **a persistent surface has
 to say which screen it lives on.** A `PanelWindow` with no `screen:` asks the compositor to choose

--- a/AGENT.md
+++ b/AGENT.md
@@ -3208,9 +3208,16 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   re-pays on every pixel of a drag, since the rect tracks the widget's position. Take the slice
   with a `ShaderEffectSource`'s `sourceRect` over a shared, unclipped, cached `Image` instead: the
   rect is free to move, and matching the request Background's own wallpaper `Image` makes means a
-  surface built while that wallpaper is on screen needs no decode at all.
+  surface built while that wallpaper is on screen needs no decode at all. That request now carries
+  a fifth parameter: a `sourceSize` bound (`bgRoot.wallpaperDecodeSize`, screen x configured zoom,
+  stable across lock), so an 8K file no longer decodes at 8K for a 1.1x-screen viewport — and every
+  sharer (the frost's `decodeWidth`/`decodeHeight`, the depth cutout's `decodeSize`) must carry the
+  SAME bound or #147 comes back with a new spelling. Qt preserves the picture's aspect under
+  `PreserveAspectCrop` + `sourceSize` (measured: 7680x2160 bounded to 2112x1188 decodes 4224x1188),
+  which is what keeps the depth registration's `coverRect` — an aspect-only computation — correct.
   33139b688 ("fix(widgets): give every desktop widget's frost one shared wallpaper decode"),
-  e15b9f166 ("test(widgets): pin the desktop frost to one shared wallpaper request").
+  e15b9f166 ("test(widgets): pin the desktop frost to one shared wallpaper request"),
+  ("perf(background): bound the wallpaper decode to what a screen can draw").
 - Desktop plugin delegates are retained for every available manifest and gated through an animated
   `FadeLoader`, rather than repeating only the enabled ids. Removing a model delegate destroys it
   immediately and makes an M3 exit transition impossible; keep disabled loaders dormant until their

--- a/AGENT.md
+++ b/AGENT.md
@@ -225,7 +225,20 @@ wait and re-check before concluding the code is broken.
 
 ## External binaries the shell drives
 
-Two non-obvious traps live here, both found the expensive way.
+**WE_REF pins the renderer, so a `WallpaperEngineSurface` property the shell reads may not exist in
+the binary a user is running.** The embedded Wallpaper Engine renderer is a patched Quickshell built
+by the satellite repo `XephyLon/qs-wallpaperengine`; the hub pins which revision in
+`sdata/subcmd-install/4.wallpaperengine.sh` as `WE_REF`, and a feature added to the module ships to
+nobody until that pin moves to a tag that has it. So a shell reading `surface.volume` or
+`surface.properties` can be running a binary from before those existed. Two mechanisms keep that from
+being a load-breaking assignment: `WallpaperEngineLayer.qml` binds every extended property inside an
+`"x" in root` guard (an absent one is a silent no-op, exactly as `audioEnabled`/`occluded` already
+were), and `services/WallpaperEngineFeatures.qml` probes the same way once and gates the selector
+sidebar's controls, so an older binary shows only the knobs it answers rather than dead ones. When
+adding a renderer property: extend the module in that repo, tag it, move `WE_REF`, AND gate every
+shell-side read - the last step is what makes the intervening versions safe.
+
+Beyond that, two non-obvious traps live here, both found the expensive way.
 
 **`DT_RUNPATH` is not transitive, and `LD_LIBRARY_PATH` is.** The Wallpaper Engine build the shell
 loads (`~/.cache/immaterial-impulse/prebuilt/<ver>/`) bundles its own libraries. Setting a correct
@@ -871,21 +884,49 @@ services/                  Singletons wrapping external state/processes - one pe
                               takes to appear, the original persisted in Persistent so a
                               restart mid-swap still undoes it - see the entry under
                               "External binaries the shell drives"
-  WallpaperEngineOverrides.qml Per-project Wallpaper Engine settings (fps, scaling, audio), keyed
-                              by runtime project ids so it is a raw FileView over
-                              wallpaper-engine-overrides.json on the PluginState pattern - never
-                              a JsonAdapter. services/we_overrides.js is the resolution (per-key
-                              fallback to the globals, clear-on-null, sanitation); `active` is
-                              THE one live derivation, read by WallpaperEngineLayer's
-                              fps/scaleMode, Background's audio routing and the selector
-                              sidebar's controls - tests/test_we_overrides_wiring.py refuses a
+  WallpaperEngineOverrides.qml Per-project Wallpaper Engine settings (fps, scaling, audio on/off
+                              + volume, audio-reactive, mouse/parallax/particles) AND each
+                              wallpaper's own project.json properties, keyed by runtime project
+                              ids so it is a raw FileView over wallpaper-engine-overrides.json on
+                              the PluginState pattern - never a JsonAdapter. services/
+                              we_overrides.js is the resolution: per-key fallback to the globals
+                              for the ENGINE flags, and a separate `properties` map with no
+                              global side (hasOverride/clearEngineOverrides leave it alone, so
+                              turning the Custom settings switch off never eats a property
+                              edit). `active` is THE one live derivation, read by
+                              WallpaperEngineLayer's dynamic bindings, Background's audio routing
+                              and the sidebar - tests/test_we_overrides_wiring.py refuses a
                               raw-config read beside it. The sidebar
                               (modules/imi/wallpaperSelector/WallpaperSelectorSidebar.qml) is the
                               editor: a places rail over local files (selector_places.js), the
-                              engine's configuration over Wallpaper Engine, and only the knobs
-                              WallpaperEngineSurface actually answers - a control for a flag the
-                              renderer does not read would be a fake action
+                              engine's whole flag set + the wallpaper's own properties
+                              (WallpaperPropertyControl, one control per project.json type) over
+                              Wallpaper Engine, gated on WallpaperEngineFeatures so an older
+                              renderer binary shows only what it answers - a control for a flag
+                              the renderer does not read would be a fake action
                               ("feat(wallpaperSelector): a sidebar - places over files, engine config over WE")
+  WallpaperEngineFeatures.qml  Which properties THIS binary's embedded renderer has, probed once
+                              by building a bare WallpaperEngineSurface (no project, so no thread
+                              or GL) and asking `"x" in surface`. The extended controls (the
+                              qs-wallpaperengine 0.3 flag set, per-project properties) gate on
+                              it; WallpaperEngineLayer binds the same properties dynamically for
+                              the same reason. See "WE_REF pins the renderer" below
+  WallpaperEngineCompat.qml    Per-wallpaper compatibility verdicts, the reference app's bulk
+                              scanner: the scan runs in a SPAWNED `qs -p` scanner process
+                              (scripts/wallpapers/we_compat_scan.qml) loading each project into a
+                              real surface, so a wallpaper that wedges or crashes the renderer
+                              kills the scanner and not the shell - this service owns the queue,
+                              respawns past the corpse (a death mid-project is that project's
+                              verdict), and records ok/broken. Its own raw-JSON store
+                              (wallpaper-engine-compat.json), NOT the overrides file: verdicts
+                              are scan-managed state, not user settings (the reference's
+                              SCAN_MANAGED_KEYS split as a file boundary). web/application are
+                              "unsupported" by construction, unscanned. The scanner speaks its
+                              verdicts on STDERR because qs's stdout is block-buffered off a tty.
+                              Decisions in services/we_compat.js; the grid badges broken tiles
+                              and the sidebar's Hide broken filters them, both through
+                              statusFor - tests/test_we_compat_wiring.py pins the one reader
+                              ("feat(wallpaperSelector): a compatibility scan that marks the wallpapers the renderer cannot start")
   SchemePreview.qml            Per-scheme swatches for the scheme pickers: one venv run of
                               scripts/colors/scheme_preview.py quantizes the wallpaper once and
                               builds every Material variant from it. Cached against the wallpaper

--- a/AGENT.md
+++ b/AGENT.md
@@ -342,6 +342,20 @@ its own 30s clock: a tick used to spawn ~9 processes and now spawns none on this
 `tests/test_resource_usage_polling.py` pins the gate, the df cadence and the sysfs reads.
 7ef4e762 ("perf(resources): poll through files, and stop waking a sleeping dGPU").
 
+The other holder is Qt itself, and it is not reachable from this repo: **constructing the first
+QtMultimedia object of any kind — a `MediaPlayer`, even a `SoundEffect` — makes the ffmpeg media
+backend probe every hardware context on the machine** (`qt.multimedia.ffmpeg.hwaccel: Check device
+types`: vdpau, cuda, vaapi, qsv, vulkan), measured at **856ms** on this machine, on the thread that
+constructs it. The cuda probe loads `libnvcuvid`/`libcuda` and leaves eight `/dev/nvidia*` file
+descriptors and a CUDA context in the process for its remaining life — this is why the running
+shell maps `libcuda` once the typing test has been opened (TypingSounds' MediaPlayer pool is the
+shell's only QtMultimedia user, and it is gated on the feature precisely so none of this happens
+at startup). None of the documented env vars stops the probe
+(`QT_FFMPEG_DECODING_HW_DEVICE_TYPES` filters codec selection, not this enumeration). Before
+adding a QtMultimedia object anywhere, know that its first construction costs a near-second stall
+and permanently attaches the process to the dGPU.
+7ef4e762 ("perf(resources): poll through files, and stop waking a sleeping dGPU").
+
 **A sound event is one `pw-play` on a path the shell resolved, and neither half of that sentence
 was true before.** `Audio.playSystemSound()` built
 `/usr/share/sounds/<theme>/stereo/<event>.oga` and the same with `.ogg`, spawned an `ffplay` at

--- a/AGENT.md
+++ b/AGENT.md
@@ -327,6 +327,21 @@ Four things around that are worth not re-deriving:
   both *and* whose 3×3 neighbourhood is uniform (which kills subpixel edges), and report RMSE plus
   what code 255 became.
 
+**`nvidia-smi` powers up a runtime-suspended dGPU on every invocation, so a periodic poll of it
+IS the thing that keeps a hybrid laptop's dGPU awake.** On this machine (AMD iGPU driving the
+display, RTX 3060 with fine-grained runtime D3) the resource monitor's 3s `nvidia-smi` poll held
+the dGPU's `runtime_status` at `active` for an entire 18h session — the wake it costs per query is
+longer than the idle window the driver needs to gate, so the GPU never sleeps and the poll always
+reads "awake". Nothing errors and the numbers look right, which is what hid it. There is no
+wake-free NVIDIA query (no sysfs busy counter; every `nvidia-smi`/NVML call wakes the device), so
+`ResourceUsage.qml` reads the dGPU's `power/runtime_status` (a plain PCI sysfs file, free) each
+tick and spawns `nvidia-smi` only while it says the GPU is already awake — a suspended GPU is 0%
+busy by definition. The same change moved every reading the kernel exposes as a file (hwmon CPU
+temperature, amdgpu busy/temp/VRAM) onto FileViews resolved once by a startup probe, and df onto
+its own 30s clock: a tick used to spawn ~9 processes and now spawns none on this machine.
+`tests/test_resource_usage_polling.py` pins the gate, the df cadence and the sysfs reads.
+7ef4e762 ("perf(resources): poll through files, and stop waking a sleeping dGPU").
+
 **A sound event is one `pw-play` on a path the shell resolved, and neither half of that sentence
 was true before.** `Audio.playSystemSound()` built
 `/usr/share/sounds/<theme>/stereo/<event>.oga` and the same with `.ogg`, spawned an `ffplay` at
@@ -684,7 +699,11 @@ services/                  Singletons wrapping external state/processes - one pe
                               subdirectory and extension rules, the .disabled marker), and this
                               singleton owns the process lifetimes. Playback is a spawned
                               `pw-play` - see "External binaries the shell drives"
-  ResourceUsage.qml           Polls /proc/meminfo, /proc/stat, df, nvidia-smi on a timer
+  ResourceUsage.qml           Polls /proc/meminfo, /proc/stat and the hwmon/amdgpu sysfs files a
+                              startup probe resolves, all through FileViews; subprocesses only
+                              where no file exists (nvidia-smi behind a runtime-status gate, df on
+                              its own 30s clock, sensors as the no-hwmon fallback) - see the
+                              nvidia-smi entry under "External binaries the shell drives"
   HyprlandData.qml            Polls `hyprctl clients/monitors/layers/workspaces -j` on Hyprland IPC
                               events - the source of truth for "what does hyprctl currently see",
                               since Quickshell's own Hyprland IPC bindings don't expose everything

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,28 @@ own repo; the installer pins which revision it builds.
 
 ## [Unreleased]
 
+### Added
+- **A Wallpaper Engine sidebar in the wallpaper selector.** Browsing WE
+  wallpapers, the selector gains a settings sidebar: frame rate, scaling,
+  audio and volume, the audio-reactive recorder, mouse/parallax/particles,
+  and each wallpaper's own project.json properties — set globally or per
+  wallpaper. Broken wallpapers are flagged by a compatibility scan. Browsing
+  local files instead, the sidebar is a "places" rail.
+- **A crop picker for the "Fill" scale mode.** When a Wallpaper Engine scene
+  or image is larger than the monitor, its thumbnail becomes a section
+  selector — drag to choose which part is shown, and the wallpaper pans live.
+  The thumbnail shows the real scene grabbed from the renderer, not the
+  wallpaper's (often portrait) preview image.
+- **A Quality dial for Wallpaper Engine wallpapers.** Native / High / Balanced
+  / Low renders the wallpaper at a fraction of native and upscales. It cuts
+  real work for video wallpapers; for a heavy scene the frame rate is the
+  better lever, and the control says so.
+
+### Fixed
+- **The dedicated GPU is left asleep.** Resource polling no longer wakes a
+  runtime-suspended NVIDIA card every tick to read its stats, and the
+  wallpaper decode is bounded to what a screen can actually draw.
+
 ## [1.0.0-rc-12] — 2026-09-03
 
 ### Added

--- a/dots/.config/hypr/hyprland/rules.lua
+++ b/dots/.config/hypr/hyprland/rules.lua
@@ -201,7 +201,14 @@ hl.layer_rule({ match = { namespace = "quickshell:regionSelector" }, no_anim = t
 hl.layer_rule({ match = { namespace = "quickshell:screenshot" }, no_anim = true})
 hl.layer_rule({ match = { namespace = "quickshell:session" }, blur = true})
 hl.layer_rule({ match = { namespace = "quickshell:session" }, no_anim = true})
-hl.layer_rule({ match = { namespace = "quickshell:session" }, ignore_alpha = 0})
+-- 0.4, not 0: the session surface stays mapped while closed now, and at
+-- ignore_alpha = 0 its fully transparent idle pixels would still clear the
+-- threshold - a permanently-mapped screen-sized surface asking the compositor
+-- to blur the entire screen. The scrim sits at ~0.88+ alpha, so 0.4 blurs it
+-- exactly as before and ignores the closed surface. Failure direction: too
+-- high unblurs the scrim (flat but harmless), too low re-frosts the idle
+-- screen.
+hl.layer_rule({ match = { namespace = "quickshell:session" }, ignore_alpha = 0.4})
 -- The sidebars' surfaces stay mapped and the panels slide in QML (EdgeSlide,
 -- on tiers pinned to the layersIn/layersOut this used to draw), so there is
 -- no map to animate. The slide rules these replaced fired only on map, which

--- a/dots/.config/hypr/hyprland/rules.lua
+++ b/dots/.config/hypr/hyprland/rules.lua
@@ -60,6 +60,16 @@ hl.window_rule({match = {class = "^(plasma-changeicons)$" }, no_initial_focus = 
 hl.window_rule({match = {class = "^(plasma-changeicons)$" }, move = {999999, 999999}})
 -- stupid dolphin copy
 hl.window_rule({match = {title = "^(Copying — Dolphin)$" }, move = {40, 80}})
+-- The wallpaper compatibility scanner (qs -p we_compat_scan.qml) needs a
+-- MAPPED window - `rendered` is its whole instrument and an unmapped surface
+-- never produces a frame - but it is not for the user to see. Without a rule
+-- Hyprland tiles it into the active workspace and focuses it on every spawn
+-- and respawn, once per broken wallpaper. Float it, deny initial focus, and
+-- park it offscreen (same shape as plasma-changeicons above) so it stays
+-- mapped but out of the way.
+hl.window_rule({match = {title = "^(Wallpaper compatibility scan)$" }, float = true})
+hl.window_rule({match = {title = "^(Wallpaper compatibility scan)$" }, no_initial_focus = true})
+hl.window_rule({match = {title = "^(Wallpaper compatibility scan)$" }, move = {999999, 999999}})
 
 -- Tiling
 hl.window_rule({match = {class = "^dev\\.warp\\.Warp$" }, tile = true})

--- a/dots/.config/quickshell/imi/GlobalStates.qml
+++ b/dots/.config/quickshell/imi/GlobalStates.qml
@@ -66,6 +66,12 @@ Singleton {
     // draws its cutout into this box and measures its clicks against the same
     // rectangle, so the pixels it judges are the pixels the depth layer masks.
     property var clockDepthViewports: ({})
+    // The active Wallpaper Engine scene's content aspect (w/h), published by
+    // Background from the live surface's real content size - which the crop
+    // picker needs because the scene's authored aspect is not the preview
+    // image's. 0 while no scene is live or before its first frame (a video
+    // has no content aspect to pan, so it stays 0).
+    property real weContentAspect: 0
     // True while a copy snip's crop/clipboard pipeline runs; cancel paths
     // must not dismiss (and thereby kill) the in-flight process.
     property bool snipCopyInFlight: false

--- a/dots/.config/quickshell/imi/GlobalStates.qml
+++ b/dots/.config/quickshell/imi/GlobalStates.qml
@@ -72,6 +72,13 @@ Singleton {
     // image's. 0 while no scene is live or before its first frame (a video
     // has no content aspect to pan, so it stays 0).
     property real weContentAspect: 0
+    // A grabbed PNG of the active scene's FULL uncropped frame (its real
+    // aspect), and which project it is for - the crop picker shows the actual
+    // scene rather than the preview image, which does not depict it. Written
+    // by Background when the renderer answers a scene grab; the picker checks
+    // the project id so a stale grab is never shown.
+    property string weSceneGrabPath: ""
+    property string weSceneGrabProject: ""
     // True while a copy snip's crop/clipboard pipeline runs; cancel paths
     // must not dismiss (and thereby kill) the in-flight process.
     property bool snipCopyInFlight: false

--- a/dots/.config/quickshell/imi/modules/common/Config.qml
+++ b/dots/.config/quickshell/imi/modules/common/Config.qml
@@ -1771,6 +1771,21 @@ Singleton {
                     property int fps: 30
                     property string scaling: "fill"
                     property bool silent: true
+                    // The rest of the engine's flag set, global defaults the
+                    // per-project overrides (WallpaperEngineOverrides) fall
+                    // back to. volume is 0..100 with 100 the renderer's old
+                    // fixed "full internal volume, mix in the system mixer";
+                    // audioProcessing is WE's audio-reactive recorder, on by
+                    // default like WE's own; the three disables mirror WE's
+                    // --disable-mouse/--disable-parallax/--disable-particles.
+                    property int volume: 100
+                    property bool audioProcessing: true
+                    property bool disableMouse: false
+                    property bool disableParallax: false
+                    property bool disableParticles: false
+                    // Hide wallpapers the compatibility scan marked broken
+                    // from the selector grid (WallpaperEngineCompat).
+                    property bool hideBroken: false
                     // Which output plays the wallpaper's sound. Empty means
                     // the first screen the compositor reports.
                     //

--- a/dots/.config/quickshell/imi/modules/common/Config.qml
+++ b/dots/.config/quickshell/imi/modules/common/Config.qml
@@ -1783,6 +1783,14 @@ Singleton {
                     property bool disableMouse: false
                     property bool disableParallax: false
                     property bool disableParticles: false
+                    // renderScale is a quality/performance dial: the renderer
+                    // draws into a window this fraction of the surface size and
+                    // the scene graph upscales, 0.25..1 with 1 = native. It is
+                    // the video path (composited at window size) where it cuts
+                    // real work; a SCENE renders into its own authored-
+                    // resolution FBO regardless, so for a heavy scene fps is the
+                    // lever and this only trims the final composite.
+                    property real renderScale: 1.0
                     // Hide wallpapers the compatibility scan marked broken
                     // from the selector grid (WallpaperEngineCompat).
                     property bool hideBroken: false

--- a/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/PluginWidget.qml
@@ -80,6 +80,10 @@ AbstractBackgroundWidget {
     property real canvasOffsetX: 0
     property real canvasOffsetY: 0
     property rect wallpaperRect: Qt.rect(0, 0, 0, 0)
+    // The decode bound the desktop's wallpaper request carries; forwarded to
+    // the frost so the two stay one pixmap-cache entry (see
+    // WallpaperBlurSurface's decodeWidth note).
+    property size wallpaperDecodeSize: Qt.size(0, 0)
 
     // This widget's top-left in the wallpaper's own coordinates - the space the
     // frost samples in. Sampling at the widget's canvas position instead is
@@ -855,6 +859,8 @@ AbstractBackgroundWidget {
             maskItem: modelData.mask ?? null
             wallpaperWidth: rootWidget.wallpaperRect.width
             wallpaperHeight: rootWidget.wallpaperRect.height
+            decodeWidth: rootWidget.wallpaperDecodeSize.width
+            decodeHeight: rootWidget.wallpaperDecodeSize.height
             surfaceX: rootWidget.frostSampleOrigin.x + x
             surfaceY: rootWidget.frostSampleOrigin.y + y
         }

--- a/dots/.config/quickshell/imi/modules/common/plugins/bundled/user-card/Widget.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/bundled/user-card/Widget.qml
@@ -231,9 +231,7 @@ Item {
                 id: avatarImage
                 anchors.fill: parent
                 anchors.margins: Appearance.spacing.space50
-                source: Config.options.profile.avatarPath !== ""
-                    ? "file://" + Config.options.profile.avatarPicture
-                    : "file:///home/" + (Quickshell.env("USER") ?? "user") + "/.face"
+                source: UserAvatar.url
                 sourceSize.width: avatarImage.width * 2
                 sourceSize.height: avatarImage.height * 2
                 fillMode: Image.PreserveAspectCrop

--- a/dots/.config/quickshell/imi/modules/common/widgets/WallpaperBlurSurface.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/WallpaperBlurSurface.qml
@@ -42,6 +42,15 @@ Item {
     property real surfaceX: 0
     property real surfaceY: 0
 
+    // The decode bound Background's own wallpaper request carries
+    // (bgRoot.wallpaperDecodeSize). A sourceSize is part of the pixmap cache
+    // key, so this must be byte-identical to the desktop's or every surface
+    // decodes for itself again - which is #147 with a fifth request parameter.
+    // 0 means unbounded, for a caller standing in front of an unbounded
+    // request.
+    property int decodeWidth: 0
+    property int decodeHeight: 0
+
     readonly property string wallpaperUrl: root.wallpaperSource
         ? "file://" + root.wallpaperSource.split('/').map(s => encodeURIComponent(s)).join('/')
         : ""
@@ -70,18 +79,19 @@ Item {
     // ---- Static image path: the whole wallpaper, laid out exactly as the
     // desktop draws it, so the slice behind this surface is just a sub-rect.
     //
-    // Asking for the plain file - no sourceSize, no sourceClipRect, cache on -
-    // is the fix for #147, not an oversight. Those are the request parameters a
-    // QQuickPixmap cache key is built from, so the per-surface clip rect this
-    // used to carry gave every surface a key of its own, and `cache: false`
-    // stopped even identical requests from being shared: eight widgets meant
-    // sixteen full-resolution decodes of one file queued on Qt's single
-    // pixmap-reader thread, and the frost came back one widget at a time, ~0.6s
-    // apart. Sharing the key means every surface - and Background's own
-    // wallpaper Image, which asks for it the same way - waits on one decode, and
-    // a surface created after that decode is Ready in the frame it is built. It
-    // also stops a drag re-requesting the wallpaper on every pixel of travel:
-    // only the sample rect below moves now.
+    // Asking for the plain file - no sourceClipRect, cache on, and exactly the
+    // decode bound the desktop's request carries - is the fix for #147, not an
+    // oversight. Those are the request parameters a QQuickPixmap cache key is
+    // built from, so the per-surface clip rect this used to carry gave every
+    // surface a key of its own, and `cache: false` stopped even identical
+    // requests from being shared: eight widgets meant sixteen full-resolution
+    // decodes of one file queued on Qt's single pixmap-reader thread, and the
+    // frost came back one widget at a time, ~0.6s apart. Sharing the key means
+    // every surface - and Background's own wallpaper Image, which asks for it
+    // the same way - waits on one decode, and a surface created after that
+    // decode is Ready in the frame it is built. It also stops a drag
+    // re-requesting the wallpaper on every pixel of travel: only the sample
+    // rect below moves now.
     Image {
         id: wallpaperImage
         width: root.wallpaperWidth
@@ -91,6 +101,16 @@ Item {
         asynchronous: true
         cache: true
         visible: false
+
+        // Applied through a gated Binding rather than a ternary on the
+        // property, because "no bound" has to leave sourceSize at its default
+        // (an invalid QSize) - a written 0x0 is a different request key.
+        Binding {
+            target: wallpaperImage
+            property: "sourceSize"
+            value: Qt.size(root.decodeWidth, root.decodeHeight)
+            when: root.decodeWidth > 0 && root.decodeHeight > 0
+        }
     }
 
     // One sampler for both paths: the source covers the whole wallpaper either

--- a/dots/.config/quickshell/imi/modules/imi/background/Background.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/Background.qml
@@ -235,6 +235,31 @@ Variants {
         readonly property real parallaxWidth: bgRoot.width * bgRoot.parallaxZoom
         readonly property real parallaxHeight: bgRoot.height * bgRoot.parallaxZoom
 
+        // The static wallpaper's decode bound: the most pixels this screen can
+        // ever draw of it (screen x the configured zoom). Without one, the
+        // wallpaper decodes at FILE resolution - an 8K picture is a ~130MB
+        // decode plus a full-size texture, for a 1.1x-screen viewport. Three
+        // properties of the bound are load-bearing:
+        // - it reads the SCREEN's size, not bgRoot.width: geometry is 0 for
+        //   the first frames, and a sourceSize that starts 0 (= unbounded) and
+        //   then lands is one full-res decode plus one bounded re-decode per
+        //   startup (the triple-decode trap the selector's own bound records);
+        // - it reads the configured zoom, not parallaxZoom: that collapses to
+        //   1 while the session is locked, and a bound that moves with it
+        //   re-decodes the wallpaper on every lock and unlock;
+        // - it is part of the pixmap cache key, so every sharer of this
+        //   request (the widget frost, the depth cutout) must carry the SAME
+        //   value - tests/tst_wallpaper_blur_sharing.qml holds the frost half.
+        // Qt keeps the picture's aspect under PreserveAspectCrop (measured:
+        // 7680x2160 bounded to 2112x1188 decodes 4224x1188), so everything
+        // reading the item's implicit size for the picture's aspect - the
+        // depth registration's coverRect - is unchanged by it.
+        readonly property size wallpaperDecodeSize: Qt.size(
+            Math.round(bgRoot.modelData.width
+                * Math.max(1, Config.options.background.parallax.workspaceZoom ?? 1)),
+            Math.round(bgRoot.modelData.height
+                * Math.max(1, Config.options.background.parallax.workspaceZoom ?? 1)))
+
         // Portrait wallpapers have vertical room to spare and no horizontal
         // story to tell, so they pan down the picture instead of across it.
         // Only stills can be measured this way - a WE project reports nothing -
@@ -948,6 +973,7 @@ Variants {
                 cache: true
                 smooth: true
                 asynchronous: true
+                sourceSize: bgRoot.wallpaperDecodeSize
                 layer.enabled: bgRoot.wallpaperAnimation !== ""
                     && bgRoot.transitionProgress < 1
                 visible: false
@@ -960,6 +986,7 @@ Variants {
                 cache: true
                 smooth: true
                 asynchronous: true
+                sourceSize: bgRoot.wallpaperDecodeSize
                 layer.enabled: bgRoot.wallpaperAnimation !== ""
                     && bgRoot.transitionProgress < 1
                 // The plain image is the wallpaper. It is always drawn (a
@@ -1417,6 +1444,7 @@ Variants {
                             ? Qt.rect(0, 0, bgRoot.width, bgRoot.height)
                             : Qt.rect(parallaxViewport.x, parallaxViewport.y,
                                 parallaxViewport.width, parallaxViewport.height)
+                        wallpaperDecodeSize: bgRoot.wallpaperDecodeSize
                     }
                 }
             }
@@ -1533,6 +1561,11 @@ Variants {
                 // outgoing frame, and reading the path would put the incoming
                 // image under the outgoing image's mask for the length of it.
                 wallpaperSource: wallpaper.source
+                // The same decode bound the wallpaper item carries - it is
+                // part of the request, and the one-decode sharing this file
+                // documents on the cutout's own Image holds only while every
+                // parameter matches.
+                decodeSize: bgRoot.wallpaperDecodeSize
                 // The live surface, never its still (spec §8.3): a masked
                 // still would freeze every animated pixel inside the
                 // silhouette. weLiveSource is the texture the WE transition

--- a/dots/.config/quickshell/imi/modules/imi/background/Background.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/Background.qml
@@ -251,16 +251,23 @@ Variants {
         //   re-decodes the wallpaper on every lock and unlock;
         // - it is part of the pixmap cache key, so every sharer of this
         //   request (the widget frost, the depth cutout) must carry the SAME
-        //   value - tests/tst_wallpaper_blur_sharing.qml holds the frost half.
+        //   value - tests/tst_wallpaper_blur_sharing.qml holds the frost half;
+        // - it scales by the output's devicePixelRatio: modelData.width/height
+        //   are LOGICAL pixels but sourceSize is DECODED pixels, so on a
+        //   fractional- or 2x-scale output an unscaled bound decodes at a
+        //   fraction of the panel's pixels and the scene graph upscales it -
+        //   the wallpaper, the frost and the depth cutout all visibly softer.
+        //   The sharers inherit the ratio through this same property.
         // Qt keeps the picture's aspect under PreserveAspectCrop (measured:
         // 7680x2160 bounded to 2112x1188 decodes 4224x1188), so everything
         // reading the item's implicit size for the picture's aspect - the
         // depth registration's coverRect - is unchanged by it.
+        readonly property real _decodeScale:
+            Math.max(1, Config.options.background.parallax.workspaceZoom ?? 1)
+            * (bgRoot.modelData.devicePixelRatio ?? 1)
         readonly property size wallpaperDecodeSize: Qt.size(
-            Math.round(bgRoot.modelData.width
-                * Math.max(1, Config.options.background.parallax.workspaceZoom ?? 1)),
-            Math.round(bgRoot.modelData.height
-                * Math.max(1, Config.options.background.parallax.workspaceZoom ?? 1)))
+            Math.round(bgRoot.modelData.width * bgRoot._decodeScale),
+            Math.round(bgRoot.modelData.height * bgRoot._decodeScale))
 
         // Portrait wallpapers have vertical room to spare and no horizontal
         // story to tell, so they pan down the picture instead of across it.
@@ -450,6 +457,25 @@ Variants {
         // where `activeStill` used to be declared in Config.qml for why storing
         // it is the bug (#103) rather than the convenience it looks like.
         readonly property bool ownsGreeterStill: bgRoot.modelData === Quickshell.screens[0]
+
+        // The project a scene grab was requested for, captured at request time
+        // so onSceneGrabReady labels the PNG with the scene it depicts, not
+        // whatever is active when the (async) grab lands.
+        property string weGrabProject: ""
+
+        // Whether the crop picker can actually use a scene grab: only a Fill
+        // wallpaper that overflows this screen, on a renderer that pans (the
+        // focus surface). Anything else shows no section picker, so grabbing
+        // the scene - a full glReadPixels + PNG on the render thread, which
+        // otherwise re-runs on every reload (a volume commit, a Quality change,
+        // a property edit) - is wasted work.
+        readonly property real _screenAspect:
+            (bgRoot.modelData.height > 0) ? bgRoot.modelData.width / bgRoot.modelData.height : 0
+        readonly property bool weCanCrop:
+            WallpaperEngineOverrides.active.scaling === "fill"
+            && WallpaperEngineFeatures.cropFocus
+            && GlobalStates.weContentAspect > 0
+            && Math.abs(GlobalStates.weContentAspect - bgRoot._screenAspect) > 0.01
 
         function captureGreeterStill() {
             if (!bgRoot.ownsGreeterStill || !(weLoader.item?.rendered ?? false)) return
@@ -911,10 +937,24 @@ Variants {
                 Connections {
                     target: weLoader.item
                     enabled: weLoader.item !== null && bgRoot.ownsGreeterStill
+                    // contentSizeChanged is a qs-wallpaperengine 0.3+ signal;
+                    // Qt matches handlers to signals at CONNECT time regardless
+                    // of `enabled`, so without this an older binary logs "no
+                    // signal of the target matches" once per screen.
+                    ignoreUnknownSignals: true
                     function onContentSizeChanged() {
                         const w = weLoader.item?.contentWidth ?? 0;
                         const h = weLoader.item?.contentHeight ?? 0;
                         GlobalStates.weContentAspect = (w > 0 && h > 0) ? w / h : 0;
+                        // weCanCrop depends on this aspect, so if it only now
+                        // became true (content size published after the first
+                        // rendered frame), kick the grab here too. The 400 ms
+                        // Timer coalesces a restart from onRenderedChanged, so
+                        // whichever signal lands last, the scene is grabbed once.
+                        if (bgRoot.ownsGreeterStill && weLoader.item?.rendered
+                                && bgRoot.weCanCrop
+                                && ("requestSceneGrab" in weLoader.item))
+                            weSceneGrabDelay.restart();
                     }
                 }
                 // A project switch (or clear) leaves a stale aspect until the
@@ -955,7 +995,11 @@ Variants {
                         // once the scene is really rendering. Screen 0 only -
                         // one grab, one file. The `?rev` is Qt's pixmap-cache
                         // buster (a rewrite at the same path is not reloaded).
+                        // Only when the picker could use it (weCanCrop), so a
+                        // reload that is not a croppable Fill scene does not pay
+                        // for a grab nobody shows.
                         if (bgRoot.ownsGreeterStill && weLoader.item?.rendered
+                                && bgRoot.weCanCrop
                                 && ("requestSceneGrab" in weLoader.item)) {
                             weSceneGrabDelay.restart();
                         }
@@ -966,20 +1010,33 @@ Variants {
                     id: weSceneGrabDelay
                     interval: 400 // let the scene settle past its warmup frame
                     onTriggered: {
-                        if (weLoader.item && ("requestSceneGrab" in weLoader.item))
+                        if (weLoader.item && ("requestSceneGrab" in weLoader.item)) {
+                            // Stamp the scene being grabbed now, so a later
+                            // project switch cannot mislabel this grab.
+                            bgRoot.weGrabProject =
+                                Config.options.wallpaperSelector.wallpaperEngine.activeProject;
                             // A plain path (trimmed of file://) - the module's
                             // QImage::save wants a filesystem path. The stills
                             // dir is already created (Directories mkdir).
                             weLoader.item.requestSceneGrab(
                                 `${Directories.wallpaperEngineStills}/scene-crop-grab.png`);
+                        }
                     }
                 }
                 Connections {
                     target: weLoader.item
                     enabled: weLoader.item !== null && bgRoot.ownsGreeterStill
                         && ("sceneGrabReady" in (weLoader.item ?? ({})))
+                    // Same 0.3+ signal caveat as contentSizeChanged: the `in`
+                    // guard gates `enabled`, but Qt still matches at connect
+                    // time, so this silences the per-screen warning.
+                    ignoreUnknownSignals: true
                     function onSceneGrabReady(path) {
-                        GlobalStates.weSceneGrabProject = Config.options.wallpaperSelector.wallpaperEngine.activeProject;
+                        // Label the grab with the project it was REQUESTED for,
+                        // not the one active now: a switch during the 400 ms +
+                        // render window would otherwise stamp the previous
+                        // scene's grab with the new project's id.
+                        GlobalStates.weSceneGrabProject = bgRoot.weGrabProject;
                         GlobalStates.weSceneGrabPath = "file://" + path + "?" + Date.now();
                     }
                 }

--- a/dots/.config/quickshell/imi/modules/imi/background/Background.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/Background.qml
@@ -924,7 +924,11 @@ Variants {
                     target: weLoader
                     enabled: bgRoot.ownsGreeterStill
                     function onActiveChanged() {
-                        if (!weLoader.active) GlobalStates.weContentAspect = 0;
+                        if (!weLoader.active) {
+                            GlobalStates.weContentAspect = 0;
+                            GlobalStates.weSceneGrabProject = "";
+                            GlobalStates.weSceneGrabPath = "";
+                        }
                     }
                 }
 
@@ -947,6 +951,36 @@ Variants {
                         // needs a still just as much as a switch does.
                         if (weLoader.item?.rendered)
                             greeterStillDelay.restart();
+                        // Grab the full uncropped scene for the crop picker,
+                        // once the scene is really rendering. Screen 0 only -
+                        // one grab, one file. The `?rev` is Qt's pixmap-cache
+                        // buster (a rewrite at the same path is not reloaded).
+                        if (bgRoot.ownsGreeterStill && weLoader.item?.rendered
+                                && ("requestSceneGrab" in weLoader.item)) {
+                            weSceneGrabDelay.restart();
+                        }
+                    }
+                }
+
+                Timer {
+                    id: weSceneGrabDelay
+                    interval: 400 // let the scene settle past its warmup frame
+                    onTriggered: {
+                        if (weLoader.item && ("requestSceneGrab" in weLoader.item))
+                            // A plain path (trimmed of file://) - the module's
+                            // QImage::save wants a filesystem path. The stills
+                            // dir is already created (Directories mkdir).
+                            weLoader.item.requestSceneGrab(
+                                `${Directories.wallpaperEngineStills}/scene-crop-grab.png`);
+                    }
+                }
+                Connections {
+                    target: weLoader.item
+                    enabled: weLoader.item !== null && bgRoot.ownsGreeterStill
+                        && ("sceneGrabReady" in (weLoader.item ?? ({})))
+                    function onSceneGrabReady(path) {
+                        GlobalStates.weSceneGrabProject = Config.options.wallpaperSelector.wallpaperEngine.activeProject;
+                        GlobalStates.weSceneGrabPath = "file://" + path + "?" + Date.now();
                     }
                 }
             }

--- a/dots/.config/quickshell/imi/modules/imi/background/Background.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/Background.qml
@@ -108,7 +108,9 @@ Variants {
         // instead of silencing it.
         readonly property bool weAudioOutput: {
             const we = Config.options.wallpaperSelector.wallpaperEngine;
-            if (we.silent ?? true)
+            // Through the per-project resolution: a project may override the
+            // global audio switch either way (WallpaperEngineOverrides).
+            if (WallpaperEngineOverrides.active.silent)
                 return false;
             const name = bgRoot.monitor?.name ?? "";
             if (name === "")

--- a/dots/.config/quickshell/imi/modules/imi/background/Background.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/Background.qml
@@ -903,6 +903,31 @@ Variants {
                     when: weLoader.item !== null
                     restoreMode: Binding.RestoreNone
                 }
+                // Publish the scene's content aspect for the crop picker. The
+                // authored size is the same on every output, so one screen
+                // writes it (the greeter-still owner, screen 0) - N writers
+                // would fight over one global. 0 (a video, or no scene) reads
+                // as "no crop to pick", which the picker gate wants.
+                Connections {
+                    target: weLoader.item
+                    enabled: weLoader.item !== null && bgRoot.ownsGreeterStill
+                    function onContentSizeChanged() {
+                        const w = weLoader.item?.contentWidth ?? 0;
+                        const h = weLoader.item?.contentHeight ?? 0;
+                        GlobalStates.weContentAspect = (w > 0 && h > 0) ? w / h : 0;
+                    }
+                }
+                // A project switch (or clear) leaves a stale aspect until the
+                // new scene's first frame; drop it at the switch so the picker
+                // does not size itself by the previous wallpaper.
+                Connections {
+                    target: weLoader
+                    enabled: bgRoot.ownsGreeterStill
+                    function onActiveChanged() {
+                        if (!weLoader.active) GlobalStates.weContentAspect = 0;
+                    }
+                }
+
                 // First rendered frame of a newly-loaded project: kick off the
                 // shader transition against the captured old frame.
                 Connections {

--- a/dots/.config/quickshell/imi/modules/imi/background/ClockDepthCutout.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/ClockDepthCutout.qml
@@ -35,6 +35,9 @@ Item {
     // every call site but the desktop layer's.
     property Item liveSource: null
     readonly property Item paintedSource: root.liveSource ?? cutoutWallpaper
+    // The wallpaper's decode bound, when the call site's sibling wallpaper
+    // request carries one (the desktop layer's does). Zero = unbounded.
+    property size decodeSize: Qt.size(0, 0)
     property string maskPath: ""
     // A token that changes when the mask file's bytes do, hung on the URL as a
     // fragment. Qt caches a pixmap by URL and a mask is rewritten at the SAME
@@ -64,16 +67,29 @@ Item {
         id: cutoutWallpaper
         anchors.fill: parent
         // Every one of these matches the `wallpaper` item inside the viewport
-        // on purpose. Same source, same size, same fill mode means the
-        // per-screen crop matches with no geometry of its own - and it means
-        // Qt's image cache serves both from ONE decode, since a fill mode's
-        // aspect flags are part of the request and a Stretch copy of the same
-        // file would decode all over again.
+        // on purpose. Same source, same size, same fill mode, same decode
+        // bound means the per-screen crop matches with no geometry of its own
+        // - and it means Qt's image cache serves both from ONE decode, since a
+        // fill mode's aspect flags and a sourceSize are both part of the
+        // request; a Stretch copy of the same file, or one asked for at a
+        // different bound, would decode all over again.
         source: root.wallpaperSource
         fillMode: Image.PreserveAspectCrop
         cache: true
         smooth: true
         asynchronous: true
+
+        // "No bound" must leave sourceSize at its default invalid QSize (a
+        // written 0x0 is a different request key), hence the gated Binding.
+        // The picker and the desktop selector pass none and keep the
+        // unbounded request they always made; only the desktop layer, whose
+        // sibling wallpaper item is bounded, passes the same bound in.
+        Binding {
+            target: cutoutWallpaper
+            property: "sourceSize"
+            value: root.decodeSize
+            when: root.decodeSize.width > 0 && root.decodeSize.height > 0
+        }
         // Drawn by the OpacityMask below, not by itself.
         visible: false
     }

--- a/dots/.config/quickshell/imi/modules/imi/background/WallpaperEngineLayer.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/WallpaperEngineLayer.qml
@@ -41,6 +41,29 @@ WallpaperEngineSurface {
         if ("audioEnabled" in root) {
             root.audioEnabled = Qt.binding(() => root.audioWanted);
         }
+        // The rest of the engine's flag set (qs-wallpaperengine 0.3+), bound
+        // dynamically for the same reason as audioEnabled: on an older binary
+        // each absent property is a silent no-op instead of a load-breaking
+        // assignment, and the sidebar hides the controls it cannot honour
+        // (WallpaperEngineFeatures reports which of these exist).
+        if ("volume" in root) {
+            root.volume = Qt.binding(() => WallpaperEngineOverrides.active.volume);
+        }
+        if ("audioProcessing" in root) {
+            root.audioProcessing = Qt.binding(() => WallpaperEngineOverrides.active.audioProcessing);
+        }
+        if ("mouseDisabled" in root) {
+            root.mouseDisabled = Qt.binding(() => WallpaperEngineOverrides.active.disableMouse);
+        }
+        if ("parallaxDisabled" in root) {
+            root.parallaxDisabled = Qt.binding(() => WallpaperEngineOverrides.active.disableParallax);
+        }
+        if ("particlesDisabled" in root) {
+            root.particlesDisabled = Qt.binding(() => WallpaperEngineOverrides.active.disableParticles);
+        }
+        if ("properties" in root) {
+            root.properties = Qt.binding(() => WallpaperEngineOverrides.active.properties);
+        }
         // `occluded` idles the RENDER THREAD while this output is covered, which
         // is the half QML cannot otherwise reach: suppressing the contents stops
         // Qt drawing the surface, but the WE thread keeps producing frames

--- a/dots/.config/quickshell/imi/modules/imi/background/WallpaperEngineLayer.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/WallpaperEngineLayer.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import Quickshell.WallpaperEngine
 import qs.modules.common
+import qs.services
 
 // Thin wrapper around the embedded Wallpaper Engine surface. Kept in its own
 // file and loaded via a source-URL Loader so that on a Quickshell binary
@@ -10,10 +11,13 @@ import qs.modules.common
 WallpaperEngineSurface {
     id: root
     live: true
-    fps: Config.options.wallpaperSelector.wallpaperEngine.fps
+    // Through the per-project override resolution, not the raw config: a
+    // project with settings of its own (WallpaperEngineOverrides) runs at
+    // those, every other project at the globals exactly as before.
+    fps: WallpaperEngineOverrides.active.fps
     // "fill" | "fit" | "stretch" | "default" - how the wallpaper is scaled to
     // the screen (user-selectable, mirrors the static-wallpaper scaling).
-    scaleMode: Config.options.wallpaperSelector.wallpaperEngine.scaling
+    scaleMode: WallpaperEngineOverrides.active.scaling
 
     // Set by Background.qml when a fullscreen window covers THIS output, and
     // forwarded to the surface's `occluded` below. Kept as a plain local

--- a/dots/.config/quickshell/imi/modules/imi/background/WallpaperEngineLayer.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/WallpaperEngineLayer.qml
@@ -64,6 +64,12 @@ WallpaperEngineSurface {
         if ("properties" in root) {
             root.properties = Qt.binding(() => WallpaperEngineOverrides.active.properties);
         }
+        // renderScale is a load-time input inside the surface (the render
+        // window is fixed when WE starts), so a change reloads - same dynamic
+        // binding as the flags above.
+        if ("renderScale" in root) {
+            root.renderScale = Qt.binding(() => WallpaperEngineOverrides.active.renderScale);
+        }
         // The "fill" crop position, live: the renderer reads it every frame,
         // so a drag on the picker pans the wallpaper with no reload.
         if ("focusX" in root) {

--- a/dots/.config/quickshell/imi/modules/imi/background/WallpaperEngineLayer.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/WallpaperEngineLayer.qml
@@ -64,6 +64,14 @@ WallpaperEngineSurface {
         if ("properties" in root) {
             root.properties = Qt.binding(() => WallpaperEngineOverrides.active.properties);
         }
+        // The "fill" crop position, live: the renderer reads it every frame,
+        // so a drag on the picker pans the wallpaper with no reload.
+        if ("focusX" in root) {
+            root.focusX = Qt.binding(() => WallpaperEngineOverrides.active.focus.x);
+        }
+        if ("focusY" in root) {
+            root.focusY = Qt.binding(() => WallpaperEngineOverrides.active.focus.y);
+        }
         // `occluded` idles the RENDER THREAD while this output is covered, which
         // is the half QML cannot otherwise reach: suppressing the contents stops
         // Qt drawing the surface, but the WE thread keeps producing frames

--- a/dots/.config/quickshell/imi/modules/imi/background/WallpaperEngineProbe.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/WallpaperEngineProbe.qml
@@ -26,6 +26,9 @@ Item {
     // The full-scene grab the crop picker's accurate thumbnail needs.
     readonly property bool sceneGrab: "requestSceneGrab" in probeSurface
 
+    // The render-scale quality dial (draw into a smaller window, upscale).
+    readonly property bool renderScale: "renderScale" in probeSurface
+
     WallpaperEngineSurface {
         id: probeSurface
         visible: false

--- a/dots/.config/quickshell/imi/modules/imi/background/WallpaperEngineProbe.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/WallpaperEngineProbe.qml
@@ -20,6 +20,9 @@ Item {
     // Per-wallpaper project.json property overrides (--set-property).
     readonly property bool projectProperties: "properties" in probeSurface
 
+    // The live "fill" crop position - the section picker's renderer support.
+    readonly property bool cropFocus: ("focusX" in probeSurface) && ("focusY" in probeSurface)
+
     WallpaperEngineSurface {
         id: probeSurface
         visible: false

--- a/dots/.config/quickshell/imi/modules/imi/background/WallpaperEngineProbe.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/WallpaperEngineProbe.qml
@@ -23,6 +23,9 @@ Item {
     // The live "fill" crop position - the section picker's renderer support.
     readonly property bool cropFocus: ("focusX" in probeSurface) && ("focusY" in probeSurface)
 
+    // The full-scene grab the crop picker's accurate thumbnail needs.
+    readonly property bool sceneGrab: "requestSceneGrab" in probeSurface
+
     WallpaperEngineSurface {
         id: probeSurface
         visible: false

--- a/dots/.config/quickshell/imi/modules/imi/background/WallpaperEngineProbe.qml
+++ b/dots/.config/quickshell/imi/modules/imi/background/WallpaperEngineProbe.qml
@@ -1,0 +1,27 @@
+import QtQuick
+import Quickshell.WallpaperEngine
+
+// A bare WallpaperEngineSurface built only to be asked which properties this
+// binary's renderer has. With no projectPath it starts no thread, no GL and
+// no timer - construction is the whole cost. Loaded by URL from
+// WallpaperEngineFeatures for the reason WallpaperEngineLayer is: on a
+// Quickshell binary without the module, only the Loader fails.
+Item {
+    // The qs-wallpaperengine 0.3 flag set: volume, the audio-reactive
+    // recorder, and WE's three feature disables. One bool for the group -
+    // they shipped together, and a sidebar offering half of a set that
+    // cannot exist is not a state worth expressing.
+    readonly property bool engineFlags: ("volume" in probeSurface)
+        && ("audioProcessing" in probeSurface)
+        && ("mouseDisabled" in probeSurface)
+        && ("parallaxDisabled" in probeSurface)
+        && ("particlesDisabled" in probeSurface)
+
+    // Per-wallpaper project.json property overrides (--set-property).
+    readonly property bool projectProperties: "properties" in probeSurface
+
+    WallpaperEngineSurface {
+        id: probeSurface
+        visible: false
+    }
+}

--- a/dots/.config/quickshell/imi/modules/imi/bar/Media.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/Media.qml
@@ -229,9 +229,7 @@ Item {
                         Image {
                             id: avatarImage
                             anchors.fill: parent
-                            source: Config.options.profile.avatarPath !== "" 
-                                ? "file://" + Config.options.profile.avatarPicture 
-                                : "file:///home/" + (Quickshell.env("USER") ?? "user") + "/.face"
+                            source: UserAvatar.url
                             sourceSize.width: avatarRect.width * 2
                             sourceSize.height: avatarRect.height * 2
                             fillMode: Image.PreserveAspectCrop

--- a/dots/.config/quickshell/imi/modules/imi/sessionScreen/SessionScreen.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sessionScreen/SessionScreen.qml
@@ -14,37 +14,94 @@ import Quickshell.Hyprland
 Scope {
     id: root
 
-    property string focusedScreenName: Hyprland.focusedMonitor?.name ?? ""
+    // The window is persistent now - one per screen, mapped at boot - because
+    // creating it per open blocked the shell's one GUI thread ~61ms while the
+    // new window got its render thread, GL context and scene graph (the
+    // sidebars' measured number, and this is a screen-sized surface). Closed,
+    // each window is a Top-layer surface with a null input mask, keyboard
+    // focus None and nothing drawn - the bar's own idle shape. The layer is
+    // promoted to Overlay only while open over a true fullscreen window
+    // (the overview's #339 rule): a permanently-mapped Overlay surface would
+    // hold the compositor's fullscreen fast path shut for every game.
+    //
+    // One surface PER SCREEN, with the open edge latching the focused
+    // monitor - the overview's #297 shape, checked by
+    // tests/test_persistent_surface_screen.py's SURFACES registry.
+    property string targetScreen: ""
+    property PanelWindow activeWindow: null
 
-    property var focusedScreen: Quickshell.screens.find(s => s.name === root.focusedScreenName)
-        ?? Quickshell.screens[0]
+    function latchTarget() {
+        root.targetScreen = WM.focusedMonitor?.name ?? "";
+    }
 
-    Loader {
-        id: sessionLoader
-        active: GlobalStates.sessionOpen
-        onActiveChanged: {
-            if (sessionLoader.active)
+    function windowForFocusedMonitor() {
+        root.latchTarget();
+        const windows = sessionWindows.instances;
+        return windows.find(w => w.modelData.name === root.targetScreen)
+            ?? windows[0] ?? null;
+    }
+
+    // One dispatcher at the scope: the latch is written, THEN the one target
+    // opens. Per-window handlers would each read the latch with nothing
+    // ordering them against it being written.
+    Connections {
+        target: GlobalStates
+        function onSessionOpenChanged() {
+            if (GlobalStates.sessionOpen) {
                 SessionWarnings.refresh();
-        }
-
-        Connections {
-            target: GlobalStates
-            function onScreenLockedChanged() {
-                if (GlobalStates.screenLocked) {
-                    GlobalStates.sessionOpen = false;
-                }
+                root.activeWindow = root.windowForFocusedMonitor();
+                root.activeWindow?.open();
+            } else {
+                root.activeWindow?.close();
             }
         }
+        function onScreenLockedChanged() {
+            if (GlobalStates.screenLocked) {
+                GlobalStates.sessionOpen = false;
+            }
+        }
+    }
 
-        sourceComponent: PanelWindow { // Session menu
+    Variants {
+        id: sessionWindows
+        model: Quickshell.screens
+
+        PanelWindow { // Session menu
             id: sessionRoot
-            screen: root.focusedScreen
-            visible: sessionLoader.active
+            required property ShellScreen modelData
+            screen: modelData
+            readonly property bool isTarget: root.activeWindow === sessionRoot
+            // The content outlives the flag by exactly one exit animation -
+            // the wallpaper selector's `reallyOpen` rule. The exit's
+            // `finished` is what clears it.
+            property bool reallyOpen: false
             property string subtitle
             property bool rebootPickerOpen: false
-            onVisibleChanged: {
-                rebootPickerOpen = false;
-                if (visible) EfiBoot.refresh();
+
+            function open() {
+                sessionRoot.reallyOpen = true;
+                sessionRoot.rebootPickerOpen = false;
+                sessionRoot.subtitle = "";
+                EfiBoot.refresh();
+                // A persistent window is created once, at boot, without
+                // keyboard focus - an open has to say where keys go, or the
+                // window activates with no focus item and every key is
+                // dropped (the sidebars' lesson).
+                sessionLock.forceActiveFocus();
+                // Park-then-enter, not enter alone: the grid is persistent
+                // now, so after the first open every member is already at
+                // full strength and a bare enter() would have nothing to
+                // animate.
+                sessionEntrance.park();
+                sessionEntrance.enter();
+                enterAnim.stop();
+                exitAnim.stop();
+                enterAnim.start();
+            }
+
+            function close() {
+                enterAnim.stop();
+                exitAnim.start();
             }
 
             function hide() {
@@ -53,9 +110,35 @@ Scope {
 
             exclusionMode: ExclusionMode.Ignore
             WlrLayershell.namespace: "quickshell:session"
-            WlrLayershell.layer: WlrLayer.Overlay
-            WlrLayershell.keyboardFocus: WlrKeyboardFocus.Exclusive
-            color: ColorUtils.transparentize(Appearance.m3colors.m3background, Appearance.m3colors.darkmode ? 0.05 : 0.12)
+            // Overlay only while open over a true fullscreen window on this
+            // monitor: fullscreen windows composite above Top, so the menu
+            // opened behind a game - but a mapped Overlay surface holds the
+            // fullscreen fast path shut, which a session menu that is closed
+            // all day may not do.
+            readonly property bool monitorHasFullscreen:
+                HyprlandData.fullscreenByMonitorName[sessionRoot.screen?.name ?? ""] ?? false
+            WlrLayershell.layer: (GlobalStates.sessionOpen && sessionRoot.isTarget && sessionRoot.monitorHasFullscreen)
+                ? WlrLayer.Overlay : WlrLayer.Top
+            // Gated on being the target as well as the flag: every sibling
+            // would otherwise go Exclusive on the same open and the
+            // compositor would pick which surface swallows the keyboard.
+            WlrLayershell.keyboardFocus: (GlobalStates.sessionOpen && sessionRoot.isTarget)
+                ? WlrKeyboardFocus.Exclusive : WlrKeyboardFocus.None
+            // A literal, with the scrim painted by a child (scrimRect): a
+            // window colour bound to a theme token is the #143 latch, and on
+            // a persistent surface there is no rebuild to recover it.
+            color: "transparent"
+
+            // The whole surface takes input while open (a click anywhere
+            // cancels), and none of it while closed - a persistent surface
+            // with an ungated mask eats every click on the screen.
+            Item {
+                id: inputRegionProxy
+                anchors.fill: parent
+            }
+            mask: Region {
+                item: (GlobalStates.sessionOpen && sessionRoot.isTarget) ? inputRegionProxy : null
+            }
 
             anchors {
                 top: true
@@ -63,12 +146,48 @@ Scope {
                 right: true
             }
 
-            implicitWidth: root.focusedScreen?.width ?? 0
-            implicitHeight: root.focusedScreen?.height ?? 0
+            implicitWidth: sessionRoot.modelData?.width ?? 0
+            implicitHeight: sessionRoot.modelData?.height ?? 0
+
+            // One scalar drives the scrim and the content together, started
+            // rather than a Behavior because the exit's `finished` owns
+            // `reallyOpen` and a Behavior never raises it.
+            property real openProgress: 0
+
+            NumberAnimation {
+                id: enterAnim
+                target: sessionRoot
+                property: "openProgress"
+                to: 1
+                duration: Appearance.animation.elementMoveFast.duration
+                easing.type: Appearance.animation.elementMoveFast.type
+                easing.bezierCurve: Appearance.animation.elementMoveFast.bezierCurve
+            }
+
+            NumberAnimation {
+                id: exitAnim
+                target: sessionRoot
+                property: "openProgress"
+                to: 0
+                duration: Appearance.animation.elementMoveFast.duration
+                easing.type: Appearance.animation.elementMoveFast.type
+                easing.bezierCurve: Appearance.animation.elementMoveFast.bezierCurve
+                onFinished: sessionRoot.reallyOpen = false
+            }
+
+            Rectangle {
+                id: scrimRect
+                anchors.fill: parent
+                visible: sessionRoot.reallyOpen
+                opacity: sessionRoot.openProgress
+                color: ColorUtils.transparentize(Appearance.m3colors.m3background,
+                    Appearance.m3colors.darkmode ? 0.05 : 0.12)
+            }
 
             MouseArea {
                 id: sessionMouseArea
                 anchors.fill: parent
+                enabled: sessionRoot.reallyOpen
                 onClicked: {
                     sessionRoot.hide();
                 }
@@ -78,6 +197,8 @@ Scope {
                 id: contentColumn
                 anchors.centerIn: parent
                 spacing: Appearance.spacing.space200
+                visible: sessionRoot.reallyOpen
+                opacity: sessionRoot.openProgress
 
                 Keys.onPressed: event => {
                     if (event.key === Qt.Key_Escape) {
@@ -132,13 +253,11 @@ Scope {
                         target: sessionGrid
                         step: Appearance.animation.staggerStep
                     }
-                    Component.onCompleted: sessionEntrance.enter()
                     columnSpacing: Appearance.spacing.space200
                     rowSpacing: Appearance.spacing.space200
 
                     SessionActionButton {
                         id: sessionLock
-                        focus: sessionRoot.visible
                         buttonIcon: "lock"
                         buttonText: Translation.tr("Lock")
                         onClicked: {
@@ -391,10 +510,12 @@ Scope {
                     horizontalCenter: contentColumn.horizontalCenter
                 }
                 spacing: Appearance.spacing.space150
+                visible: sessionRoot.reallyOpen
+                opacity: sessionRoot.openProgress
 
                 Loader {
                     Layout.alignment: Qt.AlignHCenter
-                    active: SessionWarnings.downloadRunning
+                    active: sessionRoot.reallyOpen && SessionWarnings.downloadRunning
                     visible: active
                     sourceComponent: DescriptionLabel {
                         text: Translation.tr("There might be a download in progress. Check your Downloads folder.")
@@ -405,7 +526,7 @@ Scope {
 
                 Loader {
                     Layout.alignment: Qt.AlignHCenter
-                    active: SessionWarnings.packageManagerRunning
+                    active: sessionRoot.reallyOpen && SessionWarnings.packageManagerRunning
                     visible: active
                     sourceComponent: DescriptionLabel {
                         text: Translation.tr("Your package manager is running")
@@ -452,6 +573,12 @@ Scope {
 
         function open(): void {
             GlobalStates.sessionOpen = true;
+        }
+
+        // Which screen's window the last open landed on - what the
+        // persistent-surface focus probe reads. Empty until the first open.
+        function activeScreen(): string {
+            return root.activeWindow?.modelData.name ?? "";
         }
     }
 

--- a/dots/.config/quickshell/imi/modules/imi/settings/SettingsContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/settings/SettingsContent.qml
@@ -439,9 +439,7 @@ Item {
                             Image {
                                 id: avatarImage
                                 anchors.fill: parent
-                                source: Config.options.profile.avatarPath !== "" 
-                                    ? "file://" + Config.options.profile.avatarPicture 
-                                    : "file:///home/" + (Quickshell.env("USER") ?? "user") + "/.face"
+                                source: UserAvatar.url
                                 sourceSize.width: avatarImage.width * 2
                                 sourceSize.height: avatarImage.height * 2
                                 fillMode: Image.PreserveAspectCrop

--- a/dots/.config/quickshell/imi/modules/imi/sidebarRight/SidebarRightContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarRight/SidebarRightContent.qml
@@ -276,9 +276,7 @@ Item {
                                     Image {
                                         id: avatarImage
                                         anchors.fill: parent
-                                        source: Config.options.profile.avatarPath !== "" 
-                                            ? "file://" + Config.options.profile.avatarPicture 
-                                            : "file:///home/" + (Quickshell.env("USER") ?? "user") + "/.face"
+                                        source: UserAvatar.url
                                         sourceSize.width: avatarImage.width * 2
                                         sourceSize.height: avatarImage.height * 2
                                         fillMode: Image.PreserveAspectCrop

--- a/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/WallpaperEngineGrid.qml
+++ b/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/WallpaperEngineGrid.qml
@@ -36,6 +36,10 @@ Item {
     }
     readonly property var filteredProjects: root.visibleProjects.filter(project => {
         if (root.typeFilter !== "all" && root.normType(project) !== root.typeFilter) return false;
+        // A wallpaper the compatibility scan marked broken, with the switch
+        // on (sidebar > Hide broken): out of the grid, not merely badged.
+        if ((Config.options.wallpaperSelector.wallpaperEngine.hideBroken ?? false)
+            && WallpaperEngineCompat.statusFor(project) === "broken") return false;
         const query = root.searchQuery.trim().toLowerCase();
         if (!query) return true;
         const tags = Array.isArray(project.tags) ? project.tags.join(" ") : "";
@@ -193,6 +197,36 @@ Item {
                             text: "check_circle"
                             fill: 1
                             color: Appearance.colors.colPrimary
+                        }
+
+                        // The compatibility scan's verdict, where the tile
+                        // already badges its type: a wallpaper known not to
+                        // start looks different BEFORE it is clicked.
+                        Rectangle {
+                            visible: WallpaperEngineCompat.statusFor(delegateRoot.modelData) === "broken"
+                            anchors.right: parent.right
+                            anchors.top: parent.top
+                            anchors.margins: Appearance.spacing.space75
+                            implicitWidth: brokenRow.implicitWidth + Appearance.spacing.space150
+                            implicitHeight: brokenRow.implicitHeight + Appearance.spacing.space75
+                            radius: height / 2
+                            color: Appearance.m3colors.m3errorContainer
+
+                            RowLayout {
+                                id: brokenRow
+                                anchors.centerIn: parent
+                                spacing: Appearance.spacing.space50
+                                MaterialSymbol {
+                                    text: "error"
+                                    iconSize: Appearance.font.pixelSize.small
+                                    color: Appearance.m3colors.m3onErrorContainer
+                                }
+                                StyledText {
+                                    text: Translation.tr("Broken")
+                                    font.pixelSize: Appearance.font.pixelSize.smallest
+                                    color: Appearance.m3colors.m3onErrorContainer
+                                }
+                            }
                         }
                     }
 

--- a/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/WallpaperPropertyControl.qml
+++ b/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/WallpaperPropertyControl.qml
@@ -4,6 +4,7 @@ import qs.modules.common
 import qs.modules.common.widgets
 import QtQuick
 import QtQuick.Layouts
+import "we_color.js" as WeColor
 
 // One row of a Wallpaper Engine project's own settings (project.json
 // general.properties): a control per property type, in the sidebar's rail
@@ -34,11 +35,11 @@ ColumnLayout {
 
     // Parse an "r g b" float triplet; a garbage value degrades to black
     // rather than NaN channels (Math.max(0, NaN) is NaN - guard with
-    // comparisons, the Appearance-token lesson).
+    // comparisons, the Appearance-token lesson). we_color reads a dot-less
+    // triplet as 0..255 (WE's own convention), so an integer project default
+    // like "255 128 0" is not clamped flat to (1,1,0).
     function channel(index) {
-        const parts = String(root.currentValue).trim().split(/\s+/)
-        const value = parseFloat(parts[index])
-        return value >= 0 ? Math.min(1, value) : 0
+        return WeColor.parseChannel(root.currentValue, index)
     }
 
     // ---- bool: a switch row --------------------------------------------
@@ -185,7 +186,7 @@ ColumnLayout {
                                     channels[channelRow.modelData.index] = value
                                     // Serialized at a precision WE round-trips;
                                     // full doubles make the stored file churn.
-                                    root.committed(channels.map(c => Math.round(c * 1000) / 1000).join(" "))
+                                    root.committed(WeColor.formatChannels(channels))
                                 }
                             }
                         }

--- a/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/WallpaperPropertyControl.qml
+++ b/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/WallpaperPropertyControl.qml
@@ -1,0 +1,224 @@
+import qs
+import qs.services
+import qs.modules.common
+import qs.modules.common.widgets
+import QtQuick
+import QtQuick.Layouts
+
+// One row of a Wallpaper Engine project's own settings (project.json
+// general.properties): a control per property type, in the sidebar's rail
+// width. The five types are the reference app's PROPERTY_CONTROL_TYPES;
+// anything else never reaches this file (the scanner filters).
+//
+// Values are the strings WE's --set-property takes (booleans "1"/"0", colors
+// "r g b" floats, the rest verbatim) - this control converts for display and
+// commits back in that form. Every commit reloads the wallpaper (a load-time
+// argument), so the slider and the color channels commit on RELEASE, never
+// per drag tick.
+ColumnLayout {
+    id: root
+
+    // {name, type, text, value, min?, max?, step?, options?} from the scanner.
+    property var definition: ({})
+    // The value on screen: the user's edit if there is one, else the
+    // wallpaper's own default.
+    property string currentValue: ""
+    property bool edited: false
+
+    signal committed(var value)
+
+    spacing: Appearance.spacing.space50
+
+    readonly property string kind: root.definition?.type ?? ""
+    property bool colorExpanded: false
+
+    // Parse an "r g b" float triplet; a garbage value degrades to black
+    // rather than NaN channels (Math.max(0, NaN) is NaN - guard with
+    // comparisons, the Appearance-token lesson).
+    function channel(index) {
+        const parts = String(root.currentValue).trim().split(/\s+/)
+        const value = parseFloat(parts[index])
+        return value >= 0 ? Math.min(1, value) : 0
+    }
+
+    // ---- bool: a switch row --------------------------------------------
+    Loader {
+        Layout.fillWidth: true
+        active: root.kind === "bool"
+        visible: active
+        sourceComponent: RowLayout {
+            spacing: Appearance.spacing.space100
+            StyledText {
+                Layout.fillWidth: true
+                elide: Text.ElideRight
+                text: root.definition.text
+                font.pixelSize: Appearance.font.pixelSize.small
+            }
+            StyledSwitch {
+                checkable: false
+                checked: root.currentValue === "1"
+                onClicked: root.committed(root.currentValue === "1" ? "0" : "1")
+            }
+        }
+    }
+
+    // ---- slider ---------------------------------------------------------
+    Loader {
+        Layout.fillWidth: true
+        active: root.kind === "slider"
+        visible: active
+        sourceComponent: ColumnLayout {
+            spacing: Appearance.spacing.space25
+            StyledText {
+                Layout.fillWidth: true
+                elide: Text.ElideRight
+                text: root.definition.text
+                font.pixelSize: Appearance.font.pixelSize.small
+            }
+            StyledSlider {
+                Layout.fillWidth: true
+                from: root.definition.min ?? 0
+                to: root.definition.max ?? 100
+                stepSize: root.definition.step ?? 0
+                value: parseFloat(root.currentValue) || 0
+                onPressedChanged: {
+                    if (!pressed)
+                        root.committed(String(value));
+                }
+            }
+        }
+    }
+
+    // ---- combo ----------------------------------------------------------
+    Loader {
+        Layout.fillWidth: true
+        active: root.kind === "combo"
+        visible: active
+        sourceComponent: RowLayout {
+            spacing: Appearance.spacing.space100
+            StyledText {
+                Layout.fillWidth: true
+                elide: Text.ElideRight
+                text: root.definition.text
+                font.pixelSize: Appearance.font.pixelSize.small
+            }
+            StyledComboBox {
+                id: comboBox
+                implicitWidth: 104
+                readonly property var opts: root.definition.options ?? []
+                model: comboBox.opts.map(option => ({ displayName: option.label }))
+                textRole: "displayName"
+                currentIndex: Math.max(0,
+                    comboBox.opts.findIndex(option => option.value === root.currentValue))
+                onActivated: index => root.committed(comboBox.opts[index].value)
+            }
+        }
+    }
+
+    // ---- color: a swatch that unfolds three channel sliders -------------
+    // The repo has no free-RGB picker (ColorSelectionArray picks theme
+    // tokens), and a WE scheme color is an arbitrary "r g b" triplet, so the
+    // control is the smallest honest one: the current color as a swatch,
+    // three 0..255 channel sliders while it is open.
+    Loader {
+        Layout.fillWidth: true
+        active: root.kind === "color"
+        visible: active
+        sourceComponent: ColumnLayout {
+            spacing: Appearance.spacing.space50
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: Appearance.spacing.space100
+                StyledText {
+                    Layout.fillWidth: true
+                    elide: Text.ElideRight
+                    text: root.definition.text
+                    font.pixelSize: Appearance.font.pixelSize.small
+                }
+                RippleButton {
+                    implicitWidth: 46
+                    implicitHeight: 26
+                    buttonRadius: Appearance.rounding.small
+                    toggled: root.colorExpanded
+                    onClicked: root.colorExpanded = !root.colorExpanded
+                    contentItem: Rectangle {
+                        anchors.fill: parent
+                        anchors.margins: Appearance.spacing.space25
+                        radius: Appearance.rounding.unsharpen
+                        border.width: Appearance.borderWidth.standard
+                        border.color: Appearance.colors.colOutlineVariant
+                        color: Qt.rgba(root.channel(0), root.channel(1), root.channel(2), 1)
+                    }
+                }
+            }
+            Loader {
+                Layout.fillWidth: true
+                active: root.colorExpanded
+                visible: active
+                sourceComponent: ColumnLayout {
+                    spacing: Appearance.spacing.space25
+                    Repeater {
+                        model: [
+                            { label: "R", index: 0 },
+                            { label: "G", index: 1 },
+                            { label: "B", index: 2 }
+                        ]
+                        delegate: RowLayout {
+                            id: channelRow
+                            required property var modelData
+                            Layout.fillWidth: true
+                            spacing: Appearance.spacing.space100
+                            StyledText {
+                                text: channelRow.modelData.label
+                                font.pixelSize: Appearance.font.pixelSize.smaller
+                                color: Appearance.colors.colSubtext
+                            }
+                            StyledSlider {
+                                Layout.fillWidth: true
+                                from: 0
+                                to: 1
+                                value: root.channel(channelRow.modelData.index)
+                                onPressedChanged: {
+                                    if (pressed)
+                                        return;
+                                    const channels = [root.channel(0), root.channel(1), root.channel(2)]
+                                    channels[channelRow.modelData.index] = value
+                                    // Serialized at a precision WE round-trips;
+                                    // full doubles make the stored file churn.
+                                    root.committed(channels.map(c => Math.round(c * 1000) / 1000).join(" "))
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // ---- textinput -------------------------------------------------------
+    Loader {
+        Layout.fillWidth: true
+        active: root.kind === "textinput"
+        visible: active
+        sourceComponent: ColumnLayout {
+            spacing: Appearance.spacing.space25
+            StyledText {
+                Layout.fillWidth: true
+                elide: Text.ElideRight
+                text: root.definition.text
+                font.pixelSize: Appearance.font.pixelSize.small
+            }
+            ToolbarTextField {
+                Layout.fillWidth: true
+                text: root.currentValue
+                font.pixelSize: Appearance.font.pixelSize.small
+                // Commit when editing finishes, not per keystroke: every
+                // commit is a wallpaper reload.
+                onEditingFinished: {
+                    if (text !== root.currentValue)
+                        root.committed(text);
+                }
+            }
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/WallpaperSelectorContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/WallpaperSelectorContent.qml
@@ -47,20 +47,9 @@ MouseArea {
         }
     }
 
-    property var quickDirs: [
-        { icon: "home",       name: "Home   ",       path: `${Directories.home}`,                alwaysVisible: Config.options.wallpaperSelector.showHomePath },
-        { icon: "wallpaper",  name: "Wallpapers   ", path: `${Directories.pictures}/Wallpapers`, alwaysVisible: true },
-        { icon: "imagesmode", name: "Homework   ",   path: `${Directories.pictures}/homework`,   alwaysVisible: Config.options.policies.weeb },
-        { icon: "casino",     name: "Random   ",     path: `${Directories.pictures}/Random`,     alwaysVisible: true },
-        { 
-            icon: "image",     
-            name: Config.options.wallpaperSelector.userPath?.trim().length > 0 
-                ? Config.options.wallpaperSelector.userPath.split("/").filter(s => s.length > 0).pop() + "   "
-                : "Custom   ",
-            path: Config.options.wallpaperSelector.userPath, 
-            alwaysVisible: Config.options.wallpaperSelector.userPath?.trim().length > 0 
-        }
-    ]
+    // The folder shortcuts moved into the sidebar's places rail
+    // (WallpaperSelectorSidebar.qml over selector_places.js) - one list, so
+    // the chips and the rail cannot drift apart.
 
     function updateThumbnails() {
         const item = gridLoader.item;
@@ -297,6 +286,29 @@ MouseArea {
             spacing: -Appearance.spacing.space50
             z: 1
 
+            // The left sidebar: a places rail over local files, the engine's
+            // configuration over Wallpaper Engine, nothing over the online
+            // sources (their controls live in the top toolbar). The grids
+            // keep the leftover width.
+            WallpaperSelectorSidebar {
+                id: selectorSidebar
+                source: root.source
+                visible: root.source === "local" || root.source === "wallpaperEngine"
+                // A child that is itself a layout defaults Layout.fillWidth
+                // to true inside a RowLayout - stated false, or the rail
+                // splits the window with the grid instead of keeping to its
+                // rail width (the ToolbarTextField trap, on the other axis).
+                Layout.fillWidth: false
+                Layout.preferredWidth: 232
+                Layout.minimumWidth: 232
+                Layout.maximumWidth: 232
+                Layout.fillHeight: true
+                Layout.topMargin: Appearance.spacing.space200
+                Layout.bottomMargin: Appearance.spacing.space200
+                Layout.leftMargin: Appearance.spacing.space100
+                Layout.rightMargin: Appearance.spacing.space200
+            }
+
             ColumnLayout {
                 id: gridColumnLayout
                 Layout.fillWidth: true
@@ -331,45 +343,10 @@ MouseArea {
                     Toolbar {
                         anchors.centerIn: parent
 
-                        Loader {
-                            active: root.source === "local"
-                            visible: active
-                            sourceComponent: RowLayout {
-                                spacing: Appearance.spacing.space50
-                                Repeater {
-                                    model: root.quickDirs
-                                    delegate: RippleButton {
-                                        id: dirBtn
-                                        required property var modelData
-                                        implicitHeight: 38
-                                        buttonRadius: height / 2
-                                        visible: modelData.alwaysVisible
-                                        toggled: Wallpapers.directory === Qt.resolvedUrl(modelData.path)
-                                        colBackgroundToggled: Appearance.colors.colSecondaryContainer
-                                        colBackgroundToggledHover: Appearance.colors.colSecondaryContainerHover
-                                        colRippleToggled: Appearance.colors.colSecondaryContainerActive
-                                        onClicked: Wallpapers.setDirectory(modelData.path)
-                                        contentItem: RowLayout {
-                                            anchors.fill: parent
-                                            anchors.leftMargin: Appearance.spacing.space150
-                                            anchors.rightMargin: Appearance.spacing.space150
-                                            spacing: Appearance.spacing.space100
-                                            MaterialSymbol {
-                                                text: dirBtn.modelData.icon
-                                                iconSize: Appearance.font.pixelSize.larger
-                                                color: dirBtn.toggled ? Appearance.colors.colOnSecondaryContainer : Appearance.colors.colOnLayer1
-                                                fill: dirBtn.toggled ? 1 : 0
-                                            }
-                                            StyledText {
-                                                text: dirBtn.modelData.name
-                                                color: dirBtn.toggled ? Appearance.colors.colOnSecondaryContainer : Appearance.colors.colOnLayer1
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-
+                        // The places chips and the Wallpaper Engine config
+                        // row both moved into the left sidebar
+                        // (WallpaperSelectorSidebar.qml) - the toolbar keeps
+                        // only what has no home there.
                         Loader {
                             active: root.source !== "local" && root.source !== "wallpaperEngine"
                             visible: active
@@ -401,100 +378,9 @@ MouseArea {
                         Loader {
                             active: root.source === "wallpaperEngine"
                             visible: active
-                            sourceComponent: RowLayout {
-                                spacing: Appearance.spacing.space100
-
-                                StyledText {
-                                    text: Translation.tr("Steam Workshop")
-                                    color: Appearance.colors.colOnLayer2
-                                }
-
-                                StyledComboBox {
-                                    implicitWidth: 92
-                                    model: [
-                                        { value: 24, displayName: "24 FPS" },
-                                        { value: 30, displayName: "30 FPS" },
-                                        { value: 60, displayName: "60 FPS" }
-                                    ]
-                                    textRole: "displayName"
-                                    Component.onCompleted: {
-                                        const configured = Config.options.wallpaperSelector.wallpaperEngine.fps;
-                                        currentIndex = configured === 24 ? 0 : configured === 60 ? 2 : 1;
-                                    }
-                                    onActivated: index => Config.options.wallpaperSelector.wallpaperEngine.fps = model[index].value
-                                }
-
-                                StyledComboBox {
-                                    implicitWidth: 90
-                                    model: [
-                                        { value: "fill", displayName: Translation.tr("Fill") },
-                                        { value: "fit", displayName: Translation.tr("Fit") },
-                                        { value: "stretch", displayName: Translation.tr("Stretch") }
-                                    ]
-                                    textRole: "displayName"
-                                    Component.onCompleted: {
-                                        const configured = Config.options.wallpaperSelector.wallpaperEngine.scaling;
-                                        currentIndex = configured === "fit" ? 1 : configured === "stretch" ? 2 : 0;
-                                    }
-                                    onActivated: index => Config.options.wallpaperSelector.wallpaperEngine.scaling = model[index].value
-                                }
-
-                                // Which screen plays the sound. Offered beside
-                                // the volume button because that is where the
-                                // user turns sound on, and only where the
-                                // question exists: one screen, or muted, and
-                                // there is nothing to choose.
-                                //
-                                // There is one renderer per output, so before
-                                // this the audio played once per monitor (#338).
-                                StyledComboBox {
-                                    id: audioOutputBox
-                                    implicitWidth: 116
-                                    visible: !Config.options.wallpaperSelector.wallpaperEngine.silent
-                                        && (Quickshell.screens?.length ?? 0) > 1
-
-                                    readonly property var outputs: [{
-                                        value: "",
-                                        displayName: Translation.tr("Auto")
-                                    }].concat((Quickshell.screens ?? []).map(screen => ({
-                                        value: screen.name,
-                                        displayName: screen.name
-                                    })))
-
-                                    model: audioOutputBox.outputs
-                                    textRole: "displayName"
-                                    // Bound rather than set once on completion:
-                                    // a screen can arrive or leave while this is
-                                    // on screen, and the neighbours above only
-                                    // get away with Component.onCompleted
-                                    // because their options are a fixed list.
-                                    currentIndex: Math.max(0, audioOutputBox.outputs
-                                        .findIndex(output => output.value
-                                            === (Config.options.wallpaperSelector.wallpaperEngine.audioMonitor ?? "")))
-                                    onActivated: index =>
-                                        Config.options.wallpaperSelector.wallpaperEngine.audioMonitor
-                                            = audioOutputBox.outputs[index].value
-
-                                    StyledToolTip {
-                                        text: Translation.tr("Screen that plays the wallpaper's sound")
-                                    }
-                                }
-
-                                RippleButton {
-                                    implicitWidth: 38
-                                    implicitHeight: 38
-                                    buttonRadius: height / 2
-                                    toggled: Config.options.wallpaperSelector.wallpaperEngine.silent
-                                    onClicked: Config.options.wallpaperSelector.wallpaperEngine.silent = !Config.options.wallpaperSelector.wallpaperEngine.silent
-                                    contentItem: MaterialSymbol {
-                                        anchors.centerIn: parent
-                                        horizontalAlignment: Text.AlignHCenter
-                                        verticalAlignment: Text.AlignVCenter
-                                        text: Config.options.wallpaperSelector.wallpaperEngine.silent ? "volume_off" : "volume_up"
-                                        color: parent.toggled ? Appearance.colors.colOnPrimary : Appearance.colors.colOnLayer2
-                                    }
-                                    StyledToolTip { text: Translation.tr("Wallpaper audio") }
-                                }
+                            sourceComponent: StyledText {
+                                text: Translation.tr("Steam Workshop")
+                                color: Appearance.colors.colOnLayer2
                             }
                         }
                     }

--- a/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/WallpaperSelectorSidebar.qml
+++ b/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/WallpaperSelectorSidebar.qml
@@ -66,6 +66,13 @@ ColumnLayout {
     property real previewAspect: 0
     readonly property real contentAspect: GlobalStates.weContentAspect > 0
         ? GlobalStates.weContentAspect : root.previewAspect
+    // The renderer's grabbed full-scene image for THIS project - the real
+    // 32:9 content, not the preview. Empty when it is for another project or
+    // not grabbed (a video, an older binary): the picker then falls back to
+    // the preview at its own aspect, honest but not the scene.
+    readonly property string sceneImage: GlobalStates.weSceneGrabProject === root.activeProjectId
+        ? GlobalStates.weSceneGrabPath : ""
+    readonly property bool haveSceneImage: root.sceneImage !== ""
     readonly property bool canCrop: root.activeProjectId !== ""
         && root.effective.scaling === "fill"
         && WallpaperEngineFeatures.cropFocus
@@ -247,19 +254,21 @@ ColumnLayout {
                             // cropped to that aspect with the viewport
                             // rectangle over it. Everything - the viewport
                             // maths and the drag - works in THIS box's frame.
-                            // The box is the PREVIEW's own aspect, showing it
-                            // pristine (fit, not cropped) - because the
-                            // preview image is not the scene and cropping it
-                            // to the content's wide aspect fabricates a strip
-                            // that misrepresents the wallpaper. The viewport
-                            // rectangle's SIZE still comes from the real
-                            // content-vs-screen overflow (that fraction is
-                            // aspect-ratio-only, so it is honest over any box),
-                            // so it says "this fraction of the width is on
-                            // screen"; the live desktop is the exact feedback.
+                            // The picker box is the CONTENT's real aspect
+                            // (e.g. 32:9), filled with the renderer's grabbed
+                            // scene image - the actual wallpaper, cropped to
+                            // fill the box exactly because the grab IS at the
+                            // content aspect. Only when that grab exists: it is
+                            // the whole point, because the preview image does
+                            // not depict the scene. Without it (a video, an
+                            // older binary) the box falls back to the preview's
+                            // own aspect, shown whole and honest but not the
+                            // scene.
                             Item {
                                 id: fittedBox
-                                readonly property real boxAspect: root.previewAspect > 0 ? root.previewAspect : 16 / 9
+                                readonly property real boxAspect: root.haveSceneImage && root.contentAspect > 0
+                                    ? root.contentAspect
+                                    : (root.previewAspect > 0 ? root.previewAspect : 16 / 9)
                                 readonly property real cardAspect: previewBox.width / previewBox.height
                                 width: boxAspect >= cardAspect ? previewBox.width : previewBox.height * boxAspect
                                 height: boxAspect >= cardAspect ? previewBox.width / boxAspect : previewBox.height
@@ -268,17 +277,19 @@ ColumnLayout {
 
                                 StyledImage {
                                     anchors.fill: parent
-                                    fillMode: Image.PreserveAspectFit
-                                    source: root.weConfig.activePreview
-                                    sourceSize.width: 400
-                                    sourceSize.height: 225
+                                    // The grabbed scene fills its content-aspect
+                                    // box exactly (crop); the preview fallback
+                                    // is shown whole (fit) rather than butchered.
+                                    fillMode: root.haveSceneImage ? Image.PreserveAspectCrop : Image.PreserveAspectFit
+                                    source: root.haveSceneImage ? root.sceneImage : root.weConfig.activePreview
+                                    sourceSize.width: 640
+                                    sourceSize.height: 360
                                 }
 
                                 // The viewport rectangle: the axis that
                                 // overflows uses its focus, the other stays
                                 // full-extent. The fraction is content-vs-
-                                // screen (aspect only), drawn over the
-                                // preview-aspect box.
+                                // screen (aspect only).
                                 readonly property var vp: {
                                     const h = CropPicker.viewport(root.contentAspect,
                                         root.screenAspect, width, height, root.effective.focus.x);

--- a/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/WallpaperSelectorSidebar.qml
+++ b/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/WallpaperSelectorSidebar.qml
@@ -8,7 +8,9 @@ import QtQuick.Controls
 import QtQuick.Layouts
 import Qt5Compat.GraphicalEffects
 import Quickshell
+import Quickshell.Hyprland
 import "./selector_places.js" as SelectorPlaces
+import "./crop_picker.js" as CropPicker
 
 // The selector's left sidebar. Two faces, decided by which grid is showing:
 //
@@ -49,6 +51,26 @@ ColumnLayout {
     readonly property var activeProject: WallpaperEngine.projects.find(
         p => p.id === root.activeProjectId) ?? null
     readonly property var activeProperties: root.activeProject?.properties ?? []
+
+    // The focused monitor's aspect - what a Fill crop is judged against.
+    readonly property var focusedScreen: Quickshell.screens.find(
+        s => s.name === (Hyprland.focusedMonitor?.name ?? "")) ?? Quickshell.screens[0]
+    readonly property real screenAspect: (focusedScreen?.width > 0 && focusedScreen?.height > 0)
+        ? focusedScreen.width / focusedScreen.height : 16 / 9
+    // The content aspect the crop picker judges overflow by. The live scene's
+    // REAL authored aspect when the renderer has published it
+    // (GlobalStates.weContentAspect) - because the preview image's aspect is
+    // NOT the scene's: a 32:9 ultrawide wallpaper commonly ships a portrait
+    // preview, which would pick the wrong overflow axis. The preview aspect is
+    // the fallback for a shell whose renderer does not report content size.
+    property real previewAspect: 0
+    readonly property real contentAspect: GlobalStates.weContentAspect > 0
+        ? GlobalStates.weContentAspect : root.previewAspect
+    readonly property bool canCrop: root.activeProjectId !== ""
+        && root.effective.scaling === "fill"
+        && WallpaperEngineFeatures.cropFocus
+        && root.contentAspect > 0
+        && Math.abs(root.contentAspect - root.screenAspect) > 0.01
 
     function writeSetting(key, value) {
         if (root.editingOverride) {
@@ -178,23 +200,128 @@ ColumnLayout {
                         }
                         spacing: Appearance.spacing.space100
 
-                        StyledImage {
+                        // The preview card. Normally a cropped thumbnail; when
+                        // this wallpaper can be cropped (Fill, overflow, and a
+                        // renderer that pans), it becomes a section picker - a
+                        // box at the CONTENT's real aspect with the screen's
+                        // viewport drawn over it and draggable.
+                        Rectangle {
+                            id: previewBox
                             Layout.fillWidth: true
                             Layout.preferredHeight: width * 9 / 16
-                            fillMode: Image.PreserveAspectCrop
-                            source: root.weConfig.activePreview
-                            // A thumbnail-sized decode of a preview drawn
-                            // ~200px wide; the card is width-stable so the
-                            // constant avoids the bound-to-geometry reload
-                            // trap.
-                            sourceSize.width: 400
-                            sourceSize.height: 225
-                            layer.enabled: true
-                            layer.effect: OpacityMask {
-                                maskSource: Rectangle {
-                                    width: activeCard.width
-                                    height: activeCard.width * 9 / 16
-                                    radius: Appearance.rounding.small
+                            radius: Appearance.rounding.small
+                            color: Appearance.colors.colLayer1
+                            clip: true
+
+                            // The ordinary thumbnail, shown when there is
+                            // nothing to crop. Also the source of the preview
+                            // aspect fallback (weContentAspect is the real one).
+                            StyledImage {
+                                id: previewImage
+                                anchors.fill: parent
+                                visible: !root.canCrop
+                                fillMode: Image.PreserveAspectCrop
+                                source: root.weConfig.activePreview
+                                // A thumbnail-sized decode of a preview drawn
+                                // ~200px wide; the card is width-stable so the
+                                // constant avoids the bound-to-geometry reload
+                                // trap.
+                                sourceSize.width: 400
+                                sourceSize.height: 225
+                                onStatusChanged: {
+                                    if (status === Image.Ready && implicitHeight > 0)
+                                        root.previewAspect = implicitWidth / implicitHeight;
+                                }
+                                layer.enabled: true
+                                layer.effect: OpacityMask {
+                                    maskSource: Rectangle {
+                                        width: previewBox.width
+                                        height: previewBox.height
+                                        radius: Appearance.rounding.small
+                                    }
+                                }
+                            }
+
+                            // The picker: a box at the content's own aspect,
+                            // fitted inside the card, holding the preview
+                            // cropped to that aspect with the viewport
+                            // rectangle over it. Everything - the viewport
+                            // maths and the drag - works in THIS box's frame.
+                            Item {
+                                id: fittedBox
+                                readonly property real boxAspect: root.contentAspect > 0 ? root.contentAspect : 16 / 9
+                                readonly property real cardAspect: previewBox.width / previewBox.height
+                                width: boxAspect >= cardAspect ? previewBox.width : previewBox.height * boxAspect
+                                height: boxAspect >= cardAspect ? previewBox.width / boxAspect : previewBox.height
+                                anchors.centerIn: parent
+                                visible: root.canCrop
+
+                                StyledImage {
+                                    anchors.fill: parent
+                                    fillMode: Image.PreserveAspectCrop
+                                    source: root.weConfig.activePreview
+                                    sourceSize.width: 400
+                                    sourceSize.height: 225
+                                }
+
+                                // The viewport rectangle: the axis that
+                                // overflows uses its focus, the other stays
+                                // full-extent.
+                                readonly property var vp: {
+                                    const h = CropPicker.viewport(root.contentAspect,
+                                        root.screenAspect, width, height, root.effective.focus.x);
+                                    const v = CropPicker.viewport(root.contentAspect,
+                                        root.screenAspect, width, height, root.effective.focus.y);
+                                    return {
+                                        x: h.overflowsX ? h.x : 0,
+                                        y: v.overflowsY ? v.y : 0,
+                                        width: h.overflowsX ? h.width : width,
+                                        height: v.overflowsY ? v.height : height
+                                    };
+                                }
+
+                                // Four dim panels around the viewport, so the
+                                // shown slice reads bright and the cropped-out
+                                // margins read dark.
+                                readonly property color dim: ColorUtils.transparentize(Appearance.m3colors.m3scrim, 0.4)
+                                Rectangle { // left
+                                    x: 0; y: 0; width: fittedBox.vp.x; height: fittedBox.height
+                                    color: fittedBox.dim
+                                }
+                                Rectangle { // right
+                                    x: fittedBox.vp.x + fittedBox.vp.width; y: 0
+                                    width: fittedBox.width - (fittedBox.vp.x + fittedBox.vp.width)
+                                    height: fittedBox.height; color: fittedBox.dim
+                                }
+                                Rectangle { // top
+                                    x: fittedBox.vp.x; y: 0; width: fittedBox.vp.width; height: fittedBox.vp.y
+                                    color: fittedBox.dim
+                                }
+                                Rectangle { // bottom
+                                    x: fittedBox.vp.x; y: fittedBox.vp.y + fittedBox.vp.height
+                                    width: fittedBox.vp.width
+                                    height: fittedBox.height - (fittedBox.vp.y + fittedBox.vp.height)
+                                    color: fittedBox.dim
+                                }
+                                Rectangle { // the viewport outline
+                                    x: fittedBox.vp.x; y: fittedBox.vp.y
+                                    width: fittedBox.vp.width; height: fittedBox.vp.height
+                                    color: "transparent"
+                                    border.width: Appearance.borderWidth.emphasis
+                                    border.color: Appearance.colors.colPrimary
+                                }
+
+                                MouseArea {
+                                    anchors.fill: parent
+                                    cursorShape: Qt.SizeAllCursor
+                                    function apply(mx, my) {
+                                        const f = CropPicker.focusFromPointer(
+                                            root.contentAspect, root.screenAspect,
+                                            fittedBox.width, fittedBox.height, mx, my);
+                                        WallpaperEngineOverrides.setFocus(root.activeProjectId, f.x, f.y);
+                                    }
+                                    onPressed: mouse => apply(mouse.x, mouse.y)
+                                    onPositionChanged: mouse => { if (pressed) apply(mouse.x, mouse.y); }
                                 }
                             }
                         }

--- a/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/WallpaperSelectorSidebar.qml
+++ b/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/WallpaperSelectorSidebar.qml
@@ -1,0 +1,349 @@
+import qs
+import qs.services
+import qs.modules.common
+import qs.modules.common.widgets
+import qs.modules.common.functions
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Qt5Compat.GraphicalEffects
+import Quickshell
+import "./selector_places.js" as SelectorPlaces
+
+// The selector's left sidebar. Two faces, decided by which grid is showing:
+//
+// - Local files: a places rail (the file-explorer shape) - folder shortcuts
+//   with the directory on screen lit. The rows come from selector_places.js,
+//   which is where the visibility rules and the current-place match live.
+// - Wallpaper Engine: the engine's configuration (the reference app's
+//   settings-sidebar shape, jagrat7/linux-wallpaper-engine): the active
+//   project's card, the engine settings, and per-project overrides for
+//   exactly the knobs the embedded renderer answers - fps, scaling, audio.
+//   A control for a flag WallpaperEngineSurface does not read would be a
+//   fake action, so nothing else is offered.
+//
+// The online sources get no sidebar: their controls (resolution, provider)
+// already live in the top toolbar and there is nothing filesystem-shaped to
+// navigate.
+ColumnLayout {
+    id: root
+
+    // "local" | "wallpaperEngine" | an online provider - the content host's
+    // own source string.
+    property string source: "local"
+
+    spacing: Appearance.spacing.space100
+
+    readonly property var weConfig: Config.options.wallpaperSelector.wallpaperEngine
+    readonly property string activeProjectId: root.weConfig.activeProject
+    readonly property bool hasProjectOverride: WallpaperEngineOverrides.ready
+        && WallpaperEngineOverrides.hasOverride(root.activeProjectId)
+    // What the three controls show and edit: the active project's own record
+    // while the override switch is on, the globals otherwise.
+    readonly property bool editingOverride: root.hasProjectOverride
+    readonly property var effective: WallpaperEngineOverrides.active
+
+    function writeSetting(key, value) {
+        if (root.editingOverride) {
+            WallpaperEngineOverrides.setOverride(root.activeProjectId, key, value);
+            return;
+        }
+        if (key === "fps")
+            root.weConfig.fps = value;
+        else if (key === "scaling")
+            root.weConfig.scaling = value;
+        else if (key === "silent")
+            root.weConfig.silent = value;
+    }
+
+    StyledText {
+        Layout.leftMargin: Appearance.spacing.space150
+        Layout.topMargin: Appearance.spacing.space100
+        text: root.source === "wallpaperEngine"
+            ? Translation.tr("Wallpaper Engine")
+            : Translation.tr("Places")
+        font.pixelSize: Appearance.font.pixelSize.small
+        color: Appearance.colors.colSubtext
+    }
+
+    // ---- Places rail (local files) -------------------------------------
+    Loader {
+        Layout.fillWidth: true
+        Layout.fillHeight: true
+        active: root.source === "local"
+        visible: active
+
+        sourceComponent: ColumnLayout {
+            spacing: Appearance.spacing.space25
+
+            Repeater {
+                model: SelectorPlaces.places({
+                    home: FileUtils.trimFileProtocol(Directories.home),
+                    documents: FileUtils.trimFileProtocol(Directories.documents),
+                    downloads: FileUtils.trimFileProtocol(Directories.downloads),
+                    pictures: FileUtils.trimFileProtocol(Directories.pictures),
+                    videos: FileUtils.trimFileProtocol(Directories.videos)
+                }, {
+                    showHomePath: Config.options.wallpaperSelector.showHomePath,
+                    weeb: Config.options.policies.weeb,
+                    userPath: Config.options.wallpaperSelector.userPath ?? ""
+                })
+
+                delegate: RippleButton {
+                    id: placeButton
+                    required property var modelData
+                    Layout.fillWidth: true
+                    implicitHeight: 38
+                    buttonRadius: height / 2
+                    toggled: SelectorPlaces.isCurrent(placeButton.modelData.path,
+                        Wallpapers.directory)
+                    colBackgroundToggled: Appearance.colors.colSecondaryContainer
+                    colBackgroundToggledHover: Appearance.colors.colSecondaryContainerHover
+                    colRippleToggled: Appearance.colors.colSecondaryContainerActive
+                    onClicked: Wallpapers.setDirectory(placeButton.modelData.path)
+                    contentItem: RowLayout {
+                        anchors.fill: parent
+                        anchors.leftMargin: Appearance.spacing.space150
+                        anchors.rightMargin: Appearance.spacing.space150
+                        spacing: Appearance.spacing.space100
+                        MaterialSymbol {
+                            text: placeButton.modelData.icon
+                            iconSize: Appearance.font.pixelSize.larger
+                            fill: placeButton.toggled ? 1 : 0
+                            color: placeButton.toggled
+                                ? Appearance.colors.colOnSecondaryContainer
+                                : Appearance.colors.colOnLayer1
+                        }
+                        StyledText {
+                            Layout.fillWidth: true
+                            elide: Text.ElideRight
+                            text: placeButton.modelData.translate
+                                ? Translation.tr(placeButton.modelData.name)
+                                : placeButton.modelData.name
+                            color: placeButton.toggled
+                                ? Appearance.colors.colOnSecondaryContainer
+                                : Appearance.colors.colOnLayer1
+                        }
+                    }
+                }
+            }
+
+            Item { Layout.fillHeight: true }
+        }
+    }
+
+    // ---- Engine configuration (Wallpaper Engine) -----------------------
+    Loader {
+        Layout.fillWidth: true
+        Layout.fillHeight: true
+        active: root.source === "wallpaperEngine"
+        visible: active
+
+        sourceComponent: ColumnLayout {
+            spacing: Appearance.spacing.space100
+
+            // The active project's card. Absent, the section simply is not
+            // drawn - an empty preview frame is a promise about a selection
+            // that does not exist.
+            Rectangle {
+                Layout.fillWidth: true
+                visible: root.activeProjectId !== ""
+                implicitHeight: activeCard.implicitHeight + Appearance.spacing.space150 * 2
+                radius: Appearance.rounding.normal
+                color: Appearance.colors.colLayer2
+
+                ColumnLayout {
+                    id: activeCard
+                    anchors {
+                        left: parent.left
+                        right: parent.right
+                        verticalCenter: parent.verticalCenter
+                        margins: Appearance.spacing.space150
+                    }
+                    spacing: Appearance.spacing.space100
+
+                    StyledImage {
+                        Layout.fillWidth: true
+                        Layout.preferredHeight: width * 9 / 16
+                        fillMode: Image.PreserveAspectCrop
+                        source: root.weConfig.activePreview
+                        // A thumbnail-sized decode of a preview drawn ~200px
+                        // wide; the card is width-stable so the constant
+                        // avoids the bound-to-geometry reload trap.
+                        sourceSize.width: 400
+                        sourceSize.height: 225
+                        layer.enabled: true
+                        layer.effect: OpacityMask {
+                            maskSource: Rectangle {
+                                width: activeCard.width
+                                height: activeCard.width * 9 / 16
+                                radius: Appearance.rounding.small
+                            }
+                        }
+                    }
+
+                    StyledText {
+                        Layout.fillWidth: true
+                        elide: Text.ElideRight
+                        text: WallpaperEngine.projects.find(
+                            p => p.id === root.activeProjectId)?.title ?? root.activeProjectId
+                        font.pixelSize: Appearance.font.pixelSize.small
+                    }
+
+                    RippleButton {
+                        Layout.fillWidth: true
+                        implicitHeight: 32
+                        buttonRadius: height / 2
+                        onClicked: WallpaperEngine.stop()
+                        contentItem: RowLayout {
+                            anchors.fill: parent
+                            spacing: Appearance.spacing.space75
+                            Item { Layout.fillWidth: true }
+                            MaterialSymbol {
+                                text: "stop_circle"
+                                iconSize: Appearance.font.pixelSize.larger
+                                color: Appearance.colors.colOnLayer2
+                            }
+                            StyledText {
+                                text: Translation.tr("Clear selection")
+                                font.pixelSize: Appearance.font.pixelSize.smaller
+                                color: Appearance.colors.colOnLayer2
+                            }
+                            Item { Layout.fillWidth: true }
+                        }
+                    }
+                }
+            }
+
+            ConfigSwitch {
+                Layout.fillWidth: true
+                visible: root.activeProjectId !== ""
+                buttonIcon: "tune"
+                text: Translation.tr("Custom settings")
+                description: Translation.tr("Only this wallpaper")
+                checked: root.hasProjectOverride
+                onToggleRequested: {
+                    if (root.hasProjectOverride) {
+                        WallpaperEngineOverrides.clearOverrides(root.activeProjectId);
+                    } else {
+                        // Seed the record from what runs right now, so
+                        // flipping the switch changes nothing on screen until
+                        // a control is moved.
+                        WallpaperEngineOverrides.setOverride(root.activeProjectId, "fps", root.effective.fps);
+                        WallpaperEngineOverrides.setOverride(root.activeProjectId, "scaling", root.effective.scaling);
+                        WallpaperEngineOverrides.setOverride(root.activeProjectId, "silent", root.effective.silent);
+                    }
+                }
+            }
+
+            StyledText {
+                Layout.leftMargin: Appearance.spacing.space150
+                text: root.editingOverride
+                    ? Translation.tr("This wallpaper")
+                    : Translation.tr("All wallpapers")
+                font.pixelSize: Appearance.font.pixelSize.smaller
+                color: Appearance.colors.colSubtext
+            }
+
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: Appearance.spacing.space100
+                StyledText {
+                    Layout.leftMargin: Appearance.spacing.space150
+                    Layout.fillWidth: true
+                    text: Translation.tr("Frame rate")
+                    font.pixelSize: Appearance.font.pixelSize.small
+                }
+                StyledComboBox {
+                    id: fpsBox
+                    implicitWidth: 92
+                    readonly property var values: [24, 30, 60]
+                    model: [
+                        { value: 24, displayName: "24 FPS" },
+                        { value: 30, displayName: "30 FPS" },
+                        { value: 60, displayName: "60 FPS" }
+                    ]
+                    textRole: "displayName"
+                    // Bound, not set at completion: the shown value swaps
+                    // between the globals and a project's record when the
+                    // override switch flips.
+                    currentIndex: Math.max(0, fpsBox.values.indexOf(root.effective.fps))
+                    onActivated: index => root.writeSetting("fps", fpsBox.values[index])
+                }
+            }
+
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: Appearance.spacing.space100
+                StyledText {
+                    Layout.leftMargin: Appearance.spacing.space150
+                    Layout.fillWidth: true
+                    text: Translation.tr("Scaling")
+                    font.pixelSize: Appearance.font.pixelSize.small
+                }
+                StyledComboBox {
+                    id: scalingBox
+                    implicitWidth: 92
+                    readonly property var values: ["fill", "fit", "stretch"]
+                    model: [
+                        { value: "fill", displayName: Translation.tr("Fill") },
+                        { value: "fit", displayName: Translation.tr("Fit") },
+                        { value: "stretch", displayName: Translation.tr("Stretch") }
+                    ]
+                    textRole: "displayName"
+                    currentIndex: Math.max(0, scalingBox.values.indexOf(root.effective.scaling))
+                    onActivated: index => root.writeSetting("scaling", scalingBox.values[index])
+                }
+            }
+
+            ConfigSwitch {
+                buttonIcon: "volume_up"
+                text: Translation.tr("Wallpaper audio")
+                checked: !root.effective.silent
+                onToggleRequested: root.writeSetting("silent", !root.effective.silent)
+            }
+
+            // Which screen plays the sound. Only where the question exists:
+            // one screen, or muted, and there is nothing to choose. Global
+            // always - there is one audio route however many projects there
+            // are, which is also why it is not on the override record.
+            RowLayout {
+                Layout.fillWidth: true
+                visible: !root.effective.silent && (Quickshell.screens?.length ?? 0) > 1
+                spacing: Appearance.spacing.space100
+                StyledText {
+                    Layout.leftMargin: Appearance.spacing.space150
+                    Layout.fillWidth: true
+                    text: Translation.tr("Audio on")
+                    font.pixelSize: Appearance.font.pixelSize.small
+                }
+                StyledComboBox {
+                    id: audioOutputBox
+                    implicitWidth: 116
+
+                    readonly property var outputs: [{
+                        value: "",
+                        displayName: Translation.tr("Auto")
+                    }].concat((Quickshell.screens ?? []).map(screen => ({
+                        value: screen.name,
+                        displayName: screen.name
+                    })))
+
+                    model: audioOutputBox.outputs
+                    textRole: "displayName"
+                    currentIndex: Math.max(0, audioOutputBox.outputs
+                        .findIndex(output => output.value
+                            === (root.weConfig.audioMonitor ?? "")))
+                    onActivated: index =>
+                        root.weConfig.audioMonitor = audioOutputBox.outputs[index].value
+
+                    StyledToolTip {
+                        text: Translation.tr("Screen that plays the wallpaper's sound")
+                    }
+                }
+            }
+
+            Item { Layout.fillHeight: true }
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/WallpaperSelectorSidebar.qml
+++ b/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/WallpaperSelectorSidebar.qml
@@ -247,9 +247,19 @@ ColumnLayout {
                             // cropped to that aspect with the viewport
                             // rectangle over it. Everything - the viewport
                             // maths and the drag - works in THIS box's frame.
+                            // The box is the PREVIEW's own aspect, showing it
+                            // pristine (fit, not cropped) - because the
+                            // preview image is not the scene and cropping it
+                            // to the content's wide aspect fabricates a strip
+                            // that misrepresents the wallpaper. The viewport
+                            // rectangle's SIZE still comes from the real
+                            // content-vs-screen overflow (that fraction is
+                            // aspect-ratio-only, so it is honest over any box),
+                            // so it says "this fraction of the width is on
+                            // screen"; the live desktop is the exact feedback.
                             Item {
                                 id: fittedBox
-                                readonly property real boxAspect: root.contentAspect > 0 ? root.contentAspect : 16 / 9
+                                readonly property real boxAspect: root.previewAspect > 0 ? root.previewAspect : 16 / 9
                                 readonly property real cardAspect: previewBox.width / previewBox.height
                                 width: boxAspect >= cardAspect ? previewBox.width : previewBox.height * boxAspect
                                 height: boxAspect >= cardAspect ? previewBox.width / boxAspect : previewBox.height
@@ -258,7 +268,7 @@ ColumnLayout {
 
                                 StyledImage {
                                     anchors.fill: parent
-                                    fillMode: Image.PreserveAspectCrop
+                                    fillMode: Image.PreserveAspectFit
                                     source: root.weConfig.activePreview
                                     sourceSize.width: 400
                                     sourceSize.height: 225
@@ -266,7 +276,9 @@ ColumnLayout {
 
                                 // The viewport rectangle: the axis that
                                 // overflows uses its focus, the other stays
-                                // full-extent.
+                                // full-extent. The fraction is content-vs-
+                                // screen (aspect only), drawn over the
+                                // preview-aspect box.
                                 readonly property var vp: {
                                     const h = CropPicker.viewport(root.contentAspect,
                                         root.screenAspect, width, height, root.effective.focus.x);

--- a/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/WallpaperSelectorSidebar.qml
+++ b/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/WallpaperSelectorSidebar.qml
@@ -524,10 +524,21 @@ ColumnLayout {
                         from: 0
                         to: 100
                         stepSize: 1
-                        value: root.effective.volume
                         onPressedChanged: {
                             if (!pressed)
                                 root.writeSetting("volume", Math.round(value));
+                        }
+                        // A drag sets `value` imperatively, which would break a
+                        // plain `value:` binding for good - after the first drag
+                        // the handle would stop following a project switch or a
+                        // Custom-settings toggle. A Binding element re-asserts
+                        // whenever the resolved volume changes, so it keeps
+                        // tracking without fighting the drag (effective.volume
+                        // does not change mid-drag; it is written on release).
+                        Binding {
+                            target: volumeSlider
+                            property: "value"
+                            value: root.effective.volume
                         }
                     }
                 }

--- a/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/WallpaperSelectorSidebar.qml
+++ b/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/WallpaperSelectorSidebar.qml
@@ -92,6 +92,7 @@ ColumnLayout {
         else if (key === "disableMouse") root.weConfig.disableMouse = value;
         else if (key === "disableParallax") root.weConfig.disableParallax = value;
         else if (key === "disableParticles") root.weConfig.disableParticles = value;
+        else if (key === "renderScale") root.weConfig.renderScale = value;
     }
 
     StyledText {
@@ -459,6 +460,39 @@ ColumnLayout {
                         textRole: "displayName"
                         currentIndex: Math.max(0, scalingBox.values.indexOf(root.effective.scaling))
                         onActivated: index => root.writeSetting("scaling", scalingBox.values[index])
+                    }
+                }
+
+                // Quality: renderScale, gated on a renderer that reads it.
+                // Native draws at the surface's own resolution; the lower steps
+                // render smaller and upscale. Honest about its reach - for a
+                // heavy SCENE the frame rate above is the real lever, since a
+                // scene renders at its authored resolution regardless and this
+                // only trims the final composite; it is video wallpapers, drawn
+                // at window size, where a lower quality cuts real work.
+                RowLayout {
+                    Layout.fillWidth: true
+                    visible: WallpaperEngineFeatures.renderScale
+                    spacing: Appearance.spacing.space100
+                    StyledText {
+                        Layout.leftMargin: Appearance.spacing.space150
+                        Layout.fillWidth: true
+                        text: Translation.tr("Quality")
+                        font.pixelSize: Appearance.font.pixelSize.small
+                    }
+                    StyledComboBox {
+                        id: qualityBox
+                        implicitWidth: 116
+                        readonly property var values: [1.0, 0.75, 0.5, 0.25]
+                        model: [
+                            { value: 1.0, displayName: Translation.tr("Native") },
+                            { value: 0.75, displayName: Translation.tr("High (75%)") },
+                            { value: 0.5, displayName: Translation.tr("Balanced (50%)") },
+                            { value: 0.25, displayName: Translation.tr("Low (25%)") }
+                        ]
+                        textRole: "displayName"
+                        currentIndex: Math.max(0, qualityBox.values.indexOf(root.effective.renderScale))
+                        onActivated: index => root.writeSetting("renderScale", qualityBox.values[index])
                     }
                 }
 

--- a/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/WallpaperSelectorSidebar.qml
+++ b/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/WallpaperSelectorSidebar.qml
@@ -15,12 +15,16 @@ import "./selector_places.js" as SelectorPlaces
 // - Local files: a places rail (the file-explorer shape) - folder shortcuts
 //   with the directory on screen lit. The rows come from selector_places.js,
 //   which is where the visibility rules and the current-place match live.
-// - Wallpaper Engine: the engine's configuration (the reference app's
-//   settings-sidebar shape, jagrat7/linux-wallpaper-engine): the active
-//   project's card, the engine settings, and per-project overrides for
-//   exactly the knobs the embedded renderer answers - fps, scaling, audio.
-//   A control for a flag WallpaperEngineSurface does not read would be a
-//   fake action, so nothing else is offered.
+// - Wallpaper Engine: the engine's configuration, the reference app's
+//   (jagrat7/linux-wallpaper-engine) settings-sidebar shape: the active
+//   project's card, the engine's whole flag set (frame rate, scaling, audio
+//   with its volume, the audio-reactive recorder, mouse/parallax/particles),
+//   per-project overrides of all of it, and the wallpaper's own
+//   project.json properties (bool/slider/combo/color/textinput). Only knobs
+//   the embedded WallpaperEngineSurface actually answers are offered - the
+//   extended set is gated on WallpaperEngineFeatures, so a shell running an
+//   older renderer binary shows the controls it can honour and no fake
+//   actions.
 //
 // The online sources get no sidebar: their controls (resolution, provider)
 // already live in the top toolbar and there is nothing filesystem-shaped to
@@ -38,22 +42,27 @@ ColumnLayout {
     readonly property string activeProjectId: root.weConfig.activeProject
     readonly property bool hasProjectOverride: WallpaperEngineOverrides.ready
         && WallpaperEngineOverrides.hasOverride(root.activeProjectId)
-    // What the three controls show and edit: the active project's own record
+    // What the engine controls show and edit: the active project's own record
     // while the override switch is on, the globals otherwise.
     readonly property bool editingOverride: root.hasProjectOverride
     readonly property var effective: WallpaperEngineOverrides.active
+    readonly property var activeProject: WallpaperEngine.projects.find(
+        p => p.id === root.activeProjectId) ?? null
+    readonly property var activeProperties: root.activeProject?.properties ?? []
 
     function writeSetting(key, value) {
         if (root.editingOverride) {
             WallpaperEngineOverrides.setOverride(root.activeProjectId, key, value);
             return;
         }
-        if (key === "fps")
-            root.weConfig.fps = value;
-        else if (key === "scaling")
-            root.weConfig.scaling = value;
-        else if (key === "silent")
-            root.weConfig.silent = value;
+        if (key === "fps") root.weConfig.fps = value;
+        else if (key === "scaling") root.weConfig.scaling = value;
+        else if (key === "silent") root.weConfig.silent = value;
+        else if (key === "volume") root.weConfig.volume = value;
+        else if (key === "audioProcessing") root.weConfig.audioProcessing = value;
+        else if (key === "disableMouse") root.weConfig.disableMouse = value;
+        else if (key === "disableParallax") root.weConfig.disableParallax = value;
+        else if (key === "disableParticles") root.weConfig.disableParticles = value;
     }
 
     StyledText {
@@ -139,211 +148,426 @@ ColumnLayout {
         active: root.source === "wallpaperEngine"
         visible: active
 
-        sourceComponent: ColumnLayout {
-            spacing: Appearance.spacing.space100
+        sourceComponent: StyledFlickable {
+            id: weFlickable
+            contentHeight: weColumn.implicitHeight
+            clip: true
 
-            // The active project's card. Absent, the section simply is not
-            // drawn - an empty preview frame is a promise about a selection
-            // that does not exist.
-            Rectangle {
-                Layout.fillWidth: true
-                visible: root.activeProjectId !== ""
-                implicitHeight: activeCard.implicitHeight + Appearance.spacing.space150 * 2
-                radius: Appearance.rounding.normal
-                color: Appearance.colors.colLayer2
+            ColumnLayout {
+                id: weColumn
+                width: weFlickable.width
+                spacing: Appearance.spacing.space100
 
-                ColumnLayout {
-                    id: activeCard
-                    anchors {
-                        left: parent.left
-                        right: parent.right
-                        verticalCenter: parent.verticalCenter
-                        margins: Appearance.spacing.space150
+                // The active project's card. Absent, the section simply is
+                // not drawn - an empty preview frame is a promise about a
+                // selection that does not exist.
+                Rectangle {
+                    Layout.fillWidth: true
+                    visible: root.activeProjectId !== ""
+                    implicitHeight: activeCard.implicitHeight + Appearance.spacing.space150 * 2
+                    radius: Appearance.rounding.normal
+                    color: Appearance.colors.colLayer2
+
+                    ColumnLayout {
+                        id: activeCard
+                        anchors {
+                            left: parent.left
+                            right: parent.right
+                            verticalCenter: parent.verticalCenter
+                            margins: Appearance.spacing.space150
+                        }
+                        spacing: Appearance.spacing.space100
+
+                        StyledImage {
+                            Layout.fillWidth: true
+                            Layout.preferredHeight: width * 9 / 16
+                            fillMode: Image.PreserveAspectCrop
+                            source: root.weConfig.activePreview
+                            // A thumbnail-sized decode of a preview drawn
+                            // ~200px wide; the card is width-stable so the
+                            // constant avoids the bound-to-geometry reload
+                            // trap.
+                            sourceSize.width: 400
+                            sourceSize.height: 225
+                            layer.enabled: true
+                            layer.effect: OpacityMask {
+                                maskSource: Rectangle {
+                                    width: activeCard.width
+                                    height: activeCard.width * 9 / 16
+                                    radius: Appearance.rounding.small
+                                }
+                            }
+                        }
+
+                        StyledText {
+                            Layout.fillWidth: true
+                            elide: Text.ElideRight
+                            text: root.activeProject?.title ?? root.activeProjectId
+                            font.pixelSize: Appearance.font.pixelSize.small
+                        }
+
+                        RippleButton {
+                            Layout.fillWidth: true
+                            implicitHeight: 32
+                            buttonRadius: height / 2
+                            onClicked: WallpaperEngine.stop()
+                            contentItem: RowLayout {
+                                anchors.fill: parent
+                                spacing: Appearance.spacing.space75
+                                Item { Layout.fillWidth: true }
+                                MaterialSymbol {
+                                    text: "stop_circle"
+                                    iconSize: Appearance.font.pixelSize.larger
+                                    color: Appearance.colors.colOnLayer2
+                                }
+                                StyledText {
+                                    text: Translation.tr("Clear selection")
+                                    font.pixelSize: Appearance.font.pixelSize.smaller
+                                    color: Appearance.colors.colOnLayer2
+                                }
+                                Item { Layout.fillWidth: true }
+                            }
+                        }
                     }
-                    spacing: Appearance.spacing.space100
+                }
 
-                    StyledImage {
+                ConfigSwitch {
+                    Layout.fillWidth: true
+                    visible: root.activeProjectId !== ""
+                    buttonIcon: "tune"
+                    text: Translation.tr("Custom settings")
+                    description: Translation.tr("Only this wallpaper")
+                    checked: root.hasProjectOverride
+                    onToggleRequested: {
+                        if (root.hasProjectOverride) {
+                            // Clears the ENGINE flags only: property edits
+                            // below are per-wallpaper by nature and survive.
+                            WallpaperEngineOverrides.clearEngineOverrides(root.activeProjectId);
+                        } else {
+                            // Seed the record from what runs right now, so
+                            // flipping the switch changes nothing on screen
+                            // until a control is moved.
+                            WallpaperEngineOverrides.seedOverrides(root.activeProjectId, root.effective);
+                        }
+                    }
+                }
+
+                StyledText {
+                    Layout.leftMargin: Appearance.spacing.space150
+                    text: root.editingOverride
+                        ? Translation.tr("This wallpaper")
+                        : Translation.tr("All wallpapers")
+                    font.pixelSize: Appearance.font.pixelSize.smaller
+                    color: Appearance.colors.colSubtext
+                }
+
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing: Appearance.spacing.space100
+                    StyledText {
+                        Layout.leftMargin: Appearance.spacing.space150
                         Layout.fillWidth: true
-                        Layout.preferredHeight: width * 9 / 16
-                        fillMode: Image.PreserveAspectCrop
-                        source: root.weConfig.activePreview
-                        // A thumbnail-sized decode of a preview drawn ~200px
-                        // wide; the card is width-stable so the constant
-                        // avoids the bound-to-geometry reload trap.
-                        sourceSize.width: 400
-                        sourceSize.height: 225
-                        layer.enabled: true
-                        layer.effect: OpacityMask {
-                            maskSource: Rectangle {
-                                width: activeCard.width
-                                height: activeCard.width * 9 / 16
-                                radius: Appearance.rounding.small
+                        text: Translation.tr("Frame rate")
+                        font.pixelSize: Appearance.font.pixelSize.small
+                    }
+                    StyledComboBox {
+                        id: fpsBox
+                        implicitWidth: 92
+                        readonly property var values: [24, 30, 60]
+                        model: [
+                            { value: 24, displayName: "24 FPS" },
+                            { value: 30, displayName: "30 FPS" },
+                            { value: 60, displayName: "60 FPS" }
+                        ]
+                        textRole: "displayName"
+                        // Bound, not set at completion: the shown value swaps
+                        // between the globals and a project's record when the
+                        // override switch flips.
+                        currentIndex: Math.max(0, fpsBox.values.indexOf(root.effective.fps))
+                        onActivated: index => root.writeSetting("fps", fpsBox.values[index])
+                    }
+                }
+
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing: Appearance.spacing.space100
+                    StyledText {
+                        Layout.leftMargin: Appearance.spacing.space150
+                        Layout.fillWidth: true
+                        text: Translation.tr("Scaling")
+                        font.pixelSize: Appearance.font.pixelSize.small
+                    }
+                    StyledComboBox {
+                        id: scalingBox
+                        implicitWidth: 92
+                        readonly property var values: ["fill", "fit", "stretch"]
+                        model: [
+                            { value: "fill", displayName: Translation.tr("Fill") },
+                            { value: "fit", displayName: Translation.tr("Fit") },
+                            { value: "stretch", displayName: Translation.tr("Stretch") }
+                        ]
+                        textRole: "displayName"
+                        currentIndex: Math.max(0, scalingBox.values.indexOf(root.effective.scaling))
+                        onActivated: index => root.writeSetting("scaling", scalingBox.values[index])
+                    }
+                }
+
+                ConfigSwitch {
+                    Layout.fillWidth: true
+                    buttonIcon: "volume_up"
+                    text: Translation.tr("Wallpaper audio")
+                    checked: !root.effective.silent
+                    onToggleRequested: root.writeSetting("silent", !root.effective.silent)
+                }
+
+                // Volume, only while audio plays and only on a renderer that
+                // reads it. Committed on RELEASE: every engine flag is a
+                // load-time WE argument, so a per-tick write would reload the
+                // wallpaper once per pixel of drag.
+                RowLayout {
+                    Layout.fillWidth: true
+                    Layout.leftMargin: Appearance.spacing.space150
+                    Layout.rightMargin: Appearance.spacing.space100
+                    visible: !root.effective.silent && WallpaperEngineFeatures.engineFlags
+                    spacing: Appearance.spacing.space100
+                    StyledText {
+                        text: Translation.tr("Volume")
+                        font.pixelSize: Appearance.font.pixelSize.small
+                    }
+                    StyledSlider {
+                        id: volumeSlider
+                        Layout.fillWidth: true
+                        from: 0
+                        to: 100
+                        stepSize: 1
+                        value: root.effective.volume
+                        onPressedChanged: {
+                            if (!pressed)
+                                root.writeSetting("volume", Math.round(value));
+                        }
+                    }
+                }
+
+                // The four feature toggles as a toggle bar, not four switch
+                // rows - the Widget behaviour precedent (b89908fef): four
+                // ConfigSwitches spend ~170px of a rail this narrow on four
+                // bits, a FlowButtonGroup spends ~64. A glyph cannot label
+                // itself, so the caption under the bar names the hovered
+                // toggle - and, off-hover, which are on.
+                ColumnLayout {
+                    Layout.fillWidth: true
+                    visible: WallpaperEngineFeatures.engineFlags
+                    spacing: Appearance.spacing.space50
+
+                    property string hoveredLabel: ""
+                    id: featureBar
+
+                    readonly property var featureToggles: [
+                        { key: "audioProcessing", icon: "graphic_eq",
+                          label: Translation.tr("Audio reactive"),
+                          on: root.effective.audioProcessing,
+                          invert: false },
+                        { key: "disableMouse", icon: "mouse",
+                          label: Translation.tr("Mouse interaction"),
+                          on: !root.effective.disableMouse,
+                          invert: true },
+                        { key: "disableParallax", icon: "layers",
+                          label: Translation.tr("Parallax"),
+                          on: !root.effective.disableParallax,
+                          invert: true },
+                        { key: "disableParticles", icon: "flare",
+                          label: Translation.tr("Particles"),
+                          on: !root.effective.disableParticles,
+                          invert: true }
+                    ]
+
+                    FlowButtonGroup {
+                        Layout.fillWidth: true
+                        spacing: Appearance.spacing.space50
+
+                        Repeater {
+                            model: featureBar.featureToggles
+                            delegate: IconToolbarButton {
+                                id: featureToggle
+                                required property var modelData
+                                implicitHeight: 40
+                                text: featureToggle.modelData.icon
+                                toggled: featureToggle.modelData.on
+                                onClicked: {
+                                    const next = featureToggle.modelData.on;
+                                    // `on` is the positive sense; the three
+                                    // disable-keys store its inverse.
+                                    root.writeSetting(featureToggle.modelData.key,
+                                        featureToggle.modelData.invert ? next : !next);
+                                }
+                                onHoveredChanged: {
+                                    if (featureToggle.hovered)
+                                        featureBar.hoveredLabel = featureToggle.modelData.label;
+                                    else if (featureBar.hoveredLabel === featureToggle.modelData.label)
+                                        featureBar.hoveredLabel = "";
+                                }
                             }
                         }
                     }
 
                     StyledText {
                         Layout.fillWidth: true
+                        Layout.leftMargin: Appearance.spacing.space150
                         elide: Text.ElideRight
-                        text: WallpaperEngine.projects.find(
-                            p => p.id === root.activeProjectId)?.title ?? root.activeProjectId
-                        font.pixelSize: Appearance.font.pixelSize.small
-                    }
-
-                    RippleButton {
-                        Layout.fillWidth: true
-                        implicitHeight: 32
-                        buttonRadius: height / 2
-                        onClicked: WallpaperEngine.stop()
-                        contentItem: RowLayout {
-                            anchors.fill: parent
-                            spacing: Appearance.spacing.space75
-                            Item { Layout.fillWidth: true }
-                            MaterialSymbol {
-                                text: "stop_circle"
-                                iconSize: Appearance.font.pixelSize.larger
-                                color: Appearance.colors.colOnLayer2
-                            }
-                            StyledText {
-                                text: Translation.tr("Clear selection")
-                                font.pixelSize: Appearance.font.pixelSize.smaller
-                                color: Appearance.colors.colOnLayer2
-                            }
-                            Item { Layout.fillWidth: true }
+                        font.pixelSize: Appearance.font.pixelSize.smaller
+                        color: Appearance.colors.colSubtext
+                        text: {
+                            if (featureBar.hoveredLabel.length > 0)
+                                return featureBar.hoveredLabel;
+                            const on = featureBar.featureToggles
+                                .filter(toggle => toggle.on)
+                                .map(toggle => toggle.label);
+                            return on.length > 0
+                                ? Translation.tr("On: %1").arg(on.join("  ·  "))
+                                : Translation.tr("Nothing on");
                         }
                     }
                 }
-            }
 
-            ConfigSwitch {
-                Layout.fillWidth: true
-                visible: root.activeProjectId !== ""
-                buttonIcon: "tune"
-                text: Translation.tr("Custom settings")
-                description: Translation.tr("Only this wallpaper")
-                checked: root.hasProjectOverride
-                onToggleRequested: {
-                    if (root.hasProjectOverride) {
-                        WallpaperEngineOverrides.clearOverrides(root.activeProjectId);
-                    } else {
-                        // Seed the record from what runs right now, so
-                        // flipping the switch changes nothing on screen until
-                        // a control is moved.
-                        WallpaperEngineOverrides.setOverride(root.activeProjectId, "fps", root.effective.fps);
-                        WallpaperEngineOverrides.setOverride(root.activeProjectId, "scaling", root.effective.scaling);
-                        WallpaperEngineOverrides.setOverride(root.activeProjectId, "silent", root.effective.silent);
+                // ---- The wallpaper's own properties --------------------
+                // project.json general.properties, per-wallpaper by nature
+                // (there is no global side, so these are independent of the
+                // Custom settings switch). Every edit reloads the wallpaper -
+                // a load-time --set-property - hence commit-on-release for
+                // the sliders and colors here too.
+                RowLayout {
+                    Layout.fillWidth: true
+                    Layout.topMargin: Appearance.spacing.space100
+                    visible: root.activeProjectId !== ""
+                        && WallpaperEngineFeatures.projectProperties
+                        && root.activeProperties.length > 0
+                    spacing: Appearance.spacing.space100
+                    StyledText {
+                        Layout.leftMargin: Appearance.spacing.space150
+                        Layout.fillWidth: true
+                        text: Translation.tr("Wallpaper properties")
+                        font.pixelSize: Appearance.font.pixelSize.smaller
+                        color: Appearance.colors.colSubtext
+                    }
+                    IconToolbarButton {
+                        implicitWidth: height
+                        visible: WallpaperEngineOverrides.hasProperties(root.activeProjectId)
+                        text: "restart_alt"
+                        onClicked: WallpaperEngineOverrides.clearProperties(root.activeProjectId)
+                        StyledToolTip { text: Translation.tr("Reset to the wallpaper's defaults") }
                     }
                 }
-            }
 
-            StyledText {
-                Layout.leftMargin: Appearance.spacing.space150
-                text: root.editingOverride
-                    ? Translation.tr("This wallpaper")
-                    : Translation.tr("All wallpapers")
-                font.pixelSize: Appearance.font.pixelSize.smaller
-                color: Appearance.colors.colSubtext
-            }
+                Repeater {
+                    model: (root.activeProjectId !== ""
+                        && WallpaperEngineFeatures.projectProperties)
+                        ? root.activeProperties : []
+                    delegate: WallpaperPropertyControl {
+                        required property var modelData
+                        Layout.fillWidth: true
+                        Layout.leftMargin: Appearance.spacing.space150
+                        Layout.rightMargin: Appearance.spacing.space100
+                        definition: modelData
+                        // The edited value if there is one, else the
+                        // wallpaper's own default.
+                        currentValue: WallpaperEngineOverrides.active.properties[modelData.name]
+                            ?? modelData.value
+                        edited: modelData.name in WallpaperEngineOverrides.active.properties
+                        onCommitted: value => WallpaperEngineOverrides.setProjectProperty(
+                            root.activeProjectId, modelData.name, value)
+                    }
+                }
 
-            RowLayout {
-                Layout.fillWidth: true
-                spacing: Appearance.spacing.space100
+                // ---- Compatibility -------------------------------------
+                // The reference's bulk scanner: test every wallpaper in a
+                // spawned scanner process and mark the ones the renderer
+                // cannot start, so a broken tile says so before it is
+                // clicked instead of after the desktop goes black.
                 StyledText {
                     Layout.leftMargin: Appearance.spacing.space150
-                    Layout.fillWidth: true
-                    text: Translation.tr("Frame rate")
-                    font.pixelSize: Appearance.font.pixelSize.small
+                    Layout.topMargin: Appearance.spacing.space100
+                    text: Translation.tr("Compatibility")
+                    font.pixelSize: Appearance.font.pixelSize.smaller
+                    color: Appearance.colors.colSubtext
                 }
-                StyledComboBox {
-                    id: fpsBox
-                    implicitWidth: 92
-                    readonly property var values: [24, 30, 60]
-                    model: [
-                        { value: 24, displayName: "24 FPS" },
-                        { value: 30, displayName: "30 FPS" },
-                        { value: 60, displayName: "60 FPS" }
-                    ]
-                    textRole: "displayName"
-                    // Bound, not set at completion: the shown value swaps
-                    // between the globals and a project's record when the
-                    // override switch flips.
-                    currentIndex: Math.max(0, fpsBox.values.indexOf(root.effective.fps))
-                    onActivated: index => root.writeSetting("fps", fpsBox.values[index])
-                }
-            }
 
-            RowLayout {
-                Layout.fillWidth: true
-                spacing: Appearance.spacing.space100
-                StyledText {
+                // The active wallpaper's own verdict, when there is one.
+                RowLayout {
+                    Layout.fillWidth: true
                     Layout.leftMargin: Appearance.spacing.space150
+                    visible: root.activeProject !== null
+                        && WallpaperEngineCompat.statusFor(root.activeProject) !== "unknown"
+                    spacing: Appearance.spacing.space75
+                    MaterialSymbol {
+                        readonly property string status: root.activeProject
+                            ? WallpaperEngineCompat.statusFor(root.activeProject) : "unknown"
+                        text: status === "ok" ? "check_circle" : "error"
+                        iconSize: Appearance.font.pixelSize.larger
+                        color: status === "ok"
+                            ? Appearance.colors.colPrimary
+                            : Appearance.m3colors.m3error
+                    }
+                    StyledText {
+                        Layout.fillWidth: true
+                        elide: Text.ElideRight
+                        readonly property string status: root.activeProject
+                            ? WallpaperEngineCompat.statusFor(root.activeProject) : "unknown"
+                        text: status === "ok"
+                            ? Translation.tr("Renders on this machine")
+                            : Translation.tr("Could not be started")
+                        font.pixelSize: Appearance.font.pixelSize.small
+                    }
+                }
+
+                RippleButton {
                     Layout.fillWidth: true
-                    text: Translation.tr("Scaling")
-                    font.pixelSize: Appearance.font.pixelSize.small
-                }
-                StyledComboBox {
-                    id: scalingBox
-                    implicitWidth: 92
-                    readonly property var values: ["fill", "fit", "stretch"]
-                    model: [
-                        { value: "fill", displayName: Translation.tr("Fill") },
-                        { value: "fit", displayName: Translation.tr("Fit") },
-                        { value: "stretch", displayName: Translation.tr("Stretch") }
-                    ]
-                    textRole: "displayName"
-                    currentIndex: Math.max(0, scalingBox.values.indexOf(root.effective.scaling))
-                    onActivated: index => root.writeSetting("scaling", scalingBox.values[index])
-                }
-            }
-
-            ConfigSwitch {
-                buttonIcon: "volume_up"
-                text: Translation.tr("Wallpaper audio")
-                checked: !root.effective.silent
-                onToggleRequested: root.writeSetting("silent", !root.effective.silent)
-            }
-
-            // Which screen plays the sound. Only where the question exists:
-            // one screen, or muted, and there is nothing to choose. Global
-            // always - there is one audio route however many projects there
-            // are, which is also why it is not on the override record.
-            RowLayout {
-                Layout.fillWidth: true
-                visible: !root.effective.silent && (Quickshell.screens?.length ?? 0) > 1
-                spacing: Appearance.spacing.space100
-                StyledText {
-                    Layout.leftMargin: Appearance.spacing.space150
-                    Layout.fillWidth: true
-                    text: Translation.tr("Audio on")
-                    font.pixelSize: Appearance.font.pixelSize.small
-                }
-                StyledComboBox {
-                    id: audioOutputBox
-                    implicitWidth: 116
-
-                    readonly property var outputs: [{
-                        value: "",
-                        displayName: Translation.tr("Auto")
-                    }].concat((Quickshell.screens ?? []).map(screen => ({
-                        value: screen.name,
-                        displayName: screen.name
-                    })))
-
-                    model: audioOutputBox.outputs
-                    textRole: "displayName"
-                    currentIndex: Math.max(0, audioOutputBox.outputs
-                        .findIndex(output => output.value
-                            === (root.weConfig.audioMonitor ?? "")))
-                    onActivated: index =>
-                        root.weConfig.audioMonitor = audioOutputBox.outputs[index].value
-
+                    implicitHeight: 36
+                    buttonRadius: height / 2
+                    enabled: WallpaperEngine.projects.length > 0
+                    onClicked: {
+                        if (WallpaperEngineCompat.scanning)
+                            WallpaperEngineCompat.stopScan();
+                        else
+                            WallpaperEngineCompat.startScan(WallpaperEngine.projects, false);
+                    }
+                    altAction: () => WallpaperEngineCompat.startScan(WallpaperEngine.projects, true)
+                    contentItem: RowLayout {
+                        anchors.fill: parent
+                        spacing: Appearance.spacing.space75
+                        Item { Layout.fillWidth: true }
+                        MaterialSymbol {
+                            text: WallpaperEngineCompat.scanning ? "stop_circle" : "troubleshoot"
+                            iconSize: Appearance.font.pixelSize.larger
+                            color: Appearance.colors.colOnLayer2
+                        }
+                        StyledText {
+                            text: WallpaperEngineCompat.scanning
+                                ? Translation.tr("Scanning %1/%2")
+                                    .arg(WallpaperEngineCompat.scanDone)
+                                    .arg(WallpaperEngineCompat.scanTotal)
+                                : Translation.tr("Check compatibility")
+                            font.pixelSize: Appearance.font.pixelSize.smaller
+                            color: Appearance.colors.colOnLayer2
+                        }
+                        Item { Layout.fillWidth: true }
+                    }
                     StyledToolTip {
-                        text: Translation.tr("Screen that plays the wallpaper's sound")
+                        text: WallpaperEngineCompat.scanning
+                            ? Translation.tr("Stop the scan")
+                            : Translation.tr("Test untested wallpapers in the background. Long-press to retest all.")
                     }
                 }
-            }
 
-            Item { Layout.fillHeight: true }
+                ConfigSwitch {
+                    Layout.fillWidth: true
+                    buttonIcon: "visibility_off"
+                    text: Translation.tr("Hide broken")
+                    checked: root.weConfig.hideBroken ?? false
+                    onToggleRequested: root.weConfig.hideBroken = !(root.weConfig.hideBroken ?? false)
+                }
+
+                Item { Layout.fillHeight: true }
+            }
         }
     }
 }

--- a/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/crop_picker.js
+++ b/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/crop_picker.js
@@ -1,0 +1,64 @@
+.pragma library
+
+// The "fill" crop picker's geometry. A wallpaper whose content aspect differs
+// from the screen's overflows on one axis under Fill (cover-crop): the picker
+// draws the screen's viewport as a rectangle over the preview and a drag slides
+// it along the overflowing axis, producing a focus fraction (0..1) the renderer
+// applies live (WallpaperEngineSurface.focusX/focusY).
+//
+// contentAspect is the wallpaper's own w/h (approximated by the preview image
+// here - the only image the shell has without running the scene); screenAspect
+// is the output's. previewW/previewH are the preview's drawn box.
+
+// The viewport rectangle over the preview, and which axis (if any) overflows.
+// focusX (or focusY when vertical) is the crop position 0..1.
+function viewport(contentAspect, screenAspect, previewW, previewH, focus) {
+    var result = {
+        x: 0, y: 0, width: previewW, height: previewH,
+        overflowsX: false, overflowsY: false
+    };
+    if (!(contentAspect > 0) || !(screenAspect > 0) || previewW <= 0 || previewH <= 0)
+        return result;
+    if (contentAspect > screenAspect) {
+        // Content wider than the screen: crop the sides. The viewport is full
+        // height and a fraction of the width, sliding left-right.
+        result.overflowsX = true;
+        result.width = previewW * (screenAspect / contentAspect);
+        result.height = previewH;
+        result.x = (previewW - result.width) * clamp01(focus);
+        result.y = 0;
+    } else if (contentAspect < screenAspect) {
+        // Content taller than the screen: crop top and bottom.
+        result.overflowsY = true;
+        result.width = previewW;
+        result.height = previewH * (contentAspect / screenAspect);
+        result.x = 0;
+        result.y = (previewH - result.height) * clamp01(focus);
+    }
+    return result;
+}
+
+// The focus fraction a pointer at (px, py) on the preview produces: the
+// viewport's CENTRE tracks the pointer, so the focus is the pointer's position
+// within the slack (previewSize - viewportSize). The non-overflowing axis is
+// pinned to centre.
+function focusFromPointer(contentAspect, screenAspect, previewW, previewH, px, py) {
+    var result = { x: 0.5, y: 0.5 };
+    if (!(contentAspect > 0) || !(screenAspect > 0) || previewW <= 0 || previewH <= 0)
+        return result;
+    if (contentAspect > screenAspect) {
+        var vw = previewW * (screenAspect / contentAspect);
+        var slack = previewW - vw;
+        result.x = slack > 0 ? clamp01((px - vw / 2) / slack) : 0.5;
+    } else if (contentAspect < screenAspect) {
+        var vh = previewH * (contentAspect / screenAspect);
+        var slackY = previewH - vh;
+        result.y = slackY > 0 ? clamp01((py - vh / 2) / slackY) : 0.5;
+    }
+    return result;
+}
+
+function clamp01(value) {
+    if (typeof value !== "number" || isNaN(value)) return 0.5;
+    return value < 0 ? 0 : (value > 1 ? 1 : value);
+}

--- a/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/selector_places.js
+++ b/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/selector_places.js
@@ -1,0 +1,51 @@
+.pragma library
+
+// The places the selector's sidebar offers while browsing local files, and
+// which of them is lit for the directory on screen. Pure: the visibility
+// rules and the current-place match are the decisions, and nothing about the
+// drawn sidebar is reachable from qmltestrunner.
+
+function _basename(path) {
+    var parts = String(path).split("/").filter(function (s) { return s.length > 0; });
+    return parts.length > 0 ? parts[parts.length - 1] : path;
+}
+
+// Ordered rows: {key, icon, name, path, translate}. `name` for the custom row
+// is the folder's own basename, so `translate` says whether a caller should
+// run the label through Translation.tr - a directory name is not a phrase
+// this repo owns.
+function places(dirs, options) {
+    var rows = [
+        { key: "wallpapers", icon: "wallpaper", name: "Wallpapers", path: dirs.pictures + "/Wallpapers", translate: true }
+    ];
+    if (options.showHomePath)
+        rows.push({ key: "home", icon: "home", name: "Home", path: dirs.home, translate: true });
+    rows.push({ key: "documents", icon: "description", name: "Documents", path: dirs.documents, translate: true });
+    rows.push({ key: "downloads", icon: "download", name: "Downloads", path: dirs.downloads, translate: true });
+    rows.push({ key: "pictures", icon: "imagesmode", name: "Pictures", path: dirs.pictures, translate: true });
+    rows.push({ key: "videos", icon: "movie", name: "Videos", path: dirs.videos, translate: true });
+    if (options.weeb)
+        rows.push({ key: "homework", icon: "school", name: "Homework", path: dirs.pictures + "/homework", translate: true });
+    rows.push({ key: "random", icon: "casino", name: "Random", path: dirs.pictures + "/Random", translate: true });
+    var userPath = String(options.userPath ?? "").trim();
+    if (userPath.length > 0)
+        rows.push({ key: "custom", icon: "folder_special", name: _basename(userPath), path: options.userPath, translate: false });
+    return rows;
+}
+
+// Whether a place's stored path is the directory on screen.
+// `currentDirectory` arrives as Wallpapers.directory - a resolved file:// URL
+// - while a place stores a plain path, and either side may carry a trailing
+// slash; normalising both is what lets any row light up at all.
+function _normalize(path) {
+    var p = String(path);
+    if (p.indexOf("file://") === 0)
+        p = p.substring(7);
+    while (p.length > 1 && p.charAt(p.length - 1) === "/")
+        p = p.substring(0, p.length - 1);
+    return p;
+}
+
+function isCurrent(placePath, currentDirectory) {
+    return _normalize(placePath) === _normalize(currentDirectory);
+}

--- a/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/we_color.js
+++ b/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/we_color.js
@@ -1,0 +1,33 @@
+.pragma library
+
+// Wallpaper Engine color properties on --set-property are "r g b" triplets.
+// The vendored engine's ColorBuilder::parse reads the triplet two ways: a
+// value with a decimal point anywhere is 0..1 floats; a DOT-LESS triplet is
+// 0..255 integers (the form WE also accepts and vendored projects ship). So
+// the two must not be conflated - white as the dot-less "1 1 1" is not float
+// white, it is (1/255, 1/255, 1/255), near black.
+//
+// parseChannel returns a 0..1 float for the swatch and the sliders;
+// formatChannels always writes the float form WITH a dot, so a value that is
+// integral (white = 1.000) is not re-read as 0..255 on the next load.
+
+// One channel of `text` as a 0..1 float. A dot-less triplet is 0..255 and is
+// divided down; garbage / negative / a missing channel guards to 0 (never a
+// NaN that would poison the swatch - the Math.max(0, NaN) trap).
+function parseChannel(text, index) {
+    var s = String(text).trim();
+    var raw = parseFloat(s.split(/\s+/)[index]);
+    if (!(raw >= 0)) return 0;
+    // No decimal point anywhere in the triplet: WE reads it as 0..255.
+    var v = (s.indexOf(".") === -1) ? raw / 255 : raw;
+    return v > 1 ? 1 : v;
+}
+
+// 0..1 channels -> the string WE's --set-property takes, each clamped to
+// 0..1 and always carrying a decimal point so WE reads it as a float.
+function formatChannels(channels) {
+    return channels.map(function (c) {
+        var v = (c >= 0) ? (c > 1 ? 1 : c) : 0;
+        return v.toFixed(3);
+    }).join(" ");
+}

--- a/dots/.config/quickshell/imi/scripts/wallpapers/wallpaper_engine.py
+++ b/dots/.config/quickshell/imi/scripts/wallpapers/wallpaper_engine.py
@@ -68,6 +68,19 @@ def serialize_property_value(value: object) -> str:
     return str(value)
 
 
+def serialize_combo_value(value: object) -> str:
+    # WE keys combo options by std::to_string(int), so a numeric option value
+    # has to be an integer string - "2", never "2.0" or "1.5" - or the
+    # --set-property lookup never matches and the selection is silently
+    # dropped. Non-numeric keys (strings) pass through unchanged. This is
+    # combo-only: a slider value stays a float, which WE reads with stof.
+    if isinstance(value, bool):
+        return "1" if value else "0"
+    if isinstance(value, (int, float)):
+        return str(int(value))
+    return serialize_property_value(value)
+
+
 def project_properties(data: object) -> list[dict[str, object]]:
     general = data.get("general") if isinstance(data, dict) else None
     props = general.get("properties") if isinstance(general, dict) else None
@@ -80,18 +93,20 @@ def project_properties(data: object) -> list[dict[str, object]]:
         if definition.get("type") not in PROPERTY_CONTROL_TYPES:
             continue
         options = definition.get("options")
+        is_combo = definition["type"] == "combo"
+        serialize_value = serialize_combo_value if is_combo else serialize_property_value
         row: dict[str, object] = {
             "name": str(name),
             "type": definition["type"],
             "text": str(definition.get("text") or name),
-            "value": serialize_property_value(definition.get("value")),
+            "value": serialize_value(definition.get("value")),
         }
         for bound in ("min", "max", "step"):
             if isinstance(definition.get(bound), (int, float)) and not isinstance(definition.get(bound), bool):
                 row[bound] = definition[bound]
         if isinstance(options, list):
             row["options"] = [
-                {"label": str(option["label"]), "value": serialize_property_value(option["value"])}
+                {"label": str(option["label"]), "value": serialize_combo_value(option["value"])}
                 for option in options
                 if isinstance(option, dict) and "label" in option and "value" in option
             ]

--- a/dots/.config/quickshell/imi/scripts/wallpapers/wallpaper_engine.py
+++ b/dots/.config/quickshell/imi/scripts/wallpapers/wallpaper_engine.py
@@ -51,6 +51,60 @@ def confined_preview(directory: Path, preview_name: object) -> Path:
     return candidate if candidate.is_file() else Path()
 
 
+# The five project.json property types that get a UI control; everything else
+# (text headings, groups, scenetexture, file) is display-only or unsupported.
+# The model and the serialization (booleans to "1"/"0" - the form WE's
+# --set-property takes - everything else verbatim, ordered by the author's
+# order/index keys) follow the reference implementation,
+# jagrat7/linux-wallpaper-engine's parseProjectProperties.
+PROPERTY_CONTROL_TYPES = ("bool", "slider", "combo", "color", "textinput")
+
+
+def serialize_property_value(value: object) -> str:
+    if isinstance(value, bool):
+        return "1" if value else "0"
+    if value is None:
+        return ""
+    return str(value)
+
+
+def project_properties(data: object) -> list[dict[str, object]]:
+    general = data.get("general") if isinstance(data, dict) else None
+    props = general.get("properties") if isinstance(general, dict) else None
+    if not isinstance(props, dict):
+        return []
+    rows: list[tuple[float, dict[str, object]]] = []
+    for name, definition in props.items():
+        if not isinstance(definition, dict):
+            continue
+        if definition.get("type") not in PROPERTY_CONTROL_TYPES:
+            continue
+        options = definition.get("options")
+        row: dict[str, object] = {
+            "name": str(name),
+            "type": definition["type"],
+            "text": str(definition.get("text") or name),
+            "value": serialize_property_value(definition.get("value")),
+        }
+        for bound in ("min", "max", "step"):
+            if isinstance(definition.get(bound), (int, float)) and not isinstance(definition.get(bound), bool):
+                row[bound] = definition[bound]
+        if isinstance(options, list):
+            row["options"] = [
+                {"label": str(option["label"]), "value": serialize_property_value(option["value"])}
+                for option in options
+                if isinstance(option, dict) and "label" in option and "value" in option
+            ]
+        order = definition.get("order")
+        if not isinstance(order, (int, float)) or isinstance(order, bool):
+            order = definition.get("index")
+        if not isinstance(order, (int, float)) or isinstance(order, bool):
+            order = float("inf")
+        rows.append((float(order), row))
+    rows.sort(key=lambda item: item[0])
+    return [row for _, row in rows]
+
+
 def scan(configured: str) -> list[dict[str, object]]:
     projects_by_id: dict[str, tuple[tuple[int, int, str], dict[str, object]]] = {}
     for root in project_roots(configured):
@@ -76,6 +130,7 @@ def scan(configured: str) -> list[dict[str, object]]:
                 # An empty Path() is "." and truthy, so compare explicitly to
                 # avoid emitting "." when no preview file was found.
                 "preview": str(preview) if preview != Path() else "",
+                "properties": project_properties(data),
             }
             try:
                 file_count = sum(1 for path in directory.rglob("*") if path.is_file())

--- a/dots/.config/quickshell/imi/scripts/wallpapers/we_compat_scan.qml
+++ b/dots/.config/quickshell/imi/scripts/wallpapers/we_compat_scan.qml
@@ -1,0 +1,109 @@
+import QtQuick
+import Quickshell
+import Quickshell.WallpaperEngine
+
+// The Wallpaper Engine compatibility scanner, run BY the shell as its own
+// `qs -p` process (services/WallpaperEngineCompat.qml spawns it): it loads
+// each queued project into a real WallpaperEngineSurface and reports one
+// JSON verdict line per project on stdout. A separate process on purpose -
+// a project that wedges the renderer inside WE's setup() (which the surface
+// answers by DETACHING the thread and leaking it) or that crashes the
+// engine outright takes the scanner down, not the shell; the service
+// respawns it for the rest of the queue.
+//
+// Standalone config: only binary modules (Quickshell, WallpaperEngine) are
+// importable here, no qs.* singletons. The queue arrives as JSON in the
+// WE_COMPAT_QUEUE environment variable: [{id, path}, ...].
+//
+// The window is small and titled rather than hidden, deliberately: a
+// surface that is not rendered never produces a frame, so `rendered` -
+// the scan's whole instrument - needs a mapped window. What a small
+// window cannot judge is resolution-dependent VRAM exhaustion; the scan's
+// verdicts are about STRUCTURAL breakage (a project.json the engine
+// refuses, missing assets, a codec it cannot start), which is what stays
+// true at every size.
+ShellRoot {
+    id: scanRoot
+
+    property var queue: {
+        try {
+            const parsed = JSON.parse(Quickshell.env("WE_COMPAT_QUEUE") || "[]");
+            return Array.isArray(parsed) ? parsed : [];
+        } catch (e) {
+            return [];
+        }
+    }
+    property int index: -1
+
+    function emitLine(payload) {
+        // One JSON document per line, on STDERR (console.warn), not stdout.
+        // qs's stdout logging is block-buffered when it is not a tty, so
+        // verdicts sat in a 4-8KB buffer and arrived at the service in
+        // bursts - and a renderer crash lost every line since the last
+        // flush, including the "testing" marker that names the corpse, so
+        // the service could not mark the crashing wallpaper and respawned
+        // into the same crash. stderr is unbuffered, so every line lands as
+        // it is written. The service strips the log prefix before parsing.
+        console.warn(JSON.stringify(payload));
+    }
+
+    function next() {
+        scanRoot.index += 1;
+        if (scanRoot.index >= scanRoot.queue.length) {
+            Qt.quit();
+            return;
+        }
+        const entry = scanRoot.queue[scanRoot.index];
+        scanRoot.emitLine({ id: entry.id, status: "testing" });
+        deadline.restart();
+        surface.projectPath = entry.path;
+    }
+
+    function verdict(status, error) {
+        deadline.stop();
+        const entry = scanRoot.queue[scanRoot.index];
+        scanRoot.emitLine({ id: entry.id, status: status, error: error ?? "" });
+    }
+
+    FloatingWindow {
+        id: window
+        title: "Wallpaper compatibility scan"
+        implicitWidth: 384
+        implicitHeight: 216
+        color: "#111111"
+
+        WallpaperEngineSurface {
+            id: surface
+            anchors.fill: parent
+            live: true
+
+            onRenderedChanged: {
+                if (!rendered || scanRoot.index < 0) return;
+                scanRoot.verdict("ok");
+                scanRoot.next();
+            }
+            onFailedChanged: {
+                if (!failed || scanRoot.index < 0) return;
+                scanRoot.verdict("broken", "the renderer could not start this wallpaper");
+                scanRoot.next();
+            }
+        }
+
+        // A project that neither renders nor fails inside the deadline is
+        // reported broken and ends THIS scanner: switching away from a
+        // wedged load leans on the surface's bounded-join/detach machinery,
+        // and a leaked renderer thread in the scanner would sit under every
+        // later verdict. Exiting is cheap - the service respawns with the
+        // rest of the queue.
+        Timer {
+            id: deadline
+            interval: 25000
+            onTriggered: {
+                scanRoot.verdict("broken", "timed out loading");
+                Qt.quit();
+            }
+        }
+
+        Component.onCompleted: scanRoot.next()
+    }
+}

--- a/dots/.config/quickshell/imi/services/DateTime.qml
+++ b/dots/.config/quickshell/imi/services/DateTime.qml
@@ -62,7 +62,11 @@ Singleton {
             if (minutes > 0 || !formatted)
                 formatted += `${formatted ? ", " : ""}${minutes}m`;
             uptime = formatted;
-            interval = Config.options?.resources?.updateInterval ?? 3000;
+            // The string above has minute resolution, so re-reading
+            // /proc/uptime on the resources tick (3s) was 20 reads per
+            // possible change. One per minute matches what it can display;
+            // the 1ms first tick above still fills it immediately.
+            interval = 60000;
         }
     }
 

--- a/dots/.config/quickshell/imi/services/ResourceUsage.qml
+++ b/dots/.config/quickshell/imi/services/ResourceUsage.qml
@@ -8,6 +8,15 @@ import Quickshell.Io
 
 /**
  * Simple polled resource usage service with RAM, Swap, CPU and Disk usage.
+ *
+ * Polling is arranged to cost as little as possible per tick: everything that
+ * the kernel exposes as a file (meminfo, stat, hwmon temperature, amdgpu
+ * counters, the dGPU's runtime-PM status) is read through a FileView, and a
+ * subprocess is spawned only where no file exists (nvidia-smi, df, and the
+ * `sensors` fallback on machines whose CPU sensor probeProc cannot name).
+ * Before this arrangement a 3s tick spawned bash+sensors+grep+grep+head,
+ * bash+df+awk and a GPU probe - ~9 processes every 3 seconds for the life of
+ * the shell.
  */
 Singleton {
     id: root
@@ -49,10 +58,84 @@ Singleton {
     property list<real> vramUsageHistory: []
     property string maxAvailableVramString: kbToGbString(vramTotal)
 
-    // GPU vendor for polling: "nvidia" (nvidia-smi), "amd"/"intel" (hwmon/sysfs),
-    // or "" while detection is pending or no supported GPU was found.
-    property string gpuVendor: ""
+    // Resolved once at startup by probeProc: which files answer each question
+    // on this machine. Empty paths mean "no such source here".
+    property var probes: ({
+        cpuTempPath: "",
+        gpuVendor: "",
+        gpuPaths: { busy: "", temp: "", vramUsed: "", vramTotal: "" },
+        nvidiaPmPath: ""
+    })
 
+    // GPU vendor for polling: "nvidia" (nvidia-smi), "amd"/"intel" (hwmon/
+    // sysfs), or "" while detection is pending or no supported GPU was found.
+    readonly property string gpuVendor: probes.gpuVendor
+
+    // Resolves every pollable file path in one startup spawn: the CPU
+    // temperature's hwmon input, and the GPU backend with its sysfs paths.
+    // Detection order (nvidia first) is unchanged from the old per-vendor
+    // probes so no machine changes which GPU it reports.
+    Process {
+        id: probeProc
+        running: true
+        command: ["bash", "-c", `
+            cpu=-
+            for h in /sys/class/hwmon/hwmon*; do
+                name=$(cat "$h/name" 2>/dev/null)
+                case "$name" in
+                    coretemp)
+                        for l in "$h"/temp*_label; do
+                            [ -e "$l" ] || continue
+                            if grep -q 'Package id 0' "$l" 2>/dev/null; then cpu="\${l%_label}_input"; break; fi
+                        done
+                        [ "$cpu" = - ] && [ -e "$h/temp1_input" ] && cpu="$h/temp1_input"
+                        ;;
+                    k10temp|zenpower)
+                        [ -e "$h/temp1_input" ] && cpu="$h/temp1_input"
+                        ;;
+                esac
+                [ "$cpu" != - ] && break
+            done
+            echo "cputemp $cpu"
+
+            if command -v nvidia-smi >/dev/null 2>&1; then
+                pm=-
+                for d in /sys/bus/pci/devices/*; do
+                    [ "$(cat "$d/vendor" 2>/dev/null)" = 0x10de ] || continue
+                    case "$(cat "$d/class" 2>/dev/null)" in
+                        0x0300*|0x0302*) pm="$d/power/runtime_status"; break;;
+                    esac
+                done
+                echo "gpu nvidia pm=$pm"
+            else
+                found=
+                for d in /sys/class/drm/card*/device; do
+                    [ -d "$d" ] || continue
+                    busy="$d/gpu_busy_percent"; [ -e "$busy" ] || busy=-
+                    t=$(ls "$d"/hwmon/hwmon*/temp1_input 2>/dev/null | head -1); [ -n "$t" ] || t=-
+                    if [ "$busy" != - ] || [ "$t" != - ]; then
+                        vu="$d/mem_info_vram_used";  [ -e "$vu" ] || vu=-
+                        vt="$d/mem_info_vram_total"; [ -e "$vt" ] || vt=-
+                        vendor=amd; [ "$busy" = - ] && vendor=intel
+                        echo "gpu $vendor busy=$busy temp=$t vramu=$vu vramt=$vt"
+                        found=1
+                        break
+                    fi
+                done
+                [ -n "$found" ] || echo "gpu none"
+            fi
+        `]
+        stdout: StdioCollector {
+            id: probeCollector
+            onStreamFinished: {
+                root.probes = root.parseProbes(probeCollector.text)
+            }
+        }
+    }
+
+    // Fallback for machines whose CPU sensor lives on a chip probeProc does
+    // not know (no coretemp/k10temp/zenpower hwmon). Only spawned while
+    // probes.cpuTempPath is empty.
     Process {
         id: tempProc
         command: ["bash", "-c", "sensors 2>/dev/null | grep -E 'Package id 0|Tctl|Tdie' | grep -oP '\\+\\K[0-9.]+(?=°C)' | head -1"]
@@ -78,20 +161,6 @@ Singleton {
         }
     }
 
-    // Pick a GPU polling backend once: prefer NVIDIA if nvidia-smi is present,
-    // otherwise fall back to amdgpu (gpu_busy_percent) or, failing that, any GPU
-    // exposing an hwmon temperature (e.g. Intel iGPUs).
-    Process {
-        id: gpuDetectProc
-        running: true
-        command: ["bash", "-c", "if command -v nvidia-smi >/dev/null 2>&1; then echo nvidia; elif ls /sys/class/drm/card*/device/gpu_busy_percent >/dev/null 2>&1; then echo amd; elif ls /sys/class/drm/card*/device/hwmon/hwmon*/temp1_input >/dev/null 2>&1; then echo intel; fi"]
-        stdout: StdioCollector {
-            onStreamFinished: {
-                root.gpuVendor = text.trim()
-            }
-        }
-    }
-
     Process {
         id: gpuProc
         command: ["bash", "-c", "nvidia-smi --query-gpu=temperature.gpu,utilization.gpu,memory.used,memory.total --format=csv,noheader,nounits 2>/dev/null | head -1"]
@@ -108,18 +177,52 @@ Singleton {
         }
     }
 
-    // AMD/Intel fallback via Linux hwmon/sysfs. Emits a single line:
-    //   "<busy%> <temp_millideg> <vram_used_bytes> <vram_total_bytes>"
-    // busy comes from amdgpu's gpu_busy_percent (absent on Intel iGPUs, where it
-    // reports 0/unavailable); temperature from the GPU hwmon temp1_input; VRAM
-    // from mem_info_vram_* when the driver exposes it (amdgpu). Paths are static
-    // globs, so this stays a fixed command with no untrusted interpolation.
-    Process {
-        id: gpuFallbackProc
-        command: ["bash", "-c", "for d in /sys/class/drm/card*/device; do [ -d \"$d\" ] || continue; busy=$(cat \"$d/gpu_busy_percent\" 2>/dev/null); temp=$(cat \"$d\"/hwmon/hwmon*/temp1_input 2>/dev/null | head -1); vu=$(cat \"$d/mem_info_vram_used\" 2>/dev/null); vt=$(cat \"$d/mem_info_vram_total\" 2>/dev/null); if [ -n \"$busy\" ] || [ -n \"$temp\" ]; then echo \"${busy:-0} ${temp:-0} ${vu:-0} ${vt:-0}\"; break; fi; done"]
-        stdout: StdioCollector {
-            onStreamFinished: {
-                const parsed = root.parseAmdGpu(text)
+    // The kernel-file reads behind each tick. An empty path is a real "no
+    // file" state for FileView: it emits nothing and reload() is a no-op, so
+    // an unresolved probe costs nothing.
+    FileView { id: fileMeminfo;   path: "/proc/meminfo" }
+    FileView { id: fileStat;      path: "/proc/stat" }
+    FileView { id: fileCpuTemp;   path: root.probes.cpuTempPath }
+    FileView { id: fileNvidiaPm;  path: root.probes.nvidiaPmPath }
+    FileView { id: fileGpuBusy;   path: root.probes.gpuPaths.busy }
+    FileView { id: fileGpuTemp;   path: root.probes.gpuPaths.temp }
+    FileView { id: fileGpuVramU;  path: root.probes.gpuPaths.vramUsed }
+    FileView { id: fileGpuVramT;  path: root.probes.gpuPaths.vramTotal }
+
+    Timer {
+        interval: Config?.options.resources.updateInterval ?? 3000
+        running: true
+        repeat: true
+        onTriggered: {
+            if (root.probes.cpuTempPath !== "") {
+                fileCpuTemp.reload()
+                const temp = root.parseHwmonTemp(fileCpuTemp.text())
+                if (temp !== null) root.cpuTemp = temp
+            } else {
+                tempProc.running = false
+                tempProc.running = true
+            }
+
+            if (root.gpuVendor === "nvidia") {
+                // An nvidia-smi run wakes a runtime-suspended dGPU, so on
+                // hybrid laptops polling it every tick holds the GPU out of
+                // D3 for the whole session. Poll only while it is already
+                // awake; asleep means 0% busy by definition.
+                fileNvidiaPm.reload()
+                if (root.nvidiaShouldPoll(fileNvidiaPm.text())) {
+                    gpuProc.running = false
+                    gpuProc.running = true
+                } else {
+                    root.gpuUsage = 0
+                }
+            } else if (root.gpuVendor === "amd" || root.gpuVendor === "intel") {
+                fileGpuBusy.reload()
+                fileGpuTemp.reload()
+                fileGpuVramU.reload()
+                fileGpuVramT.reload()
+                const parsed = root.parseAmdSysfs(
+                    fileGpuBusy.text(), fileGpuTemp.text(),
+                    fileGpuVramU.text(), fileGpuVramT.text())
                 if (parsed) {
                     root.gpuTemp   = parsed.gpuTemp
                     root.gpuUsage  = parsed.gpuUsage
@@ -130,22 +233,17 @@ Singleton {
         }
     }
 
+    // Disk usage moves on the scale of minutes, and df is the one remaining
+    // per-tick subprocess a fast tick would spawn - so it gets its own, much
+    // slower clock instead of riding updateInterval.
     Timer {
-        interval: Config?.options.resources.updateInterval ?? 3000
+        interval: 30000
         running: true
         repeat: true
+        triggeredOnStart: true
         onTriggered: {
-            tempProc.running = false
-            tempProc.running = true
             diskProc.running = false
             diskProc.running = true
-            if (root.gpuVendor === "nvidia") {
-                gpuProc.running = false
-                gpuProc.running = true
-            } else if (root.gpuVendor === "amd" || root.gpuVendor === "intel") {
-                gpuFallbackProc.running = false
-                gpuFallbackProc.running = true
-            }
         }
     }
 
@@ -205,6 +303,75 @@ Singleton {
             vramUsed:  vramUsed / 1024,
             vramTotal: vramTotal / 1024
         };
+    }
+
+    // The same answer assembled from the four raw sysfs files the probe
+    // resolved, so the per-tick read needs no subprocess. Both primary
+    // readings missing means the files went away - report that as null
+    // rather than as confident zeros.
+    function parseAmdSysfs(busyText, tempText, vramUsedText, vramTotalText) {
+        const busy = parseFloat(String(busyText).trim())
+        const temp = parseFloat(String(tempText).trim())
+        if (isNaN(busy) && isNaN(temp)) return null;
+        const vramUsed  = parseFloat(String(vramUsedText).trim())
+        const vramTotal = parseFloat(String(vramTotalText).trim())
+        return parseAmdGpu([
+            isNaN(busy) ? 0 : busy,
+            isNaN(temp) ? 0 : temp,
+            isNaN(vramUsed) ? 0 : vramUsed,
+            isNaN(vramTotal) ? 0 : vramTotal
+        ].join(" "));
+    }
+
+    // hwmon temp*_input is millidegrees Celsius. Garbage or an empty read is
+    // null - never a confident zero degrees (the Number(null)-is-0 trap).
+    function parseHwmonTemp(text) {
+        const trimmed = String(text).trim()
+        if (trimmed === "") return null;
+        const v = parseFloat(trimmed)
+        return isNaN(v) ? null : v / 1000;
+    }
+
+    // One record per line: "cputemp <path|->" and one of
+    // "gpu nvidia pm=<path|->", "gpu amd|intel busy=.. temp=.. vramu=.. vramt=..",
+    // "gpu none". Unknown lines are ignored; "-" resolves to "" (no file).
+    function parseProbes(text) {
+        const result = {
+            cpuTempPath: "",
+            gpuVendor: "",
+            gpuPaths: { busy: "", temp: "", vramUsed: "", vramTotal: "" },
+            nvidiaPmPath: ""
+        };
+        for (const line of String(text).split("\n")) {
+            const parts = line.trim().split(/\s+/)
+            if (parts[0] === "cputemp" && parts.length >= 2) {
+                result.cpuTempPath = parts[1] === "-" ? "" : parts[1]
+            } else if (parts[0] === "gpu" && parts.length >= 2 && parts[1] !== "none") {
+                result.gpuVendor = parts[1]
+                for (const kv of parts.slice(2)) {
+                    const eq = kv.indexOf("=")
+                    if (eq < 1) continue;
+                    const key = kv.slice(0, eq)
+                    const value = kv.slice(eq + 1)
+                    const path = value === "-" ? "" : value
+                    if (key === "pm") result.nvidiaPmPath = path
+                    else if (key === "busy") result.gpuPaths.busy = path
+                    else if (key === "temp") result.gpuPaths.temp = path
+                    else if (key === "vramu") result.gpuPaths.vramUsed = path
+                    else if (key === "vramt") result.gpuPaths.vramTotal = path
+                }
+            }
+        }
+        return result;
+    }
+
+    // Whether an nvidia-smi poll is allowed right now, from the dGPU's
+    // power/runtime_status. "suspended"/"suspending" means the poll itself
+    // would power the GPU up; anything else (active, resuming, or no
+    // runtime-status file at all on desktops) polls as before.
+    function nvidiaShouldPoll(runtimeStatusText) {
+        const status = String(runtimeStatusText).trim()
+        return status !== "suspended" && status !== "suspending";
     }
 
     function updateMemoryUsageHistory() {
@@ -273,9 +440,6 @@ Singleton {
             interval = Config.options?.resources?.updateInterval ?? 3000
         }
     }
-
-    FileView { id: fileMeminfo; path: "/proc/meminfo" }
-    FileView { id: fileStat;    path: "/proc/stat" }
 
     Process {
         id: findCpuMaxFreqProc

--- a/dots/.config/quickshell/imi/services/ResourceUsage.qml
+++ b/dots/.config/quickshell/imi/services/ResourceUsage.qml
@@ -71,6 +71,22 @@ Singleton {
     // sysfs), or "" while detection is pending or no supported GPU was found.
     readonly property string gpuVendor: probes.gpuVendor
 
+    // nvidia-smi backoff. The runtime-status gate keeps a SUSPENDED card
+    // asleep, but on its own it never lets an ACTIVE-but-idle card suspend:
+    // every tick's poll re-wakes the card, so once runtime_status reads
+    // "active" (a game, the CUDA probe, boot) the 3 s poll holds it awake for
+    // the rest of the session. So after it reads idle _nvidiaZeroThreshold
+    // times running, drop to polling once every _nvidiaBackoffTicks - the gaps
+    // are long enough to clear a typical autosuspend window, so the card can
+    // reach D3 untouched; a non-zero reading snaps back to full cadence. (This
+    // is the review's "every k-th tick after N zero readings" option; it does
+    // not read power/autosuspend_delay_ms, it bounds the gap generously.)
+    property int nvidiaZeroStreak: 0
+    property int nvidiaBackoffCounter: 0
+    readonly property int _nvidiaZeroThreshold: 3
+    readonly property int _nvidiaBackoffTicks: Math.max(2, Math.ceil(
+        12000 / (Config?.options.resources.updateInterval ?? 3000)))
+
     // Resolves every pollable file path in one startup spawn: the CPU
     // temperature's hwmon input, and the GPU backend with its sysfs paths.
     // Detection order (nvidia first) is unchanged from the old per-vendor
@@ -98,16 +114,26 @@ Singleton {
             done
             echo "cputemp $cpu"
 
+            # nvidia only if an actual 0x10de display device is on the bus -
+            # nvidia-smi alone is a userland presence (a CUDA box with an AMD
+            # display GPU has it), and choosing "nvidia" there polls a failing
+            # nvidia-smi forever. No 0x10de display device: fall through to the
+            # drm scan.
+            gpu_emitted=
             if command -v nvidia-smi >/dev/null 2>&1; then
-                pm=-
                 for d in /sys/bus/pci/devices/*; do
                     [ "$(cat "$d/vendor" 2>/dev/null)" = 0x10de ] || continue
                     case "$(cat "$d/class" 2>/dev/null)" in
-                        0x0300*|0x0302*) pm="$d/power/runtime_status"; break;;
+                        0x0300*|0x0302*)
+                            pm=-
+                            [ -e "$d/power/runtime_status" ] && pm="$d/power/runtime_status"
+                            echo "gpu nvidia pm=$pm"
+                            gpu_emitted=1
+                            break;;
                     esac
                 done
-                echo "gpu nvidia pm=$pm"
-            else
+            fi
+            if [ -z "$gpu_emitted" ]; then
                 found=
                 for d in /sys/class/drm/card*/device; do
                     [ -d "$d" ] || continue
@@ -172,6 +198,11 @@ Singleton {
                     root.gpuUsage  = parsed.gpuUsage
                     root.vramUsed  = parsed.vramUsed
                     root.vramTotal = parsed.vramTotal
+                    // Feed the backoff: a run of idle readings lets the tick
+                    // stop re-waking the card so it can autosuspend; any load
+                    // snaps back to full cadence.
+                    if (parsed.gpuUsage === 0) root.nvidiaZeroStreak++
+                    else { root.nvidiaZeroStreak = 0; root.nvidiaBackoffCounter = 0 }
                 }
             }
         }
@@ -210,10 +241,19 @@ Singleton {
                 // awake; asleep means 0% busy by definition.
                 fileNvidiaPm.reload()
                 if (root.nvidiaShouldPoll(fileNvidiaPm.text())) {
-                    gpuProc.running = false
-                    gpuProc.running = true
+                    if (root.nvidiaDueForPoll()) { // throttled once idle
+                        gpuProc.running = false
+                        gpuProc.running = true
+                    }
                 } else {
+                    // Suspended: the card is off. Zero the live readings, not
+                    // just usage - a held-over temperature or VRAM figure reads
+                    // as a warm card that is actually powered down. vramTotal is
+                    // the capacity, not a reading, so it stays.
                     root.gpuUsage = 0
+                    root.gpuTemp = 0
+                    root.vramUsed = 0
+                    root.nvidiaBackoffCounter = 0
                 }
             } else if (root.gpuVendor === "amd" || root.gpuVendor === "intel") {
                 fileGpuBusy.reload()
@@ -372,6 +412,20 @@ Singleton {
     function nvidiaShouldPoll(runtimeStatusText) {
         const status = String(runtimeStatusText).trim()
         return status !== "suspended" && status !== "suspending";
+    }
+
+    // Whether this awake tick should actually spawn nvidia-smi, or skip to let
+    // an idle card autosuspend (see the backoff note). Advances the counter as
+    // a side effect. Only meaningful once nvidiaShouldPoll() said the card is
+    // awake; a suspended card is handled by the gate, not here.
+    function nvidiaDueForPoll() {
+        if (nvidiaZeroStreak < _nvidiaZeroThreshold) return true;
+        if (nvidiaBackoffCounter >= _nvidiaBackoffTicks - 1) {
+            nvidiaBackoffCounter = 0;
+            return true;
+        }
+        nvidiaBackoffCounter++;
+        return false;
     }
 
     function updateMemoryUsageHistory() {

--- a/dots/.config/quickshell/imi/services/UserAvatar.qml
+++ b/dots/.config/quickshell/imi/services/UserAvatar.qml
@@ -1,0 +1,44 @@
+pragma Singleton
+import qs.modules.common
+import qs.modules.common.functions
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import "./avatar_source.js" as AvatarSource
+
+/**
+ * The one answer to "which picture is the user's avatar".
+ *
+ * Four widgets (the bar's media popup, the right sidebar's header, the
+ * settings header, the user-card desktop widget) each used to spell the same
+ * fallback - `file:///home/$USER/.face` - and on a machine with no ~/.face
+ * every rebuild of any of them retried the missing file and warned. The two
+ * ricer-convention files are stat'ed once here, at construction, and a
+ * missing one resolves to "" so the widgets draw their glyph fallback
+ * instead of retrying a file that is not there.
+ */
+Singleton {
+    id: root
+
+    property bool faceExists: false
+    property bool faceIconExists: false
+
+    readonly property string url: AvatarSource.resolve(
+        Config.options.profile.avatarPath,
+        Config.options.profile.avatarPicture,
+        FileUtils.trimFileProtocol(Directories.home),
+        root.faceExists,
+        root.faceIconExists)
+
+    Process {
+        running: true
+        command: ["bash", "-c", 'f=0; i=0; [ -f "$HOME/.face" ] && f=1; [ -f "$HOME/.face.icon" ] && i=1; echo "$f $i"']
+        stdout: StdioCollector {
+            onStreamFinished: {
+                const parts = text.trim().split(" ")
+                root.faceExists = parts[0] === "1"
+                root.faceIconExists = parts[1] === "1"
+            }
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/services/WallpaperEngineCompat.qml
+++ b/dots/.config/quickshell/imi/services/WallpaperEngineCompat.qml
@@ -126,29 +126,45 @@ Singleton {
                 } catch (e) { /* a stray print; the watchdog owns silence */ }
             }
         }
-        onExited: {
+        onExited: (exitCode, exitStatus) => {
             silenceWatchdog.stop();
             if (!root.scanning)
                 return;
-            // A death mid-project is that project's verdict: the renderer
-            // took the scanner down trying to load it. A death with NO
-            // marker and NO progress this run is the same verdict for the
-            // queue's head - the scanner starts at the head, so a crash
-            // early enough to lose its own marker still names its victim by
-            // position, and without this the respawn walks into the same
-            // crash until the ladder is spent.
+            // QProcess::ExitStatus: NormalExit = 0, CrashExit = 1. A CrashExit
+            // is a signal death - the renderer taking the scanner down on a
+            // wallpaper. A NormalExit, even with a non-zero code, is the
+            // scanner process ending on its own: a finished run, or a startup
+            // failure (a stock binary with no Quickshell.WallpaperEngine, an
+            // exec error, an oversized env) that never loaded anything.
+            const crashed = exitStatus !== 0;
             if (root.inFlightId !== "") {
+                // It announced which wallpaper it was loading and then died
+                // before that verdict - a scanner reaching a "testing" marker
+                // is up and running, so the wallpaper is the culprit whether
+                // the death was a crash or a normal non-zero exit.
                 root.recordVerdict({
                     id: root.inFlightId,
                     status: "broken",
                     error: "the renderer crashed loading this wallpaper"
                 });
-            } else if (!root.progressThisRun && root.pendingQueue.length > 0) {
+            } else if (crashed && !root.progressThisRun && root.pendingQueue.length > 0) {
+                // Crashed before its first marker: the scanner starts at the
+                // head, so a crash early enough to lose its own marker still
+                // names its victim by position, and without this the respawn
+                // walks into the same crash until the ladder is spent.
                 root.recordVerdict({
                     id: root.pendingQueue[0].id,
                     status: "broken",
                     error: "the renderer crashed loading this wallpaper"
                 });
+            } else if (!root.progressThisRun && root.pendingQueue.length > 0) {
+                // A NORMAL exit with no marker and no verdict: the scanner
+                // never got going. Blaming the head by position here would
+                // persist a false "broken" for the whole front of the queue as
+                // the respawn ladder marches down it. Stop, and record nothing.
+                root.scanning = false;
+                root.pendingQueue = [];
+                return;
             }
             if (root.pendingQueue.length > 0 && root.respawnsLeft > 0) {
                 root.respawnsLeft -= 1;

--- a/dots/.config/quickshell/imi/services/WallpaperEngineCompat.qml
+++ b/dots/.config/quickshell/imi/services/WallpaperEngineCompat.qml
@@ -1,0 +1,206 @@
+pragma Singleton
+import qs.modules.common
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import "./we_compat.js" as WeCompat
+
+/**
+ * Wallpaper Engine compatibility verdicts - the reference app's
+ * (jagrat7/linux-wallpaper-engine) bulk compatibility scanner, on this
+ * shell's architecture: the scan runs in a SPAWNED `qs -p` scanner process
+ * (scripts/wallpapers/we_compat_scan.qml) loading each project into a real
+ * WallpaperEngineSurface, so one wallpaper that wedges or crashes the
+ * renderer kills the scanner and not the shell; this service owns the queue,
+ * respawns the scanner past the corpse, and records the verdicts.
+ *
+ * The store is its own raw-JSON file on the PluginState pattern (runtime
+ * project ids, so never a JsonAdapter), and deliberately NOT the overrides
+ * store: verdicts are scan-managed state, not user settings - the
+ * reference's SCAN_MANAGED_KEYS split, as a file boundary.
+ *
+ * Decisions live in services/we_compat.js (tst_we_compat.qml drives them);
+ * this file owns the disk and the process.
+ */
+Singleton {
+    id: root
+
+    readonly property string filePath: `${Directories.shellConfig}/wallpaper-engine-compat.json`
+
+    // Map of project id -> { status: "ok"|"broken", error, testedAt }.
+    property var results: ({})
+    property bool ready: false
+
+    property bool scanning: false
+    property int scanTotal: 0
+    property int scanDone: 0
+    // The ids still owed a verdict this scan, and the one in flight - what
+    // lets a scanner death mark its victim and the respawn skip it.
+    property var pendingQueue: []
+    property string inFlightId: ""
+    // A scanner that dies without a "testing" line in flight died between
+    // projects (or at startup); cap the respawns so a scanner that cannot
+    // start at all does not loop forever.
+    property int respawnsLeft: 0
+
+    function statusFor(project) {
+        return WeCompat.statusOf(project, root.results);
+    }
+
+    function startScan(projects, rescan) {
+        if (root.scanning)
+            return;
+        const queue = WeCompat.scanQueue(projects, root.results, rescan === true);
+        if (queue.length === 0)
+            return;
+        root.pendingQueue = queue;
+        root.scanTotal = queue.length;
+        root.scanDone = 0;
+        root.inFlightId = "";
+        root.respawnsLeft = queue.length + 2;
+        root.scanning = true;
+        root.spawnScanner();
+    }
+
+    function stopScan() {
+        if (!root.scanning)
+            return;
+        root.scanning = false;
+        root.pendingQueue = [];
+        root.inFlightId = "";
+        scanProcess.running = false;
+        silenceWatchdog.stop();
+    }
+
+    function spawnScanner() {
+        root.progressThisRun = false;
+        scanProcess.environment = ({ WE_COMPAT_QUEUE: JSON.stringify(root.pendingQueue) });
+        silenceWatchdog.restart();
+        scanProcess.running = true;
+    }
+
+    function recordVerdict(verdict) {
+        root.progressThisRun = true;
+        root.results = WeCompat.applyVerdict(root.results, verdict, Date.now());
+        root.pendingQueue = root.pendingQueue.filter(entry => entry.id !== verdict.id);
+        root.inFlightId = "";
+        root.scanDone = root.scanTotal - root.pendingQueue.length;
+        writeTimer.restart();
+    }
+
+    // Whether the current scanner run has produced any verdict. A run that
+    // dies with none, no corpse named and the queue unmoved would respawn
+    // straight into the same crash - a scanner whose stderr was cut off
+    // before the "testing" marker looks exactly like one that never started.
+    property bool progressThisRun: false
+
+    Process {
+        id: scanProcess
+        // `qs` resolves through the same wrapper that launched the shell, so
+        // the scanner runs the exact renderer binary whose verdicts matter.
+        command: ["qs", "-p", `${Directories.scriptPath}/wallpapers/we_compat_scan.qml`]
+        // The protocol rides STDERR: qs's stdout logging is block-buffered
+        // off a tty, so verdicts arrived in 4-8KB bursts and a renderer
+        // crash lost every line since the last flush - including the marker
+        // naming the wallpaper that crashed it.
+        stderr: SplitParser {
+            onRead: data => {
+                // qs prefixes console output; the payload is the JSON
+                // document from its first brace.
+                const brace = data.indexOf("{");
+                if (brace < 0)
+                    return;
+                silenceWatchdog.restart();
+                const line = data.substring(brace);
+                const verdict = WeCompat.parseLine(line);
+                if (verdict) {
+                    root.recordVerdict(verdict);
+                    return;
+                }
+                // The "testing" marker is not a verdict; it names the corpse
+                // if the scanner dies mid-project.
+                try {
+                    const marker = JSON.parse(line);
+                    if (marker && marker.status === "testing" && marker.id)
+                        root.inFlightId = String(marker.id);
+                } catch (e) { /* a stray print; the watchdog owns silence */ }
+            }
+        }
+        onExited: {
+            silenceWatchdog.stop();
+            if (!root.scanning)
+                return;
+            // A death mid-project is that project's verdict: the renderer
+            // took the scanner down trying to load it. A death with NO
+            // marker and NO progress this run is the same verdict for the
+            // queue's head - the scanner starts at the head, so a crash
+            // early enough to lose its own marker still names its victim by
+            // position, and without this the respawn walks into the same
+            // crash until the ladder is spent.
+            if (root.inFlightId !== "") {
+                root.recordVerdict({
+                    id: root.inFlightId,
+                    status: "broken",
+                    error: "the renderer crashed loading this wallpaper"
+                });
+            } else if (!root.progressThisRun && root.pendingQueue.length > 0) {
+                root.recordVerdict({
+                    id: root.pendingQueue[0].id,
+                    status: "broken",
+                    error: "the renderer crashed loading this wallpaper"
+                });
+            }
+            if (root.pendingQueue.length > 0 && root.respawnsLeft > 0) {
+                root.respawnsLeft -= 1;
+                root.spawnScanner();
+                return;
+            }
+            root.scanning = false;
+            root.pendingQueue = [];
+        }
+    }
+
+    // A scanner that stops speaking - no verdict, no testing marker - past
+    // the per-project deadline it enforces itself has hung somewhere the
+    // deadline cannot reach; kill it and let onExited's machinery take over.
+    Timer {
+        id: silenceWatchdog
+        interval: 40000
+        onTriggered: scanProcess.running = false
+    }
+
+    Timer {
+        id: reloadTimer
+        interval: 100
+        onTriggered: compatFile.reload()
+    }
+
+    Timer {
+        id: writeTimer
+        interval: 100
+        onTriggered: compatFile.setText(JSON.stringify(root.results, null, 2))
+    }
+
+    FileView {
+        id: compatFile
+        path: Directories.configDirReady ? root.filePath : ""
+        watchChanges: true
+        onFileChanged: reloadTimer.restart()
+        onLoaded: {
+            try {
+                root.results = WeCompat.sanitize(JSON.parse(compatFile.text()));
+            } catch (e) {
+                console.warn("[WallpaperEngineCompat] unreadable store, keeping in-memory state: " + e);
+            }
+            root.ready = true;
+        }
+        onLoadFailed: error => {
+            if (error === FileViewError.FileNotFound) {
+                root.results = ({});
+                root.ready = true;
+            } else {
+                console.warn("[WallpaperEngineCompat] failed to load: " + error);
+            }
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/services/WallpaperEngineFeatures.qml
+++ b/dots/.config/quickshell/imi/services/WallpaperEngineFeatures.qml
@@ -22,6 +22,7 @@ Singleton {
     readonly property bool projectProperties: probeLoader.item?.projectProperties ?? false
     readonly property bool cropFocus: probeLoader.item?.cropFocus ?? false
     readonly property bool sceneGrab: probeLoader.item?.sceneGrab ?? false
+    readonly property bool renderScale: probeLoader.item?.renderScale ?? false
 
     Loader {
         id: probeLoader

--- a/dots/.config/quickshell/imi/services/WallpaperEngineFeatures.qml
+++ b/dots/.config/quickshell/imi/services/WallpaperEngineFeatures.qml
@@ -21,6 +21,7 @@ Singleton {
     readonly property bool engineFlags: probeLoader.item?.engineFlags ?? false
     readonly property bool projectProperties: probeLoader.item?.projectProperties ?? false
     readonly property bool cropFocus: probeLoader.item?.cropFocus ?? false
+    readonly property bool sceneGrab: probeLoader.item?.sceneGrab ?? false
 
     Loader {
         id: probeLoader

--- a/dots/.config/quickshell/imi/services/WallpaperEngineFeatures.qml
+++ b/dots/.config/quickshell/imi/services/WallpaperEngineFeatures.qml
@@ -20,6 +20,7 @@ Singleton {
 
     readonly property bool engineFlags: probeLoader.item?.engineFlags ?? false
     readonly property bool projectProperties: probeLoader.item?.projectProperties ?? false
+    readonly property bool cropFocus: probeLoader.item?.cropFocus ?? false
 
     Loader {
         id: probeLoader

--- a/dots/.config/quickshell/imi/services/WallpaperEngineFeatures.qml
+++ b/dots/.config/quickshell/imi/services/WallpaperEngineFeatures.qml
@@ -1,0 +1,28 @@
+pragma Singleton
+import QtQuick
+import Quickshell
+
+/**
+ * What this binary's embedded Wallpaper Engine renderer can be asked. The
+ * selector sidebar gates its extended controls on these, so a shell running
+ * an older qs-wallpaperengine binary (or a stock Quickshell with no module at
+ * all) shows exactly the controls the renderer answers - a control for a
+ * flag the renderer does not read would be a fake action.
+ *
+ * Probed by building one bare WallpaperEngineSurface (no project, so no
+ * thread and no GL) and asking which properties exist - the same question
+ * WallpaperEngineLayer's dynamic bindings ask, from before any project is
+ * live. The probe is loaded by URL so a binary without the module fails only
+ * this Loader.
+ */
+Singleton {
+    id: root
+
+    readonly property bool engineFlags: probeLoader.item?.engineFlags ?? false
+    readonly property bool projectProperties: probeLoader.item?.projectProperties ?? false
+
+    Loader {
+        id: probeLoader
+        source: Qt.resolvedUrl("../modules/imi/background/WallpaperEngineProbe.qml")
+    }
+}

--- a/dots/.config/quickshell/imi/services/WallpaperEngineOverrides.qml
+++ b/dots/.config/quickshell/imi/services/WallpaperEngineOverrides.qml
@@ -1,0 +1,106 @@
+pragma Singleton
+import qs.modules.common
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import "./we_overrides.js" as WeOverrides
+
+/**
+ * Per-project Wallpaper Engine settings, on the PluginState pattern: a raw
+ * FileView over its own JSON file, because the map is keyed by runtime
+ * project ids and a JsonAdapter only holds declared properties (undeclared
+ * children have segfaulted deserialization - see CONTRIBUTING.md).
+ *
+ * The decisions - per-key fallback to the globals, clear-on-null, the loaded
+ * file's sanitation - are services/we_overrides.js, kept pure so
+ * tests/tst_we_overrides.qml can drive them. This file owns only the disk.
+ */
+Singleton {
+    id: root
+
+    readonly property string filePath: `${Directories.shellConfig}/wallpaper-engine-overrides.json`
+
+    // Map of project id -> { fps?, scaling?, silent? }. Replaced whole on
+    // every change so bindings re-evaluate (a `property var` signals on
+    // reassignment only).
+    property var overrides: ({})
+    property bool ready: false
+
+    // The settings the active project runs at. THE one live derivation -
+    // the renderer, the audio routing and the sidebar's controls all read
+    // this, so a second spelling of the fallback cannot drift from it.
+    readonly property var active: WeOverrides.resolve(
+        root.overrides,
+        Config.options.wallpaperSelector.wallpaperEngine.activeProject,
+        ({
+            fps: Config.options.wallpaperSelector.wallpaperEngine.fps,
+            scaling: Config.options.wallpaperSelector.wallpaperEngine.scaling,
+            silent: Config.options.wallpaperSelector.wallpaperEngine.silent ?? true
+        }))
+
+    // The same resolution with the globals as an argument, for tests.
+    function resolveFor(projectId, globals) {
+        return WeOverrides.resolve(root.overrides, projectId, globals);
+    }
+
+    function hasOverride(projectId) {
+        return WeOverrides.hasOverride(root.overrides, projectId);
+    }
+
+    // Set (value) or clear (null) one key for one project.
+    function setOverride(projectId, key, value) {
+        if (!projectId)
+            return;
+        root.overrides = WeOverrides.setOverride(root.overrides, projectId, key, value);
+        writeTimer.restart();
+    }
+
+    function clearOverrides(projectId) {
+        if (!projectId || !WeOverrides.hasOverride(root.overrides, projectId))
+            return;
+        const next = {};
+        for (const id in root.overrides)
+            if (id !== projectId)
+                next[id] = root.overrides[id];
+        root.overrides = next;
+        writeTimer.restart();
+    }
+
+    Timer {
+        id: reloadTimer
+        interval: 100
+        onTriggered: overridesFile.reload()
+    }
+
+    Timer {
+        id: writeTimer
+        interval: 100
+        onTriggered: overridesFile.setText(JSON.stringify(root.overrides, null, 2))
+    }
+
+    FileView {
+        id: overridesFile
+        // The empty path is a real "no file" state, so nothing touches the
+        // config directory before the migration gate opens (the Config.qml
+        // rule).
+        path: Directories.configDirReady ? root.filePath : ""
+        watchChanges: true
+        onFileChanged: reloadTimer.restart()
+        onLoaded: {
+            try {
+                root.overrides = WeOverrides.sanitize(JSON.parse(overridesFile.text()));
+            } catch (e) {
+                console.warn("[WallpaperEngineOverrides] unreadable store, keeping in-memory state: " + e);
+            }
+            root.ready = true;
+        }
+        onLoadFailed: error => {
+            if (error === FileViewError.FileNotFound) {
+                root.overrides = ({});
+                root.ready = true;
+            } else {
+                console.warn("[WallpaperEngineOverrides] failed to load: " + error);
+            }
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/services/WallpaperEngineOverrides.qml
+++ b/dots/.config/quickshell/imi/services/WallpaperEngineOverrides.qml
@@ -40,7 +40,8 @@ Singleton {
             audioProcessing: Config.options.wallpaperSelector.wallpaperEngine.audioProcessing ?? true,
             disableMouse: Config.options.wallpaperSelector.wallpaperEngine.disableMouse ?? false,
             disableParallax: Config.options.wallpaperSelector.wallpaperEngine.disableParallax ?? false,
-            disableParticles: Config.options.wallpaperSelector.wallpaperEngine.disableParticles ?? false
+            disableParticles: Config.options.wallpaperSelector.wallpaperEngine.disableParticles ?? false,
+            renderScale: Config.options.wallpaperSelector.wallpaperEngine.renderScale ?? 1.0
         }))
 
     // The same resolution with the globals as an argument, for tests.
@@ -84,6 +85,7 @@ Singleton {
         next = WeOverrides.setOverride(next, projectId, "disableMouse", effective.disableMouse);
         next = WeOverrides.setOverride(next, projectId, "disableParallax", effective.disableParallax);
         next = WeOverrides.setOverride(next, projectId, "disableParticles", effective.disableParticles);
+        next = WeOverrides.setOverride(next, projectId, "renderScale", effective.renderScale);
         root.overrides = next;
         writeTimer.restart();
     }

--- a/dots/.config/quickshell/imi/services/WallpaperEngineOverrides.qml
+++ b/dots/.config/quickshell/imi/services/WallpaperEngineOverrides.qml
@@ -92,6 +92,16 @@ Singleton {
         return WeOverrides.hasProperties(root.overrides, projectId);
     }
 
+    // The "fill" crop position (0.5,0.5 = centre). Live on the renderer, so a
+    // drag pans in place; committed per move rather than on release because
+    // there is no reload to coalesce.
+    function setFocus(projectId, x, y) {
+        if (!projectId)
+            return;
+        root.overrides = WeOverrides.setFocus(root.overrides, projectId, x, y);
+        writeTimer.restart();
+    }
+
     // Set (string value) or clear (null) one of the wallpaper's own
     // project.json properties.
     function setProjectProperty(projectId, name, value) {

--- a/dots/.config/quickshell/imi/services/WallpaperEngineOverrides.qml
+++ b/dots/.config/quickshell/imi/services/WallpaperEngineOverrides.qml
@@ -132,6 +132,11 @@ Singleton {
         onTriggered: overridesFile.reload()
     }
 
+    // A corrupt store is moved aside exactly once per session (a persistently
+    // unreadable file would otherwise re-quarantine on every watch reload).
+    property bool _quarantined: false
+    Process { id: quarantineProc }
+
     Timer {
         id: writeTimer
         interval: 100
@@ -150,7 +155,19 @@ Singleton {
             try {
                 root.overrides = WeOverrides.sanitize(JSON.parse(overridesFile.text()));
             } catch (e) {
-                console.warn("[WallpaperEngineOverrides] unreadable store, keeping in-memory state: " + e);
+                // The file exists but does not parse (a hand edit gone wrong, a
+                // truncated write, a foreign format). Continuing with {} and
+                // letting the next setOverride write over it would DESTROY
+                // whatever the user had. Move the bad file aside once, so a
+                // clean file can take its place without swallowing the original.
+                console.warn("[WallpaperEngineOverrides] unreadable store, quarantining: " + e);
+                if (!root._quarantined) {
+                    root._quarantined = true;
+                    quarantineProc.command = ["bash", "-c",
+                        `mv -n -- "${root.filePath}" "${root.filePath}.corrupt-$(date +%s)"`];
+                    quarantineProc.running = true;
+                }
+                root.overrides = ({});
             }
             root.ready = true;
         }

--- a/dots/.config/quickshell/imi/services/WallpaperEngineOverrides.qml
+++ b/dots/.config/quickshell/imi/services/WallpaperEngineOverrides.qml
@@ -35,7 +35,12 @@ Singleton {
         ({
             fps: Config.options.wallpaperSelector.wallpaperEngine.fps,
             scaling: Config.options.wallpaperSelector.wallpaperEngine.scaling,
-            silent: Config.options.wallpaperSelector.wallpaperEngine.silent ?? true
+            silent: Config.options.wallpaperSelector.wallpaperEngine.silent ?? true,
+            volume: Config.options.wallpaperSelector.wallpaperEngine.volume ?? 100,
+            audioProcessing: Config.options.wallpaperSelector.wallpaperEngine.audioProcessing ?? true,
+            disableMouse: Config.options.wallpaperSelector.wallpaperEngine.disableMouse ?? false,
+            disableParallax: Config.options.wallpaperSelector.wallpaperEngine.disableParallax ?? false,
+            disableParticles: Config.options.wallpaperSelector.wallpaperEngine.disableParticles ?? false
         }))
 
     // The same resolution with the globals as an argument, for tests.
@@ -55,13 +60,56 @@ Singleton {
         writeTimer.restart();
     }
 
-    function clearOverrides(projectId) {
+    // Clear the project's ENGINE flags; property edits survive (the module's
+    // hasOverride/clearEngineOverrides split - flipping the Custom settings
+    // switch off must not eat the user's property tweaks).
+    function clearEngineOverrides(projectId) {
         if (!projectId || !WeOverrides.hasOverride(root.overrides, projectId))
             return;
-        const next = {};
-        for (const id in root.overrides)
-            if (id !== projectId)
-                next[id] = root.overrides[id];
+        root.overrides = WeOverrides.clearEngineOverrides(root.overrides, projectId);
+        writeTimer.restart();
+    }
+
+    // Seed a project's engine flags from the resolved settings, so flipping
+    // the Custom settings switch on changes nothing until a control moves.
+    function seedOverrides(projectId, effective) {
+        if (!projectId)
+            return;
+        let next = root.overrides;
+        next = WeOverrides.setOverride(next, projectId, "fps", effective.fps);
+        next = WeOverrides.setOverride(next, projectId, "scaling", effective.scaling);
+        next = WeOverrides.setOverride(next, projectId, "silent", effective.silent);
+        next = WeOverrides.setOverride(next, projectId, "volume", effective.volume);
+        next = WeOverrides.setOverride(next, projectId, "audioProcessing", effective.audioProcessing);
+        next = WeOverrides.setOverride(next, projectId, "disableMouse", effective.disableMouse);
+        next = WeOverrides.setOverride(next, projectId, "disableParallax", effective.disableParallax);
+        next = WeOverrides.setOverride(next, projectId, "disableParticles", effective.disableParticles);
+        root.overrides = next;
+        writeTimer.restart();
+    }
+
+    function hasProperties(projectId) {
+        return WeOverrides.hasProperties(root.overrides, projectId);
+    }
+
+    // Set (string value) or clear (null) one of the wallpaper's own
+    // project.json properties.
+    function setProjectProperty(projectId, name, value) {
+        if (!projectId || !name)
+            return;
+        root.overrides = WeOverrides.setProjectProperty(root.overrides, projectId, name, value);
+        writeTimer.restart();
+    }
+
+    // Take every property edit off the project - back to the wallpaper's own
+    // defaults.
+    function clearProperties(projectId) {
+        if (!WeOverrides.hasProperties(root.overrides, projectId))
+            return;
+        let next = root.overrides;
+        const names = Object.keys(root.overrides[projectId].properties);
+        for (const name of names)
+            next = WeOverrides.setProjectProperty(next, projectId, name, null);
         root.overrides = next;
         writeTimer.restart();
     }

--- a/dots/.config/quickshell/imi/services/avatar_source.js
+++ b/dots/.config/quickshell/imi/services/avatar_source.js
@@ -1,0 +1,19 @@
+.pragma library
+
+// The one resolution of "which picture is the user's avatar".
+//
+// avatarFolder is Config.options.profile.avatarPath (the configured avatar
+// FOLDER - it gates the feature), avatarPicture the file picked from it.
+// faceExists / faceIconExists are UserAvatar.qml's one-time stat of the two
+// ricer conventions (~/.face, ~/.face.icon): resolving to a path that is not
+// there makes every widget rebuild retry the missing file and warn, so absence
+// resolves to "" and the widgets draw their glyph fallback instead.
+function resolve(avatarFolder, avatarPicture, home, faceExists, faceIconExists) {
+    if (avatarFolder !== "" && avatarPicture !== "")
+        return "file://" + avatarPicture;
+    if (faceExists)
+        return "file://" + home + "/.face";
+    if (faceIconExists)
+        return "file://" + home + "/.face.icon";
+    return "";
+}

--- a/dots/.config/quickshell/imi/services/we_compat.js
+++ b/dots/.config/quickshell/imi/services/we_compat.js
@@ -1,0 +1,104 @@
+.pragma library
+
+// The Wallpaper Engine compatibility scan's decisions, kept pure so a test
+// can drive them: which projects a scan spends time on, what a scanner
+// process's NDJSON line means, and what the store records. The scan itself
+// runs in a SPAWNED scanner process (scripts/wallpapers/we_compat_scan.qml)
+// so one wallpaper that wedges or crashes the renderer kills the scanner and
+// not the shell - the reference feature (jagrat7/linux-wallpaper-engine's
+// bulk compatibility scanner) test-applies through its backend the same way.
+
+// A verdict that is knowledge rather than measurement: the embedded renderer
+// cannot run web projects (needs CEF, which breaks the shell's GL - the
+// shell already falls back to the static wallpaper for them), and an
+// application is not a wallpaper it can host. Nothing is stored for these;
+// they are unsupported by construction, whatever a scan might say.
+function staticVerdict(type) {
+    var normalized = String(type ?? "").toLowerCase();
+    if (normalized === "web" || normalized === "application")
+        return "unsupported";
+    return "";
+}
+
+// The projects a scan should test: testable types with a real path, minus -
+// unless rescan is set - the ones that already carry a verdict.
+function scanQueue(projects, results, rescan) {
+    var queue = [];
+    for (var i = 0; i < (projects?.length ?? 0); i++) {
+        var project = projects[i];
+        if (!project || !project.path || staticVerdict(project.type) !== "")
+            continue;
+        if (!rescan && results && results[project.id])
+            continue;
+        queue.push({ id: String(project.id), path: String(project.path) });
+    }
+    return queue;
+}
+
+// One line of the scanner's stdout: {"id", "status": "ok"|"broken",
+// "error"}. Anything else - a stray print, a truncated line from a dying
+// process - is null, never a throw: the reader drops it and the watchdog
+// owns the silence.
+function parseLine(line) {
+    var parsed;
+    try {
+        parsed = JSON.parse(line);
+    } catch (e) {
+        return null;
+    }
+    if (!parsed || typeof parsed !== "object" || !parsed.id)
+        return null;
+    if (parsed.status !== "ok" && parsed.status !== "broken")
+        return null;
+    return {
+        id: String(parsed.id),
+        status: parsed.status,
+        error: String(parsed.error ?? "")
+    };
+}
+
+// A new map with the verdict recorded (a `property var` signals on
+// reassignment only, so the store replaces the map whole).
+function applyVerdict(results, verdict, testedAt) {
+    var next = {};
+    for (var id in (results ?? {}))
+        next[id] = results[id];
+    next[verdict.id] = {
+        status: verdict.status,
+        error: verdict.error ?? "",
+        testedAt: testedAt
+    };
+    return next;
+}
+
+// What a tile or the sidebar says about a project: the static verdict wins
+// (it is not overridable by a scan), then the stored one, then unknown.
+function statusOf(project, results) {
+    var fixed = staticVerdict(project?.type);
+    if (fixed !== "")
+        return fixed;
+    var record = results ? results[project?.id] : null;
+    if (record && (record.status === "ok" || record.status === "broken"))
+        return record.status;
+    return "unknown";
+}
+
+// What a loaded store file becomes: records with a recognisable status only.
+function sanitize(loaded) {
+    var result = {};
+    if (!loaded || typeof loaded !== "object")
+        return result;
+    for (var id in loaded) {
+        var record = loaded[id];
+        if (!record || typeof record !== "object")
+            continue;
+        if (record.status !== "ok" && record.status !== "broken")
+            continue;
+        result[id] = {
+            status: record.status,
+            error: String(record.error ?? ""),
+            testedAt: Number(record.testedAt) > 0 ? Number(record.testedAt) : 0
+        };
+    }
+    return result;
+}

--- a/dots/.config/quickshell/imi/services/we_overrides.js
+++ b/dots/.config/quickshell/imi/services/we_overrides.js
@@ -1,0 +1,92 @@
+.pragma library
+
+// Per-project Wallpaper Engine settings, resolved against the globals.
+//
+// The shape is the reference app's (jagrat7/linux-wallpaper-engine)
+// ENGINE_OVERRIDE_FIELDS: each overridable key falls back to the global
+// config value when the project carries no override of its own, so a project
+// with no record behaves exactly as every project always has. Only the keys
+// the embedded renderer actually answers are overridable - fps, scaleMode
+// and whether audio plays (WallpaperEngineSurface's whole property surface);
+// a control for a flag the renderer does not read would be a fake action.
+//
+// The map is keyed by runtime project ids, so it lives in a raw-JSON store
+// (WallpaperEngineOverrides.qml), never a JsonAdapter - undeclared children
+// on one have segfaulted deserialization before (see CONTRIBUTING.md).
+
+var KEYS = ["fps", "scaling", "silent"];
+
+// The settings the active project runs at: its own override per key, else
+// the global. An empty project id is the absence of a key, not a key.
+function resolve(overrides, projectId, globals) {
+    var result = {
+        fps: globals.fps,
+        scaling: globals.scaling,
+        silent: globals.silent
+    };
+    if (!projectId || !overrides || typeof overrides !== "object")
+        return result;
+    var record = overrides[projectId];
+    if (!record || typeof record !== "object")
+        return result;
+    for (var i = 0; i < KEYS.length; i++) {
+        var key = KEYS[i];
+        // undefined is absence; false and 0 are values (the Number(null)
+        // trap's sibling).
+        if (record[key] !== undefined && record[key] !== null)
+            result[key] = record[key];
+    }
+    return result;
+}
+
+function hasOverride(overrides, projectId) {
+    if (!projectId || !overrides || typeof overrides !== "object")
+        return false;
+    var record = overrides[projectId];
+    return !!record && typeof record === "object" && Object.keys(record).length > 0;
+}
+
+// A new map with the key set (value) or cleared (null/undefined). A project
+// whose last key is cleared is removed whole, so the store never accretes
+// empty records - and a literal null is never stored, because a stored null
+// answers past every later fallback (the PluginState.setOption lesson).
+function setOverride(overrides, projectId, key, value) {
+    var result = {};
+    for (var id in overrides)
+        result[id] = overrides[id];
+    var record = {};
+    for (var k in (result[projectId] ?? {}))
+        record[k] = result[projectId][k];
+    if (value === null || value === undefined)
+        delete record[key];
+    else
+        record[key] = value;
+    if (Object.keys(record).length === 0)
+        delete result[projectId];
+    else
+        result[projectId] = record;
+    return result;
+}
+
+// What a loaded store file becomes: only object entries, only known keys.
+// A file another version wrote, or a hand edit, degrades to the subset this
+// version understands rather than to a parse-time throw.
+function sanitize(loaded) {
+    var result = {};
+    if (!loaded || typeof loaded !== "object")
+        return result;
+    for (var id in loaded) {
+        var record = loaded[id];
+        if (!record || typeof record !== "object")
+            continue;
+        var clean = {};
+        for (var i = 0; i < KEYS.length; i++) {
+            var key = KEYS[i];
+            if (record[key] !== undefined && record[key] !== null)
+                clean[key] = record[key];
+        }
+        if (Object.keys(clean).length > 0)
+            result[id] = clean;
+    }
+    return result;
+}

--- a/dots/.config/quickshell/imi/services/we_overrides.js
+++ b/dots/.config/quickshell/imi/services/we_overrides.js
@@ -3,74 +3,151 @@
 // Per-project Wallpaper Engine settings, resolved against the globals.
 //
 // The shape is the reference app's (jagrat7/linux-wallpaper-engine)
-// ENGINE_OVERRIDE_FIELDS: each overridable key falls back to the global
-// config value when the project carries no override of its own, so a project
-// with no record behaves exactly as every project always has. Only the keys
-// the embedded renderer actually answers are overridable - fps, scaleMode
-// and whether audio plays (WallpaperEngineSurface's whole property surface);
-// a control for a flag the renderer does not read would be a fake action.
+// ENGINE_OVERRIDE_FIELDS: each overridable engine flag falls back to the
+// global config value when the project carries no override of its own, so a
+// project with no record behaves exactly as every project always has. Only
+// keys the embedded renderer actually answers are overridable (fps,
+// scaleMode, audio on/off, volume, the audio-reactive recorder and WE's
+// mouse/parallax/particles switches - WallpaperEngineSurface's whole
+// property surface); a control for a flag the renderer does not read would
+// be a fake action.
+//
+// `properties` beside the flags is the per-wallpaper user-property map
+// (project.json general.properties, values in --set-property's string form).
+// It is inherently per-wallpaper - there is no global to fall back to - and
+// it is deliberately NOT part of the "engine override" question the sidebar's
+// Custom settings switch asks: hasOverride/clearEngineOverrides leave it
+// alone, or flipping the switch off would eat the user's property edits.
 //
 // The map is keyed by runtime project ids, so it lives in a raw-JSON store
 // (WallpaperEngineOverrides.qml), never a JsonAdapter - undeclared children
 // on one have segfaulted deserialization before (see CONTRIBUTING.md).
 
-var KEYS = ["fps", "scaling", "silent"];
+var KEYS = [
+    "fps", "scaling", "silent",
+    "volume", "audioProcessing",
+    "disableMouse", "disableParallax", "disableParticles"
+];
 
 // The settings the active project runs at: its own override per key, else
-// the global. An empty project id is the absence of a key, not a key.
+// the global; plus its property map, which has no global side. An empty
+// project id is the absence of a key, not a key.
 function resolve(overrides, projectId, globals) {
-    var result = {
-        fps: globals.fps,
-        scaling: globals.scaling,
-        silent: globals.silent
-    };
+    var result = { properties: {} };
+    for (var i = 0; i < KEYS.length; i++)
+        result[KEYS[i]] = globals[KEYS[i]];
     if (!projectId || !overrides || typeof overrides !== "object")
         return result;
     var record = overrides[projectId];
     if (!record || typeof record !== "object")
         return result;
-    for (var i = 0; i < KEYS.length; i++) {
+    for (i = 0; i < KEYS.length; i++) {
         var key = KEYS[i];
         // undefined is absence; false and 0 are values (the Number(null)
         // trap's sibling).
         if (record[key] !== undefined && record[key] !== null)
             result[key] = record[key];
     }
+    if (record.properties && typeof record.properties === "object") {
+        for (var name in record.properties)
+            result.properties[name] = record.properties[name];
+    }
     return result;
 }
 
+// Whether the project carries ENGINE flag overrides - the Custom settings
+// switch's question. A record holding only tweaked properties answers no.
 function hasOverride(overrides, projectId) {
     if (!projectId || !overrides || typeof overrides !== "object")
         return false;
     var record = overrides[projectId];
-    return !!record && typeof record === "object" && Object.keys(record).length > 0;
+    if (!record || typeof record !== "object")
+        return false;
+    for (var i = 0; i < KEYS.length; i++)
+        if (record[KEYS[i]] !== undefined && record[KEYS[i]] !== null)
+            return true;
+    return false;
 }
 
-// A new map with the key set (value) or cleared (null/undefined). A project
-// whose last key is cleared is removed whole, so the store never accretes
-// empty records - and a literal null is never stored, because a stored null
-// answers past every later fallback (the PluginState.setOption lesson).
-function setOverride(overrides, projectId, key, value) {
+// Whether the project carries property edits.
+function hasProperties(overrides, projectId) {
+    if (!projectId || !overrides || typeof overrides !== "object")
+        return false;
+    var record = overrides[projectId];
+    return !!record && typeof record === "object"
+        && !!record.properties && typeof record.properties === "object"
+        && Object.keys(record.properties).length > 0;
+}
+
+function _cloneRecord(record) {
+    var clone = {};
+    for (var k in (record ?? {})) {
+        if (k === "properties") {
+            clone.properties = {};
+            for (var name in record.properties)
+                clone.properties[name] = record.properties[name];
+        } else {
+            clone[k] = record[k];
+        }
+    }
+    return clone;
+}
+
+function _store(overrides, projectId, record) {
     var result = {};
     for (var id in overrides)
         result[id] = overrides[id];
-    var record = {};
-    for (var k in (result[projectId] ?? {}))
-        record[k] = result[projectId][k];
-    if (value === null || value === undefined)
-        delete record[key];
-    else
-        record[key] = value;
-    if (Object.keys(record).length === 0)
+    var empty = Object.keys(record).length === 0
+        || (Object.keys(record).length === 1 && "properties" in record
+            && Object.keys(record.properties).length === 0);
+    if (empty)
         delete result[projectId];
     else
         result[projectId] = record;
     return result;
 }
 
-// What a loaded store file becomes: only object entries, only known keys.
-// A file another version wrote, or a hand edit, degrades to the subset this
-// version understands rather than to a parse-time throw.
+// A new map with the engine flag set (value) or cleared (null/undefined). A
+// project whose record empties is removed whole, so the store never accretes
+// empty records - and a literal null is never stored, because a stored null
+// answers past every later fallback (the PluginState.setOption lesson).
+function setOverride(overrides, projectId, key, value) {
+    var record = _cloneRecord(overrides[projectId]);
+    if (value === null || value === undefined)
+        delete record[key];
+    else
+        record[key] = value;
+    return _store(overrides, projectId, record);
+}
+
+// A new map with one project property set (string value) or cleared (null).
+function setProjectProperty(overrides, projectId, name, value) {
+    var record = _cloneRecord(overrides[projectId]);
+    if (!record.properties)
+        record.properties = {};
+    if (value === null || value === undefined)
+        delete record.properties[name];
+    else
+        record.properties[name] = String(value);
+    if (Object.keys(record.properties).length === 0)
+        delete record.properties;
+    return _store(overrides, projectId, record);
+}
+
+// A new map with the project's ENGINE flags cleared and its property edits
+// kept - what the Custom settings switch turning off means.
+function clearEngineOverrides(overrides, projectId) {
+    var record = _cloneRecord(overrides[projectId]);
+    for (var i = 0; i < KEYS.length; i++)
+        delete record[KEYS[i]];
+    return _store(overrides, projectId, record);
+}
+
+// What a loaded store file becomes: only object entries, only known keys,
+// property values coerced to the strings WE's command line gets (an object
+// has no string form, so it drops). A file another version wrote, or a hand
+// edit, degrades to the subset this version understands rather than to a
+// parse-time throw.
 function sanitize(loaded) {
     var result = {};
     if (!loaded || typeof loaded !== "object")
@@ -84,6 +161,17 @@ function sanitize(loaded) {
             var key = KEYS[i];
             if (record[key] !== undefined && record[key] !== null)
                 clean[key] = record[key];
+        }
+        if (record.properties && typeof record.properties === "object") {
+            var properties = {};
+            for (var name in record.properties) {
+                var value = record.properties[name];
+                if (value === null || value === undefined || typeof value === "object")
+                    continue;
+                properties[name] = String(value);
+            }
+            if (Object.keys(properties).length > 0)
+                clean.properties = properties;
         }
         if (Object.keys(clean).length > 0)
             result[id] = clean;

--- a/dots/.config/quickshell/imi/services/we_overrides.js
+++ b/dots/.config/quickshell/imi/services/we_overrides.js
@@ -26,8 +26,18 @@
 var KEYS = [
     "fps", "scaling", "silent",
     "volume", "audioProcessing",
-    "disableMouse", "disableParallax", "disableParticles"
+    "disableMouse", "disableParallax", "disableParticles",
+    "renderScale"
 ];
+
+// renderScale's domain: WallpaperEngineSurface renders into a window this
+// fraction of its pixel size and upscales, 0.25..1 (1 = native). A stored
+// value outside the range is clamped, not dropped, so a hand edit degrades to
+// the nearest legal quality rather than silently falling back to native.
+function _clampScale(value) {
+    if (typeof value !== "number" || isNaN(value)) return null;
+    return value < 0.25 ? 0.25 : (value > 1 ? 1 : value);
+}
 
 // The settings the active project runs at: its own override per key, else
 // the global; plus its property map, which has no global side. An empty
@@ -197,6 +207,13 @@ function sanitize(loaded) {
             var key = KEYS[i];
             if (record[key] !== undefined && record[key] !== null)
                 clean[key] = record[key];
+        }
+        // renderScale is the one numeric flag with a bounded domain: clamp a
+        // legal-but-out-of-range value to the edge, drop a non-number.
+        if ("renderScale" in clean) {
+            var scale = _clampScale(clean.renderScale);
+            if (scale === null) delete clean.renderScale;
+            else clean.renderScale = scale;
         }
         if (record.properties && typeof record.properties === "object") {
             var properties = {};

--- a/dots/.config/quickshell/imi/services/we_overrides.js
+++ b/dots/.config/quickshell/imi/services/we_overrides.js
@@ -30,6 +30,16 @@ var KEYS = [
     "renderScale"
 ];
 
+// Each flag's type, so sanitize can reject a mistyped stored value before it
+// reaches the matching WallpaperEngineSurface property. renderScale is numeric
+// too but has a bounded domain, so it is clamped by _clampScale, not here.
+var NUMERIC_KEYS = { fps: 1, volume: 1 };
+var BOOL_KEYS = {
+    silent: 1, audioProcessing: 1,
+    disableMouse: 1, disableParallax: 1, disableParticles: 1
+};
+var STRING_KEYS = { scaling: 1 };
+
 // renderScale's domain: WallpaperEngineSurface renders into a window this
 // fraction of its pixel size and upscales, 0.25..1 (1 = native). A stored
 // value outside the range is clamped, not dropped, so a hand edit degrades to
@@ -205,11 +215,28 @@ function sanitize(loaded) {
         var clean = {};
         for (var i = 0; i < KEYS.length; i++) {
             var key = KEYS[i];
-            if (record[key] !== undefined && record[key] !== null)
-                clean[key] = record[key];
+            var raw = record[key];
+            if (raw === undefined || raw === null)
+                continue;
+            // Each flag reaches a typed WallpaperEngineSurface property, so a
+            // hand edit or a foreign file with the right key and the wrong type
+            // is a QML type error on every read. Coerce the numeric flags,
+            // keep a string/bool only when it already is one, and drop anything
+            // that cannot be typed honestly rather than guessing ("no" is not
+            // false). renderScale is the bounded numeric, clamped below.
+            if (key === "renderScale") {
+                clean[key] = raw; // clamped after the loop
+            } else if (BOOL_KEYS[key]) {
+                if (typeof raw === "boolean") clean[key] = raw;
+            } else if (NUMERIC_KEYS[key]) {
+                var n = Number(raw);
+                if (isFinite(n)) clean[key] = n;
+            } else if (STRING_KEYS[key]) {
+                if (typeof raw === "string") clean[key] = raw;
+            }
         }
-        // renderScale is the one numeric flag with a bounded domain: clamp a
-        // legal-but-out-of-range value to the edge, drop a non-number.
+        // renderScale's bounded domain: clamp a legal-but-out-of-range value to
+        // the edge, drop a non-number.
         if ("renderScale" in clean) {
             var scale = _clampScale(clean.renderScale);
             if (scale === null) delete clean.renderScale;

--- a/dots/.config/quickshell/imi/services/we_overrides.js
+++ b/dots/.config/quickshell/imi/services/we_overrides.js
@@ -33,7 +33,9 @@ var KEYS = [
 // the global; plus its property map, which has no global side. An empty
 // project id is the absence of a key, not a key.
 function resolve(overrides, projectId, globals) {
-    var result = { properties: {} };
+    // focus is the "fill" crop position (0.5,0.5 = centre); per-wallpaper
+    // like properties, with no global side.
+    var result = { properties: {}, focus: { x: 0.5, y: 0.5 } };
     for (var i = 0; i < KEYS.length; i++)
         result[KEYS[i]] = globals[KEYS[i]];
     if (!projectId || !overrides || typeof overrides !== "object")
@@ -52,7 +54,16 @@ function resolve(overrides, projectId, globals) {
         for (var name in record.properties)
             result.properties[name] = record.properties[name];
     }
+    if (record.focus && typeof record.focus === "object"
+        && typeof record.focus.x === "number" && typeof record.focus.y === "number") {
+        result.focus = { x: record.focus.x, y: record.focus.y };
+    }
     return result;
+}
+
+function _clamp01(value) {
+    if (typeof value !== "number" || isNaN(value)) return 0.5;
+    return value < 0 ? 0 : (value > 1 ? 1 : value);
 }
 
 // Whether the project carries ENGINE flag overrides - the Custom settings
@@ -86,6 +97,8 @@ function _cloneRecord(record) {
             clone.properties = {};
             for (var name in record.properties)
                 clone.properties[name] = record.properties[name];
+        } else if (k === "focus" && record.focus && typeof record.focus === "object") {
+            clone.focus = { x: record.focus.x, y: record.focus.y };
         } else {
             clone[k] = record[k];
         }
@@ -97,9 +110,15 @@ function _store(overrides, projectId, record) {
     var result = {};
     for (var id in overrides)
         result[id] = overrides[id];
-    var empty = Object.keys(record).length === 0
-        || (Object.keys(record).length === 1 && "properties" in record
-            && Object.keys(record.properties).length === 0);
+    // A record is empty when it carries no engine flags, no non-empty
+    // property map and no focus - the two sub-objects each count as nothing
+    // when they hold nothing.
+    var meaningfulKeys = Object.keys(record).filter(function (key) {
+        if (key === "properties")
+            return record.properties && Object.keys(record.properties).length > 0;
+        return true; // focus is only ever present when off-centre; flags are values
+    });
+    var empty = meaningfulKeys.length === 0;
     if (empty)
         delete result[projectId];
     else
@@ -134,8 +153,25 @@ function setProjectProperty(overrides, projectId, name, value) {
     return _store(overrides, projectId, record);
 }
 
+// A new map with the "fill" crop position set. Dead centre (0.5, 0.5) is the
+// default, so it is stored as ABSENCE - a stored 0.5/0.5 is churn, and an
+// otherwise-empty record goes with it (the _store empties check already
+// covers a record whose only key is a centred focus, since it drops focus
+// below and then the record is bare).
+function setFocus(overrides, projectId, x, y) {
+    var record = _cloneRecord(overrides[projectId]);
+    var cx = _clamp01(x);
+    var cy = _clamp01(y);
+    if (cx === 0.5 && cy === 0.5)
+        delete record.focus;
+    else
+        record.focus = { x: cx, y: cy };
+    return _store(overrides, projectId, record);
+}
+
 // A new map with the project's ENGINE flags cleared and its property edits
-// kept - what the Custom settings switch turning off means.
+// AND crop focus kept - cropping is per-wallpaper, not an engine flag, so the
+// Custom settings switch turning off leaves it alone.
 function clearEngineOverrides(overrides, projectId) {
     var record = _cloneRecord(overrides[projectId]);
     for (var i = 0; i < KEYS.length; i++)
@@ -172,6 +208,13 @@ function sanitize(loaded) {
             }
             if (Object.keys(properties).length > 0)
                 clean.properties = properties;
+        }
+        if (record.focus && typeof record.focus === "object") {
+            var fx = _clamp01(record.focus.x);
+            var fy = _clamp01(record.focus.y);
+            // A dead-centre focus is the default; do not store it.
+            if (fx !== 0.5 || fy !== 0.5)
+                clean.focus = { x: fx, y: fy };
         }
         if (Object.keys(clean).length > 0)
             result[id] = clean;

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -341,6 +341,15 @@ if ! python3 "$SCRIPT_DIR/test_we_overrides_wiring.py"; then
     exit 1
 fi
 
+# Source contract: the compatibility scan runs in a spawned scanner process
+# (a wedged wallpaper kills the scanner, not the shell) and every reader of a
+# verdict goes through WallpaperEngineCompat.statusFor.
+echo "Running Wallpaper Engine compatibility wiring contract..."
+if ! python3 "$SCRIPT_DIR/test_we_compat_wiring.py"; then
+    echo "Wallpaper Engine compatibility wiring contract failed."
+    exit 1
+fi
+
 # Static lint: an Appearance token a QML file reads must be declared. An
 # undeclared one is `undefined`, which renders 0 after a single warning - or
 # NaN, with no warning at all, where the call site does arithmetic on it.

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -332,6 +332,15 @@ if ! python3 "$SCRIPT_DIR/test_resource_usage_polling.py"; then
     exit 1
 fi
 
+# Source contract: per-project Wallpaper Engine settings reach the renderer
+# through the one resolution (WallpaperEngineOverrides.active) - a raw config
+# read makes every sidebar override a silent no-op.
+echo "Running Wallpaper Engine overrides wiring contract..."
+if ! python3 "$SCRIPT_DIR/test_we_overrides_wiring.py"; then
+    echo "Wallpaper Engine overrides wiring contract failed."
+    exit 1
+fi
+
 # Static lint: an Appearance token a QML file reads must be declared. An
 # undeclared one is `undefined`, which renders 0 after a single warning - or
 # NaN, with no warning at all, where the call site does arithmetic on it.

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -323,6 +323,15 @@ if ! python3 "$SCRIPT_DIR/test_sni_watchdog.py"; then
     exit 1
 fi
 
+# Source contract: ResourceUsage polls through FileViews, keeps df off the
+# fast tick, and never starts nvidia-smi outside the runtime-status gate -
+# the ungated spawn is what holds a hybrid laptop's dGPU out of suspend.
+echo "Running resource usage polling contract..."
+if ! python3 "$SCRIPT_DIR/test_resource_usage_polling.py"; then
+    echo "Resource usage polling contract failed."
+    exit 1
+fi
+
 # Static lint: an Appearance token a QML file reads must be declared. An
 # undeclared one is `undefined`, which renders 0 after a single warning - or
 # NaN, with no warning at all, where the call site does arithmetic on it.

--- a/dots/.config/quickshell/imi/tests/test_efiboot_contract.py
+++ b/dots/.config/quickshell/imi/tests/test_efiboot_contract.py
@@ -170,8 +170,14 @@ class WiringTests(unittest.TestCase):
     def test_session_screen_button_gated_on_real_choice(self):
         self.assertIn("visible: EfiBoot.entries.length > 1", self.screen)
         self.assertIn('buttonText: Translation.tr("Reboot into...")', self.screen)
-        # Picker resets and entries refresh on every open.
-        self.assertIn("if (visible) EfiBoot.refresh()", self.screen)
+        # Picker resets and entries refresh on every open. The window is
+        # persistent now, so "every open" is the window's open() - the old
+        # spelling hung the refresh on onVisibleChanged, which a mapped-once
+        # window never fires again.
+        self.assertRegex(self.screen,
+                         r"function open\(\)[^}]*EfiBoot\.refresh\(\)")
+        self.assertRegex(self.screen,
+                         r"function open\(\)[^}]*rebootPickerOpen = false")
         # Session screen closes before pkexec so the polkit dialog gets focus.
         self.assertRegex(self.screen,
                          r"sessionRoot\.hide\(\);\s*\n\s*EfiBoot\.rebootInto")

--- a/dots/.config/quickshell/imi/tests/test_persistent_surface_screen.py
+++ b/dots/.config/quickshell/imi/tests/test_persistent_surface_screen.py
@@ -60,6 +60,7 @@ SURFACES = {
     ROOT / "modules/imi/overview/Overview.qml": ("quickshell:overview", "isTarget", "onOverviewOpenChanged"),
     ROOT / "modules/imi/sidebarRight/SidebarRight.qml": ("quickshell:sidebarRight", "isTarget", "onSidebarRightOpenChanged"),
     ROOT / "modules/imi/sidebarLeft/SidebarLeft.qml": ("quickshell:sidebarLeft", "isTarget", "onSidebarLeftOpenChanged"),
+    ROOT / "modules/imi/sessionScreen/SessionScreen.qml": ("quickshell:session", "isTarget", "onSessionOpenChanged"),
 }
 
 # Surfaces that are NOT per-screen families, with the reason each one is

--- a/dots/.config/quickshell/imi/tests/test_resource_usage_polling.py
+++ b/dots/.config/quickshell/imi/tests/test_resource_usage_polling.py
@@ -1,0 +1,116 @@
+"""ResourceUsage's polling stays cheap, and never wakes a sleeping dGPU.
+
+perf(resources): poll through files, and stop waking a sleeping dGPU
+moved every per-tick reading the kernel exposes as a file onto FileViews
+and gated the one remaining nvidia-smi spawn on the dGPU's
+power/runtime_status. These are wiring facts a QML unit test cannot see
+(the timers and Process objects never run under qmltestrunner), so the
+source shape is pinned here:
+
+- the nvidia-smi Process is only ever started under the
+  nvidiaShouldPoll() gate, because on a hybrid laptop an ungated poll is
+  what holds the dGPU out of runtime suspend for the whole session;
+- the `sensors` subprocess fallback only runs while the probe found no
+  hwmon CPU temperature file;
+- df does not ride the fast updateInterval tick - disk usage moves on
+  the scale of minutes and df was the last per-tick subprocess.
+"""
+
+import re
+from pathlib import Path
+
+SERVICE = Path(__file__).resolve().parent.parent / "services" / "ResourceUsage.qml"
+
+
+def _handler_bodies(source, signal_name):
+    """Every `<signal_name>: {...}` block body in the file, by brace count."""
+    bodies = []
+    for match in re.finditer(rf"{signal_name}\s*:\s*{{", source):
+        depth = 0
+        start = source.index("{", match.start())
+        for i in range(start, len(source)):
+            if source[i] == "{":
+                depth += 1
+            elif source[i] == "}":
+                depth -= 1
+                if depth == 0:
+                    bodies.append(source[start:i + 1])
+                    break
+    return bodies
+
+
+def _fast_tick_body(source):
+    """The onTriggered body of the timer clocked on updateInterval."""
+    bodies = [b for b in _handler_bodies(source, "onTriggered")
+              if "updateInterval" in b or "gpuVendor" in b]
+    assert bodies, "no updateInterval tick found in ResourceUsage.qml"
+    return "\n".join(bodies)
+
+
+def _checks(source):
+    tick = _fast_tick_body(source)
+
+    # nvidia-smi may only be started under the runtime-status gate.
+    gpu_starts = [m.start() for m in re.finditer(r"gpuProc\.running\s*=\s*true", source)]
+    assert gpu_starts, "nvidia-smi is never started - the GPU reading is gone"
+    for pos in gpu_starts:
+        window = source[max(0, pos - 400):pos]
+        assert "nvidiaShouldPoll(" in window, (
+            "gpuProc started outside the nvidiaShouldPoll() gate - this is "
+            "the spawn that wakes a runtime-suspended dGPU every tick")
+
+    # The sensors fallback only runs while no hwmon temp file was resolved.
+    temp_starts = [m.start() for m in re.finditer(r"tempProc\.running\s*=\s*true", source)]
+    assert temp_starts, "the sensors fallback is gone entirely"
+    for pos in temp_starts:
+        window = source[max(0, pos - 400):pos]
+        assert re.search(r'cpuTempPath\s*[!=]==?\s*""', window), (
+            "the sensors subprocess runs unconditionally - the hwmon "
+            "FileView read is supposed to be the primary source")
+
+    # df stays off the fast tick.
+    assert "diskProc" not in tick, (
+        "diskProc is triggered from the updateInterval tick - df is a "
+        "subprocess per tick again")
+    assert "diskProc.running = true" in source, "the df poll is gone entirely"
+
+    # The per-tick GPU sysfs reads go through FileViews, not a bash walk.
+    assert "fileGpuBusy.reload()" in tick, (
+        "the amd/intel branch stopped reading its sysfs files per tick")
+
+
+def test_resource_usage_polling_contract():
+    _checks(SERVICE.read_text())
+
+
+def test_the_checks_can_fail():
+    source = SERVICE.read_text()
+
+    # Planted: an ungated nvidia-smi start.
+    planted = source.replace(
+        "if (root.nvidiaShouldPoll(fileNvidiaPm.text())) {",
+        "if (true) { // planted")
+    # Removing the gate call must trip the window check.
+    try:
+        _checks(planted)
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("an ungated gpuProc start passed the contract")
+
+    # Planted: df back on the fast tick.
+    planted = source.replace(
+        'if (root.gpuVendor === "nvidia") {',
+        'diskProc.running = true\n            if (root.gpuVendor === "nvidia") {')
+    try:
+        _checks(planted)
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("df on the fast tick passed the contract")
+
+
+if __name__ == "__main__":
+    import sys
+    from contract_runner import run
+    sys.exit(run(globals()))

--- a/dots/.config/quickshell/imi/tests/test_wallpaper_engine.py
+++ b/dots/.config/quickshell/imi/tests/test_wallpaper_engine.py
@@ -87,6 +87,37 @@ class WallpaperEngineScannerTests(unittest.TestCase):
             self.assertEqual(by_name["mode"]["options"],
                              [{"label": "A", "value": "a"}, {"label": "B", "value": "b"}])
 
+    def test_combo_numeric_option_values_are_integer_keyed(self):
+        # WE keys combo options by std::to_string(int), so a numeric option
+        # value must serialize as an integer string - "2", not "2.0"/"1.5" -
+        # or --set-property's lookup never matches and the choice is dropped.
+        # A slider's value stays a float (WE reads it with stof), so the int
+        # cast is combo-options-only.
+        scanner = load_scanner()
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            project = root / "7"
+            project.mkdir()
+            (project / "project.json").write_text(json.dumps({
+                "title": "Numeric combo",
+                "type": "scene",
+                "general": {"properties": {
+                    "quality": {"type": "combo", "text": "Quality", "value": 2, "order": 1,
+                                "options": [{"label": "Low", "value": 1},
+                                            {"label": "High", "value": 2.0}]},
+                    "speed": {"type": "slider", "text": "Speed", "value": 1.5,
+                              "min": 0, "max": 3, "step": 0.1, "order": 2},
+                }},
+            }))
+
+            by_name = {p["name"]: p for p in scanner.scan(str(root))[0]["properties"]}
+            self.assertEqual(by_name["quality"]["options"],
+                             [{"label": "Low", "value": "1"}, {"label": "High", "value": "2"}])
+            # The combo's own current value is integer-keyed the same way...
+            self.assertEqual(by_name["quality"]["value"], "2")
+            # ...but the slider keeps its float.
+            self.assertEqual(by_name["speed"]["value"], "1.5")
+
     def test_scanner_properties_default_to_an_empty_list(self):
         scanner = load_scanner()
         with tempfile.TemporaryDirectory() as directory:

--- a/dots/.config/quickshell/imi/tests/test_wallpaper_engine.py
+++ b/dots/.config/quickshell/imi/tests/test_wallpaper_engine.py
@@ -44,6 +44,59 @@ class WallpaperEngineScannerTests(unittest.TestCase):
             self.assertEqual(projects[0]["title"], "A live wallpaper")
             self.assertEqual(projects[0]["preview"], str(valid / "preview.jpg"))
 
+    def test_scanner_emits_user_settable_properties(self):
+        # The reference model (jagrat7/linux-wallpaper-engine's
+        # parseProjectProperties): only the five control types get a row,
+        # booleans serialize to "1"/"0" - the form WE's --set-property takes -
+        # everything else verbatim, ordered by the author's order/index keys.
+        scanner = load_scanner()
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            project = root / "42"
+            project.mkdir()
+            (project / "project.json").write_text(json.dumps({
+                "title": "With knobs",
+                "type": "scene",
+                "general": {"properties": {
+                    "rain": {"type": "bool", "text": "Rain", "value": True, "order": 2},
+                    "schemecolor": {"type": "color", "text": "Scheme color",
+                                    "value": "0 0.5 0", "order": 1},
+                    "speed": {"type": "slider", "text": "Speed", "value": 1.5,
+                              "min": 0, "max": 3, "step": 0.1, "order": 3},
+                    "mode": {"type": "combo", "text": "Mode", "value": "a", "order": 4,
+                             "options": [{"label": "A", "value": "a"},
+                                          {"label": "B", "value": "b"}]},
+                    "heading": {"type": "text", "text": "Just a heading"},
+                    "tex": {"type": "scenetexture", "value": "x"},
+                }},
+            }))
+
+            projects = scanner.scan(str(root))
+            props = projects[0]["properties"]
+
+            names = [p["name"] for p in props]
+            # Ordered by the author's order key; unsupported types absent.
+            self.assertEqual(names, ["schemecolor", "rain", "speed", "mode"])
+            by_name = {p["name"]: p for p in props}
+            self.assertEqual(by_name["rain"]["value"], "1")
+            self.assertEqual(by_name["rain"]["type"], "bool")
+            self.assertEqual(by_name["schemecolor"]["value"], "0 0.5 0")
+            self.assertEqual(by_name["speed"]["min"], 0)
+            self.assertEqual(by_name["speed"]["max"], 3)
+            self.assertEqual(by_name["speed"]["step"], 0.1)
+            self.assertEqual(by_name["mode"]["options"],
+                             [{"label": "A", "value": "a"}, {"label": "B", "value": "b"}])
+
+    def test_scanner_properties_default_to_an_empty_list(self):
+        scanner = load_scanner()
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            project = root / "7"
+            project.mkdir()
+            (project / "project.json").write_text(json.dumps({"title": "Plain", "type": "video"}))
+            projects = scanner.scan(str(root))
+            self.assertEqual(projects[0]["properties"], [])
+
     def test_scanner_confines_preview_to_the_project_directory(self):
         scanner = load_scanner()
         with tempfile.TemporaryDirectory() as directory:

--- a/dots/.config/quickshell/imi/tests/test_we_compat_wiring.py
+++ b/dots/.config/quickshell/imi/tests/test_we_compat_wiring.py
@@ -1,0 +1,94 @@
+"""The compatibility scan runs OUTSIDE the shell, and its verdicts have one
+reader.
+
+we_compat.js decides (tst_we_compat.qml drives it). What no QML test can see:
+that the scan is a spawned scanner process - a wallpaper that wedges or
+crashes the renderer must kill the scanner, never the shell - and that the
+grid's badge and filter both go through the service's one resolution, so a
+tile and the hide switch cannot disagree about what "broken" means.
+"""
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SERVICE = ROOT / "services/WallpaperEngineCompat.qml"
+SCANNER = ROOT / "scripts/wallpapers/we_compat_scan.qml"
+GRID = ROOT / "modules/imi/wallpaperSelector/WallpaperEngineGrid.qml"
+SIDEBAR = ROOT / "modules/imi/wallpaperSelector/WallpaperSelectorSidebar.qml"
+
+
+def _strip_comments(text):
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.S)
+    return re.sub(r"//[^\n]*", "", text)
+
+
+def _checks(service, scanner, grid, sidebar):
+    # The scan is a spawned qs -p process, never a surface inside the shell.
+    assert "we_compat_scan.qml" in service, \
+        "the service no longer spawns the scanner config"
+    assert "WallpaperEngineSurface" not in service, \
+        ("the service builds a renderer surface in the SHELL - a wallpaper "
+         "that wedges WE's setup() then detaches and leaks a thread inside "
+         "the user's session, which is what the spawned scanner exists to absorb")
+    assert "WallpaperEngineSurface" in scanner, \
+        "the scanner no longer loads projects into a real surface"
+    # The scanner ends itself on a timeout rather than switching past a
+    # wedged load and testing everything after it over a leaked renderer.
+    assert "Qt.quit()" in scanner
+
+    # The store is a raw FileView (runtime project ids), its own file - the
+    # reference's scan-managed/user-settings split, as a file boundary.
+    assert "FileView" in service and "JsonAdapter" not in service
+    assert "wallpaper-engine-compat.json" in service
+    assert "configDirReady" in service
+
+    # Badge and filter read the one resolution.
+    assert "WallpaperEngineCompat.statusFor" in grid, \
+        "the grid stopped asking the service for a project's verdict"
+    assert "WallpaperEngineCompat.statusFor" in sidebar
+    assert not re.search(r"results\[", grid), \
+        "the grid reads the raw results map - a second spelling of statusOf"
+
+    # The respawn ladder is bounded: a scanner that cannot start at all must
+    # not loop forever.
+    assert "respawnsLeft" in service
+
+
+def test_we_compat_wiring():
+    _checks(_strip_comments(SERVICE.read_text()),
+            _strip_comments(SCANNER.read_text()),
+            _strip_comments(GRID.read_text()),
+            _strip_comments(SIDEBAR.read_text()))
+
+
+def test_the_checks_can_fail():
+    service = _strip_comments(SERVICE.read_text())
+    scanner = _strip_comments(SCANNER.read_text())
+    grid = _strip_comments(GRID.read_text())
+    sidebar = _strip_comments(SIDEBAR.read_text())
+
+    # Planted: the surface moved into the shell's own service.
+    planted = service + "\n    WallpaperEngineSurface { }\n"
+    try:
+        _checks(planted, scanner, grid, sidebar)
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("an in-shell scan surface passed the contract")
+
+    # Planted: the grid reading the raw map.
+    planted = grid.replace("WallpaperEngineCompat.statusFor(project)",
+                           'WallpaperEngineCompat.results[project.id]')
+    try:
+        _checks(service, scanner, planted, sidebar)
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("a raw results read passed the contract")
+
+
+if __name__ == "__main__":
+    import sys
+    from contract_runner import run
+    sys.exit(run(globals()))

--- a/dots/.config/quickshell/imi/tests/test_we_overrides_wiring.py
+++ b/dots/.config/quickshell/imi/tests/test_we_overrides_wiring.py
@@ -31,6 +31,11 @@ def _checks(layer, background, store, sidebar, content):
         "the surface's fps does not go through the override resolution"
     assert "WallpaperEngineOverrides.active.scaling" in layer, \
         "the surface's scaleMode does not go through the override resolution"
+    # The live crop focus binds the same way, in-guarded for an older binary.
+    assert 'WallpaperEngineOverrides.active.focus.x' in layer, \
+        "the surface's focusX does not go through the override resolution"
+    assert '"focusX" in root' in layer, \
+        "focusX is bound unconditionally - an older renderer binary breaks on it"
     assert not re.search(r"fps\s*:\s*Config\.options", layer), \
         "the surface reads fps straight off the config again"
     assert not re.search(r"scaleMode\s*:\s*Config\.options", layer), \

--- a/dots/.config/quickshell/imi/tests/test_we_overrides_wiring.py
+++ b/dots/.config/quickshell/imi/tests/test_we_overrides_wiring.py
@@ -1,0 +1,107 @@
+"""Per-project Wallpaper Engine settings reach the renderer, and only through
+the one resolution.
+
+we_overrides.js decides (tst_we_overrides.qml drives it);
+WallpaperEngineOverrides.qml owns the disk; `active` is the one live
+derivation. What a QML unit test cannot see is the wiring - a renderer that
+kept reading the raw config would make every sidebar override a silent no-op,
+because the globals still hold the old value and nothing errors.
+"""
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+LAYER = ROOT / "modules/imi/background/WallpaperEngineLayer.qml"
+BACKGROUND = ROOT / "modules/imi/background/Background.qml"
+STORE = ROOT / "services/WallpaperEngineOverrides.qml"
+SIDEBAR = ROOT / "modules/imi/wallpaperSelector/WallpaperSelectorSidebar.qml"
+CONTENT = ROOT / "modules/imi/wallpaperSelector/WallpaperSelectorContent.qml"
+
+
+def _strip_comments(text):
+    text = re.sub(r"/\*.*?\*/", "", text, flags=re.S)
+    return re.sub(r"//[^\n]*", "", text)
+
+
+def _checks(layer, background, store, sidebar, content):
+    # The renderer reads the resolved settings, never the raw config keys -
+    # a raw read is the silent no-op this file documents.
+    assert "WallpaperEngineOverrides.active.fps" in layer, \
+        "the surface's fps does not go through the override resolution"
+    assert "WallpaperEngineOverrides.active.scaling" in layer, \
+        "the surface's scaleMode does not go through the override resolution"
+    assert not re.search(r"fps\s*:\s*Config\.options", layer), \
+        "the surface reads fps straight off the config again"
+    assert not re.search(r"scaleMode\s*:\s*Config\.options", layer), \
+        "the surface reads scaling straight off the config again"
+
+    # The audio route asks the same resolution about `silent`.
+    assert "WallpaperEngineOverrides.active.silent" in background, \
+        "weAudioOutput does not ask the override resolution about silent"
+
+    # The store is a raw FileView keyed by runtime project ids - never a
+    # JsonAdapter, whose undeclared children have segfaulted deserialization.
+    assert "FileView" in store and "JsonAdapter" not in store, \
+        "the overrides store is not a raw FileView"
+    assert "configDirReady" in store, \
+        "the store writes into shellConfig before the migration gate opens"
+    assert "we_overrides.js" in store, \
+        "the store spells its own resolution instead of using the module"
+
+    # The sidebar's controls write through one function that routes to the
+    # override or the global - a control writing the config directly while
+    # the override switch is on edits a value nothing displays.
+    assert "writeSetting(" in sidebar
+    assert re.search(r'onActivated:.*writeSetting\("fps"', sidebar), \
+        "the fps control does not write through the router"
+    assert re.search(r'onActivated:.*writeSetting\("scaling"', sidebar), \
+        "the scaling control does not write through the router"
+
+    # The content hosts the sidebar for exactly the two sources that have one.
+    assert "WallpaperSelectorSidebar" in content
+    assert not re.search(r"property var quickDirs", content), \
+        "the toolbar's folder-chip list is back beside the sidebar's rail - two copies"
+
+
+def test_we_override_wiring():
+    _checks(_strip_comments(LAYER.read_text()),
+            _strip_comments(BACKGROUND.read_text()),
+            _strip_comments(STORE.read_text()),
+            _strip_comments(SIDEBAR.read_text()),
+            _strip_comments(CONTENT.read_text()))
+
+
+def test_the_checks_can_fail():
+    layer = _strip_comments(LAYER.read_text())
+    good = dict(layer=layer,
+                background=_strip_comments(BACKGROUND.read_text()),
+                store=_strip_comments(STORE.read_text()),
+                sidebar=_strip_comments(SIDEBAR.read_text()),
+                content=_strip_comments(CONTENT.read_text()))
+
+    # Planted: the renderer back on the raw config.
+    planted = layer.replace("fps: WallpaperEngineOverrides.active.fps",
+                            "fps: Config.options.wallpaperSelector.wallpaperEngine.fps")
+    try:
+        _checks(planted, good["background"], good["store"], good["sidebar"], good["content"])
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("a raw-config fps read passed the contract")
+
+    # Planted: the store on a JsonAdapter.
+    planted = good["store"].replace("FileView", "JsonAdapter")
+    try:
+        _checks(good["layer"] if "layer" in good else layer, good["background"], planted,
+                good["sidebar"], good["content"])
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("a JsonAdapter store passed the contract")
+
+
+if __name__ == "__main__":
+    import sys
+    from contract_runner import run
+    sys.exit(run(globals()))

--- a/dots/.config/quickshell/imi/tests/test_we_overrides_wiring.py
+++ b/dots/.config/quickshell/imi/tests/test_we_overrides_wiring.py
@@ -36,6 +36,12 @@ def _checks(layer, background, store, sidebar, content):
         "the surface's focusX does not go through the override resolution"
     assert '"focusX" in root' in layer, \
         "focusX is bound unconditionally - an older renderer binary breaks on it"
+    # renderScale (the Quality dial) binds through the resolution too, and
+    # in-guarded like the rest - it is absent on a pre-0.3.x renderer binary.
+    assert "WallpaperEngineOverrides.active.renderScale" in layer, \
+        "the surface's renderScale does not go through the override resolution"
+    assert '"renderScale" in root' in layer, \
+        "renderScale is bound unconditionally - an older renderer binary breaks on it"
     assert not re.search(r"fps\s*:\s*Config\.options", layer), \
         "the surface reads fps straight off the config again"
     assert not re.search(r"scaleMode\s*:\s*Config\.options", layer), \
@@ -62,6 +68,8 @@ def _checks(layer, background, store, sidebar, content):
         "the fps control does not write through the router"
     assert re.search(r'onActivated:.*writeSetting\("scaling"', sidebar), \
         "the scaling control does not write through the router"
+    assert re.search(r'onActivated:.*writeSetting\("renderScale"', sidebar), \
+        "the Quality control does not write through the router"
 
     # The content hosts the sidebar for exactly the two sources that have one.
     assert "WallpaperSelectorSidebar" in content
@@ -94,6 +102,15 @@ def test_the_checks_can_fail():
         pass
     else:
         raise AssertionError("a raw-config fps read passed the contract")
+
+    # Planted: renderScale bound unconditionally (breaks an older binary).
+    planted = layer.replace('"renderScale" in root', '"renderScaleXX" in root')
+    try:
+        _checks(planted, good["background"], good["store"], good["sidebar"], good["content"])
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("an unguarded renderScale binding passed the contract")
 
     # Planted: the store on a JsonAdapter.
     planted = good["store"].replace("FileView", "JsonAdapter")

--- a/dots/.config/quickshell/imi/tests/tst_avatar_source.qml
+++ b/dots/.config/quickshell/imi/tests/tst_avatar_source.qml
@@ -1,0 +1,38 @@
+import QtQuick
+import QtTest
+import "../services/avatar_source.js" as AvatarSource
+
+// One derivation of "which picture is the user's avatar". Four widgets used to
+// each spell the fallback (`file:///home/$USER/.face`) for themselves, and on a
+// machine with no ~/.face every rebuild of any of them retried the missing file
+// and warned - 106 failed loads in one session from the bar's media popup alone.
+TestCase {
+    name: "AvatarSourceTest"
+
+    function test_configured_picture_wins() {
+        // avatarPath is the configured avatar FOLDER (the gate), avatarPicture
+        // the file picked from it.
+        compare(AvatarSource.resolve("/pics/avatars", "/pics/avatars/me.png", "/home/u", true, true),
+                "file:///pics/avatars/me.png")
+    }
+
+    function test_face_fallback_only_when_it_exists() {
+        compare(AvatarSource.resolve("", "", "/home/u", true, false), "file:///home/u/.face")
+        compare(AvatarSource.resolve("", "", "/home/u", false, true), "file:///home/u/.face.icon")
+        // .face ahead of .face.icon when both exist
+        compare(AvatarSource.resolve("", "", "/home/u", true, true), "file:///home/u/.face")
+    }
+
+    function test_nothing_available_is_empty_not_a_guess() {
+        // An empty url is the real "no avatar" state - the widgets draw their
+        // glyph fallback for it. A guessed path is a warn per rebuild.
+        compare(AvatarSource.resolve("", "", "/home/u", false, false), "")
+    }
+
+    function test_gate_without_picture_still_falls_back() {
+        // A configured folder with no picture picked yet is not an avatar.
+        compare(AvatarSource.resolve("/pics/avatars", "", "/home/u", true, false),
+                "file:///home/u/.face")
+        compare(AvatarSource.resolve("/pics/avatars", "", "/home/u", false, false), "")
+    }
+}

--- a/dots/.config/quickshell/imi/tests/tst_crop_picker.qml
+++ b/dots/.config/quickshell/imi/tests/tst_crop_picker.qml
@@ -1,0 +1,78 @@
+import QtQuick
+import QtTest
+import "../modules/imi/wallpaperSelector/crop_picker.js" as CropPicker
+
+// The Fill crop picker's geometry: the viewport rectangle drawn over the
+// preview, and the focus a drag on it produces. Pure - nothing about the drawn
+// thumbnail is reachable from qmltestrunner.
+TestCase {
+    name: "CropPickerTest"
+
+    // A 32:9 wallpaper on a 16:9 screen overflows horizontally: the viewport
+    // is a vertical slice you slide left-right.
+    function test_overflow_axis_and_viewport_size() {
+        // contentAspect 32:9 (~3.556), screenAspect 16:9 (~1.778).
+        var g = CropPicker.viewport(3.556, 1.778, 320, 90, 0.5)
+        verify(g.overflowsX)
+        verify(!g.overflowsY)
+        // The viewport covers full height and half the width (content twice
+        // as wide as the screen crop).
+        compare(Math.round(g.height), 90)
+        compare(Math.round(g.width), 160)
+        // Centred focus: the slice sits in the middle.
+        compare(Math.round(g.x), 80)
+        compare(Math.round(g.y), 0)
+    }
+
+    function test_focus_moves_the_viewport() {
+        var left = CropPicker.viewport(3.556, 1.778, 320, 90, 0.0)
+        compare(Math.round(left.x), 0)
+        var right = CropPicker.viewport(3.556, 1.778, 320, 90, 1.0)
+        compare(Math.round(right.x), 160)
+    }
+
+    function test_vertical_overflow() {
+        // A 9:16 portrait wallpaper on a 16:9 screen overflows vertically.
+        var g = CropPicker.viewport(0.5625, 1.778, 90, 160, 0.5)
+        verify(!g.overflowsX)
+        verify(g.overflowsY)
+        compare(Math.round(g.width), 90)
+        // vh = previewW / screenAspect = 90 / 1.778 = 50.6
+        compare(Math.round(g.height), 51)
+        compare(Math.round(g.y), 55)
+    }
+
+    function test_no_overflow_when_aspects_match() {
+        var g = CropPicker.viewport(1.778, 1.778, 320, 180, 0.5)
+        verify(!g.overflowsX)
+        verify(!g.overflowsY)
+        // The viewport is the whole preview - nothing to pan.
+        compare(Math.round(g.width), 320)
+        compare(Math.round(g.height), 180)
+    }
+
+    // The inverse: a pointer position on the preview becomes a focus fraction.
+    function test_focus_from_pointer_clamps_and_centres_within_the_slack() {
+        // 32:9 on 16:9, preview 320 wide, viewport 160 wide -> 160px of slack.
+        // A pointer at the preview's left edge focuses 0; right edge focuses 1.
+        compare(CropPicker.focusFromPointer(3.556, 1.778, 320, 90, 0, 45).x, 0)
+        compare(CropPicker.focusFromPointer(3.556, 1.778, 320, 90, 320, 45).x, 1)
+        // Middle -> 0.5.
+        compare(CropPicker.focusFromPointer(3.556, 1.778, 320, 90, 160, 45).x, 0.5)
+        // Out of bounds clamps.
+        compare(CropPicker.focusFromPointer(3.556, 1.778, 320, 90, -50, 45).x, 0)
+        // The non-overflowing axis is pinned to centre.
+        compare(CropPicker.focusFromPointer(3.556, 1.778, 320, 90, 160, 45).y, 0.5)
+    }
+
+    function test_focus_from_pointer_maps_the_viewport_centre_to_the_pointer() {
+        // Dragging so the viewport's CENTRE is under the pointer, then reading
+        // the focus back, is a round trip: a focus produces a viewport whose
+        // centre, fed back, returns the same focus.
+        var f = 0.3
+        var g = CropPicker.viewport(3.556, 1.778, 320, 90, f)
+        var centreX = g.x + g.width / 2
+        var back = CropPicker.focusFromPointer(3.556, 1.778, 320, 90, centreX, 45)
+        verify(Math.abs(back.x - f) < 0.001)
+    }
+}

--- a/dots/.config/quickshell/imi/tests/tst_resource_usage.qml
+++ b/dots/.config/quickshell/imi/tests/tst_resource_usage.qml
@@ -88,4 +88,96 @@ TestCase {
         var parsedInvalid = ru.parseAmdGpu(amdDataInvalid)
         verify(parsedInvalid === null)
     }
+
+    function test_parseHwmonTemp() {
+        var ru = ResourceUsage
+
+        // hwmon temp*_input is millidegrees Celsius
+        compare(ru.parseHwmonTemp("48875\n"), 48.875)
+        compare(ru.parseHwmonTemp("52000"), 52)
+
+        // Unreadable file / garbage is null, not a confident zero
+        verify(ru.parseHwmonTemp("") === null)
+        verify(ru.parseHwmonTemp("garbage") === null)
+    }
+
+    function test_parseProbes_nvidia() {
+        var ru = ResourceUsage
+        var p = ru.parseProbes(
+            "cputemp /sys/class/hwmon/hwmon5/temp1_input\n" +
+            "gpu nvidia pm=/sys/bus/pci/devices/0000:01:00.0/power/runtime_status\n")
+        compare(p.cpuTempPath, "/sys/class/hwmon/hwmon5/temp1_input")
+        compare(p.gpuVendor, "nvidia")
+        compare(p.nvidiaPmPath, "/sys/bus/pci/devices/0000:01:00.0/power/runtime_status")
+    }
+
+    function test_parseProbes_amd() {
+        var ru = ResourceUsage
+        var p = ru.parseProbes(
+            "cputemp -\n" +
+            "gpu amd busy=/sys/a/gpu_busy_percent temp=/sys/a/temp1_input" +
+            " vramu=/sys/a/mem_info_vram_used vramt=/sys/a/mem_info_vram_total\n")
+        // '-' means no hwmon CPU temp source was found
+        compare(p.cpuTempPath, "")
+        compare(p.gpuVendor, "amd")
+        compare(p.gpuPaths.busy, "/sys/a/gpu_busy_percent")
+        compare(p.gpuPaths.temp, "/sys/a/temp1_input")
+        compare(p.gpuPaths.vramUsed, "/sys/a/mem_info_vram_used")
+        compare(p.gpuPaths.vramTotal, "/sys/a/mem_info_vram_total")
+    }
+
+    function test_parseProbes_none_and_noise() {
+        var ru = ResourceUsage
+        var p = ru.parseProbes("something unexpected\ngpu none\n")
+        compare(p.gpuVendor, "")
+        compare(p.cpuTempPath, "")
+        compare(p.nvidiaPmPath, "")
+
+        var empty = ru.parseProbes("")
+        compare(empty.gpuVendor, "")
+    }
+
+    function test_parseProbes_nvidia_without_pm_path() {
+        var ru = ResourceUsage
+        // A driver stack with no PCI runtime-status file: still nvidia, no gate
+        var p = ru.parseProbes("gpu nvidia pm=-\n")
+        compare(p.gpuVendor, "nvidia")
+        compare(p.nvidiaPmPath, "")
+    }
+
+    function test_nvidiaShouldPoll() {
+        var ru = ResourceUsage
+
+        // Awake (or waking): polling costs nothing extra
+        verify(ru.nvidiaShouldPoll("active\n"))
+        verify(ru.nvidiaShouldPoll("resuming"))
+
+        // Runtime-suspended: an nvidia-smi run would WAKE the GPU - never poll
+        verify(!ru.nvidiaShouldPoll("suspended\n"))
+        verify(!ru.nvidiaShouldPoll("suspending"))
+
+        // No runtime-status file (desktops, older kernels): keep polling
+        verify(ru.nvidiaShouldPoll(""))
+    }
+
+    function test_parseAmdSysfs() {
+        var ru = ResourceUsage
+
+        // Four raw sysfs file contents in, same shape as parseAmdGpu out
+        var p = ru.parseAmdSysfs("37\n", "52000\n", "2147483648\n", "8589934592\n")
+        verify(p !== null)
+        compare(p.gpuTemp, 52)
+        compare(p.gpuUsage, 0.37)
+        compare(p.vramUsed, 2147483648 / 1024)
+        compare(p.vramTotal, 8589934592 / 1024)
+
+        // Intel iGPU: no busy file, no VRAM counters - temp still reports
+        var intel = ru.parseAmdSysfs("", "45000\n", "", "")
+        verify(intel !== null)
+        compare(intel.gpuTemp, 45)
+        compare(intel.gpuUsage, 0)
+
+        // Nothing readable at all is null, not zeros
+        verify(ru.parseAmdSysfs("", "", "", "") === null)
+    }
 }

--- a/dots/.config/quickshell/imi/tests/tst_resource_usage.qml
+++ b/dots/.config/quickshell/imi/tests/tst_resource_usage.qml
@@ -160,6 +160,35 @@ TestCase {
         verify(ru.nvidiaShouldPoll(""))
     }
 
+    function test_nvidiaDueForPoll_backs_off_when_idle() {
+        var ru = ResourceUsage
+        // Not idle yet: poll every tick, so a busy card is sampled promptly.
+        ru.nvidiaZeroStreak = 0
+        ru.nvidiaBackoffCounter = 0
+        verify(ru.nvidiaDueForPoll())
+
+        // Idle past the threshold: the gate says the card is awake, but polling
+        // it every tick is what keeps it from autosuspending. So across one
+        // backoff window it polls exactly ONCE, letting the gaps free the card.
+        ru.nvidiaZeroStreak = ru._nvidiaZeroThreshold
+        ru.nvidiaBackoffCounter = 0
+        var polls = 0
+        for (var i = 0; i < ru._nvidiaBackoffTicks; i++)
+            if (ru.nvidiaDueForPoll()) polls++
+        compare(polls, 1)
+        // The poll lands on the last tick of the window and resets the counter.
+        compare(ru.nvidiaBackoffCounter, 0)
+
+        // A load reading (streak back to 0) restores full cadence at once.
+        ru.nvidiaZeroStreak = 0
+        ru.nvidiaBackoffCounter = 5
+        verify(ru.nvidiaDueForPoll())
+
+        // Leave the singleton as found.
+        ru.nvidiaZeroStreak = 0
+        ru.nvidiaBackoffCounter = 0
+    }
+
     function test_parseAmdSysfs() {
         var ru = ResourceUsage
 

--- a/dots/.config/quickshell/imi/tests/tst_selector_places.qml
+++ b/dots/.config/quickshell/imi/tests/tst_selector_places.qml
@@ -1,0 +1,69 @@
+import QtQuick
+import QtTest
+import "../modules/imi/wallpaperSelector/selector_places.js" as SelectorPlaces
+
+// The wallpaper selector's places sidebar: which folder shortcuts are offered,
+// in what order, and which of them is lit for the directory on screen. Pure so
+// the visibility rules (weeb gate, empty custom path) and the current-place
+// match are testable - nothing about the drawn sidebar is reachable from
+// qmltestrunner.
+TestCase {
+    name: "SelectorPlacesTest"
+
+    readonly property var dirs: ({
+        home: "/home/u",
+        documents: "/home/u/Documents",
+        downloads: "/home/u/Downloads",
+        pictures: "/home/u/Pictures",
+        videos: "/home/u/Videos"
+    })
+
+    function test_standard_places_in_order() {
+        var rows = SelectorPlaces.places(dirs, { showHomePath: true, weeb: 0, userPath: "" })
+        var names = rows.map(r => r.key)
+        // Wallpapers ahead of the generic XDG places: it is what the window
+        // is for (the mock's own order).
+        compare(names[0], "wallpapers")
+        verify(names.includes("home"))
+        verify(names.includes("documents"))
+        verify(names.includes("downloads"))
+        verify(names.includes("pictures"))
+        verify(names.includes("videos"))
+        verify(names.includes("random"))
+    }
+
+    function test_wallpapers_place_is_the_pictures_subdir() {
+        var rows = SelectorPlaces.places(dirs, { showHomePath: true, weeb: 0, userPath: "" })
+        compare(rows.find(r => r.key === "wallpapers").path, "/home/u/Pictures/Wallpapers")
+    }
+
+    function test_weeb_gate_and_home_switch() {
+        var rows = SelectorPlaces.places(dirs, { showHomePath: false, weeb: 0, userPath: "" })
+        verify(!rows.some(r => r.key === "homework"))
+        verify(!rows.some(r => r.key === "home"))
+
+        rows = SelectorPlaces.places(dirs, { showHomePath: true, weeb: 1, userPath: "" })
+        verify(rows.some(r => r.key === "homework"))
+        verify(rows.some(r => r.key === "home"))
+    }
+
+    function test_custom_path_is_named_for_its_basename() {
+        var rows = SelectorPlaces.places(dirs, { showHomePath: true, weeb: 0, userPath: "/mnt/art/walls/" })
+        var custom = rows.find(r => r.key === "custom")
+        verify(custom !== undefined)
+        compare(custom.name, "walls")
+        compare(custom.path, "/mnt/art/walls/")
+
+        rows = SelectorPlaces.places(dirs, { showHomePath: true, weeb: 0, userPath: "   " })
+        verify(!rows.some(r => r.key === "custom"))
+    }
+
+    function test_current_place_matches_by_resolved_path() {
+        // Wallpapers.directory is a resolved file:// URL; a place stores a
+        // plain path. The match has to survive both spellings and a trailing
+        // slash, or no row ever lights up.
+        verify(SelectorPlaces.isCurrent("/home/u/Pictures/Wallpapers", "file:///home/u/Pictures/Wallpapers"))
+        verify(SelectorPlaces.isCurrent("/home/u/Pictures/Wallpapers/", "file:///home/u/Pictures/Wallpapers"))
+        verify(!SelectorPlaces.isCurrent("/home/u/Pictures", "file:///home/u/Pictures/Wallpapers"))
+    }
+}

--- a/dots/.config/quickshell/imi/tests/tst_wallpaper_blur_sharing.qml
+++ b/dots/.config/quickshell/imi/tests/tst_wallpaper_blur_sharing.qml
@@ -24,16 +24,19 @@ TestCase {
     // decoded the file by the time any desktop widget is built. Declared with
     // exactly that image's request parameters, because every one of them is part
     // of the cache key: a bare path rather than the file:// URL the surface
-    // builds, no sourceSize, no sourceClipRect, and PreserveAspectCrop - a fill
-    // mode that preserves aspect sets flags in the request, so the same file
-    // asked for with the default Stretch is a different request and decodes
-    // again.
+    // builds, no sourceClipRect, PreserveAspectCrop - a fill mode that preserves
+    // aspect sets flags in the request, so the same file asked for with the
+    // default Stretch is a different request and decodes again - and the
+    // sourceSize bound. The bound is part of the key too, so the frost surface
+    // has to ask with the same one or #147's per-surface decode comes back with
+    // a different spelling.
     Image {
         id: backgroundWallpaper
         fillMode: Image.PreserveAspectCrop
         cache: true
         asynchronous: true
         visible: false
+        sourceSize: Qt.size(5478, 1541)
     }
 
     Component {
@@ -52,6 +55,10 @@ TestCase {
             // pixmap cache key, which is what keeps #147 fixed.
             wallpaperWidth: 5478,
             wallpaperHeight: 1541,
+            // The decode bound Background's own request carries - the fifth
+            // request parameter, and like the others it must match exactly.
+            decodeWidth: 5478,
+            decodeHeight: 1541,
             surfaceX: 100 + index * 400,
             surfaceY: 220,
             width: 320,

--- a/dots/.config/quickshell/imi/tests/tst_we_color.qml
+++ b/dots/.config/quickshell/imi/tests/tst_we_color.qml
@@ -1,0 +1,52 @@
+import QtQuick
+import QtTest
+import "../modules/imi/wallpaperSelector/we_color.js" as WeColor
+
+// A Wallpaper Engine color property is an "r g b" triplet on --set-property.
+// The vendored engine's ColorBuilder::parse reads a triplet with a decimal
+// point as 0..1 floats and a DOT-LESS triplet as 0..255 integers, so the two
+// forms must not be conflated: white written "1 1 1" would be read as
+// (1/255, 1/255, 1/255) - near black. parse returns 0..1; format always writes
+// the float form with a dot so a round trip stays float.
+TestCase {
+    name: "WeColorTest"
+
+    function test_format_always_carries_a_dot() {
+        // White: every channel is integral, but the output must still read as
+        // float 1.0, not the integer 1 that WE would treat as 1/255.
+        compare(WeColor.formatChannels([1, 1, 1]), "1.000 1.000 1.000")
+        compare(WeColor.formatChannels([1, 0, 0]), "1.000 0.000 0.000")
+        compare(WeColor.formatChannels([0.5, 0.25, 0]), "0.500 0.250 0.000")
+    }
+
+    function test_format_clamps_out_of_range() {
+        compare(WeColor.formatChannels([2, -1, 0.5]), "1.000 0.000 0.500")
+    }
+
+    function test_parse_float_triplet_is_read_as_is() {
+        compare(WeColor.parseChannel("0.5 0.25 0", 0), 0.5)
+        compare(WeColor.parseChannel("0.5 0.25 0", 1), 0.25)
+        compare(WeColor.parseChannel("1.0 1.0 1.0", 2), 1)
+    }
+
+    function test_parse_dotless_triplet_is_read_as_0_255() {
+        // A project default the engine accepts in integer form.
+        compare(WeColor.parseChannel("255 128 0", 0), 1)
+        compare(WeColor.parseChannel("255 128 0", 1), 128 / 255)
+        compare(WeColor.parseChannel("255 128 0", 2), 0)
+    }
+
+    function test_parse_guards_garbage_to_zero() {
+        // NaN / negative / missing channel -> 0, never a NaN swatch.
+        compare(WeColor.parseChannel("", 0), 0)
+        compare(WeColor.parseChannel("0.5", 2), 0)
+        compare(WeColor.parseChannel("-1.0 0 0", 0), 0)
+    }
+
+    function test_round_trip_stays_float() {
+        // Formatting then parsing white returns 1, not 1/255 - the round trip
+        // our own writes take must not drift toward black.
+        var s = WeColor.formatChannels([1, 1, 1])
+        compare(WeColor.parseChannel(s, 0), 1)
+    }
+}

--- a/dots/.config/quickshell/imi/tests/tst_we_compat.qml
+++ b/dots/.config/quickshell/imi/tests/tst_we_compat.qml
@@ -1,0 +1,89 @@
+import QtQuick
+import QtTest
+import "../services/we_compat.js" as WeCompat
+
+// The compatibility scan's decisions: which projects need testing at all,
+// what a scanner line means, and what the store records. The scan itself
+// runs in a spawned scanner process (one bad wallpaper kills the scanner,
+// not the shell), so everything decidable lives here where a test can reach
+// it.
+TestCase {
+    name: "WeCompatTest"
+
+    function test_web_and_application_types_are_unsupported_without_a_scan() {
+        // The embedded renderer cannot run CEF, and an application is not a
+        // wallpaper it can host - both are knowledge, not measurements, so
+        // no scan is spent on them and nothing is stored.
+        compare(WeCompat.staticVerdict("web"), "unsupported")
+        compare(WeCompat.staticVerdict("application"), "unsupported")
+        compare(WeCompat.staticVerdict("scene"), "")
+        compare(WeCompat.staticVerdict("video"), "")
+        // Steam capitalizes inconsistently ("Video" is in this library).
+        compare(WeCompat.staticVerdict("Video"), "")
+        compare(WeCompat.staticVerdict("Web"), "unsupported")
+    }
+
+    function test_scan_queue_holds_testable_projects_only() {
+        var projects = [
+            { id: "1", path: "/a", type: "scene" },
+            { id: "2", path: "/b", type: "web" },
+            { id: "3", path: "/c", type: "video" },
+            { id: "4", path: "", type: "scene" }
+        ]
+        var queue = WeCompat.scanQueue(projects, {})
+        compare(queue.map(entry => entry.id), ["1", "3"])
+    }
+
+    function test_rescan_false_skips_projects_with_a_verdict() {
+        var projects = [
+            { id: "1", path: "/a", type: "scene" },
+            { id: "2", path: "/b", type: "scene" }
+        ]
+        var results = { "1": { status: "ok", testedAt: 5 } }
+        compare(WeCompat.scanQueue(projects, results).map(e => e.id), ["2"])
+        // A full rescan retests everything.
+        compare(WeCompat.scanQueue(projects, results, true).map(e => e.id), ["1", "2"])
+    }
+
+    function test_scanner_lines_parse_and_garbage_is_null() {
+        var v = WeCompat.parseLine('{"id":"42","status":"broken","error":"WE start failed"}')
+        compare(v.id, "42")
+        compare(v.status, "broken")
+        compare(v.error, "WE start failed")
+        verify(WeCompat.parseLine("not json") === null)
+        verify(WeCompat.parseLine('{"noId":true}') === null)
+        verify(WeCompat.parseLine('{"id":"1","status":"weird"}') === null)
+    }
+
+    function test_apply_verdict_returns_a_new_map_with_the_record() {
+        var results = WeCompat.applyVerdict({}, { id: "1", status: "ok", error: "" }, 1234)
+        compare(results["1"].status, "ok")
+        compare(results["1"].testedAt, 1234)
+        // ...and does not mutate the old map (a `property var` signals on
+        // reassignment only).
+        var next = WeCompat.applyVerdict(results, { id: "2", status: "broken", error: "x" }, 5678)
+        verify(!("2" in results))
+        compare(next["2"].error, "x")
+    }
+
+    function test_status_of_resolves_static_then_stored_then_unknown() {
+        var results = { "1": { status: "broken", error: "boom" } }
+        compare(WeCompat.statusOf({ id: "9", type: "web" }, results), "unsupported")
+        compare(WeCompat.statusOf({ id: "1", type: "scene" }, results), "broken")
+        compare(WeCompat.statusOf({ id: "2", type: "scene" }, results), "unknown")
+    }
+
+    function test_sanitize_keeps_known_shapes_only() {
+        var m = WeCompat.sanitize({
+            "1": { status: "ok", testedAt: 3, error: "" },
+            "2": { status: "nonsense" },
+            "3": "garbage",
+            "4": { status: "broken", error: "reason", testedAt: 9 }
+        })
+        compare(m["1"].status, "ok")
+        compare(m["4"].error, "reason")
+        verify(!("2" in m))
+        verify(!("3" in m))
+        compare(JSON.stringify(WeCompat.sanitize(null)), "{}")
+    }
+}

--- a/dots/.config/quickshell/imi/tests/tst_we_overrides.qml
+++ b/dots/.config/quickshell/imi/tests/tst_we_overrides.qml
@@ -163,6 +163,73 @@ TestCase {
         compare(m["12345"].properties.rain, "1")
     }
 
+    function test_focus_is_per_wallpaper_and_defaults_to_centre() {
+        // Like properties: no global side. Absent, it resolves to centre
+        // (0.5, 0.5) - never undefined, which would NaN the crop.
+        var r = WeOverrides.resolve({}, "12345", fullGlobals)
+        compare(r.focus.x, 0.5)
+        compare(r.focus.y, 0.5)
+
+        var overrides = { "12345": { focus: { x: 0.2, y: 0.8 } } }
+        r = WeOverrides.resolve(overrides, "12345", fullGlobals)
+        compare(r.focus.x, 0.2)
+        compare(r.focus.y, 0.8)
+    }
+
+    function test_focus_zero_survives_falsy_check() {
+        var r = WeOverrides.resolve({ "12345": { focus: { x: 0, y: 0 } } }, "12345", fullGlobals)
+        compare(r.focus.x, 0)
+        compare(r.focus.y, 0)
+    }
+
+    function test_set_focus_stores_and_clamps() {
+        var m = WeOverrides.setFocus({}, "12345", 0.3, 0.7)
+        compare(m["12345"].focus.x, 0.3)
+        compare(m["12345"].focus.y, 0.7)
+        // Out of range is clamped, not stored raw.
+        m = WeOverrides.setFocus(m, "12345", -1, 5)
+        compare(m["12345"].focus.x, 0)
+        compare(m["12345"].focus.y, 1)
+        // Back to dead centre removes the focus record entirely (and an
+        // otherwise-empty project with it) - centre is the default, so a
+        // stored 0.5/0.5 is churn.
+        m = WeOverrides.setFocus(m, "12345", 0.5, 0.5)
+        verify(!("12345" in m))
+    }
+
+    function test_focus_does_not_count_as_engine_override() {
+        // Cropping is per-wallpaper like properties, not an engine flag - the
+        // Custom settings switch must not eat it.
+        var m = WeOverrides.setFocus({}, "12345", 0.2, 0.5)
+        verify(!WeOverrides.hasOverride(m, "12345"))
+    }
+
+    function test_clear_engine_overrides_keeps_focus() {
+        var m = WeOverrides.setOverride({}, "12345", "fps", 60)
+        m = WeOverrides.setFocus(m, "12345", 0.2, 0.5)
+        m = WeOverrides.clearEngineOverrides(m, "12345")
+        verify(!WeOverrides.hasOverride(m, "12345"))
+        compare(m["12345"].focus.x, 0.2)
+    }
+
+    function test_sanitize_keeps_focus_within_range() {
+        var m = WeOverrides.sanitize({
+            "1": { focus: { x: 0.3, y: 0.9 } },
+            "2": { focus: { x: 5, y: -2 } },
+            "3": { focus: { x: "garbage", y: 0.9 } },
+            "4": { focus: "not an object" }
+        })
+        compare(m["1"].focus.x, 0.3)
+        compare(m["1"].focus.y, 0.9)
+        // Out of range clamps; a non-number axis falls to centre.
+        compare(m["2"].focus.x, 1)
+        compare(m["2"].focus.y, 0)
+        compare(m["3"].focus.x, 0.5)
+        compare(m["3"].focus.y, 0.9)
+        // A dead-centre focus is not a stored record.
+        verify(!("4" in m))
+    }
+
     function test_sanitize_keeps_string_properties_only() {
         var m = WeOverrides.sanitize({
             "12345": {

--- a/dots/.config/quickshell/imi/tests/tst_we_overrides.qml
+++ b/dots/.config/quickshell/imi/tests/tst_we_overrides.qml
@@ -1,0 +1,87 @@
+import QtQuick
+import QtTest
+import "../services/we_overrides.js" as WeOverrides
+
+// Per-project Wallpaper Engine settings: each key falls back to the global
+// config value when the project has no override of its own (the reference
+// app's ENGINE_OVERRIDE_FIELDS shape). The map lives in a raw-JSON store -
+// project ids are runtime strings, which a JsonAdapter cannot hold.
+TestCase {
+    name: "WeOverridesTest"
+
+    readonly property var globals: ({ fps: 30, scaling: "fill", silent: true })
+
+    function test_no_override_falls_back_to_globals() {
+        var r = WeOverrides.resolve({}, "12345", globals)
+        compare(r.fps, 30)
+        compare(r.scaling, "fill")
+        compare(r.silent, true)
+    }
+
+    function test_override_wins_per_key_not_per_project() {
+        var overrides = { "12345": { fps: 60 } }
+        var r = WeOverrides.resolve(overrides, "12345", globals)
+        compare(r.fps, 60)
+        // The keys the project does not override still follow the globals.
+        compare(r.scaling, "fill")
+        compare(r.silent, true)
+    }
+
+    function test_another_projects_override_does_not_leak() {
+        var overrides = { "999": { fps: 60, scaling: "stretch", silent: false } }
+        var r = WeOverrides.resolve(overrides, "12345", globals)
+        compare(r.fps, 30)
+        compare(r.scaling, "fill")
+        compare(r.silent, true)
+    }
+
+    function test_silent_false_override_survives_falsy_check() {
+        // false is a value, not an absence - the Number(null)-is-0 family.
+        var overrides = { "12345": { silent: false } }
+        var r = WeOverrides.resolve(overrides, "12345", { fps: 30, scaling: "fill", silent: true })
+        compare(r.silent, false)
+    }
+
+    function test_empty_project_id_resolves_to_globals() {
+        var r = WeOverrides.resolve({ "": { fps: 144 } }, "", globals)
+        // No active project means nothing to override - the empty id is not a
+        // key, it is the absence of one.
+        compare(r.fps, 30)
+    }
+
+    function test_set_and_clear_override() {
+        var m = WeOverrides.setOverride({}, "12345", "fps", 60)
+        compare(m["12345"].fps, 60)
+        // null clears the key (the PluginState lesson: a stored literal null
+        // would answer past every later fallback)...
+        m = WeOverrides.setOverride(m, "12345", "fps", null)
+        // ...and a project with no keys left is removed whole, so the store
+        // never accretes empty records.
+        verify(!("12345" in m))
+    }
+
+    function test_sanitize_drops_garbage() {
+        var m = WeOverrides.sanitize({
+            "12345": { fps: 60, scaling: "fit", silent: false, unknownKey: 1 },
+            "bad-entry": "not an object",
+            "null-entry": null
+        })
+        compare(m["12345"].fps, 60)
+        compare(m["12345"].scaling, "fit")
+        compare(m["12345"].silent, false)
+        verify(!("unknownKey" in m["12345"]))
+        verify(!("bad-entry" in m))
+        verify(!("null-entry" in m))
+    }
+
+    function test_sanitize_of_nothing_is_an_empty_map() {
+        compare(JSON.stringify(WeOverrides.sanitize(null)), "{}")
+        compare(JSON.stringify(WeOverrides.sanitize("garbage")), "{}")
+    }
+
+    function test_has_override_reports_per_project() {
+        verify(!WeOverrides.hasOverride({}, "12345"))
+        verify(WeOverrides.hasOverride({ "12345": { fps: 60 } }, "12345"))
+        verify(!WeOverrides.hasOverride({ "999": { fps: 60 } }, "12345"))
+    }
+}

--- a/dots/.config/quickshell/imi/tests/tst_we_overrides.qml
+++ b/dots/.config/quickshell/imi/tests/tst_we_overrides.qml
@@ -161,6 +161,29 @@ TestCase {
         verify(!("4" in m))
     }
 
+    function test_sanitize_coerces_or_drops_mistyped_flags() {
+        // A hand edit or a foreign file can carry the right key with the wrong
+        // type; unchecked it reaches WallpaperEngineSurface.fps as a QML type
+        // error on every re-read. sanitize coerces the numeric flags and drops
+        // a flag it cannot type honestly, rather than guessing.
+        var m = WeOverrides.sanitize({
+            "1": { fps: "60", volume: "40", silent: "no", audioProcessing: 1, scaling: 5 },
+            "2": { fps: 30, silent: false, scaling: "fit" }
+        })
+        // Numeric flags coerce from a numeric string.
+        compare(m["1"].fps, 60)
+        compare(m["1"].volume, 40)
+        // A non-string scaling drops (never stringified to "5")...
+        verify(!("scaling" in m["1"]))
+        // ...and a non-boolean bool drops rather than reading "no" as true.
+        verify(!("silent" in m["1"]))
+        verify(!("audioProcessing" in m["1"]))
+        // Correctly typed values pass untouched.
+        compare(m["2"].fps, 30)
+        compare(m["2"].silent, false)
+        compare(m["2"].scaling, "fit")
+    }
+
     function test_project_properties_resolve_per_wallpaper() {
         // Custom properties (project.json general.properties) are inherently
         // per-wallpaper - there is no global to fall back to, so an absent

--- a/dots/.config/quickshell/imi/tests/tst_we_overrides.qml
+++ b/dots/.config/quickshell/imi/tests/tst_we_overrides.qml
@@ -117,6 +117,50 @@ TestCase {
         compare(r.volume, 0)
     }
 
+    readonly property var scaleGlobals: ({
+        fps: 30, scaling: "fill", silent: true,
+        volume: 100, audioProcessing: true,
+        disableMouse: false, disableParallax: false, disableParticles: false,
+        renderScale: 1.0
+    })
+
+    function test_render_scale_falls_back_and_overrides() {
+        // renderScale is an ENGINE flag like fps: a per-project value wins,
+        // else the global. 1 = native; the surface renders into a window this
+        // fraction of its size and upscales.
+        var r = WeOverrides.resolve({}, "12345", scaleGlobals)
+        compare(r.renderScale, 1.0)
+
+        r = WeOverrides.resolve({ "12345": { renderScale: 0.5 } }, "12345", scaleGlobals)
+        compare(r.renderScale, 0.5)
+        // Untouched flags still follow the globals.
+        compare(r.fps, 30)
+    }
+
+    function test_render_scale_counts_as_engine_override() {
+        // It rides with the other engine flags, so the Custom settings switch
+        // owns it - clearEngineOverrides drops it.
+        var m = WeOverrides.setOverride({}, "12345", "renderScale", 0.5)
+        verify(WeOverrides.hasOverride(m, "12345"))
+        m = WeOverrides.clearEngineOverrides(m, "12345")
+        verify(!("12345" in m))
+    }
+
+    function test_sanitize_clamps_render_scale_and_drops_garbage() {
+        var m = WeOverrides.sanitize({
+            "1": { renderScale: 0.5 },
+            "2": { renderScale: 4 },
+            "3": { renderScale: 0.01 },
+            "4": { renderScale: "big" }
+        })
+        compare(m["1"].renderScale, 0.5)
+        // Out of the 0.25..1 domain clamps to the edge...
+        compare(m["2"].renderScale, 1.0)
+        compare(m["3"].renderScale, 0.25)
+        // ...and a non-number is not a value - the record empties and drops.
+        verify(!("4" in m))
+    }
+
     function test_project_properties_resolve_per_wallpaper() {
         // Custom properties (project.json general.properties) are inherently
         // per-wallpaper - there is no global to fall back to, so an absent

--- a/dots/.config/quickshell/imi/tests/tst_we_overrides.qml
+++ b/dots/.config/quickshell/imi/tests/tst_we_overrides.qml
@@ -84,4 +84,97 @@ TestCase {
         verify(WeOverrides.hasOverride({ "12345": { fps: 60 } }, "12345"))
         verify(!WeOverrides.hasOverride({ "999": { fps: 60 } }, "12345"))
     }
+
+    readonly property var fullGlobals: ({
+        fps: 30, scaling: "fill", silent: true,
+        volume: 100, audioProcessing: true,
+        disableMouse: false, disableParallax: false, disableParticles: false
+    })
+
+    function test_engine_flag_keys_resolve_with_fallback() {
+        // The reference app's ENGINE_OVERRIDE_FIELDS set, whole: volume,
+        // audio processing and the three feature switches ride the same
+        // per-key fallback as fps/scaling/silent.
+        var r = WeOverrides.resolve({}, "12345", fullGlobals)
+        compare(r.volume, 100)
+        compare(r.audioProcessing, true)
+        compare(r.disableMouse, false)
+        compare(r.disableParallax, false)
+        compare(r.disableParticles, false)
+
+        var overrides = { "12345": { volume: 40, disableParticles: true, audioProcessing: false } }
+        r = WeOverrides.resolve(overrides, "12345", fullGlobals)
+        compare(r.volume, 40)
+        compare(r.audioProcessing, false)
+        compare(r.disableParticles, true)
+        // Untouched keys still follow the globals.
+        compare(r.disableMouse, false)
+        compare(r.fps, 30)
+    }
+
+    function test_volume_zero_override_survives_falsy_check() {
+        var r = WeOverrides.resolve({ "12345": { volume: 0 } }, "12345", fullGlobals)
+        compare(r.volume, 0)
+    }
+
+    function test_project_properties_resolve_per_wallpaper() {
+        // Custom properties (project.json general.properties) are inherently
+        // per-wallpaper - there is no global to fall back to, so an absent
+        // record resolves to an empty map, never undefined.
+        var r = WeOverrides.resolve({}, "12345", fullGlobals)
+        compare(JSON.stringify(r.properties), "{}")
+
+        var overrides = { "12345": { properties: { schemecolor: "0.1 0.2 0.3", rain: "1" } } }
+        r = WeOverrides.resolve(overrides, "12345", fullGlobals)
+        compare(r.properties.schemecolor, "0.1 0.2 0.3")
+        compare(r.properties.rain, "1")
+    }
+
+    function test_set_and_clear_project_property() {
+        var m = WeOverrides.setProjectProperty({}, "12345", "rain", "1")
+        compare(m["12345"].properties.rain, "1")
+        m = WeOverrides.setProjectProperty(m, "12345", "snow", "0")
+        compare(m["12345"].properties.rain, "1")
+        compare(m["12345"].properties.snow, "0")
+        // null clears one property...
+        m = WeOverrides.setProjectProperty(m, "12345", "rain", null)
+        verify(!("rain" in m["12345"].properties))
+        // ...and clearing the last one removes the map, and with it an
+        // otherwise-empty record.
+        m = WeOverrides.setProjectProperty(m, "12345", "snow", null)
+        verify(!("12345" in m))
+    }
+
+    function test_properties_do_not_count_as_engine_override() {
+        // The "Custom settings" switch is about the ENGINE flags; a wallpaper
+        // whose only record is tweaked properties must not read as having
+        // flag overrides, or flipping the switch off would eat the user's
+        // property edits.
+        var m = WeOverrides.setProjectProperty({}, "12345", "rain", "1")
+        verify(!WeOverrides.hasOverride(m, "12345"))
+        verify(WeOverrides.hasProperties(m, "12345"))
+    }
+
+    function test_clear_engine_overrides_keeps_properties() {
+        var m = WeOverrides.setOverride({}, "12345", "fps", 60)
+        m = WeOverrides.setProjectProperty(m, "12345", "rain", "1")
+        m = WeOverrides.clearEngineOverrides(m, "12345")
+        verify(!WeOverrides.hasOverride(m, "12345"))
+        compare(m["12345"].properties.rain, "1")
+    }
+
+    function test_sanitize_keeps_string_properties_only() {
+        var m = WeOverrides.sanitize({
+            "12345": {
+                volume: 55,
+                properties: { ok: "1", nested: { bad: true }, num: 3 }
+            }
+        })
+        compare(m["12345"].volume, 55)
+        compare(m["12345"].properties.ok, "1")
+        // Non-string property values re-serialize (numbers) or drop (objects):
+        // everything WE gets is a string on its command line.
+        compare(m["12345"].properties.num, "3")
+        verify(!("nested" in m["12345"].properties))
+    }
 }


### PR DESCRIPTION
The wallpaper selector gains a Wallpaper Engine sidebar, and the resource-polling
perf work it grew on. Scope is the 13 commits on this branch over `main` (rc-12);
the widget-options / shadow-switch / rc-11–12 work an earlier draft mentioned is
already on `main` and not in this diff.

## Wallpaper Engine selector
- **A sidebar** — a places rail over local files, the engine's config over WE
  wallpapers (modelled on jagrat7/linux-wallpaper-engine).
- **The engine's full flag set + per-wallpaper properties + a compatibility
  scan** — frame rate, scaling, audio, volume, the audio-reactive recorder,
  mouse/parallax/particles, and each wallpaper's project.json properties
  (bool/slider/combo/color/textinput), global or per wallpaper. A spawned
  scanner marks broken wallpapers.
- **A Fill crop picker** on the active wallpaper's thumbnail — pick which slice
  of an over-sized scene is shown; the renderer pans it live (focus read every
  frame, no reload). The thumbnail is the real scene grabbed from the renderer
  (a 32:9 scene reads as 32:9, upright), not the portrait preview.
- **A render-scale Quality dial** — Native / High / Balanced / Low, gated on a
  renderer that reads it, and honest that fps (not scale) is the lever for a
  heavy scene.

Every extended surface property binds in-guarded, so a shell on an older
qs-wallpaperengine binary hides the controls it cannot honour instead of
breaking. Needs the matching module surface, **XephyLon/qs-wallpaperengine#21**
(merged), for users to see the new controls once `WE_REF` moves to a release
carrying it.

## Performance (the branch's origin)
- **Resource polling reads through files** and stops waking a sleeping dGPU:
  nvidia-smi runs only when the card is not runtime-suspended, and — after this
  review — backs its cadence off once the card reads idle, so an *active* card
  is also allowed to autosuspend instead of being held awake by the poll itself.
- **Wallpaper decode bounded to what a screen can draw** (now × devicePixelRatio,
  so fractional-scale outputs stay sharp); the session menu's surface outlives
  its gesture; the avatar resolves once instead of retrying a guessed path.

## Review round (maintainer review addressed)
HiDPI decode bound, the nvidia-smi autosuspend backoff, the compat scanner
blaming the queue head only on a real crash (and a window rule so its scanner
window never tiles/steals focus), color-property serialisation (always a dot, so
WE does not read white as near-black) and its 0..255 parse, combo numeric option
keys, the volume slider re-binding after a drag, `ignoreUnknownSignals` on the
0.3-only signals, the scene grab labelled and gated at request time, suspended
GPU readings zeroed, nvidia detection requiring a real 0x10de device, `sanitize`
typing every flag, a corrupt override store quarantined before overwrite, and
the AGENT.md citation/contradiction fixes.

Docs: updated AGENT.md §WallpaperEngineFeatures.qml (the Quality dial replaces the "not shipped" note) and citation fixes across the WE/resources entries.
Changelog: updated
