### PR TITLE
fix(wallpaper): show the selector's header toolbar only with its chips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ own repo; the installer pins which revision it builds.
   scanner from the start of the queue while the shell was already starting
   its replacement; the two reported over each other and wallpapers after the
   crash were marked broken. The scanner now runs without that handler.
+- **The wallpaper selector's header no longer shows a stray pill.** With
+  Wallpaper Engine selected the header drew a tall shadowed "Steam Workshop"
+  pill beside the source dropdown, and with Local an empty stub; the chip
+  rail now appears only for the online sources that have chips.
 
 ## [1.0.0-rc-15] — 2026-09-07
 

--- a/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/WallpaperSelectorContent.qml
+++ b/dots/.config/quickshell/imi/modules/imi/wallpaperSelector/WallpaperSelectorContent.qml
@@ -342,12 +342,21 @@ MouseArea {
 
                     Toolbar {
                         anchors.centerIn: parent
+                        // An M3 toolbar is a chip rail: fixed toolbarHeight,
+                        // shadow, container fill. With nothing inside it is a
+                        // stub (Local), and around one bare label it was a tall
+                        // shadowed pill reading "Steam Workshop" beside the
+                        // 40 px source dropdown. It shows only with its chips;
+                        // the source is already named by the dropdown and the
+                        // sidebar's title.
+                        visible: resolutionChips.active
 
                         // The places chips and the Wallpaper Engine config
                         // row both moved into the left sidebar
                         // (WallpaperSelectorSidebar.qml) - the toolbar keeps
                         // only what has no home there.
                         Loader {
+                            id: resolutionChips
                             active: root.source !== "local" && root.source !== "wallpaperEngine"
                             visible: active
                             sourceComponent: RowLayout {
@@ -372,15 +381,6 @@ MouseArea {
                                         }
                                     }
                                 }
-                            }
-                        }
-
-                        Loader {
-                            active: root.source === "wallpaperEngine"
-                            visible: active
-                            sourceComponent: StyledText {
-                                text: Translation.tr("Steam Workshop")
-                                color: Appearance.colors.colOnLayer2
                             }
                         }
                     }

--- a/dots/.config/quickshell/imi/tests/test_we_overrides_wiring.py
+++ b/dots/.config/quickshell/imi/tests/test_we_overrides_wiring.py
@@ -80,6 +80,14 @@ def _checks(layer, background, store, sidebar, content):
     assert "preventStealing: true" in crop, \
         "the crop picker's MouseArea does not keep its drag from the Flickable"
 
+    # The header toolbar is a chip rail and shows only with its chips: with
+    # nothing inside it was an empty stub (Local), and around one bare label
+    # it was a tall shadowed "Steam Workshop" pill beside the source dropdown.
+    assert "visible: resolutionChips.active" in content, \
+        "the header Toolbar is shown without its chips"
+    assert 'Translation.tr("Steam Workshop")' not in content, \
+        "the toolbar carries a bare label again"
+
     # The content hosts the sidebar for exactly the two sources that have one.
     assert "WallpaperSelectorSidebar" in content
     assert not re.search(r"property var quickDirs", content), \
@@ -120,6 +128,15 @@ def test_the_checks_can_fail():
         pass
     else:
         raise AssertionError("a stealable crop drag passed the contract")
+
+    # Planted: the toolbar shown regardless of its chips.
+    planted_content = good["content"].replace("visible: resolutionChips.active", "visible: true", 1)
+    try:
+        _checks(good["layer"], good["background"], good["store"], good["sidebar"], planted_content)
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("an always-visible chip rail passed the contract")
 
     # Planted: renderScale bound unconditionally (breaks an older binary).
     planted = layer.replace('"renderScale" in root', '"renderScaleXX" in root')


### PR DESCRIPTION
## Summary

The wallpaper selector's header `Toolbar` is an M3 chip rail: fixed `toolbarHeight`, shadow, container fill. With Wallpaper Engine selected it held one bare "Steam Workshop" label and drew as a tall shadowed pill beside the 40 px source dropdown (screenshot 2026-09-07); with Local it held nothing and still drew an empty stub. The label goes - the dropdown names the source and the sidebar's title says "Wallpaper Engine" - and the rail is `visible` only while the resolution chips are loaded, i.e. for the online sources.

`test_we_overrides_wiring.py` pins both (visibility bound to the chips' Loader, no bare label) with a planted failure.

## Test plan

- `test_we_overrides_wiring.py`: 2/2 here; against `main` it fails with "the header Toolbar is shown without its chips".
- Full suite: 1680 passed, 0 failed, 0 skipped (`run_tests.sh` in the branch worktree, 2026-09-07).
- Deployed live for review: header shows title, dropdown and search for Local and Wallpaper Engine; the chip rail appears for Wallhaven/Unsplash/Pexels.

Docs: not needed — one visibility binding on an existing component; the selector's contract test docstring already covers the header.
Changelog: updated
