### PR TITLE
fix(wallpaper): run the compatibility scanner without Quickshell's crash relaunch

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1768,6 +1768,15 @@ Two non-obvious behaviors have bitten this codebase before and are worth knowing
   with a one-shot migration guarded by its own `migrated*` flag, as `migrateDeadParallaxSwitches`
   and `migrateSplitCheatsheetButtons` do. Motivated by 65bd7696a ("feat(cheatsheet): draw a chord as
   one keycap per key").
+- **A helper the shell spawns as its own `qs -p` process runs with `QS_DISABLE_CRASH_HANDLER=1`.**
+  Quickshell's crash handler does not just dump: it relaunches the crashed process with the same
+  environment and the same stdio. For the compatibility scanner that meant a wallpaper crashing the
+  renderer produced a second scanner reading the original queue and writing verdicts into the
+  service's pipe while the service's own respawn ladder started its replacement; one of the two then
+  aborted in its log setup, wallpapers after the crash were recorded broken, and every death popped
+  a crash notification on the desk (2026-09-05). The parent owns retries for a helper it supervises;
+  the handler's relaunch is for the shell itself. `test_we_compat_wiring.py` pins it for the scanner.
+  249349043 ("fix(wallpaper): run the compatibility scanner without Quickshell's crash relaunch").
 - **Never spawn `qs` to call the shell's own IPC.** `Quickshell.execDetached(["qs", ..., "ipc",
   "call", ...])` from inside the shell starts a second Quickshell - 77 ms of Qt start-up on a fast
   machine and a fork of the shell's whole address space - to deliver one call back into the process

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ own repo; the installer pins which revision it builds.
 
 ## [Unreleased]
 
+### Fixed
+- **Checking Wallpaper Engine compatibility no longer spawns a second
+  scanner or pops crash notifications.** When a wallpaper crashed the
+  renderer inside the scanner, Quickshell's own crash handler relaunched the
+  scanner from the start of the queue while the shell was already starting
+  its replacement; the two reported over each other and wallpapers after the
+  crash were marked broken. The scanner now runs without that handler.
+
 ## [1.0.0-rc-15] — 2026-09-07
 
 ### Changed

--- a/dots/.config/quickshell/imi/services/WallpaperEngineCompat.qml
+++ b/dots/.config/quickshell/imi/services/WallpaperEngineCompat.qml
@@ -74,7 +74,19 @@ Singleton {
 
     function spawnScanner() {
         root.progressThisRun = false;
-        scanProcess.environment = ({ WE_COMPAT_QUEUE: JSON.stringify(root.pendingQueue) });
+        // QS_DISABLE_CRASH_HANDLER: Quickshell's own crash handler would
+        // RELAUNCH a scanner the renderer just took down - with the original
+        // queue in its environment and this Process's stderr still attached -
+        // while the ladder below spawns its replacement: two scanners at
+        // once, verdicts for the wrong wallpaper landing in this pipe, and the
+        // relaunch aborting in its own log setup (2026-09-05, five wallpapers
+        // marked broken, a crash notification per death). Without the
+        // handler a renderer crash is the plain CrashExit onExited already
+        // expects, and the ladder does the one respawn it was written for.
+        scanProcess.environment = ({
+            WE_COMPAT_QUEUE: JSON.stringify(root.pendingQueue),
+            QS_DISABLE_CRASH_HANDLER: "1"
+        });
         silenceWatchdog.restart();
         scanProcess.running = true;
     }

--- a/dots/.config/quickshell/imi/tests/test_we_compat_wiring.py
+++ b/dots/.config/quickshell/imi/tests/test_we_compat_wiring.py
@@ -54,6 +54,15 @@ def _checks(service, scanner, grid, sidebar):
     # not loop forever.
     assert "respawnsLeft" in service
 
+    # Quickshell's own crash handler must be off in the scanner: it relaunches
+    # a crashed scanner with the original queue and this pipe still attached,
+    # beside the ladder's own respawn - two scanners, verdicts for the wrong
+    # wallpaper, and a crash notification per death (2026-09-05).
+    env = service[service.index("scanProcess.environment"):]
+    env = env[:env.index("})") + 2]
+    assert re.search(r'QS_DISABLE_CRASH_HANDLER:\s*"1"', env), \
+        "the scanner runs with Quickshell's crash handler, which relaunches it behind the ladder's back"
+
 
 def test_we_compat_wiring():
     _checks(_strip_comments(SERVICE.read_text()),
@@ -76,6 +85,15 @@ def test_the_checks_can_fail():
         pass
     else:
         raise AssertionError("an in-shell scan surface passed the contract")
+
+    # Planted: the scanner spawned with the crash handler active.
+    planted = service.replace('QS_DISABLE_CRASH_HANDLER: "1"', 'QS_DISABLE_CRASH_HANDLER: "0"', 1)
+    try:
+        _checks(planted, scanner, grid, sidebar)
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("a relaunching scanner passed the contract")
 
     # Planted: the grid reading the raw map.
     planted = grid.replace("WallpaperEngineCompat.statusFor(project)",


### PR DESCRIPTION
## Summary

"Checking compatibility for WE wallpapers crashes quickshell after a while." The Sep 5 crash dumps are both the spawned scanner (`we_compat_scan.qml`), and they show the mechanism:

- 13:01, pid 2658685: SIGSEGV in `WallpaperEngine::Render::Objects::Effects::CPass::setupTextureUniforms` - the renderer taken down by a wallpaper, which is exactly what the spawned scanner exists to absorb.
- Quickshell's own crash handler then **relaunched** that scanner ("Quickshell has crashed under pid 2658685 ... Quickshell has been restarted" at the top of the next log), with the original `WE_COMPAT_QUEUE` still in its environment and the service's stderr pipe still attached, while the service's ladder spawned its own replacement. Two scanners scanned at once, verdicts for the wrong wallpaper landed in the pipe, and the relaunch died with SIGABRT in `LogManager::init` (core 2659240, 13:01:52). Five wallpapers were recorded broken in that run; every death also popped Quickshell's crash notification on the desk.

The scanner now runs with `QS_DISABLE_CRASH_HANDLER=1`. A renderer crash becomes the plain `CrashExit` `onExited` already handles: blame the in-flight wallpaper, respawn once from the remaining queue. `test_we_compat_wiring.py` pins the variable with a planted failure; the AGENT.md rule (Layer-shell section, beside the no-self-IPC entry) records that a helper the shell supervises runs without the handler's relaunch.

Not touched: the five Sep 5 verdicts already on disk. A rescan after this lands re-verdicts them.

## Test plan

- `test_we_compat_wiring.py`: 2/2 here; against `main` it fails with "the scanner runs with Quickshell's crash handler, which relaunches it behind the ladder's back".
- `lint_doc_citations.py` OK.
- Full suite: 1680 passed, 0 failed, 0 skipped (`run_tests.sh` in the branch worktree, 2026-09-07).
- Live check after deploy (yours; it loads real wallpapers on the GPU): run the compatibility check once. Expected: one "Wallpaper compatibility scan" window at a time, no crash notification when a wallpaper kills it, and the verdicts for the Sep 5 five re-evaluated.

Docs: updated AGENT.md §Layer-shell (wlr-layer-shell) gotchas
Changelog: updated
