### PR TITLE
perf(region): write the frozen frame as PPM so the selector is not held behind a PNG encode

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -3627,6 +3627,11 @@ arrays, etc.) rather than static declarations - e.g. the plugin system in
   trusting the process's output exists or is fresh; `rm -f`-ing the target path before launching the
   process (see `TempScreenshotProcess.qml`) turns a silent stale-reuse into an honest empty-file
   failure instead.
+  The same file is written as PPM, not PNG: the overlay cannot appear before grim finishes, and
+  grim's single-threaded level-6 PNG encode was ~570 ms at 5120x1440 against ~55 ms for PPM. magick
+  inherits the input container, so `ScreenshotAction` names `png:` on both crop outputs - drop that
+  and the clipboard, the annotator and the uploader get PPM; `lint_region_selector_capture.sh`
+  pins the pair. dd19a3e7f ("perf(region): write the frozen frame as PPM so the selector is not held behind a PNG encode").
 - **An overlay `Item` placed on top of an interactive control (e.g. a decorative `Flickable`-based
   mask drawn over a `TextField`/`TextArea`) will silently eat the clicks meant to focus that
   control**, unless the overlay is `enabled: false`. `ConfigTextArea`'s `password: true` mode draws

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ own repo; the installer pins which revision it builds.
   after a ten-hour session - because the QML engine's own garbage collector
   never gave the JavaScript heap back. The shell now runs a full collection
   every five minutes, which holds memory flat.
