### PR TITLE
perf(shell): collect the JavaScript heap every five minutes

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -223,6 +223,18 @@ a print can sit unflushed for several seconds before showing up, sometimes inter
 events in a way that looks like a stale/wrong value at first glance. If a debug print looks wrong,
 wait and re-check before concluding the code is broken.
 
+**The QML engine does not give the JavaScript heap back on its own; shell.qml collects it every
+five minutes.** The shell grew 2-3 MiB/min idle and ~9 MiB/min in use (2.6 GB in ten hours) with
+the driver, the WE module, the WE layer, GL itself (same growth on `QT_QUICK_BACKEND=software`)
+and jemalloc (in-use flat while RSS rose) all cleared by controls; the growth was QV4 chunks, and
+a shell calling `gc()` every 30 s stayed flat. Resource polling was the largest per-tick allocator
+(off: 0.3 MiB/min) but every timer-driven service contributes, so the collection is engine-wide
+and gated only by a live screen recording (one full collection is ~50 ms on the harness heap, more
+on a big one). Do not "tidy" that Timer away, and do not reach for per-service caps first when RSS
+climbs: reproduce in the nested harness (headless weston 5120x1440, fresh XDG dirs, a copy of
+config.json, `DBUS_SESSION_BUS_ADDRESS=unix:path=/nonexistent`, RSS from `/proc/<pid>/status`
+every 30 s), and a `gc()` timer in a copied tree is the first discriminator. 31655e7c4 ("perf(shell): collect the JavaScript heap every five minutes").
+
 ## External binaries the shell drives
 
 **WE_REF pins the renderer, so a `WallpaperEngineSurface` property the shell reads may not exist in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ own repo; the installer pins which revision it builds.
 
 ## [Unreleased]
 
+### Fixed
+- **Shell memory no longer grows without bound.** The shell gained two to
+  three megabytes a minute while idle and around nine while in use - 2.6 GB
+  after a ten-hour session - because the QML engine's own garbage collector
+  never gave the JavaScript heap back. The shell now runs a full collection
+  every five minutes, which holds memory flat.
+
 ## [1.0.0-rc-14] — 2026-09-05
 
 ### Changed

