### PR TITLE
fix(media): lyrics fetch caching + a shared MediaArtSource, and the media/lyrics review round

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1925,6 +1925,17 @@ ce41c4f9c ("feat(cava): give CavaService the producer it always implied"),
 bcf5f9ca1 ("refactor(cava): move every band consumer onto the one service"),
 004a17745 ("test(cava): pin the producer, the gate and the band contract").
 
+The same rule holds for cover art: **the download+quantize pipeline lives once, in
+`modules/imi/mediaControls/MediaArtSource.qml`** - feed it `artUrl` (via `media_art.js`'s
+resolve), read `displayedArtFilePath` and `colors`; each surface keeps only its own
+dominant-colour mix. It was copy-pasted across the bar, dock, left sidebar and popup players, and
+the copies had drifted exactly as CavaService's consumers did: the sidebar's lacked the `curl -4`
+IPv4 pin (its downloads could hang on an IPv6 stall) and the `file://` fast-path (it re-curled
+local art every track). A fifth media surface must use this component, not paste a fifth copy.
+It cannot live in `modules/common/widgets` - it spawns curl, and `lint_dumb_widgets.py` fails the
+suite on a Process there.
+1550313c ("refactor(media): one shared MediaArtSource; fix tint, progress, and waste").
+
 **A signal nothing connects to is that same hole from the other side, and only a surface can
 find it.** `PhoneScrcpy.feedback(message, ok)`, `PhoneCamera.errorOccurred(message)` and
 `PhoneMic.errorOccurred(message)` have been raised on every failure since those services landed,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,18 @@ own repo; the installer pins which revision it builds.
   picker with the real-scene thumbnail, and the Quality dial all appear once
   it is installed (Settings > Update Dots). On the previous renderer those
   controls stay hidden.
+- **Lyrics load faster and stop re-fetching.** Fetched lyrics are cached on
+  disk, so replaying a song or reopening the media sidebar no longer re-hits
+  the network; a track change now fetches once instead of two or three times,
+  and a hung fetch gives up after 20s instead of spinning forever.
+
+### Fixed
+- **Lyrics no longer flicker "no lyrics" on every track change**, and seeking
+  within a song no longer disrupts them.
+- **Media cover-art tint no longer freezes grey** on the dock after a track
+  with no artwork, and progress bars no longer misbehave on live streams or
+  when no player is present. Cover art for local files and on slow IPv6
+  networks loads reliably in the sidebar.
 
 ## [1.0.0-rc-13] — 2026-09-04
 