+- **The region selector opens sooner.** The overlay waited for grim to
+  PNG-encode the whole output before it could appear - about half a second
+  on a 5120x1440 screen. The frozen frame is now written as PPM (a tenth of
+  the encode, a third of the decode); saved files, the clipboard, the
+  annotator and the uploader still receive PNG.
 
 ## [1.0.0-rc-14] — 2026-09-05
 

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/regionSelectorUtils/ScreenshotAction.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/regionSelectorUtils/ScreenshotAction.qml
@@ -36,8 +36,11 @@ Singleton {
         
         const cropBase = `magick ${shellEscape(screenshotPath)} `
             + `-crop ${rw}x${rh}+${rx}+${ry}`
-        const cropToStdout = `${cropBase} -`
-        const cropInPlace = `${cropBase} '${shellEscape(screenshotPath)}'`
+        // The frozen frame is a PPM (TempScreenshotProcess); magick would
+        // otherwise inherit that container for its outputs and hand the
+        // clipboard, the annotator and the uploader a PPM. Name PNG.
+        const cropToStdout = `${cropBase} png:-`
+        const cropInPlace = `${cropBase} png:'${shellEscape(screenshotPath)}'`
         const cleanup = `rm '${shellEscape(screenshotPath)}'`
         const slurpRegion = `${rx},${ry} ${rw}x${rh}`
         

--- a/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/regionSelectorUtils/TempScreenshotProcess.qml
+++ b/dots/.config/quickshell/imi/modules/common/plugins/designsystem/widgets/regionSelectorUtils/TempScreenshotProcess.qml
@@ -10,5 +10,13 @@ Process {
     property string screenshotDir: Directories.screenshotTemp
     required property ShellScreen screen
     property string screenshotPath: `${screenshotDir}/image-${screen.name}`
-    command: ["bash", "-c", `mkdir -p '${Functions.StringUtils.shellSingleQuoteEscape(screenshotDir)}' && grim -o '${Functions.StringUtils.shellSingleQuoteEscape(screen.name)}' '${Functions.StringUtils.shellSingleQuoteEscape(screenshotPath)}'`]
+    // The frame is written as PPM, not PNG. It is a scratch file on tmpfs that
+    // the selector shows and later crops - nobody keeps it - and grim's
+    // single-threaded PNG encode was the whole wait before the overlay could
+    // appear: at 5120x1440, level-6 PNG measured ~570 ms against ~55 ms for
+    // PPM (level-0 PNG still ~185 ms), and Qt reads the PPM back in a third
+    // of the time. Every consumer of this file goes through ScreenshotAction,
+    // which names PNG explicitly on its outputs, so nothing downstream sees
+    // the change of container.
+    command: ["bash", "-c", `mkdir -p '${Functions.StringUtils.shellSingleQuoteEscape(screenshotDir)}' && grim -t ppm -o '${Functions.StringUtils.shellSingleQuoteEscape(screen.name)}' '${Functions.StringUtils.shellSingleQuoteEscape(screenshotPath)}'`]
 }

--- a/dots/.config/quickshell/imi/tests/lint_region_selector_capture.sh
+++ b/dots/.config/quickshell/imi/tests/lint_region_selector_capture.sh
@@ -5,7 +5,7 @@
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PROJECT_ROOT="${REGION_LINT_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 TARGET="$PROJECT_ROOT/modules/imi/regionSelector/RegionSelection.qml"
 
 if grep -qP '^\s*ScreencopyView\s*\{' "$TARGET"; then
@@ -21,6 +21,20 @@ fi
 if ! grep -q 'status === Image.Ready' "$TARGET"; then
     echo "Region selector capture lint FAILED: selector must wait for the fresh image to decode" >&2
     exit 1
+fi
+
+# The frozen frame is written as PPM so the overlay is not held behind grim's
+# single-threaded PNG encode (~570 ms vs ~55 ms at 5120x1440). magick inherits
+# the input container for its outputs, so every crop ScreenshotAction emits
+# must name PNG explicitly or the clipboard, the annotator and the uploader
+# silently receive PPM. Pin both halves together.
+UTILS="$PROJECT_ROOT/modules/common/plugins/designsystem/widgets/regionSelectorUtils"
+if grep -q -- '-t ppm' "$UTILS/TempScreenshotProcess.qml"; then
+    if ! grep -q 'cropToStdout = `${cropBase} png:-`' "$UTILS/ScreenshotAction.qml" \
+       || ! grep -q "cropInPlace = \`\${cropBase} png:'" "$UTILS/ScreenshotAction.qml"; then
+        echo "Region selector capture lint FAILED: the frame is PPM, so ScreenshotAction's crops must name png: on both outputs" >&2
+        exit 1
+    fi
 fi
 
 echo "Region selector capture lint passed: preview and crop share one fresh frame"


### PR DESCRIPTION
## Summary

The region selector's overlay cannot appear before grim has written the whole output, and grim's single-threaded level-6 PNG encode was that wait. Measured on this machine at 5120x1440 (ImageMagick on an equal-sized image, the same libpng work grim does):

| frame format | encode | decode |
|---|---|---|
| PNG level 6 (before) | 567 ms | 65 ms |
| PNG level 0 | 184 ms | - |
| PPM (after) | 54 ms | 23 ms |

The frame is a scratch file on tmpfs that only the selector's preview and its crop read, so it is now PPM. ImageMagick inherits the input container for its outputs, so `ScreenshotAction` names `png:` on both crop forms: saved files, the clipboard, the annotator, tesseract, zbarimg and the uploader receive exactly what they did before. `find-regions-venv.sh` reads the file through OpenCV, which handles PPM.

`lint_region_selector_capture.sh` pins the pair (PPM frame implies `png:` outputs) and takes `REGION_LINT_ROOT` so the failure can be shown on a copy; the AGENT.md entry on `TempScreenshotProcess` records why.

## Test plan

- `lint_region_selector_capture.sh` passes here; with `png:-` removed on a copy it fails with the new message.
- `lint_doc_citations.py` OK.
- Full suite: 1680 passed, 0 failed, 0 skipped (`run_tests.sh` in the branch worktree, 2026-09-06 19:32-19:52).
- Live check after deploy (needs a real pointer, so not done by me): trigger a region snip - the overlay should come up with no visible pause - then confirm the copied image pastes as PNG and a saved screenshot opens.

Docs: updated AGENT.md §Dynamic/data-driven QML gotchas
Changelog: updated
