### PR TITLE
chore(install): pin Wallpaper Engine prebuilt to v0.3.0 (engine settings surface)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ own repo; the installer pins which revision it builds.
 
 ## [Unreleased]
 
+### Changed
+- **Wallpaper Engine renderer pinned to qs-wallpaperengine v0.3.0.** The
+  installer now fetches the 0.3.0 prebuilt, which is the renderer the new
+  selector sidebar talks to: volume, the audio-reactive recorder,
+  mouse/parallax/particles, per-wallpaper properties, the live Fill crop
+  picker with the real-scene thumbnail, and the Quality dial all appear once
+  it is installed (Settings > Update Dots). On the previous renderer those
+  controls stay hidden.
+
 ## [1.0.0-rc-13] — 2026-09-04
 
 ### Added

--- a/sdata/subcmd-install/4.wallpaperengine.sh
+++ b/sdata/subcmd-install/4.wallpaperengine.sh
@@ -41,7 +41,7 @@ set -euo pipefail
 [[ "${INSTALL_WE:-0}" == "1" ]] || { echo "[ImI] Wallpaper Engine: skipped."; exit 0; }
 
 WE_REPO="${WE_REPO:-https://github.com/XephyLon/qs-wallpaperengine}"
-WE_REF="${WE_REF:-v0.2.6}"                       # release tag, so installs take the PREBUILT fast path; any checksum /
+WE_REF="${WE_REF:-v0.3.0}"                       # release tag, so installs take the PREBUILT fast path; any checksum /
                                                  # arch / Qt-too-old / smoke-test failure falls back to a source build, as
                                                  # does a tag whose release has not published yet. Whatever this points at
                                                  # MUST be >= 40427cf, the commit that added


### PR DESCRIPTION
Bumps `WE_REF` v0.2.6 → v0.3.0.

## Why

[qs-wallpaperengine v0.3.0](https://github.com/XephyLon/qs-wallpaperengine/releases/tag/v0.3.0) (published 2026-09-04 12:22Z, assets: tarball, `manifest.json`, `SHA256SUMS`, `build-env.txt`; `qt_min` 6.11.2-3, x86_64) is the engine settings surface that #351's selector sidebar binds to: `volume`, `audioProcessing`, `mouseDisabled`/`parallaxDisabled`/`particlesDisabled`, `properties`, `focusX`/`focusY` + `contentWidth`/`contentHeight`, `requestSceneGrab`, `renderScale`. rc-13 shipped the shell side with every read guarded (`"x" in root`, `WallpaperEngineFeatures`), so on the 0.2.6 renderer those controls are hidden. This pin is what turns them on; no shell code changes.

Verified before the tag: the 0.3.0 module rebuilt and run under a headless GL weston, first frame rendered, `contentWidth/Height` published (5120x1440 for a 32:9 scene), scene grab written at the authored aspect. The 0.3.0 CI run built, packaged, smoke-tested and published in one pass.

## Notes

- Installs on this pin take the prebuilt fast path; a checksum / arch / Qt-too-old / smoke failure falls back to the source build as before.
- Verify through Settings > Update Dots, not a terminal invocation.

Docs: not needed — version pin bump; AGENT.md's "WE_REF pins the renderer" entry already describes exactly this step, and the renderer's behaviour is documented in qs-wallpaperengine's changelog.
Changelog: updated