--- a/dots/.config/quickshell/imi/modules/common/widgets/WaveVisualizer.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/WaveVisualizer.qml
@@ -29,9 +29,13 @@ Canvas { // Visualizer
         var n = points.length;
         if (n < 2) return;
 
-        // Smoothing: simple moving average (optional)
+        // Smoothing: simple moving average (optional). Reuse the buffer across
+        // paints - reallocating it every frame (this runs at ~display rate per
+        // visible visualizer) churned the GC for nothing; only the band count
+        // changing needs a new array.
         var smoothWindow = root.smoothing; // adjust for more/less smoothing
-        root.smoothPoints = [];
+        var sp = root.smoothPoints;
+        if (sp.length !== n) { sp = new Array(n); root.smoothPoints = sp; }
         for (var i = 0; i < n; ++i) {
             var sum = 0, count = 0;
             for (var j = -smoothWindow; j <= smoothWindow; ++j) {
@@ -39,9 +43,8 @@ Canvas { // Visualizer
                 sum += points[idx];
                 count++;
             }
-            root.smoothPoints.push(sum / count);
+            sp[i] = root.live ? sum / count : 0; // not playing -> flat line
         }
-        if (!root.live) root.smoothPoints.fill(0); // If not playing, show no points
 
         ctx.beginPath();
         ctx.moveTo(0, h);

--- a/dots/.config/quickshell/imi/modules/common/widgets/WaveVisualizer.qml
+++ b/dots/.config/quickshell/imi/modules/common/widgets/WaveVisualizer.qml
@@ -35,7 +35,12 @@ Canvas { // Visualizer
         // changing needs a new array.
         var smoothWindow = root.smoothing; // adjust for more/less smoothing
         var sp = root.smoothPoints;
-        if (sp.length !== n) { sp = new Array(n); root.smoothPoints = sp; }
+        // Fill BEFORE assigning on the resize path: assigning first copies the
+        // still-empty array into the property, and the writes that follow land
+        // in the detached local - one blank frame per band-count change. The
+        // steady-state reuse writes through the wrapper, as push always did.
+        var fresh = sp.length !== n;
+        if (fresh) sp = new Array(n);
         for (var i = 0; i < n; ++i) {
             var sum = 0, count = 0;
             for (var j = -smoothWindow; j <= smoothWindow; ++j) {
@@ -45,6 +50,7 @@ Canvas { // Visualizer
             }
             sp[i] = root.live ? sum / count : 0; // not playing -> flat line
         }
+        if (fresh) root.smoothPoints = sp;
 
         ctx.beginPath();
         ctx.moveTo(0, h);

--- a/dots/.config/quickshell/imi/modules/imi/bar/Media.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/Media.qml
@@ -1,6 +1,7 @@
 pragma ComponentBehavior: Bound
 import qs.modules.common
 import qs.modules.common.widgets
+import qs.modules.imi.mediaControls
 import qs.modules.common.functions
 import qs.services
 import qs.modules.common.models
@@ -18,7 +19,6 @@ Item {
     id: root
     
     property bool vertical: false
-    property bool borderless: Config.options.bar.borderless
     property bool isMaterial: Config.options.bar.cornerStyle === 3
     readonly property MprisPlayer activePlayer: MprisController.activePlayer
 
@@ -30,41 +30,12 @@ Item {
     property bool   isPlaying:   activePlayer?.isPlaying   ?? false
     property bool   hasTrack:    trackTitle.length > 0
 
-    property string artDownloadLocation: Directories.coverArt
-    property string artFileName:         Qt.md5(artUrl)
-    property string artFilePath:         `${artDownloadLocation}/${artFileName}`
-    property bool   artDownloaded:       false
-
-    property string displayedArtFilePath: {
-        if (!root.artDownloaded) return ""
-        if (root.artUrl.startsWith("file://")) return root.artUrl
-        return Qt.resolvedUrl(artFilePath)
+    MediaArtSource {
+        id: artSource
+        artUrl: root.artUrl
     }
-
-    onArtFilePathChanged: {
-        if (!root.artUrl || root.artUrl.length === 0) {
-            root.artDownloaded = false
-            return
-        }
-        if (root.artUrl.startsWith("file://")) {
-            root.artDownloaded = true
-            return
-        }
-        artDownloader.targetFile  = root.artUrl
-        artDownloader.artFilePath = root.artFilePath
-        root.artDownloaded = false
-        artDownloader.running = true
-    }
-
-    Process {
-        id: artDownloader
-        property string targetFile:  root.artUrl
-        property string artFilePath: root.artFilePath
-        // Positional args ($1/$2), never spliced into the script body: targetFile
-        // is MPRIS artUrl (attacker-controllable), so interpolation was injectable.
-        command: ["bash", "-c", '[ -f "$1" ] || curl -sSL "$2" -o "$1"', "bash", artFilePath, targetFile]
-        onExited: { root.artDownloaded = true }
-    }
+    readonly property string displayedArtFilePath: artSource.displayedArtFilePath
+    readonly property bool artDownloaded: artSource.downloaded
 
     Layout.fillHeight: true
     implicitWidth: vertical 
@@ -108,7 +79,7 @@ Item {
         sourceComponent: ClippedOutlineCircularProgress {
             implicitSize: 20
             lineWidth: Appearance.rounding.unsharpen
-            value: root.activePlayer?.position / root.activePlayer?.length
+            value: (root.activePlayer?.length ?? 0) > 0 ? root.activePlayer.position / root.activePlayer.length : 0
             colPrimary: Appearance.colors.colOnSecondaryContainer
             enableAnimation: false
             Item {
@@ -157,7 +128,7 @@ Item {
                 Layout.leftMargin: Appearance.spacing.space50
                 implicitSize: 20
                 lineWidth: Appearance.rounding.unsharpen
-                value: root.activePlayer?.position / root.activePlayer?.length
+                value: (root.activePlayer?.length ?? 0) > 0 ? root.activePlayer.position / root.activePlayer.length : 0
                 colPrimary: Appearance.colors.colOnSecondaryContainer
                 enableAnimation: false
                 Item {

--- a/dots/.config/quickshell/imi/modules/imi/dock/Dock.qml
+++ b/dots/.config/quickshell/imi/modules/imi/dock/Dock.qml
@@ -370,7 +370,6 @@ Scope {
                                         Layout.topMargin: Appearance.spacing.space150
                                         Layout.bottomMargin: Appearance.spacing.space100
                                         Layout.leftMargin: 0
-                                        buttonPadding: dockRow.padding
                                     }
 
                                     Repeater {

--- a/dots/.config/quickshell/imi/modules/imi/dock/DockMedia.qml
+++ b/dots/.config/quickshell/imi/modules/imi/dock/DockMedia.qml
@@ -86,11 +86,15 @@ Item {
             id: blurredArt
             anchors.fill: parent
             source: root.displayedArtFilePath
-            // Bound the decode to the card, not the file: a 1200x1200 cover
-            // decoded full-res only to be blurred behind a small card wasted
-            // memory and decode time.
-            sourceSize.width: Math.max(1, Math.round(card.width))
-            sourceSize.height: Math.max(1, Math.round(card.height))
+            // Bound the decode to the card's RESTING size, not the file: a
+            // 1200x1200 cover decoded full-res only to be blurred behind a
+            // small card wasted memory and decode time. Constants, not
+            // card.width/height - the card rides root's animated implicitWidth
+            // (Behavior on show/hide), and a geometry-bound sourceSize is a
+            // full re-decode per animation frame (the bound-to-geometry reload
+            // trap the wallpaper decode entry in AGENT.md records).
+            sourceSize.width: root.cardWidth
+            sourceSize.height: 46
             fillMode: Image.PreserveAspectCrop
             cache: false
             antialiasing: true

--- a/dots/.config/quickshell/imi/modules/imi/dock/DockMedia.qml
+++ b/dots/.config/quickshell/imi/modules/imi/dock/DockMedia.qml
@@ -1,6 +1,7 @@
 pragma ComponentBehavior: Bound
 import qs.modules.common
 import qs.modules.common.widgets
+import qs.modules.imi.mediaControls
 import qs.modules.common.functions
 import qs.services
 import qs.modules.common.models
@@ -17,7 +18,6 @@ Item {
     id: root
 
     property real cardWidth:     240
-    property real buttonPadding: Appearance.spacing.space50
     property real artMargin:     Appearance.spacing.space50
 
     property var player: MprisController.activePlayer
@@ -28,59 +28,20 @@ Item {
     property bool   isPlaying:   player?.isPlaying   ?? false
     property bool   hasTrack:    trackTitle.length > 0
 
-    property string artDownloadLocation: Directories.coverArt
-    property string artFileName:         Qt.md5(artUrl)
-    property string artFilePath:         `${artDownloadLocation}/${artFileName}`
-    property bool   artDownloaded:       false
-
-    property string displayedArtFilePath: {
-        if (!root.artDownloaded) return ""
-        if (root.artUrl.startsWith("file://")) return root.artUrl
-        return Qt.resolvedUrl(artFilePath)
+    MediaArtSource {
+        id: artSource
+        artUrl: root.artUrl
     }
+    readonly property string displayedArtFilePath: artSource.displayedArtFilePath
+    readonly property bool artDownloaded: artSource.downloaded
 
     property color artDominantColor: ColorUtils.mix(
-        colorQuantizer?.colors[0] ?? Appearance.colors.colPrimary,
+        artSource.colors[0] ?? Appearance.colors.colPrimary,
         Appearance.colors.colPrimaryContainer,
         0.8)
 
     property QtObject blendedColors: AdaptedMaterialScheme {
         color: root.artDominantColor
-    }
-
-    onArtFilePathChanged: {
-        if (!root.artUrl || root.artUrl.length === 0) {
-            root.artDominantColor = Appearance.m3colors.m3secondaryContainer
-            root.artDownloaded = false
-            return
-        }
-
-        if (root.artUrl.startsWith("file://")) {
-            root.artDownloaded = true
-            return
-        }
-
-        artDownloader.targetFile  = root.artUrl
-        artDownloader.artFilePath = root.artFilePath
-        root.artDownloaded = false
-        artDownloader.running = true
-    }
-
-    Process {
-        id: artDownloader
-        property string targetFile:  root.artUrl
-        property string artFilePath: root.artFilePath
-        // Positional args ($1/$2), never spliced into the script body: targetFile
-        // is MPRIS artUrl (attacker-controllable), so interpolation was injectable.
-        command: ["bash", "-c", '[ -f "$1" ] || curl -sSL "$2" -o "$1"', "bash", artFilePath, targetFile]
-        onExited: { root.artDownloaded = true }
-    }
-
-    ColorQuantizer {
-        id: colorQuantizer
-        source: root.displayedArtFilePath
-        depth: 0
-        rescaleSize: 1
     }
 
     visible:        root.hasTrack
@@ -125,6 +86,11 @@ Item {
             id: blurredArt
             anchors.fill: parent
             source: root.displayedArtFilePath
+            // Bound the decode to the card, not the file: a 1200x1200 cover
+            // decoded full-res only to be blurred behind a small card wasted
+            // memory and decode time.
+            sourceSize.width: Math.max(1, Math.round(card.width))
+            sourceSize.height: Math.max(1, Math.round(card.height))
             fillMode: Image.PreserveAspectCrop
             cache: false
             antialiasing: true

--- a/dots/.config/quickshell/imi/modules/imi/mediaControls/Lyrics.qml
+++ b/dots/.config/quickshell/imi/modules/imi/mediaControls/Lyrics.qml
@@ -13,11 +13,15 @@ Item {
     // The player this view is showing - forwarded to the service so the
     // fetch follows the dropdown, not the global active player.
     property var player: null
+    // Only a VISIBLE view claims the service's single overridePlayer, so a
+    // hidden view (a closed sidebar, a faded-out widget) does not fight a shown
+    // one for it. Two views visible at once with DIFFERENT players is the
+    // residual case the single-owner service cannot fully express.
     Binding {
         target: LyricsService
         property: "overridePlayer"
         value: root.player
-        when: root.player !== null && root.player !== undefined
+        when: root.visible && root.player !== null && root.player !== undefined
     }
 
     // The sweep clock the active line's words follow.
@@ -58,7 +62,14 @@ Item {
     // to lyrics and destroyed when it flips back, so its lifetime is the
     // refcount's.
     Component.onCompleted: LyricsService.sidebarLyricsRefs++
-    Component.onDestruction: LyricsService.sidebarLyricsRefs--
+    Component.onDestruction: {
+        LyricsService.sidebarLyricsRefs--
+        // Release the player claim if this view held it: a Binding does not
+        // restore the property when its view is destroyed, so without this the
+        // service would keep following a now-gone view's player.
+        if (LyricsService.overridePlayer === root.player)
+            LyricsService.overridePlayer = null
+    }
 
     ColumnLayout {
         anchors.fill: parent
@@ -250,17 +261,10 @@ Item {
                         Behavior on opacity {
                             NumberAnimation { duration: root.growDuration; easing.type: Easing.OutCubic }
                         }
-                        readonly property real sweepProgress: {
-                            const span = LyricsService.activeLineSpan
-                            if (!span) return 0
-                            return Math.max(0, Math.min(1,
-                                (root.sweepPosition - span.start) / (span.end - span.start)))
-                        }
                         // A line with no per-word timing gets a single sweep
                         // at a FIXED speed, not one paced to the line's
                         // duration - restarted each time this becomes the
-                        // active swept line. (sweepProgress stays defined for
-                        // reference but no longer drives the paint.)
+                        // active swept line.
                         property real shownProgress: 0
                         onVisibleChanged: if (visible) fixedSweep.restart()
                         NumberAnimation on shownProgress {

--- a/dots/.config/quickshell/imi/modules/imi/mediaControls/MediaArtSource.qml
+++ b/dots/.config/quickshell/imi/modules/imi/mediaControls/MediaArtSource.qml
@@ -1,0 +1,65 @@
+import qs.modules.common
+import Quickshell
+import Quickshell.Io
+import QtQuick
+
+// The cover-art pipeline shared by every media surface: download the resolved
+// artUrl (or use a file:// URL in place), quantize it, and expose the
+// displayable path and the palette. This was copy-pasted across the bar,
+// dock, sidebar and popup players and had already DRIFTED - the sidebar's copy
+// lacked the `curl -4` IPv4 pin (an IPv6 stall hung its downloads) and the
+// file:// fast-path (it re-curled local art every track). One copy now.
+//
+// Feed `artUrl` (typically MediaArt.resolve(...)); read `displayedArtFilePath`
+// for an Image source and `colors` for the tint. Each surface keeps its own
+// dominant-colour mix, so a per-surface option (the sidebar's artColors gate)
+// stays with the surface.
+Item {
+    id: root
+
+    property var artUrl: ""
+    readonly property string artFilePath: `${Directories.coverArt}/${Qt.md5(String(root.artUrl ?? ""))}`
+    // True once the art is present locally: a downloaded file, or a file:// URL
+    // that needs no download.
+    property bool downloaded: false
+
+    readonly property string displayedArtFilePath: {
+        if (!root.downloaded) return ""
+        const url = String(root.artUrl ?? "")
+        if (url.startsWith("file://")) return url
+        return Qt.resolvedUrl(root.artFilePath)
+    }
+    readonly property var colors: colorQuantizer.colors
+
+    onArtUrlChanged: root.refresh()
+    Component.onCompleted: root.refresh()
+    function refresh() {
+        const url = String(root.artUrl ?? "")
+        if (url.length === 0) { root.downloaded = false; return }
+        // A file:// URL is already on disk: use it in place, no download.
+        if (url.startsWith("file://")) { root.downloaded = true; return }
+        downloader.targetFile = url
+        downloader.filePath = root.artFilePath
+        root.downloaded = false
+        downloader.running = true
+    }
+
+    Process {
+        id: downloader
+        property string targetFile
+        property string filePath
+        // Positional args ($1/$2), never spliced into the script body: artUrl
+        // is untrusted MPRIS metadata (any bus peer, including a browser tab's
+        // Media Session artwork), so interpolating it was a command-injection
+        // hole. -4 pins IPv4 - an IPv6 stall hung the download on some networks.
+        command: ["bash", "-c", '[ -f "$1" ] || curl -4 -sSL "$2" -o "$1"', "bash", filePath, targetFile]
+        onExited: (exitCode, exitStatus) => root.downloaded = true
+    }
+
+    ColorQuantizer {
+        id: colorQuantizer
+        source: root.displayedArtFilePath
+        depth: 0
+        rescaleSize: 1
+    }
+}

--- a/dots/.config/quickshell/imi/modules/imi/mediaControls/MediaArtSource.qml
+++ b/dots/.config/quickshell/imi/modules/imi/mediaControls/MediaArtSource.qml
@@ -51,9 +51,11 @@ Item {
         // Positional args ($1/$2), never spliced into the script body: artUrl
         // is untrusted MPRIS metadata (any bus peer, including a browser tab's
         // Media Session artwork), so interpolating it was a command-injection
-        // hole. -4 pins IPv4 - an IPv6 stall hung the download on some networks.
-        command: ["bash", "-c", '[ -f "$1" ] || curl -4 -sSL "$2" -o "$1"', "bash", filePath, targetFile]
-        onExited: (exitCode, exitStatus) => root.downloaded = true
+        // hole. -4 pins IPv4 (an IPv6 stall hung the download on some
+        // networks); -f fails on an HTTP error instead of saving the 404 body
+        // as "art", and downloaded follows the exit code for the same reason.
+        command: ["bash", "-c", '[ -f "$1" ] || curl -4 -fsSL "$2" -o "$1"', "bash", filePath, targetFile]
+        onExited: (exitCode, exitStatus) => root.downloaded = exitCode === 0
     }
 
     ColorQuantizer {

--- a/dots/.config/quickshell/imi/modules/imi/mediaControls/Player.qml
+++ b/dots/.config/quickshell/imi/modules/imi/mediaControls/Player.qml
@@ -18,25 +18,21 @@ Item {
     id: root
     required property MprisPlayer player
     property var artUrl: MediaArt.resolve(player?.trackArtUrl ?? "", player?.metadata)
-    property string artDownloadLocation: Directories.coverArt
-    property string artFileName: Qt.md5(artUrl)
-    property string artFilePath: `${artDownloadLocation}/${artFileName}`
+    MediaArtSource {
+        id: artSource
+        artUrl: root.artUrl
+    }
+    readonly property string displayedArtFilePath: artSource.displayedArtFilePath
+    readonly property bool downloaded: artSource.downloaded
     property color artDominantColor: ColorUtils.mix(
-        (colorQuantizer?.colors[0] ?? Appearance.colors.colPrimary),
+        (artSource.colors[0] ?? Appearance.colors.colPrimary),
         Appearance.colors.colPrimaryContainer,
         0.8) || Appearance.m3colors.m3secondaryContainer
-    property bool downloaded: false
     property list<real> visualizerPoints: []
     property real maxVisualizerValue: 1000
     property int visualizerSmoothing: 2
     property real radius
     property bool showLyrics: false
-
-    property string displayedArtFilePath: {
-        if (!root.downloaded) return ""
-        if (root.artUrl.startsWith("file://")) return root.artUrl
-        return Qt.resolvedUrl(artFilePath)
-    }
 
     property QtObject blendedColors: AdaptedMaterialScheme {
         color: artDominantColor
@@ -47,51 +43,6 @@ Item {
         interval: Config.options.resources.updateInterval
         repeat: true
         onTriggered: root.player.positionChanged()
-    }
-
-    onArtFilePathChanged: {
-        if (!root.artUrl || root.artUrl.length === 0) {
-            // Do NOT assign artDominantColor here: it has a declarative binding
-            // (to the quantizer, above), and an imperative write destroys that
-            // binding for good - after which the tint never tracked a later
-            // track and only a full restart rebuilt it. The binding already
-            // falls back to the theme colour when there is no art, so clearing
-            // `downloaded` (which empties displayedArtFilePath -> the quantizer)
-            // is enough; the colour follows on its own.
-            root.downloaded = false
-            return
-        }
-
-        if (root.artUrl.startsWith("file://")) {
-            root.downloaded = true
-            return
-        }
-
-        coverArtDownloader.targetFile = root.artUrl
-        coverArtDownloader.artFilePath = root.artFilePath
-        root.downloaded = false
-        coverArtDownloader.running = true
-    }
-
-    Process {
-        id: coverArtDownloader
-        property string targetFile: root.artUrl
-        property string artFilePath: root.artFilePath
-        // Pass path/URL as positional args ($1/$2), never interpolated into the
-        // script body: artUrl comes from MPRIS metadata (any session-bus peer,
-        // incl. a browser tab's Media Session artwork), so splicing it into the
-        // shell string was a command-injection hole.
-        command: ["bash", "-c", '[ -f "$1" ] || curl -4 -sSL "$2" -o "$1"', "bash", artFilePath, targetFile]
-        onExited: (exitCode, exitStatus) => {
-            root.downloaded = true
-        }
-    }
-
-    ColorQuantizer {
-        id: colorQuantizer
-        source: root.displayedArtFilePath
-        depth: 0
-        rescaleSize: 1
     }
 
     StyledRectangularShadow {

--- a/dots/.config/quickshell/imi/modules/imi/mediaControls/PlayerControls.qml
+++ b/dots/.config/quickshell/imi/modules/imi/mediaControls/PlayerControls.qml
@@ -153,8 +153,8 @@ Item {
                                 highlightColor: root.blendedColors.colPrimary
                                 trackColor: root.blendedColors.colSecondaryContainer
                                 handleColor: root.blendedColors.colPrimary
-                                value: root.player?.position / root.player?.length
-                                onMoved: root.player.position = value * root.player.length
+                                value: (root.player?.length ?? 0) > 0 ? root.player.position / root.player.length : 0
+                                onMoved: if (root.player) root.player.position = value * root.player.length
                             }
                         }
 
@@ -170,7 +170,7 @@ Item {
                                 wavy: root.player?.isPlaying
                                 highlightColor: root.blendedColors.colPrimary
                                 trackColor: root.blendedColors.colSecondaryContainer
-                                value: root.player?.position / root.player?.length
+                                value: (root.player?.length ?? 0) > 0 ? root.player.position / root.player.length : 0
                             }
                         }
                     }
@@ -195,7 +195,7 @@ Item {
                     property real size: 44
                     implicitWidth: size
                     implicitHeight: size
-                    downAction: () => root.player.togglePlaying()
+                    downAction: () => root.player?.togglePlaying()
 
                     buttonRadius: root.player?.isPlaying ? Appearance?.rounding.normal : size / 2
                     colBackground: root.player?.isPlaying ? root.blendedColors.colPrimary : root.blendedColors.colSecondaryContainer

--- a/dots/.config/quickshell/imi/modules/imi/mediaControls/PlayerControlsLyrics.qml
+++ b/dots/.config/quickshell/imi/modules/imi/mediaControls/PlayerControlsLyrics.qml
@@ -176,10 +176,14 @@ Item {
                                 highlightColor: root.blendedColors.colPrimary
                                 trackColor: root.blendedColors.colSecondaryContainer
                                 handleColor: root.blendedColors.colPrimary
-                                value: root.player?.position / root.player?.length
+                                value: (root.player?.length ?? 0) > 0 ? root.player.position / root.player.length : 0
                                 onMoved: {
                                     root.player.position = value * root.player.length
-                                    lyricsComp.restartLyrics()
+                                    // No lyrics refetch on seek: the sync clock
+                                    // re-anchors from the new position via
+                                    // LyricsService's onPositionChanged. (The
+                                    // old lyricsComp.restartLyrics() call also
+                                    // threw - Lyrics has no such function.)
                                 }
                             }
                         }
@@ -196,7 +200,7 @@ Item {
                                 wavy: root.player?.isPlaying
                                 highlightColor: root.blendedColors.colPrimary
                                 trackColor: root.blendedColors.colSecondaryContainer
-                                value: root.player?.position / root.player?.length
+                                value: (root.player?.length ?? 0) > 0 ? root.player.position / root.player.length : 0
                             }
                         }
                     }

--- a/dots/.config/quickshell/imi/modules/imi/sidebarLeft/SidebarPlayerControl.qml
+++ b/dots/.config/quickshell/imi/modules/imi/sidebarLeft/SidebarPlayerControl.qml
@@ -1,4 +1,5 @@
 pragma ComponentBehavior: Bound
+import qs
 import qs.modules.common
 import qs.modules.common.models
 import qs.modules.common.widgets
@@ -25,65 +26,32 @@ Item {
     // Falls back to a YouTube thumbnail when a browser player gives no
     // art (empty mpris:artUrl) but xesam:url is a watch link.
     property var artUrl: MediaArt.resolve(player?.trackArtUrl ?? "", player?.metadata)
-    property string artDownloadLocation: Directories.coverArt
-    property string artFileName: Qt.md5(artUrl)
-    property string artFilePath: `${artDownloadLocation}/${artFileName}`
+    MediaArtSource {
+        id: artSource
+        artUrl: root.artUrl
+    }
+    readonly property string displayedArtFilePath: artSource.displayedArtFilePath
+    readonly property bool downloaded: artSource.downloaded
     property color artDominantColor: Config.options.sidebar.media.artColors
         ? ColorUtils.mix(
-            (colorQuantizer?.colors[0] ?? Appearance.colors.colPrimary),
+            (artSource.colors[0] ?? Appearance.colors.colPrimary),
             Appearance.colors.colPrimaryContainer,
             0.8
           )
         : Appearance.colors.colPrimaryContainer
-    property bool downloaded: false
-    property list<real> visualizerPoints: []
-    property real maxVisualizerValue: 1000
-    property int visualizerSmoothing: 2
-    property real radius
 
-    property string displayedArtFilePath: root.downloaded ? Qt.resolvedUrl(artFilePath) : ""
-
+    // Poke the player for a fresh position only while this control can be seen.
+    // The left sidebar is built once and never destroyed, so without the open
+    // gate this fired every updateInterval for the whole session whenever any
+    // player was playing, re-evaluating position bindings nothing was showing.
     Timer {
-        running: root.player?.playbackState == MprisPlaybackState.Playing
+        running: GlobalStates.sidebarLeftOpen
+            && root.player?.playbackState == MprisPlaybackState.Playing
         interval: Config.options.resources.updateInterval
         repeat: true
-        onTriggered: root.player?.positionChanged()  
+        onTriggered: root.player?.positionChanged()
     }
 
-    onArtFilePathChanged: {
-        if (!root.artUrl || root.artUrl.length == 0) {
-            // Never assign artDominantColor imperatively: it has a declarative
-            // binding (to the quantizer, gated by the artColors option), and a
-            // write here destroyed it, freezing the tint at a grey after the
-            // first art-less moment - which is why the sidebar showed no cover
-            // colour until a full restart caught art already present. Clearing
-            // `downloaded` empties the quantizer source, and the binding falls
-            // back to the theme colour on its own.
-            root.downloaded = false
-            return
-        }
-        coverArtDownloader.targetFile = root.artUrl
-        coverArtDownloader.artFilePath = root.artFilePath
-        root.downloaded = false
-        coverArtDownloader.running = true
-    }
-
-    Process {
-        id: coverArtDownloader
-        property string targetFile: root.artUrl
-        property string artFilePath: root.artFilePath
-        // Positional args ($1/$2), never spliced into the script body: targetFile
-        // is MPRIS artUrl (attacker-controllable), so interpolation was injectable.
-        command: ["bash", "-c", '[ -f "$1" ] || curl -sSL "$2" -o "$1"', "bash", artFilePath, targetFile]
-        onExited: (exitCode, exitStatus) => { root.downloaded = true }
-    }
-
-    ColorQuantizer {
-        id: colorQuantizer
-        source: root.displayedArtFilePath
-        depth: 0
-        rescaleSize: 1
-    }
 
     property QtObject blendedColors: AdaptedMaterialScheme {
         color: artDominantColor
@@ -290,9 +258,11 @@ Item {
                             highlightColor: blendedColors.colPrimary
                             trackColor: blendedColors.colSecondaryContainer
                             handleColor: blendedColors.colPrimary
-                            value: (root?.player?.position ?? 0) / (root?.player?.length ?? 1)
-                            onMoved: {root.player.position = value * root.player.length
-                                lyricsComp.restartLyrics()
+                            value: (root.player?.length ?? 0) > 0 ? root.player.position / root.player.length : 0
+                            onMoved: {
+                                // No lyrics refetch on seek: LyricsService
+                                // re-anchors from the new position on its own.
+                                root.player.position = value * root.player.length
                             }
                         }
                     }
@@ -309,7 +279,7 @@ Item {
                             wavy: root.player?.isPlaying ?? false  
                             highlightColor: blendedColors.colPrimary
                             trackColor: blendedColors.colSecondaryContainer
-                            value: (root.player?.position ?? 0) / (root.player?.length ?? 1)
+                            value: (root.player?.length ?? 0) > 0 ? root.player.position / root.player.length : 0
                         }
                     }
                 }

--- a/dots/.config/quickshell/imi/scripts/lyrics/lyrics.py
+++ b/dots/.config/quickshell/imi/scripts/lyrics/lyrics.py
@@ -33,11 +33,80 @@ Output: one JSON line - {"ok": true, "lines": [{"t": sec, "text": "...",
 when the source carried word-level timing (enhanced LRC inline stamps, TTML
 span timings); the shell synthesizes an even sweep otherwise.
 """
+import glob
+import hashlib
 import json
+import os
 import re
 import sys
+import time
 import urllib.parse
 import urllib.request
+
+
+# On-disk cache. Every fetch otherwise re-walks up to five providers - each a
+# urlopen at timeout=12, plus Glassy's CDP poll (GLASSY_RENDER_WAIT = 9) - so a
+# replay of the same song, a sidebar reopen, or any spurious refetch re-hits
+# the whole network chain. Cache the final answer keyed by the NORMALIZED
+# (title, artist, int duration), the same inputs that determine the result.
+# Positive answers are cached long (lyrics do not change); a not_found is cached
+# briefly, so a later-added lyric is found on the next play rather than masked
+# for a month. Bounded by entry count, oldest pruned first.
+CACHE_MAX_ENTRIES = 512
+POSITIVE_TTL = 30 * 24 * 3600
+NEGATIVE_TTL = 6 * 3600
+
+
+def cache_dir():
+    base = os.environ.get("XDG_CACHE_HOME") or os.path.expanduser("~/.cache")
+    return os.path.join(base, "immaterial-impulse", "lyrics")
+
+
+def cache_key(title, artist, duration):
+    raw = "\x1f".join([(title or "").casefold(), (artist or "").casefold(),
+                       str(int(duration or 0))])
+    return hashlib.sha1(raw.encode("utf-8")).hexdigest()
+
+
+def cache_get(key):
+    try:
+        with open(os.path.join(cache_dir(), key + ".json")) as f:
+            entry = json.load(f)
+    except (OSError, ValueError):
+        return None
+    if not isinstance(entry, dict):
+        return None
+    result = entry.get("result")
+    ttl = NEGATIVE_TTL if result == "not_found" else POSITIVE_TTL
+    if time.time() - entry.get("ts", 0) > ttl:
+        return None
+    return result
+
+
+def cache_put(key, result):
+    directory = cache_dir()
+    try:
+        os.makedirs(directory, exist_ok=True)
+        tmp = os.path.join(directory, key + ".json.tmp")
+        with open(tmp, "w") as f:
+            json.dump({"ts": time.time(), "result": result}, f)
+        os.replace(tmp, os.path.join(directory, key + ".json"))
+        _prune(directory)
+    except OSError:
+        pass
+
+
+def _prune(directory):
+    try:
+        files = sorted(glob.glob(os.path.join(directory, "*.json")),
+                       key=os.path.getmtime)
+    except OSError:
+        return
+    for path in files[:-CACHE_MAX_ENTRIES]:
+        try:
+            os.remove(path)
+        except OSError:
+            pass
 
 
 # A browser-ish UA: several of these hosts (LyricsPlus behind Cloudflare)
@@ -77,8 +146,14 @@ def parse_lrc_rich(text):
                 if fragment:
                     words.append((int(stamp.group(1)) * 60 + float(stamp.group(2)), fragment))
             words = words or None
-        for stamp in re.finditer(r"\[(\d+):(\d+(?:\.\d+)?)\]", raw):
-            lines.append((int(stamp.group(1)) * 60 + float(stamp.group(2)), words_text, words))
+        # The inline word stamps are absolute to this line's FIRST timestamp,
+        # so a line repeated at several timestamps ([t1][t2] text) can only
+        # carry its words at the first; attaching the same array to the others
+        # mis-times them. A repeated line keeps its text, drops its words.
+        line_stamps = list(re.finditer(r"\[(\d+):(\d+(?:\.\d+)?)\]", raw))
+        line_words = words if len(line_stamps) == 1 else None
+        for stamp in line_stamps:
+            lines.append((int(stamp.group(1)) * 60 + float(stamp.group(2)), words_text, line_words))
     lines.sort(key=lambda entry: entry[0])
     return lines
 
@@ -403,6 +478,16 @@ def main():
         duration = float(sys.argv[3]) if len(sys.argv) > 3 else 0.0
     except ValueError:
         duration = 0.0
+    use_cache = not os.environ.get("IMI_LYRICS_NO_CACHE")
+    key = cache_key(title, artist, duration)
+    if use_cache:
+        cached = cache_get(key)
+        if cached == "not_found":
+            print("not_found")
+            return 0
+        if isinstance(cached, dict):
+            print(json.dumps(cached))
+            return 0
     PROVIDER_NAMES = {
         "from_glassy": "Glassy", "from_lyricsplus": "LyricsPlus",
         "from_cubey": "BetterLyrics", "from_unison": "Unison", "from_lrclib": "LRCLIB",
@@ -424,8 +509,13 @@ def main():
                 if translated:
                     entry["translated"] = translated
                 emitted.append(entry)
-            print(json.dumps({"ok": True, "source": source, "lines": emitted}))
+            payload = {"ok": True, "source": source, "lines": emitted}
+            if use_cache:
+                cache_put(key, payload)
+            print(json.dumps(payload))
             return 0
+    if use_cache:
+        cache_put(key, "not_found")
     print("not_found")
     return 0
 

--- a/dots/.config/quickshell/imi/scripts/lyrics/lyrics.py
+++ b/dots/.config/quickshell/imi/scripts/lyrics/lyrics.py
@@ -116,11 +116,22 @@ UA = ("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
       "(KHTML, like Gecko) Chrome/128.0 Safari/537.36")
 
 
+# How many network providers ANSWERED this run - a parsed response, even an
+# error-shape one. The negative cache rides on it: a miss with zero answers is
+# an offline moment / DNS hiccup, not a real "no lyrics exist", and caching it
+# as not_found would hide the song's lyrics for NEGATIVE_TTL after the network
+# comes back. Only a miss where something answered is a cacheable miss.
+net_answers = 0
+
+
 def http_json(url):
+    global net_answers
     try:
         request = urllib.request.Request(url, headers={"User-Agent": UA})
         with urllib.request.urlopen(request, timeout=12) as response:
-            return json.loads(response.read().decode("utf-8", "replace"))
+            data = json.loads(response.read().decode("utf-8", "replace"))
+        net_answers += 1
+        return data
     except Exception:
         return None
 
@@ -317,11 +328,13 @@ def from_cubey(title, artist, duration):
     request = urllib.request.Request(CUBEY_URL, data=data, headers={
         "Authorization": f"Bearer {token}",
         "Content-Type": "application/x-www-form-urlencoded"})
+    global net_answers
     try:
         with urllib.request.urlopen(request, timeout=12) as response:
             payload = json.loads(response.read().decode("utf-8", "replace"))
     except Exception:
         return None
+    net_answers += 1
     return parse_cubey(payload)
 
 
@@ -514,7 +527,11 @@ def main():
                 cache_put(key, payload)
             print(json.dumps(payload))
             return 0
-    if use_cache:
+    # Negative-cache only a REAL miss - at least one provider answered and had
+    # nothing. Zero answers means the network was unreachable (offline, DNS,
+    # a blanket 403): caching that as not_found would keep showing "no lyrics"
+    # for hours after connectivity returns.
+    if use_cache and net_answers > 0:
         cache_put(key, "not_found")
     print("not_found")
     return 0

--- a/dots/.config/quickshell/imi/services/LyricsService.qml
+++ b/dots/.config/quickshell/imi/services/LyricsService.qml
@@ -212,12 +212,37 @@ Singleton {
         }
     }
 
+    // The fetch can hang if several providers stall (5 x 12s + Glassy's poll);
+    // this bounds the spinner and kills the proc so a later fetch is not
+    // blocked behind a corpse.
+    readonly property int fetchTimeoutMs: 20000
+    Timer {
+        id: fetchWatchdog
+        interval: root.fetchTimeoutMs
+        onTriggered: {
+            if (lyricsProc.running) {
+                root._ignoreNextExit = true
+                lyricsProc.running = false
+            }
+            if (root.status === "loading")
+                root.status = "not_found"
+        }
+    }
+
+    // A deliberate kill (restart or watchdog) fires the OLD run's onExited
+    // asynchronously, AFTER the new fetch has set status back to "loading" -
+    // so an unguarded handler flips the fresh load to not_found. This absorbs
+    // exactly one such kill.
+    property bool _ignoreNextExit: false
+
     Process {
         id: lyricsProc
         running: false
         // A fetch that dies without printing - a network failure, a python
         // stack trace - used to strand the view on "loading" forever.
         onExited: (exitCode, exitStatus) => {
+            fetchWatchdog.stop()
+            if (root._ignoreNextExit) { root._ignoreNextExit = false; return }
             if (root.status === "loading")
                 root.status = "not_found"
         }
@@ -227,6 +252,7 @@ Singleton {
         stdout: SplitParser {
             onRead: data => {
                 const trimmed = data.trim()
+                fetchWatchdog.stop()
                 if (trimmed === "not_found") { root.status = "not_found"; return }
                 if (trimmed === "no_info")   { root.status = "no_info";   return }
 
@@ -258,9 +284,51 @@ Singleton {
         }
     }
 
-    function restartLyrics() {
+    // The last (title, artist, duration) a fetch was launched for. A repeat of
+    // the same key - metadata churn, a player re-selection, a sidebar reopen
+    // on the same song - reuses what is loaded instead of re-fetching.
+    property string lastKey: ""
+
+    // Metadata lands field by field (title before artist) and a track change
+    // fires several signals at once; each would otherwise launch, kill, and
+    // relaunch the fetcher. Debounce collapses the burst into one fetch.
+    Timer {
+        id: restartDebounce
+        interval: 200
+        onTriggered: root.doRestart()
+    }
+    function restartLyrics() { restartDebounce.restart() }
+
+    function doRestart() {
+        const title    = root.activePlayer?.trackTitle  ?? ""
+        const artist   = root.activePlayer?.trackArtist ?? ""
+        const duration = root.activePlayer?.length       ?? 0
+        const key = title + "" + artist + "" + Math.floor(duration)
+
+        if (!root.lyricsWanted) {
+            // Not shown: stop the fetch and forget the key, so reopening
+            // re-fetches - which the python-side disk cache serves instantly
+            // for a song already fetched.
+            if (lyricsProc.running) { root._ignoreNextExit = true; lyricsProc.running = false }
+            fetchWatchdog.stop()
+            root.lastKey = ""
+            root.source = ""
+            root.lyricsLines = []
+            root.activeIndex = -1
+            root.slots = []
+            root.status = "idle"
+            return
+        }
+
+        // Same track already loaded or in flight: keep it, do not relaunch.
+        if (key === root.lastKey
+                && (root.status === "loading"
+                    || (root.status === "ok" && root.lyricsLines.length > 0)))
+            return
+
+        root.lastKey = key
         root.source = ""
-        lyricsProc.running = false
+        if (lyricsProc.running) { root._ignoreNextExit = true; lyricsProc.running = false }
         root.lyricsLines = []
         root.activeIndex = -1
         root.slots = []
@@ -275,17 +343,6 @@ Singleton {
         root.lastPositionWall = 0
         root.lastKnownPosition = root.activePlayer?.position ?? 0
 
-        if (!root.lyricsWanted) {
-            root.status = "idle"
-            return
-        }
-
-        root.status = "loading"
-
-        const title    = root.activePlayer?.trackTitle  ?? ""
-        const artist   = root.activePlayer?.trackArtist ?? ""
-        const duration = root.activePlayer?.length       ?? 0
-
         // Title only: a browser/YouTube player often reports an empty
         // artist with everything packed in the title ("Sleep Token -
         // Provider - YouTube"), and scripts/lyrics/lyrics.py's normalizer
@@ -293,12 +350,14 @@ Singleton {
         // first. An unresolvable title still comes back not_found.
         if (!title) { root.status = "no_info"; return }
 
+        root.status = "loading"
         lyricsProc.command = [
             "python3",
             `${Directories.scriptPath}/lyrics/lyrics.py`,
             title, artist, String(Math.floor(duration))
         ]
         lyricsProc.running = true
+        fetchWatchdog.restart()
     }
 
     Connections {
@@ -307,13 +366,5 @@ Singleton {
         function onTrackArtistChanged() { root.restartLyrics() }
     }
 
-    onLyricsWantedChanged: {
-        if (root.lyricsWanted) root.restartLyrics()
-        else {
-            lyricsProc.running = false
-            root.lyricsLines = []
-            root.slots = []
-            root.status = "idle"
-        }
-    }
+    onLyricsWantedChanged: root.restartLyrics()
 }

--- a/dots/.config/quickshell/imi/tests/test_lyrics_providers.py
+++ b/dots/.config/quickshell/imi/tests/test_lyrics_providers.py
@@ -509,6 +509,61 @@ class CacheTests(unittest.TestCase):
                        "result": "not_found"}, f)
         self.assertIsNone(lyrics.cache_get(key))
 
+    def test_network_failure_is_not_cached_as_not_found(self):
+        # An offline moment walks every provider to None exactly like a real
+        # miss - but caching THAT as not_found hides lyrics for six hours
+        # after the Wi-Fi comes back. Only a miss where at least one provider
+        # actually answered may be negative-cached.
+        import io, contextlib, sys as _sys, os
+        orig_http, orig_glassy = lyrics.http_json, lyrics.from_glassy
+        lyrics.from_glassy = lambda *a, **k: None
+        argv = _sys.argv
+        try:
+            # Nothing reachable: http_json fails everywhere (never records an
+            # answer). not_found is printed but NOT cached.
+            lyrics.net_answers = 0
+            lyrics.http_json = lambda url: None
+            _sys.argv = ["lyrics.py", "Offline", "Song", "100"]
+            out = io.StringIO()
+            with contextlib.redirect_stdout(out):
+                lyrics.main()
+            self.assertEqual(out.getvalue().strip(), "not_found")
+            self.assertIsNone(
+                lyrics.cache_get(lyrics.cache_key("Offline", "Song", 100)),
+                "an unreachable network must not poison the negative cache")
+
+            # A provider ANSWERED and had nothing: that is a real miss, cached.
+            def answering(url):
+                lyrics.net_answers += 1
+                return {"success": False, "error": "Lyrics not found"} if "unison" in url else None
+            lyrics.net_answers = 0
+            lyrics.http_json = answering
+            _sys.argv = ["lyrics.py", "Offline", "Song", "100"]
+            with contextlib.redirect_stdout(io.StringIO()):
+                lyrics.main()
+            self.assertEqual(
+                lyrics.cache_get(lyrics.cache_key("Offline", "Song", 100)),
+                "not_found")
+        finally:
+            lyrics.http_json, lyrics.from_glassy = orig_http, orig_glassy
+            _sys.argv = argv
+
+    def test_real_http_json_records_an_answer(self):
+        # The seam the negative-cache guard rides on: a parsed response bumps
+        # net_answers, an unreachable host does not.
+        import unittest.mock as mock
+        lyrics.net_answers = 0
+        fake_response = mock.MagicMock()
+        fake_response.read.return_value = b'{"ok": 1}'
+        fake_response.__enter__ = lambda s: fake_response
+        fake_response.__exit__ = lambda s, *a: False
+        with mock.patch.object(lyrics.urllib.request, "urlopen", return_value=fake_response):
+            self.assertEqual(lyrics.http_json("http://x"), {"ok": 1})
+        self.assertEqual(lyrics.net_answers, 1)
+        with mock.patch.object(lyrics.urllib.request, "urlopen", side_effect=OSError("no route")):
+            self.assertIsNone(lyrics.http_json("http://x"))
+        self.assertEqual(lyrics.net_answers, 1)
+
     def test_main_serves_the_second_call_from_cache(self):
         import io, contextlib, sys as _sys
         calls = {"n": 0}

--- a/dots/.config/quickshell/imi/tests/test_lyrics_providers.py
+++ b/dots/.config/quickshell/imi/tests/test_lyrics_providers.py
@@ -106,6 +106,16 @@ class WordTimingTests(unittest.TestCase):
     def test_plain_lrc_has_no_words(self):
         self.assertEqual(lyrics.parse_lrc_rich("[00:10.0]hello there")[0][2], None)
 
+    def test_multi_stamp_line_drops_its_words(self):
+        # A line repeated at two timestamps carries ONE set of inline word
+        # stamps, absolute to the first occurrence; attaching them to the
+        # second position mis-times its karaoke. Both positions keep the
+        # line-level text, neither keeps the words.
+        rich = lyrics.parse_lrc_rich("[00:10.0][00:40.0]<00:10.0>hello <00:11.5>there")
+        self.assertEqual([r[0] for r in rich], [10.0, 40.0])
+        self.assertEqual([r[1] for r in rich], ["hello there", "hello there"])
+        self.assertTrue(all(r[2] is None for r in rich))
+
     def test_ttml_span_words_are_extracted(self):
         doc = ('<tt xmlns="http://www.w3.org/ns/ttml"><body><div>'
                '<p begin="10s"><span begin="10s">hello</span> '
@@ -115,7 +125,9 @@ class WordTimingTests(unittest.TestCase):
         self.assertEqual(words, [(10.0, "hello"), (11.5, "there")])
 
     def test_the_wire_is_json(self):
-        import io, contextlib, sys as _sys
+        import io, contextlib, sys as _sys, os
+        os.environ["IMI_LYRICS_NO_CACHE"] = "1"  # exercise the fetch, not the cache
+        self.addCleanup(lambda: os.environ.pop("IMI_LYRICS_NO_CACHE", None))
         argv, _sys.argv = _sys.argv, ["lyrics.py", "T", "A", "100"]
         orig = lyrics.http_json
         orig_glassy = lyrics.from_glassy
@@ -439,6 +451,91 @@ class LyricsPlusDurationRetryTests(unittest.TestCase):
         self.assertEqual(len(self.calls), 2)  # tried with duration, then without
         self.assertIn("duration", self.calls[0])
         self.assertNotIn("duration", self.calls[1])
+
+
+class CacheTests(unittest.TestCase):
+    """The on-disk cache: a repeat of the same track must not re-walk the
+    network, and a not_found must not re-walk it for a while either."""
+
+    def setUp(self):
+        import tempfile, os
+        self.tmp = tempfile.mkdtemp()
+        self.env = os.environ.get("XDG_CACHE_HOME")
+        os.environ["XDG_CACHE_HOME"] = self.tmp
+
+    def tearDown(self):
+        import os, shutil
+        if self.env is None:
+            os.environ.pop("XDG_CACHE_HOME", None)
+        else:
+            os.environ["XDG_CACHE_HOME"] = self.env
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_positive_roundtrip(self):
+        key = lyrics.cache_key("Provider", "Sleep Token", 222)
+        payload = {"ok": True, "source": "LRCLIB", "lines": [{"t": 1.0, "text": "hi"}]}
+        lyrics.cache_put(key, payload)
+        self.assertEqual(lyrics.cache_get(key), payload)
+
+    def test_negative_roundtrip(self):
+        key = lyrics.cache_key("Nope", "Nobody", 100)
+        lyrics.cache_put(key, "not_found")
+        self.assertEqual(lyrics.cache_get(key), "not_found")
+
+    def test_key_is_case_and_duration_stable_but_track_specific(self):
+        self.assertEqual(lyrics.cache_key("Provider", "Sleep Token", 222),
+                         lyrics.cache_key("provider", "sleep token", 222))
+        self.assertNotEqual(lyrics.cache_key("Provider", "Sleep Token", 222),
+                            lyrics.cache_key("Provider", "Sleep Token", 250))
+        self.assertNotEqual(lyrics.cache_key("A", "X", 100),
+                            lyrics.cache_key("B", "X", 100))
+
+    def test_expired_positive_is_a_miss(self):
+        import os, json, time
+        key = lyrics.cache_key("Old", "Song", 100)
+        path = os.path.join(lyrics.cache_dir(), key + ".json")
+        os.makedirs(lyrics.cache_dir(), exist_ok=True)
+        with open(path, "w") as f:
+            json.dump({"ts": time.time() - lyrics.POSITIVE_TTL - 10,
+                       "result": {"ok": True, "lines": []}}, f)
+        self.assertIsNone(lyrics.cache_get(key))
+
+    def test_expired_negative_is_a_miss(self):
+        import os, json, time
+        key = lyrics.cache_key("Old", "Miss", 100)
+        os.makedirs(lyrics.cache_dir(), exist_ok=True)
+        with open(os.path.join(lyrics.cache_dir(), key + ".json"), "w") as f:
+            json.dump({"ts": time.time() - lyrics.NEGATIVE_TTL - 10,
+                       "result": "not_found"}, f)
+        self.assertIsNone(lyrics.cache_get(key))
+
+    def test_main_serves_the_second_call_from_cache(self):
+        import io, contextlib, sys as _sys
+        calls = {"n": 0}
+        def counting(url):
+            calls["n"] += 1
+            return {"lyrics": "[00:01.0]hi", "format": "lrc"} if "unison" in url else None
+        orig_http, orig_glassy = lyrics.http_json, lyrics.from_glassy
+        lyrics.from_glassy = lambda *a, **k: None
+        lyrics.http_json = counting
+        argv = _sys.argv
+        try:
+            for _ in range(2):
+                _sys.argv = ["lyrics.py", "Provider", "Sleep Token", "222"]
+                out = io.StringIO()
+                with contextlib.redirect_stdout(out):
+                    lyrics.main()
+                self.assertTrue(json.loads(out.getvalue())["ok"])
+            first_call_count = calls["n"]
+            # A third identical call still adds nothing: the network ran once.
+            _sys.argv = ["lyrics.py", "Provider", "Sleep Token", "222"]
+            with contextlib.redirect_stdout(io.StringIO()):
+                lyrics.main()
+            self.assertEqual(calls["n"], first_call_count)
+            self.assertGreater(first_call_count, 0)
+        finally:
+            lyrics.http_json, lyrics.from_glassy = orig_http, orig_glassy
+            _sys.argv = argv
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
A review of the media sidebar and the lyrics feature, then the fixes it surfaced.

## Lyrics — fetching (the headline)
- **On-disk cache.** `lyrics.py` re-walked up to five providers (each a 12s urlopen, plus Glassy's ~9s CDP poll) on every fetch. It now caches the answer under `$XDG_CACHE_HOME/immaterial-impulse/lyrics` keyed by normalized (title, artist, duration) — positive 30 days, `not_found` 6 hours, bounded to 512 entries. A replay or a sidebar reopen is now instant.
- **Debounce + dedup.** Metadata lands field by field and a track change fires several signals; each launched, killed, and relaunched the fetcher. The restart is debounced to one fetch, deduped against the last key.
- **Watchdog.** A hung fetch ends after 20s instead of spinning the spinner forever.

## Lyrics — bugs
- Seeking called `lyricsComp.restartLyrics()`, which doesn't exist on `Lyrics` — a `TypeError` every drag; and re-fetching on a seek is wrong (the sync clock re-anchors itself). Removed.
- A deliberate fetch-kill's late `onExited` flipped the fresh load to `not_found` — the "spinner → no lyrics" flicker on every track change. Guarded.
- A `Lyrics` view now claims the service's single `overridePlayer` only while visible and releases it on destruction, so a hidden/gone view doesn't strand the service on a stale player.
- An enhanced-LRC line repeated at several timestamps mis-timed its karaoke (one word-stamp set, absolute to the first position, attached to all). Repeated lines drop their words.

## Media sidebar / controls
- **One shared `MediaArtSource`** replaces the cover-art pipeline copy-pasted across four surfaces — which had drifted: the sidebar lacked `curl -4` (IPv6 stall) and the `file://` fast-path. 
- **DockMedia tint froze grey** after an art-less track (imperative write to a bound property — the regression its siblings warn against). Fixed by the shared source.
- **Progress bars divided by zero/absent length** (NaN with no player, Infinity on a live stream) into the slider value; guarded everywhere.
- **Perf:** the left sidebar's position poll ran all session while hidden (gated on `sidebarLeftOpen`); DockMedia's blur decoded art full-res (bounded to the card); `WaveVisualizer` reallocated its buffer every paint (reused).
- Dead code removed; two unguarded player derefs made optional.

New/updated tests: the lyrics cache (roundtrip, TTL, main-served-from-cache), the multi-stamp fix, all against stubbed IO. Full suite green; shell loads clean.

Note on scope: two review findings were deliberately NOT taken — `desktopWidgetLyricsActive`/`slots` are pinned by `test_lyrics_widget_contract.py` as intentional API, and routing transport through `MprisController` would break the sidebar's per-player control.

Docs: updated AGENT.md §"two names for one thing" (MediaArtSource is the one cover-art pipeline).
Changelog: updated