--- a/dots/.config/quickshell/imi/shell.qml
+++ b/dots/.config/quickshell/imi/shell.qml
@@ -19,6 +19,29 @@ ShellRoot {
 
     ReloadPopup {}
 
+    // A full JavaScript garbage collection on a fixed cadence. The engine's
+    // own incremental collector does run (14 cycles in 4 min under the nested
+    // harness), yet the shell's RSS still climbed 2-3 MiB/min idle and ~9
+    // MiB/min in use - 2.6 GB after ten hours - and all of it was QV4 heap
+    // that a forced gc() hands straight back: the same nested shell with
+    // gc() every 30 s stayed flat (-2.5 MB over 5 min). The GL driver was not
+    // involved (identical growth on the Qt Quick software backend), nor was
+    // jemalloc (in-use flat while RSS rose), nor Wallpaper Engine (off: same
+    // rate); resource polling was the biggest per-tick allocator (off: 0.3
+    // MiB/min) but every timer-driven service contributes. Five minutes bounds
+    // the growth to tens of MB; one full collection measured ~50 ms on the harness's heap (a
+    // bigger live heap pauses longer), which is why it stands down while a
+    // screen recording is running.
+    Timer {
+        interval: 5 * 60 * 1000
+        running: true
+        repeat: true
+        onTriggered: {
+            if (Persistent.states?.record?.enable) return;
+            gc();
+        }
+    }
+
     // Always-on host for plugin `panel` entry points; also keeps the
     // ScreenshotEvents IPC handler alive.
     PluginPanelHost {}

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -1038,6 +1038,15 @@ if ! python3 "$SCRIPT_DIR/test_settings_row_grammar.py"; then
     exit 1
 fi
 
+# The shell's JavaScript heap is collected on a fixed cadence (shell.qml).
+# Without it the shell grew 2-3 MiB/min idle, 2.6 GB in ten hours; the pin
+# keeps the timer from being tidied away.
+echo "Running heap janitor test..."
+if ! python3 "$SCRIPT_DIR/test_heap_janitor.py"; then
+    echo "Heap janitor test failed."
+    exit 1
+fi
+
 # Stage 8 of Edit Mode: the bar and the dock edited in place. What it pins is
 # silent on screen - a suspension that touches `visible` destroys a layer
 # surface, and an affordance wired into one bar orientation and not the other

--- a/dots/.config/quickshell/imi/tests/test_heap_janitor.py
+++ b/dots/.config/quickshell/imi/tests/test_heap_janitor.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""The shell collects its JavaScript heap on a fixed cadence.
+
+QV4's incremental collector ran, and the shell still grew 2-3 MiB/min idle
+(2.6 GB after ten hours); a forced gc() reclaimed all of it and a shell
+calling it every 30 s stayed flat. shell.qml therefore runs gc() from a
+repeating Timer. This pins that the timer exists, repeats, and fires between
+once a minute and once a quarter hour - often enough to bound the growth to
+tens of MB, rarely enough that its pause stays invisible.
+"""
+import re
+import unittest
+from pathlib import Path
+
+SHELL = Path(__file__).resolve().parents[1] / "shell.qml"
+
+
+class HeapJanitor(unittest.TestCase):
+    def setUp(self):
+        self.src = SHELL.read_text(encoding="utf-8")
+
+    def _timer(self):
+        # Top-level children of ShellRoot close at four-space indent, so a
+        # handler block inside the timer does not end the match early.
+        for m in re.finditer(r"^    Timer\s*\{(.*?)^    \}", self.src, re.S | re.M):
+            body = m.group(1)
+            if re.search(r"onTriggered:\s*(\{[^}]*)?\bgc\(\)", body):
+                return body
+        self.fail("shell.qml has no Timer whose onTriggered calls gc()")
+
+    def test_gc_timer_exists_and_repeats(self):
+        body = self._timer()
+        self.assertRegex(body, r"running:\s*true")
+        self.assertRegex(body, r"repeat:\s*true")
+
+    def test_cadence_is_between_one_and_fifteen_minutes(self):
+        body = self._timer()
+        m = re.search(r"interval:\s*([0-9*\s]+)", body)
+        self.assertIsNotNone(m, "interval must be a literal expression")
+        ms = eval(m.group(1).strip(), {"__builtins__": {}}, {})  # digits and * only
+        self.assertGreaterEqual(ms, 60_000)
+        self.assertLessEqual(ms, 15 * 60_000)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

The shell's RSS grew 2-3 MiB/min while idle and ~9 MiB/min in use: 2.6 GB after a ten-hour session, 3.1 GB by the twelfth hour. Every candidate was cleared by a control rather than by reasoning, all on this machine, 2026-09-06:

| Control | Result |
|---|---|
| Stock `eglgears_wayland` on the live Hyprland (patched egl-wayland2 still installed) | flat for 2 min |
| Wallpaper Engine module alone in headless weston, user's project at 5120x1440 | -108 kB over 3 min |
| Full shell nested, WE layer off | same growth |
| Full shell nested on `QT_QUICK_BACKEND=software` (no GL driver loaded) | same growth, 2.5 MiB/min |
| jemalloc `prof` in-use across a steady-state window | -2 MB while RSS rose 3 MB |
| `resources.updateInterval` effectively off | 2.5 -> 0.3 MiB/min |
| `bar.privacyIndicator.pollInterval` effectively off | no change |
| Copied tree with `Timer { gc() }` every 30 s | flat, -2.5 MB over 5 min |
| Same, every 5 min | +5.7 MB before the collection, -4.2 MB right after, flat afterwards |

What grew was the QV4 heap - 64 KiB chunks mmap'd into one contiguous region, the single VMA that kept growing in the live process - and the engine's incremental collector, which does run (14 cycles in 4 min per `qt.qml.gc*` logging), never hands it back. A forced full collection does. Resource polling is the largest per-tick allocator but every timer-driven service feeds the same heap, so the fix is engine-wide: shell.qml runs `gc()` every five minutes, skipped while a screen recording is live (one full collection measured ~50 ms on the harness heap; a bigger live heap pauses longer).

`test_heap_janitor.py` pins the timer, its repeat, and a cadence between one and fifteen minutes; it fails on `main`. The AGENT.md entry under Runtime model records the evidence and the nested-harness recipe so the next RSS climb starts from a control, not a theory.

## Test plan

- `test_heap_janitor.py` passes here, fails on `main` (2 failures).
- `lint_doc_citations.py` OK.
- Full suite: 1680 passed, 0 failed, 0 skipped (`run_tests.sh` in the branch worktree, 2026-09-06 18:52-19:12).
- Live: deployed to the running shell (hot reload clean). Twelve-minute RSS watch after the reload: 2.23-2.28 GB for nine minutes with visible drops (the shell climbed monotonically before), one +700 MB minute at 19:03 from something opened on the desktop, then 2.94 -> 2.57 GB at the following collection and 2.56-2.61 GB since. Before this change the same process had climbed from 2.69 GB to 3.09 GB across the afternoon.

Docs: updated AGENT.md §Runtime model
Changelog: updated
