### PR TITLE
install: drop the checkout on re-runs and clear the QML compile cache at install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,11 @@ own repo; the installer pins which revision it builds.
   Engine pin used to leave the previous ~1.4 GB prebuilt behind (7 of them,
   9.6 GB, on a machine that followed the pin since v0.2.0), plus a ~5 GB
   source checkout once any run had fallen back to building. Settings > Update
-  Dots now keeps only the renderer the shell runs, drops the dead checkout,
-  prunes QML-cache entries and crash dumps untouched for 30 days, and keeps
-  five install logs instead of all of them.
+  Dots now keeps only the renderer the shell runs, drops the dead checkout
+  (also on the re-run with an unchanged pin, which is every update), clears
+  the QML compile cache (the next start recompiles what it loads, a few
+  seconds once), prunes crash dumps untouched for 30 days, and keeps five
+  install logs instead of all of them.
 
 ### Fixed
 - **Shell memory no longer grows without bound.** The shell gained two to

--- a/sdata/lib/functions.sh
+++ b/sdata/lib/functions.sh
@@ -479,15 +479,19 @@ function dedup_and_sort_listfile(){
 }
 
 # Quickshell's QML disk cache keys entries by source hash, so every edited or
-# updated .qml leaves its old compiled entry behind for good - one machine
-# carried 44,745 entries (798 MB) with 580 touched in the last week - and its
-# crash dumps pile up the same way (70 dumps, 465 MB). Drop what has not been
-# touched in 30 days: a live entry that old is simply regenerated on the next
-# start. Only these two well-known directories are touched, never the parent.
+# updated .qml leaves its old compiled entry behind for good. An age rule does
+# not reach them: on one machine 44,745 entries (798 MB) were mostly younger
+# than 30 days and still stale (767 MB survived the first prune). The cache
+# is wiped at install instead - Qt recompiles exactly the files the deployed
+# tree loads on the next start, a few seconds once. Crash dumps keep the age
+# rule (70 dumps, 465 MB, went to 31 MB). Only these two well-known
+# directories are touched, never the parent.
 function prune_shell_caches(){
-  local base="${XDG_CACHE_HOME:-$HOME/.cache}/quickshell" d
-  for d in "$base/qmlcache" "$base/crashes"; do
-    [[ -d "$d" ]] || continue
-    find "$d" -mindepth 1 -mtime +30 -delete 2>/dev/null || true
-  done
+  local base="${XDG_CACHE_HOME:-$HOME/.cache}/quickshell"
+  if [[ -d "$base/qmlcache" ]]; then
+    find "$base/qmlcache" -mindepth 1 -delete 2>/dev/null || true
+  fi
+  if [[ -d "$base/crashes" ]]; then
+    find "$base/crashes" -mindepth 1 -mtime +30 -delete 2>/dev/null || true
+  fi
 }

--- a/sdata/subcmd-install/4.wallpaperengine.sh
+++ b/sdata/subcmd-install/4.wallpaperengine.sh
@@ -380,6 +380,11 @@ if up_to_date; then
   install_wrapper "$_stamp_bin" "$_stamp_lib"
   write_stamp "$WE_REF" "$_stamp_bin" "$_stamp_lib"
   prune_prebuilt "$WE_REF"
