### PR TITLE
fix(wallpaper): the crop picker keeps its drag from the sidebar's Flickable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ own repo; the installer pins which revision it builds.
 
 ## [Unreleased]
 
+### Fixed
+- **Dragging the Wallpaper Engine crop box no longer scrolls the sidebar.**
+  A vertical drag on the Fill crop picker moved the box and scrolled the
+  whole settings column with it; the picker now keeps the drag to itself.
+
 ### Changed
 - **The installer stops hoarding old renderers and caches.** Each Wallpaper
   Engine pin used to leave the previous ~1.4 GB prebuilt behind (7 of them,

--- a/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/WallpaperSelectorSidebar.qml
+++ b/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/WallpaperSelectorSidebar.qml
@@ -338,6 +338,11 @@ ColumnLayout {
                                 MouseArea {
                                     anchors.fill: parent
                                     cursorShape: Qt.SizeAllCursor
+                                    // The picker sits inside the sidebar's Flickable, which steals
+                                    // any press the moment the pointer travels past the drag
+                                    // threshold - so a vertical crop drag scrolled the whole column
+                                    // while the box moved. The gesture is ours from the press.
+                                    preventStealing: true
                                     function apply(mx, my) {
                                         const f = CropPicker.focusFromPointer(
                                             root.contentAspect, root.screenAspect,

--- a/dots/.config/quickshell/imi/tests/test_we_overrides_wiring.py
+++ b/dots/.config/quickshell/imi/tests/test_we_overrides_wiring.py
@@ -71,6 +71,15 @@ def _checks(layer, background, store, sidebar, content):
     assert re.search(r'onActivated:.*writeSetting\("renderScale"', sidebar), \
         "the Quality control does not write through the router"
 
+    # The crop picker's MouseArea lives inside the sidebar's Flickable, which
+    # steals any press past the drag threshold; without preventStealing a
+    # vertical crop drag scrolls the column while the box moves (recorded
+    # 2026-09-07).
+    crop = sidebar[sidebar.index("cursorShape: Qt.SizeAllCursor"):]
+    crop = crop[:crop.index("function apply(")]
+    assert "preventStealing: true" in crop, \
+        "the crop picker's MouseArea does not keep its drag from the Flickable"
+
     # The content hosts the sidebar for exactly the two sources that have one.
     assert "WallpaperSelectorSidebar" in content
     assert not re.search(r"property var quickDirs", content), \
@@ -102,6 +111,15 @@ def test_the_checks_can_fail():
         pass
     else:
         raise AssertionError("a raw-config fps read passed the contract")
+
+    # Planted: the crop picker hands its drag back to the Flickable.
+    planted_sidebar = good["sidebar"].replace("preventStealing: true", "preventStealing: false", 1)
+    try:
+        _checks(good["layer"], good["background"], good["store"], planted_sidebar, good["content"])
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("a stealable crop drag passed the contract")
 
     # Planted: renderScale bound unconditionally (breaks an older binary).
     planted = layer.replace('"renderScale" in root', '"renderScaleXX" in root')


### PR DESCRIPTION
## Summary

Dragging the Fill crop box in the Wallpaper Engine sidebar scrolled the whole settings column along with the box (recording 2026-09-07 07:51; frames 2 s apart show the column shifted up while the box moved). The picker is a `MouseArea` inside the sidebar's `StyledFlickable`, and a Flickable steals any press once the pointer travels past the drag threshold. `preventStealing: true` keeps the gesture with the picker from the press. `StyledFlickable`'s own MouseAreas take no buttons (wheel only), so nothing else contends for it.

`test_we_overrides_wiring.py` pins the property on that MouseArea and plants its removal in its can-fail self-test.

## Test plan

- `test_we_overrides_wiring.py`: 2/2 here; against `main`'s tree it fails with "the crop picker's MouseArea does not keep its drag from the Flickable".
- Full suite: first run 2026-09-07 failed only in the WidgetResizeGrip nested-weston harness ("A connection to the bus can't be made" from its private session bus, unrelated to this change); that test passes alone (33 s) and a full rerun is in progress, result to follow in a comment.
- Live check after deploy (needs a real pointer, so yours): open the WE sidebar for a project, drag the crop box up and down - the column must stay put.

Docs: not needed — one-property gesture fix inside an existing component; no AGENT.md rule changes and the wiring test's docstring already covers the sidebar contract.
Changelog: updated
