### PR TITLE
fix(theme): apply a rewritten palette on the load that finished, animated

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -458,6 +458,14 @@ pick, all outputs carried one palette, `path.txt` read "Null" (matugen ran in `c
 `--noswitch` is the only flag that keeps the accent (picker, mode toggles, presets pass it). When
 theming looks stuck across wallpapers, check `palette.accentColor` in config.json before the
 generators. a33f2a8d3 ("fix(theme): a Wallpaper Engine pick resets the accent like a static switch").
+**`FileView.loaded` is a property that stays true across reloads; react to the `loaded()` signal,
+never to `onLoadedChanged`, when a watched file is rewritten.** `MaterialThemeLoader` applied its
+startup palette from `onLoadedChanged` and every later one from a fixed timer that read `text()`
+before the asynchronous reload had landed - the previous palette went in and the new one waited for
+the next trigger - and it did so with `animated=false`, so no wallpaper change ever transitioned.
+`onLoaded` fires per completed load; guard for the empty or partial file that an in-place rewrite
+(matugen: truncate, then write) exposes on its first change event. `ThemeReloadRuntimeTest.qml`
+measures it: first change 20 ms, an intermediate value seen, settled 200 ms. afde22316 ("fix(theme): apply a rewritten palette on the load that finished, animated").
 
 **A pipeline of per-app steps run by a caller that does not stop on failure
 starves every step after the first broken one, silently.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,14 +13,6 @@ own repo; the installer pins which revision it builds.
 ## [Unreleased]
 
 ### Fixed
-- **Picking a Wallpaper Engine wallpaper themes from it again.** A
-  previously chosen accent colour stayed in force across Wallpaper Engine
-  picks (a static wallpaper pick already cleared it), so every WE wallpaper
-  produced the same palette and the preview was ignored. A WE pick now resets
-  the accent like any other wallpaper choice; the accent picker, presets and
-  the light/dark toggles keep their behaviour.
-
-### Fixed
 - **Checking Wallpaper Engine compatibility no longer spawns a second
   scanner or pops crash notifications.** When a wallpaper crashed the
   renderer inside the scanner, Quickshell's own crash handler relaunched the
@@ -31,6 +23,17 @@ own repo; the installer pins which revision it builds.
   Wallpaper Engine selected the header drew a tall shadowed "Steam Workshop"
   pill beside the source dropdown, and with Local an empty stub; the chip
   rail now appears only for the online sources that have chips.
+- **Picking a Wallpaper Engine wallpaper themes from it again.** A
+  previously chosen accent colour stayed in force across Wallpaper Engine
+  picks (a static wallpaper pick already cleared it), so every WE wallpaper
+  produced the same palette and the preview was ignored. A WE pick now resets
+  the accent like any other wallpaper choice; the accent picker, presets and
+  the light/dark toggles keep their behaviour.
+- **New colours arrive on time and fade in.** After a wallpaper or accent
+  change the shell sometimes kept the previous palette until something else
+  nudged it, and when it did change it snapped. The theme loader now applies
+  each palette when the file has actually finished loading, and transitions
+  every change after startup.
 
 ## [1.0.0-rc-15] — 2026-09-07
 

--- a/dots/.config/quickshell/imi/ThemeReloadRuntimeTest.qml
+++ b/dots/.config/quickshell/imi/ThemeReloadRuntimeTest.qml
@@ -1,0 +1,86 @@
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import qs.modules.common
+import qs.services
+
+/**
+ * Drives MaterialThemeLoader against a real generated colors.json rewritten
+ * the way matugen rewrites it (truncate, then write) and watches
+ * Appearance.m3colors follow: how soon the first change lands, whether the
+ * roles travel (an intermediate value between old and new) instead of
+ * snapping, and that the final value is the new palette.
+ *
+ * The loader used to apply on a fixed 20 ms timer that read text() before
+ * the async reload had finished (stale palette, "sometimes takes a while")
+ * and with animated=false (no transition). Launched by
+ * tests/test_theme_reload_runtime.py with a throwaway XDG_STATE_HOME.
+ */
+ShellRoot {
+    id: harness
+    property int failures: 0
+    property int checksRun: 0
+    property int elapsed: 0
+    readonly property string themePath: Directories.generatedMaterialThemePath
+    readonly property color oldPrimary: "#202020"
+    readonly property color newPrimary: "#e0e0e0"
+    property int firstChangeMs: -1
+    property bool sawIntermediate: false
+    property int settledMs: -1
+    property int sampleMs: 0
+    // Keep the singleton alive - nothing else in this harness references it.
+    readonly property var loader: MaterialThemeLoader
+
+    function check(label, ok) {
+        harness.checksRun++;
+        console.log(`[ThemeReload] ${label}: ${ok ? "ok" : "FAIL"}`);
+        if (!ok) harness.failures++;
+    }
+    function finish() {
+        console.log(`[ThemeReload] checks: ${harness.checksRun} failures: ${harness.failures}`);
+        Qt.exit(harness.failures === 0 ? 0 : 1);
+    }
+
+    // 1. Wait for the seeded palette to land (startup apply).
+    Timer {
+        id: waitForStart
+        interval: 50; repeat: true; running: true
+        onTriggered: {
+            harness.elapsed += interval;
+            if (Appearance.m3colors.m3primary !== harness.oldPrimary) {
+                if (harness.elapsed >= 15000) {
+                    harness.check(`startup palette applied (primary ${Appearance.m3colors.m3primary})`, false);
+                    harness.finish();
+                }
+                return;
+            }
+            waitForStart.running = false;
+            rewrite.running = true;
+        }
+    }
+    // 2. Rewrite like matugen: truncate, then write.
+    Process {
+        id: rewrite
+        command: ["bash", "-c", `: > "$1"; printf '%s' '{"primary":"#e0e0e0","background":"#f0f0f0"}' > "$1"`, "rewrite", harness.themePath]
+        onExited: sample.running = true
+    }
+    // 3. Sample the role every 20 ms.
+    Timer {
+        id: sample
+        interval: 20; repeat: true
+        onTriggered: {
+            harness.sampleMs += interval;
+            const p = Appearance.m3colors.m3primary;
+            if (harness.firstChangeMs < 0 && p !== harness.oldPrimary) harness.firstChangeMs = harness.sampleMs;
+            if (p !== harness.oldPrimary && p !== harness.newPrimary) harness.sawIntermediate = true;
+            if (harness.settledMs < 0 && p === harness.newPrimary) harness.settledMs = harness.sampleMs;
+            const done = harness.settledMs >= 0 && harness.sampleMs >= harness.settledMs + 200;
+            if (!done && harness.sampleMs < 4000) return;
+            sample.running = false;
+            harness.check(`first change within 500 ms (${harness.firstChangeMs} ms)`, harness.firstChangeMs >= 0 && harness.firstChangeMs <= 500);
+            harness.check("the role travels through an intermediate value (animated)", harness.sawIntermediate);
+            harness.check(`settles on the new palette (${harness.settledMs} ms)`, harness.settledMs >= 0 && harness.settledMs <= 3000);
+            harness.finish();
+        }
+    }
+}

--- a/dots/.config/quickshell/imi/services/MaterialThemeLoader.qml
+++ b/dots/.config/quickshell/imi/services/MaterialThemeLoader.qml
@@ -212,15 +212,6 @@ Singleton {
         }
     }
 
-    Timer {
-        id: delayedFileRead
-        interval: Config.options?.hacks?.arbitraryRaceConditionDelay ?? 100
-        repeat: false
-        running: false
-        onTriggered: {
-            if (!root.lockThemeActive) root.applyColors(themeFileView.text())
-        }
-    }
 
     Process {
         id: lockThemeProc
@@ -304,13 +295,26 @@ Singleton {
         id: themeFileView
         path: Qt.resolvedUrl(root.filePath)
         watchChanges: true
-        onFileChanged: {
-            this.reload()
-            delayedFileRead.start()
-        }
-        onLoadedChanged: {
-            const fileContent = themeFileView.text()
-            if (!root.lockThemeActive) root.applyColors(fileContent)
+        onFileChanged: this.reload()
+        // One apply path, on the load that actually finished. `loaded` (the
+        // property) stays true across reloads, so onLoadedChanged fired once
+        // at startup and every later palette came through a fixed 20 ms
+        // timer that read text() before the async reload had landed - the
+        // old colours applied, and the new ones waited for the next trigger
+        // ("sometimes takes a while") - and it applied with animated=false,
+        // so a wallpaper switch never transitioned. The loaded() SIGNAL fires
+        // per completed load. matugen rewrites the file in place (truncate,
+        // then write), so the first of its two change events can load an
+        // empty or partial file: skip anything that is not a JSON object.
+        // The first apply is instant (startup); every later one animates.
+        property bool appliedOnce: false
+        onLoaded: {
+            if (root.lockThemeActive) return;
+            const fileContent = themeFileView.text();
+            if (!fileContent || fileContent.trim() === "") return;
+            try { JSON.parse(fileContent); } catch (e) { return; }
+            root.applyColors(fileContent, themeFileView.appliedOnce);
+            themeFileView.appliedOnce = true;
         }
         onLoadFailed: root.resetFilePathNextTime();
     }

--- a/dots/.config/quickshell/imi/tests/run_tests.sh
+++ b/dots/.config/quickshell/imi/tests/run_tests.sh
@@ -1739,6 +1739,16 @@ if ! python3 "$SCRIPT_DIR/test_kboptions_migration_runtime.py"; then
     exit 1
 fi
 
+# A rewritten colors.json must reach Appearance promptly and animated. The
+# loader applied every post-startup palette from a 20 ms timer that read the
+# FileView before its async reload landed (stale palette, "takes a while")
+# and with animated=false (no transition). Brings its own headless weston.
+echo "Running theme reload runtime tests..."
+if ! python3 "$SCRIPT_DIR/test_theme_reload_runtime.py"; then
+    echo "Theme reload runtime tests failed."
+    exit 1
+fi
+
 # The block is a set of paths into the theme's directory and at the apply
 # script sudo will accept; the directory was renamed and the script moved. A
 # wrong path here means the login screen silently stops following the

--- a/dots/.config/quickshell/imi/tests/test_theme_reload_runtime.py
+++ b/dots/.config/quickshell/imi/tests/test_theme_reload_runtime.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""A rewritten colors.json reaches Appearance promptly and animated.
+
+MaterialThemeLoader used to apply every palette after startup from a fixed
+20 ms timer that read the FileView's text() before the asynchronous reload
+had finished - so the previous palette was applied and the new one waited
+for the next trigger - and it applied with animated=false, so a wallpaper
+switch snapped instead of transitioning. It now applies on the FileView's
+loaded() signal, animated after the first apply. This launches the shell's
+theme loader against a throwaway state dir, rewrites colors.json the way
+matugen does (truncate, then write) and watches the role follow.
+"""
+import json
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+import nested_display
+
+ROOT = Path(__file__).resolve().parent.parent
+HARNESS = ROOT / "ThemeReloadRuntimeTest.qml"
+SHIPPED_DEFAULT = ROOT / "defaults/config.json"
+EXPECTED_CHECKS = 3
+
+
+def _runtime_available():
+    return nested_display.available()
+
+
+@unittest.skipUnless(_runtime_available(),
+                     "needs qs, weston and dbus-run-session on PATH")
+class ThemeReloadRuntimeTest(unittest.TestCase):
+    def setUp(self):
+        self.home = Path(tempfile.mkdtemp(prefix="imi-theme-reload-"))
+        self.addCleanup(shutil.rmtree, self.home, ignore_errors=True)
+        self.config_home = self.home / "config"
+        (self.config_home / "immaterial-impulse").mkdir(parents=True)
+        config = json.loads(SHIPPED_DEFAULT.read_text())
+        config["migratedUpstreamSchema"] = True
+        (self.config_home / "immaterial-impulse/config.json").write_text(json.dumps(config, indent=2))
+        generated = self.home / "state/quickshell/user/generated"
+        generated.mkdir(parents=True)
+        (generated / "colors.json").write_text(json.dumps({"primary": "#202020", "background": "#101010"}))
+
+    def test_a_rewritten_palette_lands_promptly_and_animated(self):
+        env = nested_display.start(self, "theme-reload")
+        env["XDG_CONFIG_HOME"] = str(self.config_home)
+        env["XDG_STATE_HOME"] = str(self.home / "state")
+        env["XDG_CACHE_HOME"] = str(self.home / "cache")
+        env["XDG_DATA_HOME"] = str(self.home / "data")
+        proc = subprocess.run(["dbus-run-session", "--", "qs", "-p", str(HARNESS)], cwd=str(ROOT),
+                              env=env, capture_output=True, text=True, timeout=180)
+        output = proc.stdout + proc.stderr
+        # The measured numbers belong in the suite log, not only in a failure.
+        for line in output.splitlines():
+            if "[ThemeReload]" in line:
+                print(line.strip())
+        failed = [line for line in output.splitlines() if "[ThemeReload]" in line and "FAIL" in line]
+        self.assertEqual(failed, [], f"harness reported failures:\n{output}")
+        self.assertIn(f"[ThemeReload] checks: {EXPECTED_CHECKS} failures: 0", output,
+                      f"harness did not finish cleanly:\n{output}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Two reports after the accent fix: colours "sometimes take a while" to update, and when they change they snap instead of transitioning. Both come from how `MaterialThemeLoader` consumed the rewritten colors.json.

`FileView.loaded` is a property that stays true across reloads (Quickshell's own doc comment says so), so `onLoadedChanged` fired once at startup. Every later palette came through `delayedFileRead`: a fixed timer (`hacks.arbitraryRaceConditionDelay`, 20 ms) that read `text()` before the asynchronous reload had landed, so the previous palette was applied and the new one waited for the next trigger; and it called `applyColors` with `animated=false`, so nothing ever transitioned.

The loader now has one apply path, on the FileView's `loaded()` signal (fires per completed load): instant on the first apply, animated through the existing ColorAnimation roles afterwards. matugen rewrites the file in place (truncate, then write), so the first change event can load an empty or partial file; anything that is not a JSON object is skipped. The delayed timer is gone.

## Test plan

- `ThemeReloadRuntimeTest.qml` + `test_theme_reload_runtime.py` (wired into `run_tests.sh`): rewrites colors.json the matugen way under a throwaway state dir and watches `m3primary`. With the fix: first change 20 ms, intermediate value seen, settled 200 ms. Against the old loader the animated check fails (it snaps). Ran alone, 6 s.
- `lint_doc_citations.py` OK.
- Full suite: **not run**, on the maintainer's instruction today.
- Live: deployed (hot reload clean); pick a wallpaper and watch the palette fade in.

Docs: updated AGENT.md §External binaries the shell drives
Changelog: updated
