### PR TITLE
perf: stop spawning a second Quickshell for snip buttons and clipboard refresh

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1768,6 +1768,14 @@ Two non-obvious behaviors have bitten this codebase before and are worth knowing
   with a one-shot migration guarded by its own `migrated*` flag, as `migrateDeadParallaxSwitches`
   and `migrateSplitCheatsheetButtons` do. Motivated by 65bd7696a ("feat(cheatsheet): draw a chord as
   one keycap per key").
+- **Never spawn `qs` to call the shell's own IPC.** `Quickshell.execDetached(["qs", ..., "ipc",
+  "call", ...])` from inside the shell starts a second Quickshell - 77 ms of Qt start-up on a fast
+  machine and a fork of the shell's whole address space - to deliver one call back into the process
+  that spawned it; six buttons did this for the region selector and Hyprland's exec-once did it after
+  every clipboard store. In-process callers emit `GlobalStates.regionRequested(action)` (the selector
+  dispatches it a turn later so a caller's own surface has closed first); the clipboard is watched
+  by a resident `wl-paste --watch` in `Cliphist`. `IpcHandler`s and `GlobalShortcut`s remain for
+  callers outside the process. `lint_no_self_ipc_spawn.sh` pins it. b2a332f47 ("perf(region): request the selector in-process instead of spawning qs at ourselves").
 - **The region selector intentionally takes exclusive focus.** Dismissable panels normally close
   when `GlobalFocusGrab` is cleared, but the selector first sets
   `GlobalStates.settingsHeldForRegionSelector` so Settings can remain visible in screenshots without

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,12 @@ own repo; the installer pins which revision it builds.
   on a 5120x1440 screen. The frozen frame is now written as PPM (a tenth of
   the encode, a third of the decode); saved files, the clipboard, the
   annotator and the uploader still receive PNG.
+- **Snip buttons and clipboard history no longer launch a second shell.**
+  The bar's snip button, the Screen snip quick toggle, the recorder overlay
+  and the overview's image search each started another Quickshell process to
+  send one command back to the running shell, and every copy did the same
+  to refresh clipboard history. They now call in-process; the clipboard is
+  watched by the shell itself.
 
 ## [1.0.0-rc-14] — 2026-09-05
 

--- a/dots/.config/hypr/hyprland/execs.lua
+++ b/dots/.config/hypr/hyprland/execs.lua
@@ -21,8 +21,11 @@ hl.on("hyprland.start", function ()
 
     -- Clipboard: history
     --hl.exec_cmd("wl-paste --watch cliphist store")
-    hl.exec_cmd("wl-paste --type text --watch bash -c 'cliphist store && qs -c $qsConfig ipc call cliphistService update'")
-    hl.exec_cmd("wl-paste --type image --watch bash -c 'cliphist store && qs -c $qsConfig ipc call cliphistService update'")
+    -- The shell watches the clipboard itself (services/Cliphist.qml) and
+    -- refreshes on change; chaining `qs ... ipc call cliphistService update`
+    -- here started a second Quickshell process per copy.
+    hl.exec_cmd("wl-paste --type text --watch cliphist store")
+    hl.exec_cmd("wl-paste --type image --watch cliphist store")
 
     -- Cursor: theme/size come from the shell config (Settings > Cursor); the
     -- script's fallbacks match the values that used to be hardcoded here.

--- a/dots/.config/quickshell/imi/GlobalStates.qml
+++ b/dots/.config/quickshell/imi/GlobalStates.qml
@@ -12,6 +12,14 @@ pragma ComponentBehavior: Bound
 Singleton {
     id: root
     property bool barOpen: true
+    // Ask the region selector for an action ("screenshot", "search", "ocr",
+    // "record", "recordWithSound") from anywhere in the shell. Buttons used to
+    // do this by spawning `qs ... ipc call region <action>` at themselves: a
+    // second Quickshell process (77 ms of Qt start-up on this machine, a fork
+    // of the whole shell) to deliver one call back into this one. The
+    // selector's Scope in shell.qml listens; IPC and GlobalShortcut still work
+    // for callers outside the process.
+    signal regionRequested(string action)
     property bool crosshairOpen: false
     property bool sidebarLeftOpen: false
     // A path here opens the fullscreen image viewer on it; "" closes it.

--- a/dots/.config/quickshell/imi/modules/common/models/quickToggles/ScreenSnipToggle.qml
+++ b/dots/.config/quickshell/imi/modules/common/models/quickToggles/ScreenSnipToggle.qml
@@ -21,7 +21,7 @@ QuickToggleModel {
         interval: 300
         repeat: false
         onTriggered: {
-            Quickshell.execDetached(["qs", "-p", Quickshell.shellPath(""), "ipc", "call", "region", "screenshot"]);
+            GlobalStates.regionRequested("screenshot");
         }
     }
 

--- a/dots/.config/quickshell/imi/modules/imi/bar/UtilButtons.qml
+++ b/dots/.config/quickshell/imi/modules/imi/bar/UtilButtons.qml
@@ -34,14 +34,14 @@ Item {
             id: screenSnipM3
             UtilButton {
                 iconText: "screenshot_region"
-                onClicked: Quickshell.execDetached(["qs", "-p", Quickshell.shellPath(""), "ipc", "call", "region", "screenshot"])
+                onClicked: GlobalStates.regionRequested("screenshot")
             }
         }
 
         Component {
             id: legacyScreenSnip
             CircleUtilButton {
-                onClicked: Quickshell.execDetached(["qs", "-p", Quickshell.shellPath(""), "ipc", "call", "region", "screenshot"])
+                onClicked: GlobalStates.regionRequested("screenshot")
                 MaterialSymbol {
                     horizontalAlignment: Qt.AlignHCenter
                     fill: 1; text: "screenshot_region"

--- a/dots/.config/quickshell/imi/modules/imi/overlay/recorder/Recorder.qml
+++ b/dots/.config/quickshell/imi/modules/imi/overlay/recorder/Recorder.qml
@@ -31,7 +31,7 @@ StyledOverlayWidget {
                     name: "Screenshot region"
                     onClicked: {
                         GlobalStates.overlayOpen = false;
-                        Quickshell.execDetached(["qs", "-p", Quickshell.shellPath(""), "ipc", "call", "region", "screenshot"]);
+                        GlobalStates.regionRequested("screenshot");
                     }
                 }
 
@@ -49,7 +49,7 @@ StyledOverlayWidget {
                     name: "Record region"
                     onClicked: {
                         GlobalStates.overlayOpen = false;
-                        Quickshell.execDetached(["qs", "-p", Quickshell.shellPath(""), "ipc", "call", "region", "recordWithSound"]);
+                        GlobalStates.regionRequested("recordWithSound");
                     }
                 }
                 

--- a/dots/.config/quickshell/imi/modules/imi/overview/SearchBar.qml
+++ b/dots/.config/quickshell/imi/modules/imi/overview/SearchBar.qml
@@ -112,7 +112,7 @@ RowLayout {
         Layout.bottomMargin: Appearance.spacing.space50
         onClicked: {
             GlobalStates.overviewOpen = false;
-            Quickshell.execDetached(["qs", "-p", Quickshell.shellPath(""), "ipc", "call", "region", "search"]);
+            GlobalStates.regionRequested("search");
         }
         text: "image_search"
         StyledToolTip {

--- a/dots/.config/quickshell/imi/modules/imi/regionSelector/RegionSelector.qml
+++ b/dots/.config/quickshell/imi/modules/imi/regionSelector/RegionSelector.qml
@@ -102,6 +102,27 @@ Scope {
         GlobalStates.regionSelectorOpen = true
     }
 
+    // In-process callers (bar button, quick toggle, recorder overlay, overview
+    // search). Deferred one event-loop turn so a caller that closes its own
+    // surface first (`GlobalStates.overlayOpen = false`) has that state
+    // applied before the selector's exclusive-focus layer comes up - the
+    // out-of-process spawn this replaces gave that ordering for free.
+    Connections {
+        target: GlobalStates
+        function onRegionRequested(action) {
+            Qt.callLater(() => {
+                switch (action) {
+                case "screenshot": root.screenshot(); break;
+                case "search": root.search(); break;
+                case "ocr": root.ocr(); break;
+                case "record": root.record(); break;
+                case "recordWithSound": root.recordWithSound(); break;
+                default: console.warn(`[RegionSelector] unknown region action: ${action}`);
+                }
+            });
+        }
+    }
+
     IpcHandler {
         target: "region"
 

--- a/dots/.config/quickshell/imi/services/Cliphist.qml
+++ b/dots/.config/quickshell/imi/services/Cliphist.qml
@@ -275,6 +275,27 @@ Singleton {
 
     Component.onCompleted: pinsFileView.reload()
 
+    // Refresh when the clipboard changes. Hyprland's exec-once used to chain
+    // `qs ... ipc call cliphistService update` after every `cliphist store`,
+    // which started a second Quickshell process per copy (77 ms of Qt
+    // start-up, a fork of the whole shell) to deliver one call. One resident
+    // wl-paste watcher inside the shell does it instead; the 250 ms debounce
+    // covers the store that Hyprland's watcher is finishing concurrently.
+    // The IPC target below stays for callers outside the process.
+    Process {
+        id: clipboardWatch
+        running: true
+        command: ["wl-paste", "--watch", "echo", "changed"]
+        stdout: SplitParser {
+            onRead: refreshDebounce.restart()
+        }
+    }
+    Timer {
+        id: refreshDebounce
+        interval: 250
+        onTriggered: root.refresh()
+    }
+
     IpcHandler {
         target: "cliphistService"
 

--- a/dots/.config/quickshell/imi/tests/lint_no_self_ipc_spawn.sh
+++ b/dots/.config/quickshell/imi/tests/lint_no_self_ipc_spawn.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# The shell must not spawn a second Quickshell to talk to itself.
+#
+# `Quickshell.execDetached(["qs", ..., "ipc", "call", ...])` from inside the
+# shell, or Hyprland chaining `qs ... ipc call` after every clipboard store,
+# starts a whole Qt process (77 ms on a fast machine, a fork of the shell's
+# address space) to deliver one call back into the process that spawned it.
+# In-process callers use GlobalStates.regionRequested / a resident watcher.
+# LINT_ROOT points the check at another tree (the failure demonstration).
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="${LINT_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+status=0
+
+hits=$(grep -rn --include='*.qml' -E 'execDetached\(\["qs", .*"ipc", "call"' "$ROOT/modules" "$ROOT/services" 2>/dev/null)
+if [[ -n "$hits" ]]; then
+    echo "No-self-IPC lint FAILED: the shell spawns qs to call its own IPC:" >&2
+    echo "$hits" >&2
+    status=1
+fi
+
+EXECS="$ROOT/../../hypr/hyprland/execs.lua"
+if [[ -f "$EXECS" ]] && grep -v '^\s*--' "$EXECS" | grep -q 'ipc call cliphistService'; then
+    echo "No-self-IPC lint FAILED: execs.lua still spawns qs after every clipboard store" >&2
+    status=1
+fi
+
+if [[ $status -eq 0 ]]; then
+    echo "No-self-IPC lint passed: no in-shell qs spawns, clipboard watched in-process"
+fi
+exit $status

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -255,6 +255,16 @@ if ! bash "$SCRIPT_DIR/lint_region_selector_capture.sh"; then
     exit 1
 fi
 
+# The shell must not spawn a second Quickshell to reach its own IPC: six
+# buttons did `qs ... ipc call region ...` and Hyprland chained the same after
+# every clipboard store. lint_no_self_ipc_spawn.sh keeps them from coming
+# back.
+echo "Running no-self-IPC lint..."
+if ! bash "$SCRIPT_DIR/lint_no_self_ipc_spawn.sh"; then
+    echo "No-self-IPC lint failed."
+    exit 1
+fi
+
 # Static lint: spacing/padding/margin must use Appearance.spacing tokens, not
 # raw pixel literals in the token range.
 echo "Running Material icon lint..."


### PR DESCRIPTION
## Summary

Six buttons inside the shell - the bar's snip button (both styles), the Screen snip quick toggle, the recorder overlay's region screenshot and region record, and the overview's image search - each ran `qs -p <shell> ipc call region <action>`: a second Quickshell process (77 ms of Qt start-up here, plus a fork of the shell's address space) to deliver one call back into the process that spawned it. Hyprland's exec-once did the same after every clipboard store (`cliphist store && qs -c imi ipc call cliphistService update`), so every copy paid it too.

- `GlobalStates.regionRequested(action)`: the selector's Scope in shell.qml dispatches it one event-loop turn later, so a caller that closes its own surface first has that applied before the exclusive-focus layer comes up (the ordering the spawn gave for free). IPC target and GlobalShortcuts unchanged for out-of-process callers.
- `Cliphist` runs one resident `wl-paste --watch` and refreshes on change (250 ms debounce covers the store Hyprland's own watcher is finishing). Hyprland keeps storing, so history still survives a shell restart; execs.lua drops the `qs` chain.
- `lint_no_self_ipc_spawn.sh` fails on any in-shell `execDetached(["qs", ..., "ipc", "call", ...])` and on execs.lua chaining `ipc call cliphistService`; against `main` it reports all six sites and the exec line.

## Test plan

- New lint passes here, fails on `main` (six hits + execs.lua).
- `lint_doc_citations.py` OK.
- Full suite: 1680 passed, 0 failed, 0 skipped (`run_tests.sh` in the branch worktree, 2026-09-06 19:52-20:12).
- Live check after deploy and a Hyprland config reload (needs a real pointer, so not done by me): bar snip button, Screen snip quick toggle, recorder overlay buttons and overview image search all open the selector; copy something and the launcher's clipboard page shows it without `qs` appearing in `ps`.

Docs: updated AGENT.md §Layer-shell (wlr-layer-shell) gotchas
Changelog: updated