+  # A re-run with an unchanged pin is the common case (every Update Dots), and
+  # it is where the first prune left the 5 GB checkout standing: only the
+  # fresh-prebuilt path dropped it. If the wrapper points into a prebuilt, the
+  # checkout is dead here too.
+  case "$_stamp_bin" in "$PREBUILT_ROOT"/*) prune_build_dir ;; esac
   exit 0
 fi
 if try_prebuilt; then exit 0; fi

--- a/sdata/tests/test_install_housekeeping.py
+++ b/sdata/tests/test_install_housekeeping.py
@@ -30,7 +30,7 @@ class ShellCacheHousekeeping(unittest.TestCase):
                        env={"PATH": os.environ["PATH"], "HOME": str(cache_home)},
                        capture_output=True, text=True, check=True)
 
-    def test_old_entries_go_and_recent_ones_stay(self):
+    def test_qmlcache_is_wiped_and_only_old_crash_dumps_go(self):
         import time
         with tempfile.TemporaryDirectory() as tmp:
             home = Path(tmp)
@@ -40,12 +40,16 @@ class ShellCacheHousekeeping(unittest.TestCase):
             for f in (qml / "old.qmlc", crashes / "old.dump"):
                 f.write_text("x"); os.utime(f, (old, old))
             (qml / "fresh.qmlc").write_text("x")
+            (crashes / "fresh.dump").write_text("x")
             (home / "quickshell/other.txt").write_text("x")
             os.utime(home / "quickshell/other.txt", (old, old))
             self._prune(home)
             self.assertFalse((qml / "old.qmlc").exists())
+            self.assertFalse((qml / "fresh.qmlc").exists(),
+                             "stale qmlcache entries are mostly young; the cache is wiped")
+            self.assertTrue(qml.is_dir(), "the directory itself stays")
             self.assertFalse((crashes / "old.dump").exists())
-            self.assertTrue((qml / "fresh.qmlc").exists())
+            self.assertTrue((crashes / "fresh.dump").exists())
             self.assertTrue((home / "quickshell/other.txt").exists(),
                             "only qmlcache/ and crashes/ are ours to prune")
 

--- a/sdata/tests/test_we_cache_prune.py
+++ b/sdata/tests/test_we_cache_prune.py
@@ -115,6 +115,15 @@ class EveryStampWriterPrunes(unittest.TestCase):
         body = src[src.index("try_prebuilt(){"):src.index("source_build(){")]
         self.assertIn("prune_build_dir", body)
 
+    def test_already_installed_prebuilt_also_drops_the_source_tree(self):
+        """Every Update Dots with an unchanged pin takes this path; the first
+        prune left the checkout standing there."""
+        src = SCRIPT.read_text(encoding="utf-8")
+        tail = src[src.index("if up_to_date; then"):]
+        tail = tail[:tail.index("exit 0")]
+        self.assertRegex(tail, r'case "\$_stamp_bin" in "\$PREBUILT_ROOT"/\*\) prune_build_dir',
+                         "the already-installed path must drop the checkout when the live binary is a prebuilt")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Follow-up to #355 after one Settings > Update Dots run on this machine. Prebuilts went to `v0.3.0` alone (1.4 GB), install logs to five, crash dumps 465 -> 31 MB. Two things the first prune did not reach:

- **The 5.3 GB source checkout stayed.** Only the fresh-prebuilt path dropped it; the re-run with an unchanged pin - the path every update takes - matched the stamp, refreshed the wrapper and exited. That path now drops the checkout whenever the stamped binary lives under `PREBUILT_ROOT`.
- **The QML compile cache barely moved: 44,745 -> 42,585 entries, 798 -> 767 MB.** Stale entries are mostly younger than 30 days, because every deploy strands the previous entry of each edited `.qml`. `prune_shell_caches` now wipes `qmlcache/` at install; Qt recompiles exactly what the deployed tree loads on the next start, a few seconds once. Crash dumps keep the 30-day rule.

## Test plan

- `sdata/tests/test_we_cache_prune.py` (9) and `sdata/tests/test_install_housekeeping.py` (4): the new cases fail against `main`'s scripts (1 failure each) and pass here.
- `test_wallpaperengine_prebuilt.py`: 17 passed.
- Full suite: 1680 passed, 0 failed, 0 skipped (`run_tests.sh` in the branch worktree, 2026-09-07).
- User path after merge: one Update Dots run here should remove `~/.cache/immaterial-impulse/qs-wallpaperengine-build` and leave `~/.cache/quickshell/qmlcache` near-empty until the next shell start; I will check and report.

Docs: not needed — the tests-README bullet from #355 already describes these two tests and stays accurate.
Changelog: updated
