### PR TITLE
fix(theme): a Wallpaper Engine pick resets the accent like a static switch

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -448,6 +448,17 @@ from a successful parse, so a scan that fails outright still clears the queue.
 cbd8e707e ("feat(sounds): scan the sound-theme roots into one catalogue"),
 a3a8f65cf ("fix(sounds): play one resolved file instead of two guessed ones").
 
+**A configured accent wins over the image on every `switchwall.sh` run, so every path that means
+"the user picked a wallpaper" must clear it first.** `palette.accentColor` is written by the accent
+picker (`--color`), and a static switch (`--image`) resets it before theming. The Wallpaper Engine
+pick themes with `--coloronly --image <preview>` - color-only because the live wallpaper must not be
+torn down - and that flag was exempted from the reset by a comment about "transient" runs that
+described the lock screen, which uses `--lock-colors-only`. Result: a stale accent won on every WE
+pick, all outputs carried one palette, `path.txt` read "Null" (matugen ran in `color hex` mode).
+`--noswitch` is the only flag that keeps the accent (picker, mode toggles, presets pass it). When
+theming looks stuck across wallpapers, check `palette.accentColor` in config.json before the
+generators. a33f2a8d3 ("fix(theme): a Wallpaper Engine pick resets the accent like a static switch").
+
 **A pipeline of per-app steps run by a caller that does not stop on failure
 starves every step after the first broken one, silently.**
 `scripts/colors/apply_matugen_app_themes.py` themes cava, btop, tmux and kitty

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ own repo; the installer pins which revision it builds.
 ## [Unreleased]
 
 ### Fixed
+- **Picking a Wallpaper Engine wallpaper themes from it again.** A
+  previously chosen accent colour stayed in force across Wallpaper Engine
+  picks (a static wallpaper pick already cleared it), so every WE wallpaper
+  produced the same palette and the preview was ignored. A WE pick now resets
+  the accent like any other wallpaper choice; the accent picker, presets and
+  the light/dark toggles keep their behaviour.
+
+### Fixed
 - **Checking Wallpaper Engine compatibility no longer spawns a second
   scanner or pops crash notifications.** When a wallpaper crashed the
   renderer inside the scanner, Quickshell's own crash handler relaunched the

--- a/dots/.config/quickshell/imi/scripts/colors/switchwall.sh
+++ b/dots/.config/quickshell/imi/scripts/colors/switchwall.sh
@@ -450,10 +450,15 @@ main() {
         imgpath="$(kdialog --getopenfilename . --title 'Choose wallpaper')"
     fi
 
-    # A color-only run is transient (e.g. the lock screen recoloring); it must
-    # not wipe the user's configured accent color. When an accent is set it
-    # still wins over the image, same as a normal switch.
-    if [[ -n "$imgpath" && -z "$noswitch_flag" && -z "$coloronly_flag" ]]; then
+    # An explicit wallpaper pick resets the configured accent, on every path:
+    # a static switch (--image) and a Wallpaper Engine pick (--coloronly
+    # --image, which themes from the preview without tearing the live
+    # wallpaper down). --noswitch is the one flag that keeps the accent - the
+    # accent picker, the mode toggles and preset application all pass it.
+    # --coloronly used to be exempt as well, so a WE pick never cleared a
+    # stale accent and every WE wallpaper regenerated the same palette from
+    # it while the preview was ignored (2026-09-07).
+    if [[ -n "$imgpath" && -z "$noswitch_flag" ]]; then
         set_accent_color ""
         color_flag=""
         color=""

--- a/dots/.config/quickshell/imi/tests/test_wallpaper_engine.py
+++ b/dots/.config/quickshell/imi/tests/test_wallpaper_engine.py
@@ -287,6 +287,19 @@ class WallpaperScriptTests(unittest.TestCase):
         self.assertIn('[[ -z "$coloronly" ]] && kill_existing_mpvpaper', switcher)
         self.assertIn('[[ -z "$coloronly" ]] && check_and_prompt_upscale "$imgpath" &', switcher)
 
+    def test_a_wallpaper_engine_pick_resets_the_accent_like_a_static_switch(self):
+        """--coloronly --image is a wallpaper choice; only --noswitch keeps
+        the accent. With coloronly exempt, a configured accent won over the
+        preview on every WE pick and each wallpaper produced the same palette."""
+        switcher = (ROOT / "scripts/colors/switchwall.sh").read_text()
+        self.assertIn('if [[ -n "$imgpath" && -z "$noswitch_flag" ]]; then\n        set_accent_color ""',
+                      switcher.replace("\r", ""))
+        self.assertNotIn('-z "$noswitch_flag" && -z "$coloronly_flag" ]]; then\n        set_accent_color', switcher)
+        engine = (ROOT / "services/WallpaperEngine.qml").read_text()
+        theme = engine[engine.index("function enqueueTheme"):engine.index("function stop()")]
+        self.assertIn('"--coloronly", "--image", project.preview', theme)
+        self.assertNotIn("--noswitch", theme, "the WE theme run must not keep the accent")
+
     def test_presets_theme_from_engine_preview_without_a_runtime(self):
         presets = (ROOT / "scripts/presets.sh").read_text()
         self.assertIn(".wallpaperSelector.wallpaperEngine.activePath // empty", presets)


### PR DESCRIPTION
## Summary

"matugen doesn't seem to be correctly set when changing WE wallpapers." It was running - kitty, GTK and the shell's colors.json all changed at the same second as the pick - but it was fed a fixed colour, not the wallpaper: matugen's own dominant colour for the picked preview is purple (`#623aa8`), every output carried salmon-on-brown (`#ffb4ab` on `#1a1110`), and `path.txt` read "Null", which is what the wallpaper template writes when matugen runs in `color hex` mode.

`palette.accentColor` was `#882822` in config.json. switchwall.sh lets a configured accent win over the image on every run; a static switch clears it first, but the Wallpaper Engine path themes with `--coloronly --image <preview>` (so the live wallpaper is not torn down) and `--coloronly` was exempted from the reset by a comment about "transient" runs that described the lock screen - which uses `--lock-colors-only`, not this flag. So a stale accent won on every WE pick.

Now only `--noswitch` keeps the accent: the accent picker, the light/dark toggles and preset application all pass it, so they are unchanged; a WE pick resets it like any other wallpaper choice. `test_wallpaper_engine.py` pins the condition and that the WE theme run does not carry `--noswitch`; the AGENT.md entry (External binaries) says where to look when theming looks stuck across wallpapers.

## Test plan

- `test_wallpaper_engine.py`: 18/18 here; against `main` the new case fails.
- `lint_doc_citations.py` OK; `bash -n` on switchwall.sh.
- Full suite: **not run**, on the maintainer's instruction for this change.
- Live: deployed; the next WE pick on this machine should clear the stale accent and theme from the preview.

Docs: updated AGENT.md §External binaries the shell drives
Changelog: updated
